### PR TITLE
Split --files into flat list and --layout for tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dotnet-inspect System.Text.Json                    # Metadata (latest version)
 dotnet-inspect System.Text.Json@8.0.4 -v:d         # Detailed (shows vulnerability)
 dotnet-inspect System.Text.Json --versions         # List available versions
 dotnet-inspect System.Text.Json --sourcelink-audit  # Provenance verification
-dotnet-inspect System.Text.Json --files --all      # File structure
+dotnet-inspect System.Text.Json --layout --all      # File structure
 ```
 
 #### Multi-assembly packages
@@ -49,7 +49,9 @@ Some packages bundle multiple assemblies per TFM (e.g., `Microsoft.Azure.SignalR
 
 ```bash
 dotnet-inspect Microsoft.Azure.SignalR                # Shows Libraries: 2
-dotnet-inspect Microsoft.Azure.SignalR --files        # See all assemblies per TFM
+dotnet-inspect Microsoft.Azure.SignalR --files        # List assemblies per TFM
+dotnet-inspect Microsoft.Azure.SignalR --files --tfm net8.0  # Files for specific TFM
+dotnet-inspect Microsoft.Azure.SignalR --layout       # Show file tree
 dotnet-inspect Microsoft.Azure.SignalR --tfms         # List target frameworks
 ```
 
@@ -58,7 +60,7 @@ dotnet-inspect Microsoft.Azure.SignalR --tfms         # List target frameworks
 | Libraries | 2 |
 ```
 
-Use `--files` to see the full layout:
+Use `--layout` to see the full tree:
 
 ```text
 └─ lib

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -823,9 +823,10 @@ public static class CommandLineBuilder
 
         var depsOption = new Option<bool>("--deps") { Description = "Include dependency analysis" };
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree" };
-        var filesOption = new Option<bool>("--files") { Description = "List DLLs in the package" };
+        var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree (lib/tools structure)" };
+        var filesOption = new Option<bool>("--files") { Description = "List files in the package (flat list, filterable with --tfm)" };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };
-        var allFilesOption = new Option<bool>("--all") { Description = "With --files: list all files in entire package" };
+        var allFilesOption = new Option<bool>("--all") { Description = "With --files/--layout: include all files in entire package" };
         var versionsOption = new Option<bool>("--versions") { Description = "List available versions from nuget.org" };
         var prereleaseOption = new Option<bool>("--preview") { Description = "With --versions: include prerelease versions" };
         prereleaseOption.Aliases.Add("--prerelease");
@@ -842,6 +843,7 @@ public static class CommandLineBuilder
         packageCommand.Arguments.Add(packageNameArg);
         packageCommand.Options.Add(depsOption);
         packageCommand.Options.Add(dependenciesOption);
+        packageCommand.Options.Add(layoutOption);
         packageCommand.Options.Add(filesOption);
         packageCommand.Options.Add(tfmsOption);
         packageCommand.Options.Add(allFilesOption);
@@ -911,6 +913,7 @@ public static class CommandLineBuilder
                 IncludeDeps = parseResult.GetValue(depsOption),
                 ShowDependencies = parseResult.GetValue(dependenciesOption),
                 Tfm = parseResult.GetValue(tfmOption),
+                ListLayout = parseResult.GetValue(layoutOption),
                 ListFiles = parseResult.GetValue(filesOption),
                 ListTfms = parseResult.GetValue(tfmsOption),
                 ListAllFiles = parseResult.GetValue(allFilesOption),
