### PR TITLE
Extract output formatters for Platform, Extensions, Implements commands

### DIFF
--- a/src/dotnet-inspect/Commands/CliSchemaCommand.cs
+++ b/src/dotnet-inspect/Commands/CliSchemaCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Help;
 using DotnetInspector.Options;
+using DotnetInspector.Views;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -104,28 +105,4 @@ public class CliSchemaCommand
 
         return name;
     }
-}
-
-[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
-public class CliSchemaView
-{
-    [MarkoutIgnore]
-    public string Name { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string Version { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string Title => $"{Name} {Version}";
-
-    [MarkoutIgnore]
-    public string Description { get; set; } = "";
-
-    [MarkoutIgnoreInTable]
-    public List<TreeNode> Commands { get; set; } = [];
-}
-
-[MarkoutContext(typeof(CliSchemaView))]
-public partial class CliSchemaContext : MarkoutSerializerContext
-{
 }

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -5,7 +5,6 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
-using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -138,48 +137,7 @@ public class ExtensionsCommand
 
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results)
     {
-        var writer = new MarkoutWriter();
-
-        writer.WriteHeading(1, $"Extension Methods for {targetType}");
-
-        // Group by source, then by reachable path
-        var directExtensions = results.Where(r => r.ReachablePath == null).ToList();
-        var reachableExtensions = results.Where(r => r.ReachablePath != null)
-            .GroupBy(r => r.ReachablePath)
-            .ToList();
-
-        // Direct extensions (always shown)
-        writer.WriteHeading(2, $"{targetType} Extensions ({directExtensions.Count})");
-        if (directExtensions.Count > 0)
-            WriteExtensionTable(writer, directExtensions);
-        else
-            writer.WriteParagraph("None found.");
-
-        // Reachable extensions
-        foreach (var group in reachableExtensions)
-        {
-            var reachableType = group.First().ReachableFromType;
-            writer.WriteHeading(2, $"{reachableType} Extensions ({group.Count()}; Via {group.Key})");
-            WriteExtensionTable(writer, group.ToList());
-        }
-
-        Console.WriteLine(writer.ToString());
-    }
-
-    private static void WriteExtensionTable(MarkoutWriter writer, List<ExtensionMethodResult> results)
-    {
-        // Group by extension class
-        var byClass = results.GroupBy(r => r.ExtensionClass).ToList();
-
-        var headers = new[] { "Name", "Kind", "Class", "Assembly", "Source" };
-        var rows = byClass.SelectMany(classGroup => classGroup.Select(ext =>
-        {
-            var sourceDisplay = ext.SourceVersion != null
-                ? $"{ext.Source}@{ext.SourceVersion}"
-                : ext.Source;
-            return new[] { ext.MethodName, ext.Kind, ext.ExtensionClass ?? "", ext.Assembly ?? "", sourceDisplay ?? "" };
-        }));
-        writer.WriteTable(headers, rows);
+        Console.WriteLine(ExtensionsOutputFormatter.FormatResults(targetType, results));
     }
 }
 

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -5,7 +5,6 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
-using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -120,37 +119,7 @@ public class ImplementsCommand
 
     private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results)
     {
-        var writer = new MarkoutWriter();
-        
-        writer.WriteHeading(1, $"Types Implementing {targetType}");
-
-        if (results.Count == 0)
-        {
-            writer.WriteParagraph("No implementing types found.");
-            Console.WriteLine(writer.ToString());
-            return;
-        }
-
-        writer.WriteField("Matches", results.Count);
-
-        // Group by source
-        var bySource = results.GroupBy(r => r.Source).ToList();
-
-        foreach (var sourceGroup in bySource)
-        {
-            var source = sourceGroup.Key;
-            var version = sourceGroup.First().SourceVersion;
-            var sourceDisplay = version != null ? $"{source}@{version}" : source;
-
-            writer.WriteHeading(2, sourceDisplay ?? "Unknown");
-
-            var headers = new[] { "Type", "Kind", "Relationship", "Assembly" };
-            var rows = sourceGroup.OrderBy(r => r.TypeName)
-                .Select(impl => new[] { impl.TypeName, impl.Kind, impl.Relationship, impl.Assembly ?? "" });
-            writer.WriteTable(headers, rows);
-        }
-
-        Console.WriteLine(writer.ToString());
+        Console.WriteLine(ImplementsOutputFormatter.FormatResults(targetType, results));
     }
 }
 

--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -3,7 +3,6 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
-using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -64,34 +63,7 @@ public class PlatformCommand
             return 0;
         }
 
