### PR TITLE
Add ApiDiffAnalyzer service to DotnetInspector.Metadata

### DIFF
--- a/src/DotnetInspector.Metadata/ApiDiffAnalyzer.cs
+++ b/src/DotnetInspector.Metadata/ApiDiffAnalyzer.cs
@@ -1,0 +1,437 @@
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Classification of an API change's impact on consumers.
+/// </summary>
+public enum ChangeClassification
+{
+    /// <summary>New API that doesn't affect existing consumers.</summary>
+    Additive,
+    /// <summary>Change that will break existing consumers.</summary>
+    Breaking,
+    /// <summary>Change that may break some consumers depending on usage.</summary>
+    PotentiallyBreaking
+}
+
+/// <summary>
+/// The specific kind of API change detected.
+/// </summary>
+public enum ChangeKind
+{
+    // Type-level
+    TypeAdded,
+    TypeRemoved,
+    TypeKindChanged,
+    SealedAdded,
+    SealedRemoved,
+    AbstractAdded,
+    AbstractRemoved,
+    BaseTypeChanged,
+    InterfaceAdded,
+    InterfaceRemoved,
+    TypeParameterCountChanged,
+    TypeParameterVarianceChanged,
+    TypeParameterConstraintTightened,
+    TypeParameterConstraintLoosened,
+
+    // Member-level
+    MemberAdded,
+    MemberRemoved,
+    MemberSignatureChanged,
+    VirtualRemoved,
+    AbstractMemberAdded,
+    EnumValueChanged
+}
+
+/// <summary>
+/// A single detected API change.
+/// </summary>
+public record ApiChange(
+    ChangeKind Kind,
+    ChangeClassification Classification,
+    string Message,
+    string? OldValue = null,
+    string? NewValue = null);
+
+/// <summary>
+/// All changes detected for a single type.
+/// </summary>
+public record TypeDiff(string TypeFullName, IReadOnlyList<ApiChange> Changes)
+{
+    public int BreakingCount => CountByClassification(ChangeClassification.Breaking);
+    public int AdditiveCount => CountByClassification(ChangeClassification.Additive);
+    public int PotentiallyBreakingCount => CountByClassification(ChangeClassification.PotentiallyBreaking);
+
+    public bool IsAdded => Changes.Count == 1 && Changes[0].Kind == ChangeKind.TypeAdded;
+    public bool IsRemoved => Changes.Count == 1 && Changes[0].Kind == ChangeKind.TypeRemoved;
+
+    private int CountByClassification(ChangeClassification classification)
+    {
+        int count = 0;
+        foreach (var change in Changes)
+        {
+            if (change.Classification == classification)
+                count++;
+        }
+        return count;
+    }
+}
+
+/// <summary>
+/// The complete result of comparing two API surfaces.
+/// </summary>
+public class ApiDiff
+{
+    public IReadOnlyList<TypeDiff> TypeDiffs { get; init; } = [];
+    public int TotalBreaking { get; init; }
+    public int TotalAdditive { get; init; }
+    public int TotalPotentiallyBreaking { get; init; }
+    public bool IsEmpty => TypeDiffs.Count == 0;
+}
+
+/// <summary>
+/// Compares two <see cref="ApiSurface"/> instances and produces a structured diff
+/// with change classification (breaking, additive, potentially breaking).
+/// </summary>
+public static class ApiDiffAnalyzer
+{
+    public static ApiDiff Compare(ApiSurface oldSurface, ApiSurface newSurface)
+    {
+        var oldTypes = BuildTypeLookup(oldSurface);
+        var newTypes = BuildTypeLookup(newSurface);
+
+        var allTypeNames = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var key in oldTypes.Keys) allTypeNames.Add(key);
+        foreach (var key in newTypes.Keys) allTypeNames.Add(key);
+
+        var typeDiffs = new List<TypeDiff>();
+        int totalBreaking = 0;
+        int totalAdditive = 0;
+        int totalPotentiallyBreaking = 0;
+
+        foreach (var typeName in allTypeNames)
+        {
+            bool inOld = oldTypes.TryGetValue(typeName, out var oldType);
+            bool inNew = newTypes.TryGetValue(typeName, out var newType);
+
+            List<ApiChange> changes;
+
+            if (inOld && !inNew)
+            {
+                changes = [new ApiChange(ChangeKind.TypeRemoved, ChangeClassification.Breaking,
+                    $"Type '{typeName}' was removed")];
+            }
+            else if (!inOld && inNew)
+            {
+                changes = [new ApiChange(ChangeKind.TypeAdded, ChangeClassification.Additive,
+                    $"Type '{typeName}' was added")];
+            }
+            else
+            {
+                changes = CompareTypes(oldType!, newType!);
+            }
+
+            if (changes.Count > 0)
+            {
+                var diff = new TypeDiff(typeName, changes);
+                typeDiffs.Add(diff);
+                totalBreaking += diff.BreakingCount;
+                totalAdditive += diff.AdditiveCount;
+                totalPotentiallyBreaking += diff.PotentiallyBreakingCount;
+            }
+        }
+
+        return new ApiDiff
+        {
+            TypeDiffs = typeDiffs,
+            TotalBreaking = totalBreaking,
+            TotalAdditive = totalAdditive,
+            TotalPotentiallyBreaking = totalPotentiallyBreaking
+        };
+    }
+
+    private static Dictionary<string, ApiType> BuildTypeLookup(ApiSurface surface)
+    {
+        var lookup = new Dictionary<string, ApiType>(StringComparer.Ordinal);
+        foreach (var type in surface.Types)
+        {
+            lookup[type.FullName] = type;
+        }
+        return lookup;
+    }
+
+    private static List<ApiChange> CompareTypes(ApiType oldType, ApiType newType)
+    {
+        var changes = new List<ApiChange>();
+        CompareTypeMetadata(oldType, newType, changes);
+        CompareTypeParameters(oldType, newType, changes);
+        CompareMembers(oldType, newType, changes);
+        return changes;
+    }
+
+    private static void CompareTypeMetadata(ApiType oldType, ApiType newType, List<ApiChange> changes)
+    {
+        // Kind changed
+        if (oldType.Kind != newType.Kind)
+        {
+            changes.Add(new ApiChange(ChangeKind.TypeKindChanged, ChangeClassification.Breaking,
+                $"Type kind changed from '{oldType.Kind}' to '{newType.Kind}'",
+                oldType.Kind, newType.Kind));
+        }
+
+        // Sealed changes — skip for static types (IsSealed && IsAbstract both true)
+        bool oldIsStatic = oldType.IsSealed && oldType.IsAbstract;
+        bool newIsStatic = newType.IsSealed && newType.IsAbstract;
+
+        if (!oldIsStatic && !newIsStatic)
+        {
+            if (!oldType.IsSealed && newType.IsSealed)
+            {
+                changes.Add(new ApiChange(ChangeKind.SealedAdded, ChangeClassification.Breaking,
+                    "Type was sealed"));
+            }
+            else if (oldType.IsSealed && !newType.IsSealed)
+            {
+                changes.Add(new ApiChange(ChangeKind.SealedRemoved, ChangeClassification.Additive,
+                    "Type was unsealed"));
+            }
+
+            if (!oldType.IsAbstract && newType.IsAbstract)
+            {
+                changes.Add(new ApiChange(ChangeKind.AbstractAdded, ChangeClassification.Breaking,
+                    "Type was made abstract"));
+            }
+            else if (oldType.IsAbstract && !newType.IsAbstract)
+            {
+                changes.Add(new ApiChange(ChangeKind.AbstractRemoved, ChangeClassification.Additive,
+                    "Type was made non-abstract"));
+            }
+        }
+
+        // Base type changed
+        if (oldType.BaseType != newType.BaseType)
+        {
+            changes.Add(new ApiChange(ChangeKind.BaseTypeChanged, ChangeClassification.Breaking,
+                $"Base type changed from '{oldType.BaseType ?? "none"}' to '{newType.BaseType ?? "none"}'",
+                oldType.BaseType, newType.BaseType));
+        }
+
+        // Interfaces
+        var oldInterfaces = new HashSet<string>(oldType.Interfaces ?? [], StringComparer.Ordinal);
+        var newInterfaces = new HashSet<string>(newType.Interfaces ?? [], StringComparer.Ordinal);
+
+        foreach (var removed in oldInterfaces.Except(newInterfaces).Order())
+        {
+            changes.Add(new ApiChange(ChangeKind.InterfaceRemoved, ChangeClassification.Breaking,
+                $"Interface '{removed}' was removed"));
+        }
+
+        foreach (var added in newInterfaces.Except(oldInterfaces).Order())
+        {
+            // Adding interface to an interface is potentially breaking (implementers must add it)
+            var classification = newType.Kind == "interface"
+                ? ChangeClassification.PotentiallyBreaking
+                : ChangeClassification.Additive;
+
+            changes.Add(new ApiChange(ChangeKind.InterfaceAdded, classification,
+                $"Interface '{added}' was added"));
+        }
+    }
+
+    private static void CompareTypeParameters(ApiType oldType, ApiType newType, List<ApiChange> changes)
+    {
+        var oldParams = oldType.TypeParameters ?? [];
+        var newParams = newType.TypeParameters ?? [];
+
+        if (oldParams.Count != newParams.Count)
+        {
+            changes.Add(new ApiChange(ChangeKind.TypeParameterCountChanged, ChangeClassification.Breaking,
+                $"Generic parameter count changed from {oldParams.Count} to {newParams.Count}",
+                oldParams.Count.ToString(), newParams.Count.ToString()));
+            return; // No point comparing individual params when count changed
+        }
+
+        for (int i = 0; i < oldParams.Count; i++)
+        {
+            var oldParam = oldParams[i];
+            var newParam = newParams[i];
+
+            // Variance changed
+            if (oldParam.Variance != newParam.Variance)
+            {
+                changes.Add(new ApiChange(ChangeKind.TypeParameterVarianceChanged, ChangeClassification.Breaking,
+                    $"Generic parameter '{newParam.Name}' variance changed from '{oldParam.Variance ?? "none"}' to '{newParam.Variance ?? "none"}'",
+                    oldParam.Variance, newParam.Variance));
+            }
+
+            // Constraints changed
+            var oldConstraints = new HashSet<string>(oldParam.Constraints, StringComparer.Ordinal);
+            var newConstraints = new HashSet<string>(newParam.Constraints, StringComparer.Ordinal);
+
+            var added = newConstraints.Except(oldConstraints).ToList();
+            var removed = oldConstraints.Except(newConstraints).ToList();
+
+            if (added.Count > 0)
+            {
+                changes.Add(new ApiChange(ChangeKind.TypeParameterConstraintTightened, ChangeClassification.Breaking,
+                    $"Generic parameter '{newParam.Name}' added constraints: {string.Join(", ", added)}"));
+            }
+
+            if (removed.Count > 0)
+            {
+                changes.Add(new ApiChange(ChangeKind.TypeParameterConstraintLoosened, ChangeClassification.Additive,
+                    $"Generic parameter '{newParam.Name}' removed constraints: {string.Join(", ", removed)}"));
+            }
+        }
+    }
+
+    private static void CompareMembers(ApiType oldType, ApiType newType, List<ApiChange> changes)
+    {
+        var oldMembers = FilterMembers(oldType.Members);
+        var newMembers = FilterMembers(newType.Members);
+
+        // Build signature sets for matching
+        var oldBySignature = new Dictionary<string, ApiMember>(StringComparer.Ordinal);
+        foreach (var m in oldMembers)
+        {
+            var key = GetMemberKey(m);
+            oldBySignature.TryAdd(key, m);
+        }
+
+        var newBySignature = new Dictionary<string, ApiMember>(StringComparer.Ordinal);
+        foreach (var m in newMembers)
+        {
+            var key = GetMemberKey(m);
+            newBySignature.TryAdd(key, m);
+        }
+
+        // Find matched (by full signature key), unmatched old, unmatched new
+        var matchedOldKeys = new HashSet<string>(StringComparer.Ordinal);
+        var matchedNewKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var key in oldBySignature.Keys)
+        {
+            if (newBySignature.ContainsKey(key))
+            {
+                matchedOldKeys.Add(key);
+                matchedNewKeys.Add(key);
+            }
+        }
+
+        var unmatchedOld = new List<ApiMember>();
+        foreach (var kvp in oldBySignature)
+        {
+            if (!matchedOldKeys.Contains(kvp.Key))
+                unmatchedOld.Add(kvp.Value);
+        }
+
+        var unmatchedNew = new List<ApiMember>();
+        foreach (var kvp in newBySignature)
+        {
+            if (!matchedNewKeys.Contains(kvp.Key))
+                unmatchedNew.Add(kvp.Value);
+        }
+
+        // Pair unmatched by (Name, Kind) for signature changes
+        var pairedOld = new HashSet<ApiMember>(ReferenceEqualityComparer.Instance);
+        var pairedNew = new HashSet<ApiMember>(ReferenceEqualityComparer.Instance);
+
+        foreach (var oldMember in unmatchedOld)
+        {
+            foreach (var newMember in unmatchedNew)
+            {
+                if (pairedNew.Contains(newMember))
+                    continue;
+
+                if (oldMember.Name == newMember.Name && oldMember.Kind == newMember.Kind)
+                {
+                    pairedOld.Add(oldMember);
+                    pairedNew.Add(newMember);
+
+                    changes.Add(new ApiChange(ChangeKind.MemberSignatureChanged, ChangeClassification.Breaking,
+                        $"Member '{oldMember.Name}' signature changed",
+                        GetMemberKey(oldMember), GetMemberKey(newMember)));
+                    break;
+                }
+            }
+        }
+
+        // Remaining unmatched → removed / added
+        foreach (var oldMember in unmatchedOld)
+        {
+            if (!pairedOld.Contains(oldMember))
+            {
+                changes.Add(new ApiChange(ChangeKind.MemberRemoved, ChangeClassification.Breaking,
+                    $"Member '{oldMember.Name}' was removed"));
+            }
+        }
+
+        foreach (var newMember in unmatchedNew)
+        {
+            if (!pairedNew.Contains(newMember))
+            {
+                // Adding member to interface is potentially breaking
+                var classification = newType.Kind == "interface"
+                    ? ChangeClassification.PotentiallyBreaking
+                    : ChangeClassification.Additive;
+
+                changes.Add(new ApiChange(ChangeKind.MemberAdded, classification,
+                    $"Member '{newMember.Name}' was added"));
+            }
+        }
+
+        // For members matched by full signature, check modifier changes
+        foreach (var key in matchedOldKeys)
+        {
+            var oldMember = oldBySignature[key];
+            var newMember = newBySignature[key];
+            CompareMemberModifiers(oldMember, newMember, changes);
+        }
+    }
+
+    private static void CompareMemberModifiers(ApiMember oldMember, ApiMember newMember, List<ApiChange> changes)
+    {
+        // Virtual removed
+        if (oldMember.IsVirtual && !newMember.IsVirtual)
+        {
+            changes.Add(new ApiChange(ChangeKind.VirtualRemoved, ChangeClassification.Breaking,
+                $"Member '{oldMember.Name}' is no longer virtual"));
+        }
+
+        // Abstract added
+        if (!oldMember.IsAbstract && newMember.IsAbstract)
+        {
+            changes.Add(new ApiChange(ChangeKind.AbstractMemberAdded, ChangeClassification.Breaking,
+                $"Member '{oldMember.Name}' was made abstract"));
+        }
+
+        // Enum value changed
+        if (oldMember.EnumValue != null && newMember.EnumValue != null &&
+            oldMember.EnumValue != newMember.EnumValue)
+        {
+            changes.Add(new ApiChange(ChangeKind.EnumValueChanged, ChangeClassification.PotentiallyBreaking,
+                $"Enum member '{oldMember.Name}' value changed from {oldMember.EnumValue} to {newMember.EnumValue}",
+                oldMember.EnumValue.Value.ToString(), newMember.EnumValue.Value.ToString()));
+        }
+    }
+
+    private static List<ApiMember> FilterMembers(List<ApiMember>? members)
+    {
+        if (members == null || members.Count == 0)
+            return [];
+
+        var filtered = new List<ApiMember>(members.Count);
+        foreach (var member in members)
+        {
+            if (!MemberFilters.IsCompilerGenerated(member.Name))
+                filtered.Add(member);
+        }
+        return filtered;
+    }
+
+    private static string GetMemberKey(ApiMember member)
+    {
+        // Use signature when available (methods, properties), else fall back to kind + name
+        return member.Signature ?? $"{member.Kind}:{member.Name}";
+    }
+}

