### PR TITLE
Fix --tips option on root command

### DIFF
--- a/docs/lap-around.md
+++ b/docs/lap-around.md
@@ -1,0 +1,34 @@
+# Lap around `dotnet-inspect`
+
+`dotnet-inspect` exposes a lot of functionality. The following "lap around" walkthough demonstrates a set of highlights and also a natural progression of using the commands.
+
+The tool operates of three types of content:
+
+- Packages
+- Libraries
+- Platform libraries
+
+Packages download honors `nuget.config`.
+
+There are mulptiple ways to run the tool, via `dnx`, as an installed tool (`dotnet-inspect` / `dotnet inspect`), or from source via `dotnet run`. These commands use `dotnet-inspect` as a tool. Only the commands are recorded, not the output.
+
+## Tool help
+
+No args launch:
+
+```bash
+dotnet inspect                          # tool help
+```
+
+## Packages
+
+Metadata-oriented markdown documents:
+
+```bash
+dotnet inspect System.Text.Json         # Metadata view for package (same as -v:m)
+dotnet inspect System.Text.Json -v:d    # Metadata, statistics, and direct package dependencies
+dotnet inspect System.Text.Json -v:q    # Terse 3-line details about latest package version
+```
+
+Pure data:
+

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -49,7 +49,7 @@ public static class CommandLineBuilder
         var includeSectionsOption = new Option<string?>("-s") { Description = "Include only these sections by name (comma-separated, e.g., -s:Methods,Properties).\nUse -s alone for header only.", Arity = ArgumentArity.ZeroOrOne };
         var excludeSectionsOption = new Option<string?>("-x") { Description = "Exclude these sections by name (comma-separated, e.g., -x:Methods)" };
         var limitOption = new Option<int?>("-n") { Description = "Limit number of results" };
-        var tipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)", Hidden = true };
+        var tipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)" };
 
         // NuGet source options (shared across package-consuming commands)
         var sourceOption = new Option<string[]>("--source")
@@ -71,6 +71,8 @@ public static class CommandLineBuilder
 
         // Root-level display option (distinct instance so it appears in root help)
         rootCommand.Options.Add(new Option<string?>("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)" });
+        var rootTipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)" };
+        rootCommand.Options.Add(rootTipsOption);
 
         // API command
         var apiCommand = CreateApiCommand(jsonOption, markoutOption, verboseOption, verbosityOption, limitOption, includeSectionsOption, excludeSectionsOption, sourceOption, addSourceOption, nugetConfigOption);
@@ -137,9 +139,14 @@ public static class CommandLineBuilder
         // No-args: show help + tips
         rootCommand.SetAction((parseResult) =>
         {
+            var sw = new System.IO.StringWriter();
+            var original = Console.Out;
+            Console.SetOut(sw);
             new HelpAction().Invoke(parseResult);
+            Console.SetOut(original);
+            Console.WriteLine(sw.ToString().TrimEnd());
 
-            var tipLevel = ParseTipLevel(null);
+            var tipLevel = ParseTipLevel(parseResult.GetValue(rootTipsOption));
             Hints.WriteTips(tipLevel,
                 new Tip(PackageCommand.Name, "<package>", "inspect a NuGet package"),
                 new Tip(LlmsTxtCommand.Name, "", "complete usage examples"),

--- a/src/dotnet-inspect/Output/Hints.cs
+++ b/src/dotnet-inspect/Output/Hints.cs
@@ -19,7 +19,6 @@ public static class Hints
         var visible = tips.Take(max).ToList();
         int commentColumn = visible.Max(t => t.CommandText.Length) + 3;
         Console.Out.Flush();
-        Console.Error.WriteLine();
         foreach (var tip in visible)
             Console.Error.WriteLine($"Tip: {tip.CommandText.PadRight(commentColumn)}# {tip.Comment}");
     }


### PR DESCRIPTION
## Problem

`dotnet-inspect --tips:d` fails with "Unrecognized command or argument" because the `--tips` option was only added to subcommands (package, diff, find), not the root command.

## Fix

- Add `--tips` option to the root command
- Wire up the root action to read the `--tips` value (was hardcoded to `null`)
- Unhide `--tips` on all commands so it appears in help output

## Result

| Command | Before | After |
|---------|--------|-------|
| `dotnet-inspect --tips:d` | Error: unrecognized | Shows all 6 tips |
| `dotnet-inspect --tips:q` | Error: unrecognized | Suppresses tips |
| `dotnet-inspect` (default) | 3 tips (minimal) | *(unchanged)* |