### PR TITLE
Fix stale documentation: ghost commands, flags, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,17 @@ dotnet tool install -g dotnet-inspect
 | `package X` | Package metadata, dependencies, files |
 | `platform X` | Inspect SDK/runtime assembly |
 | `assembly ./path` | Inspect local file |
-| `audit X` | Verify provenance (SourceLink, determinism) |
-| `api X` | Public API surface |
-| `type X` | Type hierarchy and members |
+| `api X` | Public API surface (table format, or `--tree` for hierarchy) |
 | `diff X` | Compare versions with breaking/additive classification |
 | `extensions X` | Find extension methods/properties for a type |
+| `implements X` | Find types implementing an interface or extending a class |
 | `find X` | Search for types |
 
 ### Common Flags
 
 | Flag | Description |
 |------|-------------|
-| `--audit` | Full provenance verification (always strict) |
-| `--sourcelink` | Show SourceLink presence/URL (fast, no HTTP) |
+| `--sourcelink-audit` | Full provenance verification (parallel HTTP HEAD) |
 | `--json` | JSON output |
 | `-v:q/m/n/d` | Verbosity: quiet, minimal, normal, detailed |
 
@@ -41,22 +39,9 @@ Inspect NuGet packages. This is the default command.
 dotnet-inspect System.Text.Json                    # Metadata (latest version)
 dotnet-inspect System.Text.Json@8.0.4 -v:d         # Detailed (shows vulnerability)
 dotnet-inspect System.Text.Json --versions         # List available versions
