### PR TITLE
Add PackageCacheService to abstract cache access

### DIFF
--- a/src/DotnetInspector.Services.Tests/PackageCacheServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCacheServiceTests.cs
@@ -1,0 +1,86 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Services.Tests;
+
+public class PackageCacheServiceTests
+{
+    [Fact]
+    public void GetCacheInfo_ReturnsLocation()
+    {
+        NuGetCache.Initialize("dotnet-inspect-test");
+        var info = PackageCacheService.GetCacheInfo();
+
+        Assert.NotNull(info.Location);
+        Assert.Contains("dotnet-inspect-test", info.Location);
+    }
+
+    [Fact]
+    public void GetCacheInfo_EmptyCache_ReturnsZeroStats()
+    {
+        NuGetCache.Initialize("dotnet-inspect-cache-test-empty-" + Guid.NewGuid().ToString("N")[..8]);
+        var info = PackageCacheService.GetCacheInfo();
+
+        Assert.Empty(info.Categories);
+        Assert.Equal(0, info.TotalSize);
+    }
+
+    [Fact]
+    public void ClearCache_EmptyCache_ReturnsZero()
+    {
+        NuGetCache.Initialize("dotnet-inspect-cache-test-clean-" + Guid.NewGuid().ToString("N")[..8]);
+        long freed = PackageCacheService.ClearCache();
+
+        Assert.Equal(0, freed);
+    }
+
+    [Fact]
+    public void CacheSource_ThenRetrieve()
+    {
+        NuGetCache.Initialize("dotnet-inspect-cache-test-src-" + Guid.NewGuid().ToString("N")[..8]);
+        var testUrl = $"https://example.com/test-{Guid.NewGuid():N}.cs";
+        var content = "// test source content";
+
+        try
+        {
+            // Should not exist initially
+            Assert.Null(PackageCacheService.TryGetCachedSource(testUrl));
+
+            // Cache it
+            PackageCacheService.CacheSource(testUrl, content);
+
+            // Should now be retrievable
+            var cached = PackageCacheService.TryGetCachedSource(testUrl);
+            Assert.Equal(content, cached);
+        }
+        finally
+        {
+            // Clean up
+            try { PackageCacheService.ClearCache(); } catch { }
+        }
+    }
+
+    [Fact]
+    public void CacheInfo_Record_Properties()
+    {
+        var categories = new List<PackageCacheService.CacheCategoryInfo>
+        {
+            new("Packages", 1024, 5),
+            new("Sources", 512, 10)
+        };
+        var info = new PackageCacheService.CacheInfo("/some/path", categories, 1536);
+
+        Assert.Equal("/some/path", info.Location);
+        Assert.Equal(2, info.Categories.Count);
+        Assert.Equal(1536, info.TotalSize);
+    }
+
+    [Fact]
+    public void CacheCategoryInfo_Record_Properties()
+    {
+        var category = new PackageCacheService.CacheCategoryInfo("Packages", 2048, 3);
+
+        Assert.Equal("Packages", category.Name);
+        Assert.Equal(2048, category.Size);
+        Assert.Equal(3, category.Count);
+    }
+}

