### PR TITLE
Extract PackageInspector from PackageCommand

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -173,94 +173,30 @@ public class PackageCommand
                 return 0;
             }
 
-            // Create result and run inspections
-            var result = new InspectionResult
-            {
-                PackageName = packageName,
-                Version = version
-            };
-
-            // Always parse nuspec for basic metadata (needed for --readme to find correct file)
+            // Parse nuspec (needed for --readme and --dependencies early exits, and full inspection)
+            NuspecData? nuspec = null;
             string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
             if (nuspecFiles.Length > 0)
-            {
-                ApplyNuspec(Services.NuspecParser.Parse(nuspecFiles[0]), result);
-            }
+                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
 
             // Handle --readme mode: print README and exit early
             if (options.ShowReadme)
             {
-                return PrintReadme(extractPath, result.ReadmeFile, options);
+                return PrintReadme(extractPath, nuspec?.ReadmeFile, options);
             }
 
             // Handle --dependencies mode: resolve transitive deps and show tree
             if (options.ShowDependencies)
             {
-                return await ShowDependencyTreeAsync(client, result, options, logger);
+                var depResult = new InspectionResult { PackageName = packageName, Version = version };
+                if (nuspec != null) ApplyNuspec(nuspec, depResult);
+                return await ShowDependencyTreeAsync(client, depResult, options, logger);
             }
 
-            // Check for README (use nuspec-specified file or fall back to README.md)
-            string readmeFileName = result.ReadmeFile ?? "README.md";
-            result.HasReadme = File.Exists(Path.Combine(extractPath, readmeFileName));
-
-            // Always analyze directory structure
-            string toolsDir = Path.Combine(extractPath, "tools");
-            string libDir = Path.Combine(extractPath, "lib");
-            bool hasToolsDir = Directory.Exists(toolsDir);
-            bool hasLibDir = Directory.Exists(libDir);
-
-            if (hasToolsDir)
-            {
-                ToolsAnalyzer.AnalyzeToolsDirectory(toolsDir, result);
-            }
-
-            if (hasLibDir)
-            {
-                ToolsAnalyzer.AnalyzeLibDirectory(libDir, result);
-
-                string runtimesDir = Path.Combine(extractPath, "runtimes");
-                if (Directory.Exists(runtimesDir))
-                {
-                    ToolsAnalyzer.AnalyzeRuntimesDirectory(runtimesDir, result);
-                }
-            }
-
-            // Determine package type if not already set by nuspec PackageTypes
-            if (result.PackageTypes is not { Count: > 0 })
-            {
-                // Only classify as tool if tools/ has actual DLLs and there's no lib/ dir.
-                // Packages like AWSSDK.* have tools/ with only .ps1 scripts alongside lib/.
-                result.IsToolPackage = hasToolsDir && !hasLibDir
-                    && Directory.GetFiles(toolsDir, "*.dll", SearchOption.AllDirectories).Length > 0;
-            }
-
-            // Analyze content directories and count assemblies
-            ToolsAnalyzer.AnalyzeContentDirectories(extractPath, result);
-            result.AssemblyCount = ToolsAnalyzer.CountAssemblies(extractPath);
-
-            // Parse deps.json files if deps flag is set
-            if (options.IncludeDeps)
-            {
-                string[] depsFiles = Directory.GetFiles(extractPath, "*.deps.json", SearchOption.AllDirectories);
-                foreach (string depsFile in depsFiles)
-                {
-                    ApplyDepsJson(Services.DepsJsonParser.Parse(depsFile), result);
-                }
-            }
-
-            // Verify RID-specific packages exist (always do this for RID pointer packages)
-            if (result.IsRidSpecificPointerPackage && result.RuntimeIdentifierPackages is { Count: > 0 })
-            {
-                string? localDir = isLocalFile ? Path.GetDirectoryName(Path.GetFullPath(packageArgs[0])) : null;
-                await RidPackageVerifier.VerifyAsync(client, result, result.Version, localDir, logger);
-            }
-
-            // Fetch package metadata from NuGet (only for remote packages)
-            if (!isLocalFile)
-            {
-                var metadata = await PackageMetadataService.FetchAllMetadataAsync(client, packageName, version, logger.Log);
-                ApplyMetadata(result, metadata);
-            }
+            var result = await PackageInspector.InspectAsync(
+                extractPath, packageName, version, isLocalFile,
+                isLocalFile ? packageArgs[0] : null,
+                options.IncludeDeps, nuspec, client, logger);
 
             // Filter output based on options
             FilterResultForOutput(result, options);
@@ -312,74 +248,12 @@ public class PackageCommand
         result.DependencyGroups = nuspec.DependencyGroups;
     }
 
