### PR TITLE
Add contextual tips for --files/--layout and -t alias for --tips

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -50,6 +50,7 @@ public static class CommandLineBuilder
         var excludeSectionsOption = new Option<string?>("-x") { Description = "Exclude these sections by name (comma-separated, e.g., -x:Methods)" };
         var limitOption = new Option<int?>("-n") { Description = "Limit number of results" };
         var tipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)" };
+        tipsOption.Aliases.Add("-t");
 
         // NuGet source options (shared across package-consuming commands)
         var sourceOption = new Option<string[]>("--source")
@@ -72,6 +73,7 @@ public static class CommandLineBuilder
         // Root-level display option (distinct instance so it appears in root help)
         rootCommand.Options.Add(new Option<string?>("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)" });
         var rootTipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)" };
+        rootTipsOption.Aliases.Add("-t");
         rootCommand.Options.Add(rootTipsOption);
 
         // API command
@@ -955,6 +957,11 @@ public static class CommandLineBuilder
                 return await AssemblyCommand.ExecuteAsync(null, assemblyOptions);
             }
 
+            var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
+            var jsonOutput = parseResult.GetValue(jsonOption);
+            var tipLevel = jsonOutput || verbosity == Verbosity.Quiet
+                ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption));
+
             var options = new InspectionOptions
             {
                 IncludeDeps = parseResult.GetValue(depsOption),
@@ -971,18 +978,16 @@ public static class CommandLineBuilder
                 OutputPath = parseResult.GetValue(outOption),
                 Discover = parseResult.GetValue(discoverOption),
                 Limit = parseResult.GetValue(limitOption),
-                JsonOutput = parseResult.GetValue(jsonOption),
+                JsonOutput = jsonOutput,
                 Verbose = parseResult.GetValue(verboseOption),
-                Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
+                Verbosity = verbosity,
+                TipLevel = tipLevel,
                 IncludeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption)),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
             var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options, explicitVersion);
-
-            var tipLevel = options.JsonOutput || options.Verbosity == Verbosity.Quiet
-                ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption));
 
             if (exitCode == 0 && packageArgs.Length > 0
                 && !options.ListVersions && !options.ListFiles && !options.ListLayout && !options.ListTfms && !options.Discover && !options.ShowReadme)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -153,14 +153,14 @@ public class PackageCommand
             // Handle --layout mode: show file tree and exit early
             if (options.ListLayout)
             {
-                ListPackageLayout(extractPath, options);
+                ListPackageLayout(extractPath, options, packageName, options.TipLevel);
                 return 0;
             }
 
             // Handle --files mode: list files and exit early
             if (options.ListFiles)
             {
-                ListPackageFiles(extractPath, options);
+                ListPackageFiles(extractPath, options, packageName, options.TipLevel);
                 return 0;
             }
 
@@ -381,7 +381,7 @@ public class PackageCommand
         }
     }
 
-    private static void ListPackageLayout(string extractPath, InspectionOptions options)
+    private static void ListPackageLayout(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel)
     {
         var (searchPath, error) = ResolveScopedPath(extractPath, options);
         if (error != null)
@@ -405,9 +405,10 @@ public class PackageCommand
             : relativePaths.ToList();
 
         WriteFileTree(results);
+        WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: true);
     }
 
-    private static void ListPackageFiles(string extractPath, InspectionOptions options)
+    private static void ListPackageFiles(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel)
     {
         string searchPath;
         bool useFileNameOnly = false;
@@ -462,6 +463,26 @@ public class PackageCommand
         {
             Console.WriteLine(file);
         }
+        WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: false);
+    }
+
+    private static void WriteFileLayoutTips(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel, bool isLayout)
+    {
+        if (options.ScopeLib || options.ScopeTools || !string.IsNullOrEmpty(options.Tfm)) return;
+
+        var tips = new List<Tip>();
+        var flag = isLayout ? "--layout" : "--files";
+        var otherFlag = isLayout ? "--files" : "--layout";
+        var otherDesc = isLayout ? "flat file list" : "file tree";
+
+        tips.Add(new(PackageCommand.Name, $"{packageName} {otherFlag}", otherDesc));
+
+        if (Directory.Exists(Path.Combine(extractPath, "lib")))
+            tips.Add(new(PackageCommand.Name, $"{packageName} {flag} --lib", "lib/ folder only"));
+        if (Directory.Exists(Path.Combine(extractPath, "tools")))
+            tips.Add(new(PackageCommand.Name, $"{packageName} {flag} --tools", "tools/ folder only"));
+
+        Hints.WriteTips(tipLevel, [.. tips]);
     }
 
     private static (string path, string? error) ResolveScopedPath(string extractPath, InspectionOptions options)

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -93,6 +93,11 @@ public record InspectionOptions
     public Verbosity Verbosity { get; init; } = Verbosity.Minimal;
 
     /// <summary>
+    /// Tip verbosity level.
+    /// </summary>
+    public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
+
+    /// <summary>
     /// Sections to include by heading name. If null, all sections are included.
     /// </summary>
     public HashSet<string>? IncludeSections { get; init; }


### PR DESCRIPTION
## Changes

- `--files` and `--layout` now show contextual tips when viewing all files (no scope)
- Tips hit-test for `lib/` and `tools/` directories before suggesting `--lib`/`--tools`
- Tips suppress when already scoped (`--lib`, `--tools`, or `--tfm`)
- Add `-t` alias for `--tips` (like `-v` for verbosity)

## Example

```
$ dotnet-inspect AWSSDK.S3 --files
.signature.p7s
analyzers/dotnet/cs/AWSSDK.S3.CodeAnalysis.dll
...
tools/uninstall.ps1
Tip: package awssdk.s3 --layout          # file tree
Tip: package awssdk.s3 --files --lib     # lib/ folder only
Tip: package awssdk.s3 --files --tools   # tools/ folder only

$ dotnet-inspect AWSSDK.S3 --files --lib
lib/net472/AWSSDK.S3.dll
...
(no tips — already scoped)
```