--- a/src/DotnetInspector.Services/PackageCacheService.cs
+++ b/src/DotnetInspector.Services/PackageCacheService.cs
@@ -1,0 +1,108 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Provides cache management operations.
+/// Enforces the invariant: NuGet cache is read-only, writes go to the app cache.
+/// </summary>
+public static class PackageCacheService
+{
+    /// <summary>
+    /// Per-category cache statistics.
+    /// </summary>
+    public record CacheCategoryInfo(string Name, long Size, int Count);
+
+    /// <summary>
+    /// Overall cache information.
+    /// </summary>
+    public record CacheInfo(string Location, List<CacheCategoryInfo> Categories, long TotalSize);
+
+    /// <summary>
+    /// Returns cache location and per-category statistics.
+    /// </summary>
+    public static CacheInfo GetCacheInfo()
+    {
+        var basePath = NuGetCache.GetAppCacheBasePath();
+        var categories = new List<CacheCategoryInfo>();
+        long totalSize = 0;
+
+        if (Directory.Exists(basePath))
+        {
+            foreach (var (name, subdir) in new[] { ("Packages", "packages"), ("Sources", "sources"), ("Symbols", "symbols") })
+            {
+                var path = Path.Combine(basePath, subdir);
+                if (Directory.Exists(path))
+                {
+                    var (size, count) = GetDirectoryStats(path);
+                    categories.Add(new CacheCategoryInfo(name, size, count));
+                    totalSize += size;
+                }
+            }
+        }
+
+        return new CacheInfo(basePath, categories, totalSize);
+    }
+
+    /// <summary>
+    /// Clears the app cache. Returns the number of bytes freed.
+    /// </summary>
+    public static long ClearCache()
+    {
+        var basePath = NuGetCache.GetAppCacheBasePath();
+
+        if (!Directory.Exists(basePath))
+            return 0;
+
+        var (size, _) = GetDirectoryStats(basePath);
+        Directory.Delete(basePath, recursive: true);
+        return size;
+    }
+
+    /// <summary>
+    /// Retrieves cached source content for a URL, if available.
+    /// </summary>
+    public static string? TryGetCachedSource(string url)
+    {
+        return NuGetCache.TryGetCachedSource(url);
+    }
+
+    /// <summary>
+    /// Caches source content for a URL (writes to app cache only).
+    /// </summary>
+    public static void CacheSource(string url, string content)
+    {
+        NuGetCache.CacheSource(url, content);
+    }
+
+    private static (long size, int count) GetDirectoryStats(string path)
+    {
+        if (!Directory.Exists(path))
+            return (0, 0);
+
+        long size = 0;
+        int count = 0;
+
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    size += new FileInfo(file).Length;
+                    count++;
+                }
+                catch
+                {
+                    // Skip files we can't access
+                }
+            }
+        }
+        catch
+        {
+            // Skip directories we can't access
+        }
+
+        return (size, count);
+    }
+}

--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -1,6 +1,5 @@
-using DotnetInspector.Packages;
 using DotnetInspector.Options;
-using DotnetInspector.Output;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 
@@ -11,79 +10,53 @@ public class CacheCommand
 {
     public static Task<int> ExecuteAsync(CacheOptions options)
     {
-        var context = new CommandContext(options.Verbose);
-        var logger = context.Logger;
-
-        var basePath = NuGetCache.GetAppCacheBasePath();
-        
         if (options.Clean)
         {
-            return CleanCacheAsync(basePath, logger);
+            return CleanCacheAsync();
         }
 
-        return ShowCacheInfoAsync(basePath, logger);
+        return ShowCacheInfoAsync();
     }
 
-    private static Task<int> ShowCacheInfoAsync(string basePath, VerboseLogger logger)
+    private static Task<int> ShowCacheInfoAsync()
     {
-        Console.WriteLine($"Cache location: {basePath}");
+        var info = PackageCacheService.GetCacheInfo();
+
+        Console.WriteLine($"Cache location: {info.Location}");
         Console.WriteLine();
 
-        if (!Directory.Exists(basePath))
+        if (info.Categories.Count == 0)
         {
             Console.WriteLine("Cache is empty.");
             return Task.FromResult(0);
         }
 
-        var packagePath = Path.Combine(basePath, "packages");
-        var sourcePath = Path.Combine(basePath, "sources");
-        var symbolPath = Path.Combine(basePath, "symbols");
-
-        long totalSize = 0;
-
-        if (Directory.Exists(packagePath))
+        foreach (var category in info.Categories)
         {
-            var (size, count) = GetDirectoryStats(packagePath);
-            totalSize += size;
-            Console.WriteLine($"Packages: {FormatSize(size)} ({count} packages)");
-        }
-
-        if (Directory.Exists(sourcePath))
-        {
-            var (size, count) = GetDirectoryStats(sourcePath);
-            totalSize += size;
-            Console.WriteLine($"Sources:  {FormatSize(size)} ({count} files)");
-        }
-
-        if (Directory.Exists(symbolPath))
-        {
-            var (size, count) = GetDirectoryStats(symbolPath);
-            totalSize += size;
-            Console.WriteLine($"Symbols:  {FormatSize(size)} ({count} files)");
+            Console.WriteLine($"{category.Name + ":",-10}{FormatSize(category.Size)} ({category.Count} {(category.Name == "Packages" ? "packages" : "files")})");
         }
 
         Console.WriteLine();
-        Console.WriteLine($"Total:    {FormatSize(totalSize)}");
+        Console.WriteLine($"{"Total:",-10}{FormatSize(info.TotalSize)}");
         Console.WriteLine();
         Console.WriteLine("Run 'dotnet-inspect cache --clean' to clear the cache.");
 
         return Task.FromResult(0);
     }
 
-    private static Task<int> CleanCacheAsync(string basePath, VerboseLogger logger)
+    private static Task<int> CleanCacheAsync()
     {
-        if (!Directory.Exists(basePath))
-        {
-            Console.WriteLine("Cache is already empty.");
-            return Task.FromResult(0);
-        }
-
-        var (size, _) = GetDirectoryStats(basePath);
-
         try
         {
-            Directory.Delete(basePath, recursive: true);
-            Console.WriteLine($"Cleared {FormatSize(size)} from cache.");
+            long freed = PackageCacheService.ClearCache();
+            if (freed == 0)
+            {
+                Console.WriteLine("Cache is already empty.");
+            }
+            else
+            {
+                Console.WriteLine($"Cleared {FormatSize(freed)} from cache.");
+            }
             return Task.FromResult(0);
         }
         catch (Exception ex)
@@ -91,37 +64,6 @@ public class CacheCommand
             Console.Error.WriteLine($"Error clearing cache: {ex.Message}");
             return Task.FromResult(1);
         }
-    }
-
-    private static (long size, int count) GetDirectoryStats(string path)
-    {
-        if (!Directory.Exists(path))
-            return (0, 0);
-
-        long size = 0;
-        int count = 0;
-
-        try
-        {
-            foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    size += new FileInfo(file).Length;
-                    count++;
-                }
-                catch
-                {
-                    // Skip files we can't access
-                }
-            }
-        }
-        catch
-        {
-            // Skip directories we can't access
-        }
-
-        return (size, count);
     }
 
     private static string FormatSize(long bytes)

