### PR TITLE
Support --tfm filtering in --layout view

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -385,17 +385,44 @@ public class PackageCommand
 
     private static void ListPackageLayout(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel)
     {
-        var (searchPath, error) = ResolveScopedPath(extractPath, options);
-        if (error != null)
+        string searchPath;
+        string relativeBase;
+
+        // Scope to a specific TFM if requested
+        if (!string.IsNullOrEmpty(options.Tfm))
         {
-            Console.Error.WriteLine(error);
-            return;
+            string libDir = Path.Combine(extractPath, "lib", options.Tfm);
+            string toolsDir = Path.Combine(extractPath, "tools", options.Tfm);
+
+            if (Directory.Exists(libDir))
+                searchPath = libDir;
+            else if (Directory.Exists(toolsDir))
+                searchPath = toolsDir;
+            else
+            {
+                Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
+                return;
+            }
+
+            // Show paths relative to parent of TFM dir so TFM appears as root node
+            relativeBase = Path.GetDirectoryName(searchPath)!;
+        }
+        else
+        {
+            var (resolved, error) = ResolveScopedPath(extractPath, options);
+            if (error != null)
+            {
+                Console.Error.WriteLine(error);
+                return;
+            }
+            searchPath = resolved;
+            relativeBase = extractPath;
         }
 
         string[] files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
 
         var relativePaths = files
-            .Select(f => Path.GetRelativePath(extractPath, f))
+            .Select(f => Path.GetRelativePath(relativeBase, f))
             .Where(p => !p.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
             .Where(p => !p.StartsWith("_rels", StringComparison.OrdinalIgnoreCase))
             .Where(p => !p.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Adds `--tfm` scoping to `--layout`, aligning it with the existing `--files` behavior.

## Changes

When `--tfm` is specified with `--layout`, the file tree is scoped to `lib/{tfm}` or `tools/{tfm}` with the TFM as the root node — matching how `--files --tfm` already works.

**Example:** `dotnet-inspect package Foo --layout --tfm net10.0` shows the tree rooted at `net10.0/`.

## Before

`--layout --tfm net10.0` ignored the `--tfm` option and showed the full package tree.

## After

`--layout --tfm net10.0` scopes to the TFM directory and shows only its subtree.