### PR TITLE
Extract parse helpers from CommandLineBuilder to OptionParsers

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1306,81 +1306,12 @@ public static class CommandLineBuilder
         return apiCommand;
     }
 
-    public static Verbosity ParseVerbosity(string? value)
-    {
-        if (string.IsNullOrEmpty(value)) return Verbosity.Minimal;
-
-        var v = value.TrimStart(':').ToLowerInvariant();
-        return v switch
-        {
-            "q" or "quiet" => Verbosity.Quiet,
-            "m" or "minimal" => Verbosity.Minimal,
-            "n" or "normal" => Verbosity.Normal,
-            "d" or "detailed" => Verbosity.Detailed,
-            _ => Verbosity.Minimal
-        };
-    }
-
-    public static TipLevel ParseTipLevel(string? value, bool optionPresent)
-    {
-        // Bare -T (no value) means quiet
-        if (optionPresent && string.IsNullOrEmpty(value))
-            return TipLevel.Quiet;
-
-        // --tips flag takes precedence, then DOTNET_INSPECT_TIPS env var, then default
-        if (string.IsNullOrEmpty(value))
-            value = Environment.GetEnvironmentVariable("DOTNET_INSPECT_TIPS");
-        if (string.IsNullOrEmpty(value)) return TipLevel.Minimal;
-
-        var v = value.TrimStart(':').ToLowerInvariant();
-        return v switch
-        {
-            "q" or "quiet" => TipLevel.Quiet,
-            "m" or "minimal" => TipLevel.Minimal,
-            "d" or "detailed" => TipLevel.Detailed,
-            _ => TipLevel.Minimal
-        };
-    }
-
-    public static HashSet<string>? ParseSectionList(string? value)
-    {
-        if (string.IsNullOrEmpty(value)) return null;
-
-        var v = value.TrimStart(':');
-        var sections = new HashSet<string>();
-        foreach (var part in v.Split(',', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var trimmed = part.Trim();
-            if (trimmed.Length > 0)
-                sections.Add(trimmed);
-        }
-        return sections.Count > 0 ? sections : null;
-    }
-
-
-    /// <summary>
-    /// Creates NuGetSourceOptions from parsed command line values.
-    /// </summary>
+    // Parse helpers delegated to OptionParsers
+    public static Verbosity ParseVerbosity(string? value) => OptionParsers.ParseVerbosity(value);
+    public static TipLevel ParseTipLevel(string? value, bool optionPresent) => OptionParsers.ParseTipLevel(value, optionPresent);
+    public static HashSet<string>? ParseSectionList(string? value) => OptionParsers.ParseSectionList(value);
     public static NuGetSourceOptions ParseNuGetSourceOptions(
-        ParseResult parseResult,
-        Option<string[]> sourceOption,
-        Option<string[]> addSourceOption,
-        Option<string?> nugetConfigOption)
-    {
-        var sources = parseResult.GetValue(sourceOption) ?? [];
-        var addSources = parseResult.GetValue(addSourceOption) ?? [];
-        var configFile = parseResult.GetValue(nugetConfigOption);
-
-        if (sources.Length == 0 && addSources.Length == 0 && configFile == null)
-        {
-            return NuGetSourceOptions.Default;
-        }
-
-        return new NuGetSourceOptions
-        {
-            Sources = sources,
-            AdditionalSources = addSources,
-            ConfigFile = configFile
-        };
-    }
+        ParseResult parseResult, Option<string[]> sourceOption,
+        Option<string[]> addSourceOption, Option<string?> nugetConfigOption)
+        => OptionParsers.ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption);
 }

--- a/src/dotnet-inspect/OptionParsers.cs
+++ b/src/dotnet-inspect/OptionParsers.cs
@@ -1,0 +1,90 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector;
+
+/// <summary>
+/// Parses CLI option values into typed domain objects.
+/// </summary>
+public static class OptionParsers
+{
+    public static Verbosity ParseVerbosity(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return Verbosity.Minimal;
+
+        var v = value.TrimStart(':').ToLowerInvariant();
+        return v switch
+        {
+            "q" or "quiet" => Verbosity.Quiet,
+            "m" or "minimal" => Verbosity.Minimal,
+            "n" or "normal" => Verbosity.Normal,
+            "d" or "detailed" => Verbosity.Detailed,
+            _ => Verbosity.Minimal
+        };
+    }
+
+    public static TipLevel ParseTipLevel(string? value, bool optionPresent)
+    {
+        // Bare -T (no value) means quiet
+        if (optionPresent && string.IsNullOrEmpty(value))
+            return TipLevel.Quiet;
+
+        // --tips flag takes precedence, then DOTNET_INSPECT_TIPS env var, then default
+        if (string.IsNullOrEmpty(value))
+            value = Environment.GetEnvironmentVariable("DOTNET_INSPECT_TIPS");
+        if (string.IsNullOrEmpty(value)) return TipLevel.Minimal;
+
+        var v = value.TrimStart(':').ToLowerInvariant();
+        return v switch
+        {
+            "q" or "quiet" => TipLevel.Quiet,
+            "m" or "minimal" => TipLevel.Minimal,
+            "d" or "detailed" => TipLevel.Detailed,
+            _ => TipLevel.Minimal
+        };
+    }
+
+    public static HashSet<string>? ParseSectionList(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+
+        var v = value.TrimStart(':');
+        var sections = new HashSet<string>();
+        foreach (var part in v.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length > 0)
+                sections.Add(trimmed);
+        }
+        return sections.Count > 0 ? sections : null;
+    }
+
+    /// <summary>
+    /// Creates NuGetSourceOptions from parsed command line values.
+    /// </summary>
+    public static NuGetSourceOptions ParseNuGetSourceOptions(
+        ParseResult parseResult,
+        Option<string[]> sourceOption,
+        Option<string[]> addSourceOption,
+        Option<string?> nugetConfigOption)
+    {
+        var sources = parseResult.GetValue(sourceOption) ?? [];
+        var addSources = parseResult.GetValue(addSourceOption) ?? [];
+        var configFile = parseResult.GetValue(nugetConfigOption);
+
+        if (sources.Length == 0 && addSources.Length == 0 && configFile == null)
+        {
+            return NuGetSourceOptions.Default;
+        }
+
+        return new NuGetSourceOptions
+        {
+            Sources = sources,
+            AdditionalSources = addSources,
+            ConfigFile = configFile
+        };
+    }
+}


### PR DESCRIPTION
CommandLineBuilder (1386 lines) had parsing utilities mixed in with CLI wiring. Extracted to a focused `OptionParsers` class:

- `ParseVerbosity` — maps `-v:q/m/n/d` to `Verbosity` enum
- `ParseTipLevel` — maps `-T:q/m/d` to `TipLevel` enum (with env var fallback)
- `ParseSectionList` — parses comma-separated section names
- `ParseNuGetSourceOptions` — builds `NuGetSourceOptions` from parsed values

CommandLineBuilder retains thin forwarding methods for backward compatibility with existing tests (they call `CommandLineBuilder.ParseVerbosity` etc.).

CommandLineBuilder: 1386 → 1317 lines.

All 253 tests pass.