### PR TITLE
Fix DLL discovery and type classification for packages with tools/ and lib/

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -194,25 +194,33 @@ public class PackageCommand
 
             // Always analyze directory structure
             string toolsDir = Path.Combine(extractPath, "tools");
-            if (Directory.Exists(toolsDir))
+            string libDir = Path.Combine(extractPath, "lib");
+            bool hasToolsDir = Directory.Exists(toolsDir);
+            bool hasLibDir = Directory.Exists(libDir);
+
+            if (hasToolsDir)
             {
-                result.IsToolPackage = true;
                 ToolsAnalyzer.AnalyzeToolsDirectory(toolsDir, result);
             }
-            else
+
+            if (hasLibDir)
             {
-                result.IsToolPackage = false;
-                string libDir = Path.Combine(extractPath, "lib");
-                if (Directory.Exists(libDir))
-                {
-                    ToolsAnalyzer.AnalyzeLibDirectory(libDir, result);
-                }
+                ToolsAnalyzer.AnalyzeLibDirectory(libDir, result);
 
                 string runtimesDir = Path.Combine(extractPath, "runtimes");
                 if (Directory.Exists(runtimesDir))
                 {
                     ToolsAnalyzer.AnalyzeRuntimesDirectory(runtimesDir, result);
                 }
+            }
+
+            // Determine package type if not already set by nuspec PackageTypes
+            if (result.PackageTypes is not { Count: > 0 })
+            {
+                // Only classify as tool if tools/ has actual DLLs and there's no lib/ dir.
+                // Packages like AWSSDK.* have tools/ with only .ps1 scripts alongside lib/.
+                result.IsToolPackage = hasToolsDir && !hasLibDir
+                    && Directory.GetFiles(toolsDir, "*.dll", SearchOption.AllDirectories).Length > 0;
             }
 
             // Analyze content directories and count assemblies

--- a/src/dotnet-inspect/Inspectors/TfmSelector.cs
+++ b/src/dotnet-inspect/Inspectors/TfmSelector.cs
@@ -10,16 +10,18 @@ internal static class TfmSelector
         var toolsDir = Path.Combine(extractPath, "tools");
         var libDir = Path.Combine(extractPath, "lib");
 
-        string[] candidates;
+        string[] candidates = [];
         if (Directory.Exists(toolsDir))
         {
             candidates = Directory.GetFiles(toolsDir, "*.dll", SearchOption.AllDirectories);
         }
-        else if (Directory.Exists(libDir))
+
+        if (candidates.Length == 0 && Directory.Exists(libDir))
         {
             candidates = Directory.GetFiles(libDir, "*.dll", SearchOption.AllDirectories);
         }
-        else
+
+        if (candidates.Length == 0)
         {
             candidates = Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories);
         }


### PR DESCRIPTION
## Problem

Packages like `AWSSDK.Core` and `AWSSDK.S3` have a `tools/` directory containing only PowerShell scripts (no DLLs) alongside a `lib/` directory with the actual assemblies. This caused two bugs:

1. **`assembly --package AWSSDK.Core --dependencies` fails with "No DLLs found in package"** — `TfmSelector.GetPackageDlls` used `if/else if` to check `tools/` then `lib/`. When `tools/` existed (even with zero DLLs), `lib/` was never searched.

2. **`dotnet-inspect AWSSDK.S3` shows `Type: Tool`** — `PackageCommand` classified any package with a `tools/` directory as a tool and skipped `lib/` analysis entirely, hiding TFM and target framework info.

## Fix

**TfmSelector.cs**: Changed to cascading fallback — check `tools/` for DLLs, fall through to `lib/` if none found, then search the full extract path as a last resort.

**PackageCommand.cs**: Both `tools/` and `lib/` directories are now always analyzed when present. Nuspec `PackageTypes` (e.g. `DotnetTool`) takes priority for type classification. The directory-based heuristic only sets `Tool` when `tools/` contains actual DLLs and no `lib/` directory exists.

## Testing

- All 330 existing tests pass
- Verified `AWSSDK.Core` and `AWSSDK.S3` now show `Type: Library` with correct TFM info
- Verified `dotnet-ef` still correctly shows `Type: Tool`
- Verified `assembly --package AWSSDK.Core --dependencies` works