### PR TITLE
Fix multi-assembly package handling and add README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,41 @@ dotnet-inspect System.Text.Json --sourcelink-audit  # Provenance verification
 dotnet-inspect System.Text.Json --files --all      # File structure
 ```
 
+#### Multi-assembly packages
+
+Some packages bundle multiple assemblies per TFM (e.g., `Microsoft.Azure.SignalR` ships both `Microsoft.Azure.SignalR.dll` and `Microsoft.Azure.SignalR.Common.dll`). The `Libraries` field shows when a package contains more than one assembly.
+
+```bash
+dotnet-inspect Microsoft.Azure.SignalR                # Shows Libraries: 2
+dotnet-inspect Microsoft.Azure.SignalR --files        # See all assemblies per TFM
+dotnet-inspect Microsoft.Azure.SignalR --tfms         # List target frameworks
+```
+
+```text
+| Target Frameworks | 2 |
+| Libraries | 2 |
+```
+
+Use `--files` to see the full layout:
+
+```text
+└─ lib
+   ├─ net8.0
+   │  ├─ Microsoft.Azure.SignalR.Common.dll
+   │  └─ Microsoft.Azure.SignalR.dll
+   └─ netstandard2.0
+      ├─ Microsoft.Azure.SignalR.Common.dll
+      └─ Microsoft.Azure.SignalR.dll
+```
+
+Inspect or compare individual assemblies using `package --metadata` with `--tfm`:
+
+```bash
+dotnet-inspect package Microsoft.Azure.SignalR --metadata                   # Primary assembly (highest TFM)
+dotnet-inspect package Microsoft.Azure.SignalR --metadata --tfm net8.0      # Specific TFM
+dotnet-inspect api Microsoft.Azure.SignalR                                  # API surface (all assemblies)
+```
+
 ### platform
 
 List frameworks or inspect platform assemblies.

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -248,7 +248,7 @@ public class AssemblyCommand
                 return null;
             }
 
-            var (selectedPath, selectedTfm) = TfmSelector.SelectHighestTfmAssembly(candidates, extractPath);
+            var (selectedPath, selectedTfm) = TfmSelector.SelectHighestTfmAssembly(candidates, extractPath, resolution.PackageName);
             if (selectedPath == null)
             {
                 // No TFM structure found, fall back to first DLL

--- a/src/dotnet-inspect/InspectionResult.cs
+++ b/src/dotnet-inspect/InspectionResult.cs
@@ -430,7 +430,7 @@ public class InspectionResult
             fields.Add(MarkoutField.Create("Target Frameworks", TargetFrameworkCount));
         if (SupportedRidCount > 0)
             fields.Add(MarkoutField.Create("Runtime Identifiers", SupportedRidCount));
-        if (AssemblyCount > 0)
+        if (AssemblyCount > 1)
             fields.Add(MarkoutField.Create("Libraries", AssemblyCount));
         if (HasReadme)
             fields.Add(MarkoutField.Create("Readme", true));

--- a/src/dotnet-inspect/Inspectors/TfmSelector.cs
+++ b/src/dotnet-inspect/Inspectors/TfmSelector.cs
@@ -29,7 +29,7 @@ internal static class TfmSelector
         return candidates.OrderBy(f => f).ToList();
     }
 
-    internal static (string? path, string? tfm) SelectHighestTfmAssembly(List<string> dlls, string extractPath)
+    internal static (string? path, string? tfm) SelectHighestTfmAssembly(List<string> dlls, string extractPath, string? packageName = null)
     {
         dlls = dlls.Where(d => !d.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)).ToList();
 
@@ -60,6 +60,15 @@ internal static class TfmSelector
 
         var highestTfm = sortedTfms[0].tfm;
         var assemblies = byTfm[highestTfm];
+
+        // Prefer assembly matching the package name
+        if (packageName != null)
+        {
+            var match = assemblies.FirstOrDefault(d =>
+                Path.GetFileNameWithoutExtension(d).Equals(packageName, StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+                return (match, highestTfm);
+        }
 
         var directDll = assemblies.FirstOrDefault(d =>
         {

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -159,25 +159,14 @@ public static class ToolsAnalyzer
     /// </summary>
     public static int CountAssemblies(string extractPath)
     {
-        var toolsDir = Path.Combine(extractPath, "tools");
-        var libDir = Path.Combine(extractPath, "lib");
+        var dlls = TfmSelector.GetPackageDlls(extractPath)
+            .Where(f => !f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase));
 
-        string searchDir;
-        if (Directory.Exists(toolsDir))
-        {
-            searchDir = toolsDir;
-        }
-        else if (Directory.Exists(libDir))
-        {
-            searchDir = libDir;
-        }
-        else
-        {
-            return 0;
-        }
-
-        return Directory.GetFiles(searchDir, "*.dll", SearchOption.AllDirectories)
-            .Count(f => !f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase));
+        // Count unique assembly names (deduplicated across TFMs)
+        return dlls
+            .Select(f => Path.GetFileName(f))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
     }
 
     public static void AnalyzeRuntimesDirectory(string runtimesDir, InspectionResult result)


### PR DESCRIPTION
## Changes

### Assembly selection
`SelectHighestTfmAssembly` now accepts an optional `packageName` parameter and prefers the assembly whose filename matches the package name. Previously it picked alphabetically, so `assembly --package Microsoft.Azure.SignalR` selected `Microsoft.Azure.SignalR.Common.dll` instead of the primary `Microsoft.Azure.SignalR.dll`.

### Library count
`CountAssemblies` now deduplicates by filename across TFMs and reuses `TfmSelector.GetPackageDlls` (fixing the same tools/lib fallback bug from #45). `Libraries` is now hidden for single-assembly packages.

| Package | Before | After |
|---------|--------|-------|
| AWSSDK.S3 (1 DLL × 4 TFMs) | Libraries: 4 | _(hidden)_ |
| Microsoft.Azure.SignalR (2 DLLs × 2 TFMs) | Libraries: 4 | Libraries: 2 |
| Microsoft.Azure.Cosmos (4 unique DLLs) | Libraries: 4 | Libraries: 4 |

### README
Added "Multi-assembly packages" subsection under `package` command using `Microsoft.Azure.SignalR` as an example, showing `--files`, `--tfms`, `--metadata`, and `api` commands.

## Testing
All 330 existing tests pass.