### PR TITLE
Make domain provider libraries app-agnostic

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -1,6 +1,3 @@
-using System.Text.Json.Serialization;
-using Markout;
-
 namespace DotnetInspector.Metadata;
 
 /// <summary>
@@ -17,7 +14,6 @@ public class DocComment
     /// <summary>
     /// Sample code references extracted from doc comments.
     /// </summary>
-    [MarkoutIgnoreInTable]
     public List<SampleReference>? Samples { get; set; }
 }
 
@@ -29,7 +25,6 @@ public class SampleReference
     /// <summary>
     /// Relative path to the sample file from the source file.
     /// </summary>
-    [JsonPropertyName("relative_path")]
     public string RelativePath { get; set; } = "";
 
     /// <summary>
@@ -45,7 +40,6 @@ public class SampleReference
     /// <summary>
     /// Resolved URL to the sample file (computed from SourceLink).
     /// </summary>
-    [JsonPropertyName("resolved_url")]
     public string? ResolvedUrl { get; set; }
 
     /// <summary>
@@ -59,13 +53,10 @@ public class SampleReference
 /// </summary>
 public class PartialSourceFileInfo
 {
-    [JsonPropertyName("file_path")]
     public string? FilePath { get; set; }
 
-    [JsonPropertyName("source_url")]
     public string? SourceUrl { get; set; }
 
-    [JsonPropertyName("github_browse_url")]
     public string? GitHubBrowseUrl { get; set; }
 }
 
@@ -79,7 +70,6 @@ public class ApiSurface
     /// </summary>
     public string? Name { get; set; }
 
-    [MarkoutIgnoreInTable]
     public List<ApiType> Types { get; set; } = [];
 
     public int PublicTypeCount { get; set; }
@@ -101,7 +91,6 @@ public class ApiSurface
     /// <summary>
     /// Type forwarders in this assembly (types re-exported from other assemblies).
     /// </summary>
-    [MarkoutIgnoreInTable]
     public List<TypeForwarder> TypeForwarders { get; set; } = [];
 
     /// <summary>
@@ -146,19 +135,16 @@ public class TypeParameter
     /// Includes special constraints (class, struct, notnull, unmanaged, new())
     /// and type constraints (interfaces, base class).
     /// </summary>
-    [MarkoutIgnoreInTable]
     public List<string> Constraints { get; set; } = [];
 
     /// <summary>
     /// Returns the parameter name with variance prefix (e.g., "out T", "in TKey").
     /// </summary>
-    [JsonIgnore]
     public string DisplayName => Variance != null ? $"{Variance} {Name}" : Name;
 
     /// <summary>
     /// Returns constraints as a comma-separated string, or null if none.
     /// </summary>
-    [JsonIgnore]
     public string? ConstraintsSummary => Constraints.Count > 0
         ? string.Join(", ", Constraints)
         : null;
@@ -175,64 +161,50 @@ public class ApiType
     public bool IsStatic { get; set; }
 
     public string? BaseType { get; set; }
-    [MarkoutIgnoreInTable]
     public List<string>? Interfaces { get; set; }
 
     /// <summary>
     /// Known derived types within the same assembly.
     /// </summary>
-    [MarkoutIgnoreInTable]
     public List<string>? DerivedTypes { get; set; }
 
     /// <summary>
     /// Generic type parameters with their constraints.
     /// </summary>
-    [MarkoutIgnoreInTable]
     public List<TypeParameter>? TypeParameters { get; set; }
 
-    [MarkoutIgnoreInTable]
     public List<ApiMember>? Members { get; set; }
 
     // Source information (populated with --source-url)
-    [JsonPropertyName("source_file_path")]
     public string? SourceFilePath { get; set; }
 
-    [JsonPropertyName("source_url")]
     public string? SourceUrl { get; set; }
 
-    [JsonPropertyName("github_browse_url")]
     public string? GitHubBrowseUrl { get; set; }
 
-    [JsonPropertyName("source_line_number")]
     public int? SourceLineNumber { get; set; }
 
     /// <summary>
     /// How the source URL was resolved: "SourceLink" (from method debug info) or "Inferred" (from document name).
     /// </summary>
-    [JsonPropertyName("source_resolution")]
     public string? SourceResolution { get; set; }
 
     /// <summary>
     /// Additional source files for partial types. Only populated when type spans multiple files.
     /// </summary>