@@ -934,7 +937,7 @@ public static class CommandLineBuilder
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption));
 
             if (exitCode == 0 && packageArgs.Length > 0
-                && !options.ListVersions && !options.ListFiles && !options.ListTfms && !options.Discover && !options.ShowReadme)
+                && !options.ListVersions && !options.ListFiles && !options.ListLayout && !options.ListTfms && !options.Discover && !options.ShowReadme)
             {
                 var pkg = packageArgs[0];
                 if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
@@ -949,6 +952,7 @@ public static class CommandLineBuilder
                 tips.Add(new(DiffCommand.Name, $"--package {pkg}@<prev>..<cur>", "diff versions"));
                 tips.Add(new(PackageCommand.Name, $"{pkg} --readme", "view README"));
                 tips.Add(new(PackageCommand.Name, $"{pkg} --files", "list package files"));
+                tips.Add(new(PackageCommand.Name, $"{pkg} --layout", "show file tree"));
                 tips.Add(new(LlmsTxtCommand.Name, "", "complete usage examples"));
 
                 Hints.WriteTips(tipLevel, [.. tips]);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -149,6 +149,13 @@ public class PackageCommand
 
             extractPath = resolution.ExtractPath;
 
+            // Handle --layout mode: show file tree and exit early
+            if (options.ListLayout)
+            {
+                ListPackageLayout(extractPath, options);
+                return 0;
+            }
+
             // Handle --files mode: list files and exit early
             if (options.ListFiles)
             {
@@ -331,7 +338,7 @@ public class PackageCommand
         }
     }
 
-    private static void ListPackageFiles(string extractPath, InspectionOptions options)
+    private static void ListPackageLayout(string extractPath, InspectionOptions options)
     {
         string searchPath;
         string pattern;
@@ -379,6 +386,80 @@ public class PackageCommand
             : relativePaths.ToList();
 
         WriteFileTree(results);
+    }
+
+    private static void ListPackageFiles(string extractPath, InspectionOptions options)
+    {
+        string searchPath;
+        string pattern;
+
+        if (options.ListAllFiles)
+        {
+            searchPath = extractPath;
+            pattern = "*";
+        }
+        else
+        {
+            // Scope to a specific TFM if requested
+            if (!string.IsNullOrEmpty(options.Tfm))
+            {
+                string libDir = Path.Combine(extractPath, "lib", options.Tfm);
+                string toolsDir = Path.Combine(extractPath, "tools", options.Tfm);
+
+                if (Directory.Exists(libDir))
+                    searchPath = libDir;
+                else if (Directory.Exists(toolsDir))
+                    searchPath = toolsDir;
+                else
+                {
+                    Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
+                    return;
+                }
+
+                pattern = "*";
+            }
+            else
+            {
+                string toolsDir = Path.Combine(extractPath, "tools");
+                string libDir = Path.Combine(extractPath, "lib");
+
+                if (Directory.Exists(libDir))
+                    searchPath = libDir;
+                else if (Directory.Exists(toolsDir))
+                    searchPath = toolsDir;
+                else
+                {
+                    Console.Error.WriteLine("No lib or tools directory found. Use --all to list all files.");
+                    return;
+                }
+
+                pattern = "*";
+            }
+        }
+
+        string[] files = Directory.GetFiles(searchPath, pattern, SearchOption.AllDirectories);
+
+        // Use bare filenames when scoped to a specific TFM, relative paths otherwise
+        bool useFileNameOnly = !string.IsNullOrEmpty(options.Tfm) && !options.ListAllFiles;
+        var fileNames = files
+            .Select(f => useFileNameOnly
+                ? Path.GetFileName(f)
+                : Path.GetRelativePath(options.ListAllFiles ? extractPath : searchPath, f).Replace('\\', '/'))
+            .Where(p => !p.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.StartsWith("_rels", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(p => p);
+
+        var results = options.Limit.HasValue
+            ? fileNames.Take(options.Limit.Value)
+            : fileNames;
+
+        foreach (var file in results)
+        {
+            Console.WriteLine(file);
+        }
     }
 
     private static void ListPackageTfms(string extractPath)

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -23,7 +23,12 @@ public record InspectionOptions
     public string? Tfm { get; init; }
 
     /// <summary>
-    /// List files in the package instead of showing metadata.
+    /// Show the package file tree (lib/tools structure).
+    /// </summary>
+    public bool ListLayout { get; init; }
+
+    /// <summary>
+    /// List files in the package (flat list, filterable with --tfm).
     /// </summary>
     public bool ListFiles { get; init; }
 


### PR DESCRIPTION
Renames --files (tree view) to --layout. New --files prints flat file list with --tfm filtering. All 330 tests pass.