### PR TITLE
Move metadata operations into DotnetInspector.Metadata library

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -1,0 +1,257 @@
+using System.Text.Json.Serialization;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Represents extracted documentation comments from source code.
+/// </summary>
+public class DocComment
+{
+    public string? Summary { get; set; }
+    public string? Remarks { get; set; }
+
+    internal Dictionary<string, string>? Parameters { get; set; }
+    public string? Returns { get; set; }
+
+    /// <summary>
+    /// Sample code references extracted from doc comments.
+    /// </summary>
+    public List<SampleReference>? Samples { get; set; }
+}
+
+/// <summary>
+/// Represents a reference to sample code in the same repository.
+/// </summary>
+public class SampleReference
+{
+    /// <summary>
+    /// Relative path to the sample file from the source file.
+    /// </summary>
+    [JsonPropertyName("relative_path")]
+    public string RelativePath { get; set; } = "";
+
+    /// <summary>
+    /// Human-readable description or title of the sample.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Optional region name to extract from the sample file.
+    /// </summary>
+    public string? Region { get; set; }
+
+    /// <summary>
+    /// Resolved URL to the sample file (computed from SourceLink).
+    /// </summary>
+    [JsonPropertyName("resolved_url")]
+    public string? ResolvedUrl { get; set; }
+
+    /// <summary>
+    /// Fetched sample content (populated when --inline is used).
+    /// </summary>
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Represents a source file that is part of a partial type definition.
+/// </summary>
+public class PartialSourceFileInfo
+{
+    [JsonPropertyName("file_path")]
+    public string? FilePath { get; set; }
+
+    [JsonPropertyName("source_url")]
+    public string? SourceUrl { get; set; }
+
+    [JsonPropertyName("github_browse_url")]
+    public string? GitHubBrowseUrl { get; set; }
+}
+
+/// <summary>
+/// Represents the extracted public API surface of an assembly.
+/// </summary>
+public class ApiSurface
+{
+    /// <summary>
+    /// Package or assembly name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    public List<ApiType> Types { get; set; } = [];
+
+    public int PublicTypeCount { get; set; }
+    public int PublicMethodCount { get; set; }
+    public int PublicPropertyCount { get; set; }
+    public int PublicEventCount { get; set; }
+    public int PublicFieldCount { get; set; }
+
+    /// <summary>
+    /// Target framework moniker for the API surface.
+    /// </summary>
+    public string? Tfm { get; set; }
+
+    /// <summary>
+    /// Repository URL extracted from SourceLink (if available).
+    /// </summary>
+    public string? RepositoryUrl { get; set; }
+
+    /// <summary>
+    /// Type forwarders in this assembly (types re-exported from other assemblies).
+    /// </summary>
+    public List<TypeForwarder> TypeForwarders { get; set; } = [];
+
+    /// <summary>
+    /// True if this assembly is a type-forwarding assembly (types resolved from target assemblies).
+    /// </summary>
+    public bool IsTypeForwardingAssembly { get; set; }
+}
+
+/// <summary>
+/// Represents a type forwarded to another assembly.
+/// </summary>
+public class TypeForwarder
+{
+    /// <summary>
+    /// Full name of the forwarded type.
+    /// </summary>
+    public string TypeName { get; set; } = "";
+
+    /// <summary>
+    /// Name of the target assembly where the type is defined.
+    /// </summary>
+    public string TargetAssembly { get; set; } = "";
+}
+
+/// <summary>
+/// Represents a generic type parameter with its constraints.
+/// </summary>
+public class TypeParameter
+{
+    /// <summary>
+    /// The name of the type parameter (e.g., "T", "TKey").
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Variance modifier: "out" (covariant), "in" (contravariant), or null.
+    /// </summary>
+    public string? Variance { get; set; }
+
+    /// <summary>
+    /// List of constraints on this type parameter.
+    /// Includes special constraints (class, struct, notnull, unmanaged, new())
+    /// and type constraints (interfaces, base class).
+    /// </summary>
+    public List<string> Constraints { get; set; } = [];
+
+    /// <summary>
+    /// Returns the parameter name with variance prefix (e.g., "out T", "in TKey").
+    /// </summary>
+    [JsonIgnore]
+    public string DisplayName => Variance != null ? $"{Variance} {Name}" : Name;
+
+    /// <summary>
+    /// Returns constraints as a comma-separated string, or null if none.
+    /// </summary>
+    [JsonIgnore]
+    public string? ConstraintsSummary => Constraints.Count > 0
+        ? string.Join(", ", Constraints)
+        : null;
+}
+
+public class ApiType
+{
+    public string? Namespace { get; set; }
+    public string Name { get; set; } = "";
+    public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate
+
+    public bool IsSealed { get; set; }
+    public bool IsAbstract { get; set; }
+    public bool IsStatic { get; set; }
+
+    public string? BaseType { get; set; }
+    public List<string>? Interfaces { get; set; }
+
+    /// <summary>
+    /// Known derived types within the same assembly.
+    /// </summary>
+    public List<string>? DerivedTypes { get; set; }
+
+    /// <summary>
+    /// Generic type parameters with their constraints.
+    /// </summary>
+    public List<TypeParameter>? TypeParameters { get; set; }
+
+    public List<ApiMember>? Members { get; set; }
+
+    // Source information (populated with --source-url)
+    [JsonPropertyName("source_file_path")]
+    public string? SourceFilePath { get; set; }
+
+    [JsonPropertyName("source_url")]
+    public string? SourceUrl { get; set; }
+
+    [JsonPropertyName("github_browse_url")]
+    public string? GitHubBrowseUrl { get; set; }
+
+    [JsonPropertyName("source_line_number")]
+    public int? SourceLineNumber { get; set; }
+
+    /// <summary>
+    /// How the source URL was resolved: "SourceLink" (from method debug info) or "Inferred" (from document name).
+    /// </summary>
+    [JsonPropertyName("source_resolution")]
+    public string? SourceResolution { get; set; }
+
+    /// <summary>
+    /// Additional source files for partial types. Only populated when type spans multiple files.
+    /// </summary>
+    [JsonPropertyName("additional_source_files")]
+    public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
+
+    /// <summary>
+    /// Indicates whether this type is defined across multiple partial files.
+    /// </summary>
+    [JsonPropertyName("is_partial_type")]
+    public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
+
+    // Documentation (populated with --docs)
+    public DocComment? Documentation { get; set; }
+}
+
+public class ApiMember
+{
+    public string Name { get; set; } = "";
+    public string Kind { get; set; } = "";  // method, property, field, event, constructor
+
+    public string? ReturnType { get; set; }
+    public string? Signature { get; set; }
+
+    public bool IsStatic { get; set; }
+    public bool IsVirtual { get; set; }
+    public bool IsAbstract { get; set; }
+    public bool IsUnsafe { get; set; }
+
+    /// <summary>
+    /// True if this is an extension method.
+    /// </summary>
+    public bool IsExtension { get; set; }
+
+    /// <summary>
+    /// The type that this extension method extends (first parameter type).
+    /// Only populated when IsExtension is true.
+    /// </summary>
+    [JsonPropertyName("extended_type")]
+    public string? ExtendedType { get; set; }
+
+    // Enum value (for enum fields only)
+    [JsonPropertyName("enum_value")]
+    public long? EnumValue { get; set; }
+
+    // Source information (populated with --source-url)
+    [JsonPropertyName("source_line_number")]
+    public int? SourceLineNumber { get; set; }
+
+    // Documentation (populated with --docs)
+    public DocComment? Documentation { get; set; }
+}

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using DotnetInspector.Metadata;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Metadata;
 
 /// <summary>
 /// Extracts public API surface from assemblies.
@@ -74,7 +73,7 @@ public static class ApiSurfaceExtractor
             bool isExtensionClass = apiType.IsStatic && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes());
 
             // Get type's generic context for resolving interface type parameters
-            var typeContext = Metadata.GenericContext.ForType(reader, typeDef);
+            var typeContext = GenericContext.ForType(reader, typeDef);
 
             // Get generic type parameters with constraints
             var genericParams = typeDef.GetGenericParameters();
@@ -240,8 +239,8 @@ public static class ApiSurfaceExtractor
                 string? fieldType = null;
                 if (!isEnum)
                 {
-                    var context = Metadata.GenericContext.ForType(reader, typeDef);
-                    fieldType = field.DecodeSignature(Metadata.SignatureDecoder.Instance, context);
+                    var context = GenericContext.ForType(reader, typeDef);
+                    fieldType = field.DecodeSignature(SignatureDecoder.Instance, context);
                 }
 
                 var member = new ApiMember