-        var writer = new MarkoutWriter();
-        writer.WriteHeading(1, "Installed Frameworks");
-
-        // Show summary info in detailed mode
-        if (options.Verbosity == Verbosity.Detailed)
-        {
-            var latestVersion = frameworks.Max(f => f.LatestVersion) ?? "";
-            var majorVersion = latestVersion.Contains('.') ? latestVersion[..latestVersion.IndexOf('.')] + ".0" : latestVersion;
-            var majorVersions = frameworks
-                .SelectMany(f => f.AllVersions)
-                .Select(v => v.Contains('.') ? v[..v.IndexOf('.')] : v)
-                .Distinct()
-                .Count();
-            var dotnetRoot = Path.GetDirectoryName(packsDir) ?? packsDir;
-
-            writer.WriteCompactFields(
-                new MarkoutField("Latest", majorVersion),
-                new MarkoutField("Patch", latestVersion),
-                new MarkoutField("Majors", majorVersions.ToString()),
-                new MarkoutField("Runtimes", frameworks.Count.ToString()),
-                new MarkoutField("Location", dotnetRoot));
-        }
-
-        var headers = new[] { "Framework", "Version", "Assemblies" };
-        var rows = frameworks.Select(f => new[] { f.ShortName, f.LatestVersion, f.AssemblyCount.ToString() });
-        writer.WriteTable(headers, rows);
-
-        Console.WriteLine(writer.ToString());
+        Console.WriteLine(PlatformOutputFormatter.FormatFrameworks(frameworks, options.Verbosity, packsDir));
         return 0;
     }
 
@@ -132,28 +104,7 @@ public class PlatformCommand
             return 0;
         }
 
-        var writer = new MarkoutWriter();
-        writer.WriteHeading(1, "Installed Versions");
-
-        foreach (var framework in frameworks)
-        {
-            writer.WriteHeading(2, framework.ShortName);
-            
-            var versions = framework.AllVersions;
-            if (options.Limit.HasValue)
-            {
-                versions = versions.Take(options.Limit.Value).ToList();
-            }
-
-            writer.WriteArray(versions);
-
-            if (options.Limit.HasValue && framework.AllVersions.Count > options.Limit.Value)
-            {
-                writer.WriteParagraph($"... *and {framework.AllVersions.Count - options.Limit.Value} more*");
-            }
-        }
-
-        Console.WriteLine(writer.ToString());
+        Console.WriteLine(PlatformOutputFormatter.FormatVersions(frameworks, options.Limit));
         return 0;
     }
 
@@ -192,56 +143,10 @@ public class PlatformCommand
             return ListAssembliesJson(frameworks, requestedVersion, options);
         }
 
-        var writer = new MarkoutWriter();
-
-        // Add header if multiple frameworks
-        if (frameworks.Count > 1 || string.IsNullOrEmpty(options.Framework))
-        {
-            writer.WriteHeading(1, "Platform Assemblies");
-            writer.WriteField("Packs Directory", packsDir);
-        }
-
-        foreach (var framework in frameworks)
-        {
-            var version = requestedVersion ?? framework.LatestVersion;
-            var refPath = PlatformResolver.GetRefAssemblyPath(framework.Path, version);
-            
-            if (refPath == null)
-            {
-                logger.Log($"Could not find ref path for {framework.ShortName} {version}");
-                continue;
-            }
-
-            var assemblies = PlatformResolver.GetAssemblies(refPath);
-
-            writer.WriteHeading(2, $"{framework.ShortName} ({version})");
-
-            var displayAssemblies = assemblies.AsEnumerable();
-            if (options.Limit.HasValue)
-            {
-                displayAssemblies = displayAssemblies.Take(options.Limit.Value);
-            }
-
-            if (options.IncludeTypes)
-            {
-                var headers = new[] { "Assembly", "Types" };
-                var rows = displayAssemblies.Select(a => new[] { a.Name, CountPublicTypes(a.Path).ToString() });
-                writer.WriteTable(headers, rows);
-            }
-            else
-            {
-                var headers = new[] { "Assembly" };
-                var rows = displayAssemblies.Select(a => new[] { a.Name });
-                writer.WriteTable(headers, rows);
-            }
-
-            if (options.Limit.HasValue && assemblies.Count > options.Limit.Value)
-            {
-                writer.WriteParagraph($"... *and {assemblies.Count - options.Limit.Value} more assemblies*");
-            }
-        }
-
-        Console.WriteLine(writer.ToString());
+        var multipleFrameworks = frameworks.Count > 1 || string.IsNullOrEmpty(options.Framework);
+        Console.WriteLine(PlatformOutputFormatter.FormatAssemblies(
+            frameworks, requestedVersion, options.IncludeTypes, options.Limit,
+            packsDir, multipleFrameworks, CountPublicTypes, logger));
         return 0;
     }
 

