### PR TITLE
Extract formatters for Samples, Cache, Package commands

### DIFF
--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
@@ -22,25 +23,11 @@ public class CacheCommand
     {
         var info = PackageCacheService.GetCacheInfo();
 
-        Console.WriteLine($"Cache location: {info.Location}");
-        Console.WriteLine();
+        var categories = info.Categories
+            .Select(c => (c.Name, c.Size, c.Count))
+            .ToList();
 
-        if (info.Categories.Count == 0)
-        {
-            Console.WriteLine("Cache is empty.");
-            return Task.FromResult(0);
-        }
-
-        foreach (var category in info.Categories)
-        {
-            Console.WriteLine($"{category.Name + ":",-10}{FormatSize(category.Size)} ({category.Count} {(category.Name == "Packages" ? "packages" : "files")})");
-        }
-
-        Console.WriteLine();
-        Console.WriteLine($"{"Total:",-10}{FormatSize(info.TotalSize)}");
-        Console.WriteLine();
-        Console.WriteLine("Run 'dotnet-inspect cache --clean' to clear the cache.");
-
+        Console.WriteLine(CacheOutputFormatter.FormatCacheInfo(info.Location, categories, info.TotalSize));
         return Task.FromResult(0);
     }
 
@@ -55,7 +42,7 @@ public class CacheCommand
             }
             else
             {
-                Console.WriteLine($"Cleared {FormatSize(freed)} from cache.");
+                Console.WriteLine($"Cleared {CacheOutputFormatter.FormatSize(freed)} from cache.");
             }
             return Task.FromResult(0);
         }
@@ -66,14 +53,4 @@ public class CacheCommand
         }
     }
 
-    private static string FormatSize(long bytes)
-    {
-        return bytes switch
-        {
-            < 1024 => $"{bytes} B",
-            < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
-            < 1024 * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
-            _ => $"{bytes / (1024.0 * 1024 * 1024):F2} GB"
-        };
-    }
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
+using DotnetInspector.Views;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -405,7 +406,7 @@ public class PackageCommand
             ? relativePaths.Take(options.Limit.Value).ToList()
             : relativePaths.ToList();
 
-        WriteFileTree(results);
+        PackageOutputFormatter.WriteFileTree(results);
         WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: true);
     }
 
@@ -518,62 +519,6 @@ public class PackageCommand
         }
     }
 
-    private static void WriteFileTree(List<string> paths)
-    {
-        // Build tree structure from file paths
-        var root = new Dictionary<string, object>();
-        
-        foreach (var path in paths)
-        {
-            var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var current = root;
-            
-            for (int i = 0; i < parts.Length; i++)
-            {
-                var part = parts[i];
-                if (i == parts.Length - 1)
-                {
-                    // Leaf node (file)
-                    current[part] = new Dictionary<string, object>();
-                }
-                else
-                {
-                    // Directory node
-                    if (!current.TryGetValue(part, out var next))
-                    {
-                        next = new Dictionary<string, object>();
-                        current[part] = next;
-                    }
-                    current = (Dictionary<string, object>)next;
-                }
-            }
-        }
-
-        // Convert to TreeNode structure and serialize
-        var view = new FileTreeView { Files = BuildTreeNodes(root) };
-        MarkoutSerializer.Serialize(view, Console.Out, FileTreeContext.Default);
-    }
-
-    private static List<TreeNode> BuildTreeNodes(Dictionary<string, object> dict)
-    {
-        var nodes = new List<TreeNode>();
-        
-        foreach (var kvp in dict.OrderBy(k => k.Key))
-        {
-            var children = (Dictionary<string, object>)kvp.Value;
-            if (children.Count == 0)
-            {
-                nodes.Add(new TreeNode(kvp.Key));
-            }
-            else
-            {
-                nodes.Add(new TreeNode(kvp.Key, BuildTreeNodes(children)));
-            }
-        }
-        
-        return nodes;
-    }
-
     private static async Task<int> ShowDependencyTreeAsync(
         HttpClient client, InspectionResult result, InspectionOptions options, VerboseLogger logger)
     {
@@ -661,61 +606,4 @@ public class PackageCommand
         
         return 0;
     }
