### PR TITLE
Update Markout to 0.2.1

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -273,23 +273,23 @@ public class CommandLineTests
     [Fact]
     public void ParseSectionList_WithValidSections_ParsesCorrectly()
     {
-        var result = CommandLineBuilder.ParseSectionList("1,3,5");
+        var result = CommandLineBuilder.ParseSectionList("Metadata,Statistics,Files");
 
         Assert.NotNull(result);
-        Assert.Contains(1, result);
-        Assert.Contains(3, result);
-        Assert.Contains(5, result);
+        Assert.Contains("Metadata", result);
+        Assert.Contains("Statistics", result);
+        Assert.Contains("Files", result);
         Assert.Equal(3, result.Count);
     }
 
     [Fact]
     public void ParseSectionList_WithColonPrefix_ParsesCorrectly()
     {
-        var result = CommandLineBuilder.ParseSectionList(":1,2");
+        var result = CommandLineBuilder.ParseSectionList(":Metadata,Statistics");
 
         Assert.NotNull(result);
-        Assert.Contains(1, result);
-        Assert.Contains(2, result);
+        Assert.Contains("Metadata", result);
+        Assert.Contains("Statistics", result);
     }
 
     [Fact]

--- a/src/dotnet-inspect/ApiSurface.cs
+++ b/src/dotnet-inspect/ApiSurface.cs
@@ -24,7 +24,6 @@ public class DocComment
 /// <summary>
 /// Represents a reference to sample code in the same repository.
 /// </summary>
