### PR TITLE
Add --version flag, stderr hints, and audit disambiguation

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector;
@@ -782,6 +784,7 @@ public static class CommandLineBuilder
         var auditOption = new Option<bool>("--audit") { Description = "Verify SourceLink, determinism, and signature (always strict)" };
         var sourcelinkOption = new Option<bool>("--sourcelink") { Description = "Show SourceLink presence and URL (fast, no verification)" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select assembly by TFM (e.g., net8.0)" };
+        var versionOption = new Option<string?>("--version") { Description = "Package version" };
 
         packageCommand.Arguments.Add(packageNameArg);
         packageCommand.Options.Add(depsOption);
@@ -795,6 +798,7 @@ public static class CommandLineBuilder
         packageCommand.Options.Add(auditOption);
         packageCommand.Options.Add(sourcelinkOption);
         packageCommand.Options.Add(tfmOption);
+        packageCommand.Options.Add(versionOption);
         packageCommand.Options.Add(outOption);
         packageCommand.Options.Add(discoverOption);
         packageCommand.Options.Add(limitOption);
@@ -811,12 +815,13 @@ public static class CommandLineBuilder
         packageCommand.SetAction(async (parseResult, ct) =>
         {
             var packageArgs = parseResult.GetValue(packageNameArg) ?? [];
-            
+            var explicitVersion = parseResult.GetValue(versionOption);
+
             // Handle --assembly, --audit, or --sourcelink: delegate to AssemblyCommand
             bool showAssembly = parseResult.GetValue(assemblyOption);
             bool runAudit = parseResult.GetValue(auditOption);
             bool showSourcelink = parseResult.GetValue(sourcelinkOption);
-            
+
             if (showAssembly || runAudit || showSourcelink)
             {
                 if (packageArgs.Length < 1)
@@ -827,7 +832,9 @@ public static class CommandLineBuilder
 
                 var assemblyOptions = new AssemblyOptions
                 {
-                    PackagePath = packageArgs[0],
+                    PackagePath = explicitVersion != null && !packageArgs[0].Contains('@')
+                        ? $"{packageArgs[0]}@{explicitVersion}"
+                        : packageArgs[0],
                     Tfm = parseResult.GetValue(tfmOption),
                     IncludeAudit = runAudit || showSourcelink,
                     StrictAudit = runAudit, // --audit is always strict
@@ -862,7 +869,17 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            return await PackageCommand.ExecuteAsync(packageArgs, options);
+            var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options, explicitVersion);
+
+            if (exitCode == 0 && !options.JsonOutput && options.Verbosity != Verbosity.Quiet
+                && packageArgs.Length > 0 && !options.ListVersions && !options.ListFiles && !options.Discover && !options.ShowReadme)
+            {
+                var pkg = packageArgs[0];
+                if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
+                Hints.WriteHint($"dotnet-inspect api --package {pkg}   # view public API surface");
+            }
+
+            return exitCode;
         });
 
         return packageCommand;
@@ -885,9 +902,11 @@ public static class CommandLineBuilder
         };
 
         var tfmOption = new Option<string?>("--tfm") { Description = "Select assembly by TFM (e.g., net8.0)" };
+        var versionOption = new Option<string?>("--version") { Description = "Package version" };
 
         auditCommand.Arguments.Add(targetArg);
         auditCommand.Options.Add(tfmOption);
+        auditCommand.Options.Add(versionOption);
         auditCommand.Options.Add(jsonOption);
         auditCommand.Options.Add(verboseOption);
         auditCommand.Options.Add(verbosityOption);
@@ -905,6 +924,7 @@ public static class CommandLineBuilder
             }
 
             var tfm = parseResult.GetValue(tfmOption);
+            var explicitVersion = parseResult.GetValue(versionOption);
             var verbose = parseResult.GetValue(verboseOption);
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
             var jsonOutput = parseResult.GetValue(jsonOption);
