### PR TITLE
Upgrade to Markout 0.4.0; replace manual field builders with declarative attributes

### DIFF
--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -7,29 +7,39 @@ namespace DotnetInspector.Views;
 /// <summary>
 /// View model for single-type rendering. Pre-computes all display values from ApiType + options.
 /// </summary>
-[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description), AutoFields = false)]
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
 public class ApiTypeView
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     [MarkoutIgnore] public string? Description { get; set; }
 
-    // Backing data (all [MarkoutIgnore] for JSON/table serialization)
-    [MarkoutIgnore] public string Kind { get; set; } = "";
-    [MarkoutIgnore] public string? Modifiers { get; set; }
-    [MarkoutIgnore] public string? BaseType { get; set; }
-    [MarkoutIgnore] public string? TypeParametersInline { get; set; }
-    [MarkoutIgnore] public string? Implements { get; set; }
-    [MarkoutIgnore] public string? Assembly { get; set; }
-    [MarkoutIgnore] public string? Package { get; set; }
-    [MarkoutIgnore] public string? Version { get; set; }
-    [MarkoutIgnore] public string? SamplesInfo { get; set; }
+    public string Kind { get; set; } = "";
 
-    /// <summary>
-    /// Identity fields (rendered as key-value fields under the title).
-    /// </summary>
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Identity => GetIdentityFields();
+    [MarkoutSkipNull]
+    public string? Modifiers { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Base")]
+    public string? BaseType { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Type Parameters")]
+    public string? TypeParametersInline { get; set; }
+
+    [MarkoutIgnore] public string? Implements { get; set; }
+
+    [MarkoutSkipNull]
+    public string? Assembly { get; set; }
+
+    [MarkoutSkipNull]
+    public string? Package { get; set; }
+
+    [MarkoutSkipNull]
+    public string? Version { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Samples")]
+    public string? SamplesInfo { get; set; }
 
     /// <summary>
     /// Enum values without Description column (default).
@@ -66,26 +76,6 @@ public class ApiTypeView
     [JsonIgnore]
     public List<BaseclassRow>? BaseclassRows { get; set; }
 
-    private List<MarkoutField> GetIdentityFields()
-    {
-        var fields = new List<MarkoutField>();
-        fields.Add(new("Kind", Kind));
-        if (!string.IsNullOrEmpty(Modifiers))
-            fields.Add(new("Modifiers", Modifiers));
-        if (!string.IsNullOrEmpty(BaseType))
-            fields.Add(new("Base", BaseType));
-        if (!string.IsNullOrEmpty(TypeParametersInline))
-            fields.Add(new("Type Parameters", TypeParametersInline));
-        if (!string.IsNullOrEmpty(Assembly))
-            fields.Add(new("Assembly", Assembly));
-        if (!string.IsNullOrEmpty(Package))
-            fields.Add(new("Package", Package));
-        if (!string.IsNullOrEmpty(Version))
-            fields.Add(new("Version", Version));
-        if (!string.IsNullOrEmpty(SamplesInfo))
-            fields.Add(new("Samples", SamplesInfo));
-        return fields;
-    }
 }
 
 [MarkoutSerializable]
@@ -118,7 +108,7 @@ public class BaseclassRow
 /// <summary>
 /// Markout-aware wrapper for ApiSurface used in --all-types serialization path.
 /// </summary>
-[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+[MarkoutSerializable(TitleProperty = nameof(Name))]
 public class CliApiSurface
 {
     private readonly ApiSurface _inner;
@@ -128,28 +118,21 @@ public class CliApiSurface
         _inner = inner;
     }
 
-    [MarkoutPropertyName("Name")]
+    [MarkoutIgnore]
     public string? Name => _inner.Name;
 
-    /// <summary>
-    /// Summary fields (rendered as key-value fields under the title).
-    /// </summary>
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Summary => GetSummaryFields();
+    public int Types => _inner.PublicTypeCount;
+    public int Methods => _inner.PublicMethodCount;
+    public int Properties => _inner.PublicPropertyCount;
 
-    private List<MarkoutField> GetSummaryFields()
-    {
-        var fields = new List<MarkoutField>();
-        fields.Add(new("Types", _inner.PublicTypeCount.ToString()));
-        fields.Add(new("Methods", _inner.PublicMethodCount.ToString()));
-        fields.Add(new("Properties", _inner.PublicPropertyCount.ToString()));
-        if (_inner.Tfm != null)
-            fields.Add(new("TFM", _inner.Tfm));
-        if (!string.IsNullOrEmpty(_inner.RepositoryUrl))
-            fields.Add(new("Repository", _inner.RepositoryUrl));
-        return fields;
-    }
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("TFM")]
+    public string? Tfm => _inner.Tfm;
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Repository")]
+    [MarkoutLink]
+    public string? RepositoryUrl => _inner.RepositoryUrl;
 }
 
 /// <summary>
@@ -161,45 +144,22 @@ public class TypeShapeView
     [MarkoutIgnore]
     public string FullName { get; set; } = "";
 
-    [MarkoutIgnore]
     public string Kind { get; set; } = "";
 
-    [MarkoutIgnore]
+    [MarkoutSkipNull]
     public string? Modifiers { get; set; }
 
-    [MarkoutIgnore]
+    [MarkoutSkipNull]
     public string? Assembly { get; set; }
 
-    [MarkoutIgnore]
+    [MarkoutSkipNull]
     public string? Package { get; set; }
 
-    [MarkoutIgnore]
+    [MarkoutSkipNull]
     public string? Version { get; set; }
-
-    /// <summary>
-    /// Identity fields (rendered as key-value fields under the title).
-    /// </summary>
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Identity => GetIdentityFields();
 
     [MarkoutIgnoreInTable]
     public List<TreeNode> Members { get; set; } = [];
-
-    private List<MarkoutField> GetIdentityFields()
-    {
-        var fields = new List<MarkoutField>();
-        fields.Add(new("Kind", Kind));
-        if (!string.IsNullOrEmpty(Modifiers))
-            fields.Add(new("Modifiers", Modifiers));
-        if (!string.IsNullOrEmpty(Assembly))
-            fields.Add(new("Assembly", Assembly));
-        if (!string.IsNullOrEmpty(Package))
-            fields.Add(new("Package", Package));
-        if (!string.IsNullOrEmpty(Version))
-            fields.Add(new("Version", Version));
-        return fields;
-    }
 }
 
 [MarkoutContext(typeof(TypeShapeView))]