--- a/src/dotnet-inspect/Inspectors/SourceFetcher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceFetcher.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
 
@@ -24,7 +25,7 @@ public class SourceFetcher(HttpClient httpClient)
         }
 
         // Check persistent disk cache
-        var diskCached = NuGetCache.TryGetCachedSource(url);
+        var diskCached = PackageCacheService.TryGetCachedSource(url);
         if (diskCached != null)
         {
             _memoryCache[url] = diskCached;
@@ -38,7 +39,7 @@ public class SourceFetcher(HttpClient httpClient)
             if (content == null)
                 return null;
             _memoryCache[url] = content;
-            NuGetCache.CacheSource(url, content);
+            PackageCacheService.CacheSource(url, content);
             return content;
         }
         catch


### PR DESCRIPTION
## Summary

The app layer no longer reaches into `NuGetCache` directly. A new `PackageCacheService` in `DotnetInspector.Services` wraps all cache operations, enforcing the invariant:

> **NuGet cache (`~/.nuget/packages`) is read-only; all writes go to the app cache.**

## API

```csharp
// Cache info and management
PackageCacheService.GetCacheInfo()   // → CacheInfo { Location, Categories[], TotalSize }
PackageCacheService.ClearCache()     // → bytes freed

// Source file caching
PackageCacheService.TryGetCachedSource(url)   // → cached content or null
PackageCacheService.CacheSource(url, content) // → writes to app cache
```

## Changes

- **CacheCommand** — removed `NuGetCache` dependency, `GetDirectoryStats()`, hardcoded subdirectory knowledge (`packages/sources/symbols`). Now uses `GetCacheInfo()` and `ClearCache()`. Net -57 lines.
- **SourceFetcher** — uses `PackageCacheService` instead of `NuGetCache.TryGetCachedSource/CacheSource`
- **Remaining `NuGetCache` reference** — only `Program.cs: NuGetCache.Initialize()` (acceptable one-time app init)

## Tests

6 new tests covering cache info retrieval, empty cache handling, source caching round-trip.
All 399 tests pass (330 app + 69 services).