### PR TITLE
Extract rendering logic to Output formatters

### DIFF
--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
@@ -22,7 +23,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: false);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: false);
 
         Assert.Equal("Command CommandResult Option OptionResult", output);
     }
@@ -41,7 +42,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: true);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: true);
         var lines = output.Split(Environment.NewLine);
 
         Assert.Equal(2, lines.Length);
@@ -64,7 +65,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: false);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: false);
 
         // Should be deduplicated and sorted
         Assert.Equal("Option Version VersionOption", output);
@@ -82,7 +83,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: false);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: false);
 
         Assert.Equal("Alpha Middle Zebra", output);
     }
@@ -95,7 +96,7 @@ public class FindCommandTests
             ["NoMatch*"] = []
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: false);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: false);
 
         Assert.Equal("", output);
     }
@@ -112,7 +113,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatNameOnlyOutput(results);
+        var output = FindOutputFormatter.FormatNameOnlyOutput(results);
         var lines = output.Split(Environment.NewLine);
 
         Assert.Equal(3, lines.Length);
@@ -136,7 +137,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatNameOnlyOutput(results);
+        var output = FindOutputFormatter.FormatNameOnlyOutput(results);
         var lines = output.Split(Environment.NewLine);
 
         Assert.Equal(3, lines.Length);
@@ -153,7 +154,7 @@ public class FindCommandTests
             ["NoMatch*"] = []
         };
 
-        var output = FindCommand.FormatNameOnlyOutput(results);
+        var output = FindOutputFormatter.FormatNameOnlyOutput(results);
 
         Assert.Equal("", output);
     }
@@ -170,7 +171,7 @@ public class FindCommandTests
             ]
         };
 
-        var output = FindCommand.FormatOneLineOutput(results, grouped: true);
+        var output = FindOutputFormatter.FormatOneLineOutput(results, grouped: true);
 
         Assert.Equal("Test*: TestA, TestM, TestZ", output);
     }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -3,7 +3,6 @@ using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
-using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -215,12 +214,12 @@ public class DiffCommand
         typeDiffs = FilterByClassification(typeDiffs, options);
 
         if (options.NameOnly)
-            return RenderNameOnly(typeDiffs);
+            return DiffOutputFormatter.RenderNameOnly(typeDiffs);
 
         if (options.Stat)
-            return RenderStat(name, typeDiffs, fromVersion, toVersion);
+            return DiffOutputFormatter.RenderStat(name, typeDiffs, fromVersion, toVersion);
 
-        return RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
+        return DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
     }
 
     private static IReadOnlyList<TypeDiff> FilterByClassification(IReadOnlyList<TypeDiff> typeDiffs, DiffOptions options)
@@ -240,141 +239,6 @@ public class DiffCommand
                 filtered.Add(new TypeDiff(td.TypeFullName, changes));
         }
         return filtered;
