### PR TITLE
Fix assembly --package deprecation message

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -982,7 +982,7 @@ public static class CommandLineBuilder
         var sourcelinkAuditOption = new Option<bool>("--sourcelink-audit") { Description = "Full provenance verification (parallel HTTP HEAD on all source files)" };
         var referencesOption = new Option<bool>("--references") { Description = "Show assembly references" };
         var transitiveOption = new Option<bool>("--transitive") { Description = "Show transitive assembly references (full dependency tree)" };
-        var asmPackageOption = new Option<string?>("--package") { Description = "[Deprecated: use 'package X --metadata'] Extract from package" };
+        var asmPackageOption = new Option<string?>("--package") { Description = "[Deprecated: use 'package X --metadata/--symbols/--sourcelink-audit'] Extract from package" };
         var asmPlatformOption = new Option<string?>("--platform") { Description = "Inspect platform assembly (e.g., System.Text.Json)" };
         var asmFrameworkOption = new Option<string?>("--framework") { Description = "Platform framework (runtime, aspnetcore). Use @version for specific version" };
         var asmTfmOption = new Option<string?>("--tfm") { Description = "Select assembly by TFM (e.g., net8.0, or 'all' for every TFM)" };


### PR DESCRIPTION
## Summary

- Update deprecation hint from `package X --metadata` to `package X --metadata/--symbols/--sourcelink-audit` since all three audit tiers are available on the package command

## Test plan

- [ ] `dotnet-inspect assembly --help` shows updated deprecation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)