### PR TITLE
Move 7 inspectors to DotnetInspector.Services

### DIFF
--- a/src/DotnetInspector.Services.Tests/DepsJsonParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/DepsJsonParserTests.cs
@@ -1,7 +1,4 @@
-using DotnetInspector;
-using DotnetInspector.Inspectors;
-
-namespace DotnetInspector.Tests;
+namespace DotnetInspector.Services.Tests;
 
 /// <summary>
 /// Tests for DepsJsonParser JSON parsing functionality.
@@ -26,7 +23,7 @@ public class DepsJsonParserTests : IDisposable
 
     private string WriteDepsJson(string content)
     {
-        var path = Path.Combine(_tempDir, "test.deps.json");
+        var path = Path.Combine(_tempDir, $"test-{Guid.NewGuid():N}.deps.json");
         File.WriteAllText(path, content);
         return path;
     }
@@ -42,8 +39,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Equal("linux-x64", result.RuntimeTargetRid);
     }
@@ -59,8 +55,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Null(result.RuntimeTargetRid);
     }
@@ -81,8 +76,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.NotNull(result.RuntimeDependencies);
         Assert.Equal(2, result.RuntimeDependencies.Count);
@@ -109,8 +103,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.NotNull(result.RuntimeDependencies);
         Assert.Single(result.RuntimeDependencies);
@@ -126,8 +119,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Null(result.RuntimeDependencies);
     }
@@ -143,8 +135,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Null(result.RuntimeDependencies);
     }
@@ -165,8 +156,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         // Only the valid entry should be parsed
         Assert.NotNull(result.RuntimeDependencies);
