### PR TITLE
Add src/Directory.Build.props, fix warnings, validate package version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,2 @@
 <Project>
-
-  <PropertyGroup>
-    <UseArtifactsOutput>true</UseArtifactsOutput>
-    <IncludeProjectNameInArtifactsPaths>true</IncludeProjectNameInArtifactsPaths>
-  </PropertyGroup>
-
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
+    <IncludeProjectNameInArtifactsPaths>true</IncludeProjectNameInArtifactsPaths>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Markout;
 
 namespace DotnetInspector.Metadata;
 
@@ -16,6 +17,7 @@ public class DocComment
     /// <summary>
     /// Sample code references extracted from doc comments.
     /// </summary>
+    [MarkoutIgnoreInTable]
     public List<SampleReference>? Samples { get; set; }
 }
 
@@ -77,6 +79,7 @@ public class ApiSurface
     /// </summary>
     public string? Name { get; set; }
 
+    [MarkoutIgnoreInTable]
     public List<ApiType> Types { get; set; } = [];
 
     public int PublicTypeCount { get; set; }
@@ -98,6 +101,7 @@ public class ApiSurface
     /// <summary>
     /// Type forwarders in this assembly (types re-exported from other assemblies).
     /// </summary>
+    [MarkoutIgnoreInTable]
     public List<TypeForwarder> TypeForwarders { get; set; } = [];
 
     /// <summary>
@@ -142,6 +146,7 @@ public class TypeParameter
     /// Includes special constraints (class, struct, notnull, unmanaged, new())
     /// and type constraints (interfaces, base class).
     /// </summary>
+    [MarkoutIgnoreInTable]
     public List<string> Constraints { get; set; } = [];
 
     /// <summary>
@@ -170,18 +175,22 @@ public class ApiType
     public bool IsStatic { get; set; }
 
     public string? BaseType { get; set; }
+    [MarkoutIgnoreInTable]
     public List<string>? Interfaces { get; set; }
 
     /// <summary>
     /// Known derived types within the same assembly.
     /// </summary>
+    [MarkoutIgnoreInTable]
     public List<string>? DerivedTypes { get; set; }
 
     /// <summary>
     /// Generic type parameters with their constraints.
     /// </summary>
+    [MarkoutIgnoreInTable]
     public List<TypeParameter>? TypeParameters { get; set; }
 
+    [MarkoutIgnoreInTable]
     public List<ApiMember>? Members { get; set; }
 
     // Source information (populated with --source-url)
@@ -207,6 +216,7 @@ public class ApiType
     /// Additional source files for partial types. Only populated when type spans multiple files.
     /// </summary>
     [JsonPropertyName("additional_source_files")]
+    [MarkoutIgnoreInTable]
     public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
 
     /// <summary>
@@ -216,6 +226,7 @@ public class ApiType
     public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
 
     // Documentation (populated with --docs)
+    [MarkoutIgnoreInTable]
     public DocComment? Documentation { get; set; }
 }
 
@@ -253,5 +264,6 @@ public class ApiMember
     public int? SourceLineNumber { get; set; }
 
     // Documentation (populated with --docs)
+    [MarkoutIgnoreInTable]
     public DocComment? Documentation { get; set; }
 }

--- a/src/DotnetInspector.Metadata/AssemblyInfo.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Markout;
 
 namespace DotnetInspector.Metadata;
 
@@ -87,11 +88,13 @@ public class AssemblyInfo
     /// List of assemblies referenced by this assembly.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [MarkoutIgnoreInTable]
     public List<AssemblyReference>? References { get; set; }
 
     /// <summary>
     /// Transitive reference tree (when --transitive is used).
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [MarkoutIgnoreInTable]
     public List<AssemblyReferenceNode>? TransitiveReferences { get; set; }
 }

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14.0</LangVersion>
-    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,6 +16,11 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-inspect" />
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
+  </ItemGroup>
+
+  <!-- Markout attribute-only: ExcludeAssets="analyzers" skips source gen, keeps [MarkoutIgnoreInTable] -->
+  <ItemGroup>
+    <PackageReference Include="Markout" Version="0.3.1" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <!-- System.Reflection.Metadata is part of net10.0 BCL -->

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14.0</LangVersion>
-    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -104,6 +104,16 @@ public class PackageCommand
                 version = latestVersion;
             }
 
+            // Validate version looks like a NuGet version
+            if (!NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+            {
+                string badVersion = packageArgs.Length >= 2 ? packageArgs[1] : version;
+                Console.Error.WriteLine($"Error: '{badVersion}' is not a valid package version.");
+                Console.Error.WriteLine("Versions look like: 1.0.0, 8.0.5, 13.0.3-beta1");
+                Console.Error.WriteLine($"To list available versions: dotnet-inspect package {packageName} --versions");
+                return 1;
+            }
+
             tempDir = Path.Combine(Path.GetTempPath(), $"inspect-{packageName}-{version}-{Guid.NewGuid():N}");
         }
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14.0</LangVersion>
-    <IsAotCompatible>true</IsAotCompatible>
     <RollForward>LatestMajor</RollForward>
     <!-- Size optimizations for Native AOT (11M → 9.8M) -->
     <StackTraceSupport>false</StackTraceSupport>


### PR DESCRIPTION
## Summary

- **Centralize build properties** in `src/Directory.Build.props`: `TreatWarningsAsErrors`, `UseArtifactsOutput`, `IncludeProjectNameInArtifactsPaths`, `IsAotCompatible` — removed duplicates from individual csproj files
- **Fix all 13 MARKOUT001 warnings** by adding `[MarkoutIgnoreInTable]` to complex/array properties in `ApiSurface.cs` and `AssemblyInfo.cs` (added Markout reference to Metadata with `ExcludeAssets="analyzers"`)
- **Validate package version early** — `NuGetVersion.TryParse` check before attempting download, with clear error message and `--versions` hint

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 324 tests pass
- [x] `dotnet run -- package System.Text.Json JsonSerializer` → clear error: `'JsonSerializer' is not a valid package version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)