-}
-
-/// <summary>
-/// View model for file tree output (minimal wrapper for tree serialization).
-/// </summary>
-public class FileTreeView
-{
-    [MarkoutIgnoreInTable]
-    public List<TreeNode> Files { get; set; } = [];
-}
-
-[MarkoutContext(typeof(FileTreeView))]
-public partial class FileTreeContext : MarkoutSerializerContext
-{
-}
-
-/// <summary>
-/// View model for package dependency tree output (--dependencies).
-/// </summary>
-[MarkoutSerializable(TitleProperty = nameof(Title))]
-public class PackageDependenciesView
-{
-    [MarkoutIgnore]
-    public string Title { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string Package { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string Version { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string? Tfm { get; set; }
-
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Identity => GetIdentityFields();
-
-    [MarkoutIgnoreInTable]
-    public List<TreeNode> Dependencies { get; set; } = [];
-
-    private List<MarkoutField> GetIdentityFields()
-    {
-        var fields = new List<MarkoutField>();
-        if (!string.IsNullOrEmpty(Package))
-            fields.Add(new("Package", Package));
-        if (!string.IsNullOrEmpty(Version))
-            fields.Add(new("Version", Version));
-        if (!string.IsNullOrEmpty(Tfm))
-            fields.Add(new("TFM", Tfm));
-        return fields;
-    }
-}
-
-[MarkoutContext(typeof(PackageDependenciesView))]
-public partial class PackageDependenciesContext : MarkoutSerializerContext
-{
 }

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -206,11 +206,7 @@ public class SamplesCommand
         var writer = new MarkoutWriter(Console.Out);
 
         // H1 title - output immediately
-        var title = assemblyName ?? packageName ?? "Samples";
-        var packageInfo = packageName != null && packageVersion != null
-            ? $" ({packageName} {packageVersion})"
-            : packageName != null && assemblyName != packageName ? $" ({packageName})" : "";
-        writer.WriteHeading(1, $"Samples: {title}{packageInfo}");
+        SamplesOutputFormatter.WriteSamplesTitle(writer, assemblyName, packageName, packageVersion);
 
         // Process samples in batches for parallel fetching with progressive output
         for (int batchStart = 0; batchStart < samples.Count; batchStart += BatchSize)
@@ -232,22 +228,7 @@ public class SamplesCommand
             // Output results in order (already sorted by index)
             foreach (var result in results.OrderBy(r => r.Index))
             {
-                var sample = result.TypedSample.Sample;
-                var description = sample.Description ?? Path.GetFileName(sample.RelativePath);
-
-                writer.WriteHeading(2, $"{result.Index + 1}. {result.TypedSample.FullTypeName} - {description}");
-
-                if (result.Content != null)
-                {
-                    var lang = GetLanguageFromPath(sample.RelativePath);
-                    writer.WriteCodeBlockStart(lang);
-                    Console.Out.WriteLine(result.Content);
-                    writer.WriteCodeBlockEnd();
-                }
-                else
-                {
-                    writer.WriteParagraph("*Failed to fetch sample content*");
-                }
+                SamplesOutputFormatter.WriteSamplesWithContent(writer, result.Index, result.TypedSample, result.Content);
             }
 
             // Small delay between batches to reduce contention
@@ -267,34 +248,7 @@ public class SamplesCommand
         string? assemblyName,
         SamplesOptions options)
     {
-        var writer = new MarkoutWriter();
-
-        // H1 title
-        var title = assemblyName ?? packageName ?? "Samples";
-        var packageInfo = packageName != null && packageVersion != null
-            ? $" ({packageName} {packageVersion})"
-            : packageName != null && assemblyName != packageName ? $" ({packageName})" : "";
-        writer.WriteHeading(1, $"Samples: {title}{packageInfo}");
-
-        var items = samples.Select((typedSample, i) =>
-        {
-            var sample = typedSample.Sample;
-            var description = sample.Description ?? Path.GetFileName(sample.RelativePath);
-            var url = sample.ResolvedUrl != null
-                ? GitHubUrlResolver.ConvertToGitHubRawUrl(sample.ResolvedUrl) ?? sample.ResolvedUrl
-                : sample.RelativePath;
-
-            if (options.BrowsableUrls && url != sample.RelativePath)
-            {
-                url = GitHubUrlResolver.ConvertRawToBlobUrl(url);
-            }
-
-            return $"{typedSample.FullTypeName} - {description}: {url}";
-        });
-
-        writer.WriteArray(items);
-
-        return writer.ToString().TrimEnd();
+        return SamplesOutputFormatter.FormatSamplesList(samples, packageName, packageVersion, assemblyName, options.BrowsableUrls);
     }
 
     private static async Task<string?> FetchSampleContentAsync(SourceFetcher fetcher, SampleReference sample, VerboseLogger logger)
@@ -325,28 +279,12 @@ public class SamplesCommand
         return content;
     }
 
-    private static string GetLanguageFromPath(string path)
-    {
-        var ext = Path.GetExtension(path).ToLowerInvariant();
-        return ext switch
-        {
-            ".cs" => "csharp",
-            ".fs" => "fsharp",
-            ".vb" => "vb",
-            ".json" => "json",
-            ".xml" => "xml",
-            ".yaml" or ".yml" => "yaml",
-            ".md" => "markdown",
-            _ => ""
-        };
-    }
-
 }
 
 /// <summary>
 /// A sample reference with its owning type information.
 /// </summary>
