### PR TITLE
Remove "Claude Code" from skill command help text

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -130,7 +130,7 @@ public static class CommandLineBuilder
         llmsTxtCommand.SetAction((parseResult) => LlmsTxtCommand.Execute());
         rootCommand.Subcommands.Add(llmsTxtCommand);
 
-        var skillCommand = new Command("skill", "Show Claude Code skill definition");
+        var skillCommand = new Command("skill", "Show skill definition");
         skillCommand.SetAction((parseResult) => SkillCommand.Execute());
         rootCommand.Subcommands.Add(skillCommand);
 


### PR DESCRIPTION
## Summary

- Change skill command description from "Show Claude Code skill definition" to "Show skill definition"

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet run -- --help | grep skill` shows updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)