@@ -915,15 +935,47 @@ public static class CommandLineBuilder
             foreach (var target in targets)
             {
                 // Determine input type and create appropriate options
-                bool isFilePath = target.Contains('/') || target.Contains('\\') || 
+                bool isFilePath = target.Contains('/') || target.Contains('\\') ||
                                   target.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
                                   target.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+
+                // Disambiguation for System.*/Microsoft.* bare names
+                if (!isFilePath && !target.Contains('@') && explicitVersion == null)
+                {
+                    string bareName = target;
+                    if (bareName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
+                        bareName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var (platformPath, _, _, platformError) =
+                            PlatformResolver.ResolveAssembly(bareName);
+
+                        if (platformError == null && platformPath != null)
+                        {
+                            Console.Error.WriteLine($"'{bareName}' is available as both a NuGet package and a platform assembly.");
+                            Console.Error.WriteLine();
+                            Console.Error.WriteLine($"  dotnet-inspect audit {bareName}@<version>       # audit NuGet package (specific version)");
+                            Console.Error.WriteLine($"  dotnet-inspect package {bareName} --audit        # audit NuGet package (latest)");
+                            Console.Error.WriteLine($"  dotnet-inspect platform {bareName} --audit       # audit platform assembly");
+                            Console.Error.WriteLine();
+                            Console.Error.WriteLine($"Tip: Use 'dotnet-inspect package {bareName} --versions -n 5' to find recent versions.");
+                            failures++;
+                            continue;
+                        }
+                    }
+                }
+
+                // Apply --version to bare package names
+                var effectiveTarget = target;
+                if (explicitVersion != null && !isFilePath && !target.Contains('@'))
+                {
+                    effectiveTarget = $"{target}@{explicitVersion}";
+                }
 
                 var options = new AssemblyOptions
                 {
                     IncludeAudit = true,
                     StrictAudit = true, // audit always runs strict verification
-                    PackagePath = isFilePath ? null : target,
+                    PackagePath = isFilePath ? null : effectiveTarget,
                     Tfm = tfm,
                     JsonOutput = jsonOutput,
                     Verbose = verbose,
@@ -938,6 +990,19 @@ public static class CommandLineBuilder
                 if (result != 0)
                 {
                     failures++;
+                }
+            }
+
+            if (failures == 0 && !jsonOutput && verbosity != Verbosity.Quiet)
+            {
+                // Hint about --sourcelink for quick checks when auditing packages
+                var firstTarget = targets[0];
+                bool firstIsFile = firstTarget.Contains('/') || firstTarget.Contains('\\') ||
+                                   firstTarget.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+                                   firstTarget.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+                if (!firstIsFile)
+                {
+                    Hints.WriteHint($"dotnet-inspect package {firstTarget} --sourcelink   # quick SourceLink check (no verification)");
                 }
             }
 
@@ -1156,7 +1221,16 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            return await ApiCommand.ExecuteAsync(typeName, options);
+            var exitCode = await ApiCommand.ExecuteAsync(typeName, options);
+
+            if (exitCode == 0 && !options.JsonOutput && options.Verbosity != Verbosity.Quiet
+                && !options.SignaturesOnly && !options.ShowDocs
+                && !string.IsNullOrEmpty(options.PackagePath))
+            {
+                Hints.WriteHint($"dotnet-inspect api --package {options.PackagePath} --docs   # include XML doc comments");
+            }
+
+            return exitCode;
         });
 
         return apiCommand;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -13,7 +13,7 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class PackageCommand
 {
-    public static async Task<int> ExecuteAsync(string[] packageArgs, InspectionOptions options)
+    public static async Task<int> ExecuteAsync(string[] packageArgs, InspectionOptions options, string? explicitVersion = null)
     {
         // Handle --discover mode: list sections and exit early
         if (options.Discover)
@@ -71,7 +71,15 @@ public class PackageCommand
             string packageArg = packageArgs[0];
             int atIndex = packageArg.IndexOf('@');
 
-            if (atIndex > 0)
+            if (explicitVersion != null)
+            {
+                packageName = atIndex > 0
+                    ? packageArg[..atIndex].ToLowerInvariant()
+                    : packageArg.ToLowerInvariant();
+                version = explicitVersion.ToLowerInvariant();
+                logger.Log($"Using --version: {version}");
+            }
+            else if (atIndex > 0)
             {
                 packageName = packageArg[..atIndex].ToLowerInvariant();
                 version = packageArg[(atIndex + 1)..].ToLowerInvariant();

--- a/src/dotnet-inspect/Output/Hints.cs
+++ b/src/dotnet-inspect/Output/Hints.cs
@@ -1,0 +1,11 @@
+namespace DotnetInspector.Output;
+
+public static class Hints
+{
+    public static void WriteHint(string hint)
+    {
+        Console.Out.Flush();
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Tip: {hint}");
+    }
+}


### PR DESCRIPTION
## Summary

- **`--version` flag**: Added to `package` and `audit` commands so users can write `dotnet-inspect package Foo --version 1.0` instead of only `Foo@1.0`. All four input variants now work: `pkg`, `pkg@ver`, `pkg ver`, `pkg --version ver`.
- **Stderr hints**: After successful `package`, `api`, and `audit` commands, a contextual tip is printed to stderr suggesting a natural next step. Suppressed when `--json`, `-v:q`, or non-zero exit code.
- **Audit disambiguation**: `dotnet-inspect audit System.Text.Json` now detects that the bare name matches both a NuGet package and a platform assembly, and prints clear alternatives instead of silently downloading the NuGet package. Bypassed when a version is specified via `@` or `--version`.

## Test plan

- [x] `dotnet build` succeeds
- [x] All 324 tests pass
- [x] `package Markout --version 0.1.8` resolves correct version
- [x] `audit Markout --version 0.1.8` resolves correct version
- [x] `audit System.Text.Json` shows disambiguation message
- [x] `audit System.Text.Json@9.0.0` bypasses disambiguation
- [x] `audit System.Text.Json --version 9.0.0` bypasses disambiguation
- [x] `package Markout` shows hint on stderr
- [x] `package Markout -v:q` suppresses hint
- [x] `package Markout --json` suppresses hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)