### PR TITLE
Update Markout to 0.2.0

### DIFF
--- a/src/dotnet-inspect/ApiSurface.cs
+++ b/src/dotnet-inspect/ApiSurface.cs
@@ -6,14 +6,12 @@ namespace DotnetInspector;
 /// <summary>
 /// Represents extracted documentation comments from source code.
 /// </summary>
-[MarkoutSerializable]
 public class DocComment
 {
     public string? Summary { get; set; }
     public string? Remarks { get; set; }
 
-    [MarkoutIgnore]
-    public Dictionary<string, string>? Parameters { get; set; }
+    internal Dictionary<string, string>? Parameters { get; set; }
     public string? Returns { get; set; }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -41,14 +41,15 @@ public static class OutputFormatter
 
     private static string RenderMarkout(InspectionResult result, InspectionOptions options)
     {
-        var context = new MarkoutContext
+        var context = new MarkoutContext();
+        var writerOptions = new MarkoutWriterOptions
         {
             IncludeSections = options.IncludeSections,
             ExcludeSections = GetExcludeSections(options),
             IncludeDescription = options.Verbosity != Verbosity.Quiet
         };
 
-        return context.Serialize(result).TrimEnd();
+        return context.Serialize(result, writerOptions).TrimEnd();
     }
 
     private static HashSet<int>? GetExcludeSections(InspectionOptions options)

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -66,7 +66,7 @@
   -->
   <!-- PackageReference: Use for releases after new Markout version is published -->
   <ItemGroup>
-    <PackageReference Include="Markout" Version="0.1.8" />
+    <PackageReference Include="Markout" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Update Markout NuGet package from 0.1.8 to 0.2.0
- Adapt to API change: writer options (`IncludeSections`, `ExcludeSections`, `IncludeDescription`) moved from `MarkoutSerializerContext` to `MarkoutWriterOptions`
- Fix source generator MARKOUT003 error: make `DocComment.Parameters` internal (Dictionary types now validated even on `[MarkoutIgnore]` properties)

## Test plan
- [x] `dotnet build` succeeds
- [x] All 324 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)