--- a/src/dotnet-inspect/Views/AssemblyAuditView.cs
+++ b/src/dotnet-inspect/Views/AssemblyAuditView.cs
@@ -162,12 +162,19 @@ public class AssemblyAuditView
         !_data.UseDependenciesView || _data.AssemblyInfo?.TransitiveReferences is not { Count: > 0 } ? null :
         BuildNestedDependencyTree(_data.AssemblyInfo.TransitiveReferences);
 
-    [MarkoutSection(Name = "Non-normalized Paths")]
-    public List<string>? NonNormalizedPathsSection =>
-        _data.NonNormalizedPaths is { Count: > 0 } ? _data.NonNormalizedPaths : null;
+    [MarkoutIgnore]
+    public bool HasNonNormalizedPaths => _data.NonNormalizedPaths is { Count: > 0 };
 
-    [MarkoutSection(Name = "Missing Sources")]
-    public List<string>? MissingSourcesSection => GetMissingSourcesDisplay();
+    [MarkoutSection(Name = "Non-normalized Paths", ShowWhenProperty = nameof(HasNonNormalizedPaths))]
+    public List<string>? NonNormalizedPathsSection => _data.NonNormalizedPaths;
+
+    [MarkoutIgnore]
+    public bool HasMissingSources => _data.MissingSourceFiles is { Count: > 0 };
+
+    [MarkoutSection(Name = "Missing Sources", ShowWhenProperty = nameof(HasMissingSources))]
+    [MarkoutMaxItems(10)]
+    public List<string>? MissingSourcesSection =>
+        _data.MissingSourceFiles?.Select(f => $"`{f}`").ToList();
 
     private List<MarkoutField> GetAssemblyInfoFields()
     {
@@ -257,15 +264,6 @@ public class AssemblyAuditView
             fields.Add(new("Embedded", $"{_data.EmbeddedSourceFiles} files"));
 
         return fields;
-    }
-
-    private List<string>? GetMissingSourcesDisplay()
-    {
-        if (_data.MissingSourceFiles is not { Count: > 0 }) return null;
-        var display = _data.MissingSourceFiles.Take(10).Select(f => $"`{f}`").ToList();
-        if (_data.MissingSourceFiles.Count > 10)
-            display.Add($"... and {_data.MissingSourceFiles.Count - 10} more");
-        return display;
     }
 
     private static List<TreeNode> BuildFlatTransitiveTree(List<AssemblyReferenceNode> nodes)

