### PR TITLE
Bind MarkoutWriterOptions at MarkoutContext construction

### DIFF
--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -27,15 +27,14 @@ public static class OutputFormatter
 
     private static string RenderMarkout(InspectionResult result, InspectionOptions options)
     {
-        var context = new MarkoutContext();
-        var writerOptions = new MarkoutWriterOptions
+        var context = new MarkoutContext(new MarkoutWriterOptions
         {
             IncludeSections = options.IncludeSections,
             ExcludeSections = GetExcludeSections(options),
             IncludeDescription = options.Verbosity != Verbosity.Quiet
-        };
+        });
 
-        return context.Serialize(result, writerOptions).TrimEnd();
+        return context.Serialize(result).TrimEnd();
     }
 
     private static HashSet<string>? GetExcludeSections(InspectionOptions options)


### PR DESCRIPTION
## Summary

- Passes `MarkoutWriterOptions` to the `MarkoutContext` constructor instead of constructing a default context and passing separate options to `Serialize`
- Removes a wasted allocation (the default context's unused bound options) and makes ownership explicit

## Test plan

- [ ] `dotnet build` passes
- [ ] Verify markdown output is unchanged for `inspect` commands with various `--verbosity` levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)