-    }
-
-    private static string RenderNameOnly(IReadOnlyList<TypeDiff> typeDiffs)
-    {
-        var names = typeDiffs.Select(td => td.TypeFullName).OrderBy(n => n);
-        return string.Join(Environment.NewLine, names);
-    }
-
-    private static string RenderStat(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
-    {
-        int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
-        foreach (var td in typeDiffs)
-        {
-            totalBreaking += td.BreakingCount;
-            totalAdditive += td.AdditiveCount;
-            totalPotentiallyBreaking += td.PotentiallyBreakingCount;
-        }
-
-        var sb = new System.Text.StringBuilder();
-        sb.Append(name);
-        sb.Append(' ');
-        sb.Append(fromVersion);
-        sb.Append("..");
-        sb.Append(toVersion);
-        sb.Append("  ");
-        sb.AppendLine(FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking));
-
-        foreach (var td in typeDiffs.OrderBy(td => td.TypeFullName))
-        {
-            char symbol;
-            string detail;
-
-            if (td.IsAdded)
-            {
-                symbol = '+';
-                detail = "(added)";
-            }
-            else if (td.IsRemoved)
-            {
-                symbol = '-';
-                detail = "(removed)";
-            }
-            else if (td.BreakingCount > 0)
-            {
-                symbol = '\u2717'; // ✗
-                detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
-            }
-            else
-            {
-                symbol = '~';
-                detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
-            }
-
-            sb.AppendLine($" {symbol} {TypeMatcher.GetSimpleName(td.TypeFullName),-40} {detail}");
-        }
-
-        return sb.ToString().TrimEnd();
-    }
-
-    private static string FormatSummaryCounts(int breaking, int additive, int potentiallyBreaking)
-    {
-        var parts = new List<string>(3);
-        if (breaking > 0) parts.Add($"{breaking} breaking");
-        if (additive > 0) parts.Add($"{additive} additive");
-        if (potentiallyBreaking > 0) parts.Add($"{potentiallyBreaking} potentially breaking");
-        return parts.Count > 0 ? string.Join(", ", parts) : "no changes";
-    }
-
-    private static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
-    {
-        var writer = new MarkoutWriter();
-
-        writer.WriteHeading(1, $"API Diff: {name}");
-        writer.WriteParagraph($"**{fromVersion}** → **{toVersion}**");
-
-        if (typeDiffs.Count == 0)
-        {
-            writer.WriteParagraph("*No API changes detected.*");
-            return writer.ToString().TrimEnd();
-        }
-
-        int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
-        foreach (var td in typeDiffs)
-        {
-            totalBreaking += td.BreakingCount;
-            totalAdditive += td.AdditiveCount;
-            totalPotentiallyBreaking += td.PotentiallyBreakingCount;
-        }
-
-        var summary = FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking);
-        writer.WriteParagraph($"**Summary:** {summary} across {typeDiffs.Count} types");
-
-        // Group by classification: breaking first, then potentially breaking, then additive
-        WriteSection(writer, "Breaking Changes", ChangeClassification.Breaking, typeDiffs);
-        WriteSection(writer, "Potentially Breaking Changes", ChangeClassification.PotentiallyBreaking, typeDiffs);
-        WriteSection(writer, "Additive Changes", ChangeClassification.Additive, typeDiffs);
-
-        return writer.ToString().TrimEnd();
-    }
-
-    private static void WriteSection(MarkoutWriter writer, string heading, ChangeClassification classification, IReadOnlyList<TypeDiff> typeDiffs)
-    {
-        // Collect types that have changes of this classification
-        var relevantTypes = typeDiffs
-            .Where(td => td.Changes.Any(c => c.Classification == classification))
-            .OrderBy(td => td.TypeFullName)
-            .ToList();
-
-        if (relevantTypes.Count == 0)
-            return;
-
-        writer.WriteHeading(2, heading);
-
-        foreach (var td in relevantTypes)
-        {
-            writer.WriteHeading(3, TypeMatcher.GetSimpleName(td.TypeFullName));
-
-            var changes = td.Changes
-                .Where(c => c.Classification == classification)
-                .ToList();
-
-            foreach (var change in changes)
-            {
-                var message = change.Message;
-
-                // For signature changes, append old → new values
-                if (change.Kind == ChangeKind.MemberSignatureChanged &&
-                    change.OldValue != null && change.NewValue != null)
-                {
-                    message += $": `{change.OldValue}` → `{change.NewValue}`";
-                }
-
-                writer.WriteListItem(message);
-            }
-        }
     }
 }
 

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -4,7 +4,6 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
-using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -87,23 +86,18 @@ public class FindCommand
         }
         else if (options.NameOnly)
         {
-            WriteNameOnlyOutput(resultsByPattern);
+            Console.WriteLine(FindOutputFormatter.FormatNameOnlyOutput(resultsByPattern));
         }
         else if (options.OneLine)
         {
-            WriteOneLineOutput(resultsByPattern, options.Grouped);
+            Console.WriteLine(FindOutputFormatter.FormatOneLineOutput(resultsByPattern, options.Grouped));
         }
         else
         {
-            WriteMultiPatternOutput(resultsByPattern, options.Limit);
+            Console.WriteLine(FindOutputFormatter.FormatMultiPatternOutput(resultsByPattern));
         }
 
         return 0;
-    }
-
-    private static void WriteNameOnlyOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern)
-    {
-        Console.WriteLine(FormatNameOnlyOutput(resultsByPattern));
     }
 
     private static async Task<int> ExecuteSinglePatternAsync(string pattern, FindOptions options, VerboseLogger logger, List<string> tempDirs, HttpClient httpClient)
