### PR TITLE
Add skill command to print SKILL.md

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -17,7 +17,7 @@ public static class CommandLineBuilder
     /// </summary>
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
-        "package", "assembly", "api", "diff", "find", "search", "samples", "platform", "llmstxt", "extensions", "implements", "cache", "cli", "help", "--help", "-h", "-?", "--version"
+        "package", "assembly", "api", "diff", "find", "search", "samples", "platform", "llmstxt", "skill", "extensions", "implements", "cache", "cli", "help", "--help", "-h", "-?", "--version"
     };
 
     /// <summary>
@@ -129,6 +129,10 @@ public static class CommandLineBuilder
         var llmsTxtCommand = new Command("llmstxt", "Show usage examples (run this first)");
         llmsTxtCommand.SetAction((parseResult) => LlmsTxtCommand.Execute());
         rootCommand.Subcommands.Add(llmsTxtCommand);
+
+        var skillCommand = new Command("skill", "Show Claude Code skill definition");
+        skillCommand.SetAction((parseResult) => SkillCommand.Execute());
+        rootCommand.Subcommands.Add(skillCommand);
 
         // No-args: show help + tips
         rootCommand.SetAction((parseResult) =>

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace DotnetInspector.Commands;
+
+/// <summary>
+/// Prints the SKILL.md file for LLM consumption.
+/// </summary>
+public class SkillCommand
+{
+    public const string Name = "skill";
+    public static int Execute()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        using var stream = assembly.GetManifestResourceStream("dotnet-inspect.SKILL.md");
+
+        if (stream == null)
+        {
+            Console.Error.WriteLine("Error: SKILL.md resource not found.");
+            return 1;
+        }
+
+        using var reader = new StreamReader(stream);
+        Console.WriteLine(reader.ReadToEnd());
+
+        return 0;
+    }
+}

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: dotnet-inspect
+description: Inspect .NET assemblies and NuGet packages. Use when you need to understand package contents, view public API surfaces, compare APIs between versions, or audit assemblies for SourceLink/determinism. Essential for .NET development tasks involving package exploration or API discovery.
+---
+
+# dotnet-inspect
+
+A CLI tool for inspecting .NET assemblies and NuGet packages.
+
+## Requirements
+
+- .NET 10+ SDK
+
+## Installation
+
+Use `dnx` to run without global installation (like `npx` for Node):
+
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+**Important**:
+
+- Always use `-y` to skip the interactive confirmation prompt (which breaks LLM tool use). New package versions also trigger this prompt.
+- Always use `--` to separate dnx options from tool arguments. Without it, `--help` shows dnx help, not dotnet-inspect help.
+
+## Quick Patterns
+
+Start with these common workflows:
+
+```bash
+# Understand a type's API shape (start here - most useful for learning APIs)
+dnx dotnet-inspect -y -- type JsonSerializer --package System.Text.Json
+
+# Compare API changes between versions (essential for migrations)
+dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.2
+dnx dotnet-inspect -y -- diff Command --package System.CommandLine@2.0.0-beta4.22272.1..2.0.2
+dnx dotnet-inspect -y -- diff "*Json*" --package System.Text.Json@9.0.0..10.0.0
+
+# Search for types by pattern (single or batch with comma-separated patterns)
+dnx dotnet-inspect -y -- find "*Handler*" --package System.CommandLine
+dnx dotnet-inspect -y -- find "Option*,Argument*,Command*" --package System.CommandLine --terse
+
+# Find extension methods for a type
+dnx dotnet-inspect -y -- extensions HttpClient --framework runtime
+dnx dotnet-inspect -y -- extensions HttpClient --framework runtime --reachable
+
+# Find types implementing an interface or extending a class
+dnx dotnet-inspect -y -- implements IDisposable --framework runtime
+dnx dotnet-inspect -y -- implements Stream --framework runtime
+
+# Package metadata and versions
+dnx dotnet-inspect -y -- package System.Text.Json
+dnx dotnet-inspect -y -- package System.Text.Json --versions
+
+# Get XML documentation for a type
+dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
+```
+
+## Key Flags
+
+| Flag | Purpose | Commands |
+| ---- | ------- | -------- |
+| `-v:d` | Detailed output (full signatures, more info) | all commands |
+| `--docs` | Include XML documentation from source | `type`, `api` |
+| `-m Name` | Filter to specific member(s) | `type`, `api` |
+| `-t Name` | Filter to specific type(s), supports globs | `diff` |
+| `-n 10` | Limit results | `find`, `extensions`, `package --versions` |
+| `--terse` | Compact output (alias for --oneline --grouped) | `find` |
+| `--oneline` | Space-separated type names on one line | `find` |
+| `--name-only` | Show only names, one per line | `find`, `diff` |
+| `--stat` | Show only statistics (no member details) | `diff` |
+| `--grouped` | Group results by pattern (with --oneline) | `find` |
+| `--reachable` | Include extensions on reachable types | `extensions` |
+| `--prerelease` | Include prerelease versions | `package --versions` |
+
+**Signatures include `params` and default values** — you can determine calling conventions directly from output:
+`void .ctor(string name, params string[] aliases)`, `Parse(args, configuration = null)`
+
+**Generic types:** Use quotes around generic types: `'Option<T>'`, `'IEnumerable<T>'`
+
+**Diff supports globs and whole-package comparison:** Omit the type name to see all changes across a package version range. Use glob patterns like `"*Writer*"` to filter.
+
+## Command Reference
+
+| Command | Purpose |
+| ------- | ------- |
+| `type <type>` | **Start here.** Type shape with hierarchy and members (tree view) |
+| `diff` | Compare API surfaces between package versions (whole-package or filtered) |
+| `api <type>` | View public API surface (table format) |
+| `find <pattern>` | Search for types across packages, assemblies, or frameworks |
+| `extensions <type>` | Find extension methods for a type |
+| `implements <type>` | Find types implementing an interface or extending a class |
+| `package <name>` | Package metadata, files, versions, dependencies |
+| `assembly <path>` | Assembly info, SourceLink/determinism audit |
+| `llmstxt` | Complete usage examples for all commands |
+
+## Full Documentation
+
+For comprehensive examples and edge cases:
+
+```bash
+dnx dotnet-inspect -y -- llmstxt
+```
+
+## When to Use This Skill
+
+- Exploring what types/APIs a NuGet package provides
+- Searching for types by pattern across packages or frameworks
+- Finding types that implement an interface or extend a base class
+- Understanding method signatures and overloads
+- Comparing API changes between package versions
+- Auditing assemblies for SourceLink and determinism
+- Finding types matching a pattern (`--filter "Progress*"`)
+- Getting documentation from source (`--docs`)

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="llms.txt" />
+    <EmbeddedResource Include="SKILL.md" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add `skill` command that prints the embedded SKILL.md file, following the same pattern as `llmstxt`
- Embed `SKILL.md` as a resource in the project
- Register command in `CommandLineBuilder` and known commands list

## Test plan

- [ ] CI passes
- [ ] `dotnet-inspect skill` prints the SKILL.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)