-dotnet-inspect System.Text.Json --audit            # Provenance verification; optional `--strict` mode
+dotnet-inspect System.Text.Json --sourcelink-audit  # Provenance verification
 dotnet-inspect System.Text.Json --files --all      # File structure
 ```
-
-### audit
-
-Verify package/assembly provenance. Always runs strict verification.
-
-```bash
-dotnet-inspect audit Markout@0.1.4                 # Package
-dotnet-inspect audit ./bin/MyLib.dll               # Local file
-dotnet-inspect audit ./artifacts/*.nupkg           # Multiple nupkgs
-dotnet-inspect audit Markout@0.1.4 -v:q            # Quiet (pass/fail)
-```
-
-Note: Strict audit hits the network and will take longer.
 
 ### platform
 
@@ -66,7 +51,7 @@ List frameworks or inspect platform assemblies.
 dotnet-inspect platform                            # List frameworks
 dotnet-inspect platform --framework runtime        # List runtime assemblies
 dotnet-inspect platform System.Text.Json           # Inspect assembly
-dotnet-inspect platform System.Text.Json --audit   # Audit platform assembly
+dotnet-inspect platform System.Text.Json --sourcelink-audit  # Audit platform assembly
 ```
 
 ### api
@@ -132,7 +117,7 @@ Inspect a specific assembly file.
 
 ```bash
 dotnet-inspect assembly ./bin/MyLib.dll            # Local file
-dotnet-inspect assembly ./bin/MyLib.dll --audit    # With provenance check
+dotnet-inspect assembly ./bin/MyLib.dll --sourcelink-audit  # With provenance check
 ```
 
 ### diff
@@ -149,12 +134,14 @@ dotnet-inspect diff System.Text.Json@9.0.0..10.0.2 --additive     # additive cha
 dotnet-inspect diff System.Text.Json@9.0.0..10.0.2 JsonSerializer  # filter to type
 ```
 
-### type
+### implements
 
-Show type hierarchy with members.
+Find types implementing an interface or extending a class.
 
 ```bash
-dotnet-inspect type JsonSerializer --package System.Text.Json
+dotnet-inspect implements IDisposable --framework runtime
+dotnet-inspect implements Stream --framework runtime
+dotnet-inspect implements IJsonTypeInfoResolver --package System.Text.Json
 ```
 
 ## Custom NuGet Sources

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -95,9 +95,9 @@ Type: Library | TFM: net10.0 | Updated: 2026-01-13 | Vulnerabilities: 1
 For detailed output, you can include or exclude specific sections:
 
 ```bash
-dotnet-inspect package --discover       # List available sections
-dotnet-inspect System.Text.Json -v:d -x:3,4   # Exclude sections 3 and 4
-dotnet-inspect System.Text.Json -v:d -s:1     # Only section 1
+dotnet-inspect package --discover                        # List available sections
+dotnet-inspect System.Text.Json -v:d -x:Statistics,Files # Exclude sections by name
+dotnet-inspect System.Text.Json -v:d -s:Metadata         # Include only named sections
 ```
 
 This enables precision: request exactly the data you need.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -30,7 +30,7 @@ Start with these common workflows:
 
 ```bash
 # Understand a type's API shape (start here - most useful for learning APIs)
-dnx dotnet-inspect -y -- type JsonSerializer --package System.Text.Json
+dnx dotnet-inspect -y -- api JsonSerializer --package System.Text.Json --tree
 
 # Compare API changes between versions (essential for migrations)
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.2
@@ -54,7 +54,7 @@ dnx dotnet-inspect -y -- package System.Text.Json
 dnx dotnet-inspect -y -- package System.Text.Json --versions
 
 # Get XML documentation for a type
-dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
+dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
 ```
 
 ## Key Flags
@@ -62,14 +62,16 @@ dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
 | Flag | Purpose | Commands |
 | ---- | ------- | -------- |
 | `-v:d` | Detailed output (full signatures, more info) | all commands |
-| `--docs` | Include XML documentation from source | `type`, `api` |
-| `-m Name` | Filter to specific member(s) | `type`, `api` |
+| `--docs` | Include XML documentation from source | `api` |
+| `-m Name` | Filter to specific member(s) | `api` |
 | `-t Name` | Filter to specific type(s), supports globs | `diff` |
 | `-n 10` | Limit results | `find`, `extensions`, `package --versions` |
 | `--terse` | Compact output (alias for --oneline --grouped) | `find` |
 | `--oneline` | Space-separated type names on one line | `find` |
 | `--name-only` | Show only names, one per line | `find`, `diff` |
 | `--stat` | Show only statistics (no member details) | `diff` |
+| `--breaking` | Show only breaking changes | `diff` |
+| `--additive` | Show only additive changes | `diff` |
 | `--grouped` | Group results by pattern (with --oneline) | `find` |
 | `--reachable` | Include extensions on reachable types | `extensions` |
 | `--prerelease` | Include prerelease versions | `package --versions` |
@@ -85,9 +87,8 @@ dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
 
 | Command | Purpose |
 | ------- | ------- |
-| `type <type>` | **Start here.** Type shape with hierarchy and members (tree view) |
+| `api <type>` | **Start here.** Public API surface (table format, or `--tree` for hierarchy) |
 | `diff` | Compare API surfaces between package versions (whole-package or filtered) |
-| `api <type>` | View public API surface (table format) |
 | `find <pattern>` | Search for types across packages, assemblies, or frameworks |
 | `extensions <type>` | Find extension methods for a type |
 | `implements <type>` | Find types implementing an interface or extending a class |

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -30,7 +30,7 @@ Start with these common workflows:
 
 ```bash
 # Understand a type's API shape (start here - most useful for learning APIs)
-dnx dotnet-inspect -y -- type JsonSerializer --package System.Text.Json
+dnx dotnet-inspect -y -- api JsonSerializer --package System.Text.Json --tree
 
 # Compare API changes between versions (essential for migrations)
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.2
@@ -54,7 +54,7 @@ dnx dotnet-inspect -y -- package System.Text.Json
 dnx dotnet-inspect -y -- package System.Text.Json --versions
 
 # Get XML documentation for a type
-dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
+dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
 ```
 
 ## Key Flags
@@ -62,14 +62,16 @@ dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
 | Flag | Purpose | Commands |
 | ---- | ------- | -------- |
 | `-v:d` | Detailed output (full signatures, more info) | all commands |
-| `--docs` | Include XML documentation from source | `type`, `api` |
-| `-m Name` | Filter to specific member(s) | `type`, `api` |
+| `--docs` | Include XML documentation from source | `api` |
+| `-m Name` | Filter to specific member(s) | `api` |
 | `-t Name` | Filter to specific type(s), supports globs | `diff` |
 | `-n 10` | Limit results | `find`, `extensions`, `package --versions` |
 | `--terse` | Compact output (alias for --oneline --grouped) | `find` |
 | `--oneline` | Space-separated type names on one line | `find` |
 | `--name-only` | Show only names, one per line | `find`, `diff` |
 | `--stat` | Show only statistics (no member details) | `diff` |
+| `--breaking` | Show only breaking changes | `diff` |
+| `--additive` | Show only additive changes | `diff` |
 | `--grouped` | Group results by pattern (with --oneline) | `find` |
 | `--reachable` | Include extensions on reachable types | `extensions` |
 | `--prerelease` | Include prerelease versions | `package --versions` |
@@ -85,9 +87,8 @@ dnx dotnet-inspect -y -- type Option --package System.CommandLine --docs
 
 | Command | Purpose |
 | ------- | ------- |
-| `type <type>` | **Start here.** Type shape with hierarchy and members (tree view) |
+| `api <type>` | **Start here.** Public API surface (table format, or `--tree` for hierarchy) |
 | `diff` | Compare API surfaces between package versions (whole-package or filtered) |
-| `api <type>` | View public API surface (table format) |
 | `find <pattern>` | Search for types across packages, assemblies, or frameworks |
 | `extensions <type>` | Find extension methods for a type |
 | `implements <type>` | Find types implementing an interface or extending a class |

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -59,7 +59,7 @@ dotnet-inspect api 'IEnumerable<T>' --platform System.Runtime -v n  # Type param
 ### assembly
 
 ```bash
-dotnet-inspect assembly --package System.Text.Json --tfm net8.0 --audit
+dotnet-inspect assembly --package System.Text.Json --tfm net8.0 --sourcelink-audit
 ```
 
 ### diff
@@ -86,6 +86,10 @@ dotnet-inspect diff HttpClient --platform System.Net.Http@9.0.0..10.0.0 --framew
 | `--package` | Package with version range (Package@v1..v2) |
 | `--platform` | Platform assembly with version range (Assembly@v1..v2) |
 | `--framework` | Framework for platform diff (runtime, aspnetcore). Default: runtime |
+| `--stat` | Show only statistics per type (no member details) |
+| `--breaking` | Show only breaking changes |
+| `--additive` | Show only additive changes |
+| `--name-only` | Show only type names that changed |
 
 ### find
 
@@ -206,7 +210,7 @@ dotnet-inspect platform --list-versions            # Installed SDK versions
 dotnet-inspect platform --framework runtime        # List runtime assemblies
 dotnet-inspect platform --framework aspnetcore     # List ASP.NET Core assemblies
 dotnet-inspect api --platform System.Text.Json     # API from platform assembly
-dotnet-inspect api JsonSerializer --platform System.Text.Json --interfaces  # With interfaces
+dotnet-inspect api JsonSerializer --platform System.Text.Json -v:d -s:Interfaces  # With interfaces
 ```
 
 ## Output
@@ -269,7 +273,7 @@ dotnet-inspect api System.Text.Json JsonSerializer -s              # Header only
 | `--docs` | Fetch XML documentation |
 | `--all` | Include hidden/obsolete |
 | `--unsafe` | Filter to pointer methods |
-| `--audit` | SourceLink/determinism check |
+| `--sourcelink-audit` | SourceLink/determinism check |
 | `--deps` | Show runtime dependencies |
 
 ## Package vs Platform
@@ -325,7 +329,7 @@ void .ctor(string name, params string[] aliases)
 ParseResult Parse(Command command, IReadOnlyList<string> args, ParserConfiguration? configuration = null)
 ```
 
-This means you can determine calling conventions directly from `type` or `api` output without additional lookups.
+This means you can determine calling conventions directly from `api` output without additional lookups.
 
 ### Generic Type Syntax
 
@@ -368,12 +372,12 @@ dotnet-inspect implements Stream --framework runtime  # Find subclasses
 
 ### Flag Compatibility Matrix
 
-| Flag | api | type | find | extensions | implements | diff |
-|------|-----|------|------|------------|------------|------|
-| `--package` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `--platform` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `--assembly` | ✓ | ✓ | ✓ | ✓ | ✓ | |
-| `--framework` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Flag | api | find | extensions | implements | diff |
+|------|-----|------|------------|------------|------|
+| `--package` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `--platform` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `--assembly` | ✓ | ✓ | ✓ | ✓ | |
+| `--framework` | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### Common Assembly Names
 
@@ -394,7 +398,7 @@ dotnet-inspect implements Stream --framework runtime  # Find subclasses
 dotnet-inspect find "*List*" --framework runtime
 
 # Get interfaces implemented by a type
-dotnet-inspect api "List<T>" --platform System.Collections --interfaces
+dotnet-inspect api "List<T>" --platform System.Collections -v:d -s:Interfaces
 
 # Get full type shape with members
 dotnet-inspect api "Dictionary<TKey, TValue>" --platform System.Collections --tree


### PR DESCRIPTION
## Summary

- Remove `type` command references (deleted command) — replaced with `api --tree`
- Remove `audit` command section from README (deleted in #31)
- Replace `--audit` and `--sourcelink` ghost flags with `--sourcelink-audit`
- Replace `--interfaces` ghost flag with `-s:Interfaces` section filter
- Remove `type` column from llms.txt flag compatibility matrix
- Add `--breaking`/`--additive` diff flags to SKILL.md and llms.txt (added in #34)
- Add `implements` command to README quick reference (was missing)
- Fix docs/llm-design.md section filtering examples from numeric indices to named sections

## Test plan

- [ ] Verify every command example in README runs without error
- [ ] Verify every command example in llms.txt runs without error
- [ ] Verify SKILL.md examples work via `dnx dotnet-inspect -y --`
- [ ] Confirm no remaining references to `type` command, `--audit`, `--sourcelink`, or `--interfaces` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)