--- a/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
@@ -1,0 +1,55 @@
+using DotnetInspector.Commands;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats extension method search results for display.
+/// </summary>
+public static class ExtensionsOutputFormatter
+{
+    public static string FormatResults(string targetType, List<ExtensionMethodResult> results)
+    {
+        var writer = new MarkoutWriter();
+
+        writer.WriteHeading(1, $"Extension Methods for {targetType}");
+
+        // Group by source, then by reachable path
+        var directExtensions = results.Where(r => r.ReachablePath == null).ToList();
+        var reachableExtensions = results.Where(r => r.ReachablePath != null)
+            .GroupBy(r => r.ReachablePath)
+            .ToList();
+
+        // Direct extensions (always shown)
+        writer.WriteHeading(2, $"{targetType} Extensions ({directExtensions.Count})");
+        if (directExtensions.Count > 0)
+            WriteExtensionTable(writer, directExtensions);
+        else
+            writer.WriteParagraph("None found.");
+
+        // Reachable extensions
+        foreach (var group in reachableExtensions)
+        {
+            var reachableType = group.First().ReachableFromType;
+            writer.WriteHeading(2, $"{reachableType} Extensions ({group.Count()}; Via {group.Key})");
+            WriteExtensionTable(writer, group.ToList());
+        }
+
+        return writer.ToString();
+    }
+
+    private static void WriteExtensionTable(MarkoutWriter writer, List<ExtensionMethodResult> results)
+    {
+        var byClass = results.GroupBy(r => r.ExtensionClass).ToList();
+
+        var headers = new[] { "Name", "Kind", "Class", "Assembly", "Source" };
+        var rows = byClass.SelectMany(classGroup => classGroup.Select(ext =>
+        {
+            var sourceDisplay = ext.SourceVersion != null
+                ? $"{ext.Source}@{ext.SourceVersion}"
+                : ext.Source;
+            return new[] { ext.MethodName, ext.Kind, ext.ExtensionClass ?? "", ext.Assembly ?? "", sourceDisplay ?? "" };
+        }));
+        writer.WriteTable(headers, rows);
+    }
+}

--- a/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
@@ -1,0 +1,44 @@
+using DotnetInspector.Commands;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats implementer search results for display.
+/// </summary>
+public static class ImplementsOutputFormatter
+{
+    public static string FormatResults(string targetType, List<ImplementerResult> results)
+    {
+        var writer = new MarkoutWriter();
+
+        writer.WriteHeading(1, $"Types Implementing {targetType}");
+
+        if (results.Count == 0)
+        {
+            writer.WriteParagraph("No implementing types found.");
+            return writer.ToString();
+        }
+
+        writer.WriteField("Matches", results.Count);
+
+        // Group by source
+        var bySource = results.GroupBy(r => r.Source).ToList();
+
+        foreach (var sourceGroup in bySource)
+        {
+            var source = sourceGroup.Key;
+            var version = sourceGroup.First().SourceVersion;
+            var sourceDisplay = version != null ? $"{source}@{version}" : source;
+
+            writer.WriteHeading(2, sourceDisplay ?? "Unknown");
+
+            var headers = new[] { "Type", "Kind", "Relationship", "Assembly" };
+            var rows = sourceGroup.OrderBy(r => r.TypeName)
+                .Select(impl => new[] { impl.TypeName, impl.Kind, impl.Relationship, impl.Assembly ?? "" });
+            writer.WriteTable(headers, rows);
+        }
+
+        return writer.ToString();
+    }
+}