-    private static void ApplyDepsJson(DepsJsonData depsJson, InspectionResult result)
-    {
-        if (depsJson.RuntimeTargetRid != null)
-        {
-            result.RuntimeTargetRid = depsJson.RuntimeTargetRid;
-        }
-
-        if (depsJson.RuntimeDependencies != null)
-        {
-            result.RuntimeDependencies ??= [];
-            result.RuntimeDependencies.AddRange(depsJson.RuntimeDependencies);
-        }
-    }
-
-    private static void ApplyMetadata(InspectionResult result, PackageMetadata metadata)
-    {
-        result.Published = metadata.Published;
-        result.TotalDownloads = metadata.TotalDownloads;
-        result.VersionDownloads = metadata.VersionDownloads;
-        result.VersionCount = metadata.VersionCount;
-        result.PackageSize = metadata.PackageSize;
-        result.IsVerified = metadata.IsVerified;
-        result.Owners = metadata.Owners;
-        result.Deprecation = metadata.Deprecation;
-        result.Vulnerabilities = metadata.Vulnerabilities;
-    }
-
     private static void FilterResultForOutput(InspectionResult result, InspectionOptions options)
     {
         // If deps is not requested, clear runtime dependencies
         if (!options.IncludeDeps)
         {
             result.RuntimeDependencies = null;
-        }
-    }
-
-    /// <summary>
-    /// Populates the Files list for detailed verbosity output.
-    /// </summary>
-    private static void PopulateFilesForDetailedView(string extractPath, InspectionResult result)
-    {
-        // Get DLLs from tools or lib directory
-        string toolsDir = Path.Combine(extractPath, "tools");
-        string libDir = Path.Combine(extractPath, "lib");
-
-        string searchPath;
-        if (Directory.Exists(toolsDir))
-        {
-            searchPath = toolsDir;
-        }
-        else if (Directory.Exists(libDir))
-        {
-            searchPath = libDir;
-        }
-        else
-        {
-            return;
-        }
-
-        var files = Directory.GetFiles(searchPath, "*.dll", SearchOption.AllDirectories)
-            .Select(f => Path.GetRelativePath(extractPath, f))
-            .Where(p => !p.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .OrderBy(p => p)
-            .ToList();
-
-        if (files.Count > 0)
-        {
-            result.Files = files;
         }
     }
 

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -1,0 +1,172 @@
+using DotnetInspector.Models;
+using DotnetInspector.Output;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Builds an InspectionResult for a NuGet package by running nuspec, directory,
+/// deps.json, RID-verification, and NuGet metadata inspections.
+/// </summary>
+internal static class PackageInspector
+{
+    public static async Task<InspectionResult> InspectAsync(
+        string extractPath,
+        string packageName,
+        string version,
+        bool isLocalFile,
+        string? localFilePath,
+        bool includeDeps,
+        NuspecData? nuspec,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        var result = new InspectionResult
+        {
+            PackageName = packageName,
+            Version = version
+        };
+
+        // Apply nuspec metadata (already parsed by caller)
+        if (nuspec != null)
+        {
+            result.PackageName = nuspec.PackageName ?? result.PackageName;
+            result.Version = nuspec.Version ?? result.Version;
+            result.Description = nuspec.Description;
+            result.Authors = nuspec.Authors;
+            result.Repository = nuspec.Repository;
+            result.License = nuspec.License;
+            result.PackageTypes = nuspec.PackageTypes;
+            result.IsToolPackage = nuspec.IsToolPackage;
+            result.ReadmeFile = nuspec.ReadmeFile;
+            result.DependencyGroups = nuspec.DependencyGroups;
+        }
+
+        // Check for README (use nuspec-specified file or fall back to README.md)
+        string readmeFileName = result.ReadmeFile ?? "README.md";
+        result.HasReadme = File.Exists(Path.Combine(extractPath, readmeFileName));
+
+        // Analyze directory structure
+        string toolsDir = Path.Combine(extractPath, "tools");
+        string libDir = Path.Combine(extractPath, "lib");
+        bool hasToolsDir = Directory.Exists(toolsDir);
+        bool hasLibDir = Directory.Exists(libDir);
+
+        if (hasToolsDir)
+        {
+            ToolsAnalyzer.AnalyzeToolsDirectory(toolsDir, result);
+        }
+
+        if (hasLibDir)
+        {
+            ToolsAnalyzer.AnalyzeLibDirectory(libDir, result);
+
+            string runtimesDir = Path.Combine(extractPath, "runtimes");
+            if (Directory.Exists(runtimesDir))
+            {
+                ToolsAnalyzer.AnalyzeRuntimesDirectory(runtimesDir, result);
+            }
+        }
+
+        // Determine package type if not already set by nuspec PackageTypes
+        if (result.PackageTypes is not { Count: > 0 })
+        {
+            // Only classify as tool if tools/ has actual DLLs and there's no lib/ dir.
+            // Packages like AWSSDK.* have tools/ with only .ps1 scripts alongside lib/.
+            result.IsToolPackage = hasToolsDir && !hasLibDir
+                && Directory.GetFiles(toolsDir, "*.dll", SearchOption.AllDirectories).Length > 0;
+        }
+
+        // Analyze content directories and count assemblies
+        ToolsAnalyzer.AnalyzeContentDirectories(extractPath, result);
+        result.AssemblyCount = ToolsAnalyzer.CountAssemblies(extractPath);
+
+        // Parse deps.json files if deps flag is set
+        if (includeDeps)
+        {
+            string[] depsFiles = Directory.GetFiles(extractPath, "*.deps.json", SearchOption.AllDirectories);
+            foreach (string depsFile in depsFiles)
+            {
+                ApplyDepsJson(DepsJsonParser.Parse(depsFile), result);
+            }
+        }
+
+        // Verify RID-specific packages exist (always do this for RID pointer packages)
+        if (result.IsRidSpecificPointerPackage && result.RuntimeIdentifierPackages is { Count: > 0 })
+        {
+            string? localDir = isLocalFile ? Path.GetDirectoryName(Path.GetFullPath(localFilePath!)) : null;
+            await RidPackageVerifier.VerifyAsync(httpClient, result, result.Version, localDir, logger);
+        }
+
+        // Fetch package metadata from NuGet (only for remote packages)
+        if (!isLocalFile)
+        {
+            var metadata = await PackageMetadataService.FetchAllMetadataAsync(httpClient, packageName, version, logger.Log);
+            ApplyMetadata(result, metadata);
+        }
+
+        return result;
+    }
+
+    private static void ApplyDepsJson(DepsJsonData depsJson, InspectionResult result)
+    {
+        if (depsJson.RuntimeTargetRid != null)
+        {
+            result.RuntimeTargetRid = depsJson.RuntimeTargetRid;
+        }
+
+        if (depsJson.RuntimeDependencies != null)
+        {
+            result.RuntimeDependencies ??= [];
+            result.RuntimeDependencies.AddRange(depsJson.RuntimeDependencies);
+        }
+    }
+
+    private static void ApplyMetadata(InspectionResult result, PackageMetadata metadata)
+    {
+        result.Published = metadata.Published;
+        result.TotalDownloads = metadata.TotalDownloads;
+        result.VersionDownloads = metadata.VersionDownloads;
+        result.VersionCount = metadata.VersionCount;
+        result.PackageSize = metadata.PackageSize;
+        result.IsVerified = metadata.IsVerified;
+        result.Owners = metadata.Owners;
+        result.Deprecation = metadata.Deprecation;
+        result.Vulnerabilities = metadata.Vulnerabilities;
+    }
+
+    /// <summary>
+    /// Populates the Files list for detailed verbosity output.
+    /// </summary>
+    private static void PopulateFilesForDetailedView(string extractPath, InspectionResult result)
+    {
+        // Get DLLs from tools or lib directory
+        string toolsDir = Path.Combine(extractPath, "tools");
+        string libDir = Path.Combine(extractPath, "lib");
+
+        string searchPath;
+        if (Directory.Exists(toolsDir))
+        {
+            searchPath = toolsDir;
+        }
+        else if (Directory.Exists(libDir))
+        {
+            searchPath = libDir;
+        }
+        else
+        {
+            return;
+        }
+
+        var files = Directory.GetFiles(searchPath, "*.dll", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(extractPath, f))
+            .Where(p => !p.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p)
+            .ToList();
+
+        if (files.Count > 0)
+        {
+            result.Files = files;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `InspectionResult` construction pipeline from `PackageCommand` into new `PackageInspector.InspectAsync()` in `Inspectors/`, following the `LibraryMetadataService` pattern
- `PackageCommand` becomes a thin orchestrator: resolve inputs, call inspector, format output
- Moves `ApplyDepsJson`, `ApplyMetadata`, and `PopulateFilesForDetailedView` into `PackageInspector` as private helpers; `ApplyNuspec` stays in `PackageCommand` (used by `--dependencies` early exit)

## Test plan

- [x] `dotnet build` compiles cleanly
- [x] All 406 tests pass (253 CLI + 122 Services + 31 Metadata)
- [ ] Smoke: `dotnet run -- package System.Text.Json` (full inspection)
- [ ] Smoke: `dotnet run -- package System.Text.Json --versions` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --layout` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --files` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --tfms` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --readme` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --dependencies` (early exit)
- [ ] Smoke: `dotnet run -- package System.Text.Json --json` (JSON output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)