### PR TITLE
Move file I/O from OutputFormatter to command layer

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -202,7 +202,15 @@ public class PackageCommand
             FilterResultForOutput(result, options);
 
             // Output results
-            OutputFormatter.WriteResult(result, options);
+            var output = OutputFormatter.FormatResult(result, options);
+            if (!string.IsNullOrEmpty(options.OutputPath))
+            {
+                File.WriteAllText(options.OutputPath, output);
+            }
+            else
+            {
+                Console.WriteLine(output);
+            }
 
             return 0;
         }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -11,19 +11,14 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class OutputFormatter
 {
-    public static void WriteResult(InspectionResult result, InspectionOptions options)
+    public static string FormatResult(InspectionResult result, InspectionOptions options)
     {
-        string output;
         if (options.JsonOutput)
         {
-            output = JsonSerializer.Serialize(result, JsonContext.Default.InspectionResult);
+            return JsonSerializer.Serialize(result, JsonContext.Default.InspectionResult);
         }
-        else
-        {
-            output = RenderMarkout(result, options);
-        }
-        
-        WriteOutput(output, options.OutputPath);
+
+        return RenderMarkout(result, options);
     }
 
     private static string RenderMarkout(InspectionResult result, InspectionOptions options)
@@ -117,18 +112,4 @@ public static class OutputFormatter
         return null;
     }
 
-    /// <summary>
-    /// Writes output to file if path is specified, otherwise to stdout.
-    /// </summary>
-    public static void WriteOutput(string content, string? outputPath)
-    {
-        if (!string.IsNullOrEmpty(outputPath))
-        {
-            File.WriteAllText(outputPath, content);
-        }
-        else
-        {
-            Console.WriteLine(content);
-        }
-    }
 }


### PR DESCRIPTION
OutputFormatter.WriteResult() was writing to files via `File.WriteAllText` — I/O that belongs in the app layer, not the presentation layer.

**Changes:**
- Renamed `WriteResult` → `FormatResult` (returns string instead of writing)
- Removed `WriteOutput` helper from the formatter
- PackageCommand now handles the file-vs-stdout decision

The formatter is now a pure renderer — it formats data and returns strings, with no side effects.

All 253 tests pass.