@@ -179,10 +169,8 @@ public class DepsJsonParserTests : IDisposable
     {
         var deps = WriteDepsJson("{ invalid json }");
 
-        var result = new InspectionResult();
-
         // Should not throw
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Null(result.RuntimeDependencies);
         Assert.Null(result.RuntimeTargetRid);
@@ -204,8 +192,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         Assert.Equal("win-x64", result.RuntimeTargetRid);
         Assert.NotNull(result.RuntimeDependencies);
@@ -228,8 +215,7 @@ public class DepsJsonParserTests : IDisposable
             }
             """);
 
-        var result = new InspectionResult();
-        DepsJsonParser.Parse(deps, result);
+        var result = DepsJsonParser.Parse(deps);
 
         // Only the entry with type should be processed
         Assert.NotNull(result.RuntimeDependencies);

--- a/src/DotnetInspector.Services.Tests/GenericTypeNameTests.cs
+++ b/src/DotnetInspector.Services.Tests/GenericTypeNameTests.cs
@@ -1,6 +1,6 @@
-using DotnetInspector.Inspectors;
 
-namespace DotnetInspector.Tests;
+
+namespace DotnetInspector.Services.Tests;
 
 /// <summary>
 /// Tests for generic type name conversion from C# syntax to metadata format.

--- a/src/DotnetInspector.Services.Tests/SampleUrlResolutionTests.cs
+++ b/src/DotnetInspector.Services.Tests/SampleUrlResolutionTests.cs
@@ -1,6 +1,6 @@
-using DotnetInspector.Inspectors;
 
-namespace DotnetInspector.Tests;
+
+namespace DotnetInspector.Services.Tests;
 
 /// <summary>
 /// Tests for sample URL resolution from relative paths.

--- a/src/DotnetInspector.Services.Tests/SignatureVerifierTests.cs
+++ b/src/DotnetInspector.Services.Tests/SignatureVerifierTests.cs
@@ -1,6 +1,6 @@
-using DotnetInspector.Inspectors;
 
-namespace DotnetInspector.Tests;
+
+namespace DotnetInspector.Services.Tests;
 
 /// <summary>
 /// Tests for SignatureVerifier parsing logic.

--- a/src/DotnetInspector.Services/DepsJsonData.cs
+++ b/src/DotnetInspector.Services/DepsJsonData.cs
@@ -1,0 +1,12 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Data parsed from a .deps.json file.
+/// </summary>
+public class DepsJsonData
+{
+    public string? RuntimeTargetRid { get; set; }
+    public List<PackageDependency>? RuntimeDependencies { get; set; }
+}

--- a/src/DotnetInspector.Services/DepsJsonParser.cs
+++ b/src/DotnetInspector.Services/DepsJsonParser.cs
@@ -1,15 +1,17 @@
 using System.Text.Json;
 using DotnetInspector.Packages;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Parses .deps.json files for runtime dependencies.
 /// </summary>
 public static class DepsJsonParser
 {
-    public static void Parse(string depsPath, InspectionResult result)
+    public static DepsJsonData Parse(string depsPath)
     {
+        var result = new DepsJsonData();
+
         try
         {
             string json = File.ReadAllText(depsPath);
@@ -59,5 +61,7 @@ public static class DepsJsonParser
         {
             // Ignore parse errors
         }
+
+        return result;
     }
 }

--- a/src/DotnetInspector.Services/GenericTypeNameConverter.cs
+++ b/src/DotnetInspector.Services/GenericTypeNameConverter.cs
@@ -1,12 +1,12 @@
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Converts C#-style generic type names to CLR backtick notation.
 /// e.g., "Dictionary&lt;TKey,TValue&gt;" → "Dictionary`2"
 /// </summary>
-internal static class GenericTypeNameConverter
+public static class GenericTypeNameConverter
 {
-    internal static string Convert(string typeName)
+    public static string Convert(string typeName)
     {
         int angleBracketStart = typeName.IndexOf('<');
         if (angleBracketStart < 0)

--- a/src/DotnetInspector.Services/GitHubUrlResolver.cs
+++ b/src/DotnetInspector.Services/GitHubUrlResolver.cs
@@ -1,16 +1,16 @@
 using System.Text.RegularExpressions;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Utilities for resolving and converting GitHub URLs.
 /// </summary>
-internal static class GitHubUrlResolver
+public static class GitHubUrlResolver
 {
     /// <summary>
     /// Resolves a relative sample path to a full URL based on the source file URL.
     /// </summary>
-    internal static string? ResolveSampleUrl(string sourceUrl, string relativePath)
+    public static string? ResolveSampleUrl(string sourceUrl, string relativePath)
     {
         try
         {
@@ -76,7 +76,7 @@ internal static class GitHubUrlResolver
     /// <summary>
     /// Converts a GitHub /raw/ URL to a /blob/ URL for browser viewing.
     /// </summary>
-    internal static string ConvertRawToBlobUrl(string url)
+    public static string ConvertRawToBlobUrl(string url)
     {
         return url.Replace("/raw/", "/blob/");
     }
@@ -84,7 +84,7 @@ internal static class GitHubUrlResolver
     /// <summary>
     /// Converts a raw.githubusercontent.com URL to a github.com/raw/ URL for display.
     /// </summary>
-    internal static string? ConvertToGitHubRawUrl(string? rawUrl)
+    public static string? ConvertToGitHubRawUrl(string? rawUrl)
     {
         if (rawUrl == null) return null;
 
@@ -99,7 +99,7 @@ internal static class GitHubUrlResolver
     /// <summary>
     /// Converts a github.com raw/blob URL to a raw.githubusercontent.com URL for fetching content.
     /// </summary>
-    internal static string ConvertToRawGitHubContentUrl(string url)
+    public static string ConvertToRawGitHubContentUrl(string url)
     {
         if (url.Contains("github.com"))
         {

--- a/src/DotnetInspector.Services/PackageReferenceParser.cs
+++ b/src/DotnetInspector.Services/PackageReferenceParser.cs
@@ -1,11 +1,11 @@
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Parses package references from various formats (name@version, .nupkg files, paths).
 /// </summary>
-internal static class PackageReferenceParser
+public static class PackageReferenceParser
 {
-    internal static (string? name, string? version) ParsePackageReference(string packageSource)
+    public static (string? name, string? version) ParsePackageReference(string packageSource)
     {
         if (packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
         {
@@ -37,7 +37,7 @@ internal static class PackageReferenceParser
         return (fileName, null);
     }
 
-    internal static string? ExtractVersionFromPath(string dllPath, string packageName)
+    public static string? ExtractVersionFromPath(string dllPath, string packageName)
     {
         var normalizedPath = dllPath.Replace('\\', '/');
         var normalizedPackageName = packageName.ToLowerInvariant();

--- a/src/DotnetInspector.Services/SignatureVerifier.cs
+++ b/src/DotnetInspector.Services/SignatureVerifier.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Result of NuGet package signature verification.

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -1,7 +1,6 @@
 using DotnetInspector.Packages;
-using DotnetInspector.Services;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Fetches source files from URLs with persistent disk caching and in-memory caching.

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -1,13 +1,13 @@
 using DotnetInspector.Packages;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// TFM selection and assembly discovery within package layouts.
 /// </summary>
-internal static class TfmSelector
+public static class TfmSelector
 {
-    internal static List<string> GetPackageDlls(string extractPath)
+    public static List<string> GetPackageDlls(string extractPath)
     {
         var toolsDir = Path.Combine(extractPath, "tools");
         var libDir = Path.Combine(extractPath, "lib");
@@ -31,7 +31,7 @@ internal static class TfmSelector
         return candidates.OrderBy(f => f).ToList();
     }
 
-    internal static (string? path, string? tfm) SelectHighestTfmAssembly(List<string> dlls, string extractPath, string? packageName = null)
+    public static (string? path, string? tfm) SelectHighestTfmAssembly(List<string> dlls, string extractPath, string? packageName = null)
     {
         dlls = dlls.Where(d => !d.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)).ToList();
 
@@ -82,7 +82,7 @@ internal static class TfmSelector
         return (directDll ?? assemblies[0], highestTfm);
     }
 
-    internal static string? FindAssemblyByTfm(string extractPath, string tfm)
+    public static string? FindAssemblyByTfm(string extractPath, string tfm)
     {
         var libDir = Path.Combine(extractPath, "lib");
         var toolsDir = Path.Combine(extractPath, "tools");

--- a/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
+++ b/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Sockets;
-using DotnetInspector.Inspectors;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Services;
 using Markout;
 
 namespace DotnetInspector.Commands;

--- a/src/dotnet-inspect/Commands/ApiServices.cs
+++ b/src/dotnet-inspect/Commands/ApiServices.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -242,7 +242,7 @@ public class PackageCommand
                 string[] depsFiles = Directory.GetFiles(extractPath, "*.deps.json", SearchOption.AllDirectories);
                 foreach (string depsFile in depsFiles)
                 {
-                    DepsJsonParser.Parse(depsFile, result);
+                    ApplyDepsJson(Services.DepsJsonParser.Parse(depsFile), result);
                 }
             }
 
@@ -308,6 +308,20 @@ public class PackageCommand
         result.IsToolPackage = nuspec.IsToolPackage;
         result.ReadmeFile = nuspec.ReadmeFile;
         result.DependencyGroups = nuspec.DependencyGroups;
+    }
+
+    private static void ApplyDepsJson(DepsJsonData depsJson, InspectionResult result)
+    {
+        if (depsJson.RuntimeTargetRid != null)
+        {
+            result.RuntimeTargetRid = depsJson.RuntimeTargetRid;
+        }
+
+        if (depsJson.RuntimeDependencies != null)
+        {
+            result.RuntimeDependencies ??= [];
+            result.RuntimeDependencies.AddRange(depsJson.RuntimeDependencies);
+        }
     }
 
     private static void ApplyMetadata(InspectionResult result, PackageMetadata metadata)

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -1,9 +1,9 @@
 using System.Text;
-using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 using Markout;
 
 namespace DotnetInspector.Commands;

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
 


### PR DESCRIPTION
Moves 7 app-agnostic utilities from Inspectors/ to the shared Services library:

- **DepsJsonParser** — returns `DepsJsonData` DTO instead of mutating `InspectionResult`
- **PackageReferenceParser** — pure parsing utility (used by 4 commands)
- **TfmSelector** — TFM selection and assembly discovery (used by 4+ commands)
- **GitHubUrlResolver** — URL manipulation utility (used by 3 commands)
- **SignatureVerifier** — NuGet signature verification
- **GenericTypeNameConverter** — generic name conversion
- **SourceFetcher** — source file fetching with caching (already used PackageCacheService)

Remaining in Inspectors/ (app-coupled):
- ToolsAnalyzer, RidPackageVerifier, AssemblyCollector (mutate InspectionResult or use app types)
- PlatformResolver, DocCommentParser, XmlDocFileParser (heavier/coupled, future candidates)

All 385 tests pass (263 app + 122 services). Net +17 lines (added `DepsJsonData` DTO + `ApplyDepsJson` in PackageCommand).