@@ -316,14 +315,14 @@ public static class ApiSurfaceExtractor
         foreach (var exportedTypeHandle in reader.ExportedTypes)
         {
             var exportedType = reader.GetExportedType(exportedTypeHandle);
-            
+
             // Type forwarders have IsForwarder flag set
             if (!exportedType.IsForwarder)
                 continue;
 
-            var typeName = reader.GetString(exportedType.Name);
+            var eTypeName = reader.GetString(exportedType.Name);
             var ns = reader.GetString(exportedType.Namespace);
-            var fullName = string.IsNullOrEmpty(ns) ? typeName : $"{ns}.{typeName}";
+            var fullName = string.IsNullOrEmpty(ns) ? eTypeName : $"{ns}.{eTypeName}";
 
             // Get the target assembly
             string targetAssembly = "";
@@ -348,8 +347,8 @@ public static class ApiSurfaceExtractor
     /// </summary>
     public static void PopulateDerivedTypes(ApiSurface surface, ApiType targetType)
     {
-        var fullName = string.IsNullOrEmpty(targetType.Namespace) 
-            ? targetType.Name 
+        var fullName = string.IsNullOrEmpty(targetType.Namespace)
+            ? targetType.Name
             : $"{targetType.Namespace}.{targetType.Name}";
 
         var derivedTypes = new List<string>();
@@ -392,8 +391,8 @@ public static class ApiSurfaceExtractor
     private static string GetMethodSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
     {
         string name = reader.GetString(method.Name);
-        var context = Metadata.GenericContext.ForMethod(reader, typeDef, method);
-        var signature = method.DecodeSignature(Metadata.SignatureDecoder.Instance, context);
+        var context = GenericContext.ForMethod(reader, typeDef, method);
+        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
 
         // Get parameter names from metadata
         var paramHandles = method.GetParameters().ToList();
@@ -495,8 +494,8 @@ public static class ApiSurfaceExtractor
     private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors)
     {
         string name = reader.GetString(prop.Name);
-        var context = Metadata.GenericContext.ForType(reader, typeDef);
-        var signature = prop.DecodeSignature(Metadata.SignatureDecoder.Instance, context);
+        var context = GenericContext.ForType(reader, typeDef);
+        var signature = prop.DecodeSignature(SignatureDecoder.Instance, context);
 
         // Determine accessor visibility
         bool hasPublicGetter = false;
@@ -537,8 +536,8 @@ public static class ApiSurfaceExtractor
     /// </summary>
     private static string? GetFirstParameterType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
     {
-        var context = Metadata.GenericContext.ForMethod(reader, typeDef, method);
-        var signature = method.DecodeSignature(Metadata.SignatureDecoder.Instance, context);
+        var context = GenericContext.ForMethod(reader, typeDef, method);
+        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
         return signature.ParameterTypes.Length > 0 ? signature.ParameterTypes[0] : null;
     }
 

--- a/src/DotnetInspector.Metadata/AssemblyAuditInfo.cs
+++ b/src/DotnetInspector.Metadata/AssemblyAuditInfo.cs
@@ -1,0 +1,21 @@
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Audit-relevant information extracted from a PE assembly's debug directory and PDB.
+/// This is a pure data type without rendering concerns.
+/// </summary>
+public class AssemblyAuditInfo
+{
+    public bool HasReproducibleFlag { get; set; }
+    public bool HasEmbeddedPdb { get; set; }
+    public bool? HasNormalizedPaths { get; set; }
+    public string? PdbPath { get; set; }
+    public string? PdbFormat { get; set; }
+    public bool HasSourceLink { get; set; }
+    public string? SourceLinkJson { get; set; }
+    public string? RepositoryUrl { get; set; }
+    public List<string>? NonNormalizedPaths { get; set; }
+    public bool IsDeterministic { get; set; }
+    public bool IsNativeAot { get; set; }
+    public AssemblyInfo? AssemblyInfo { get; set; }
+}

--- a/src/DotnetInspector.Metadata/AssemblyInfo.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
-using Markout;
 
-namespace DotnetInspector;
+namespace DotnetInspector.Metadata;
 
 /// <summary>
 /// Represents a reference to another assembly.
@@ -21,25 +20,25 @@ public class AssemblyReferenceNode
     public string Name { get; set; } = "";
     public string Version { get; set; } = "";
     public string? PublicKeyToken { get; set; }
-    
+
     /// <summary>
     /// Tree depth (0 = direct reference, 1 = reference of reference, etc.)
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Depth { get; set; }
-    
+
     /// <summary>
     /// How the assembly was resolved: "local", "platform", or null if unresolved.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ResolvedFrom { get; set; }
-    
+
     /// <summary>
     /// Resolved file path, or null if not found.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Path { get; set; }
-    
+
     /// <summary>
     /// True if this node was already seen earlier in the tree (circular reference).
     /// </summary>
@@ -49,102 +48,50 @@ public class AssemblyReferenceNode
 
 public class AssemblyInfo
 {
-    [MarkoutPropertyName("Name")]
     public string? AssemblyName { get; set; }
-
-    [MarkoutPropertyName("Assembly Version")]
     public string? AssemblyVersion { get; set; }
-
-    [MarkoutPropertyName("File Version")]
     public string? FileVersion { get; set; }
-
-    [MarkoutPropertyName("Informational Version")]
     public string? InformationalVersion { get; set; }
-
-    // Assembly identity attributes
-    [MarkoutPropertyName("Product")]
     public string? Product { get; set; }
-
-    [MarkoutPropertyName("Company")]
     public string? Company { get; set; }
-
-    [MarkoutPropertyName("Copyright")]
     public string? Copyright { get; set; }
-
-    [MarkoutPropertyName("Description")]
     public string? Description { get; set; }
-
-    [MarkoutPropertyName("Target Framework")]
     public string? TargetFramework { get; set; }
-
     public string? Culture { get; set; }
 
     // PE header information
     public string? Architecture { get; set; }  // AnyCPU, x86, x64, ARM, ARM64
-
-    [MarkoutPropertyName("Any CPU")]
     public bool IsAnyCpu { get; set; }
-
-    [MarkoutPropertyName("Prefers 32-bit")]
-    [MarkoutSkipDefault]
     public bool Prefers32Bit { get; set; }
-
-    [MarkoutPropertyName("Executable")]
     public bool IsExecutable { get; set; }
-
-    [MarkoutPropertyName("DLL")]
     public bool IsDll { get; set; }
 
     // Assembly characteristics
-    [MarkoutPropertyName("Signed")]
     public bool IsSigned { get; set; }
-
-    [MarkoutPropertyName("Public Key Token")]
     public string? PublicKeyToken { get; set; }
-
-    [MarkoutPropertyName("Unsafe Code")]
-    [MarkoutSkipDefault]
     public bool HasUnsafeCode { get; set; }
 
     // Metadata
-    [MarkoutPropertyName("Runtime Version")]
     public string? RuntimeVersion { get; set; }
-
-    [MarkoutPropertyName("Metadata Version")]
     public int MetadataVersion { get; set; }
 
     // Compilation type detection
-    [MarkoutPropertyName("Compilation Type")]
     public string? CompilationType { get; set; }  // "CoreCLR", "NativeAOT", "Native", "ReadyToRun"
-
-    [MarkoutPropertyName("Native AOT")]
-    [MarkoutSkipDefault]
     public bool IsNativeAot { get; set; }
-
-    [MarkoutPropertyName("Ready To Run")]
-    [MarkoutSkipDefault]
     public bool IsReadyToRun { get; set; }
-
-    [MarkoutPropertyName("Managed Metadata")]
     public bool HasManagedMetadata { get; set; }
-
-    [MarkoutPropertyName("COR Header")]
     public bool HasCorHeader { get; set; }
-
-    [MarkoutPropertyName("IL Code")]
     public bool HasILCode { get; set; }
 
     /// <summary>
     /// List of assemblies referenced by this assembly.
     /// </summary>
-    [MarkoutIgnore]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<AssemblyReference>? References { get; set; }
 
     /// <summary>
     /// Transitive reference tree (when --transitive is used).
     /// </summary>
-    [MarkoutIgnore]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<AssemblyReferenceNode>? TransitiveReferences { get; set; }
 }

--- a/src/DotnetInspector.Metadata/AssemblyInspector.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInspector.cs
@@ -1,0 +1,581 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Inspects .NET assemblies to extract PE header info, assembly metadata, and references.
+/// </summary>
+public static class AssemblyInspector
+{
+    /// <summary>
+    /// Extracts assembly info from a PEReader, including PE headers, CorFlags, architecture,
+    /// and optionally assembly references.
+    /// </summary>
+    public static AssemblyInfo ExtractAssemblyInfo(PEReader peReader, bool includeReferences = false)
+    {
+        var info = new AssemblyInfo();
+        var peHeaders = peReader.PEHeaders;
+        var coffHeader = peHeaders.CoffHeader;
+        var corHeader = peHeaders.CorHeader;
+
+        info.HasCorHeader = corHeader != null;
+        info.HasManagedMetadata = peReader.HasMetadata;
+
+        bool hasR2R = corHeader != null && corHeader.ManagedNativeHeaderDirectory.Size > 0;
+        bool hasILCode = corHeader != null && peReader.HasMetadata;
+        bool isILOnly = corHeader?.Flags.HasFlag(CorFlags.ILOnly) == true;
+
+        info.HasILCode = hasILCode;
+        info.IsReadyToRun = hasR2R;
+
+        if (corHeader == null)
+        {
+            info.CompilationType = "Native";
+        }
+        else if (hasR2R)
+        {
+            info.CompilationType = "ReadyToRun";
+        }
+        else if (isILOnly || hasILCode)
+        {
+            info.CompilationType = "CoreCLR";
+        }
+        else
+        {
+            info.CompilationType = "Unknown";
+        }
+
+        info.Architecture = coffHeader.Machine switch
+        {
+            Machine.I386 =>
+                corHeader?.Flags.HasFlag(CorFlags.Requires32Bit) == true ? "x86" :
+                corHeader?.Flags.HasFlag(CorFlags.Prefers32Bit) == true ? "AnyCPU (32-bit preferred)" : "AnyCPU",
+            Machine.Amd64 => "x64",
+            Machine.Arm => "ARM",
+            Machine.Arm64 => "ARM64",
+            _ => coffHeader.Machine.ToString()
+        };
+
+        info.IsAnyCpu = coffHeader.Machine == Machine.I386 &&
+                        corHeader?.Flags.HasFlag(CorFlags.Requires32Bit) != true;
+        info.Prefers32Bit = corHeader?.Flags.HasFlag(CorFlags.Prefers32Bit) == true;
+        info.IsSigned = corHeader?.Flags.HasFlag(CorFlags.StrongNameSigned) == true;
+
+        info.IsExecutable = peHeaders.IsExe;
+        info.IsDll = peHeaders.IsDll;
+
+        if (peReader.HasMetadata)
+        {
+            var metadataReader = peReader.GetMetadataReader();
+            info.RuntimeVersion = metadataReader.MetadataVersion;
+
+            if (metadataReader.IsAssembly)
+            {
+                var assemblyDef = metadataReader.GetAssemblyDefinition();
+                info.AssemblyName = metadataReader.GetString(assemblyDef.Name);
+                info.AssemblyVersion = assemblyDef.Version.ToString();
+                info.Culture = metadataReader.GetString(assemblyDef.Culture);
+                if (string.IsNullOrEmpty(info.Culture))
+                    info.Culture = "neutral";
+
+                var publicKey = metadataReader.GetBlobBytes(assemblyDef.PublicKey);
+                if (publicKey.Length > 0)
+                {
+                    info.PublicKeyToken = Convert.ToHexString(publicKey.TakeLast(8).ToArray()).ToLowerInvariant();
+                }
+            }
+
+            ExtractCustomAttributes(metadataReader, info);
+
+            if (includeReferences)
+            {
+                info.References = ExtractReferences(metadataReader);
+            }
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    /// Extracts full assembly info including MetadataVersion and HasUnsafeCode.
+    /// Used by the package auditor which needs these additional fields.
+    /// </summary>
+    public static AssemblyInfo ExtractFullAssemblyInfo(PEReader peReader)
+    {
+        var info = ExtractAssemblyInfo(peReader);
+
+        if (peReader.HasMetadata)
+        {
+            var metadataReader = peReader.GetMetadataReader();
+            info.MetadataVersion = metadataReader.GetTableRowCount(TableIndex.Module);
+            info.HasUnsafeCode = CheckForUnsafeCode(metadataReader);
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    /// Creates an AssemblyInfo for a native (non-managed) binary.
+    /// </summary>
+    public static AssemblyInfo CreateNativeInfo(PEReader peReader)
+    {
+        var peHeaders = peReader.PEHeaders;
+        var coffHeader = peHeaders.CoffHeader;
+
+        return new AssemblyInfo
+        {
+            HasCorHeader = false,
+            HasManagedMetadata = false,
+            HasILCode = false,
+            IsExecutable = peHeaders.IsExe,
+            IsDll = peHeaders.IsDll,
+            Architecture = coffHeader.Machine switch
+            {
+                Machine.I386 => "x86",
+                Machine.Amd64 => "x64",
+                Machine.Arm => "ARM",
+                Machine.Arm64 => "ARM64",
+                _ => coffHeader.Machine.ToString()
+            },
+            CompilationType = "Native"
+        };
+    }
+
+    /// <summary>
+    /// Detects if a native binary is NativeAOT compiled.
+    /// </summary>
+    public static bool DetectNativeAot(PEReader peReader)
+    {
+        try
+        {
+            foreach (var entry in peReader.ReadDebugDirectory())
+            {
+                if (entry.Type == DebugDirectoryEntryType.Reproducible)
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            // If we can't analyze, default to unknown
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Audits a DLL file for build quality: SourceLink, determinism, PDB info.
+    /// Handles both managed and native binaries.
+    /// </summary>
+    public static AssemblyAuditInfo AuditDll(string dllPath)
+    {
+        using FileStream stream = File.OpenRead(dllPath);
+        using PEReader peReader = new(stream);
+
+        if (!peReader.HasMetadata)
+        {
+            var nativeInfo = CreateNativeInfo(peReader);
+            bool isNativeAot = DetectNativeAot(peReader);
+            nativeInfo.IsNativeAot = isNativeAot;
+            nativeInfo.CompilationType = isNativeAot ? "NativeAOT" : "Native";
+
+            return new AssemblyAuditInfo
+            {
+                AssemblyInfo = nativeInfo,
+                IsNativeAot = isNativeAot
+            };
+        }
+
+        return AuditManagedDll(peReader);
+    }
+
+    /// <summary>
+    /// Audits a managed DLL for build quality: SourceLink, determinism, PDB info.
+    /// </summary>
+    public static AssemblyAuditInfo AuditManagedDll(PEReader peReader)
+    {
+        var audit = new AssemblyAuditInfo();
+
+        // Check debug directory entries
+        foreach (var entry in peReader.ReadDebugDirectory())
+        {
+            if (entry.Type == DebugDirectoryEntryType.Reproducible)
+            {
+                audit.HasReproducibleFlag = true;
+            }
+
+            if (entry.Type == DebugDirectoryEntryType.CodeView)
+            {
+                var cvData = peReader.ReadCodeViewDebugDirectoryData(entry);
+                audit.PdbPath = cvData.Path;
+
+                if (!cvData.Path.StartsWith("/_/", StringComparison.Ordinal) &&
+                    Path.GetDirectoryName(cvData.Path) is string dir && !string.IsNullOrEmpty(dir))
+                {
+                    audit.HasNormalizedPaths = false;
+                    audit.NonNormalizedPaths ??= [];
+                    audit.NonNormalizedPaths.Add($"PDB Path: {cvData.Path}");
+                }
+                else
+                {
+                    audit.HasNormalizedPaths = true;
+                }
+            }
+
+            if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
+            {
+                audit.HasEmbeddedPdb = true;
+                audit.PdbFormat = "Portable";
+                using MetadataReaderProvider provider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+                MetadataReader reader = provider.GetMetadataReader();
+
+                string? sourceLink = ExtractSourceLinkFromReader(reader);
+                if (sourceLink != null)
+                {
+                    audit.HasSourceLink = true;
+                    audit.SourceLinkJson = sourceLink;
+
+                    var (pathsNormalized, nonNormalizedPaths) = CheckSourceLinkPaths(sourceLink);
+                    if (!pathsNormalized)
+                    {
+                        audit.HasNormalizedPaths = false;
+                        audit.NonNormalizedPaths ??= [];
+                        foreach (var path in nonNormalizedPaths)
+                        {
+                            audit.NonNormalizedPaths.Add($"SourceLink: {path}");
+                        }
+                    }
+
+                    audit.RepositoryUrl = ExtractRepositoryUrlFromSourceLink(sourceLink);
+                }
+            }
+        }
+
+        audit.IsDeterministic = audit.HasReproducibleFlag && audit.HasNormalizedPaths != false;
+        audit.AssemblyInfo = ExtractFullAssemblyInfo(peReader);
+
+        return audit;
+    }
+
+    /// <summary>
+    /// Audits a standalone Portable PDB file.
+    /// Returns null if the file is not a Portable PDB.
+    /// </summary>
+    public static AssemblyAuditInfo? AuditStandalonePdb(Stream pdbStream)
+    {
+        byte[] header = new byte[4];
+        pdbStream.ReadExactly(header, 0, 4);
+        pdbStream.Position = 0;
+
+        // Only handle Portable PDBs (BSJB header)
+        if (header[0] != 'B' || header[1] != 'S' || header[2] != 'J' || header[3] != 'B')
+        {
+            return new AssemblyAuditInfo
+            {
+                PdbFormat = "Windows PDB (legacy)",
+                HasSourceLink = false,
+                IsDeterministic = false
+            };
+        }
+
+        using MetadataReaderProvider provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        MetadataReader reader = provider.GetMetadataReader();
+
+        var audit = new AssemblyAuditInfo
+        {
+            PdbFormat = "Portable PDB"
+        };
+
+        string? sourceLink = ExtractSourceLinkFromReader(reader);
+        if (sourceLink != null)
+        {
+            audit.HasSourceLink = true;
+            audit.SourceLinkJson = sourceLink;
+
+            var (pathsNormalized, nonNormalizedPaths) = CheckSourceLinkPaths(sourceLink);
+            audit.HasNormalizedPaths = pathsNormalized;
+            if (!pathsNormalized)
+            {
+                audit.NonNormalizedPaths = nonNormalizedPaths;
+            }
+
+            audit.RepositoryUrl = ExtractRepositoryUrlFromSourceLink(sourceLink);
+            audit.IsDeterministic = pathsNormalized;
+        }
+
+        return audit;
+    }
+
+    /// <summary>
+    /// Checks if a PDB file is a Windows PDB (MSF format).
+    /// </summary>
+    public static bool IsWindowsPdb(string pdbPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(pdbPath);
+            byte[] header = new byte[4];
+            if (stream.Read(header, 0, 4) < 4)
+                return false;
+
+            return header[0] == 'M' && header[1] == 'i' && header[2] == 'c' && header[3] == 'r';
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a PDB file is a Portable PDB.
+    /// </summary>
+    public static bool IsPortablePdb(string pdbPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(pdbPath);
+            byte[] header = new byte[4];
+            if (stream.Read(header, 0, 4) < 4)
+                return false;
+
+            return header[0] == 'B' && header[1] == 'S' && header[2] == 'J' && header[3] == 'B';
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Extracts SourceLink JSON from a PDB MetadataReader.
+    /// </summary>
+    public static string? ExtractSourceLinkFromReader(MetadataReader reader)
+    {
+        foreach (CustomDebugInformationHandle handle in reader.CustomDebugInformation)
+        {
+            CustomDebugInformation info = reader.GetCustomDebugInformation(handle);
+            Guid kind = reader.GetGuid(info.Kind);
+
+            if (kind == SourceLinkGuid)
+            {
+                byte[] bytes = reader.GetBlobBytes(info.Value);
+                return System.Text.Encoding.UTF8.GetString(bytes);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts SourceLink JSON from a standalone Portable PDB file.
+    /// </summary>
+    public static string? ExtractSourceLinkFromFile(string pdbPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(pdbPath);
+            using var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
+            var reader = provider.GetMetadataReader();
+            return ExtractSourceLinkFromReader(reader);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // SourceLink GUID: CC110556-A091-4D38-9FEC-25AB9A351A6A
+    private static readonly Guid SourceLinkGuid = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+
+    private static (bool isNormalized, List<string> nonNormalizedPaths) CheckSourceLinkPaths(string sourceLink)
+    {
+        var nonNormalizedPaths = new List<string>();
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(sourceLink);
+            if (doc.RootElement.TryGetProperty("documents", out var documents))
+            {
+                foreach (var prop in documents.EnumerateObject())
+                {
+                    if (!prop.Name.StartsWith("/_", StringComparison.Ordinal))
+                    {
+                        nonNormalizedPaths.Add(prop.Name);
+                    }
+                }
+            }
+            return (nonNormalizedPaths.Count == 0, nonNormalizedPaths);
+        }
+        catch
+        {
+            return (false, nonNormalizedPaths);
+        }
+    }
+
+    private static string? ExtractRepositoryUrlFromSourceLink(string sourceLink)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(sourceLink);
+            if (doc.RootElement.TryGetProperty("documents", out var documents))
+            {
+                foreach (var prop in documents.EnumerateObject())
+                {
+                    string url = prop.Value.GetString() ?? "";
+                    if (url.Contains("github.com", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var match = System.Text.RegularExpressions.Regex.Match(url,
+                            @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/");
+                        if (match.Success)
+                        {
+                            return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}";
+                        }
+                    }
+                    else if (url.Contains("dev.azure.com", StringComparison.OrdinalIgnoreCase) ||
+                             url.Contains("visualstudio.com", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return url.Split('_')[0].TrimEnd('/');
+                    }
+                    break; // Just use the first document URL
+                }
+            }
+        }
+        catch
+        {
+            // Ignore parse errors
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts assembly references from a file path.
+    /// </summary>
+    public static List<AssemblyReference> ExtractReferences(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        if (!peReader.HasMetadata)
+            return [];
+
+        var metadataReader = peReader.GetMetadataReader();
+        return ExtractReferences(metadataReader) ?? [];
+    }
+
+    private static List<AssemblyReference>? ExtractReferences(MetadataReader metadataReader)
+    {
+        var references = new List<AssemblyReference>();
+        foreach (var refHandle in metadataReader.AssemblyReferences)
+        {
+            var assemblyRef = metadataReader.GetAssemblyReference(refHandle);
+            var name = metadataReader.GetString(assemblyRef.Name);
+            var version = assemblyRef.Version.ToString();
+            var culture = metadataReader.GetString(assemblyRef.Culture);
+            if (string.IsNullOrEmpty(culture))
+                culture = "neutral";
+
+            string? publicKeyToken = null;
+            var pkToken = metadataReader.GetBlobBytes(assemblyRef.PublicKeyOrToken);
+            if (pkToken.Length > 0)
+            {
+                publicKeyToken = Convert.ToHexString(pkToken).ToLowerInvariant();
+            }
+
+            references.Add(new AssemblyReference(name, version, culture, publicKeyToken));
+        }
+
+        return references.Count > 0 ? references : null;
+    }
+
+    private static void ExtractCustomAttributes(MetadataReader metadataReader, AssemblyInfo info)
+    {
+        foreach (var attrHandle in metadataReader.CustomAttributes)
+        {
+            var attr = metadataReader.GetCustomAttribute(attrHandle);
+            string? attrName = GetAttributeName(metadataReader, attr);
+
+            if (attrName == "System.Runtime.Versioning.TargetFrameworkAttribute")
+            {
+                info.TargetFramework = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyFileVersionAttribute")
+            {
+                info.FileVersion = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyInformationalVersionAttribute")
+            {
+                info.InformationalVersion = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyProductAttribute")
+            {
+                info.Product = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyCompanyAttribute")
+            {
+                info.Company = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyCopyrightAttribute")
+            {
+                info.Copyright = GetAttributeStringValue(metadataReader, attr);
+            }
+            else if (attrName == "System.Reflection.AssemblyDescriptionAttribute")
+            {
+                info.Description = GetAttributeStringValue(metadataReader, attr);
+            }
+        }
+    }
+
+    private static bool CheckForUnsafeCode(MetadataReader reader)
+    {
+        foreach (var attrHandle in reader.CustomAttributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            string? attrName = GetAttributeName(reader, attr);
+            if (attrName == "System.Security.UnverifiableCodeAttribute")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static string? GetAttributeName(MetadataReader reader, CustomAttribute attr)
+    {
+        if (attr.Constructor.Kind == HandleKind.MemberReference)
+        {
+            var memberRef = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
+            if (memberRef.Parent.Kind == HandleKind.TypeReference)
+            {
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
+                string ns = reader.GetString(typeRef.Namespace);
+                string name = reader.GetString(typeRef.Name);
+                return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+            }
+        }
+        else if (attr.Constructor.Kind == HandleKind.MethodDefinition)
+        {
+            var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)attr.Constructor);
+            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
+            string ns = reader.GetString(typeDef.Namespace);
+            string name = reader.GetString(typeDef.Name);
+            return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+        }
+        return null;
+    }
+
+    internal static string? GetAttributeStringValue(MetadataReader reader, CustomAttribute attr)
+    {
+        try
+        {
+            var value = reader.GetBlobReader(attr.Value);
+            value.ReadUInt16(); // Skip prolog
+            return value.ReadSerializedString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/DotnetInspector.Metadata/AssemblyReader.cs
+++ b/src/DotnetInspector.Metadata/AssemblyReader.cs
@@ -1,0 +1,111 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Convenience layer for common assembly reading operations.
+/// Hides PEReader boilerplate from callers.
+/// </summary>
+public static class AssemblyReader
+{
+    /// <summary>
+    /// Extracts the public API surface from a DLL file on disk.
+    /// Returns null if the file cannot be read or has no metadata.
+    /// </summary>
+    public static ApiSurface? ExtractApiSurface(string dllPath, bool includeAll = false)
+    {
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            return ExtractApiSurface(stream, includeAll);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the public API surface from a stream containing a PE image.
+    /// Returns null if the stream cannot be read or has no metadata.
+    /// </summary>
+    public static ApiSurface? ExtractApiSurface(Stream stream, bool includeAll = false)
+    {
+        try
+        {
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+                return null;
+
+            return ApiSurfaceExtractor.Extract(peReader, includeAll);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Finds all types in an assembly that implement or extend the target type.
+    /// </summary>
+    public static IEnumerable<TypeRelationship> FindImplementers(string dllPath, string targetType, bool includeHidden = false)
+    {
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            // Must materialize results before PEReader is disposed
+            return TypeHierarchyScanner.FindImplementers(peReader, targetType, includeHidden).ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Counts the number of public types in an assembly.
+    /// Returns 0 if the file cannot be read.
+    /// </summary>
+    public static int CountPublicTypes(string dllPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+                return 0;
+
+            var reader = peReader.GetMetadataReader();
+            int count = 0;
+
+            foreach (var typeDefHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeDefHandle);
+                var attributes = typeDef.Attributes;
+
+                bool isPublic = (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.Public ||
+                                (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic;
+
+                if (isPublic)
+                {
+                    var name = reader.GetString(typeDef.Name);
+                    if (!name.StartsWith("<") && !name.StartsWith("__"))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -14,6 +14,11 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="dotnet-inspect" />
+    <InternalsVisibleTo Include="dotnet-inspect.Tests" />
+  </ItemGroup>
+
   <!-- System.Reflection.Metadata is part of net10.0 BCL -->
 
 </Project>

--- a/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
@@ -1,0 +1,265 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Information about a discovered extension method.
+/// </summary>
+public record ExtensionMethodInfo(
+    string MethodName,
+    string ExtensionClass,
+    string? Namespace,
+    string ExtendedType,
+    string Signature,
+    string? Assembly = null);
+
+/// <summary>
+/// Scans assemblies for extension methods targeting a specific type.
+/// </summary>
+public static class ExtensionMethodScanner
+{
+    /// <summary>
+    /// Finds extension methods in an assembly that extend the specified target type.
+    /// </summary>
+    public static IEnumerable<ExtensionMethodInfo> FindExtensions(
+        PEReader peReader, string targetType, bool includeAll = false)
+    {
+        if (!peReader.HasMetadata)
+            yield break;
+
+        var reader = peReader.GetMetadataReader();
+        var normalizedTarget = TypeMatcher.Normalize(targetType);
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            var typeAttrs = typeDef.Attributes;
+
+            // Extension methods must be in static classes
+            bool isStatic = (typeAttrs & TypeAttributes.Sealed) != 0 &&
+                           (typeAttrs & TypeAttributes.Abstract) != 0;
+            if (!isStatic) continue;
+
+            // Class must have [Extension] attribute
+            if (!AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())) continue;
+
+            // Skip hidden types unless includeAll
+            if (!includeAll && AttributeReader.HasHiddenAttribute(reader, typeDef.GetCustomAttributes()))
+                continue;
+
+            string className = reader.GetString(typeDef.Name);
+            string classNs = reader.GetString(typeDef.Namespace);
+            string fullClassName = string.IsNullOrEmpty(classNs) ? className : $"{classNs}.{className}";
+
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+                if ((method.Attributes & MethodAttributes.Static) == 0) continue;
+                if (!AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes())) continue;
+
+                // Skip hidden methods unless includeAll
+                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
+                    continue;
+
+                // Decode signature to get first parameter type
+                var context = GenericContext.ForMethod(reader, typeDef, method);
+                var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                if (signature.ParameterTypes.Length == 0) continue;
+
+                var extendedType = signature.ParameterTypes[0];
+                var normalizedExtended = TypeMatcher.Normalize(extendedType);
+
+                // Match against target
+                if (TypeMatcher.Matches(normalizedExtended, normalizedTarget))
+                {
+                    string methodName = reader.GetString(method.Name);
+                    yield return new ExtensionMethodInfo(
+                        MethodName: methodName,
+                        ExtensionClass: fullClassName,
+                        Namespace: classNs,
+                        ExtendedType: extendedType,
+                        Signature: FormatMethodSignature(reader, typeDef, method, context));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds extension methods in a stream containing a PE image.
+    /// </summary>
+    public static IEnumerable<ExtensionMethodInfo> FindExtensions(
+        Stream peStream, string targetType, bool includeAll = false)
+    {
+        using var peReader = new PEReader(peStream);
+        // Must materialize results before PEReader is disposed
+        return FindExtensions(peReader, targetType, includeAll).ToList();
+    }
+
+    /// <summary>
+    /// Finds types reachable from a target type by traversing public members.
+    /// Used for the --reachable flag to discover transitive extension methods.
+    /// </summary>
+    public static List<(string Type, string Path)> FindReachableTypes(
+        string targetType,
+        IEnumerable<string> assemblyPaths,
+        int maxDepth)
+    {
+        var results = new List<(string Type, string Path)>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var toProcess = new Queue<(string TypeName, string Path, int Depth)>();
+
+        toProcess.Enqueue((targetType, "", maxDepth));
+        visited.Add(targetType);
+
+        while (toProcess.Count > 0)
+        {
+            var (currentType, currentPath, remainingDepth) = toProcess.Dequeue();
+            if (remainingDepth <= 0) continue;
+
+            // Find this type in any assembly
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                try
+                {
+                    using var stream = File.OpenRead(assemblyPath);
+                    using var peReader = new PEReader(stream);
+                    if (!peReader.HasMetadata) continue;
+
+                    var reader = peReader.GetMetadataReader();
+
+                    foreach (var typeDefHandle in reader.TypeDefinitions)
+                    {
+                        var typeDef = reader.GetTypeDefinition(typeDefHandle);
+                        string typeName = reader.GetString(typeDef.Name);
+                        string typeNs = reader.GetString(typeDef.Namespace);
+                        string fullName = string.IsNullOrEmpty(typeNs) ? typeName : $"{typeNs}.{typeName}";
+
+                        // Match by simple name or full name
+                        if (!typeName.Equals(currentType, StringComparison.OrdinalIgnoreCase) &&
+                            !fullName.Equals(currentType, StringComparison.OrdinalIgnoreCase) &&
+                            !typeName.Equals(currentType.Split('.').Last(), StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        // Found the type - extract reachable types from its members
+                        var context = GenericContext.ForType(reader, typeDef);
+
+                        // Properties
+                        foreach (var propHandle in typeDef.GetProperties())
+                        {
+                            var prop = reader.GetPropertyDefinition(propHandle);
+                            var propName = reader.GetString(prop.Name);
+
+                            try
+                            {
+                                var sig = prop.DecodeSignature(SignatureDecoder.Instance, context);
+                                var propType = UnwrapAsyncType(sig.ReturnType);
+
+                                if (!string.IsNullOrEmpty(propType) && !IsPrimitiveType(propType) && visited.Add(propType))
+                                {
+                                    var path = $"{currentPath}.{propName}";
+                                    results.Add((propType, path));
+                                    toProcess.Enqueue((propType, path, remainingDepth - 1));
+                                }
+                            }
+                            catch { }
+                        }
+
+                        // Methods (return types)
+                        foreach (var methodHandle in typeDef.GetMethods())
+                        {
+                            var method = reader.GetMethodDefinition(methodHandle);
+                            if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+
+                            string methodName = reader.GetString(method.Name);
+                            if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||
+                                methodName.StartsWith("add_") || methodName.StartsWith("remove_") ||
+                                methodName.StartsWith("."))
+                                continue;
+
+                            try
+                            {
+                                var methodContext = GenericContext.ForMethod(reader, typeDef, method);
+                                var sig = method.DecodeSignature(SignatureDecoder.Instance, methodContext);
+                                var retType = UnwrapAsyncType(sig.ReturnType);
+
+                                if (!string.IsNullOrEmpty(retType) && retType != "void" &&
+                                    !IsPrimitiveType(retType) && visited.Add(retType))
+                                {
+                                    var path = $"{currentPath}.{methodName}()";
+                                    results.Add((retType, path));
+                                    toProcess.Enqueue((retType, path, remainingDepth - 1));
+                                }
+                            }
+                            catch { }
+                        }
+
+                        goto foundType;
+                    }
+                }
+                catch { }
+            }
+            foundType:;
+        }
+
+        return results;
+    }
+
+    private static string UnwrapAsyncType(string type)
+    {
+        if (type.StartsWith("Task<") && type.EndsWith(">"))
+            return type.Substring(5, type.Length - 6);
+        if (type.StartsWith("ValueTask<") && type.EndsWith(">"))
+            return type.Substring(10, type.Length - 11);
+        if (type.StartsWith("Task") && !type.Contains('<'))
+            return "";
+        return type;
+    }
+
+    private static bool IsPrimitiveType(string type) => type switch
+    {
+        "string" or "int" or "long" or "bool" or "byte" or "void" or
+        "double" or "float" or "decimal" or "char" or "object" or
+        "TimeSpan" or "DateTime" or "DateTimeOffset" or "Guid" or
+        "Uri" or "Version" or "CancellationToken" => true,
+        _ when type.EndsWith("[]") => true,
+        _ => false
+    };
+
+    private static string FormatMethodSignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method,
+        GenericContext? context)
+    {
+        string name = reader.GetString(method.Name);
+        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+
+        var paramHandles = method.GetParameters().ToList();
+        var paramTypes = signature.ParameterTypes;
+
+        var parameters = new List<string>();
+        for (int i = 0; i < paramTypes.Length; i++)
+        {
+            string type = paramTypes[i];
+            string? paramName = null;
+            foreach (var handle in paramHandles)
+            {
+                var param = reader.GetParameter(handle);
+                if (param.SequenceNumber == i + 1)
+                {
+                    paramName = reader.GetString(param.Name);
+                    break;
+                }
+            }
+
+            // Mark first parameter as 'this' for extension methods
+            var prefix = i == 0 ? "this " : "";
+            parameters.Add($"{prefix}{type} {paramName ?? $"arg{i}"}");
+        }
+
+        return $"{signature.ReturnType} {name}({string.Join(", ", parameters)})";
+    }
+}

--- a/src/DotnetInspector.Metadata/SourceLinkResolver.cs
+++ b/src/DotnetInspector.Metadata/SourceLinkResolver.cs
@@ -1,9 +1,10 @@
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Metadata;
 
 /// <summary>
 /// Resolves types and members to their source file locations using SourceLink information from PDBs.
@@ -36,13 +37,13 @@ public class SourceLinkResolver
         /// Only populated when type has multiple source files.
         /// </summary>
         public List<PartialSourceFile>? AdditionalSourceFiles { get; init; }
-        
+
         /// <summary>
         /// Indicates whether this type is defined across multiple partial files.
         /// </summary>
         public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
     }
-    
+
     /// <summary>
     /// Represents a source file that is part of a partial type definition.
     /// </summary>
@@ -86,7 +87,7 @@ public class SourceLinkResolver
 
         // Collect ALL unique source files from all methods of this type
         var allSourceFiles = CollectAllSourceFiles(metadata, pdb, typeHandle);
-        
+
         // Also check PDB documents for files matching the type name pattern
         // This catches files that may not have any methods (e.g., partial with only fields)
         var documentFiles = FindDocumentsMatchingTypeName(pdb, typeName);
@@ -107,7 +108,7 @@ public class SourceLinkResolver
 
         // Determine the primary file (prefer {TypeName}.cs over {TypeName}.*.cs)
         var primaryFile = SelectPrimarySourceFile(allSourceFiles.Values.ToList(), typeName);
-        
+
         // Build additional source files list (excluding primary)
         List<PartialSourceFile>? additionalFiles = null;
         if (allSourceFiles.Count > 1)
@@ -129,7 +130,66 @@ public class SourceLinkResolver
             AdditionalSourceFiles = additionalFiles
         };
     }
-    
+
+    /// <summary>
+    /// Resolves source information for a type by name, without requiring a TypeDefinitionHandle.
+    /// Finds the type definition handle internally.
+    /// </summary>
+    public TypeSourceInfo? ResolveTypeSource(MetadataReader metadata, MetadataReader pdb, string typeName)
+    {
+        var typeHandle = FindTypeDefinitionHandle(metadata, typeName);
+        if (typeHandle == null)
+            return null;
+
+        return ResolveTypeSource(metadata, pdb, typeHandle.Value);
+    }
+
+    /// <summary>
+    /// Extracts the repository URL from SourceLink document mappings.
+    /// </summary>
+    public string? ExtractRepositoryUrl()
+    {
+        foreach (var (_, urlTemplate) in _documentMappings)
+        {
+            // Extract repository URL from raw.githubusercontent.com patterns
+            var match = Regex.Match(urlTemplate,
+                @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/");
+            if (match.Success)
+                return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the repository URL from a PDB reader's SourceLink information.
+    /// </summary>
+    public static string? ExtractRepositoryUrl(MetadataReader pdbReader)
+    {
+        var resolver = Create(pdbReader);
+        return resolver?.ExtractRepositoryUrl();
+    }
+
+    /// <summary>
+    /// Finds a TypeDefinitionHandle by type name in the metadata reader.
+    /// </summary>
+    private static TypeDefinitionHandle? FindTypeDefinitionHandle(MetadataReader reader, string typeName)
+    {
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string name = reader.GetString(typeDef.Name);
+            string ns = reader.GetString(typeDef.Namespace);
+            string fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+
+            if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
+                name.Equals(typeName, StringComparison.OrdinalIgnoreCase))
+            {
+                return typeDefHandle;
+            }
+        }
+        return null;
+    }
+
     /// <summary>
     /// Collects all unique source files from all methods of a type.
     /// </summary>
@@ -158,34 +218,34 @@ public class SourceLinkResolver
 
         return sourceFiles;
     }
-    
+
     /// <summary>
     /// Finds PDB documents matching the type name pattern (e.g., JObject.cs, JObject.Async.cs).
     /// </summary>
     private List<PartialSourceFile> FindDocumentsMatchingTypeName(MetadataReader pdb, string typeName)
     {
         var matches = new List<PartialSourceFile>();
-        
+
         foreach (var docHandle in pdb.Documents)
         {
             var document = pdb.GetDocument(docHandle);
             string filePath = pdb.GetString(document.Name);
             string fileName = Path.GetFileName(filePath);
-            
+
             // Match {TypeName}.cs or {TypeName}.*.cs patterns
             if (fileName.Equals($"{typeName}.cs", StringComparison.OrdinalIgnoreCase) ||
-                (fileName.StartsWith($"{typeName}.", StringComparison.OrdinalIgnoreCase) && 
+                (fileName.StartsWith($"{typeName}.", StringComparison.OrdinalIgnoreCase) &&
                  fileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
             {
                 string? sourceUrl = ApplySourceLinkMapping(filePath);
-                string? browseUrl = ConvertToGitHubRawUrl(sourceUrl);
+                string? browseUrl = ConvertToGitHubBrowseUrl(sourceUrl);
                 matches.Add(new PartialSourceFile(filePath, sourceUrl, browseUrl));
             }
         }
 
         return matches;
     }
-    
+
     /// <summary>
     /// Selects the primary source file from a list of candidates.
     /// Prefers {TypeName}.cs over {TypeName}.*.cs patterns.
@@ -194,9 +254,9 @@ public class SourceLinkResolver
     {
         // Prefer exact match: {TypeName}.cs
         var primaryPattern = $"{typeName}.cs";
-        var primary = files.FirstOrDefault(f => 
+        var primary = files.FirstOrDefault(f =>
             Path.GetFileName(f.FilePath).Equals(primaryPattern, StringComparison.OrdinalIgnoreCase));
-        
+
         if (primary != null)
             return primary;
 
@@ -210,19 +270,16 @@ public class SourceLinkResolver
     /// </summary>
     private TypeSourceInfo? ResolveTypeSourceByDocumentName(MetadataReader pdb, string typeName)
     {
-        // Look for documents that match the type name pattern
-        // e.g., for "IContractResolver", look for "*IContractResolver.cs" or similar
         foreach (var docHandle in pdb.Documents)
         {
             var document = pdb.GetDocument(docHandle);
             string filePath = pdb.GetString(document.Name);
-            
-            // Check if the file name matches the type name
+
             string fileName = Path.GetFileNameWithoutExtension(filePath);
             if (fileName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
             {
                 string? sourceUrl = ApplySourceLinkMapping(filePath);
-                string? browseUrl = ConvertToGitHubRawUrl(sourceUrl);
+                string? browseUrl = ConvertToGitHubBrowseUrl(sourceUrl);
                 return new TypeSourceInfo(filePath, sourceUrl, null, browseUrl, SourceResolutionMethod.Inferred);
             }
         }
@@ -235,7 +292,6 @@ public class SourceLinkResolver
     /// </summary>
     public TypeSourceInfo? ResolveMethodSource(MetadataReader pdb, MethodDefinitionHandle methodHandle)
     {
-        // Method debug information row ID matches the method row ID
         var debugInfoHandle = MetadataTokens.MethodDebugInformationHandle(MetadataTokens.GetRowNumber(methodHandle));
 
         try
@@ -248,7 +304,6 @@ public class SourceLinkResolver
             var document = pdb.GetDocument(debugInfo.Document);
             string filePath = pdb.GetString(document.Name);
 
-            // Get the first sequence point for line number
             int? lineNumber = null;
             foreach (var sp in debugInfo.GetSequencePoints())
             {
@@ -259,9 +314,8 @@ public class SourceLinkResolver
                 }
             }
 
-            // Apply SourceLink mapping (no line number for type-level URLs - they're not useful)
             string? sourceUrl = ApplySourceLinkMapping(filePath);
-            string? browseUrl = ConvertToGitHubRawUrl(sourceUrl);
+            string? browseUrl = ConvertToGitHubBrowseUrl(sourceUrl);
 
             return new TypeSourceInfo(filePath, sourceUrl, lineNumber, browseUrl);
         }
@@ -276,22 +330,17 @@ public class SourceLinkResolver
     /// </summary>
     private string? ApplySourceLinkMapping(string filePath)
     {
-        // Normalize path separators
         filePath = filePath.Replace('\\', '/');
 
         foreach (var (pattern, urlTemplate) in _documentMappings)
         {
-            // SourceLink patterns use * as wildcard
-            // e.g., "/_/*" -> "https://raw.githubusercontent.com/dotnet/runtime/abc123/*"
             if (pattern.Contains('*'))
             {
-                // Convert pattern to regex: "/_/*" becomes "^/_/(.*)$"
                 string regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", "(.*)") + "$";
                 var match = Regex.Match(filePath, regexPattern);
 
                 if (match.Success && match.Groups.Count > 1)
                 {
-                    // Replace * in URL template with captured group
                     string captured = match.Groups[1].Value;
                     return urlTemplate.Replace("*", captured);
                 }
@@ -305,7 +354,20 @@ public class SourceLinkResolver
         return null;
     }
 
-    private static string? ConvertToGitHubRawUrl(string? rawUrl) => GitHubUrlResolver.ConvertToGitHubRawUrl(rawUrl);
+    /// <summary>
+    /// Converts a raw.githubusercontent.com URL to a github.com browse URL.
+    /// </summary>
+    private static string? ConvertToGitHubBrowseUrl(string? rawUrl)
+    {
+        if (rawUrl == null) return null;
+
+        var match = Regex.Match(rawUrl,
+            @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/(.+)");
+        if (match.Success)
+            return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}/raw/{match.Groups[3].Value}/{match.Groups[4].Value}";
+
+        return rawUrl;
+    }
 
     private static string? ExtractSourceLinkFromReader(MetadataReader reader)
     {

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,6 +1,5 @@
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -1,7 +1,6 @@
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
-using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 
 namespace DotnetInspector.Tests;

--- a/src/dotnet-inspect/ApiSurface.cs
+++ b/src/dotnet-inspect/ApiSurface.cs
@@ -1,155 +1,8 @@
 using System.Text.Json.Serialization;
+using DotnetInspector.Metadata;
 using Markout;
 
 namespace DotnetInspector;
-
-/// <summary>
-/// Represents extracted documentation comments from source code.
-/// </summary>
-public class DocComment
-{
-    public string? Summary { get; set; }
-    public string? Remarks { get; set; }
-
-    internal Dictionary<string, string>? Parameters { get; set; }
-    public string? Returns { get; set; }
-
-    /// <summary>
-    /// Sample code references extracted from doc comments.
-    /// </summary>
-    [MarkoutIgnore]
-    public List<SampleReference>? Samples { get; set; }
-}
-
-/// <summary>
-/// Represents a reference to sample code in the same repository.
-/// </summary>
-public class SampleReference
-{
-    /// <summary>
-    /// Relative path to the sample file from the source file.
-    /// </summary>
-    [JsonPropertyName("relative_path")]
-    public string RelativePath { get; set; } = "";
-
-    /// <summary>
-    /// Human-readable description or title of the sample.
-    /// </summary>
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Optional region name to extract from the sample file.
-    /// </summary>
-    public string? Region { get; set; }
-
-    /// <summary>
-    /// Resolved URL to the sample file (computed from SourceLink).
-    /// </summary>
-    [JsonPropertyName("resolved_url")]
-    public string? ResolvedUrl { get; set; }
-
-    /// <summary>
-    /// Fetched sample content (populated when --inline is used).
-    /// </summary>
-    [MarkoutIgnore]
-    public string? Content { get; set; }
-}
-
-/// <summary>
-/// Represents a source file that is part of a partial type definition.
-/// </summary>
-public class PartialSourceFileInfo
-{
-    [JsonPropertyName("file_path")]
-    public string? FilePath { get; set; }
-    
-    [JsonPropertyName("source_url")]
-    public string? SourceUrl { get; set; }
-    
-    [JsonPropertyName("github_browse_url")]
-    public string? GitHubBrowseUrl { get; set; }
-}
-
-[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
-public class ApiSurface
-{
-    /// <summary>
-    /// Package or assembly name.
-    /// </summary>
-    [MarkoutPropertyName("Name")]
-    public string? Name { get; set; }
-
-    [MarkoutIgnore]
-    public List<ApiType> Types { get; set; } = [];
-
-    [MarkoutPropertyName("Public Types")]
-    [MarkoutIgnore]
-    public int PublicTypeCount { get; set; }
-
-    [MarkoutPropertyName("Public Methods")]
-    [MarkoutIgnore]
-    public int PublicMethodCount { get; set; }
-
-    [MarkoutPropertyName("Public Properties")]
-    [MarkoutIgnore]
-    public int PublicPropertyCount { get; set; }
-
-    [MarkoutPropertyName("Public Events")]
-    [MarkoutIgnore]
-    public int PublicEventCount { get; set; }
-
-    [MarkoutPropertyName("Public Fields")]
-    [MarkoutIgnore]
-    public int PublicFieldCount { get; set; }
-
-    /// <summary>
-    /// Target framework moniker for the API surface.
-    /// </summary>
-    [MarkoutPropertyName("TFM")]
-    [MarkoutIgnore]
-    public string? Tfm { get; set; }
-
-    /// <summary>
-    /// Repository URL extracted from SourceLink (if available).
-    /// </summary>
-    [MarkoutPropertyName("Repository")]
-    [MarkoutIgnore]
-    public string? RepositoryUrl { get; set; }
-
-    /// <summary>
-    /// Type forwarders in this assembly (types re-exported from other assemblies).
-    /// </summary>
-    [MarkoutIgnore]
-    public List<TypeForwarder> TypeForwarders { get; set; } = [];
-
-    /// <summary>
-    /// True if this assembly is a type-forwarding assembly (types resolved from target assemblies).
-    /// </summary>
-    [MarkoutIgnore]
-    public bool IsTypeForwardingAssembly { get; set; }
-
-    // ===== Field Collections for Serializer =====
-
-    /// <summary>
-    /// Summary fields (rendered as key-value fields under the title).
-    /// </summary>
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Summary => GetSummaryFields();
-
-    private List<MarkoutField> GetSummaryFields()
-    {
-        var fields = new List<MarkoutField>();
-        fields.Add(new("Types", PublicTypeCount.ToString()));
-        fields.Add(new("Methods", PublicMethodCount.ToString()));
-        fields.Add(new("Properties", PublicPropertyCount.ToString()));
-        if (Tfm != null)
-            fields.Add(new("TFM", Tfm));
-        if (!string.IsNullOrEmpty(RepositoryUrl))
-            fields.Add(new("Repository", RepositoryUrl));
-        return fields;
-    }
-}
 
 /// <summary>
 /// View model for single-type rendering. Pre-computes all display values from ApiType + options.
@@ -235,145 +88,6 @@ public class ApiTypeView
     }
 }
 
-/// <summary>
-/// Represents a type forwarded to another assembly.
-/// </summary>
-public class TypeForwarder
-{
-    /// <summary>
-    /// Full name of the forwarded type.
-    /// </summary>
-    public string TypeName { get; set; } = "";
-
-    /// <summary>
-    /// Name of the target assembly where the type is defined.
-    /// </summary>
-    public string TargetAssembly { get; set; } = "";
-}
-
-/// <summary>
-/// Represents a generic type parameter with its constraints.
-/// </summary>
-public class TypeParameter
-{
-    /// <summary>
-    /// The name of the type parameter (e.g., "T", "TKey").
-    /// </summary>
-    public string Name { get; set; } = "";
-
-    /// <summary>
-    /// Variance modifier: "out" (covariant), "in" (contravariant), or null.
-    /// </summary>
-    public string? Variance { get; set; }
-
-    /// <summary>
-    /// List of constraints on this type parameter.
-    /// Includes special constraints (class, struct, notnull, unmanaged, new())
-    /// and type constraints (interfaces, base class).
-    /// </summary>
-    [MarkoutIgnore]
-    public List<string> Constraints { get; set; } = [];
-
-    /// <summary>
-    /// Returns the parameter name with variance prefix (e.g., "out T", "in TKey").
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonIgnore]
-    public string DisplayName => Variance != null ? $"{Variance} {Name}" : Name;
-
-    /// <summary>
-    /// Returns constraints as a comma-separated string, or null if none.
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonIgnore]
-    public string? ConstraintsSummary => Constraints.Count > 0
-        ? string.Join(", ", Constraints)
-        : null;
-}
-
-public class ApiType
-{
-    public string? Namespace { get; set; }
-    public string Name { get; set; } = "";
-    public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate
-
-    [MarkoutPropertyName("Sealed")]
-    [MarkoutSkipDefault]
-    public bool IsSealed { get; set; }
-
-    [MarkoutPropertyName("Abstract")]
-    [MarkoutSkipDefault]
-    public bool IsAbstract { get; set; }
-
-    [MarkoutPropertyName("Static")]
-    [MarkoutSkipDefault]
-    public bool IsStatic { get; set; }
-
-    [MarkoutPropertyName("Base Type")]
-    public string? BaseType { get; set; }
-
-    [MarkoutPropertyName("Interfaces")]
-    [MarkoutJoin(", ")]
-    public List<string>? Interfaces { get; set; }
-
-    /// <summary>
-    /// Known derived types within the same assembly.
-    /// </summary>
-    [MarkoutIgnore]
-    public List<string>? DerivedTypes { get; set; }
-
-    /// <summary>
-    /// Generic type parameters with their constraints.
-    /// </summary>
-    [MarkoutIgnore]
-    public List<TypeParameter>? TypeParameters { get; set; }
-
-    [MarkoutIgnore]
-    public List<ApiMember>? Members { get; set; }
-
-    // Source information (populated with --source-url)
-    [MarkoutIgnore]
-    [JsonPropertyName("source_file_path")]
-    public string? SourceFilePath { get; set; }
-
-    [MarkoutIgnore]
-    [JsonPropertyName("source_url")]
-    public string? SourceUrl { get; set; }
-
-    [MarkoutIgnore]
-    [JsonPropertyName("github_browse_url")]
-    public string? GitHubBrowseUrl { get; set; }
-
-    [MarkoutIgnore]
-    [JsonPropertyName("source_line_number")]
-    public int? SourceLineNumber { get; set; }
-
-    /// <summary>
-    /// How the source URL was resolved: "SourceLink" (from method debug info) or "Inferred" (from document name).
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonPropertyName("source_resolution")]
-    public string? SourceResolution { get; set; }
-    
-    /// <summary>
-    /// Additional source files for partial types. Only populated when type spans multiple files.
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonPropertyName("additional_source_files")]
-    public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
-    
-    /// <summary>
-    /// Indicates whether this type is defined across multiple partial files.
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonPropertyName("is_partial_type")]
-    public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
-
-    // Documentation (populated with --docs)
-    [MarkoutIgnore]
-    public DocComment? Documentation { get; set; }
-}
-
 [MarkoutSerializable]
 public class EnumValueRow
 {
@@ -401,58 +115,39 @@ public class BaseclassRow
     public string Type { get; set; } = "";
 }
 
-public class ApiMember
+/// <summary>
+/// Markout-aware wrapper for ApiSurface used in --all-types serialization path.
+/// </summary>
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class CliApiSurface
 {
-    public string Name { get; set; } = "";
-    public string Kind { get; set; } = "";  // method, property, field, event, constructor
+    private readonly ApiSurface _inner;
 
-    [MarkoutPropertyName("Return Type")]
-    public string? ReturnType { get; set; }
+    public CliApiSurface(ApiSurface inner)
+    {
+        _inner = inner;
+    }
 
-    public string? Signature { get; set; }
-
-    [MarkoutPropertyName("Static")]
-    [MarkoutSkipDefault]
-    public bool IsStatic { get; set; }
-
-    [MarkoutPropertyName("Virtual")]
-    [MarkoutSkipDefault]
-    public bool IsVirtual { get; set; }
-
-    [MarkoutPropertyName("Abstract")]
-    [MarkoutSkipDefault]
-    public bool IsAbstract { get; set; }
-
-    [MarkoutPropertyName("Unsafe")]
-    [MarkoutSkipDefault]
-    public bool IsUnsafe { get; set; }
+    [MarkoutPropertyName("Name")]
+    public string? Name => _inner.Name;
 
     /// <summary>
-    /// True if this is an extension method.
+    /// Summary fields (rendered as key-value fields under the title).
     /// </summary>
-    [MarkoutPropertyName("Extension")]
-    [MarkoutSkipDefault]
-    public bool IsExtension { get; set; }
+    [JsonIgnore]
+    [MarkoutIgnoreInTable]
+    public List<MarkoutField> Summary => GetSummaryFields();
 
-    /// <summary>
-    /// The type that this extension method extends (first parameter type).
-    /// Only populated when IsExtension is true.
-    /// </summary>
-    [MarkoutIgnore]
-    [JsonPropertyName("extended_type")]
-    public string? ExtendedType { get; set; }
-
-    // Enum value (for enum fields only)
-    [MarkoutIgnore]
-    [JsonPropertyName("enum_value")]
-    public long? EnumValue { get; set; }
-
-    // Source information (populated with --source-url)
-    [MarkoutIgnore]
-    [JsonPropertyName("source_line_number")]
-    public int? SourceLineNumber { get; set; }
-
-    // Documentation (populated with --docs)
-    [MarkoutIgnore]
-    public DocComment? Documentation { get; set; }
+    private List<MarkoutField> GetSummaryFields()
+    {
+        var fields = new List<MarkoutField>();
+        fields.Add(new("Types", _inner.PublicTypeCount.ToString()));
+        fields.Add(new("Methods", _inner.PublicMethodCount.ToString()));
+        fields.Add(new("Properties", _inner.PublicPropertyCount.ToString()));
+        if (_inner.Tfm != null)
+            fields.Add(new("TFM", _inner.Tfm));
+        if (!string.IsNullOrEmpty(_inner.RepositoryUrl))
+            fields.Add(new("Repository", _inner.RepositoryUrl));
+        return fields;
+    }
 }

--- a/src/dotnet-inspect/AssemblyAudit.cs
+++ b/src/dotnet-inspect/AssemblyAudit.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using DotnetInspector.Metadata;
 using Markout;
 
 namespace DotnetInspector;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -347,8 +347,8 @@ public class ApiCommand
         };
         var writer = new MarkoutWriter(writerOptions);
 
-        // Serialize title + summary fields
-        new MarkoutContext().Serialize(api, writer);
+        // Serialize title + summary fields via CLI wrapper
+        new MarkoutContext().Serialize(new CliApiSurface(api), writer);
 
         if (totalCount == 0)
         {

--- a/src/dotnet-inspect/Commands/ApiServices.cs
+++ b/src/dotnet-inspect/Commands/ApiServices.cs
@@ -1,9 +1,9 @@
 using DotnetInspector.Packages;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 
@@ -206,32 +206,21 @@ internal static class ApiServices
 
         foreach (var dllFile in dllFiles)
         {
-            try
+            var api = AssemblyReader.ExtractApiSurface(dllFile, includeAll);
+            if (api == null)
+                continue;
+
+            var match = api.Types.FirstOrDefault(t =>
             {
-                using FileStream stream = File.OpenRead(dllFile);
-                using PEReader peReader = new(stream);
+                var fullName = string.IsNullOrEmpty(t.Namespace) ? t.Name : $"{t.Namespace}.{t.Name}";
+                return fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
+                       t.Name.Equals(typeName, StringComparison.OrdinalIgnoreCase);
+            });
 
-                if (!peReader.HasMetadata)
-                    continue;
-
-                var api = ApiSurfaceExtractor.Extract(peReader, includeAll);
-
-                var match = api.Types.FirstOrDefault(t =>
-                {
-                    var fullName = string.IsNullOrEmpty(t.Namespace) ? t.Name : $"{t.Namespace}.{t.Name}";
-                    return fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
-                           t.Name.Equals(typeName, StringComparison.OrdinalIgnoreCase);
-                });
-
-                if (match != null)
-                {
-                    logger.Log($"Found in: {Path.GetFileName(dllFile)}");
-                    return (match, Path.GetFileName(dllFile), dllFile, api);
-                }
-            }
-            catch
+            if (match != null)
             {
-                // Skip unreadable files
+                logger.Log($"Found in: {Path.GetFileName(dllFile)}");
+                return (match, Path.GetFileName(dllFile), dllFile, api);
             }
         }
 
@@ -277,20 +266,8 @@ internal static class ApiServices
 
         logger.Log($"Extracting API from: {Path.GetFileName(dllFile)}");
 
-        try
-        {
-            using FileStream stream = File.OpenRead(dllFile);
-            using PEReader peReader = new(stream);
-
-            if (!peReader.HasMetadata)
-                return (null, null);
-
-            return (ApiSurfaceExtractor.Extract(peReader, includeAll), dllFile);
-        }
-        catch
-        {
-            return (null, null);
-        }
+        var api = AssemblyReader.ExtractApiSurface(dllFile, includeAll);
+        return (api, api != null ? dllFile : null);
     }
 
     /// <summary>
@@ -322,13 +299,9 @@ internal static class ApiServices
 
             try
             {
-                using FileStream stream = File.OpenRead(targetPath);
-                using PEReader peReader = new(stream);
-
-                if (!peReader.HasMetadata)
+                var targetApi = AssemblyReader.ExtractApiSurface(targetPath, includeAll);
+                if (targetApi == null)
                     continue;
-
-                var targetApi = ApiSurfaceExtractor.Extract(peReader, includeAll);
 
                 foreach (var type in targetApi.Types)
                 {
@@ -434,8 +407,8 @@ internal static class ApiServices
                 return;
             }
 
-            TypeDefinitionHandle? typeHandle = FindTypeDefinitionHandle(metadataReader, typeName);
-            if (typeHandle == null)
+            var sourceInfo = resolver.ResolveTypeSource(metadataReader, pdbReader, typeName);
+            if (sourceInfo == null)
             {
                 var forwardTarget = FindTypeForwarderTarget(metadataReader, typeName);
                 if (forwardTarget != null)
@@ -451,8 +424,6 @@ internal static class ApiServices
                 logger.Log($"Could not find type definition for '{typeName}'.");
                 return;
             }
-
-            var sourceInfo = resolver.ResolveTypeSource(metadataReader, pdbReader, typeHandle.Value);
             if (sourceInfo != null)
             {
                 apiType.SourceFilePath = sourceInfo.SourceFilePath;
@@ -614,12 +585,7 @@ internal static class ApiServices
         foreach (var apiType in types)
         {
             var typeName = string.IsNullOrEmpty(apiType.Namespace) ? apiType.Name : $"{apiType.Namespace}.{apiType.Name}";
-            TypeDefinitionHandle? typeHandle = FindTypeDefinitionHandle(metadataReader, typeName);
-
-            if (typeHandle == null)
-                continue;
-
-            var sourceInfo = resolver.ResolveTypeSource(metadataReader, pdbReader, typeHandle.Value);
+            var sourceInfo = resolver.ResolveTypeSource(metadataReader, pdbReader, typeName);
             typeSourceInfo.Add((apiType, typeName, sourceInfo));
 
             if (sourceInfo?.SourceUrl != null)
@@ -915,40 +881,7 @@ internal static class ApiServices
 
             using var _ = pdbResult.Provider;
 
-            string? sourceLinkJson = null;
-            foreach (var handle in pdbResult.Reader.CustomDebugInformation)
-            {
-                var info = pdbResult.Reader.GetCustomDebugInformation(handle);
-                var guid = pdbResult.Reader.GetGuid(info.Kind);
-                if (guid == new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A"))
-                {
-                    var bytes = pdbResult.Reader.GetBlobBytes(info.Value);
-                    sourceLinkJson = System.Text.Encoding.UTF8.GetString(bytes);
-                    break;
-                }
-            }
-
-            if (sourceLinkJson == null)
-                return null;
-
-            using var doc = JsonDocument.Parse(sourceLinkJson);
-            if (doc.RootElement.TryGetProperty("documents", out var documents))
-            {
-                foreach (var prop in documents.EnumerateObject())
-                {
-                    string url = prop.Value.GetString() ?? "";
-                    if (url.Contains("githubusercontent.com", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var match = Regex.Match(url,
-                            @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/");
-                        if (match.Success)
-                        {
-                            return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}";
-                        }
-                    }
-                    break;
-                }
-            }
+            return SourceLinkResolver.ExtractRepositoryUrl(pdbResult.Reader);
         }
         catch (Exception ex)
         {
@@ -958,24 +891,6 @@ internal static class ApiServices
     }
 
     // ===== Private Enrichment Helpers =====
-
-    private static TypeDefinitionHandle? FindTypeDefinitionHandle(MetadataReader reader, string typeName)
-    {
-        foreach (var typeHandle in reader.TypeDefinitions)
-        {
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            string name = reader.GetString(typeDef.Name);
-            string ns = reader.GetString(typeDef.Namespace);
-            string fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-
-            if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
-                name.Equals(typeName, StringComparison.OrdinalIgnoreCase))
-            {
-                return typeHandle;
-            }
-        }
-        return null;
-    }
 
     private static string? FindTypeForwarderTarget(MetadataReader reader, string typeName)
     {

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -1,11 +1,13 @@
 using System.IO.Compression;
-using DotnetInspector.Packages;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using AssemblyReference = DotnetInspector.Metadata.AssemblyReference;
 
 namespace DotnetInspector.Commands;
 
@@ -414,7 +416,17 @@ public class AssemblyCommand
             if (!peReader.HasMetadata)
             {
                 // Native binary - still provide basic info
-                return CreateNativeAudit(peReader, path);
+                var nativeInfo = AssemblyInspector.CreateNativeInfo(peReader);
+                bool isNativeAot = AssemblyInspector.DetectNativeAot(peReader);
+                nativeInfo.IsNativeAot = isNativeAot;
+                nativeInfo.CompilationType = isNativeAot ? "NativeAOT" : "Native";
+
+                return new AssemblyAudit
+                {
+                    FileName = Path.GetFileName(path),
+                    FileType = "native",
+                    AssemblyInfo = nativeInfo
+                };
             }
 
             var audit = new AssemblyAudit
@@ -424,7 +436,7 @@ public class AssemblyCommand
             };
 
             // Always extract basic assembly info
-            audit.AssemblyInfo = ExtractAssemblyInfo(peReader, options.IncludeReferences || options.TransitiveReferences);
+            audit.AssemblyInfo = AssemblyInspector.ExtractAssemblyInfo(peReader, options.IncludeReferences || options.TransitiveReferences);
 
             // Build transitive reference tree if requested
             if (options.TransitiveReferences && audit.AssemblyInfo?.References != null)
@@ -432,10 +444,10 @@ public class AssemblyCommand
                 var sourceDir = Path.GetDirectoryName(path);
                 var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 visited.Add(audit.AssemblyInfo.AssemblyName ?? Path.GetFileNameWithoutExtension(path));
-                
+
                 audit.AssemblyInfo.TransitiveReferences = BuildTransitiveReferences(
-                    audit.AssemblyInfo.References, 
-                    sourceDir, 
+                    audit.AssemblyInfo.References,
+                    sourceDir,
                     visited,
                     logger);
             }
@@ -454,38 +466,6 @@ public class AssemblyCommand
         }
     }
 
-    private static AssemblyAudit CreateNativeAudit(PEReader peReader, string path)
-    {
-        var audit = new AssemblyAudit
-        {
-            FileName = Path.GetFileName(path),
-            FileType = "native"
-        };
-
-        var peHeaders = peReader.PEHeaders;
-        var coffHeader = peHeaders.CoffHeader;
-
-        audit.AssemblyInfo = new AssemblyInfo
-        {
-            HasCorHeader = false,
-            HasManagedMetadata = false,
-            HasILCode = false,
-            IsExecutable = peHeaders.IsExe,
-            IsDll = peHeaders.IsDll,
-            Architecture = coffHeader.Machine switch
-            {
-                System.Reflection.PortableExecutable.Machine.I386 => "x86",
-                System.Reflection.PortableExecutable.Machine.Amd64 => "x64",
-                System.Reflection.PortableExecutable.Machine.Arm => "ARM",
-                System.Reflection.PortableExecutable.Machine.Arm64 => "ARM64",
-                _ => coffHeader.Machine.ToString()
-            },
-            CompilationType = "Native"
-        };
-
-        return audit;
-    }
-
     private static async Task AuditAssemblyAsync(
         PEReader peReader,
         AssemblyAudit audit,
@@ -502,12 +482,12 @@ public class AssemblyCommand
         MetadataReader? pdbReader = null;
         foreach (var entry in peReader.ReadDebugDirectory())
         {
-            if (entry.Type == System.Reflection.PortableExecutable.DebugDirectoryEntryType.Reproducible)
+            if (entry.Type == DebugDirectoryEntryType.Reproducible)
             {
                 audit.HasReproducibleFlag = true;
             }
 
-            if (entry.Type == System.Reflection.PortableExecutable.DebugDirectoryEntryType.CodeView)
+            if (entry.Type == DebugDirectoryEntryType.CodeView)
             {
                 var cvData = peReader.ReadCodeViewDebugDirectoryData(entry);
                 audit.PdbPath = cvData.Path;
@@ -525,7 +505,7 @@ public class AssemblyCommand
                 }
             }
 
-            if (entry.Type == System.Reflection.PortableExecutable.DebugDirectoryEntryType.EmbeddedPortablePdb)
+            if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
             {
                 audit.HasEmbeddedPdb = true;
                 audit.PdbFormat = "Portable";
@@ -533,7 +513,7 @@ public class AssemblyCommand
                 embeddedPdbProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
                 pdbReader = embeddedPdbProvider.GetMetadataReader();
 
-                string? sourceLink = ExtractSourceLink(pdbReader);
+                string? sourceLink = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
                 if (sourceLink != null)
                 {
                     audit.HasSourceLink = true;
@@ -548,13 +528,13 @@ public class AssemblyCommand
             var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
             if (File.Exists(pdbPath))
             {
-                if (IsWindowsPdb(pdbPath))
+                if (AssemblyInspector.IsWindowsPdb(pdbPath))
                 {
                     audit.WindowsPdbDetected = true;
                     audit.PdbFormat = "Windows";
                     audit.PdbLocation = "Standalone";
                 }
-                else if (IsPortablePdb(pdbPath))
+                else if (AssemblyInspector.IsPortablePdb(pdbPath))
                 {
                     audit.PdbFormat = "Portable";
                     audit.PdbLocation = "Standalone";
@@ -563,7 +543,7 @@ public class AssemblyCommand
                     var standalonePdbProvider = MetadataReaderProvider.FromPortablePdbStream(stream);
                     externalPdbProvider = standalonePdbProvider;
                     pdbReader = standalonePdbProvider.GetMetadataReader();
-                    audit.SourceLinkJson = ExtractSourceLink(pdbReader);
+                    audit.SourceLinkJson = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
                     audit.HasSourceLink = audit.SourceLinkJson != null;
                 }
             }
@@ -582,7 +562,7 @@ public class AssemblyCommand
                     audit.PdbLocation = "Symbol Package";
                     audit.SymbolServer = pdbResult.SymbolServer;
 
-                    string? sourceLink = ExtractSourceLink(pdbReader);
+                    string? sourceLink = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
                     if (sourceLink != null)
                     {
                         audit.HasSourceLink = true;
@@ -732,9 +712,6 @@ public class AssemblyCommand
         logger.Log($"Source coverage: {accessibleFiles + embeddedFiles}/{totalFiles} files accessible");
     }
 
-    /// <summary>
-    /// Parses SourceLink JSON into path prefix to URL mappings.
-    /// </summary>
     private static Dictionary<string, string> ParseSourceLinkMappings(string sourceLinkJson)
     {
         var mappings = new Dictionary<string, string>();
@@ -756,17 +733,13 @@ public class AssemblyCommand
         return mappings;
     }
 
-    /// <summary>
-    /// Applies SourceLink mappings to convert a file path to a source URL.
-    /// </summary>
     private static string? ApplySourceLinkMapping(string filePath, Dictionary<string, string> mappings)
     {
         foreach (var (pattern, urlTemplate) in mappings)
         {
-            // SourceLink patterns use * as wildcard
             if (pattern.EndsWith("*"))
             {
-                string prefix = pattern[..^1]; // Remove trailing *
+                string prefix = pattern[..^1];
                 if (filePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
                     string relativePath = filePath[prefix.Length..];
@@ -776,24 +749,6 @@ public class AssemblyCommand
             else if (filePath.Equals(pattern, StringComparison.OrdinalIgnoreCase))
             {
                 return urlTemplate;
-            }
-        }
-        return null;
-    }
-
-    private static readonly Guid SourceLinkGuid = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-
-    private static string? ExtractSourceLink(System.Reflection.Metadata.MetadataReader reader)
-    {
-        foreach (var handle in reader.CustomDebugInformation)
-        {
-            var info = reader.GetCustomDebugInformation(handle);
-            Guid kind = reader.GetGuid(info.Kind);
-
-            if (kind == SourceLinkGuid)
-            {
-                byte[] bytes = reader.GetBlobBytes(info.Value);
-                return System.Text.Encoding.UTF8.GetString(bytes);
             }
         }
         return null;
@@ -839,206 +794,6 @@ public class AssemblyCommand
 
         // Can't determine (e.g., Windows PDB case)
         return null;
-    }
-
-    /// <summary>
-    /// Extracts SourceLink JSON from a standalone Portable PDB file.
-    /// </summary>
-    private static string? ExtractSourceLinkFromFile(string pdbPath)
-    {
-        try
-        {
-            using var stream = File.OpenRead(pdbPath);
-            using var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
-            var reader = provider.GetMetadataReader();
-            return ExtractSourceLink(reader);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Checks if a PDB file is a Windows PDB (MSF format) rather than a Portable PDB.
-    /// </summary>
-    private static bool IsWindowsPdb(string pdbPath)
-    {
-        try
-        {
-            using var stream = File.OpenRead(pdbPath);
-            byte[] header = new byte[4];
-            if (stream.Read(header, 0, 4) < 4)
-                return false;
-
-            // Windows PDB starts with "Microsoft C/C++ MSF 7.00" - first 4 bytes are "Micr"
-            return header[0] == 'M' && header[1] == 'i' && header[2] == 'c' && header[3] == 'r';
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Checks if a PDB file is a Portable PDB.
-    /// </summary>
-    private static bool IsPortablePdb(string pdbPath)
-    {
-        try
-        {
-            using var stream = File.OpenRead(pdbPath);
-            byte[] header = new byte[4];
-            if (stream.Read(header, 0, 4) < 4)
-                return false;
-
-            // Portable PDB starts with "BSJB"
-            return header[0] == 'B' && header[1] == 'S' && header[2] == 'J' && header[3] == 'B';
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static AssemblyInfo ExtractAssemblyInfo(PEReader peReader, bool includeReferences = false)
-    {
-        var info = new AssemblyInfo();
-        var peHeaders = peReader.PEHeaders;
-        var coffHeader = peHeaders.CoffHeader;
-        var corHeader = peHeaders.CorHeader;
-
-        info.HasCorHeader = corHeader != null;
-        info.HasManagedMetadata = peReader.HasMetadata;
-
-        bool hasR2R = corHeader != null && corHeader.ManagedNativeHeaderDirectory.Size > 0;
-        bool hasILCode = corHeader != null && peReader.HasMetadata;
-        bool isILOnly = corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.ILOnly) == true;
-
-        info.HasILCode = hasILCode;
-        info.IsReadyToRun = hasR2R;
-
-        if (corHeader == null)
-        {
-            info.CompilationType = "Native";
-        }
-        else if (hasR2R)
-        {
-            info.CompilationType = "ReadyToRun";
-        }
-        else if (isILOnly || hasILCode)
-        {
-            info.CompilationType = "CoreCLR";
-        }
-        else
-        {
-            info.CompilationType = "Unknown";
-        }
-
-        info.Architecture = coffHeader.Machine switch
-        {
-            System.Reflection.PortableExecutable.Machine.I386 =>
-                corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.Requires32Bit) == true ? "x86" :
-                corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.Prefers32Bit) == true ? "AnyCPU (32-bit preferred)" : "AnyCPU",
-            System.Reflection.PortableExecutable.Machine.Amd64 => "x64",
-            System.Reflection.PortableExecutable.Machine.Arm => "ARM",
-            System.Reflection.PortableExecutable.Machine.Arm64 => "ARM64",
-            _ => coffHeader.Machine.ToString()
-        };
-
-        info.IsAnyCpu = coffHeader.Machine == System.Reflection.PortableExecutable.Machine.I386 &&
-                        corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.Requires32Bit) != true;
-        info.Prefers32Bit = corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.Prefers32Bit) == true;
-        info.IsSigned = corHeader?.Flags.HasFlag(System.Reflection.PortableExecutable.CorFlags.StrongNameSigned) == true;
-
-        info.IsExecutable = peHeaders.IsExe;
-        info.IsDll = peHeaders.IsDll;
-
-        var metadataReader = peReader.GetMetadataReader();
-        info.RuntimeVersion = metadataReader.MetadataVersion;
-
-        if (metadataReader.IsAssembly)
-        {
-            var assemblyDef = metadataReader.GetAssemblyDefinition();
-            info.AssemblyName = metadataReader.GetString(assemblyDef.Name);
-            info.AssemblyVersion = assemblyDef.Version.ToString();
-            info.Culture = metadataReader.GetString(assemblyDef.Culture);
-            if (string.IsNullOrEmpty(info.Culture))
-                info.Culture = "neutral";
-
-            var publicKey = metadataReader.GetBlobBytes(assemblyDef.PublicKey);
-            if (publicKey.Length > 0)
-            {
-                info.PublicKeyToken = Convert.ToHexString(publicKey.TakeLast(8).ToArray()).ToLowerInvariant();
-            }
-        }
-
-        // Get target framework from custom attributes
-        foreach (var attrHandle in metadataReader.CustomAttributes)
-        {
-            var attr = metadataReader.GetCustomAttribute(attrHandle);
-            string? attrName = GetAttributeName(metadataReader, attr);
-
-            if (attrName == "System.Runtime.Versioning.TargetFrameworkAttribute")
-            {
-                info.TargetFramework = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyFileVersionAttribute")
-            {
-                info.FileVersion = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyInformationalVersionAttribute")
-            {
-                info.InformationalVersion = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyProductAttribute")
-            {
-                info.Product = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyCompanyAttribute")
-            {
-                info.Company = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyCopyrightAttribute")
-            {
-                info.Copyright = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyDescriptionAttribute")
-            {
-                info.Description = GetAttributeStringValue(metadataReader, attr);
-            }
-        }
-
-        // Extract assembly references if requested
-        if (includeReferences)
-        {
-            var references = new List<AssemblyReference>();
-            foreach (var refHandle in metadataReader.AssemblyReferences)
-            {
-                var assemblyRef = metadataReader.GetAssemblyReference(refHandle);
-                var name = metadataReader.GetString(assemblyRef.Name);
-                var version = assemblyRef.Version.ToString();
-                var culture = metadataReader.GetString(assemblyRef.Culture);
-                if (string.IsNullOrEmpty(culture))
-                    culture = "neutral";
-
-                string? publicKeyToken = null;
-                var pkToken = metadataReader.GetBlobBytes(assemblyRef.PublicKeyOrToken);
-                if (pkToken.Length > 0)
-                {
-                    publicKeyToken = Convert.ToHexString(pkToken).ToLowerInvariant();
-                }
-
-                references.Add(new AssemblyReference(name, version, culture, publicKeyToken));
-            }
-
-            if (references.Count > 0)
-            {
-                info.References = references;
-            }
-        }
-
-        return info;
     }
 
     private static List<AssemblyReferenceNode> BuildTransitiveReferences(
@@ -1105,7 +860,7 @@ public class AssemblyCommand
             {
                 try
                 {
-                    var childRefs = ExtractReferencesFromPath(resolvedPath);
+                    var childRefs = AssemblyInspector.ExtractReferences(resolvedPath);
                     if (childRefs.Count > 0)
                     {
                         // Clone visited set for this branch to allow diamond dependencies
@@ -1122,70 +877,6 @@ public class AssemblyCommand
         }
 
         return nodes;
-    }
-
-    private static List<AssemblyReference> ExtractReferencesFromPath(string assemblyPath)
-    {
-        var references = new List<AssemblyReference>();
-
-        using var stream = File.OpenRead(assemblyPath);
-        using var peReader = new PEReader(stream);
-
-        if (!peReader.HasMetadata)
-            return references;
-
-        var metadataReader = peReader.GetMetadataReader();
-
-        foreach (var refHandle in metadataReader.AssemblyReferences)
-        {
-            var assemblyRef = metadataReader.GetAssemblyReference(refHandle);
-            var name = metadataReader.GetString(assemblyRef.Name);
-            var version = assemblyRef.Version.ToString();
-            var culture = metadataReader.GetString(assemblyRef.Culture);
-            if (string.IsNullOrEmpty(culture))
-                culture = "neutral";
-
-            string? publicKeyToken = null;
-            var pkToken = metadataReader.GetBlobBytes(assemblyRef.PublicKeyOrToken);
-            if (pkToken.Length > 0)
-            {
-                publicKeyToken = Convert.ToHexString(pkToken).ToLowerInvariant();
-            }
-
-            references.Add(new AssemblyReference(name, version, culture, publicKeyToken));
-        }
-
-        return references;
-    }
-
-    private static string? GetAttributeName(System.Reflection.Metadata.MetadataReader reader, System.Reflection.Metadata.CustomAttribute attr)
-    {
-        if (attr.Constructor.Kind == System.Reflection.Metadata.HandleKind.MemberReference)
-        {
-            var memberRef = reader.GetMemberReference((System.Reflection.Metadata.MemberReferenceHandle)attr.Constructor);
-            if (memberRef.Parent.Kind == System.Reflection.Metadata.HandleKind.TypeReference)
-            {
-                var typeRef = reader.GetTypeReference((System.Reflection.Metadata.TypeReferenceHandle)memberRef.Parent);
-                string ns = reader.GetString(typeRef.Namespace);
-                string name = reader.GetString(typeRef.Name);
-                return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-            }
-        }
-        return null;
-    }
-
-    private static string? GetAttributeStringValue(System.Reflection.Metadata.MetadataReader reader, System.Reflection.Metadata.CustomAttribute attr)
-    {
-        try
-        {
-            var value = reader.GetBlobReader(attr.Value);
-            value.ReadUInt16(); // Skip prolog
-            return value.ReadSerializedString();
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static string? ExtractTfmFromPath(string relativePath)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -175,20 +173,7 @@ public class DiffCommand
 
     private static ApiSurface? ExtractApiSurface(string assemblyPath, bool includeAll)
     {
-        try
-        {
-            using FileStream stream = File.OpenRead(assemblyPath);
-            using PEReader peReader = new(stream);
-
-            if (!peReader.HasMetadata)
-                return null;
-
-            return ApiSurfaceExtractor.Extract(peReader, includeAll);
-        }
-        catch
-        {
-            return null;
-        }
+        return AssemblyReader.ExtractApiSurface(assemblyPath, includeAll);
     }
 
     private static (string? package, string? fromVersion, string? toVersion) ParseVersionRange(string input)

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
 using DotnetInspector.Packages;
-using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
@@ -53,11 +49,12 @@ public class ExtensionsCommand
             // If --reachable, find extensions on reachable types
             if (options.Reachable && results.Count > 0)
             {
-                var reachableTypes = FindReachableTypes(targetType, assemblyInfos, options.Depth, logger);
+                var assemblyPaths = assemblyInfos.Select(a => a.Path).ToList();
+                var reachableTypes = ExtensionMethodScanner.FindReachableTypes(targetType, assemblyPaths, options.Depth);
                 foreach (var (reachableType, path) in reachableTypes)
                 {
                     if (reachableType == targetType) continue;
-                    
+
                     foreach (var asmInfo in assemblyInfos)
                     {
                         var extensions = ScanForExtensions(asmInfo.Path, reachableType, options.IncludeAll, logger);
@@ -98,69 +95,28 @@ public class ExtensionsCommand
     }
 
     private static List<ExtensionMethodResult> ScanForExtensions(
-        string assemblyPath, 
+        string assemblyPath,
         string targetType,
         bool includeAll,
         VerboseLogger logger)
     {
         var results = new List<ExtensionMethodResult>();
-        var normalizedTarget = TypeMatcher.Normalize(targetType);
 
         try
         {
             using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(stream);
-            
-            if (!peReader.HasMetadata) return results;
-            
-            var reader = peReader.GetMetadataReader();
-            var provider = new ExtensionSignatureTypeProvider();
+            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
 
-            foreach (var typeDefHandle in reader.TypeDefinitions)
+            foreach (var ext in ExtensionMethodScanner.FindExtensions(stream, targetType, includeAll))
             {
-                var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                var typeAttrs = typeDef.Attributes;
-
-                // Extension methods must be in static classes
-                bool isStatic = (typeAttrs & TypeAttributes.Sealed) != 0 && 
-                               (typeAttrs & TypeAttributes.Abstract) != 0;
-                if (!isStatic) continue;
-
-                // Class must have [Extension] attribute
-                if (!AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())) continue;
-
-                string className = reader.GetString(typeDef.Name);
-                string classNs = reader.GetString(typeDef.Namespace);
-                string fullClassName = string.IsNullOrEmpty(classNs) ? className : $"{classNs}.{className}";
-
-                foreach (var methodHandle in typeDef.GetMethods())
+                results.Add(new ExtensionMethodResult
                 {
-                    var method = reader.GetMethodDefinition(methodHandle);
-                    if ((method.Attributes & MethodAttributes.Public) == 0) continue;
-                    if ((method.Attributes & MethodAttributes.Static) == 0) continue;
-                    if (!AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes())) continue;
-
-                    // Decode signature to get first parameter type
-                    var signature = method.DecodeSignature(provider, null);
-                    if (signature.ParameterTypes.Length == 0) continue;
-
-                    var extendedType = signature.ParameterTypes[0];
-                    var normalizedExtended = TypeMatcher.Normalize(extendedType);
-
-                    // Match against target
-                    if (TypeMatcher.Matches(normalizedExtended, normalizedTarget))
-                    {
-                        string methodName = reader.GetString(method.Name);
-                        results.Add(new ExtensionMethodResult
-                        {
-                            MethodName = methodName,
-                            ExtensionClass = fullClassName,
-                            ExtendedType = extendedType,
-                            Assembly = Path.GetFileNameWithoutExtension(assemblyPath),
-                            Signature = FormatMethodSignature(reader, typeDef, method, provider)
-                        });
-                    }
-                }
+                    MethodName = ext.MethodName,
+                    ExtensionClass = ext.ExtensionClass,
+                    ExtendedType = ext.ExtendedType,
+                    Assembly = assemblyName,
+                    Signature = ext.Signature
+                });
             }
         }
         catch (Exception ex)
@@ -169,167 +125,6 @@ public class ExtensionsCommand
         }
 
         return results;
-    }
-
-    private static List<(string type, string path)> FindReachableTypes(
-        string targetType,
-        List<AssemblyCollector.AssemblyInfo> assemblyPaths,
-        int maxDepth,
-        VerboseLogger logger)
-    {
-        var results = new List<(string type, string path)>();
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var provider = new ExtensionSignatureTypeProvider();
-        var toProcess = new Queue<(string typeName, string path, int depth)>();
-        
-        toProcess.Enqueue((targetType, "", maxDepth));
-        visited.Add(targetType);
-
-        while (toProcess.Count > 0)
-        {
-            var (currentType, currentPath, remainingDepth) = toProcess.Dequeue();
-            if (remainingDepth <= 0) continue;
-
-            // Find this type in any assembly
-            foreach (var asmInfo in assemblyPaths)
-            {
-                try
-                {
-                    using var stream = File.OpenRead(asmInfo.Path);
-                    using var peReader = new PEReader(stream);
-                    if (!peReader.HasMetadata) continue;
-                    
-                    var reader = peReader.GetMetadataReader();
-                    
-                    foreach (var typeDefHandle in reader.TypeDefinitions)
-                    {
-                        var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                        string typeName = reader.GetString(typeDef.Name);
-                        string typeNs = reader.GetString(typeDef.Namespace);
-                        string fullName = string.IsNullOrEmpty(typeNs) ? typeName : $"{typeNs}.{typeName}";
-                        
-                        // Match by simple name or full name
-                        if (!typeName.Equals(currentType, StringComparison.OrdinalIgnoreCase) &&
-                            !fullName.Equals(currentType, StringComparison.OrdinalIgnoreCase) &&
-                            !typeName.Equals(currentType.Split('.').Last(), StringComparison.OrdinalIgnoreCase))
-                            continue;
-
-                        // Found the type - extract reachable types from its members
-                        
-                        // Properties
-                        foreach (var propHandle in typeDef.GetProperties())
-                        {
-                            var prop = reader.GetPropertyDefinition(propHandle);
-                            var propName = reader.GetString(prop.Name);
-                            
-                            try
-                            {
-                                var sig = prop.DecodeSignature(provider, null);
-                                var propType = UnwrapAsyncType(sig.ReturnType);
-                                
-                                if (!string.IsNullOrEmpty(propType) && !IsPrimitiveType(propType) && visited.Add(propType))
-                                {
-                                    var path = $"{currentPath}.{propName}";
-                                    results.Add((propType, path));
-                                    toProcess.Enqueue((propType, path, remainingDepth - 1));
-                                }
-                            }
-                            catch { }
-                        }
-
-                        // Methods (return types)
-                        foreach (var methodHandle in typeDef.GetMethods())
-                        {
-                            var method = reader.GetMethodDefinition(methodHandle);
-                            if ((method.Attributes & MethodAttributes.Public) == 0) continue;
-                            
-                            string methodName = reader.GetString(method.Name);
-                            if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||
-                                methodName.StartsWith("add_") || methodName.StartsWith("remove_") ||
-                                methodName.StartsWith("."))
-                                continue;
-
-                            try
-                            {
-                                var sig = method.DecodeSignature(provider, null);
-                                var retType = UnwrapAsyncType(sig.ReturnType);
-                                
-                                if (!string.IsNullOrEmpty(retType) && retType != "Void" && 
-                                    !IsPrimitiveType(retType) && visited.Add(retType))
-                                {
-                                    var path = $"{currentPath}.{methodName}()";
-                                    results.Add((retType, path));
-                                    toProcess.Enqueue((retType, path, remainingDepth - 1));
-                                }
-                            }
-                            catch { }
-                        }
-                        
-                        goto foundType; // Break out of both loops once we've processed this type
-                    }
-                }
-                catch { }
-            }
-            foundType:;
-        }
-
-        return results;
-    }
-
-    private static string UnwrapAsyncType(string type)
-    {
-        if (type.StartsWith("Task<") && type.EndsWith(">"))
-            return type.Substring(5, type.Length - 6);
-        if (type.StartsWith("ValueTask<") && type.EndsWith(">"))
-            return type.Substring(10, type.Length - 11);
-        if (type.StartsWith("Task") && !type.Contains("<"))
-            return "";
-        return type;
-    }
-
-    private static bool IsPrimitiveType(string type) => type switch
-    {
-        "String" or "Int32" or "Int64" or "Boolean" or "Byte" or "Void" or
-        "Double" or "Single" or "Decimal" or "Char" or "Object" or
-        "TimeSpan" or "DateTime" or "DateTimeOffset" or "Guid" or
-        "Uri" or "Version" or "CancellationToken" => true,
-        _ when type.EndsWith("[]") => true,
-        _ => false
-    };
-
-    private static string FormatMethodSignature(
-        MetadataReader reader, 
-        TypeDefinition typeDef, 
-        MethodDefinition method,
-        ExtensionSignatureTypeProvider provider)
-    {
-        string name = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(provider, null);
-        
-        var paramHandles = method.GetParameters().ToList();
-        var paramTypes = signature.ParameterTypes;
-        
-        var parameters = new List<string>();
-        for (int i = 0; i < paramTypes.Length; i++)
-        {
-            string type = paramTypes[i];
-            string? paramName = null;
-            foreach (var handle in paramHandles)
-            {
-                var param = reader.GetParameter(handle);
-                if (param.SequenceNumber == i + 1)
-                {
-                    paramName = reader.GetString(param.Name);
-                    break;
-                }
-            }
-            
-            // Mark first parameter as 'this' for extension methods
-            var prefix = i == 0 ? "this " : "";
-            parameters.Add($"{prefix}{type} {paramName ?? $"arg{i}"}");
-        }
-
-        return $"{signature.ReturnType} {name}({string.Join(", ", parameters)})";
     }
 
     private static void WriteJsonOutput(List<ExtensionMethodResult> results, bool compact)
@@ -384,8 +179,8 @@ public class ExtensionsCommand
         var headers = new[] { "Method", "Class", "Assembly", "Source" };
         var rows = byClass.SelectMany(classGroup => classGroup.Select(ext =>
         {
-            var sourceDisplay = ext.SourceVersion != null 
-                ? $"{ext.Source}@{ext.SourceVersion}" 
+            var sourceDisplay = ext.SourceVersion != null
+                ? $"{ext.Source}@{ext.SourceVersion}"
                 : ext.Source;
             return new[] { ext.MethodName, ext.ExtensionClass ?? "", ext.Assembly ?? "", sourceDisplay ?? "" };
         }));
@@ -424,58 +219,6 @@ public class ExtensionMethodResult
 
     [JsonPropertyName("reachable_from_type")]
     public string? ReachableFromType { get; set; }
-}
-
-/// <summary>
-/// Simple signature type provider for extension method scanning.
-/// </summary>
-internal class ExtensionSignatureTypeProvider : ISignatureTypeProvider<string, object?>
-{
-    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
-    
-    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-    {
-        var typeDef = reader.GetTypeDefinition(handle);
-        string ns = reader.GetString(typeDef.Namespace);
-        string name = reader.GetString(typeDef.Name);
-        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-    }
-    
-    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-    {
-        var typeRef = reader.GetTypeReference(handle);
-        string ns = reader.GetString(typeRef.Namespace);
-        string name = reader.GetString(typeRef.Name);
-        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-    }
-    
-    public string GetSZArrayType(string elementType) => $"{elementType}[]";
-    
-    public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
-        => $"{genericType}<{string.Join(", ", typeArguments)}>";
-    
-    public string GetArrayType(string elementType, ArrayShape shape) 
-        => $"{elementType}[{new string(',', shape.Rank - 1)}]";
-    
-    public string GetByReferenceType(string elementType) => $"ref {elementType}";
-    
-    public string GetPointerType(string elementType) => $"{elementType}*";
-    
-    public string GetFunctionPointerType(MethodSignature<string> signature) => "delegate*";
-    
-    public string GetGenericMethodParameter(object? context, int index) => $"T{index}";
-    
-    public string GetGenericTypeParameter(object? context, int index) => $"T{index}";
-    
-    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
-    
-    public string GetPinnedType(string elementType) => elementType;
-    
-    public string GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
-    {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        return typeSpec.DecodeSignature(this, context);
-    }
 }
 
 [JsonSerializable(typeof(List<ExtensionMethodResult>))]

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -1,10 +1,9 @@
-using System.Reflection.Metadata;
 using DotnetInspector.Packages;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using Markout;
@@ -534,13 +533,10 @@ public class FindCommand
 
         try
         {
-            using var fs = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(fs);
-
-            if (!peReader.HasMetadata)
+            var api = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll);
+            if (api == null)
                 return results;
 
-            var api = ApiSurfaceExtractor.Extract(peReader, includeAll);
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
 
             foreach (var type in api.Types)
@@ -662,13 +658,10 @@ public class FindCommand
 
         try
         {
-            using var fs = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(fs);
-
-            if (!peReader.HasMetadata)
+            var api = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll);
+            if (api == null)
                 return results;
 
-            var api = ApiSurfaceExtractor.Extract(peReader, includeAll);
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
 
             foreach (var type in api.Types)

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -1,4 +1,3 @@
-using System.Reflection.PortableExecutable;
 using DotnetInspector.Packages;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -89,15 +88,9 @@ public class ImplementsCommand
 
         try
         {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(stream);
-
-            if (!peReader.HasMetadata)
-                return results;
-
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
 
-            foreach (var relationship in TypeHierarchyScanner.FindImplementers(peReader, targetType, includeAll))
+            foreach (var relationship in AssemblyReader.FindImplementers(assemblyPath, targetType, includeAll))
             {
                 results.Add(new ImplementerResult
                 {

--- a/src/dotnet-inspect/Commands/MemberTableFormatter.cs
+++ b/src/dotnet-inspect/Commands/MemberTableFormatter.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 
 namespace DotnetInspector.Commands;

--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -1,7 +1,6 @@
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using Markout;
@@ -282,41 +281,7 @@ public class PlatformCommand
 
     private static int CountPublicTypes(string assemblyPath)
     {
-        try
-        {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(stream);
-            
-            if (!peReader.HasMetadata)
-                return 0;
-
-            var reader = peReader.GetMetadataReader();
-            int count = 0;
-
-            foreach (var typeDefHandle in reader.TypeDefinitions)
-            {
-                var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                var attributes = typeDef.Attributes;
-
-                bool isPublic = (attributes & System.Reflection.TypeAttributes.VisibilityMask) == System.Reflection.TypeAttributes.Public ||
-                                (attributes & System.Reflection.TypeAttributes.VisibilityMask) == System.Reflection.TypeAttributes.NestedPublic;
-
-                if (isPublic)
-                {
-                    var name = reader.GetString(typeDef.Name);
-                    if (!name.StartsWith("<") && !name.StartsWith("__"))
-                    {
-                        count++;
-                    }
-                }
-            }
-
-            return count;
-        }
-        catch
-        {
-            return 0;
-        }
+        return AssemblyReader.CountPublicTypes(assemblyPath);
     }
 }
 

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;

--- a/src/dotnet-inspect/Inspectors/AssemblyAuditor.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyAuditor.cs
@@ -1,20 +1,13 @@
-using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
-using System.Text.Json;
-using System.Text.RegularExpressions;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Inspectors;
 
 /// <summary>
 /// Audits assemblies for SourceLink, deterministic builds, and assembly information.
+/// Delegates PE/metadata inspection to AssemblyInspector in the Metadata library.
 /// </summary>
 public static class AssemblyAuditor
 {
-    // SourceLink GUID: CC110556-A091-4D38-9FEC-25AB9A351A6A
-    private static readonly Guid SourceLinkGuid = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-
     public static void AuditAssemblies(string extractPath, InspectionResult result, bool includeApi = false)
     {
         // Find all DLL files
@@ -80,481 +73,68 @@ public static class AssemblyAuditor
 
     private static AssemblyAudit? AuditDll(string dllPath, string extractPath, bool includeApi)
     {
-        using FileStream stream = File.OpenRead(dllPath);
-        using PEReader peReader = new(stream);
-
         string relativePath = Path.GetRelativePath(extractPath, dllPath);
 
-        // Handle native binaries (no managed metadata)
-        if (!peReader.HasMetadata)
-        {
-            return AuditNativeBinary(peReader, relativePath);
-        }
+        var auditInfo = AssemblyInspector.AuditDll(dllPath);
+
+        // Determine if this is a native binary
+        bool isNative = auditInfo.AssemblyInfo?.HasManagedMetadata == false;
 
         var audit = new AssemblyAudit
         {
             FileName = relativePath,
-            FileType = "dll"
+            FileType = isNative ? "native" : "dll",
+            HasReproducibleFlag = auditInfo.HasReproducibleFlag,
+            HasEmbeddedPdb = auditInfo.HasEmbeddedPdb,
+            HasNormalizedPaths = auditInfo.HasNormalizedPaths,
+            PdbPath = auditInfo.PdbPath,
+            HasSourceLink = auditInfo.HasSourceLink,
+            SourceLinkJson = auditInfo.SourceLinkJson,
+            RepositoryUrl = auditInfo.RepositoryUrl,
+            NonNormalizedPaths = auditInfo.NonNormalizedPaths,
+            IsDeterministic = auditInfo.IsDeterministic,
+            AssemblyInfo = auditInfo.AssemblyInfo
         };
 
-        // Check debug directory entries
-        foreach (var entry in peReader.ReadDebugDirectory())
-        {
-            if (entry.Type == DebugDirectoryEntryType.Reproducible)
-            {
-                audit.HasReproducibleFlag = true;
-            }
-
-            if (entry.Type == DebugDirectoryEntryType.CodeView)
-            {
-                var cvData = peReader.ReadCodeViewDebugDirectoryData(entry);
-                audit.PdbPath = cvData.Path;
-
-                // Check for normalized paths (deterministic builds use /_/ prefix or just filename)
-                if (!cvData.Path.StartsWith("/_/", StringComparison.Ordinal) &&
-                    Path.GetDirectoryName(cvData.Path) is string dir && !string.IsNullOrEmpty(dir))
-                {
-                    audit.HasNormalizedPaths = false;
-                    audit.NonNormalizedPaths ??= [];
-                    audit.NonNormalizedPaths.Add($"PDB Path: {cvData.Path}");
-                }
-                else
-                {
-                    audit.HasNormalizedPaths = true;
-                }
-            }
-
-            if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
-            {
-                audit.HasEmbeddedPdb = true;
-                using MetadataReaderProvider provider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
-                MetadataReader reader = provider.GetMetadataReader();
-
-                string? sourceLink = ExtractSourceLinkFromReader(reader);
-                if (sourceLink != null)
-                {
-                    audit.HasSourceLink = true;
-                    audit.SourceLinkJson = sourceLink;
-
-                    var (pathsNormalized, nonNormalizedPaths) = CheckSourceLinkPaths(sourceLink);
-                    if (!pathsNormalized)
-                    {
-                        audit.HasNormalizedPaths = false;
-                        audit.NonNormalizedPaths ??= [];
-                        foreach (var path in nonNormalizedPaths)
-                        {
-                            audit.NonNormalizedPaths.Add($"SourceLink: {path}");
-                        }
-                    }
-
-                    // Extract repository URL from SourceLink
-                    audit.RepositoryUrl = ExtractRepositoryUrl(sourceLink);
-                }
-            }
-        }
-
-        // Determine overall deterministic status
-        audit.IsDeterministic = audit.HasReproducibleFlag && audit.HasNormalizedPaths != false;
-
-        // Extract assembly info
-        audit.AssemblyInfo = ExtractAssemblyInfo(peReader);
+        if (auditInfo.PdbFormat != null)
+            audit.PdbFormat = auditInfo.PdbFormat;
 
         // Determine reason for missing SourceLink
-        // Note: AssemblyAuditor is used for package inspection where we have the PDB available
-        // For assemblies without embedded PDB and no standalone PDB found, SourceLink won't be available
-        if (!audit.HasSourceLink && !audit.HasEmbeddedPdb && audit.PdbPath != null)
+        if (!isNative && !audit.HasSourceLink && !audit.HasEmbeddedPdb && audit.PdbPath != null)
         {
-            // External PDB referenced but not found in the package
             audit.SourceLinkUnavailableReason = "PDB not in package";
         }
 
         // Extract API surface only if requested
-        if (includeApi)
+        if (includeApi && !isNative)
         {
-            audit.ApiSurface = ApiSurfaceExtractor.Extract(peReader);
+            audit.ApiSurface = AssemblyReader.ExtractApiSurface(dllPath);
         }
 
         return audit;
-    }
-
-    private static AssemblyAudit AuditNativeBinary(PEReader peReader, string relativePath)
-    {
-        var audit = new AssemblyAudit
-        {
-            FileName = relativePath,
-            FileType = "native"
-        };
-
-        var peHeaders = peReader.PEHeaders;
-        var coffHeader = peHeaders.CoffHeader;
-
-        // Create AssemblyInfo for native binaries
-        var info = new AssemblyInfo
-        {
-            HasCorHeader = false,
-            HasManagedMetadata = false,
-            HasILCode = false,
-            IsExecutable = peHeaders.IsExe,
-            IsDll = peHeaders.IsDll
-        };
-
-        // Determine architecture
-        info.Architecture = coffHeader.Machine switch
-        {
-            Machine.I386 => "x86",
-            Machine.Amd64 => "x64",
-            Machine.Arm => "ARM",
-            Machine.Arm64 => "ARM64",
-            _ => coffHeader.Machine.ToString()
-        };
-
-        // Detect if this is a NativeAOT binary
-        bool isNativeAot = DetectNativeAot(peReader);
-
-        info.IsNativeAot = isNativeAot;
-        info.CompilationType = isNativeAot ? "NativeAOT" : "Native";
-
-        audit.AssemblyInfo = info;
-        return audit;
-    }
-
-    private static bool DetectNativeAot(PEReader peReader)
-    {
-        try
-        {
-            // Check for debug directory entries that might indicate NativeAOT
-            foreach (var entry in peReader.ReadDebugDirectory())
-            {
-                // NativeAOT binaries may have reproducible/deterministic markers
-                if (entry.Type == DebugDirectoryEntryType.Reproducible)
-                {
-                    // Having reproducible flag without metadata suggests NativeAOT
-                    return true;
-                }
-            }
-        }
-        catch
-        {
-            // If we can't analyze, default to unknown
-        }
-
-        return false;
     }
 
     private static AssemblyAudit? AuditStandalonePdb(string pdbPath, string extractPath)
     {
         using FileStream stream = File.OpenRead(pdbPath);
 
-        byte[] header = new byte[4];
-        stream.ReadExactly(header, 0, 4);
-        stream.Position = 0;
-
-        // Only handle Portable PDBs (BSJB header)
-        if (header[0] != 'B' || header[1] != 'S' || header[2] != 'J' || header[3] != 'B')
-        {
-            return new AssemblyAudit
-            {
-                FileName = Path.GetRelativePath(extractPath, pdbPath),
-                FileType = "pdb",
-                PdbFormat = "Windows PDB (legacy)",
-                HasSourceLink = false,
-                IsDeterministic = false
-            };
-        }
-
-        using MetadataReaderProvider provider = MetadataReaderProvider.FromPortablePdbStream(stream);
-        MetadataReader reader = provider.GetMetadataReader();
+        var auditInfo = AssemblyInspector.AuditStandalonePdb(stream);
+        if (auditInfo == null)
+            return null;
 
         string relativePath = Path.GetRelativePath(extractPath, pdbPath);
-        var audit = new AssemblyAudit
+
+        return new AssemblyAudit
         {
             FileName = relativePath,
             FileType = "pdb",
-            PdbFormat = "Portable PDB"
+            PdbFormat = auditInfo.PdbFormat,
+            HasSourceLink = auditInfo.HasSourceLink,
+            SourceLinkJson = auditInfo.SourceLinkJson,
+            HasNormalizedPaths = auditInfo.HasNormalizedPaths,
+            NonNormalizedPaths = auditInfo.NonNormalizedPaths,
+            RepositoryUrl = auditInfo.RepositoryUrl,
+            IsDeterministic = auditInfo.IsDeterministic
         };
-
-        string? sourceLink = ExtractSourceLinkFromReader(reader);
-        if (sourceLink != null)
-        {
-            audit.HasSourceLink = true;
-            audit.SourceLinkJson = sourceLink;
-
-            var (pathsNormalized, nonNormalizedPaths) = CheckSourceLinkPaths(sourceLink);
-            audit.HasNormalizedPaths = pathsNormalized;
-            if (!pathsNormalized)
-            {
-                audit.NonNormalizedPaths = nonNormalizedPaths;
-            }
-
-            audit.RepositoryUrl = ExtractRepositoryUrl(sourceLink);
-            audit.IsDeterministic = pathsNormalized;
-        }
-
-        return audit;
-    }
-
-    private static string? ExtractSourceLinkFromReader(MetadataReader reader)
-    {
-        foreach (CustomDebugInformationHandle handle in reader.CustomDebugInformation)
-        {
-            CustomDebugInformation info = reader.GetCustomDebugInformation(handle);
-            Guid kind = reader.GetGuid(info.Kind);
-
-            if (kind == SourceLinkGuid)
-            {
-                byte[] bytes = reader.GetBlobBytes(info.Value);
-                return System.Text.Encoding.UTF8.GetString(bytes);
-            }
-        }
-
-        return null;
-    }
-
-    private static (bool isNormalized, List<string> nonNormalizedPaths) CheckSourceLinkPaths(string sourceLink)
-    {
-        var nonNormalizedPaths = new List<string>();
-        try
-        {
-            using var doc = JsonDocument.Parse(sourceLink);
-            if (doc.RootElement.TryGetProperty("documents", out var documents))
-            {
-                foreach (var prop in documents.EnumerateObject())
-                {
-                    // Deterministic builds should have paths starting with /_
-                    if (!prop.Name.StartsWith("/_", StringComparison.Ordinal))
-                    {
-                        nonNormalizedPaths.Add(prop.Name);
-                    }
-                }
-            }
-            return (nonNormalizedPaths.Count == 0, nonNormalizedPaths);
-        }
-        catch
-        {
-            return (false, nonNormalizedPaths);
-        }
-    }
-
-    private static string? ExtractRepositoryUrl(string sourceLink)
-    {
-        try
-        {
-            using var doc = JsonDocument.Parse(sourceLink);
-            if (doc.RootElement.TryGetProperty("documents", out var documents))
-            {
-                foreach (var prop in documents.EnumerateObject())
-                {
-                    string url = prop.Value.GetString() ?? "";
-                    // Extract base URL from SourceLink URL pattern
-                    if (url.Contains("github.com", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var match = Regex.Match(url,
-                            @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/");
-                        if (match.Success)
-                        {
-                            return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}";
-                        }
-                    }
-                    else if (url.Contains("dev.azure.com", StringComparison.OrdinalIgnoreCase) ||
-                             url.Contains("visualstudio.com", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return url.Split('_')[0].TrimEnd('/');
-                    }
-                    break; // Just use the first document URL
-                }
-            }
-        }
-        catch
-        {
-            // Ignore parse errors
-        }
-        return null;
-    }
-
-    private static AssemblyInfo ExtractAssemblyInfo(PEReader peReader)
-    {
-        var info = new AssemblyInfo();
-
-        var peHeaders = peReader.PEHeaders;
-        var coffHeader = peHeaders.CoffHeader;
-        var corHeader = peHeaders.CorHeader;
-
-        info.HasCorHeader = corHeader != null;
-        info.HasManagedMetadata = peReader.HasMetadata;
-
-        // Check for ReadyToRun (R2R) compilation
-        bool hasR2R = false;
-        if (corHeader != null)
-        {
-            var managedNativeHeader = corHeader.ManagedNativeHeaderDirectory;
-            hasR2R = managedNativeHeader.Size > 0;
-        }
-
-        bool hasILCode = corHeader != null && peReader.HasMetadata;
-        bool isILOnly = corHeader?.Flags.HasFlag(CorFlags.ILOnly) == true;
-
-        info.HasILCode = hasILCode;
-        info.IsReadyToRun = hasR2R;
-
-        // Determine compilation type
-        if (corHeader == null)
-        {
-            info.CompilationType = "Native";
-            info.IsNativeAot = false;
-        }
-        else if (hasR2R)
-        {
-            info.CompilationType = "ReadyToRun";
-            info.IsNativeAot = false;
-        }
-        else if (isILOnly)
-        {
-            info.CompilationType = "CoreCLR";
-            info.IsNativeAot = false;
-        }
-        else if (hasILCode)
-        {
-            info.CompilationType = "CoreCLR";
-            info.IsNativeAot = false;
-        }
-        else
-        {
-            info.CompilationType = "Unknown";
-            info.IsNativeAot = false;
-        }
-
-        // Determine architecture
-        info.Architecture = coffHeader.Machine switch
-        {
-            Machine.I386 => corHeader?.Flags.HasFlag(CorFlags.Requires32Bit) == true ? "x86" :
-                            corHeader?.Flags.HasFlag(CorFlags.Prefers32Bit) == true ? "AnyCPU (32-bit preferred)" : "AnyCPU",
-            Machine.Amd64 => "x64",
-            Machine.Arm => "ARM",
-            Machine.Arm64 => "ARM64",
-            _ => coffHeader.Machine.ToString()
-        };
-
-        info.IsAnyCpu = coffHeader.Machine == Machine.I386 &&
-                        corHeader?.Flags.HasFlag(CorFlags.Requires32Bit) != true;
-        info.Prefers32Bit = corHeader?.Flags.HasFlag(CorFlags.Prefers32Bit) == true;
-        info.IsSigned = corHeader?.Flags.HasFlag(CorFlags.StrongNameSigned) == true;
-
-        info.IsExecutable = peHeaders.IsExe;
-        info.IsDll = peHeaders.IsDll;
-
-        var metadataReader = peReader.GetMetadataReader();
-
-        info.RuntimeVersion = metadataReader.MetadataVersion;
-        info.MetadataVersion = metadataReader.GetTableRowCount(TableIndex.Module);
-
-        info.HasUnsafeCode = CheckForUnsafeCode(metadataReader);
-
-        if (metadataReader.IsAssembly)
-        {
-            var assemblyDef = metadataReader.GetAssemblyDefinition();
-            info.AssemblyName = metadataReader.GetString(assemblyDef.Name);
-            info.AssemblyVersion = assemblyDef.Version.ToString();
-            info.Culture = metadataReader.GetString(assemblyDef.Culture);
-            if (string.IsNullOrEmpty(info.Culture))
-                info.Culture = "neutral";
-
-            var publicKey = metadataReader.GetBlobBytes(assemblyDef.PublicKey);
-            if (publicKey.Length > 0)
-            {
-                info.PublicKeyToken = Convert.ToHexString(publicKey.TakeLast(8).ToArray()).ToLowerInvariant();
-            }
-        }
-
-        // Get custom attributes for additional info
-        foreach (var attrHandle in metadataReader.CustomAttributes)
-        {
-            var attr = metadataReader.GetCustomAttribute(attrHandle);
-            string? attrName = GetAttributeName(metadataReader, attr);
-
-            if (attrName == "System.Runtime.Versioning.TargetFrameworkAttribute")
-            {
-                info.TargetFramework = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyFileVersionAttribute")
-            {
-                info.FileVersion = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyInformationalVersionAttribute")
-            {
-                info.InformationalVersion = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyProductAttribute")
-            {
-                info.Product = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyCompanyAttribute")
-            {
-                info.Company = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyCopyrightAttribute")
-            {
-                info.Copyright = GetAttributeStringValue(metadataReader, attr);
-            }
-            else if (attrName == "System.Reflection.AssemblyDescriptionAttribute")
-            {
-                info.Description = GetAttributeStringValue(metadataReader, attr);
-            }
-        }
-
-        return info;
-    }
-
-    private static bool CheckForUnsafeCode(MetadataReader reader)
-    {
-        foreach (var attrHandle in reader.CustomAttributes)
-        {
-            var attr = reader.GetCustomAttribute(attrHandle);
-            string? attrName = GetAttributeName(reader, attr);
-            if (attrName == "System.Security.UnverifiableCodeAttribute")
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static string? GetAttributeName(MetadataReader reader, CustomAttribute attr)
-    {
-        if (attr.Constructor.Kind == HandleKind.MemberReference)
-        {
-            var memberRef = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
-            if (memberRef.Parent.Kind == HandleKind.TypeReference)
-            {
-                var typeRef = reader.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
-                string ns = reader.GetString(typeRef.Namespace);
-                string name = reader.GetString(typeRef.Name);
-                return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-            }
-        }
-        else if (attr.Constructor.Kind == HandleKind.MethodDefinition)
-        {
-            var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)attr.Constructor);
-            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
-            string ns = reader.GetString(typeDef.Namespace);
-            string name = reader.GetString(typeDef.Name);
-            return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-        }
-        return null;
-    }
-
-    private static string? GetAttributeStringValue(MetadataReader reader, CustomAttribute attr)
-    {
-        try
-        {
-            var value = reader.GetBlobReader(attr.Value);
-            // Skip prolog (2 bytes)
-            value.ReadUInt16();
-            // Read the string value
-            return value.ReadSerializedString();
-        }
-        catch
-        {
-            return null;
-        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/DocCommentParser.cs
+++ b/src/dotnet-inspect/Inspectors/DocCommentParser.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Inspectors;
 

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Inspectors;
 

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using DotnetInspector.Metadata;
 
 namespace DotnetInspector;
 

--- a/src/dotnet-inspect/MarkoutContext.cs
+++ b/src/dotnet-inspect/MarkoutContext.cs
@@ -4,10 +4,7 @@ namespace DotnetInspector;
 
 [MarkoutContext(typeof(InspectionResult))]
 [MarkoutContext(typeof(AssemblyAudit))]
-[MarkoutContext(typeof(AssemblyInfo))]
-[MarkoutContext(typeof(ApiSurface))]
-[MarkoutContext(typeof(ApiType))]
-[MarkoutContext(typeof(ApiMember))]
+[MarkoutContext(typeof(CliApiSurface))]
 [MarkoutContext(typeof(ApiTypeView))]
 [MarkoutContext(typeof(EnumValueRow))]
 [MarkoutContext(typeof(TypeParameterRow))]

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using Markout;
 


### PR DESCRIPTION
## Summary

- **Phase 1:** Move `ApiSurface` POCOs, `ApiSurfaceExtractor`, and new `AssemblyReader` convenience layer into `DotnetInspector.Metadata`. Update `DiffCommand`, `FindCommand`, `PlatformCommand`, `ImplementsCommand` to use `AssemblyReader` instead of inline `PEReader` usage.
- **Phase 2:** Consolidate extension method scanning into `ExtensionMethodScanner` in Metadata, eliminating duplicate `ExtensionSignatureTypeProvider` from CLI.
- **Phase 3:** Move `SourceLinkResolver` to Metadata with new string-based `ResolveTypeSource` overload. Remove `FindTypeDefinitionHandle` from `ApiServices`.
- **Phase 4:** Move `AssemblyInfo`/`AssemblyReference`/`AssemblyReferenceNode` to Metadata. Create `AssemblyInspector` for PE header, debug directory audit, and reference extraction. Rewrite `AssemblyAuditor` to delegate all SRM work.

SRM imports reduced from 10 CLI files to 2 (`AssemblyCommand`, `ApiServices`), both retained only for the PDB download pipeline which exposes `PEReader`/`MetadataReader` in its public API.

## Test plan

- [x] All 324 existing tests pass
- [ ] Smoke test: `dotnet-inspect api System.Text.Json`
- [ ] Smoke test: `dotnet-inspect assembly --package Newtonsoft.Json --audit`
- [ ] Smoke test: `dotnet-inspect extensions IEnumerable`
- [ ] Verify `grep -r "using System.Reflection.Metadata" src/dotnet-inspect/` shows only `AssemblyCommand.cs` and `ApiServices.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)