### PR TITLE
Remove executable name from tips

### DIFF
--- a/src/dotnet-inspect/Output/Hints.cs
+++ b/src/dotnet-inspect/Output/Hints.cs
@@ -6,8 +6,8 @@ public record Tip(string Subcommand, string Args, string Comment)
 {
     public string CommandText =>
         string.IsNullOrEmpty(Args)
-            ? $"{VersionInfo.ToolName} {Subcommand}"
-            : $"{VersionInfo.ToolName} {Subcommand} {Args}";
+            ? Subcommand
+            : $"{Subcommand} {Args}";
 }
 
 public static class Hints


### PR DESCRIPTION
Tips now show just the subcommand and args, solving two problems:

1. **Line wrapping** — tips are shorter, fitting better in standard terminals
2. **Invocation-agnostic** — works whether invoked as `dotnet-inspect`, `dotnet inspect`, or `dnx dotnet-inspect`

```
Before: Tip: dotnet-inspect package AWSSDK.S3 -v:d  # detailed metadata
After:  Tip: package AWSSDK.S3 -v:d                 # detailed metadata
```

One-line change in `Hints.cs` — removed `VersionInfo.ToolName` from `Tip.CommandText`. All 330 tests pass.