### PR TITLE
Move service types from Commands/ to Inspectors/

### DIFF
--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -6,7 +6,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Services;
 
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Inspectors;
 
 /// <summary>
 /// Shared extraction, enrichment, and utility methods used by API-related commands.

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -7,7 +7,7 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using AssemblyReference = DotnetInspector.Metadata.AssemblyReference;
 
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Inspectors;
 
 /// <summary>
 /// Inspects assemblies/libraries: metadata extraction, PDB audit, SourceLink verification,

--- a/src/dotnet-inspect/Inspectors/SignatureParser.cs
+++ b/src/dotnet-inspect/Inspectors/SignatureParser.cs
@@ -1,4 +1,4 @@
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Inspectors;
 
 /// <summary>
 /// Pure functions for parsing member signature strings.

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -1,11 +1,11 @@
-using DotnetInspector.Inspectors;
+using DotnetInspector.Commands;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 
-namespace DotnetInspector.Commands;
+namespace DotnetInspector.Inspectors;
 
 /// <summary>
 /// Collects types from multiple sources: packages, assemblies, platform frameworks,

--- a/src/dotnet-inspect/Output/MemberTableFormatter.cs
+++ b/src/dotnet-inspect/Output/MemberTableFormatter.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 


### PR DESCRIPTION
Final PR in the Phase 8 architecture cleanup. Moves app-specific service types from Commands/ to Inspectors/ where they belong.

## Files Moved

| File | Purpose |
|------|---------|
| **ApiServices.cs** | API extraction, PDB acquisition, SourceLink enrichment |
| **LibraryMetadataService.cs** | Assembly inspection pipeline, PDB audit, transitive references |
| **TypeSearchService.cs** | Multi-source type collection (packages, assemblies, platform) |
| **SignatureParser.cs** | Pure signature string parsing functions |

## Why Inspectors/

These types perform inspection and extraction work — they're not command orchestration. They depend on app-specific types (`ApiOptions`, `VerboseLogger`, etc.) so they can't go to the shared `DotnetInspector.Services` library, but they don't belong in `Commands/` either.

## Stats
- 6 files changed, +7 / -5 (just namespace changes and using additions)
- All 253 tests pass