### PR TITLE
Remove service calls from PlatformOutputFormatter

### DIFF
--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -138,45 +138,63 @@ public class PlatformCommand
             requestedVersion = version;
         }
 
+        var frameworkData = ResolveFrameworkAssemblies(frameworks, requestedVersion, options.IncludeTypes, logger);
+
         if (options.JsonOutput)
         {
-            return ListAssembliesJson(frameworks, requestedVersion, options);
+            return ListAssembliesJson(frameworkData, options);
         }
 
         var multipleFrameworks = frameworks.Count > 1 || string.IsNullOrEmpty(options.Framework);
         Console.WriteLine(PlatformOutputFormatter.FormatAssemblies(
-            frameworks, requestedVersion, options.IncludeTypes, options.Limit,
-            packsDir, multipleFrameworks, CountPublicTypes, logger));
+            frameworkData, options.IncludeTypes, options.Limit, packsDir, multipleFrameworks));
         return 0;
     }
 
-    private static int ListAssembliesJson(List<FrameworkInfo> frameworks, string? requestedVersion, PlatformOptions options)
+    private static List<FrameworkAssemblyData> ResolveFrameworkAssemblies(
+        List<FrameworkInfo> frameworks, string? requestedVersion, bool includeTypes, VerboseLogger logger)
     {
-        var result = new List<PlatformAssembliesJson>();
+        var result = new List<FrameworkAssemblyData>();
 
         foreach (var framework in frameworks)
         {
             var version = requestedVersion ?? framework.LatestVersion;
             var refPath = PlatformResolver.GetRefAssemblyPath(framework.Path, version);
-            
+
             if (refPath == null)
+            {
+                logger.Log($"Could not find ref path for {framework.ShortName} {version}");
                 continue;
+            }
 
             var assemblies = PlatformResolver.GetAssemblies(refPath);
-            
-            var displayAssemblies = assemblies.AsEnumerable();
+            var entries = assemblies.Select(a => new AssemblyEntry(
+                a.Name,
+                includeTypes ? CountPublicTypes(a.Path) : null
+            )).ToList();
+
+            result.Add(new FrameworkAssemblyData(framework.ShortName, version, entries));
+        }
+
+        return result;
+    }
+
+    private static int ListAssembliesJson(List<FrameworkAssemblyData> frameworkData, PlatformOptions options)
+    {
+        var result = frameworkData.Select(data =>
+        {
+            var displayAssemblies = data.Assemblies.AsEnumerable();
             if (options.Limit.HasValue)
             {
                 displayAssemblies = displayAssemblies.Take(options.Limit.Value);
             }
 
             var assemblyList = displayAssemblies.Select(a => new PlatformAssemblyJson(
-                a.Name,
-                options.IncludeTypes ? CountPublicTypes(a.Path) : null
+                a.Name, a.PublicTypeCount
             )).ToList();
 
-            result.Add(new PlatformAssembliesJson(framework.ShortName, version, assemblyList));
-        }
+            return new PlatformAssembliesJson(data.FrameworkName, data.Version, assemblyList);
+        }).ToList();
 
         var typeInfo = options.CompactJson 
             ? PlatformCompactJsonContext.Default.ListPlatformAssembliesJson 

--- a/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
@@ -5,6 +5,16 @@ using Markout;
 namespace DotnetInspector.Output;
 
 /// <summary>
+/// Data passed from PlatformCommand to the formatter for assembly listing.
+/// </summary>
+public record FrameworkAssemblyData(string FrameworkName, string Version, List<AssemblyEntry> Assemblies);
+
+/// <summary>
+/// A single assembly entry with an optional public type count.
+/// </summary>
+public record AssemblyEntry(string Name, int? PublicTypeCount = null);
+
+/// <summary>
 /// Formats platform command results for display.
 /// </summary>
 public static class PlatformOutputFormatter
@@ -66,9 +76,8 @@ public static class PlatformOutputFormatter
         return writer.ToString();
     }
 
-    public static string FormatAssemblies(List<FrameworkInfo> frameworks, string? requestedVersion,
-        bool includeTypes, int? limit, string packsDir, bool multipleFrameworks,
-        Func<string, int> countPublicTypes, VerboseLogger logger)
+    public static string FormatAssemblies(List<FrameworkAssemblyData> frameworkData, bool includeTypes,
+        int? limit, string packsDir, bool multipleFrameworks)
     {
         var writer = new MarkoutWriter();
 
@@ -78,22 +87,11 @@ public static class PlatformOutputFormatter
             writer.WriteField("Packs Directory", packsDir);
         }
 
-        foreach (var framework in frameworks)
+        foreach (var data in frameworkData)
         {
-            var version = requestedVersion ?? framework.LatestVersion;
-            var refPath = PlatformResolver.GetRefAssemblyPath(framework.Path, version);
+            writer.WriteHeading(2, $"{data.FrameworkName} ({data.Version})");
 
-            if (refPath == null)
-            {
-                logger.Log($"Could not find ref path for {framework.ShortName} {version}");
-                continue;
-            }
-
-            var assemblies = PlatformResolver.GetAssemblies(refPath);
-
-            writer.WriteHeading(2, $"{framework.ShortName} ({version})");
-
-            var displayAssemblies = assemblies.AsEnumerable();
+            var displayAssemblies = data.Assemblies.AsEnumerable();
             if (limit.HasValue)
             {
                 displayAssemblies = displayAssemblies.Take(limit.Value);
@@ -102,7 +100,7 @@ public static class PlatformOutputFormatter
             if (includeTypes)
             {
                 var headers = new[] { "Assembly", "Types" };
-                var rows = displayAssemblies.Select(a => new[] { a.Name, countPublicTypes(a.Path).ToString() });
+                var rows = displayAssemblies.Select(a => new[] { a.Name, (a.PublicTypeCount ?? 0).ToString() });
                 writer.WriteTable(headers, rows);
             }
             else
@@ -112,9 +110,9 @@ public static class PlatformOutputFormatter
                 writer.WriteTable(headers, rows);
             }
 
-            if (limit.HasValue && assemblies.Count > limit.Value)
+            if (limit.HasValue && data.Assemblies.Count > limit.Value)
             {
-                writer.WriteParagraph($"... *and {assemblies.Count - limit.Value} more assemblies*");
+                writer.WriteParagraph($"... *and {data.Assemblies.Count - limit.Value} more assemblies*");
             }
         }
 


### PR DESCRIPTION
PlatformOutputFormatter was calling `PlatformResolver.GetRefAssemblyPath()` and `GetAssemblies()` directly — a presentation-layer type reaching into the data layer.

**Before:** Formatter accepted `List<FrameworkInfo>`, a `Func<string, int> countPublicTypes` callback, and a `VerboseLogger`, then called `PlatformResolver` internally to resolve ref assembly paths and enumerate assemblies.

**After:** Command resolves assembly data via `ResolveFrameworkAssemblies()` and passes `List<FrameworkAssemblyData>` records to the formatter. Both JSON and Markout paths share the same resolved data. Formatter is now a pure renderer with no service dependencies.

New data types:
- `FrameworkAssemblyData(FrameworkName, Version, Assemblies)`
- `AssemblyEntry(Name, PublicTypeCount?)`

All 253 tests pass.