-[MarkoutSerializable]
 public class SampleReference
 {
     /// <summary>
@@ -59,7 +58,6 @@ public class SampleReference
 /// <summary>
 /// Represents a source file that is part of a partial type definition.
 /// </summary>
-[MarkoutSerializable]
 public class PartialSourceFileInfo
 {
     [JsonPropertyName("file_path")]
@@ -72,7 +70,6 @@ public class PartialSourceFileInfo
     public string? GitHubBrowseUrl { get; set; }
 }
 
-[MarkoutSerializable]
 public class ApiSurface
 {
     /// <summary>
@@ -127,7 +124,6 @@ public class ApiSurface
 /// <summary>
 /// Represents a type forwarded to another assembly.
 /// </summary>
-[MarkoutSerializable]
 public class TypeForwarder
 {
     /// <summary>
@@ -144,7 +140,6 @@ public class TypeForwarder
 /// <summary>
 /// Represents a generic type parameter with its constraints.
 /// </summary>
-[MarkoutSerializable]
 public class TypeParameter
 {
     /// <summary>
@@ -182,7 +177,6 @@ public class TypeParameter
         : null;
 }
 
-[MarkoutSerializable]
 public class ApiType
 {
     public string? Namespace { get; set; }
@@ -268,7 +262,6 @@ public class ApiType
     public DocComment? Documentation { get; set; }
 }
 
-[MarkoutSerializable]
 public class ApiMember
 {
     public string Name { get; set; } = "";

--- a/src/dotnet-inspect/AssemblyAudit.cs
+++ b/src/dotnet-inspect/AssemblyAudit.cs
@@ -5,7 +5,6 @@ namespace DotnetInspector;
 
 // Summary helper for AssemblyInfo in table display
 
-[MarkoutSerializable]
 public class AssemblyAudit
 {
     [MarkoutPropertyName("File")]

--- a/src/dotnet-inspect/AssemblyInfo.cs
+++ b/src/dotnet-inspect/AssemblyInfo.cs
@@ -47,7 +47,6 @@ public class AssemblyReferenceNode
     public bool IsCyclic { get; set; }
 }
 
-[MarkoutSerializable]
 public class AssemblyInfo
 {
     [MarkoutPropertyName("Name")]

--- a/src/dotnet-inspect/AuditSummary.cs
+++ b/src/dotnet-inspect/AuditSummary.cs
@@ -2,7 +2,6 @@ using Markout;
 
 namespace DotnetInspector;
 
-[MarkoutSerializable]
 public class AuditSummary
 {
     [MarkoutPropertyName("Total Assemblies")]

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1251,18 +1251,17 @@ public static class CommandLineBuilder
         };
     }
 
-    public static HashSet<int>? ParseSectionList(string? value)
+    public static HashSet<string>? ParseSectionList(string? value)
     {
         if (string.IsNullOrEmpty(value)) return null;
 
         var v = value.TrimStart(':');
-        var sections = new HashSet<int>();
+        var sections = new HashSet<string>();
         foreach (var part in v.Split(',', StringSplitOptions.RemoveEmptyEntries))
         {
-            if (int.TryParse(part.Trim(), out int section) && section > 0)
-            {
-                sections.Add(section);
-            }
+            var trimmed = part.Trim();
+            if (trimmed.Length > 0)
+                sections.Add(trimmed);
         }
         return sections.Count > 0 ? sections : null;
     }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -18,9 +18,10 @@ public class PackageCommand
         // Handle --discover mode: list sections and exit early
         if (options.Discover)
         {
-            for (int i = 0; i < OutputFormatter.SectionNames.Length; i++)
+            string[] sectionNames = ["Metadata", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"];
+            foreach (var name in sectionNames)
             {
-                Console.WriteLine($"{i + 1}. {OutputFormatter.SectionNames[i]}");
+                Console.WriteLine(name);
             }
             return 0;
         }
@@ -963,7 +964,6 @@ public class PackageCommand
 /// <summary>
 /// View model for file tree output (minimal wrapper for tree serialization).
 /// </summary>
-[MarkoutSerializable]
 public class FileTreeView
 {
     [MarkoutIgnoreInTable]

--- a/src/dotnet-inspect/DependencyGroup.cs
+++ b/src/dotnet-inspect/DependencyGroup.cs
@@ -2,7 +2,6 @@ using Markout;
 
 namespace DotnetInspector;
 
-[MarkoutSerializable]
 public class DependencyGroup
 {
     [MarkoutPropertyName("Target Framework")]

--- a/src/dotnet-inspect/FlatDependency.cs
+++ b/src/dotnet-inspect/FlatDependency.cs
@@ -2,7 +2,6 @@ using Markout;
 
 namespace DotnetInspector;
 
-[MarkoutSerializable]
 public class FlatDependency
 {
     [MarkoutPropertyName("Target Framework")]

--- a/src/dotnet-inspect/InspectionResult.cs
+++ b/src/dotnet-inspect/InspectionResult.cs
@@ -513,7 +513,6 @@ public class PackageDeprecation
 /// <summary>
 /// Security vulnerability information for a NuGet package.
 /// </summary>
-[MarkoutSerializable]
 public class PackageVulnerability
 {
     /// <summary>

--- a/src/dotnet-inspect/Options/AssemblyOptions.cs
+++ b/src/dotnet-inspect/Options/AssemblyOptions.cs
@@ -68,14 +68,14 @@ public record AssemblyOptions
     public Verbosity Verbosity { get; init; } = Verbosity.Normal;
 
     /// <summary>
-    /// Sections to include (1-indexed). If empty, all sections are included.
+    /// Sections to include by heading name. If null, all sections are included.
     /// </summary>
-    public HashSet<int>? IncludeSections { get; init; }
+    public HashSet<string>? IncludeSections { get; init; }
 
     /// <summary>
-    /// Sections to exclude (1-indexed).
+    /// Sections to exclude by heading name.
     /// </summary>
-    public HashSet<int>? ExcludeSections { get; init; }
+    public HashSet<string>? ExcludeSections { get; init; }
 
     /// <summary>
     /// NuGet source configuration options.

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -73,14 +73,14 @@ public record InspectionOptions
     public Verbosity Verbosity { get; init; } = Verbosity.Minimal;
 
     /// <summary>
-    /// Sections to include (1-indexed). If empty, all sections are included.
+    /// Sections to include by heading name. If null, all sections are included.
     /// </summary>
-    public HashSet<int>? IncludeSections { get; init; }
+    public HashSet<string>? IncludeSections { get; init; }
 
     /// <summary>
-    /// Sections to exclude (1-indexed).
+    /// Sections to exclude by heading name.
     /// </summary>
-    public HashSet<int>? ExcludeSections { get; init; }
+    public HashSet<string>? ExcludeSections { get; init; }
 
     /// <summary>
     /// NuGet source configuration options.

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -10,20 +10,6 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class OutputFormatter
 {
-    /// <summary>
-    /// Section names in order for package command.
-    /// </summary>
-    public static readonly string[] SectionNames =
-    [
-        "Metadata",
-        "Statistics",
-        "Package Dependencies",
-        "Files",
-        "Vulnerabilities",
-        "RID Packages",
-        "Runtime Dependencies"
-    ];
-
     public static void WriteResult(InspectionResult result, InspectionOptions options)
     {
         string output;
@@ -52,7 +38,7 @@ public static class OutputFormatter
         return context.Serialize(result, writerOptions).TrimEnd();
     }
 
-    private static HashSet<int>? GetExcludeSections(InspectionOptions options)
+    private static HashSet<string>? GetExcludeSections(InspectionOptions options)
     {
         // If user specified explicit excludes, use those
         if (options.ExcludeSections != null)
@@ -62,11 +48,11 @@ public static class OutputFormatter
         return options.Verbosity switch
         {
             // Quiet: exclude all sections (just title + compact line)
-            Verbosity.Quiet => [1, 2, 3, 4, 5, 6, 7, 8],
+            Verbosity.Quiet => ["Metadata", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"],
             // Minimal: exclude all sections (just title + description + compact line)
-            Verbosity.Minimal => [1, 2, 3, 4, 5, 6, 7, 8],
-            // Normal: show Metadata (1), exclude Statistics (2), Package Deps (3), Files (4)
-            Verbosity.Normal => [2, 3, 4],
+            Verbosity.Minimal => ["Metadata", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"],
+            // Normal: show Metadata, exclude Statistics, Package Dependencies, Files
+            Verbosity.Normal => ["Statistics", "Package Dependencies", "Files"],
             // Detailed: show everything
             Verbosity.Detailed => null,
             _ => null

--- a/src/dotnet-inspect/PackageDependency.cs
+++ b/src/dotnet-inspect/PackageDependency.cs
@@ -1,8 +1,5 @@
-using Markout;
-
 namespace DotnetInspector;
 
-[MarkoutSerializable]
 public class PackageDependency
 {
     public string Id { get; set; } = "";

--- a/src/dotnet-inspect/RidPackageReference.cs
+++ b/src/dotnet-inspect/RidPackageReference.cs
@@ -2,7 +2,6 @@ using Markout;
 
 namespace DotnetInspector;
 
-[MarkoutSerializable]
 public class RidPackageReference
 {
     [MarkoutPropertyName("RID")]

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -66,7 +66,7 @@
   -->
   <!-- PackageReference: Use for releases after new Markout version is published -->
   <ItemGroup>
-    <PackageReference Include="Markout" Version="0.2.0" />
+    <PackageReference Include="Markout" Version="0.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Markout package from 0.2.0 to 0.2.1 and migrate to updated API.

## Changes
- Updated Markout PackageReference from 0.2.0 to 0.2.1
- Migrated code to Markout 0.2.1 API changes across 15 files

## Verification
- Build succeeds
- All 324 tests pass