-    [JsonPropertyName("additional_source_files")]
-    [MarkoutIgnoreInTable]
     public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
 
     /// <summary>
     /// Indicates whether this type is defined across multiple partial files.
     /// </summary>
-    [JsonPropertyName("is_partial_type")]
     public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
 
     /// <summary>
     /// Full name of the type (Namespace.Name, or just Name if no namespace).
     /// </summary>
-    [JsonIgnore]
     public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
 
     // Documentation (populated with --docs)
-    [MarkoutIgnoreInTable]
     public DocComment? Documentation { get; set; }
 }
 
@@ -258,18 +230,14 @@ public class ApiMember
     /// The type that this extension method extends (first parameter type).
     /// Only populated when IsExtension is true.
     /// </summary>
-    [JsonPropertyName("extended_type")]
     public string? ExtendedType { get; set; }
 
     // Enum value (for enum fields only)
-    [JsonPropertyName("enum_value")]
     public long? EnumValue { get; set; }
 
     // Source information (populated with --source-url)
-    [JsonPropertyName("source_line_number")]
     public int? SourceLineNumber { get; set; }
 
     // Documentation (populated with --docs)
-    [MarkoutIgnoreInTable]
     public DocComment? Documentation { get; set; }
 }

--- a/src/DotnetInspector.Metadata/AssemblyInfo.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInfo.cs
@@ -1,6 +1,3 @@
-using System.Text.Json.Serialization;
-using Markout;
-
 namespace DotnetInspector.Metadata;
 
 /// <summary>
@@ -25,25 +22,21 @@ public class AssemblyReferenceNode
     /// <summary>
     /// Tree depth (0 = direct reference, 1 = reference of reference, etc.)
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Depth { get; set; }
 
     /// <summary>
     /// How the assembly was resolved: "local", "platform", or null if unresolved.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ResolvedFrom { get; set; }
 
     /// <summary>
     /// Resolved file path, or null if not found.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Path { get; set; }
 
     /// <summary>
     /// True if this node was already seen earlier in the tree (circular reference).
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsCyclic { get; set; }
 }
 
@@ -87,14 +80,10 @@ public class AssemblyInfo
     /// <summary>
     /// List of assemblies referenced by this assembly.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [MarkoutIgnoreInTable]
     public List<AssemblyReference>? References { get; set; }
 
     /// <summary>
     /// Transitive reference tree (when --transitive is used).
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [MarkoutIgnoreInTable]
     public List<AssemblyReferenceNode>? TransitiveReferences { get; set; }
 }

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -18,11 +18,6 @@
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
   </ItemGroup>
 
-  <!-- Markout attribute-only: ExcludeAssets="analyzers" skips source gen, keeps [MarkoutIgnoreInTable] -->
-  <ItemGroup>
-    <PackageReference Include="Markout" Version="0.3.1" ExcludeAssets="analyzers" />
-  </ItemGroup>
-
   <!-- System.Reflection.Metadata is part of net10.0 BCL -->
 
 </Project>

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -7,9 +7,26 @@ namespace DotnetInspector.Packages;
 /// Utilities for working with package and content caches.
 /// Uses cross-platform paths via Environment.SpecialFolder.
 /// Never writes to ~/.nuget/packages (read-only).
+/// Call <see cref="Initialize"/> before using app cache methods.
 /// </summary>
 public static class NuGetCache
 {
+    private static string? _appName;
+
+    /// <summary>
+    /// Initializes the cache with the application name used for the cache directory.
+    /// Must be called before any app cache operations.
+    /// </summary>
+    /// <param name="appName">Application name used as the cache subdirectory (e.g., "dotnet-inspect")</param>
+    public static void Initialize(string appName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appName);
+        _appName = appName;
+    }
+
+    private static string AppName => _appName
+        ?? throw new InvalidOperationException("NuGetCache.Initialize(appName) must be called before using app cache methods.");
+
     /// <summary>
     /// Gets the path to the NuGet package cache (read-only).
     /// </summary>
@@ -30,18 +47,18 @@ public static class NuGetCache
     }
 
     /// <summary>
-    /// Gets the base path for dotnet-inspect caches (read-write).
-    /// Windows: %LOCALAPPDATA%\dotnet-inspect
-    /// macOS/Linux: ~/.local/share/dotnet-inspect
+    /// Gets the base path for application caches (read-write).
+    /// Windows: %LOCALAPPDATA%\{appName}
+    /// macOS/Linux: ~/.local/share/{appName}
     /// </summary>
     public static string GetAppCacheBasePath()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "dotnet-inspect");
