### PR TITLE
Introduce PdbContext to eliminate SRM imports from CLI

### DIFF
--- a/src/DotnetInspector.Metadata/PdbContext.cs
+++ b/src/DotnetInspector.Metadata/PdbContext.cs
@@ -1,0 +1,387 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// CodeView debug info needed for symbol server lookup (no SRM types in signature).
+/// </summary>
+public record CodeViewInfo(Guid Guid, int Age, string PdbFileName, bool IsPortable);
+
+/// <summary>
+/// Source document info for strict verification (no SRM types in signature).
+/// </summary>
+public record SourceDocument(string FilePath, bool IsEmbedded, string? ResolvedUrl);
+
+/// <summary>
+/// Wraps PE + PDB readers, exposes high-level operations with no SRM in public signatures.
+/// CLI orchestrates PDB acquisition (download via Packages), then calls back into this context.
+/// </summary>
+public class PdbContext : IDisposable
+{
+    private readonly PEReader _peReader;
+    private readonly FileStream _peStream;
+    private readonly Action<string>? _log;
+    private readonly string _assemblyPath;
+
+    private MetadataReaderProvider? _pdbProvider;
+    private MetadataReader? _pdbReader;
+    private SourceLinkResolver? _resolver;
+    private readonly List<IDisposable> _disposables = [];
+
+    /// <summary>
+    /// The path to the assembly file that was opened.
+    /// </summary>
+    public string AssemblyPath => _assemblyPath;
+
+    // --- PE/Assembly ---
+    public bool HasMetadata => _peReader.HasMetadata;
+
+    // --- Debug directory (POCO) ---
+    public bool HasReproducibleFlag { get; private set; }
+    public bool HasEmbeddedPdb { get; private set; }
+    public string? CodeViewPdbPath { get; private set; }
+    public bool? HasNormalizedPaths { get; private set; }
+    public List<string>? NonNormalizedPaths { get; private set; }
+
+    // --- PDB acquisition ---
+    public CodeViewInfo? PdbId { get; private set; }
+    public bool NeedsPdb => PdbId != null && !HasPdb;
+    public bool HasPdb { get; private set; }
+    public bool WindowsPdbDetected { get; set; }
+    public string? PdbFormat { get; private set; }
+    public string? PdbLocation { get; private set; }
+    public string? SymbolServer { get; private set; }
+
+    // --- SourceLink ---
+    public string? SourceLinkJson { get; private set; }
+    public bool HasSourceLink => SourceLinkJson != null;
+
+    private PdbContext(FileStream peStream, PEReader peReader, string assemblyPath, Action<string>? log)
+    {
+        _peStream = peStream;
+        _peReader = peReader;
+        _assemblyPath = assemblyPath;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Opens a PE file and probes for PDB (embedded, then standalone adjacent).
+    /// After return, check NeedsPdb to see if CLI should download a PDB.
+    /// </summary>
+    public static PdbContext Open(string assemblyPath, Action<string>? log = null)
+    {
+        var stream = File.OpenRead(assemblyPath);
+        var peReader = new PEReader(stream);
+        var context = new PdbContext(stream, peReader, assemblyPath, log);
+
+        if (!peReader.HasMetadata)
+            return context;
+
+        context.ReadDebugDirectory();
+        context.TryLoadLocalPdb();
+
+        return context;
+    }
+
+    /// <summary>
+    /// Extracts assembly info from the PE reader.
+    /// </summary>
+    public AssemblyInfo ExtractAssemblyInfo(bool includeReferences = false)
+        => AssemblyInspector.ExtractAssemblyInfo(_peReader, includeReferences);
+
+    /// <summary>
+    /// Creates an AssemblyInfo for a native (non-managed) binary.
+    /// </summary>
+    public AssemblyInfo CreateNativeInfo()
+    {
+        var info = AssemblyInspector.CreateNativeInfo(_peReader);
+        bool isNativeAot = AssemblyInspector.DetectNativeAot(_peReader);
+        info.IsNativeAot = isNativeAot;
+        info.CompilationType = isNativeAot ? "NativeAOT" : "Native";
+        return info;
+    }
+
+    /// <summary>
+    /// Loads a PDB from a file path (called by CLI after downloading).
+    /// </summary>
+    public void LoadPdbFromFile(string pdbFilePath, string? pdbLocation = null, string? symbolServer = null)
+    {
+        try
+        {
+            var stream = File.OpenRead(pdbFilePath);
+            _disposables.Add(stream);
+
+            // Check for Portable PDB magic header (BSJB)
+            byte[] header = new byte[4];
+            stream.ReadExactly(header, 0, 4);
+            stream.Position = 0;
+
+            if (header[0] != 'B' || header[1] != 'S' || header[2] != 'J' || header[3] != 'B')
+            {
+                bool isWindowsPdb = header[0] == 'M' && header[1] == 'i' && header[2] == 'c' && header[3] == 'r';
+                if (isWindowsPdb)
+                {
+                    WindowsPdbDetected = true;
+                    PdbFormat = "Windows";
+                    _log?.Invoke("Windows PDB detected (not supported)");
+                }
+                return;
+            }
+
+            var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
+            _disposables.Add(provider);
+            _pdbProvider = provider;
+            _pdbReader = provider.GetMetadataReader();
+
+            HasPdb = true;
+            PdbFormat = "Portable";
+            PdbLocation = pdbLocation ?? "Standalone";
+            SymbolServer = symbolServer;
+
+            SourceLinkJson = AssemblyInspector.ExtractSourceLinkFromReader(_pdbReader);
+            _resolver = _pdbReader != null ? SourceLinkResolver.Create(_pdbReader) : null;
+
+            _log?.Invoke($"Loaded PDB: {PdbFormat}, {PdbLocation}");
+        }
+        catch (Exception ex)
+        {
+            _log?.Invoke($"Error loading PDB: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Resolves source information for a type by name.
+    /// </summary>
+    public SourceLinkResolver.TypeSourceInfo? ResolveTypeSource(string typeName)
+    {
+        if (_resolver == null || _pdbReader == null || !_peReader.HasMetadata)
+            return null;
+
+        var metadataReader = _peReader.GetMetadataReader();
+        return _resolver.ResolveTypeSource(metadataReader, _pdbReader, typeName);
+    }
+
+    /// <summary>
+    /// Finds a type forwarder target assembly name for a given type.
+    /// </summary>
+    public string? FindTypeForwarder(string typeName)
+    {
+        if (!_peReader.HasMetadata)
+            return null;
+
+        var reader = _peReader.GetMetadataReader();
+        foreach (var exportedTypeHandle in reader.ExportedTypes)
+        {
+            var exportedType = reader.GetExportedType(exportedTypeHandle);
+            if (!exportedType.IsForwarder)
+                continue;
+
+            var name = reader.GetString(exportedType.Name);
+            var ns = reader.GetString(exportedType.Namespace);
+            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+
+            if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (exportedType.Implementation.Kind == HandleKind.AssemblyReference)
+                {
+                    var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)exportedType.Implementation);
+                    return reader.GetString(assemblyRef.Name);
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Enumerates all source documents in the PDB for strict verification.
+    /// </summary>
+    public IEnumerable<SourceDocument> EnumerateSourceDocuments()
+    {
+        if (_pdbReader == null)
+            yield break;
+
+        // GUID for embedded source: 0E8A571B-6926-466E-B4AD-8AB04611F5FE
+        var embeddedSourceGuid = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+
+        foreach (var docHandle in _pdbReader.Documents)
+        {
+            var document = _pdbReader.GetDocument(docHandle);
+            string filePath = _pdbReader.GetString(document.Name);
+
+            // Skip non-source files
+            if (!filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) &&
+                !filePath.EndsWith(".vb", StringComparison.OrdinalIgnoreCase) &&
+                !filePath.EndsWith(".fs", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            bool isEmbedded = false;
+            foreach (var cdiHandle in _pdbReader.GetCustomDebugInformation(docHandle))
+            {
+                var cdi = _pdbReader.GetCustomDebugInformation(cdiHandle);
+                if (_pdbReader.GetGuid(cdi.Kind) == embeddedSourceGuid)
+                {
+                    isEmbedded = true;
+                    break;
+                }
+            }
+
+            string? resolvedUrl = _resolver?.ApplySourceLinkMapping(filePath);
+            yield return new SourceDocument(filePath, isEmbedded, resolvedUrl);
+        }
+    }
+
+    /// <summary>
+    /// Extracts the repository URL from SourceLink information.
+    /// </summary>
+    public string? ExtractRepositoryUrl()
+        => _resolver?.ExtractRepositoryUrl();
+
+    /// <summary>
+    /// Gets the SourceLinkResolver for batch operations (e.g. resolving multiple types).
+    /// Returns null if no PDB/SourceLink is available.
+    /// </summary>
+    internal SourceLinkResolver? GetResolver() => _resolver;
+
+    /// <summary>
+    /// Gets the PDB MetadataReader for batch operations.
+    /// Returns null if no PDB is loaded.
+    /// </summary>
+    internal MetadataReader? GetPdbReader() => _pdbReader;
+
+    /// <summary>
+    /// Gets the PE MetadataReader for batch operations.
+    /// Returns null if no metadata is available.
+    /// </summary>
+    internal MetadataReader? GetMetadataReader()
+        => _peReader.HasMetadata ? _peReader.GetMetadataReader() : null;
+
+    public void Dispose()
+    {
+        foreach (var d in _disposables)
+        {
+            try { d.Dispose(); } catch { }
+        }
+        _disposables.Clear();
+        _pdbProvider = null;
+        _pdbReader = null;
+        _resolver = null;
+
+        try { _peReader.Dispose(); } catch { }
+        try { _peStream.Dispose(); } catch { }
+    }
+
+    // --- Private implementation ---
+
+    private void ReadDebugDirectory()
+    {
+        CodeViewDebugDirectoryData? portableCodeView = null;
+        CodeViewDebugDirectoryData? windowsCodeView = null;
+
+        foreach (var entry in _peReader.ReadDebugDirectory())
+        {
+            if (entry.Type == DebugDirectoryEntryType.Reproducible)
+            {
+                HasReproducibleFlag = true;
+            }
+
+            if (entry.Type == DebugDirectoryEntryType.CodeView)
+            {
+                var cvData = _peReader.ReadCodeViewDebugDirectoryData(entry);
+                bool isPortable = entry.MinorVersion == 0x504d;
+
+                CodeViewPdbPath = cvData.Path;
+
+                if (!cvData.Path.StartsWith("/_/", StringComparison.Ordinal) &&
+                    Path.GetDirectoryName(cvData.Path) is string dir && !string.IsNullOrEmpty(dir))
+                {
+                    HasNormalizedPaths = false;
+                    NonNormalizedPaths ??= [];
+                    NonNormalizedPaths.Add($"PDB Path: {cvData.Path}");
+                }
+                else
+                {
+                    HasNormalizedPaths = true;
+                }
+
+                if (isPortable)
+                {
+                    portableCodeView = cvData;
+                    PdbId = new CodeViewInfo(cvData.Guid, cvData.Age, Path.GetFileName(cvData.Path), true);
+                }
+                else
+                {
+                    windowsCodeView = cvData;
+                    if (portableCodeView == null)
+                    {
+                        // Only use Windows PDB as fallback
+                        PdbId = new CodeViewInfo(cvData.Guid, cvData.Age, Path.GetFileName(cvData.Path), false);
+                    }
+                }
+            }
+
+            if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
+            {
+                HasEmbeddedPdb = true;
+                PdbFormat = "Portable";
+                PdbLocation = "Embedded";
+
+                var provider = _peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+                _disposables.Add(provider);
+                _pdbProvider = provider;
+                _pdbReader = provider.GetMetadataReader();
+                HasPdb = true;
+
+                SourceLinkJson = AssemblyInspector.ExtractSourceLinkFromReader(_pdbReader);
+                _resolver = SourceLinkResolver.Create(_pdbReader);
+
+                _log?.Invoke("Using embedded PDB");
+            }
+        }
+
+        if (windowsCodeView != null && portableCodeView != null)
+        {
+            _log?.Invoke("Found both Windows (.ni.pdb) and Portable PDB entries, using Portable");
+        }
+    }
+
+    private void TryLoadLocalPdb()
+    {
+        if (HasPdb)
+            return;
+
+        var pdbPath = Path.ChangeExtension(_assemblyPath, ".pdb");
+        if (!File.Exists(pdbPath))
+            return;
+
+        // Check header
+        try
+        {
+            using var checkStream = File.OpenRead(pdbPath);
+            byte[] header = new byte[4];
+            checkStream.ReadExactly(header, 0, 4);
+
+            if (header[0] == 'M' && header[1] == 'i' && header[2] == 'c' && header[3] == 'r')
+            {
+                WindowsPdbDetected = true;
+                PdbFormat = "Windows";
+                PdbLocation = "Standalone";
+                _log?.Invoke("Standalone Windows PDB found (not supported)");
+                return;
+            }
+
+            if (header[0] != 'B' || header[1] != 'S' || header[2] != 'J' || header[3] != 'B')
+                return;
+        }
+        catch
+        {
+            return;
+        }
+
+        // It's a Portable PDB — open it
+        LoadPdbFromFile(pdbPath, "Standalone");
+    }
+}

--- a/src/DotnetInspector.Metadata/SourceLinkResolver.cs
+++ b/src/DotnetInspector.Metadata/SourceLinkResolver.cs
@@ -328,7 +328,7 @@ public class SourceLinkResolver
     /// <summary>
     /// Applies SourceLink URL pattern to convert a file path to a source URL.
     /// </summary>
-    private string? ApplySourceLinkMapping(string filePath)
+    public string? ApplySourceLinkMapping(string filePath)
     {
         filePath = filePath.Replace('\\', '/');
 

--- a/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
+++ b/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
@@ -16,6 +16,15 @@ public record PdbLookupResult(
 );
 
 /// <summary>
+/// Result of downloading a PDB file (no SRM types).
+/// </summary>
+public record PdbDownloadResult(
+    string? PdbFilePath,
+    bool WindowsPdbDetected = false,
+    string? SymbolServer = null
+);
+
+/// <summary>
 /// Downloads and manages symbol packages (.snupkg) from NuGet for SourceLink resolution.
 /// Only supports Portable PDBs (embedded or standalone) and snupkg files.
 /// </summary>
@@ -71,14 +80,14 @@ public class SymbolPackageDownloader(HttpClient client)
         DebugDirectoryEntry? codeViewEntry = null;
         CodeViewDebugDirectoryData? windowsCodeView = null;
         DebugDirectoryEntry? windowsCodeViewEntry = null;
-        
+
         foreach (var entry in peReader.ReadDebugDirectory())
         {
             if (entry.Type == DebugDirectoryEntryType.CodeView)
             {
                 var cv = peReader.ReadCodeViewDebugDirectoryData(entry);
                 bool isPortable = entry.MinorVersion == 0x504d;
-                
+
                 if (isPortable)
                 {
                     // Prefer Portable PDB entries
@@ -91,7 +100,7 @@ public class SymbolPackageDownloader(HttpClient client)
                     codeView = cv;
                     codeViewEntry = entry;
                 }
-                
+
                 // Also track Windows PDB entry separately for detection
                 if (!isPortable)
                 {
@@ -109,7 +118,7 @@ public class SymbolPackageDownloader(HttpClient client)
 
         // Check if this is a Portable PDB (MinorVersion == 0x504d means "PM" for Portable Metadata)
         bool isPortablePdb = codeViewEntry.Value.MinorVersion == 0x504d;
-        
+
         // If we have both Windows and Portable PDB entries, log it
         if (windowsCodeView != null && isPortablePdb)
         {
@@ -154,28 +163,280 @@ public class SymbolPackageDownloader(HttpClient client)
     }
 
     /// <summary>
-    /// Extracts SourceLink JSON from a PDB file, checking embedded PDB first, then external sources.
+    /// Downloads a PDB file and returns its path on disk. No SRM types in signature.
+    /// The caller (PdbContext) is responsible for opening and reading the PDB.
     /// </summary>
-    public async Task<(string? json, bool windowsPdbDetected)> GetSourceLinkJsonAsync(
-        PEReader peReader,
+    public async Task<PdbDownloadResult> DownloadPdbAsync(
+        Guid pdbGuid, int pdbAge, string pdbFileName, bool isPortable,
         string assemblyPath,
         string? packageName = null,
         string? packageVersion = null,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        bool isPlatformAssembly = false)
     {
-        var result = await GetPdbReaderAsync(peReader, assemblyPath, packageName, packageVersion, log);
-        if (result.Reader == null)
-            return (null, result.WindowsPdbDetected);
+        bool windowsPdbDetected = false;
+
+        var guid = pdbGuid.ToString("N").ToUpperInvariant();
+        var symbolKey = isPortable
+            ? $"{guid}FFFFFFFF"
+            : $"{guid}{pdbAge:x}";
+
+        // For Microsoft packages or platform assemblies, try MSDL first
+        bool isMicrosoftPackage = isPlatformAssembly || IsMicrosoftPackage(packageName);
+        if (isMicrosoftPackage)
+        {
+            log?.Invoke(isPlatformAssembly ? "Platform assembly, trying MSDL symbol server" : "Microsoft package detected, trying MSDL symbol server first");
+            var msdlResult = await TryLocateFromMsdlAsync(pdbFileName, symbolKey, log);
+            if (msdlResult.PdbFilePath != null)
+                return msdlResult;
+            if (msdlResult.WindowsPdbDetected)
+                windowsPdbDetected = true;
+        }
+
+        // Try downloading symbol package (.snupkg)
+        if (!string.IsNullOrEmpty(packageName) && !string.IsNullOrEmpty(packageVersion))
+        {
+            var snupkgResult = await TryLocateFromSymbolPackageAsync(
+                packageName, packageVersion, assemblyPath, log);
+            if (snupkgResult.PdbFilePath != null)
+                return snupkgResult;
+            if (snupkgResult.WindowsPdbDetected)
+                windowsPdbDetected = true;
+        }
+
+        // Try NuGet symbol server, then MSDL as fallback (for non-Microsoft packages)
+        if (!isMicrosoftPackage)
+        {
+            var symbolResult = await TryLocateFromSymbolServerAsync(pdbFileName, symbolKey, log);
+            if (symbolResult.PdbFilePath != null)
+                return symbolResult;
+            if (symbolResult.WindowsPdbDetected)
+                windowsPdbDetected = true;
+        }
+
+        log?.Invoke("No Portable PDB available");
+        return new PdbDownloadResult(null, windowsPdbDetected);
+    }
+
+    // ===== File-path-returning variants (for DownloadPdbAsync) =====
+
+    private async Task<PdbDownloadResult> TryLocateFromMsdlAsync(
+        string pdbFileName, string symbolKey, Action<string>? log)
+    {
+        bool windowsPdbDetected = false;
+
+        var cachePath = GetSymbolServerCachePath(pdbFileName, symbolKey);
+        if (File.Exists(cachePath))
+        {
+            log?.Invoke("Using cached PDB from MSDL");
+            var check = CheckPdbHeader(cachePath);
+            if (check == PdbHeaderKind.Portable)
+                return new PdbDownloadResult(cachePath, SymbolServer: "msdl.microsoft.com");
+            if (check == PdbHeaderKind.Windows)
+                windowsPdbDetected = true;
+        }
+
+        var url = $"https://msdl.microsoft.com/download/symbols/{pdbFileName}/{symbolKey}/{pdbFileName}";
+        log?.Invoke("Trying MSDL symbol server");
 
         try
         {
-            return (ExtractSourceLinkFromReader(result.Reader), false);
+            using var response = await HttpRetryHelper.GetWithRetryAsync(_client, url, log: log);
+            if (response == null || !response.IsSuccessStatusCode)
+            {
+                log?.Invoke("MSDL: symbol not found");
+                return new PdbDownloadResult(null, windowsPdbDetected);
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+            using (var fs = File.Create(cachePath))
+            {
+                await response.Content.CopyToAsync(fs);
+            }
+
+            var headerCheck = CheckPdbHeader(cachePath);
+            if (headerCheck == PdbHeaderKind.Portable)
+            {
+                log?.Invoke("Successfully downloaded PDB from MSDL");
+                return new PdbDownloadResult(cachePath, SymbolServer: "msdl.microsoft.com");
+            }
+            if (headerCheck == PdbHeaderKind.Windows)
+            {
+                windowsPdbDetected = true;
+                log?.Invoke("MSDL returned a Windows PDB (not supported)");
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"MSDL error: {ex.Message}");
+        }
+
+        return new PdbDownloadResult(null, windowsPdbDetected);
+    }
+
+    private async Task<PdbDownloadResult> TryLocateFromSymbolPackageAsync(
+        string packageName, string packageVersion, string assemblyPath, Action<string>? log)
+    {
+        var normalizedName = packageName.ToLowerInvariant();
+        var normalizedVersion = packageVersion.ToLowerInvariant();
+        bool windowsPdbDetected = false;
+
+        // Check cache first
+        var cachedPdbPath = GetCachedPdbPath(normalizedName, normalizedVersion, assemblyPath);
+        if (cachedPdbPath != null && File.Exists(cachedPdbPath))
+        {
+            log?.Invoke($"Using cached PDB: {Path.GetFileName(cachedPdbPath)}");
+            var check = CheckPdbHeader(cachedPdbPath);
+            if (check == PdbHeaderKind.Portable)
+                return new PdbDownloadResult(cachedPdbPath, SymbolServer: "nuget.org");
+            if (check == PdbHeaderKind.Windows)
+                windowsPdbDetected = true;
+        }
+
+        // Try NuGet global CDN first
+        var snupkgUrls = new[]
+        {
+            $"https://globalcdn.nuget.org/symbol-packages/{normalizedName}.{normalizedVersion}.snupkg",
+            $"https://api.nuget.org/v3-flatcontainer/{normalizedName}/{normalizedVersion}/{normalizedName}.{normalizedVersion}.snupkg"
+        };
+
+        log?.Invoke($"Trying symbol package: {normalizedName}.{normalizedVersion}.snupkg");
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            foreach (var snupkgUrl in snupkgUrls)
+            {
+                response = await HttpRetryHelper.GetWithRetryAsync(_client, snupkgUrl, log: log);
+                if (response != null && response.IsSuccessStatusCode)
+                {
+                    log?.Invoke($"Found symbol package at: {snupkgUrl}");
+                    break;
+                }
+                response?.Dispose();
+                response = null;
+            }
+
+            if (response == null || !response.IsSuccessStatusCode)
+            {
+                log?.Invoke("Symbol package not found on NuGet");
+                return new PdbDownloadResult(null, windowsPdbDetected);
+            }
+
+            var tempDir = Path.Combine(Path.GetTempPath(), $"snupkg-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var snupkgPath = Path.Combine(tempDir, "package.snupkg");
+                using (var fs = File.Create(snupkgPath))
+                {
+                    await response.Content.CopyToAsync(fs);
+                }
+                response.Dispose();
+                response = null;
+
+                var extractPath = Path.Combine(tempDir, "extracted");
+                ZipFile.ExtractToDirectory(snupkgPath, extractPath);
+
+                var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+                var pdbFiles = Directory.GetFiles(extractPath, $"{assemblyName}.pdb", SearchOption.AllDirectories);
+
+                if (pdbFiles.Length == 0)
+                {
+                    log?.Invoke("No matching PDB found in symbol package");
+                    return new PdbDownloadResult(null, windowsPdbDetected);
+                }
+
+                var pdbFile = pdbFiles[0];
+                var cachePath = EnsureCachedPdbPath(normalizedName, normalizedVersion, assemblyPath);
+                if (cachePath != null)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+                    File.Copy(pdbFile, cachePath, overwrite: true);
+                    log?.Invoke($"Cached PDB to: {cachePath}");
+                    pdbFile = cachePath;
+                }
+
+                var headerCheck = CheckPdbHeader(pdbFile);
+                if (headerCheck == PdbHeaderKind.Portable)
+                {
+                    log?.Invoke("Successfully located PDB from symbol package");
+                    return new PdbDownloadResult(pdbFile, SymbolServer: "nuget.org");
+                }
+                if (headerCheck == PdbHeaderKind.Windows)
+                    windowsPdbDetected = true;
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Error downloading symbol package: {ex.Message}");
         }
         finally
         {
-            result.Provider?.Dispose();
+            response?.Dispose();
         }
+
+        return new PdbDownloadResult(null, windowsPdbDetected);
     }
+
+    private async Task<PdbDownloadResult> TryLocateFromSymbolServerAsync(
+        string pdbFileName, string symbolKey, Action<string>? log)
+    {
+        bool windowsPdbDetected = false;
+
+        var symbolServers = new[]
+        {
+            "https://symbols.nuget.org/download/symbols",
+            "https://msdl.microsoft.com/download/symbols"
+        };
+
+        foreach (var server in symbolServers)
+        {
+            var url = $"{server}/{pdbFileName}/{symbolKey}/{pdbFileName}";
+            log?.Invoke($"Trying symbol server: {server}");
+
+            try
+            {
+                using var response = await HttpRetryHelper.GetWithRetryAsync(_client, url, log: log);
+                if (response == null || !response.IsSuccessStatusCode)
+                    continue;
+
+                var cachePath = GetSymbolServerCachePath(pdbFileName, symbolKey);
+                Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+
+                using (var fs = File.Create(cachePath))
+                {
+                    await response.Content.CopyToAsync(fs);
+                }
+
+                var headerCheck = CheckPdbHeader(cachePath);
+                if (headerCheck == PdbHeaderKind.Portable)
+                {
+                    var serverHost = new Uri(server).Host;
+                    log?.Invoke("Successfully downloaded PDB from symbol server");
+                    return new PdbDownloadResult(cachePath, SymbolServer: serverHost);
+                }
+                if (headerCheck == PdbHeaderKind.Windows)
+                {
+                    windowsPdbDetected = true;
+                    log?.Invoke("Symbol server returned a Windows PDB (not supported)");
+                }
+            }
+            catch (Exception ex)
+            {
+                log?.Invoke($"Symbol server error: {ex.Message}");
+            }
+        }
+
+        return new PdbDownloadResult(null, windowsPdbDetected);
+    }
+
+    // ===== Reader-returning variants (legacy, used by GetPdbReaderAsync) =====
 
     private async Task<PdbLookupResult> TryDownloadSymbolPackageAsync(
         string packageName,
@@ -308,10 +569,10 @@ public class SymbolPackageDownloader(HttpClient client)
         var pdbName = Path.GetFileName(codeView.Path);
         var guid = codeView.Guid.ToString("N").ToUpperInvariant();
         var age = codeView.Age;
-        
+
         // Portable PDBs use FFFFFFFF, Windows PDBs use the actual age
-        var symbolKey = isPortablePdb 
-            ? $"{guid}FFFFFFFF" 
+        var symbolKey = isPortablePdb
+            ? $"{guid}FFFFFFFF"
             : $"{guid}{age:x}";
 
         // Try NuGet symbol server first (typically has Portable PDBs)
@@ -390,11 +651,11 @@ public class SymbolPackageDownloader(HttpClient client)
         var pdbName = Path.GetFileName(codeView.Path);
         var guid = codeView.Guid.ToString("N").ToUpperInvariant();
         var age = codeView.Age;
-        
+
         // Portable PDBs use FFFFFFFF, Windows PDBs use the actual age
         // See: https://github.com/dotnet/symstore/blob/main/src/Microsoft.SymbolStore/KeyGenerators/PortablePDBFileKeyGenerator.cs
-        var symbolKey = isPortablePdb 
-            ? $"{guid}FFFFFFFF" 
+        var symbolKey = isPortablePdb
+            ? $"{guid}FFFFFFFF"
             : $"{guid}{age:x}";
 
         // Check cache first
@@ -448,6 +709,32 @@ public class SymbolPackageDownloader(HttpClient client)
         return new PdbLookupResult(null, null, windowsPdbDetected);
     }
 
+    // ===== Shared helpers =====
+
+    private enum PdbHeaderKind { Unknown, Portable, Windows }
+
+    private static PdbHeaderKind CheckPdbHeader(string pdbPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(pdbPath);
+            byte[] header = new byte[4];
+            if (stream.Read(header, 0, 4) < 4)
+                return PdbHeaderKind.Unknown;
+
+            if (header[0] == 'B' && header[1] == 'S' && header[2] == 'J' && header[3] == 'B')
+                return PdbHeaderKind.Portable;
+            if (header[0] == 'M' && header[1] == 'i' && header[2] == 'c' && header[3] == 'r')
+                return PdbHeaderKind.Windows;
+
+            return PdbHeaderKind.Unknown;
+        }
+        catch
+        {
+            return PdbHeaderKind.Unknown;
+        }
+    }
+
     private (MetadataReader? reader, IDisposable? provider, bool isWindowsPdb) TryReadPortablePdb(string pdbPath, Action<string>? log)
     {
         try
@@ -492,25 +779,6 @@ public class SymbolPackageDownloader(HttpClient client)
     private string GetSymbolServerCachePath(string pdbName, string symbolKey)
     {
         return Path.Combine(_cachePath, "servers", pdbName, symbolKey, pdbName);
-    }
-
-    private static readonly Guid SourceLinkGuid = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-
-    private static string? ExtractSourceLinkFromReader(MetadataReader reader)
-    {
-        foreach (CustomDebugInformationHandle handle in reader.CustomDebugInformation)
-        {
-            CustomDebugInformation info = reader.GetCustomDebugInformation(handle);
-            Guid kind = reader.GetGuid(info.Kind);
-
-            if (kind == SourceLinkGuid)
-            {
-                byte[] bytes = reader.GetBlobBytes(info.Value);
-                return System.Text.Encoding.UTF8.GetString(bytes);
-            }
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ApiServices.cs
+++ b/src/dotnet-inspect/Commands/ApiServices.cs
@@ -1,6 +1,4 @@
 using DotnetInspector.Packages;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -331,6 +329,30 @@ internal static class ApiServices
         }
     }
 
+    // ===== PDB Acquisition Helper =====
+
+    /// <summary>
+    /// Orchestrates PDB download for a PdbContext. Shared by AssemblyCommand and API enrichment.
+    /// </summary>
+    internal static async Task AcquirePdbAsync(
+        PdbContext context, HttpClient httpClient,
+        string? packageName, string? packageVersion,
+        bool isPlatformAssembly, Action<string>? log)
+    {
+        if (!context.NeedsPdb) return;
+
+        var downloader = new SymbolPackageDownloader(httpClient);
+        var result = await downloader.DownloadPdbAsync(
+            context.PdbId!.Guid, context.PdbId.Age, context.PdbId.PdbFileName,
+            context.PdbId.IsPortable, context.AssemblyPath,
+            packageName, packageVersion, log, isPlatformAssembly);
+
+        if (result.PdbFilePath != null)
+            context.LoadPdbFromFile(result.PdbFilePath, "Symbol Package", result.SymbolServer);
+        else if (result.WindowsPdbDetected)
+            context.WindowsPdbDetected = true;
+    }
+
     // ===== Enrichment Pipeline =====
 
     internal static async Task EnrichTypeWithSourceInfoAsync(ApiType apiType, string typeName, string dllPath, ApiOptions options, VerboseLogger logger, HttpClient httpClient)
@@ -343,10 +365,9 @@ internal static class ApiServices
 
         try
         {
-            using FileStream stream = File.OpenRead(dllPath);
-            using PEReader peReader = new(stream);
+            using var context = PdbContext.Open(dllPath, logger.Log);
 
-            if (!peReader.HasMetadata)
+            if (!context.HasMetadata)
             {
                 logger.Log("No metadata in assembly, cannot resolve source.");
                 return;
@@ -364,12 +385,10 @@ internal static class ApiServices
                 }
             }
 
-            var symbolDownloader = new SymbolPackageDownloader(httpClient);
-            var pdbResult = await symbolDownloader.GetPdbReaderAsync(
-                peReader, dllPath, packageName, packageVersion, logger.Log,
-                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly));
+            await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
+                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
 
-            if (pdbResult.Reader == null || pdbResult.Provider == null)
+            if (!context.HasPdb)
             {
                 if (!string.IsNullOrEmpty(options.PlatformAssembly) && options.ShowDocs)
                 {
@@ -379,7 +398,7 @@ internal static class ApiServices
                 }
 
                 Console.Error.WriteLine();
-                if (pdbResult.WindowsPdbDetected)
+                if (context.WindowsPdbDetected)
                 {
                     Console.Error.WriteLine("Warning: PDB could not be read (Windows PDB format is not supported).");
                     Console.Error.WriteLine("         Only Portable PDBs are supported. Consider asking the maintainer");
@@ -394,23 +413,16 @@ internal static class ApiServices
                 return;
             }
 
-            var pdbReader = pdbResult.Reader;
-            var pdbProvider = pdbResult.Provider;
-
-            using var _ = pdbProvider;
-            var metadataReader = peReader.GetMetadataReader();
-
-            var resolver = SourceLinkResolver.Create(pdbReader);
-            if (resolver == null)
+            if (!context.HasSourceLink)
             {
                 logger.Log("No SourceLink information found in PDB.");
                 return;
             }
 
-            var sourceInfo = resolver.ResolveTypeSource(metadataReader, pdbReader, typeName);
+            var sourceInfo = context.ResolveTypeSource(typeName);
             if (sourceInfo == null)
             {
-                var forwardTarget = FindTypeForwarderTarget(metadataReader, typeName);
+                var forwardTarget = context.FindTypeForwarder(typeName);
                 if (forwardTarget != null)
                 {
                     logger.Log($"Type '{typeName}' is forwarded to '{forwardTarget}'.");
@@ -542,23 +554,20 @@ internal static class ApiServices
             }
         }
 
-        using FileStream stream = File.OpenRead(dllPath);
-        using PEReader peReader = new(stream);
+        using var context = PdbContext.Open(dllPath, logger.Log);
 
-        if (!peReader.HasMetadata)
+        if (!context.HasMetadata)
         {
             logger.Log("No metadata in assembly, cannot resolve source.");
             return;
         }
 
-        var symbolDownloader = new SymbolPackageDownloader(httpClient);
-        var pdbResult = await symbolDownloader.GetPdbReaderAsync(
-            peReader, dllPath, packageName, packageVersion, logger.Log,
-            isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly));
+        await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
+            isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
 
-        if (pdbResult.Reader == null || pdbResult.Provider == null)
+        if (!context.HasPdb)
         {
-            if (pdbResult.WindowsPdbDetected)
+            if (context.WindowsPdbDetected)
             {
                 Console.Error.WriteLine();
                 Console.Error.WriteLine("Warning: PDB could not be read (Windows PDB format is not supported).");
@@ -568,12 +577,11 @@ internal static class ApiServices
             return;
         }
 
-        using var _ = pdbResult.Provider;
-        var pdbReader = pdbResult.Reader;
-        var metadataReader = peReader.GetMetadataReader();
+        var resolver = context.GetResolver();
+        var pdbReader = context.GetPdbReader();
+        var metadataReader = context.GetMetadataReader();
 
-        var resolver = SourceLinkResolver.Create(pdbReader);
-        if (resolver == null)
+        if (resolver == null || pdbReader == null || metadataReader == null)
         {
             logger.Log("No SourceLink information found in PDB.");
             return;
@@ -854,10 +862,9 @@ internal static class ApiServices
     {
         try
         {
-            using FileStream stream = File.OpenRead(dllPath);
-            using PEReader peReader = new(stream);
+            using var context = PdbContext.Open(dllPath, logger.Log);
 
-            if (!peReader.HasMetadata)
+            if (!context.HasMetadata)
                 return null;
 
             string? packageName = null;
@@ -871,17 +878,10 @@ internal static class ApiServices
                 }
             }
 
-            var symbolDownloader = new SymbolPackageDownloader(httpClient);
-            var pdbResult = await symbolDownloader.GetPdbReaderAsync(
-                peReader, dllPath, packageName, packageVersion, logger.Log,
-                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly));
+            await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
+                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
 
-            if (pdbResult.Reader == null || pdbResult.Provider == null)
-                return null;
-
-            using var _ = pdbResult.Provider;
-
-            return SourceLinkResolver.ExtractRepositoryUrl(pdbResult.Reader);
+            return context.ExtractRepositoryUrl();
         }
         catch (Exception ex)
         {
@@ -891,30 +891,6 @@ internal static class ApiServices
     }
 
     // ===== Private Enrichment Helpers =====
-
-    private static string? FindTypeForwarderTarget(MetadataReader reader, string typeName)
-    {
-        foreach (var exportedTypeHandle in reader.ExportedTypes)
-        {
-            var exportedType = reader.GetExportedType(exportedTypeHandle);
-            if (!exportedType.IsForwarder)
-                continue;
-
-            var name = reader.GetString(exportedType.Name);
-            var ns = reader.GetString(exportedType.Namespace);
-            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-
-            if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
-            {
-                if (exportedType.Implementation.Kind == HandleKind.AssemblyReference)
-                {
-                    var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)exportedType.Implementation);
-                    return reader.GetString(assemblyRef.Name);
-                }
-            }
-        }
-        return null;
-    }
 
     private static async Task<bool> TryEnrichFromForwardedAssemblyAsync(
         ApiType apiType,

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -1,6 +1,4 @@
 using System.IO.Compression;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text.Json;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -19,8 +17,8 @@ public class AssemblyCommand
     public static async Task<int> ExecuteAsync(string? assemblyPath, AssemblyOptions options)
     {
         // Check for valid input source
-        if (string.IsNullOrEmpty(assemblyPath) && 
-            string.IsNullOrEmpty(options.PackagePath) && 
+        if (string.IsNullOrEmpty(assemblyPath) &&
+            string.IsNullOrEmpty(options.PackagePath) &&
             string.IsNullOrEmpty(options.PlatformAssembly))
         {
             Console.Error.WriteLine("Error: Assembly path, --package, or --platform required.");
@@ -58,7 +56,7 @@ public class AssemblyCommand
                 }
 
                 logger.Log($"Using platform runtime assembly: {framework} {version}");
-                
+
                 var audit = await InspectAssemblyAsync(resolvedPath!, options, logger, null, null, context.HttpClient, isPlatformAssembly: true);
                 if (audit == null)
                 {
@@ -410,16 +408,12 @@ public class AssemblyCommand
 
         try
         {
-            using FileStream stream = File.OpenRead(path);
-            using PEReader peReader = new(stream);
+            using var pdbContext = PdbContext.Open(path, logger.Log);
 
-            if (!peReader.HasMetadata)
+            if (!pdbContext.HasMetadata)
             {
                 // Native binary - still provide basic info
-                var nativeInfo = AssemblyInspector.CreateNativeInfo(peReader);
-                bool isNativeAot = AssemblyInspector.DetectNativeAot(peReader);
-                nativeInfo.IsNativeAot = isNativeAot;
-                nativeInfo.CompilationType = isNativeAot ? "NativeAOT" : "Native";
+                var nativeInfo = pdbContext.CreateNativeInfo();
 
                 return new AssemblyAudit
                 {
@@ -436,7 +430,7 @@ public class AssemblyCommand
             };
 
             // Always extract basic assembly info
-            audit.AssemblyInfo = AssemblyInspector.ExtractAssemblyInfo(peReader, options.IncludeReferences || options.TransitiveReferences);
+            audit.AssemblyInfo = pdbContext.ExtractAssemblyInfo(options.IncludeReferences || options.TransitiveReferences);
 
             // Build transitive reference tree if requested
             if (options.TransitiveReferences && audit.AssemblyInfo?.References != null)
@@ -455,7 +449,7 @@ public class AssemblyCommand
             // Audit if requested
             if (options.IncludeAudit)
             {
-                await AuditAssemblyAsync(peReader, audit, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, options.StrictAudit);
+                await AuditAssemblyAsync(pdbContext, audit, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, options.StrictAudit);
             }
 
             return audit;
@@ -467,7 +461,7 @@ public class AssemblyCommand
     }
 
     private static async Task AuditAssemblyAsync(
-        PEReader peReader,
+        PdbContext pdbContext,
         AssemblyAudit audit,
         string assemblyPath,
         string? packageName,
@@ -477,105 +471,47 @@ public class AssemblyCommand
         bool isPlatformAssembly = false,
         bool strictAudit = false)
     {
-        MetadataReaderProvider? embeddedPdbProvider = null;
-        IDisposable? externalPdbProvider = null;
-        MetadataReader? pdbReader = null;
-        foreach (var entry in peReader.ReadDebugDirectory())
+        // Populate audit from PdbContext properties (debug directory already read by Open)
+        audit.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
+        audit.HasEmbeddedPdb = pdbContext.HasEmbeddedPdb;
+        audit.PdbPath = pdbContext.CodeViewPdbPath;
+        audit.HasNormalizedPaths = pdbContext.HasNormalizedPaths;
+        audit.NonNormalizedPaths = pdbContext.NonNormalizedPaths;
+
+        // If embedded PDB was found, it's already loaded
+        if (pdbContext.HasPdb)
         {
-            if (entry.Type == DebugDirectoryEntryType.Reproducible)
-            {
-                audit.HasReproducibleFlag = true;
-            }
-
-            if (entry.Type == DebugDirectoryEntryType.CodeView)
-            {
-                var cvData = peReader.ReadCodeViewDebugDirectoryData(entry);
-                audit.PdbPath = cvData.Path;
-
-                if (!cvData.Path.StartsWith("/_/", StringComparison.Ordinal) &&
-                    Path.GetDirectoryName(cvData.Path) is string dir && !string.IsNullOrEmpty(dir))
-                {
-                    audit.HasNormalizedPaths = false;
-                    audit.NonNormalizedPaths ??= [];
-                    audit.NonNormalizedPaths.Add($"PDB Path: {cvData.Path}");
-                }
-                else
-                {
-                    audit.HasNormalizedPaths = true;
-                }
-            }
-
-            if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
-            {
-                audit.HasEmbeddedPdb = true;
-                audit.PdbFormat = "Portable";
-                audit.PdbLocation = "Embedded";
-                embeddedPdbProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
-                pdbReader = embeddedPdbProvider.GetMetadataReader();
-
-                string? sourceLink = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
-                if (sourceLink != null)
-                {
-                    audit.HasSourceLink = true;
-                    audit.SourceLinkJson = sourceLink;
-                }
-            }
+            audit.PdbFormat = pdbContext.PdbFormat;
+            audit.PdbLocation = pdbContext.PdbLocation;
+            audit.HasSourceLink = pdbContext.HasSourceLink;
+            audit.SourceLinkJson = pdbContext.SourceLinkJson;
         }
 
-        // Check for standalone PDB file (if no embedded PDB)
-        if (!audit.HasEmbeddedPdb)
+        // Check for standalone PDB file (already attempted by PdbContext.Open via TryLoadLocalPdb)
+        if (!pdbContext.HasPdb && pdbContext.WindowsPdbDetected)
         {
-            var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
-            if (File.Exists(pdbPath))
+            audit.WindowsPdbDetected = true;
+            audit.PdbFormat = pdbContext.PdbFormat;
+            audit.PdbLocation = pdbContext.PdbLocation;
+        }
+
+        // If no local PDB, try downloading
+        if (!pdbContext.HasPdb && !pdbContext.WindowsPdbDetected)
+        {
+            await ApiServices.AcquirePdbAsync(pdbContext, httpClient, packageName, packageVersion, isPlatformAssembly, logger.Log);
+
+            if (pdbContext.HasPdb)
             {
-                if (AssemblyInspector.IsWindowsPdb(pdbPath))
-                {
-                    audit.WindowsPdbDetected = true;
-                    audit.PdbFormat = "Windows";
-                    audit.PdbLocation = "Standalone";
-                }
-                else if (AssemblyInspector.IsPortablePdb(pdbPath))
-                {
-                    audit.PdbFormat = "Portable";
-                    audit.PdbLocation = "Standalone";
-                    // Open the PDB reader for potential strict verification
-                    var stream = File.OpenRead(pdbPath);
-                    var standalonePdbProvider = MetadataReaderProvider.FromPortablePdbStream(stream);
-                    externalPdbProvider = standalonePdbProvider;
-                    pdbReader = standalonePdbProvider.GetMetadataReader();
-                    audit.SourceLinkJson = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
-                    audit.HasSourceLink = audit.SourceLinkJson != null;
-                }
+                audit.PdbFormat = pdbContext.PdbFormat;
+                audit.PdbLocation = pdbContext.PdbLocation;
+                audit.SymbolServer = pdbContext.SymbolServer;
+                audit.HasSourceLink = pdbContext.HasSourceLink;
+                audit.SourceLinkJson = pdbContext.SourceLinkJson;
             }
-            else
+            else if (pdbContext.WindowsPdbDetected)
             {
-                // No local PDB - try to fetch from symbol package or symbol server
-                var symbolDownloader = new SymbolPackageDownloader(httpClient);
-                var pdbResult = await symbolDownloader.GetPdbReaderAsync(
-                    peReader, assemblyPath, packageName, packageVersion, logger.Log, isPlatformAssembly);
-
-                if (pdbResult.Reader != null && pdbResult.Provider != null)
-                {
-                    externalPdbProvider = pdbResult.Provider;
-                    pdbReader = pdbResult.Reader;
-                    audit.PdbFormat = "Portable";
-                    audit.PdbLocation = "Symbol Package";
-                    audit.SymbolServer = pdbResult.SymbolServer;
-
-                    string? sourceLink = AssemblyInspector.ExtractSourceLinkFromReader(pdbReader);
-                    if (sourceLink != null)
-                    {
-                        audit.HasSourceLink = true;
-                        audit.SourceLinkJson = sourceLink;
-                    }
-                }
-                else if (pdbResult.WindowsPdbDetected)
-                {
-                    audit.WindowsPdbDetected = true;
-                    audit.PdbFormat = "Windows";
-                    // Location unknown - we found it but can't read it
-                }
-                // else: no PDB found, leave Format and Location as null (Unknown)
+                audit.WindowsPdbDetected = true;
+                audit.PdbFormat = "Windows";
             }
         }
 
@@ -605,86 +541,47 @@ public class AssemblyCommand
         audit.Builder = InferBuilder(audit);
 
         // Strict verification: check that all source files are accessible
-        if (strictAudit && pdbReader != null && audit.HasSourceLink && audit.SourceLinkJson != null)
+        if (strictAudit && pdbContext.HasPdb && audit.HasSourceLink && audit.SourceLinkJson != null)
         {
             logger.Log("Running strict source verification...");
-            await VerifySourceAccessibilityAsync(pdbReader, audit, httpClient, logger);
+            await VerifySourceAccessibilityAsync(pdbContext, audit, httpClient, logger);
         }
-
-        // Cleanup PDB providers
-        embeddedPdbProvider?.Dispose();
-        externalPdbProvider?.Dispose();
     }
 
     /// <summary>
     /// Verifies that all source files in the PDB are accessible via SourceLink or embedded.
     /// </summary>
     private static async Task VerifySourceAccessibilityAsync(
-        MetadataReader pdbReader,
+        PdbContext pdbContext,
         AssemblyAudit audit,
         HttpClient httpClient,
         VerboseLogger logger)
     {
-        var sourceLinkMappings = ParseSourceLinkMappings(audit.SourceLinkJson!);
-        if (sourceLinkMappings.Count == 0)
-        {
-            audit.AllSourcesAccessible = false;
-            return;
-        }
-
-        // GUID for embedded source: 0E8A571B-6926-466E-B4AD-8AB04611F5FE
-        var embeddedSourceGuid = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
-
         int totalFiles = 0;
         int accessibleFiles = 0;
         int embeddedFiles = 0;
         var missingFiles = new List<string>();
 
-        foreach (var docHandle in pdbReader.Documents)
+        foreach (var doc in pdbContext.EnumerateSourceDocuments())
         {
-            var document = pdbReader.GetDocument(docHandle);
-            string filePath = pdbReader.GetString(document.Name);
+            totalFiles++;
 
-            // Skip non-source files (e.g., compiled resources)
-            if (!filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) &&
-                !filePath.EndsWith(".vb", StringComparison.OrdinalIgnoreCase) &&
-                !filePath.EndsWith(".fs", StringComparison.OrdinalIgnoreCase))
+            if (doc.IsEmbedded)
             {
+                embeddedFiles++;
                 continue;
             }
 
-            totalFiles++;
-
-            // Check if source is embedded
-            bool isEmbedded = false;
-            foreach (var cdiHandle in pdbReader.GetCustomDebugInformation(docHandle))
+            if (doc.ResolvedUrl == null)
             {
-                var cdi = pdbReader.GetCustomDebugInformation(cdiHandle);
-                if (pdbReader.GetGuid(cdi.Kind) == embeddedSourceGuid)
-                {
-                    isEmbedded = true;
-                    embeddedFiles++;
-                    break;
-                }
-            }
-
-            if (isEmbedded)
-            {
-                continue; // Source is embedded, no need to verify URL
-            }
-
-            // Try to resolve SourceLink URL and verify accessibility
-            string? sourceUrl = ApplySourceLinkMapping(filePath, sourceLinkMappings);
-            if (sourceUrl == null)
-            {
-                missingFiles.Add(filePath);
+                missingFiles.Add(doc.FilePath);
                 continue;
             }
 
             // Check if URL is accessible (HTTP HEAD request)
             try
             {
-                using var request = new HttpRequestMessage(HttpMethod.Head, sourceUrl);
+                using var request = new HttpRequestMessage(HttpMethod.Head, doc.ResolvedUrl);
                 using var response = await httpClient.SendAsync(request);
                 if (response.IsSuccessStatusCode)
                 {
@@ -692,14 +589,14 @@ public class AssemblyCommand
                 }
                 else
                 {
-                    missingFiles.Add(filePath);
-                    logger.Log($"  Source not accessible: {filePath} ({response.StatusCode})");
+                    missingFiles.Add(doc.FilePath);
+                    logger.Log($"  Source not accessible: {doc.FilePath} ({response.StatusCode})");
                 }
             }
             catch
             {
-                missingFiles.Add(filePath);
-                logger.Log($"  Source not accessible: {filePath} (request failed)");
+                missingFiles.Add(doc.FilePath);
+                logger.Log($"  Source not accessible: {doc.FilePath} (request failed)");
             }
         }
 
@@ -710,48 +607,6 @@ public class AssemblyCommand
         audit.MissingSourceFiles = missingFiles.Count > 0 ? missingFiles : null;
 
         logger.Log($"Source coverage: {accessibleFiles + embeddedFiles}/{totalFiles} files accessible");
-    }
-
-    private static Dictionary<string, string> ParseSourceLinkMappings(string sourceLinkJson)
-    {
-        var mappings = new Dictionary<string, string>();
-        try
-        {
-            using var doc = JsonDocument.Parse(sourceLinkJson);
-            if (doc.RootElement.TryGetProperty("documents", out var documents))
-            {
-                foreach (var prop in documents.EnumerateObject())
-                {
-                    mappings[prop.Name] = prop.Value.GetString() ?? "";
-                }
-            }
-        }
-        catch
-        {
-            // Invalid JSON
-        }
-        return mappings;
-    }
-
-    private static string? ApplySourceLinkMapping(string filePath, Dictionary<string, string> mappings)
-    {
-        foreach (var (pattern, urlTemplate) in mappings)
-        {
-            if (pattern.EndsWith("*"))
-            {
-                string prefix = pattern[..^1];
-                if (filePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    string relativePath = filePath[prefix.Length..];
-                    return urlTemplate.Replace("*", relativePath);
-                }
-            }
-            else if (filePath.Equals(pattern, StringComparison.OrdinalIgnoreCase))
-            {
-                return urlTemplate;
-            }
-        }
-        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **New `PdbContext` class** in `DotnetInspector.Metadata` wraps PE + PDB readers behind a public API with zero `System.Reflection.Metadata` types in its signatures
- **New `DownloadPdbAsync` method** on `SymbolPackageDownloader` accepts/returns primitive types (`Guid`, `string`, `bool`) instead of SRM types, returning a `PdbDownloadResult` POCO
- **Refactored `AssemblyCommand` and `ApiServices`** to use the three-step orchestration pattern (`PdbContext.Open()` → `DownloadPdbAsync()` → `LoadPdbFromFile()`), removing all SRM imports from the CLI project
- **Shared `AcquirePdbAsync` helper** in `ApiServices` deduplicates PDB download orchestration between `AssemblyCommand` and API enrichment
- Made `SourceLinkResolver.ApplySourceLinkMapping` public (used by `PdbContext.EnumerateSourceDocuments`)

After this change, `grep -rn "using System.Reflection.Metadata\|using System.Reflection.PortableExecutable" src/dotnet-inspect/` returns nothing — SRM is fully encapsulated in the Metadata library.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 324 tests pass
- [x] Verified zero SRM imports in `src/dotnet-inspect/` via grep
- [ ] `dotnet run --project src/dotnet-inspect -- assembly --audit --package Newtonsoft.Json`
- [ ] `dotnet run --project src/dotnet-inspect -- api JsonConvert --package Newtonsoft.Json --docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)