### PR TITLE
Fix api command: remove Repository field, add -t/--tips option

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -77,7 +77,7 @@ public static class CommandLineBuilder
         rootCommand.Options.Add(rootTipsOption);
 
         // API command
-        var apiCommand = CreateApiCommand(jsonOption, markoutOption, verboseOption, verbosityOption, limitOption, includeSectionsOption, excludeSectionsOption, sourceOption, addSourceOption, nugetConfigOption);
+        var apiCommand = CreateApiCommand(jsonOption, markoutOption, verboseOption, verbosityOption, tipsOption, limitOption, includeSectionsOption, excludeSectionsOption, sourceOption, addSourceOption, nugetConfigOption);
         rootCommand.Subcommands.Add(apiCommand);
 
         // Assembly command
@@ -1127,6 +1127,7 @@ public static class CommandLineBuilder
         Option<bool> markoutOption,
         Option<bool> verboseOption,
         Option<string?> verbosityOption,
+        Option<string?> tipsOption,
         Option<int?> limitOption,
         Option<string?> includeSectionsOption,
         Option<string?> excludeSectionsOption,
@@ -1195,6 +1196,7 @@ public static class CommandLineBuilder
         apiCommand.Options.Add(sourceOption);
         apiCommand.Options.Add(addSourceOption);
         apiCommand.Options.Add(nugetConfigOption);
+        apiCommand.Options.Add(tipsOption);
 
         apiCommand.SetAction(async (parseResult, ct) =>
         {
@@ -1281,6 +1283,8 @@ public static class CommandLineBuilder
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
+                TipLevel = parseResult.GetValue(verbosityOption)?.TrimStart(':').StartsWith("q", StringComparison.OrdinalIgnoreCase) == true
+                    ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -32,4 +32,5 @@ public record ApiOptions
     public HashSet<string>? IncludeSections { get; init; }
     public HashSet<string>? ExcludeSections { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
+    public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -128,11 +128,6 @@ public class CliApiSurface
     [MarkoutSkipNull]
     [MarkoutPropertyName("TFM")]
     public string? Tfm => _inner.Tfm;
-
-    [MarkoutSkipNull]
-    [MarkoutPropertyName("Repository")]
-    [MarkoutLink]
-    public string? RepositoryUrl => _inner.RepositoryUrl;
 }
 
 /// <summary>


### PR DESCRIPTION
Fixes three inconsistencies in the `api` command:

1. **Repository field removed** — The api compact line included a Repository field that isn't needed (package command doesn't show it in its compact line either)
2. **Repository link format** — Was rendering as a markdown link `[url](url)` via `[MarkoutLink]` while package showed it as plain text. Resolved by removing the field entirely.
3. **`-t:q` now works** — The `-t`/`--tips` option was missing from the api command, causing `-t:q` to be interpreted as a type name argument (`Error: Type '-t:q' not found`). Added `tipsOption` and `TipLevel` to `ApiOptions`.