-internal record TypedSample(string TypeName, string? TypeNamespace, SampleReference Sample)
+public record TypedSample(string TypeName, string? TypeNamespace, SampleReference Sample)
 {
     public string FullTypeName => string.IsNullOrEmpty(TypeNamespace) ? TypeName : $"{TypeNamespace}.{TypeName}";
 }

--- a/src/dotnet-inspect/Output/CacheOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/CacheOutputFormatter.cs
@@ -1,0 +1,44 @@
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats cache command output for display.
+/// </summary>
+public static class CacheOutputFormatter
+{
+    public static string FormatCacheInfo(string location, List<(string Name, long Size, int Count)> categories, long totalSize)
+    {
+        var lines = new List<string>();
+        lines.Add($"Cache location: {location}");
+        lines.Add("");
+
+        if (categories.Count == 0)
+        {
+            lines.Add("Cache is empty.");
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        foreach (var category in categories)
+        {
+            var label = category.Name == "Packages" ? "packages" : "files";
+            lines.Add($"{category.Name + ":",-10}{FormatSize(category.Size)} ({category.Count} {label})");
+        }
+
+        lines.Add("");
+        lines.Add($"{"Total:",-10}{FormatSize(totalSize)}");
+        lines.Add("");
+        lines.Add("Run 'dotnet-inspect cache --clean' to clear the cache.");
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static string FormatSize(long bytes)
+    {
+        return bytes switch
+        {
+            < 1024 => $"{bytes} B",
+            < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+            < 1024 * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+            _ => $"{bytes / (1024.0 * 1024 * 1024):F2} GB"
+        };
+    }
+}

--- a/src/dotnet-inspect/Output/PackageOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PackageOutputFormatter.cs
@@ -1,0 +1,63 @@
+using DotnetInspector.Views;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats package file tree output for display.
+/// </summary>
+public static class PackageOutputFormatter
+{
+    public static void WriteFileTree(List<string> paths)
+    {
+        // Build tree structure from file paths
+        var root = new Dictionary<string, object>();
+
+        foreach (var path in paths)
+        {
+            var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var current = root;
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                var part = parts[i];
+                if (i == parts.Length - 1)
+                {
+                    current[part] = new Dictionary<string, object>();
+                }
+                else
+                {
+                    if (!current.TryGetValue(part, out var next))
+                    {
+                        next = new Dictionary<string, object>();
+                        current[part] = next;
+                    }
+                    current = (Dictionary<string, object>)next;
+                }
+            }
+        }
+
+        var view = new FileTreeView { Files = BuildTreeNodes(root) };
+        MarkoutSerializer.Serialize(view, Console.Out, FileTreeContext.Default);
+    }
+
+    private static List<TreeNode> BuildTreeNodes(Dictionary<string, object> dict)
+    {
+        var nodes = new List<TreeNode>();
+
+        foreach (var kvp in dict.OrderBy(k => k.Key))
+        {
+            var children = (Dictionary<string, object>)kvp.Value;
+            if (children.Count == 0)
+            {
+                nodes.Add(new TreeNode(kvp.Key));
+            }
+            else
+            {
+                nodes.Add(new TreeNode(kvp.Key, BuildTreeNodes(children)));
+            }
+        }
+
+        return nodes;
+    }
+}

--- a/src/dotnet-inspect/Output/SamplesOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/SamplesOutputFormatter.cs
@@ -1,0 +1,100 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Services;
+using Markout;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Formats samples command results for display.
+/// </summary>
+public static class SamplesOutputFormatter
+{
+    public static string FormatSamplesList(
+        List<TypedSample> samples,
+        string? packageName,
+        string? packageVersion,
+        string? assemblyName,
+        bool browsableUrls)
+    {
+        var writer = new MarkoutWriter();
+
+        var title = assemblyName ?? packageName ?? "Samples";
+        var packageInfo = packageName != null && packageVersion != null
+            ? $" ({packageName} {packageVersion})"
+            : packageName != null && assemblyName != packageName ? $" ({packageName})" : "";
+        writer.WriteHeading(1, $"Samples: {title}{packageInfo}");
+
+        var items = samples.Select((typedSample, i) =>
+        {
+            var sample = typedSample.Sample;
+            var description = sample.Description ?? Path.GetFileName(sample.RelativePath);
+            var url = sample.ResolvedUrl != null
+                ? GitHubUrlResolver.ConvertToGitHubRawUrl(sample.ResolvedUrl) ?? sample.ResolvedUrl
+                : sample.RelativePath;
+
+            if (browsableUrls && url != sample.RelativePath)
+            {
+                url = GitHubUrlResolver.ConvertRawToBlobUrl(url);
+            }
+
+            return $"{typedSample.FullTypeName} - {description}: {url}";
+        });
+
+        writer.WriteArray(items);
+
+        return writer.ToString().TrimEnd();
+    }
+
+    public static void WriteSamplesWithContent(
+        MarkoutWriter writer,
+        int index,
+        TypedSample typedSample,
+        string? content)
+    {
+        var sample = typedSample.Sample;
+        var description = sample.Description ?? Path.GetFileName(sample.RelativePath);
+
+        writer.WriteHeading(2, $"{index + 1}. {typedSample.FullTypeName} - {description}");
+
+        if (content != null)
+        {
+            var lang = GetLanguageFromPath(sample.RelativePath);
+            writer.WriteCodeBlockStart(lang);
+            Console.Out.WriteLine(content);
+            writer.WriteCodeBlockEnd();
+        }
+        else
+        {
+            writer.WriteParagraph("*Failed to fetch sample content*");
+        }
+    }
+
+    public static void WriteSamplesTitle(
+        MarkoutWriter writer,
+        string? assemblyName,
+        string? packageName,
+        string? packageVersion)
+    {
+        var title = assemblyName ?? packageName ?? "Samples";
+        var packageInfo = packageName != null && packageVersion != null
+            ? $" ({packageName} {packageVersion})"
+            : packageName != null && assemblyName != packageName ? $" ({packageName})" : "";
+        writer.WriteHeading(1, $"Samples: {title}{packageInfo}");
+    }
+
+    private static string GetLanguageFromPath(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".cs" => "csharp",
+            ".fs" => "fsharp",
+            ".vb" => "vb",
+            ".json" => "json",
+            ".xml" => "xml",
+            ".yaml" or ".yml" => "yaml",
+            ".md" => "markdown",
+            _ => ""
+        };
+    }
+}

