### PR TITLE
Show all package files by default for --files and --layout

### DIFF
--- a/docs/lap-around.md
+++ b/docs/lap-around.md
@@ -17,7 +17,22 @@ There are mulptiple ways to run the tool, via `dnx`, as an installed tool (`dotn
 No args launch:
 
 ```bash
-dotnet inspect                          # tool help
+dotnet-inspect                          # tool help
+dotnet-inspect --tips:d                 # more tips
+dotnet-inspect --tips:q                 # quiet tips
+dotnet-inspect 2>/dev/null              # another way to quiet tips
+DOTNET_INSPECT_TIPS=quiet dotnet-inspect # another way to quiet tips
+```
+
+Tips are contextual suggestions written to `stderr` to guide the next step.
+
+For example:
+
+```bash
+$ dotnet-inspect | grep Tips
+Tip: package <package>   # inspect a NuGet package
+Tip: llmstxt             # complete usage examples
+Tip: --tips:d            # show more tips per command
 ```
 
 ## Packages
@@ -25,10 +40,15 @@ dotnet inspect                          # tool help
 Metadata-oriented markdown documents:
 
 ```bash
-dotnet inspect System.Text.Json         # Metadata view for package (same as -v:m)
-dotnet inspect System.Text.Json -v:d    # Metadata, statistics, and direct package dependencies
-dotnet inspect System.Text.Json -v:q    # Terse 3-line details about latest package version
+dotnet-inspect System.Text.Json         # Metadata view for package (same as -v:m)
+dotnet-inspect System.Text.Json@10.0.2  # Specify a version; positional and --version also works
+dotnet-inspect System.Text.Json -v:d    # Metadata, statistics, and direct package dependencies
+dotnet-inspect System.Text.Json -v:q    # Terse 3-line details about latest package version
 ```
 
 Pure data:
 
+```bash
+dotnet-inspect System.Text.Json --files # List all file in the package, package-root qualified, one per line
+dotnet-inspect System.Text.Json --tfms  # Lists TFM folders in the package, one per line
+```

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -868,10 +868,9 @@ public static class CommandLineBuilder
 
         var depsOption = new Option<bool>("--deps") { Description = "Include dependency analysis" };
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree" };
-        var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree (lib/tools structure)" };
+        var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
         var filesOption = new Option<bool>("--files") { Description = "List files in the package (flat list, filterable with --tfm)" };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };
-        var allFilesOption = new Option<bool>("--all") { Description = "With --files/--layout: include all files in entire package" };
         var versionsOption = new Option<bool>("--versions") { Description = "List available versions from nuget.org" };
         var prereleaseOption = new Option<bool>("--preview") { Description = "With --versions: include prerelease versions" };
         prereleaseOption.Aliases.Add("--prerelease");
@@ -891,7 +890,6 @@ public static class CommandLineBuilder
         packageCommand.Options.Add(layoutOption);
         packageCommand.Options.Add(filesOption);
         packageCommand.Options.Add(tfmsOption);
-        packageCommand.Options.Add(allFilesOption);
         packageCommand.Options.Add(versionsOption);
         packageCommand.Options.Add(prereleaseOption);
         packageCommand.Options.Add(readmeOption);
@@ -961,7 +959,6 @@ public static class CommandLineBuilder
                 ListLayout = parseResult.GetValue(layoutOption),
                 ListFiles = parseResult.GetValue(filesOption),
                 ListTfms = parseResult.GetValue(tfmsOption),
-                ListAllFiles = parseResult.GetValue(allFilesOption),
                 ListVersions = parseResult.GetValue(versionsOption),
                 IncludePrerelease = parseResult.GetValue(prereleaseOption),
                 ShowReadme = parseResult.GetValue(readmeOption),

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -369,36 +369,8 @@ public class PackageCommand
 
     private static void ListPackageLayout(string extractPath, InspectionOptions options)
     {
-        string searchPath;
-        string pattern;
-
-        if (options.ListAllFiles)
-        {
-            // --all: search entire package for all files
-            searchPath = extractPath;
-            pattern = "*";
-        }
-        else
-        {
-            // Tools packages use 'tools' directory, regular packages use 'lib'
-            string toolsDir = Path.Combine(extractPath, "tools");
-            string libDir = Path.Combine(extractPath, "lib");
-
-            if (Directory.Exists(toolsDir))
-            {
-                searchPath = toolsDir;
-            }
-            else if (Directory.Exists(libDir))
-            {
-                searchPath = libDir;
-            }
-            else
-            {
-                Console.Error.WriteLine("No lib or tools directory found. Use --all to list all files.");
-                return;
-            }
-            pattern = "*.dll";
-        }
+        string searchPath = extractPath;
+        string pattern = "*";
 
         string[] files = Directory.GetFiles(searchPath, pattern, SearchOption.AllDirectories);
 
@@ -420,60 +392,36 @@ public class PackageCommand
     private static void ListPackageFiles(string extractPath, InspectionOptions options)
     {
         string searchPath;
-        string pattern;
 
-        if (options.ListAllFiles)
+        // Scope to a specific TFM if requested
+        if (!string.IsNullOrEmpty(options.Tfm))
         {
-            searchPath = extractPath;
-            pattern = "*";
+            string libDir = Path.Combine(extractPath, "lib", options.Tfm);
+            string toolsDir = Path.Combine(extractPath, "tools", options.Tfm);
+
+            if (Directory.Exists(libDir))
+                searchPath = libDir;
+            else if (Directory.Exists(toolsDir))
+                searchPath = toolsDir;
+            else
+            {
+                Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
+                return;
+            }
         }
         else
         {
-            // Scope to a specific TFM if requested
-            if (!string.IsNullOrEmpty(options.Tfm))
-            {
-                string libDir = Path.Combine(extractPath, "lib", options.Tfm);
-                string toolsDir = Path.Combine(extractPath, "tools", options.Tfm);
-
-                if (Directory.Exists(libDir))
-                    searchPath = libDir;
-                else if (Directory.Exists(toolsDir))
-                    searchPath = toolsDir;
-                else
-                {
-                    Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
-                    return;
-                }
-
-                pattern = "*";
-            }
-            else
-            {
-                string toolsDir = Path.Combine(extractPath, "tools");
-                string libDir = Path.Combine(extractPath, "lib");
-
-                if (Directory.Exists(libDir))
-                    searchPath = libDir;
-                else if (Directory.Exists(toolsDir))
-                    searchPath = toolsDir;
-                else
-                {
-                    Console.Error.WriteLine("No lib or tools directory found. Use --all to list all files.");
-                    return;
-                }
-
-                pattern = "*";
-            }
+            searchPath = extractPath;
         }
 
-        string[] files = Directory.GetFiles(searchPath, pattern, SearchOption.AllDirectories);
+        string[] files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
 
         // Use bare filenames when scoped to a specific TFM, relative paths otherwise
-        bool useFileNameOnly = !string.IsNullOrEmpty(options.Tfm) && !options.ListAllFiles;
+        bool useFileNameOnly = !string.IsNullOrEmpty(options.Tfm);
         var fileNames = files
             .Select(f => useFileNameOnly
                 ? Path.GetFileName(f)
-                : Path.GetRelativePath(options.ListAllFiles ? extractPath : searchPath, f).Replace('\\', '/'))
+                : Path.GetRelativePath(extractPath, f).Replace('\\', '/'))
             .Where(p => !p.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
             .Where(p => !p.StartsWith("_rels", StringComparison.OrdinalIgnoreCase))
             .Where(p => !p.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase))

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -38,11 +38,6 @@ public record InspectionOptions
     public bool ListTfms { get; init; }
 
     /// <summary>
-    /// When listing files, include all files (not just .dll files).
-    /// </summary>
-    public bool ListAllFiles { get; init; }
-
-    /// <summary>
     /// List available versions of the package from nuget.org.
     /// </summary>
     public bool ListVersions { get; init; }


### PR DESCRIPTION
## Problem

`--files` and `--layout` only showed files from `lib/` or `tools/` directories, missing analyzers, images, scripts, and other package content. Required `--all` to see everything.

## Fix

| Command | Before | After |
|---------|--------|-------|
| `--files` | lib/tools files only | All package files |
| `--layout` | lib/tools DLLs only | Full package tree |
| `--files --tfm net8.0` | *(unchanged)* | Scoped to `lib/net8.0/` |
| `--all` | Required for full listing | Removed (no longer needed) |

## Example

```
$ dotnet-inspect AWSSDK.S3 --files
.signature.p7s
analyzers/dotnet/cs/AWSSDK.S3.CodeAnalysis.dll
analyzers/dotnet/cs/SharedAnalysisCode.dll
images/AWSLogo.png
lib/net472/AWSSDK.S3.dll
...
tools/install.ps1
tools/uninstall.ps1
```