+        return Path.Combine(localAppData, AppName);
     }
 
     /// <summary>
-    /// Gets the path to the dotnet-inspect package cache (read-write).
+    /// Gets the path to the application package cache (read-write).
     /// </summary>
     public static string GetAppCachePath()
     {

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
 
@@ -8,6 +9,10 @@ namespace DotnetInspector.Tests;
 /// </summary>
 public class CacheCommandTests
 {
+    public CacheCommandTests()
+    {
+        NuGetCache.Initialize("dotnet-inspect");
+    }
     [Fact]
     public async Task ExecuteAsync_ShowsInfo_ReturnsZero()
     {

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -1,5 +1,3 @@
-using DotnetInspector.Packages;
-
 namespace DotnetInspector.Tests;
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/NuGetCacheTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetCacheTests.cs
@@ -98,6 +98,7 @@ public class NuGetCacheTests
     [Fact]
     public void GetAppCacheBasePath_ReturnsNonEmptyPath()
     {
+        NuGetCache.Initialize("dotnet-inspect");
         var path = NuGetCache.GetAppCacheBasePath();
 
         Assert.False(string.IsNullOrEmpty(path));

--- a/src/dotnet-inspect/Commands/CommandContext.cs
+++ b/src/dotnet-inspect/Commands/CommandContext.cs
@@ -1,5 +1,4 @@
 using DotnetInspector.Output;
-using DotnetInspector.Packages;
 
 namespace DotnetInspector.Commands;
 

--- a/src/dotnet-inspect/HttpClientFactory.cs
+++ b/src/dotnet-inspect/HttpClientFactory.cs
@@ -1,6 +1,6 @@
 using System.Net;
 
-namespace DotnetInspector.Packages;
+namespace DotnetInspector;
 
 /// <summary>
 /// Factory for creating HttpClient instances with consistent configuration.

--- a/src/dotnet-inspect/MarkoutContext.cs
+++ b/src/dotnet-inspect/MarkoutContext.cs
@@ -2,6 +2,7 @@ using Markout;
 
 namespace DotnetInspector;
 
+[MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(InspectionResult))]
 [MarkoutContext(typeof(AssemblyAudit))]
 [MarkoutContext(typeof(AssemblyAuditReport))]

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -1,4 +1,8 @@
 using DotnetInspector;
+using DotnetInspector.Packages;
+
+// Initialize library configuration
+NuGetCache.Initialize("dotnet-inspect");
 
 // Handle --version explicitly to show short commit hash
 if (args.Length == 1 && args[0] == "--version")

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -66,7 +66,7 @@
   -->
   <!-- PackageReference: Use for releases after new Markout version is published -->
   <ItemGroup>
-    <PackageReference Include="Markout" Version="0.3.2" />
+    <PackageReference Include="Markout" Version="0.3.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Cleans up the domain provider libraries (DotnetInspector.Metadata, DotnetInspector.Packages) to be truly app-agnostic, as part of a bottom-up architecture cleanup.

## Changes

### DotnetInspector.Packages
- **NuGetCache**: Replace hardcoded `"dotnet-inspect"` cache directory with configurable `Initialize(appName)` pattern. The caching behavior is unchanged — only the identity is no longer baked in.
- **HttpClientFactory**: Move to app project. All library classes already accept `HttpClient` as a parameter; the factory was only consumed by `CommandContext`.

### DotnetInspector.Metadata
- **Remove `[MarkoutIgnoreInTable]`**: 13 attributes removed from `ApiSurface.cs` and `AssemblyInfo.cs`. Presentation concerns don't belong on domain models.
- **Remove `[JsonPropertyName]` and conditional `[JsonIgnore]`**: All were redundant with the app's `SnakeCaseLower` naming policy or `DefaultIgnoreCondition`. Serialization choices belong in the app layer.
- **Remove Markout package dependency** from `DotnetInspector.Metadata.csproj` — the library now has **zero external package dependencies**.

### App layer (dotnet-inspect)
- Call `NuGetCache.Initialize("dotnet-inspect")` at startup
- Add `[MarkoutContextOptions(SuppressTableWarnings = true)]` to handle Metadata types processed transitively by Markout source generator
- Update to Markout 0.3.3 (adds `SuppressTableWarnings` option — [richlander/markout#32](https://github.com/richlander/markout/pull/32))

## Testing

All 327 tests pass.