### PR TITLE
Extract shared DotnetInspector.Services library

### DIFF
--- a/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
+++ b/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
+    <RootNamespace>DotnetInspector.Services.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotnetInspector.Services.Tests/PackageResolverServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageResolverServiceTests.cs
@@ -1,0 +1,52 @@
+namespace DotnetInspector.Services.Tests;
+
+public class PackageResolverServiceTests
+{
+    [Theory]
+    [InlineData("Newtonsoft.Json.13.0.3", "Newtonsoft.Json", "13.0.3")]
+    [InlineData("System.Text.Json.9.0.0", "System.Text.Json", "9.0.0")]
+    [InlineData("Microsoft.Extensions.DependencyInjection.9.0.0", "Microsoft.Extensions.DependencyInjection", "9.0.0")]
+    [InlineData("xunit.2.9.3", "xunit", "2.9.3")]
+    [InlineData("Foo.1.0.0-preview.1", "Foo", "1.0.0-preview.1")]
+    public void ParsePackageFileName_SplitsNameAndVersion(string fileName, string expectedName, string expectedVersion)
+    {
+        var (name, version) = PackageResolverService.ParsePackageFileName(fileName);
+
+        Assert.Equal(expectedName, name);
+        Assert.Equal(expectedVersion, version);
+    }
+
+    [Theory]
+    [InlineData("NoVersionHere")]
+    [InlineData("JustAName")]
+    public void ParsePackageFileName_NoVersion_ReturnsFileNameAsName(string fileName)
+    {
+        var (name, version) = PackageResolverService.ParsePackageFileName(fileName);
+
+        Assert.Equal(fileName, name);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public async Task ResolvePackageAsync_LocalFile_DoesNotExist_ReturnsNull()
+    {
+        var result = await PackageResolverService.ResolvePackageAsync(
+            "/nonexistent/path/package.nupkg", null, null, new HttpClient());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PackageResolution_Record_Properties()
+    {
+        var resolution = new PackageResolverService.PackageResolution(
+            "/extract", "/temp", "MyPackage", "1.0.0", "/path.nupkg", FromCache: true);
+
+        Assert.Equal("/extract", resolution.ExtractPath);
+        Assert.Equal("/temp", resolution.TempDir);
+        Assert.Equal("MyPackage", resolution.PackageName);
+        Assert.Equal("1.0.0", resolution.Version);
+        Assert.Equal("/path.nupkg", resolution.NupkgPath);
+        Assert.True(resolution.FromCache);
+    }
+}

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+
+namespace DotnetInspector.Services.Tests;
+
+public class ProjectAssetsParserTests
+{
+    [Fact]
+    public void Parse_EmptyTargets_ReturnsEmpty()
+    {
+        var assetsPath = CreateTempAssetsFile(new
+        {
+            targets = new { }
+        });
+
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Empty(results);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_NoTargetsProperty_ReturnsEmpty()
+    {
+        var assetsPath = CreateTempAssetsFile(new { version = 3 });
+
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Empty(results);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_SkipsProjectTypeLibraries()
+    {
+        var json = """
+        {
+            "targets": {
+                "net9.0": {
+                    "MyProject/1.0.0": {
+                        "type": "package",
+                        "compile": { "lib/net9.0/MyProject.dll": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "MyProject/1.0.0": {
+                    "type": "project",
+                    "path": "myproject/1.0.0"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Empty(results);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_SkipsPlaceholderAssemblies()
+    {
+        var json = """
+        {
+            "targets": {
+                "net9.0": {
+                    "System.Runtime/9.0.0": {
+                        "compile": { "lib/net9.0/_._": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "System.Runtime/9.0.0": {
+                    "type": "package",
+                    "path": "system.runtime/9.0.0"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Empty(results);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_WithTfmFilter_SelectsMatchingTfm()
+    {
+        var json = """
+        {
+            "targets": {
+                "net8.0": {
+                    "Foo/1.0.0": {
+                        "compile": { "lib/net8.0/Foo.dll": {} }
+                    }
+                },
+                "net9.0": {
+                    "Foo/1.0.0": {
+                        "compile": { "lib/net9.0/Foo.dll": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Foo/1.0.0": {
+                    "type": "package",
+                    "path": "foo/1.0.0"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        var messages = new List<string>();
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, "net8.0", s => messages.Add(s));
+            // Won't find actual files on disk, but the TFM should be selected
+            Assert.Contains(messages, m => m.Contains("net8.0"));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_InvalidJson_ReturnsEmptyAndLogs()
+    {
+        var assetsPath = WriteTempFile("not valid json {{{");
+        var messages = new List<string>();
+
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, s => messages.Add(s));
+            Assert.Empty(results);
+            Assert.Single(messages);
+            Assert.Contains("Warning", messages[0]);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_WithoutTfmFilter_SelectsHighestPriorityTfm()
+    {
+        var json = """
+        {
+            "targets": {
+                "net6.0": {
+                    "Foo/1.0.0": {
+                        "compile": { "lib/net6.0/Foo.dll": {} }
+                    }
+                },
+                "net9.0": {
+                    "Foo/1.0.0": {
+                        "compile": { "lib/net9.0/Foo.dll": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Foo/1.0.0": {
+                    "type": "package",
+                    "path": "foo/1.0.0"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        var messages = new List<string>();
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, s => messages.Add(s));
+            // net9.0 should be preferred over net6.0
+            Assert.Contains(messages, m => m.Contains("net9.0"));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_ReturnsAssemblyPaths_WhenFileExists()
+    {
+        // Create a temp directory structure that mimics NuGet cache
+        var tempDir = Path.Combine(Path.GetTempPath(), $"parser-test-{Guid.NewGuid():N}");
+        var packageDir = Path.Combine(tempDir, "foo", "1.0.0", "lib", "net9.0");
+        Directory.CreateDirectory(packageDir);
+        var dllPath = Path.Combine(packageDir, "Foo.dll");
+        File.WriteAllText(dllPath, "fake assembly");
+
+        // Build a relative path from NuGet cache
+        var nugetCache = DotnetInspector.Packages.NuGetCache.GetNuGetCachePath();
+        var relPath = Path.GetRelativePath(nugetCache, Path.Combine(tempDir, "foo", "1.0.0"));
+
+        var json = $$"""
+        {
+            "targets": {
+                "net9.0": {
+                    "Foo/1.0.0": {
+                        "compile": { "lib/net9.0/Foo.dll": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Foo/1.0.0": {
+                    "type": "package",
+                    "path": "{{relPath.Replace("\\", "/")}}"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            // The file needs to exist at the NuGet cache location, which is tricky to simulate
+            // This test verifies the parsing logic runs without error
+            // Files won't be found since our temp dir isn't the NuGet cache
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string CreateTempAssetsFile(object content)
+    {
+        var json = JsonSerializer.Serialize(content);
+        return WriteTempFile(json);
+    }
+
+    private static string WriteTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"project-assets-test-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Shared services for NuGet package resolution and project asset discovery</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetInspector.Services.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotnetInspector.Services/PackageResolverService.cs
+++ b/src/DotnetInspector.Services/PackageResolverService.cs
@@ -1,15 +1,13 @@
 using System.IO.Compression;
 using System.Text.Json;
-using DotnetInspector.Inspectors;
-using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Resolves NuGet packages: version discovery, cache lookup, download, and extraction.
 /// </summary>
-internal static class PackageResolverService
+public static class PackageResolverService
 {
     /// <summary>
     /// Result of resolving and extracting a NuGet package.
@@ -29,14 +27,14 @@ internal static class PackageResolverService
     public static async Task<PackageResolution?> ResolvePackageAsync(
         string packageSource,
         string? version,
-        VerboseLogger logger,
+        Action<string>? log,
         HttpClient httpClient)
     {
         bool isLocalFile = packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
 
         if (isLocalFile)
         {
-            return ExtractLocalPackage(packageSource, logger);
+            return ExtractLocalPackage(packageSource, log);
         }
 
         // Parse package@version format
@@ -46,7 +44,7 @@ internal static class PackageResolverService
         {
             packageName = packageSource[..atIndex].ToLowerInvariant();
             version = packageSource[(atIndex + 1)..].ToLowerInvariant();
-            logger.Log($"Using specified version: {version}");
+            log?.Invoke($"Using specified version: {version}");
         }
         else
         {
@@ -56,7 +54,7 @@ internal static class PackageResolverService
         // Discover latest version if not specified
         if (string.IsNullOrEmpty(version))
         {
-            version = await GetLatestVersionAsync(httpClient, packageName, logger);
+            version = await GetLatestVersionAsync(httpClient, packageName, log);
             if (version == null)
             {
                 return null;
@@ -67,7 +65,7 @@ internal static class PackageResolverService
         var cachedPath = NuGetCache.TryGetCachedPackage(packageName, version);
         if (cachedPath != null && NuGetCache.IsCachedPackageValid(cachedPath))
         {
-            logger.Log($"Using cached package: {cachedPath}");
+            log?.Invoke($"Using cached package: {cachedPath}");
             var expectedNupkg = Path.Combine(cachedPath, $"{packageName}.{version}.nupkg");
             string? nupkgPath = File.Exists(expectedNupkg) ? expectedNupkg : null;
             return new PackageResolution(cachedPath, null, packageName, version, nupkgPath, FromCache: true);
@@ -79,7 +77,7 @@ internal static class PackageResolverService
         Directory.CreateDirectory(tempDir);
 
         string nupkgUrl = $"https://api.nuget.org/v3-flatcontainer/{packageName}/{version}/{packageName}.{version}.nupkg";
-        logger.Log($"Downloading: {nupkgUrl}");
+        log?.Invoke($"Downloading: {nupkgUrl}");
 
         byte[]? packageBytes = await HttpRetryHelper.GetBytesWithRetryAsync(httpClient, nupkgUrl);
         if (packageBytes == null)
@@ -91,13 +89,13 @@ internal static class PackageResolverService
         string nupkgFilePath = Path.Combine(tempDir, $"{packageName}.{version}.nupkg");
         await File.WriteAllBytesAsync(nupkgFilePath, packageBytes);
         ZipFile.ExtractToDirectory(nupkgFilePath, extractPath);
-        logger.Log("Package downloaded successfully.");
+        log?.Invoke("Package downloaded successfully.");
 
         // Cache for future use
         var newCachePath = NuGetCache.CachePackage(extractPath, packageName, version);
         if (newCachePath != null)
         {
-            logger.Log($"Cached to: {newCachePath}");
+            log?.Invoke($"Cached to: {newCachePath}");
         }
 
         return new PackageResolution(extractPath, tempDir, packageName, version, nupkgFilePath, FromCache: false);
@@ -107,16 +105,16 @@ internal static class PackageResolverService
     /// Gets the latest version of a package from NuGet. Prefers stable versions.
     /// </summary>
     public static async Task<string?> GetLatestVersionAsync(
-        HttpClient client, string packageName, VerboseLogger logger)
+        HttpClient client, string packageName, Action<string>? log)
     {
-        var versions = await FetchVersionIndexAsync(client, packageName, logger);
+        var versions = await FetchVersionIndexAsync(client, packageName, log);
         if (versions == null || versions.Count == 0)
             return null;
 
         // Prefer stable versions (those without a hyphen)
         var stableVersions = versions.Where(v => !v.Contains('-')).ToList();
         string latest = stableVersions.Count > 0 ? stableVersions[^1] : versions[^1];
-        logger.Log($"Latest version: {latest}");
+        log?.Invoke($"Latest version: {latest}");
         return latest;
     }
 
@@ -125,9 +123,9 @@ internal static class PackageResolverService
     /// </summary>
     public static async Task<List<string>?> GetVersionsAsync(
         HttpClient client, string packageName, bool includePrerelease,
-        int? limit, VerboseLogger logger)
+        int? limit, Action<string>? log)
     {
-        var versions = await FetchVersionIndexAsync(client, packageName, logger);
+        var versions = await FetchVersionIndexAsync(client, packageName, log);
         if (versions == null)
             return null;
 
@@ -147,7 +145,7 @@ internal static class PackageResolverService
         return result;
     }
 
-    private static PackageResolution? ExtractLocalPackage(string path, VerboseLogger logger)
+    private static PackageResolution? ExtractLocalPackage(string path, Action<string>? log)
     {
         if (!File.Exists(path))
         {
@@ -158,23 +156,38 @@ internal static class PackageResolverService
         string extractPath = Path.Combine(tempDir, "extracted");
         Directory.CreateDirectory(tempDir);
 
-        logger.Log($"Extracting package: {Path.GetFileName(path)}");
+        log?.Invoke($"Extracting package: {Path.GetFileName(path)}");
         ZipFile.ExtractToDirectory(path, extractPath);
 
-        // Derive package name from filename
+        // Derive package name from filename (e.g., Foo.Bar.1.0.0.nupkg)
         string fileName = Path.GetFileNameWithoutExtension(path);
-        var (packageName, version) = PackageReferenceParser.ParsePackageReference(fileName);
+        var (packageName, version) = ParsePackageFileName(fileName);
 
         return new PackageResolution(extractPath, tempDir, packageName ?? fileName, version ?? "", path, FromCache: false);
     }
 
+    internal static (string? name, string? version) ParsePackageFileName(string fileName)
+    {
+        var parts = fileName.Split('.');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (parts[i].Length > 0 && char.IsDigit(parts[i][0]))
+            {
+                var name = string.Join(".", parts.Take(i));
+                var version = string.Join(".", parts.Skip(i));
+                return (name, version);
+            }
+        }
+        return (fileName, null);
+    }
+
     private static async Task<List<string>?> FetchVersionIndexAsync(
-        HttpClient client, string packageName, VerboseLogger logger)
+        HttpClient client, string packageName, Action<string>? log)
     {
         try
         {
             string indexUrl = $"https://api.nuget.org/v3-flatcontainer/{packageName}/index.json";
-            logger.Log($"Fetching versions from: {indexUrl}");
+            log?.Invoke($"Fetching versions from: {indexUrl}");
 
             string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl);
             if (json == null)
@@ -192,7 +205,7 @@ internal static class PackageResolverService
         }
         catch (HttpRequestException ex)
         {
-            logger.Log($"Error fetching versions: {ex.Message}");
+            log?.Invoke($"Error fetching versions: {ex.Message}");
         }
 
         return null;

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -1,19 +1,17 @@
 using System.Text.Json;
-using DotnetInspector.Inspectors;
-using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Parses project.assets.json to discover NuGet package assemblies in a project.
 /// </summary>
-internal static class ProjectAssetsParser
+public static class ProjectAssetsParser
 {
     /// <summary>
     /// Parses a project.assets.json file and returns the assembly paths with package metadata.
     /// </summary>
-    public static List<(string Path, string PackageName, string Version)> Parse(string assetsPath, string? tfmFilter, VerboseLogger logger)
+    public static List<(string Path, string PackageName, string Version)> Parse(string assetsPath, string? tfmFilter, Action<string>? log)
     {
         var results = new List<(string Path, string PackageName, string Version)>();
         var nugetCache = NuGetCache.GetNuGetCachePath();
@@ -53,7 +51,7 @@ internal static class ProjectAssetsParser
             if (selectedTfm == null)
                 return results;
 
-            logger.Log($"Using target framework: {selectedTfm}");
+            log?.Invoke($"Using target framework: {selectedTfm}");
 
             if (!doc.RootElement.TryGetProperty("libraries", out var libraries))
                 return results;
@@ -91,7 +89,7 @@ internal static class ProjectAssetsParser
                         if (asm.Name.Contains("_._"))
                             continue;
 
-                        var fullPath = System.IO.Path.Combine(nugetCache, packagePath, asm.Name.Replace('/', System.IO.Path.DirectorySeparatorChar));
+                        var fullPath = Path.Combine(nugetCache, packagePath, asm.Name.Replace('/', Path.DirectorySeparatorChar));
                         if (File.Exists(fullPath))
                         {
                             results.Add((fullPath, packageName, version));
@@ -102,7 +100,7 @@ internal static class ProjectAssetsParser
         }
         catch (Exception ex)
         {
-            logger.Log($"Warning: Failed to parse project.assets.json: {ex.Message}");
+            log?.Invoke($"Warning: Failed to parse project.assets.json: {ex.Message}");
         }
 
         return results;

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 
@@ -181,7 +182,7 @@ public class AssemblyCommand
 
     private static async Task<(List<string> assemblyPaths, string extractPath, string? tempDir, string? nupkgPath)?> ExtractFromPackageAsync(string? assemblyName, string packageSource, string? tfm, VerboseLogger logger, HttpClient httpClient)
     {
-        var resolution = await PackageResolverService.ResolvePackageAsync(packageSource, null, logger, httpClient);
+        var resolution = await PackageResolverService.ResolvePackageAsync(packageSource, null, logger.Log, httpClient);
         if (resolution == null)
         {
             bool isLocalFile = packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Services;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -40,7 +41,7 @@ public class PackageCommand
         if (options.ListVersions)
         {
             string normalizedName = packageArgs[0].ToLowerInvariant();
-            var versions = await PackageResolverService.GetVersionsAsync(context.HttpClient, normalizedName, options.IncludePrerelease, options.Limit, logger);
+            var versions = await PackageResolverService.GetVersionsAsync(context.HttpClient, normalizedName, options.IncludePrerelease, options.Limit, logger.Log);
             if (versions == null)
             {
                 Console.Error.WriteLine($"Error: Package '{packageArgs[0]}' not found on nuget.org");
@@ -106,7 +107,7 @@ public class PackageCommand
             {
                 packageName = packageArg.ToLowerInvariant();
                 // Auto-discover latest version
-                string? latestVersion = await PackageResolverService.GetLatestVersionAsync(client, packageName, logger);
+                string? latestVersion = await PackageResolverService.GetLatestVersionAsync(client, packageName, logger.Log);
                 if (latestVersion == null)
                 {
                     Console.Error.WriteLine($"Error: Package '{packageArg}' not found on nuget.org");
@@ -134,7 +135,7 @@ public class PackageCommand
             resolution = await PackageResolverService.ResolvePackageAsync(
                 isLocalFile ? packageArgs[0] : packageName,
                 isLocalFile ? null : version,
-                logger,
+                logger.Log,
                 client);
 
             if (resolution == null)

--- a/src/dotnet-inspect/Commands/TypeSearchService.cs
+++ b/src/dotnet-inspect/Commands/TypeSearchService.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 
@@ -167,7 +168,7 @@ internal static class TypeSearchService
             }
 
             logger.Log($"Using assets: {assetsPath}");
-            var assemblies = ProjectAssetsParser.Parse(assetsPath, options.Tfm, logger);
+            var assemblies = ProjectAssetsParser.Parse(assetsPath, options.Tfm, logger.Log);
             logger.Log($"Searching {assemblies.Count} assemblies from {projectName}");
 
             foreach (var (asmPath, packageName, packageVersion) in assemblies)

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Metadata\DotnetInspector.Metadata.csproj" />
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Summary

Moves `PackageResolverService` and `ProjectAssetsParser` from `dotnet-inspect/Commands/` into a new `DotnetInspector.Services` class library, enabling other apps (like `dotnet-scope`) to reference the same package resolution and project asset parsing logic.

## Changes

**New library: `DotnetInspector.Services`**
- `PackageResolverService` — version discovery, cache lookup, download, extraction
- `ProjectAssetsParser` — project.assets.json → assembly paths with TFM selection

**Key adaptations:**
- `internal static` → `public static` visibility
- `VerboseLogger` → `Action<string>?` log callback (removes app-layer coupling)
- Inlined `ParsePackageFileName` from `PackageReferenceParser` (avoids app dependency)
- References only `DotnetInspector.Packages` (no app-layer dependencies)

**dotnet-inspect updates:**
- Added ProjectReference to `DotnetInspector.Services`
- Commands pass `logger.Log` (method group) instead of `VerboseLogger` instance
- Removed duplicate service files from `Commands/`

**Tests:**
- 17 new tests in `DotnetInspector.Services.Tests` covering filename parsing, JSON parsing, TFM selection, placeholder filtering, and error handling
- All 347 tests pass (330 existing + 17 new)

## Architecture

This is Phase 3 of the bottom-up architecture cleanup:
- Phase 1: Domain provider cleanup (PR #39)
- Phase 2: Service layer extraction (PR #43)
- **Phase 3: Shared services library (this PR)**