@@ -131,7 +125,7 @@ public class FindCommand
             }
             else
             {
-                WriteMarkoutOutput(results, pattern, totalCount, options.Limit);
+                Console.WriteLine(FindOutputFormatter.FormatMarkoutOutput(results, pattern, totalCount, options.Limit));
             }
 
             return 0;
@@ -142,116 +136,12 @@ public class FindCommand
         return await TypeSearchService.CollectTypesAsync(options, null, logger, tempDirs, httpClient);
     }
 
-    private static void WriteOneLineOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern, bool grouped)
-    {
-        Console.WriteLine(FormatOneLineOutput(resultsByPattern, grouped));
-    }
-
-    internal static string FormatOneLineOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern, bool grouped)
-    {
-        if (grouped)
-        {
-            // Grouped: one line per pattern with matching type names
-            var lines = new List<string>();
-            foreach (var (pattern, results) in resultsByPattern)
-            {
-                var typeNames = results.Select(r => r.TypeName).Distinct().OrderBy(n => n);
-                lines.Add($"{pattern}: {string.Join(", ", typeNames)}");
-            }
-            return string.Join(Environment.NewLine, lines);
-        }
-        else
-        {
-            // Flat: all type names space-separated on one line
-            var allTypeNames = resultsByPattern.Values
-                .SelectMany(r => r)
-                .Select(r => r.TypeName)
-                .Distinct()
-                .OrderBy(n => n);
-            return string.Join(" ", allTypeNames);
-        }
-    }
-
-    internal static string FormatNameOnlyOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern)
-    {
-        var allTypeNames = resultsByPattern.Values
-            .SelectMany(r => r)
-            .Select(r => r.TypeName)
-            .Distinct()
-            .OrderBy(n => n);
-        return string.Join(Environment.NewLine, allTypeNames);
-    }
-
-    private static void WriteMultiPatternOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern, int? limit)
-    {
-        var writer = new MarkoutWriter();
-        writer.WriteHeading(1, "Find Results");
-
-        foreach (var (pattern, results) in resultsByPattern)
-        {
-            writer.WriteHeading(2, pattern);
-            writer.WriteField("Matches", results.Count);
-
-            if (results.Count == 0)
-            {
-                writer.WriteParagraph("*No types found.*");
-            }
-            else
-            {
-                var headers = new[] { "Type", "Namespace", "Kind", "Assembly", "Source" };
-                var rows = results.Select(result =>
-                {
-                    var ns = result.Namespace ?? "";
-                    var source = result.SourceVersion != null
-                        ? $"{result.Source}@{result.SourceVersion}"
-                        : result.Source ?? "";
-                    return new[] { result.TypeName, ns, result.Kind ?? "", result.Assembly ?? "", source };
-                });
-                writer.WriteTable(headers, rows);
-            }
-        }
-
-        Console.WriteLine(writer.ToString());
-    }
-
     private static void WriteJsonOutput(List<TypeSearchResult> results, bool compact)
     {
         var typeInfo = compact
             ? FindCompactJsonContext.Default.ListTypeSearchResult
             : FindJsonContext.Default.ListTypeSearchResult;
         Console.WriteLine(JsonSerializer.Serialize(results, typeInfo));
-    }
-
-    private static void WriteMarkoutOutput(List<TypeSearchResult> results, string pattern, int totalCount, int? limit)
-    {
-        var writer = new MarkoutWriter();
-        writer.WriteHeading(1, $"Find: {pattern}");
-        writer.WriteField("Matches", totalCount);
-
-        if (results.Count == 0)
-        {
-            writer.WriteParagraph("*No types found matching the pattern.*");
-        }
-        else
-        {
-            var headers = new[] { "Type", "Namespace", "Kind", "Assembly", "Source" };
-            var rows = results.Select(result =>
-            {
-                var ns = result.Namespace ?? "";
-                var source = result.SourceVersion != null 
-                    ? $"{result.Source}@{result.SourceVersion}" 
-                    : result.Source ?? "";
-                return new[] { result.TypeName, ns, result.Kind ?? "", result.Assembly ?? "", source };
-            });
-            writer.WriteTable(headers, rows);
-
-            if (limit.HasValue && totalCount > limit.Value)
-            {
-                writer.WriteParagraph($"... *and {totalCount - limit.Value} more types*");
-            }
-        }
-
-        Console.WriteLine(writer.ToString());
     }
 }
 

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -1,0 +1,145 @@
+using DotnetInspector.Metadata;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats diff command results for display.
+/// </summary>
+public static class DiffOutputFormatter
+{
+    public static string RenderNameOnly(IReadOnlyList<TypeDiff> typeDiffs)
+    {
+        var names = typeDiffs.Select(td => td.TypeFullName).OrderBy(n => n);
+        return string.Join(Environment.NewLine, names);
+    }
+
+    public static string RenderStat(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
+    {
+        int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
+        foreach (var td in typeDiffs)
+        {
+            totalBreaking += td.BreakingCount;
+            totalAdditive += td.AdditiveCount;
+            totalPotentiallyBreaking += td.PotentiallyBreakingCount;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append(name);
+        sb.Append(' ');
+        sb.Append(fromVersion);
+        sb.Append("..");
+        sb.Append(toVersion);
+        sb.Append("  ");
+        sb.AppendLine(FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking));
+
+        foreach (var td in typeDiffs.OrderBy(td => td.TypeFullName))
+        {
+            char symbol;
+            string detail;
+
+            if (td.IsAdded)
+            {
+                symbol = '+';
+                detail = "(added)";
+            }
+            else if (td.IsRemoved)
+            {
+                symbol = '-';
+                detail = "(removed)";
+            }
+            else if (td.BreakingCount > 0)
+            {
+                symbol = '\u2717'; // ✗
+                detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
+            }
+            else
+            {
+                symbol = '~';
+                detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
+            }
+
+            sb.AppendLine($" {symbol} {TypeMatcher.GetSimpleName(td.TypeFullName),-40} {detail}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
+    {
+        var writer = new MarkoutWriter();
+
+        writer.WriteHeading(1, $"API Diff: {name}");
+        writer.WriteParagraph($"**{fromVersion}** → **{toVersion}**");
+
+        if (typeDiffs.Count == 0)
+        {
+            writer.WriteParagraph("*No API changes detected.*");
+            return writer.ToString().TrimEnd();
+        }
+
+        int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
+        foreach (var td in typeDiffs)
+        {
+            totalBreaking += td.BreakingCount;
+            totalAdditive += td.AdditiveCount;
+            totalPotentiallyBreaking += td.PotentiallyBreakingCount;
+        }
+
+        var summary = FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking);
+        writer.WriteParagraph($"**Summary:** {summary} across {typeDiffs.Count} types");
+
+        // Group by classification: breaking first, then potentially breaking, then additive
+        WriteSection(writer, "Breaking Changes", ChangeClassification.Breaking, typeDiffs);
+        WriteSection(writer, "Potentially Breaking Changes", ChangeClassification.PotentiallyBreaking, typeDiffs);
+        WriteSection(writer, "Additive Changes", ChangeClassification.Additive, typeDiffs);
+
+        return writer.ToString().TrimEnd();
+    }
+
+    internal static string FormatSummaryCounts(int breaking, int additive, int potentiallyBreaking)
+    {
+        var parts = new List<string>(3);
+        if (breaking > 0) parts.Add($"{breaking} breaking");
+        if (additive > 0) parts.Add($"{additive} additive");
+        if (potentiallyBreaking > 0) parts.Add($"{potentiallyBreaking} potentially breaking");
+        return parts.Count > 0 ? string.Join(", ", parts) : "no changes";
+    }
+
+    private static void WriteSection(MarkoutWriter writer, string heading, ChangeClassification classification, IReadOnlyList<TypeDiff> typeDiffs)
+    {
+        // Collect types that have changes of this classification
+        var relevantTypes = typeDiffs
+            .Where(td => td.Changes.Any(c => c.Classification == classification))
+            .OrderBy(td => td.TypeFullName)
+            .ToList();
+
+        if (relevantTypes.Count == 0)
+            return;
+
+        writer.WriteHeading(2, heading);
+
+        foreach (var td in relevantTypes)
+        {
+            writer.WriteHeading(3, TypeMatcher.GetSimpleName(td.TypeFullName));
+
+            var changes = td.Changes
+                .Where(c => c.Classification == classification)
+                .ToList();
+
+            foreach (var change in changes)
+            {
+                var message = change.Message;
+
+                // For signature changes, append old → new values
+                if (change.Kind == ChangeKind.MemberSignatureChanged &&
+                    change.OldValue != null && change.NewValue != null)
+                {
+                    message += $": `{change.OldValue}` → `{change.NewValue}`";
+                }
+
+                writer.WriteListItem(message);
+            }
+        }
+    }
+}

--- a/src/dotnet-inspect/Output/FindOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/FindOutputFormatter.cs
@@ -1,0 +1,105 @@
+using DotnetInspector.Commands;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats find command results for display.
+/// </summary>
+public static class FindOutputFormatter
+{
+    public static string FormatOneLineOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern, bool grouped)
+    {
+        if (grouped)
+        {
+            // Grouped: one line per pattern with matching type names
+            var lines = new List<string>();
+            foreach (var (pattern, results) in resultsByPattern)
+            {
+                var typeNames = results.Select(r => r.TypeName).Distinct().OrderBy(n => n);
+                lines.Add($"{pattern}: {string.Join(", ", typeNames)}");
+            }
+            return string.Join(Environment.NewLine, lines);
+        }
+        else
+        {
+            // Flat: all type names space-separated on one line
+            var allTypeNames = resultsByPattern.Values
+                .SelectMany(r => r)
+                .Select(r => r.TypeName)
+                .Distinct()
+                .OrderBy(n => n);
+            return string.Join(" ", allTypeNames);
+        }
+    }
+
+    public static string FormatNameOnlyOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern)
+    {
+        var allTypeNames = resultsByPattern.Values
+            .SelectMany(r => r)
+            .Select(r => r.TypeName)
+            .Distinct()
+            .OrderBy(n => n);
+        return string.Join(Environment.NewLine, allTypeNames);
+    }
+
+    public static string FormatMultiPatternOutput(Dictionary<string, List<TypeSearchResult>> resultsByPattern)
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteHeading(1, "Find Results");
+
+        foreach (var (pattern, results) in resultsByPattern)
+        {
+            writer.WriteHeading(2, pattern);
+            writer.WriteField("Matches", results.Count);
+
+            if (results.Count == 0)
+            {
+                writer.WriteParagraph("*No types found.*");
+            }
+            else
+            {
+                WriteResultTable(writer, results);
+            }
+        }
+
+        return writer.ToString().TrimEnd();
+    }
+
+    public static string FormatMarkoutOutput(List<TypeSearchResult> results, string pattern, int totalCount, int? limit)
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteHeading(1, $"Find: {pattern}");
+        writer.WriteField("Matches", totalCount);
+
+        if (results.Count == 0)
+        {
+            writer.WriteParagraph("*No types found matching the pattern.*");
+        }
+        else
+        {
+            WriteResultTable(writer, results);
+
+            if (limit.HasValue && totalCount > limit.Value)
+            {
+                writer.WriteParagraph($"... *and {totalCount - limit.Value} more types*");
+            }
+        }
+
+        return writer.ToString().TrimEnd();
+    }
+
+    private static void WriteResultTable(MarkoutWriter writer, List<TypeSearchResult> results)
+    {
+        var headers = new[] { "Type", "Namespace", "Kind", "Assembly", "Source" };
+        var rows = results.Select(result =>
+        {
+            var ns = result.Namespace ?? "";
+            var source = result.SourceVersion != null
+                ? $"{result.Source}@{result.SourceVersion}"
+                : result.Source ?? "";
+            return new[] { result.TypeName, ns, result.Kind ?? "", result.Assembly ?? "", source };
+        });
+        writer.WriteTable(headers, rows);
+    }
+}


### PR DESCRIPTION
Extracts inline rendering/formatting from command classes into dedicated formatters in `Output/`:

- **`FindOutputFormatter`** — all rendering from FindCommand (Markout tables, oneline, name-only). Deduplicates row-building that was repeated between `WriteMultiPatternOutput` and `WriteMarkoutOutput`.
- **`DiffOutputFormatter`** — all rendering from DiffCommand (stat view, full markdown, name-only, section writing, summary counts).

Commands now contain only orchestration + data logic. Neither FindCommand nor DiffCommand import Markout directly anymore.

All 385 tests pass (263 app + 122 services).