### PR TITLE
Migrate AssemblyAudit rendering to hybrid source-gen

### DIFF
--- a/src/dotnet-inspect/AssemblyAudit.cs
+++ b/src/dotnet-inspect/AssemblyAudit.cs
@@ -5,6 +5,7 @@ namespace DotnetInspector;
 
 // Summary helper for AssemblyInfo in table display
 
+[MarkoutSerializable(TitleProperty = nameof(FileName), AutoFields = false)]
 public class AssemblyAudit
 {
     [MarkoutPropertyName("File")]
@@ -213,4 +214,110 @@ public class AssemblyAudit
         null => null,
         var api => $"{api.PublicTypeCount} types, {api.PublicMethodCount} methods"
     };
+
+    // ===== Field Collection Sections for Source-Gen Serializer =====
+
+    [MarkoutSection(Name = "Assembly Info")]
+    [JsonIgnore]
+    public List<MarkoutField> AssemblyInfoSection => GetAssemblyInfoFields();
+
+    [MarkoutSection(Name = "Build Audit")]
+    [JsonIgnore]
+    public List<MarkoutField> BuildAuditSection => GetBuildAuditFields();
+
+    [MarkoutSection(Name = "PDB")]
+    [JsonIgnore]
+    public List<MarkoutField> PdbSection => GetPdbFields();
+
+    [MarkoutSection(Name = "Source Coverage")]
+    [JsonIgnore]
+    public List<MarkoutField> SourceCoverageSection => GetSourceCoverageFields();
+
+    private List<MarkoutField> GetAssemblyInfoFields()
+    {
+        var fields = new List<MarkoutField>();
+        if (AssemblyInfo is not { } info) return fields;
+
+        if (!string.IsNullOrEmpty(info.AssemblyName))
+            fields.Add(new("Name", info.AssemblyName));
+        if (!string.IsNullOrEmpty(info.AssemblyVersion))
+            fields.Add(new("Version", info.AssemblyVersion));
+        if (!string.IsNullOrEmpty(info.TargetFramework))
+            fields.Add(new("Target Framework", info.TargetFramework));
+        if (!string.IsNullOrEmpty(info.Architecture))
+            fields.Add(new("Architecture", info.Architecture));
+        if (!string.IsNullOrEmpty(info.CompilationType))
+            fields.Add(new("Compilation", info.CompilationType));
+        if (!string.IsNullOrEmpty(info.InformationalVersion))
+            fields.Add(new("Informational Version", info.InformationalVersion));
+        if (!string.IsNullOrEmpty(info.Product))
+            fields.Add(new("Product", info.Product));
+        if (!string.IsNullOrEmpty(info.Company))
+            fields.Add(new("Company", info.Company));
+        if (!string.IsNullOrEmpty(info.Copyright))
+            fields.Add(new("Copyright", info.Copyright));
+        if (info.IsSigned)
+            fields.Add(new("Signed", "Yes"));
+        if (!string.IsNullOrEmpty(info.PublicKeyToken))
+            fields.Add(new("Public Key Token", info.PublicKeyToken));
+
+        return fields;
+    }
+
+    private List<MarkoutField> GetBuildAuditFields()
+    {
+        var fields = new List<MarkoutField>
+        {
+            new("Deterministic", IsDeterministic ? "✓" : "✗"),
+            new("Reproducible Flag", HasReproducibleFlag ? "✓" : "✗"),
+            new("SourceLink", SourceLinkStatus)
+        };
+
+        if (!string.IsNullOrEmpty(Builder))
+            fields.Add(new("Builder", Builder));
+        if (!string.IsNullOrEmpty(Publisher))
+        {
+            var publisherStatus = PublisherVerified ? "(Verified)" : "";
+            fields.Add(new("Publisher", $"{Publisher} {publisherStatus}".Trim()));
+        }
+        else if (!string.IsNullOrEmpty(SignatureStatus))
+        {
+            fields.Add(new("Publisher", SignatureStatus));
+        }
+        if (RepositoryVerified)
+            fields.Add(new("Repository", "nuget.org (Verified)"));
+
+        return fields;
+    }
+
+    private List<MarkoutField> GetPdbFields()
+    {
+        var fields = new List<MarkoutField>
+        {
+            new("Format", PdbFormat ?? "Unknown"),
+            new("Location", PdbLocation ?? "Unknown")
+        };
+
+        if (!string.IsNullOrEmpty(SymbolServer))
+            fields.Add(new("Server", SymbolServer));
+        if (!string.IsNullOrEmpty(PdbPath))
+            fields.Add(new("Path", PdbPath));
+
+        return fields;
+    }
+
+    private List<MarkoutField> GetSourceCoverageFields()
+    {
+        var fields = new List<MarkoutField>();
+        if (TotalSourceFiles <= 0) return fields;
+
+        int accessible = AccessibleSourceFiles + EmbeddedSourceFiles;
+        string status = AllSourcesAccessible == true ? "✓" : "✗";
+        fields.Add(new("Status", $"{status} {accessible}/{TotalSourceFiles} files accessible"));
+
+        if (EmbeddedSourceFiles > 0)
+            fields.Add(new("Embedded", $"{EmbeddedSourceFiles} files"));
+
+        return fields;
+    }
 }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -75,44 +75,27 @@ public static class OutputFormatter
 
     private static string RenderAssemblyMarkdown(AssemblyAudit audit, AssemblyOptions options)
     {
+        // Determine which sections to exclude
+        HashSet<string>? excludeSections = null;
+        if (!options.IncludeAudit)
+        {
+            excludeSections = ["Build Audit", "PDB", "Source Coverage"];
+        }
+
+        var context = new MarkoutContext(new MarkoutWriterOptions
+        {
+            ExcludeSections = excludeSections
+        });
+
+        var output = context.Serialize(audit);
+
+        // Append sections that need imperative rendering
         var writer = new MarkoutWriter();
 
-        // Header
-        writer.WriteHeading(1, audit.FileName);
-
-        // Assembly Info
+        // Assembly References (tree vs table format requires imperative control)
         if (audit.AssemblyInfo != null)
         {
             var info = audit.AssemblyInfo;
-            writer.WriteHeading(2, "Assembly Info");
-
-            var infoFields = new List<string[]>();
-            if (!string.IsNullOrEmpty(info.AssemblyName))
-                infoFields.Add(new[] { "Name", info.AssemblyName });
-            if (!string.IsNullOrEmpty(info.AssemblyVersion))
-                infoFields.Add(new[] { "Version", info.AssemblyVersion });
-            if (!string.IsNullOrEmpty(info.TargetFramework))
-                infoFields.Add(new[] { "Target Framework", info.TargetFramework });
-            if (!string.IsNullOrEmpty(info.Architecture))
-                infoFields.Add(new[] { "Architecture", info.Architecture });
-            if (!string.IsNullOrEmpty(info.CompilationType))
-                infoFields.Add(new[] { "Compilation", info.CompilationType });
-            if (!string.IsNullOrEmpty(info.InformationalVersion))
-                infoFields.Add(new[] { "Informational Version", info.InformationalVersion });
-            if (!string.IsNullOrEmpty(info.Product))
-                infoFields.Add(new[] { "Product", info.Product });
-            if (!string.IsNullOrEmpty(info.Company))
-                infoFields.Add(new[] { "Company", info.Company });
-            if (!string.IsNullOrEmpty(info.Copyright))
-                infoFields.Add(new[] { "Copyright", info.Copyright });
-            if (info.IsSigned)
-                infoFields.Add(new[] { "Signed", "Yes" });
-            if (!string.IsNullOrEmpty(info.PublicKeyToken))
-                infoFields.Add(new[] { "Public Key Token", info.PublicKeyToken });
-
-            writer.WriteTable(new[] { "Property", "Value" }, infoFields);
-
-            // Assembly References section
             if (info.TransitiveReferences is { Count: > 0 })
             {
                 writer.WriteHeading(2, "Assembly References (Transitive)");
@@ -128,12 +111,10 @@ public static class OutputFormatter
             }
         }
 
-        // Audit section (if --audit was specified)
         if (options.IncludeAudit)
         {
-            writer.WriteHeading(2, "Build Audit");
-
-            // Show fields before the table
+            // RepositoryUrl and NonNormalizedPaths appear before the audit table
+            // but after the Assembly Info section — append them here
             if (!string.IsNullOrEmpty(audit.RepositoryUrl))
             {
                 writer.WriteField("Repository", audit.RepositoryUrl);
@@ -144,51 +125,7 @@ public static class OutputFormatter
                 writer.WriteArray("Non-normalized paths", audit.NonNormalizedPaths);
             }
 
-            // Build the checkmark table
-            var auditRows = new List<string[]>
-            {
-                new[] { "Deterministic", audit.IsDeterministic ? "✓" : "✗" },
-                new[] { "Reproducible Flag", audit.HasReproducibleFlag ? "✓" : "✗" },
-                new[] { "SourceLink", audit.SourceLinkStatus ?? "Unknown" }
-            };
-            if (!string.IsNullOrEmpty(audit.Builder))
-            {
-                auditRows.Add(new[] { "Builder", audit.Builder });
-            }
-            if (!string.IsNullOrEmpty(audit.Publisher))
-            {
-                var publisherStatus = audit.PublisherVerified ? "(Verified)" : "";
-                auditRows.Add(new[] { "Publisher", $"{audit.Publisher} {publisherStatus}" });
-            }
-            else if (!string.IsNullOrEmpty(audit.SignatureStatus))
-            {
-                auditRows.Add(new[] { "Publisher", audit.SignatureStatus });
-            }
-            if (audit.RepositoryVerified)
-            {
-                auditRows.Add(new[] { "Repository", "nuget.org (Verified)" });
-            }
-
-            writer.WriteTable(new[] { "Check", "Status" }, auditRows);
-
-            // PDB section
-            writer.WriteHeading(2, "PDB");
-
-            var pdbRows = new List<string[]>
-            {
-                new[] { "Format", audit.PdbFormat ?? "Unknown" },
-                new[] { "Location", audit.PdbLocation ?? "Unknown" }
-            };
-            if (!string.IsNullOrEmpty(audit.SymbolServer))
-            {
-                pdbRows.Add(new[] { "Server", audit.SymbolServer });
-            }
-            if (!string.IsNullOrEmpty(audit.PdbPath))
-            {
-                pdbRows.Add(new[] { "Path", audit.PdbPath });
-            }
-            writer.WriteTable(new[] { "Property", "Value" }, pdbRows);
-
+            // Windows PDB warning
             if (audit.PdbLocation == null && !string.IsNullOrEmpty(audit.PdbPath))
             {
                 writer.WriteParagraph("*Path is from the CodeView record in the assembly; actual PDB location is unknown.*");
@@ -201,34 +138,20 @@ public static class OutputFormatter
                 writer.WriteParagraph("Consider asking the package maintainer to publish Portable PDBs.");
             }
 
-            // Source Coverage section (shown when strict audit was run)
-            if (audit.TotalSourceFiles > 0)
+            // Missing source files (truncated to 10)
+            if (audit.MissingSourceFiles is { Count: > 0 })
             {
-                writer.WriteHeading(2, "Source Coverage");
-
-                int accessible = audit.AccessibleSourceFiles + audit.EmbeddedSourceFiles;
-                string status = audit.AllSourcesAccessible == true ? "✓" : "✗";
-                writer.WriteField("Status", $"{status} {accessible}/{audit.TotalSourceFiles} files accessible");
-
-                if (audit.EmbeddedSourceFiles > 0)
+                var displayFiles = audit.MissingSourceFiles.Take(10).Select(f => $"`{f}`").ToList();
+                if (audit.MissingSourceFiles.Count > 10)
                 {
-                    writer.WriteField("Embedded", $"{audit.EmbeddedSourceFiles} files");
+                    displayFiles.Add($"... and {audit.MissingSourceFiles.Count - 10} more");
                 }
-
-                if (audit.MissingSourceFiles is { Count: > 0 })
-                {
-                    // Show first 10 missing files, truncate if more
-                    var displayFiles = audit.MissingSourceFiles.Take(10).Select(f => $"`{f}`").ToList();
-                    if (audit.MissingSourceFiles.Count > 10)
-                    {
-                        displayFiles.Add($"... and {audit.MissingSourceFiles.Count - 10} more");
-                    }
-                    writer.WriteArray("Missing sources", displayFiles);
-                }
+                writer.WriteArray("Missing sources", displayFiles);
             }
         }
 
-        return writer.ToString().TrimEnd();
+        var additional = writer.ToString();
+        return (output + additional).TrimEnd();
     }
 
     private static List<TreeNode> BuildReferenceTree(List<AssemblyReferenceNode> nodes)


### PR DESCRIPTION
## Summary

Migrates AssemblyAudit markdown rendering from fully imperative `MarkoutWriter` code to a hybrid source-gen + imperative approach using Markout 0.3.0 features.

## Changes

### AssemblyAudit.cs
- Added `[MarkoutSerializable(TitleProperty = "FileName", AutoFields = false)]`
- Added 4 `[MarkoutSection]` properties: `AssemblyInfoSection`, `BuildAuditSection`, `PdbSection`, `SourceCoverageSection`
- Added 4 field builder methods that encapsulate the conditional field logic previously in OutputFormatter

### OutputFormatter.cs
- `RenderAssemblyMarkdown()` now calls `context.Serialize(audit)` for structured sections
- Imperative code retained only for dynamic content that can't be expressed declaratively:
  - Assembly References (tree vs table format)
  - RepositoryUrl / NonNormalizedPaths fields
  - Windows PDB warnings
  - Missing source files with truncation
- Net reduction of ~30 lines

## Motivation

Moves data assembly logic closer to the data type, improving separation of concerns. The structured sections (Assembly Info, Build Audit, PDB, Source Coverage) are now declared on AssemblyAudit itself, while OutputFormatter only handles rendering that requires imperative control flow.