--- a/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
@@ -1,0 +1,123 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats platform command results for display.
+/// </summary>
+public static class PlatformOutputFormatter
+{
+    public static string FormatFrameworks(List<FrameworkInfo> frameworks, Verbosity verbosity, string packsDir)
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteHeading(1, "Installed Frameworks");
+
+        if (verbosity == Verbosity.Detailed)
+        {
+            var latestVersion = frameworks.Max(f => f.LatestVersion) ?? "";
+            var majorVersion = latestVersion.Contains('.') ? latestVersion[..latestVersion.IndexOf('.')] + ".0" : latestVersion;
+            var majorVersions = frameworks
+                .SelectMany(f => f.AllVersions)
+                .Select(v => v.Contains('.') ? v[..v.IndexOf('.')] : v)
+                .Distinct()
+                .Count();
+            var dotnetRoot = Path.GetDirectoryName(packsDir) ?? packsDir;
+
+            writer.WriteCompactFields(
+                new MarkoutField("Latest", majorVersion),
+                new MarkoutField("Patch", latestVersion),
+                new MarkoutField("Majors", majorVersions.ToString()),
+                new MarkoutField("Runtimes", frameworks.Count.ToString()),
+                new MarkoutField("Location", dotnetRoot));
+        }
+
+        var headers = new[] { "Framework", "Version", "Assemblies" };
+        var rows = frameworks.Select(f => new[] { f.ShortName, f.LatestVersion, f.AssemblyCount.ToString() });
+        writer.WriteTable(headers, rows);
+
+        return writer.ToString();
+    }
+
+    public static string FormatVersions(List<FrameworkInfo> frameworks, int? limit)
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteHeading(1, "Installed Versions");
+
+        foreach (var framework in frameworks)
+        {
+            writer.WriteHeading(2, framework.ShortName);
+
+            var versions = framework.AllVersions;
+            if (limit.HasValue)
+            {
+                versions = versions.Take(limit.Value).ToList();
+            }
+
+            writer.WriteArray(versions);
+
+            if (limit.HasValue && framework.AllVersions.Count > limit.Value)
+            {
+                writer.WriteParagraph($"... *and {framework.AllVersions.Count - limit.Value} more*");
+            }
+        }
+
+        return writer.ToString();
+    }
+
+    public static string FormatAssemblies(List<FrameworkInfo> frameworks, string? requestedVersion,
+        bool includeTypes, int? limit, string packsDir, bool multipleFrameworks,
+        Func<string, int> countPublicTypes, VerboseLogger logger)
+    {
+        var writer = new MarkoutWriter();
+
+        if (multipleFrameworks)
+        {
+            writer.WriteHeading(1, "Platform Assemblies");
+            writer.WriteField("Packs Directory", packsDir);
+        }
+
+        foreach (var framework in frameworks)
+        {
+            var version = requestedVersion ?? framework.LatestVersion;
+            var refPath = PlatformResolver.GetRefAssemblyPath(framework.Path, version);
+
+            if (refPath == null)
+            {
+                logger.Log($"Could not find ref path for {framework.ShortName} {version}");
+                continue;
+            }
+
+            var assemblies = PlatformResolver.GetAssemblies(refPath);
+
+            writer.WriteHeading(2, $"{framework.ShortName} ({version})");
+
+            var displayAssemblies = assemblies.AsEnumerable();
+            if (limit.HasValue)
+            {
+                displayAssemblies = displayAssemblies.Take(limit.Value);
+            }
+
+            if (includeTypes)
+            {
+                var headers = new[] { "Assembly", "Types" };
+                var rows = displayAssemblies.Select(a => new[] { a.Name, countPublicTypes(a.Path).ToString() });
+                writer.WriteTable(headers, rows);
+            }
+            else
+            {
+                var headers = new[] { "Assembly" };
+                var rows = displayAssemblies.Select(a => new[] { a.Name });
+                writer.WriteTable(headers, rows);
+            }
+
+            if (limit.HasValue && assemblies.Count > limit.Value)
+            {
+                writer.WriteParagraph($"... *and {assemblies.Count - limit.Value} more assemblies*");
+            }
+        }
+
+        return writer.ToString();
+    }
+}

--- a/src/dotnet-inspect/Views/CliSchemaView.cs
+++ b/src/dotnet-inspect/Views/CliSchemaView.cs
@@ -1,0 +1,27 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
+public class CliSchemaView
+{
+    [MarkoutIgnore]
+    public string Name { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string Version { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string Title => $"{Name} {Version}";
+
+    [MarkoutIgnore]
+    public string Description { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    public List<TreeNode> Commands { get; set; } = [];
+}
+
+[MarkoutContext(typeof(CliSchemaView))]
+public partial class CliSchemaContext : MarkoutSerializerContext
+{
+}


### PR DESCRIPTION
Continues the architecture cleanup by moving Markout rendering out of commands into dedicated Output/ formatters.

## Changes

### New Output Formatters
- **PlatformOutputFormatter** — `FormatFrameworks`, `FormatVersions`, `FormatAssemblies`
- **ExtensionsOutputFormatter** — `FormatResults`
- **ImplementsOutputFormatter** — `FormatResults`

### View Type Moved
- **CliSchemaView** + **CliSchemaContext** moved from `CliSchemaCommand.cs` to `Views/CliSchemaView.cs`

### Commands Cleaned
- `PlatformCommand`, `ExtensionsCommand`, `ImplementsCommand` no longer import Markout
- Commands delegate all Markdown rendering to formatters, keeping only orchestration logic

### Stats
- 8 files changed, +258 / -200
- All 253 app tests pass
- Zero behavior change — output identical before/after