--- a/tests/DotnetInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
+++ b/tests/DotnetInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
@@ -1,0 +1,524 @@
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Metadata.Tests;
+
+public class ApiDiffAnalyzerTests
+{
+    #region Helpers
+
+    private static ApiSurface Surface(params ApiType[] types)
+    {
+        var surface = new ApiSurface();
+        surface.Types.AddRange(types);
+        return surface;
+    }
+
+    private static ApiType Type(
+        string name,
+        string kind = "class",
+        string? ns = "TestNamespace",
+        bool isSealed = false,
+        bool isAbstract = false,
+        string? baseType = null,
+        List<string>? interfaces = null,
+        List<TypeParameter>? typeParameters = null,
+        List<ApiMember>? members = null)
+    {
+        return new ApiType
+        {
+            Name = name,
+            Kind = kind,
+            Namespace = ns,
+            IsSealed = isSealed,
+            IsAbstract = isAbstract,
+            IsStatic = isSealed && isAbstract,
+            BaseType = baseType,
+            Interfaces = interfaces,
+            TypeParameters = typeParameters,
+            Members = members ?? []
+        };
+    }
+
+    private static ApiMember Method(string name, string signature, bool isVirtual = false, bool isAbstract = false)
+    {
+        return new ApiMember
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            IsVirtual = isVirtual,
+            IsAbstract = isAbstract
+        };
+    }
+
+    private static ApiMember Property(string name, string signature)
+    {
+        return new ApiMember { Name = name, Kind = "property", Signature = signature };
+    }
+
+    private static ApiMember Field(string name, long? enumValue = null)
+    {
+        return new ApiMember { Name = name, Kind = "field", EnumValue = enumValue };
+    }
+
+    private static ApiMember Event(string name)
+    {
+        return new ApiMember { Name = name, Kind = "event" };
+    }
+
+    #endregion
+
+    [Fact]
+    public void IdenticalSurfaces_ReturnsEmptyDiff()
+    {
+        var type = Type("Foo", members: [Method("Bar", "void Bar()")]);
+        var oldSurface = Surface(type);
+        var newSurface = Surface(type);
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.True(diff.IsEmpty);
+        Assert.Equal(0, diff.TotalBreaking);
+        Assert.Equal(0, diff.TotalAdditive);
+        Assert.Equal(0, diff.TotalPotentiallyBreaking);
+    }
+
+    [Fact]
+    public void TypeAdded_IsAdditive()
+    {
+        var oldSurface = Surface();
+        var newSurface = Surface(Type("Foo"));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.Single(diff.TypeDiffs);
+        var typeDiff = diff.TypeDiffs[0];
+        Assert.True(typeDiff.IsAdded);
+        Assert.False(typeDiff.IsRemoved);
+        Assert.Equal(1, diff.TotalAdditive);
+        Assert.Equal(0, diff.TotalBreaking);
+    }
+
+    [Fact]
+    public void TypeRemoved_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo"));
+        var newSurface = Surface();
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.Single(diff.TypeDiffs);
+        var typeDiff = diff.TypeDiffs[0];
+        Assert.True(typeDiff.IsRemoved);
+        Assert.False(typeDiff.IsAdded);
+        Assert.Equal(1, diff.TotalBreaking);
+    }
+
+    [Fact]
+    public void TypeKindChanged_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", kind: "class"));
+        var newSurface = Surface(Type("Foo", kind: "struct"));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.TypeKindChanged);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+        Assert.Equal("class", change.OldValue);
+        Assert.Equal("struct", change.NewValue);
+    }
+
+    [Fact]
+    public void SealedAdded_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", isSealed: false));
+        var newSurface = Surface(Type("Foo", isSealed: true));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.SealedAdded);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void SealedRemoved_IsAdditive()
+    {
+        var oldSurface = Surface(Type("Foo", isSealed: true));
+        var newSurface = Surface(Type("Foo", isSealed: false));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.SealedRemoved);
+        Assert.Equal(ChangeClassification.Additive, change.Classification);
+    }
+
+    [Fact]
+    public void AbstractAdded_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", isAbstract: false));
+        var newSurface = Surface(Type("Foo", isAbstract: true));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.AbstractAdded);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void AbstractRemoved_IsAdditive()
+    {
+        var oldSurface = Surface(Type("Foo", isAbstract: true));
+        var newSurface = Surface(Type("Foo", isAbstract: false));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.AbstractRemoved);
+        Assert.Equal(ChangeClassification.Additive, change.Classification);
+    }
+
+    [Fact]
+    public void StaticType_NoSpuriousSealedOrAbstractChanges()
+    {
+        // Static types have both IsSealed and IsAbstract true — should not report changes
+        var oldSurface = Surface(Type("Foo", isSealed: true, isAbstract: true));
+        var newSurface = Surface(Type("Foo", isSealed: true, isAbstract: true));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void BaseTypeChanged_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", baseType: "System.Object"));
+        var newSurface = Surface(Type("Foo", baseType: "System.Exception"));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.BaseTypeChanged);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+        Assert.Equal("System.Object", change.OldValue);
+        Assert.Equal("System.Exception", change.NewValue);
+    }
+
+    [Fact]
+    public void InterfaceRemoved_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", interfaces: ["IDisposable", "ICloneable"]));
+        var newSurface = Surface(Type("Foo", interfaces: ["IDisposable"]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.InterfaceRemoved);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+        Assert.Contains("ICloneable", change.Message);
+    }
+
+    [Fact]
+    public void InterfaceAddedOnClass_IsAdditive()
+    {
+        var oldSurface = Surface(Type("Foo", kind: "class", interfaces: ["IDisposable"]));
+        var newSurface = Surface(Type("Foo", kind: "class", interfaces: ["IDisposable", "ICloneable"]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.InterfaceAdded);
+        Assert.Equal(ChangeClassification.Additive, change.Classification);
+    }
+
+    [Fact]
+    public void InterfaceAddedOnInterface_IsPotentiallyBreaking()
+    {
+        var oldSurface = Surface(Type("IFoo", kind: "interface"));
+        var newSurface = Surface(Type("IFoo", kind: "interface", interfaces: ["IBar"]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.InterfaceAdded);
+        Assert.Equal(ChangeClassification.PotentiallyBreaking, change.Classification);
+    }
+
+    [Fact]
+    public void GenericParamCountChanged_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T" }]));
+        var newSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T" }, new TypeParameter { Name = "U" }]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.TypeParameterCountChanged);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void GenericVarianceChanged_IsBreaking()
+    {
+        var oldSurface = Surface(Type("IFoo", kind: "interface", typeParameters:
+            [new TypeParameter { Name = "T", Variance = "out" }]));
+        var newSurface = Surface(Type("IFoo", kind: "interface", typeParameters:
+            [new TypeParameter { Name = "T", Variance = "in" }]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.TypeParameterVarianceChanged);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void ConstraintTightened_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T" }]));
+        var newSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T", Constraints = { "class" } }]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.TypeParameterConstraintTightened);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void ConstraintLoosened_IsAdditive()
+    {
+        var oldSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T", Constraints = { "class" } }]));
+        var newSurface = Surface(Type("Foo", typeParameters:
+            [new TypeParameter { Name = "T" }]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.TypeParameterConstraintLoosened);
+        Assert.Equal(ChangeClassification.Additive, change.Classification);
+    }
+
+    [Fact]
+    public void MemberAddedOnClass_IsAdditive()
+    {
+        var oldSurface = Surface(Type("Foo", members: [Method("Bar", "void Bar()")]));
+        var newSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar()"), Method("Baz", "void Baz()")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.MemberAdded);
+        Assert.Equal(ChangeClassification.Additive, change.Classification);
+        Assert.Contains("Baz", change.Message);
+    }
+
+    [Fact]
+    public void MemberAddedOnInterface_IsPotentiallyBreaking()
+    {
+        var oldSurface = Surface(Type("IFoo", kind: "interface",
+            members: [Method("Bar", "void Bar()")]));
+        var newSurface = Surface(Type("IFoo", kind: "interface",
+            members: [Method("Bar", "void Bar()"), Method("Baz", "void Baz()")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.MemberAdded);
+        Assert.Equal(ChangeClassification.PotentiallyBreaking, change.Classification);
+    }
+
+    [Fact]
+    public void MemberRemoved_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar()"), Method("Baz", "void Baz()")]));
+        var newSurface = Surface(Type("Foo", members: [Method("Bar", "void Bar()")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.MemberRemoved);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+        Assert.Contains("Baz", change.Message);
+    }
+
+    [Fact]
+    public void MemberSignatureChanged_PairsAndReportsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar(int x)")]));
+        var newSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar(string x)")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.MemberSignatureChanged);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+        Assert.Equal("void Bar(int x)", change.OldValue);
+        Assert.Equal("void Bar(string x)", change.NewValue);
+    }
+
+    [Fact]
+    public void VirtualRemoved_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar()", isVirtual: true)]));
+        var newSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar()", isVirtual: false)]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.VirtualRemoved);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void AbstractMemberAdded_IsBreaking()
+    {
+        var oldSurface = Surface(Type("Foo", isAbstract: true, members:
+            [Method("Bar", "void Bar()", isAbstract: false, isVirtual: true)]));
+        var newSurface = Surface(Type("Foo", isAbstract: true, members:
+            [Method("Bar", "void Bar()", isAbstract: true, isVirtual: true)]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.AbstractMemberAdded);
+        Assert.Equal(ChangeClassification.Breaking, change.Classification);
+    }
+
+    [Fact]
+    public void EnumValueChanged_IsPotentiallyBreaking()
+    {
+        var oldSurface = Surface(Type("MyEnum", kind: "enum", members:
+            [Field("One", enumValue: 1), Field("Two", enumValue: 2)]));
+        var newSurface = Surface(Type("MyEnum", kind: "enum", members:
+            [Field("One", enumValue: 1), Field("Two", enumValue: 3)]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var change = Assert.Single(diff.TypeDiffs).Changes
+            .Single(c => c.Kind == ChangeKind.EnumValueChanged);
+        Assert.Equal(ChangeClassification.PotentiallyBreaking, change.Classification);
+        Assert.Equal("2", change.OldValue);
+        Assert.Equal("3", change.NewValue);
+    }
+
+    [Fact]
+    public void CompilerGeneratedMembers_AreFiltered()
+    {
+        var oldSurface = Surface(Type("Foo", members:
+        [
+            Method("Bar", "void Bar()"),
+            new ApiMember { Name = "<Clone>$", Kind = "method", Signature = "Foo <Clone>$()" }
+        ]));
+        var newSurface = Surface(Type("Foo", members:
+            [Method("Bar", "void Bar()")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        // Compiler-generated <Clone>$ should be filtered, so no diff
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void MultipleChangesOnOneType_AllCaptured()
+    {
+        var oldSurface = Surface(Type("Foo",
+            isSealed: false,
+            interfaces: ["IDisposable"],
+            members: [Method("Bar", "void Bar()"), Method("Baz", "void Baz()")]));
+        var newSurface = Surface(Type("Foo",
+            isSealed: true,
+            interfaces: ["IDisposable", "ICloneable"],
+            members: [Method("Bar", "void Bar()")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var typeDiff = Assert.Single(diff.TypeDiffs);
+        Assert.Equal(3, typeDiff.Changes.Count);
+
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.SealedAdded);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.InterfaceAdded);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.MemberRemoved);
+    }
+
+    [Fact]
+    public void AggregateCounts_AreCorrect()
+    {
+        var oldSurface = Surface(
+            Type("Foo", members: [Method("Bar", "void Bar()")]),
+            Type("Removed"));
+        var newSurface = Surface(
+            Type("Foo", members: [Method("Bar", "void Bar()"), Method("Baz", "void Baz()")]),
+            Type("Added"));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        // Removed type = 1 breaking, Added type = 1 additive, Baz added = 1 additive
+        Assert.Equal(1, diff.TotalBreaking);
+        Assert.Equal(2, diff.TotalAdditive);
+        Assert.Equal(0, diff.TotalPotentiallyBreaking);
+    }
+
+    [Fact]
+    public void TypesAreSortedByName()
+    {
+        var oldSurface = Surface(Type("Zebra"), Type("Alpha"));
+        var newSurface = Surface();
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.Equal(2, diff.TypeDiffs.Count);
+        Assert.Equal("TestNamespace.Alpha", diff.TypeDiffs[0].TypeFullName);
+        Assert.Equal("TestNamespace.Zebra", diff.TypeDiffs[1].TypeFullName);
+    }
+
+    [Fact]
+    public void EmptySurfaces_ReturnsEmptyDiff()
+    {
+        var diff = ApiDiffAnalyzer.Compare(new ApiSurface(), new ApiSurface());
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void FieldMembers_MatchByKindAndName()
+    {
+        // Fields don't have signatures — matched by kind:name key
+        var oldSurface = Surface(Type("Foo", members:
+            [Field("MaxValue")]));
+        var newSurface = Surface(Type("Foo", members:
+            [Field("MaxValue")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void EventMember_AddedAndRemoved()
+    {
+        var oldSurface = Surface(Type("Foo", members: [Event("Click")]));
+        var newSurface = Surface(Type("Foo", members: [Event("Tap")]));
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+
+        var typeDiff = Assert.Single(diff.TypeDiffs);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.MemberRemoved);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.MemberAdded);
+    }
+}

--- a/tests/DotnetInspector.Metadata.Tests/DotnetInspector.Metadata.Tests.csproj
+++ b/tests/DotnetInspector.Metadata.Tests/DotnetInspector.Metadata.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Extracts diff analysis into a reusable `ApiDiffAnalyzer` service in the Metadata library, following the static-class-over-POCOs pattern used by `ApiSurfaceExtractor` and `TypeHierarchyScanner`
- Classifies API changes as breaking, additive, or potentially breaking using rich metadata (`Kind`, `IsSealed`, `IsAbstract`, `IsVirtual`, `BaseType`, `Interfaces`, `TypeParameters`, `EnumValue`) rather than flat signature-string comparison
- Adds a dedicated `DotnetInspector.Metadata.Tests` test project with 31 tests covering all 20 change kinds, classification rules, member pairing logic, and edge cases

## Test plan

- [x] All 31 new tests pass (`dotnet test tests/DotnetInspector.Metadata.Tests/`)
- [x] Existing project builds cleanly (`dotnet build src/dotnet-inspect/`)
- [ ] Verify no regressions in existing CLI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)