--- a/src/dotnet-inspect/Views/PackageViews.cs
+++ b/src/dotnet-inspect/Views/PackageViews.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Serialization;
+using Markout;
+
+namespace DotnetInspector.Views;
+
+/// <summary>
+/// View model for file tree output (minimal wrapper for tree serialization).
+/// </summary>
+public class FileTreeView
+{
+    [MarkoutIgnoreInTable]
+    public List<TreeNode> Files { get; set; } = [];
+}
+
+[MarkoutContext(typeof(FileTreeView))]
+public partial class FileTreeContext : MarkoutSerializerContext
+{
+}
+
+/// <summary>
+/// View model for package dependency tree output (--dependencies).
+/// </summary>
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class PackageDependenciesView
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string Package { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string Version { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string? Tfm { get; set; }
+
+    [JsonIgnore]
+    [MarkoutIgnoreInTable]
+    public List<MarkoutField> Identity => GetIdentityFields();
+
+    [MarkoutIgnoreInTable]
+    public List<TreeNode> Dependencies { get; set; } = [];
+
+    private List<MarkoutField> GetIdentityFields()
+    {
+        var fields = new List<MarkoutField>();
+        if (!string.IsNullOrEmpty(Package))
+            fields.Add(new("Package", Package));
+        if (!string.IsNullOrEmpty(Version))
+            fields.Add(new("Version", Version));
+        if (!string.IsNullOrEmpty(Tfm))
+            fields.Add(new("TFM", Tfm));
+        return fields;
+    }
+}
+
+[MarkoutContext(typeof(PackageDependenciesView))]
+public partial class PackageDependenciesContext : MarkoutSerializerContext
+{
+}


### PR DESCRIPTION
Continues PR #63 by extracting remaining presentation concerns from commands.

## New Output Formatters

- **SamplesOutputFormatter** — `FormatSamplesList`, `WriteSamplesWithContent`, `WriteSamplesTitle`
- **CacheOutputFormatter** — `FormatCacheInfo`, `FormatSize` (replaces ad-hoc Console.WriteLine)
- **PackageOutputFormatter** — `WriteFileTree` (file tree building + Markout serialization)

## View Types Moved

- **FileTreeView** + **FileTreeContext** — moved from PackageCommand.cs to `Views/PackageViews.cs`
- **PackageDependenciesView** + **PackageDependenciesContext** — same

## Commands Cleaned

- `CacheCommand` no longer has inline formatting logic or `FormatSize` helper
- `SamplesCommand` delegates all Markout rendering to formatter (still creates MarkoutWriter for streaming)
- `PackageCommand` delegates file tree rendering to formatter; inline view types removed

## Stats
- 7 files changed, +280 / -209
- All 253 app tests pass
- Zero behavior change