### PR TITLE
Upgrade to Markout 0.3.0 and apply new features

### DIFF
--- a/src/dotnet-inspect/ApiSurface.cs
+++ b/src/dotnet-inspect/ApiSurface.cs
@@ -184,25 +184,23 @@ public class ApiType
     public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate
 
     [MarkoutPropertyName("Sealed")]
+    [MarkoutSkipDefault]
     public bool IsSealed { get; set; }
 
     [MarkoutPropertyName("Abstract")]
+    [MarkoutSkipDefault]
     public bool IsAbstract { get; set; }
 
     [MarkoutPropertyName("Static")]
+    [MarkoutSkipDefault]
     public bool IsStatic { get; set; }
 
     [MarkoutPropertyName("Base Type")]
     public string? BaseType { get; set; }
 
-    [MarkoutIgnore]
-    public List<string>? Interfaces { get; set; }
-
     [MarkoutPropertyName("Interfaces")]
-    [JsonIgnore]
-    public string? InterfacesSummary => Interfaces is { Count: > 0 }
-        ? string.Join(", ", Interfaces)
-        : null;
+    [MarkoutJoin(", ")]
+    public List<string>? Interfaces { get; set; }
 
     /// <summary>
     /// Known derived types within the same assembly.
@@ -273,21 +271,26 @@ public class ApiMember
     public string? Signature { get; set; }
 
     [MarkoutPropertyName("Static")]
+    [MarkoutSkipDefault]
     public bool IsStatic { get; set; }
 
     [MarkoutPropertyName("Virtual")]
+    [MarkoutSkipDefault]
     public bool IsVirtual { get; set; }
 
     [MarkoutPropertyName("Abstract")]
+    [MarkoutSkipDefault]
     public bool IsAbstract { get; set; }
 
     [MarkoutPropertyName("Unsafe")]
+    [MarkoutSkipDefault]
     public bool IsUnsafe { get; set; }
 
     /// <summary>
     /// True if this is an extension method.
     /// </summary>
     [MarkoutPropertyName("Extension")]
+    [MarkoutSkipDefault]
     public bool IsExtension { get; set; }
 
     /// <summary>

--- a/src/dotnet-inspect/AssemblyInfo.cs
+++ b/src/dotnet-inspect/AssemblyInfo.cs
@@ -86,6 +86,7 @@ public class AssemblyInfo
     public bool IsAnyCpu { get; set; }
 
     [MarkoutPropertyName("Prefers 32-bit")]
+    [MarkoutSkipDefault]
     public bool Prefers32Bit { get; set; }
 
     [MarkoutPropertyName("Executable")]
@@ -102,6 +103,7 @@ public class AssemblyInfo
     public string? PublicKeyToken { get; set; }
 
     [MarkoutPropertyName("Unsafe Code")]
+    [MarkoutSkipDefault]
     public bool HasUnsafeCode { get; set; }
 
     // Metadata
@@ -116,9 +118,11 @@ public class AssemblyInfo
     public string? CompilationType { get; set; }  // "CoreCLR", "NativeAOT", "Native", "ReadyToRun"
 
     [MarkoutPropertyName("Native AOT")]
+    [MarkoutSkipDefault]
     public bool IsNativeAot { get; set; }
 
     [MarkoutPropertyName("Ready To Run")]
+    [MarkoutSkipDefault]
     public bool IsReadyToRun { get; set; }
 
     [MarkoutPropertyName("Managed Metadata")]

--- a/src/dotnet-inspect/InspectionResult.cs
+++ b/src/dotnet-inspect/InspectionResult.cs
@@ -7,7 +7,7 @@ namespace DotnetInspector;
     TitleProperty = nameof(PackageName), 
     TitleContextProperty = nameof(Version), 
     DescriptionProperty = nameof(Description),
-    RenderScalars = false)]
+    AutoFields = false)]
 public class InspectionResult
 {
     [MarkoutPropertyName("Package")]
@@ -162,6 +162,7 @@ public class InspectionResult
     /// <summary>
     /// Indicates whether the package contains a README.md file.
     /// </summary>
+    [MarkoutSkipDefault]
     public bool HasReadme { get; set; }
 
     /// <summary>
@@ -170,6 +171,7 @@ public class InspectionResult
     [JsonIgnore]
     public string? ReadmeFile { get; set; }
 
+    [MarkoutSkipDefault]
     public bool IsToolPackage { get; set; }
 
     [MarkoutIgnoreInTable]
@@ -290,12 +292,15 @@ public class InspectionResult
     public int AssemblyCount { get; set; }
 
     [MarkoutPropertyName("Framework Dependent")]
+    [MarkoutSkipDefault]
     public bool IsFrameworkDependent { get; set; }
 
     [MarkoutPropertyName("RID-Specific Assets")]
+    [MarkoutSkipDefault]
     public bool HasRidSpecificAssets { get; set; }
 
     [MarkoutPropertyName("Native Dependencies")]
+    [MarkoutSkipDefault]
     public bool HasNativeDependencies { get; set; }
 
     // RID-specific tool (DotNetCliTool Version="2") properties
@@ -303,6 +308,7 @@ public class InspectionResult
     public string? ToolFormat { get; set; }
 
     [MarkoutPropertyName("RID-Specific Pointer Package")]
+    [MarkoutSkipDefault]
     public bool IsRidSpecificPointerPackage { get; set; }
 
     [MarkoutIgnoreInTable]

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -66,7 +66,7 @@
   -->
   <!-- PackageReference: Use for releases after new Markout version is published -->
   <ItemGroup>
-    <PackageReference Include="Markout" Version="0.2.4" />
+    <PackageReference Include="Markout" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades Markout from 0.2.4 to 0.3.0 and applies the new `[MarkoutSkipDefault]` and `[MarkoutJoin]` attributes to reduce output noise and eliminate a companion property.

### Changes

**Package upgrade:**
- Markout 0.2.4 → 0.3.0
- Fix breaking rename: `RenderScalars` → `AutoFields`

**`[MarkoutSkipDefault]` on 15 bool properties** — these are `false` by default and only interesting when `true`:
- **AssemblyInfo** (4): `Prefers32Bit`, `HasUnsafeCode`, `IsNativeAot`, `IsReadyToRun`
- **ApiType** (3): `IsSealed`, `IsAbstract`, `IsStatic`
- **ApiMember** (5): `IsStatic`, `IsVirtual`, `IsAbstract`, `IsUnsafe`, `IsExtension`
- **InspectionResult** (6): `HasReadme`, `IsToolPackage`, `IsFrameworkDependent`, `HasRidSpecificAssets`, `HasNativeDependencies`, `IsRidSpecificPointerPackage`

**`[MarkoutJoin]` replacing companion property:**
- `ApiType.Interfaces`: replaced `[MarkoutIgnore]` + `InterfacesSummary` companion with `[MarkoutJoin(", ")]` directly on the list

**Not changed (by design):**
- `AssemblyAudit` bool properties — these use `[MarkoutBoolFormat("✓", "✗")]` and showing ✗ is meaningful in audit context
- `AuditSummary` counts/bools — all values are meaningful even when 0/false
- `InspectionResult` companion properties (OwnersDisplay, ContentSummary, etc.) — these serve both Markout serialization AND manual `GetMetadataFields()` builders since `AutoFields = false`

### Testing
- 324 tests pass