### PR TITLE
Add --lib and --tools scoping for --files and --layout

### DIFF
--- a/docs/lap-around.md
+++ b/docs/lap-around.md
@@ -17,11 +17,11 @@ There are mulptiple ways to run the tool, via `dnx`, as an installed tool (`dotn
 No args launch:
 
 ```bash
-dotnet-inspect                          # tool help
-dotnet-inspect --tips:d                 # more tips
-dotnet-inspect --tips:q                 # quiet tips
-dotnet-inspect 2>/dev/null              # another way to quiet tips
-DOTNET_INSPECT_TIPS=quiet dotnet-inspect # another way to quiet tips
+dotnet-inspect                              # tool help
+dotnet-inspect --tips:d                     # more tips
+dotnet-inspect --tips:q                     # quiet tips
+dotnet-inspect 2>/dev/null                  # another way to quiet tips
+DOTNET_INSPECT_TIPS=quiet dotnet-inspect    # another way to quiet tips
 ```
 
 Tips are contextual suggestions written to `stderr` to guide the next step.
@@ -40,15 +40,22 @@ Tip: --tips:d            # show more tips per command
 Metadata-oriented markdown documents:
 
 ```bash
-dotnet-inspect System.Text.Json         # Metadata view for package (same as -v:m)
-dotnet-inspect System.Text.Json@10.0.2  # Specify a version; positional and --version also works
-dotnet-inspect System.Text.Json -v:d    # Metadata, statistics, and direct package dependencies
-dotnet-inspect System.Text.Json -v:q    # Terse 3-line details about latest package version
+dotnet-inspect System.Text.Json             # Metadata view for package (same as -v:m)
+dotnet-inspect System.Text.Json@10.0.2      # Specify a version; positional and --version also works
+dotnet-inspect System.Text.Json -v:d        # Metadata, statistics, and direct package dependencies
+dotnet-inspect System.Text.Json -v:q        # Terse 3-line details about latest package version
 ```
 
 Pure data:
 
 ```bash
-dotnet-inspect System.Text.Json --files # List all file in the package, package-root qualified, one per line
-dotnet-inspect System.Text.Json --tfms  # Lists TFM folders in the package, one per line
+dotnet-inspect System.Text.Json --files     # List all file in the package, package-root qualified, one per line
+dotnet-inspect System.Text.Json --tfms      # Lists TFM folders in the package, one per line
+dotnet-inspect System.Text.Json --files --tfm net10.0   # Lists files in a given TFM file, filesnames only, one per line
+```
+
+Fancy:
+
+```bash
+dotnet-inspect System.Text.Json --layout    # Tree view of all files in the package
 ```

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -871,6 +871,8 @@ public static class CommandLineBuilder
         var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
         var filesOption = new Option<bool>("--files") { Description = "List files in the package (flat list, filterable with --tfm)" };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };
+        var libOption = new Option<bool>("--lib") { Description = "Scope to lib/ folder (use with --files or --layout)" };
+        var toolsOption = new Option<bool>("--tools") { Description = "Scope to tools/ folder (use with --files or --layout)" };
         var versionsOption = new Option<bool>("--versions") { Description = "List available versions from nuget.org" };
         var prereleaseOption = new Option<bool>("--preview") { Description = "With --versions: include prerelease versions" };
         prereleaseOption.Aliases.Add("--prerelease");
@@ -890,6 +892,8 @@ public static class CommandLineBuilder
         packageCommand.Options.Add(layoutOption);
         packageCommand.Options.Add(filesOption);
         packageCommand.Options.Add(tfmsOption);
+        packageCommand.Options.Add(libOption);
+        packageCommand.Options.Add(toolsOption);
         packageCommand.Options.Add(versionsOption);
         packageCommand.Options.Add(prereleaseOption);
         packageCommand.Options.Add(readmeOption);
@@ -959,6 +963,8 @@ public static class CommandLineBuilder
                 ListLayout = parseResult.GetValue(layoutOption),
                 ListFiles = parseResult.GetValue(filesOption),
                 ListTfms = parseResult.GetValue(tfmsOption),
+                ScopeLib = parseResult.GetValue(libOption),
+                ScopeTools = parseResult.GetValue(toolsOption),
                 ListVersions = parseResult.GetValue(versionsOption),
                 IncludePrerelease = parseResult.GetValue(prereleaseOption),
                 ShowReadme = parseResult.GetValue(readmeOption),

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -383,10 +383,14 @@ public class PackageCommand
 
     private static void ListPackageLayout(string extractPath, InspectionOptions options)
     {
-        string searchPath = extractPath;
-        string pattern = "*";
+        var (searchPath, error) = ResolveScopedPath(extractPath, options);
+        if (error != null)
+        {
+            Console.Error.WriteLine(error);
+            return;
+        }
 
-        string[] files = Directory.GetFiles(searchPath, pattern, SearchOption.AllDirectories);
+        string[] files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
 
         var relativePaths = files
             .Select(f => Path.GetRelativePath(extractPath, f))
@@ -406,6 +410,7 @@ public class PackageCommand
     private static void ListPackageFiles(string extractPath, InspectionOptions options)
     {
         string searchPath;
+        bool useFileNameOnly = false;
 
         // Scope to a specific TFM if requested
         if (!string.IsNullOrEmpty(options.Tfm))
@@ -422,16 +427,22 @@ public class PackageCommand
                 Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
                 return;
             }
+            useFileNameOnly = true;
         }
         else
         {
-            searchPath = extractPath;
+            var (resolved, error) = ResolveScopedPath(extractPath, options);
+            if (error != null)
+            {
+                Console.Error.WriteLine(error);
+                return;
+            }
+            searchPath = resolved;
         }
 
         string[] files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
 
         // Use bare filenames when scoped to a specific TFM, relative paths otherwise
-        bool useFileNameOnly = !string.IsNullOrEmpty(options.Tfm);
         var fileNames = files
             .Select(f => useFileNameOnly
                 ? Path.GetFileName(f)
@@ -451,6 +462,21 @@ public class PackageCommand
         {
             Console.WriteLine(file);
         }
+    }
+
+    private static (string path, string? error) ResolveScopedPath(string extractPath, InspectionOptions options)
+    {
+        if (options.ScopeLib)
+        {
+            var dir = Path.Combine(extractPath, "lib");
+            return Directory.Exists(dir) ? (dir, null) : (dir, "No lib/ directory found in package.");
+        }
+        if (options.ScopeTools)
+        {
+            var dir = Path.Combine(extractPath, "tools");
+            return Directory.Exists(dir) ? (dir, null) : (dir, "No tools/ directory found in package.");
+        }
+        return (extractPath, null);
     }
 
     private static void ListPackageTfms(string extractPath)

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -33,6 +33,16 @@ public record InspectionOptions
     public bool ListFiles { get; init; }
 
     /// <summary>
+    /// Scope to lib/ folder (use with --files or --layout).
+    /// </summary>
+    public bool ScopeLib { get; init; }
+
+    /// <summary>
+    /// Scope to tools/ folder (use with --files or --layout).
+    /// </summary>
+    public bool ScopeTools { get; init; }
+
+    /// <summary>
     /// List target frameworks in the package, one per line.
     /// </summary>
     public bool ListTfms { get; init; }


### PR DESCRIPTION
Adds `--lib` and `--tools` flags to scope `--files` and `--layout` to specific package directories.

| Command | Result |
|---------|--------|
| `--files` | All package files |
| `--files --lib` | lib/ folder only |
| `--files --tools` | tools/ folder only |
| `--files --tfm net8.0` | lib/net8.0/ files only |
| `--layout --lib` | lib/ tree only |
| `--layout --tools` | tools/ tree only |