--- a/src/dotnet-inspect/Views/PackageViews.cs
+++ b/src/dotnet-inspect/Views/PackageViews.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Markout;
 
 namespace DotnetInspector.Views;
@@ -26,33 +25,16 @@ public class PackageDependenciesView
     [MarkoutIgnore]
     public string Title { get; set; } = "";
 
-    [MarkoutIgnore]
     public string Package { get; set; } = "";
 
-    [MarkoutIgnore]
     public string Version { get; set; } = "";
 
-    [MarkoutIgnore]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("TFM")]
     public string? Tfm { get; set; }
-
-    [JsonIgnore]
-    [MarkoutIgnoreInTable]
-    public List<MarkoutField> Identity => GetIdentityFields();
 
     [MarkoutIgnoreInTable]
     public List<TreeNode> Dependencies { get; set; } = [];
-
-    private List<MarkoutField> GetIdentityFields()
-    {
-        var fields = new List<MarkoutField>();
-        if (!string.IsNullOrEmpty(Package))
-            fields.Add(new("Package", Package));
-        if (!string.IsNullOrEmpty(Version))
-            fields.Add(new("Version", Version));
-        if (!string.IsNullOrEmpty(Tfm))
-            fields.Add(new("TFM", Tfm));
-        return fields;
-    }
 }
 
 [MarkoutContext(typeof(PackageDependenciesView))]

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -67,7 +67,7 @@
   -->
   <!-- PackageReference: Use for releases after new Markout version is published -->
   <ItemGroup>
-    <PackageReference Include="Markout" Version="0.3.4" />
+    <PackageReference Include="Markout" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bump Markout 0.3.4 → 0.4.0
- Replace 4 manual `GetIdentityFields()`/`GetSummaryFields()` methods with declarative auto fields using `[MarkoutSkipNull]`, `[MarkoutPropertyName]`, and `[MarkoutLink]` in `ApiTypeView`, `TypeShapeView`, `CliApiSurface`, and `PackageDependenciesView`
- Replace `GetMissingSourcesDisplay()` manual truncation with `[MarkoutMaxItems(10)]` in `AssemblyAuditView`
- Use `[MarkoutSection(ShowWhenProperty)]` for `NonNormalizedPaths` and `MissingSources` sections in `AssemblyAuditView`

Net: -60 lines (58 added, 118 removed)

## Test plan

- [x] `dotnet build` compiles cleanly
- [x] All 253 CLI tests pass
- [ ] Smoke: `dotnet run -- api System.Text.Json JsonSerializer` (ApiTypeView fields)
- [ ] Smoke: `dotnet run -- api System.Text.Json --all-types` (CliApiSurface fields)
- [ ] Smoke: `dotnet run -- api System.Text.Json JsonSerializer --shape` (TypeShapeView fields)
- [ ] Smoke: `dotnet run -- package System.Text.Json --dependencies` (PackageDependenciesView fields)
- [ ] Smoke: `dotnet run -- assembly /path/to.dll` (AssemblyAuditView sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)