### PR TITLE
Scope StringBuilder to --stat block in DiffCommand

### DIFF
--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -215,8 +215,6 @@ public class DiffCommand
     private static string GeneratePackageDiff(string name, ApiSurface fromSurface, ApiSurface toSurface, 
         string fromVersion, string toVersion, DiffOptions options)
     {
-        var sb = new StringBuilder();
-
         // Build type dictionaries by full name
         var fromTypes = fromSurface.Types.ToDictionary(GetTypeFullName, t => t);
         var toTypes = toSurface.Types.ToDictionary(GetTypeFullName, t => t);
@@ -275,6 +273,7 @@ public class DiffCommand
         // --stat: compact statistics
         if (options.Stat)
         {
+            var sb = new StringBuilder();
             sb.AppendLine($"{name} {fromVersion}..{toVersion}  +{addedTypes.Count} -{removedTypes.Count} ~{changedTypes.Count} types");
             foreach (var t in removedTypes)
             {


### PR DESCRIPTION
## Summary
- Move `StringBuilder` declaration from method-level into the `--stat` branch where it's the only consumer
- Avoids unnecessary allocation on the default `MarkoutWriter` path

## Test plan
- [x] `dotnet build` succeeds
- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)