### PR TITLE
Make -v:q suppress tips on root command

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -1,4 +1,6 @@
 using DotnetInspector;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
@@ -14,6 +16,90 @@ public class CommandLineTests
 
         // Root command has a default action (help + tips), so no parse errors
         Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void RootCommand_WithVerbosityQuiet_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["-v:q"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task RootCommand_WithVerbosityQuiet_SuppressesTips()
+    {
+        var originalErr = Console.Error;
+        var errWriter = new System.IO.StringWriter();
+        Console.SetError(errWriter);
+        try
+        {
+            var root = CommandLineBuilder.CreateRootCommand();
+            await root.Parse(["-v:q"]).InvokeAsync();
+            var stderr = errWriter.ToString();
+            Assert.DoesNotContain("Tip:", stderr);
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public async Task RootCommand_WithoutVerbosityQuiet_ShowsTips()
+    {
+        var originalErr = Console.Error;
+        var originalOut = Console.Out;
+        var errWriter = new System.IO.StringWriter();
+        var outWriter = new System.IO.StringWriter();
+        Console.SetError(errWriter);
+        Console.SetOut(outWriter);
+        try
+        {
+            var root = CommandLineBuilder.CreateRootCommand();
+            await root.Parse([]).InvokeAsync();
+            var stderr = errWriter.ToString();
+            Assert.Contains("Tip:", stderr);
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void WriteTips_WithQuietLevel_WritesNothing()
+    {
+        var originalErr = Console.Error;
+        var errWriter = new System.IO.StringWriter();
+        Console.SetError(errWriter);
+        try
+        {
+            Hints.WriteTips(TipLevel.Quiet, new Tip("package", "Foo", "inspect"));
+            Assert.Empty(errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void WriteTips_WithMinimalLevel_WritesTips()
+    {
+        var originalErr = Console.Error;
+        var errWriter = new System.IO.StringWriter();
+        Console.SetError(errWriter);
+        try
+        {
+            Hints.WriteTips(TipLevel.Minimal, new Tip("package", "Foo", "inspect"));
+            Assert.Contains("Tip:", errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -71,7 +71,8 @@ public static class CommandLineBuilder
         // Commands in alphabetical order (llmstxt last as meta command)
 
         // Root-level display option (distinct instance so it appears in root help)
-        rootCommand.Options.Add(new Option<string?>("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)" });
+        var rootVerbosityOption = new Option<string?>("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)" };
+        rootCommand.Options.Add(rootVerbosityOption);
         var rootTipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)", Arity = ArgumentArity.ZeroOrOne };
         rootTipsOption.Aliases.Add("-T");
         rootCommand.Options.Add(rootTipsOption);
@@ -148,7 +149,9 @@ public static class CommandLineBuilder
             Console.SetOut(original);
             Console.WriteLine(sw.ToString().TrimEnd());
 
-            var tipLevel = ParseTipLevel(parseResult.GetValue(rootTipsOption), parseResult.GetResult(rootTipsOption) != null);
+            var verbosity = ParseVerbosity(parseResult.GetValue(rootVerbosityOption));
+            var tipLevel = verbosity == Verbosity.Quiet
+                ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(rootTipsOption), parseResult.GetResult(rootTipsOption) != null);
             Hints.WriteTips(tipLevel,
                 new Tip(PackageCommand.Name, "<package>", "inspect a NuGet package"),
                 new Tip(LlmsTxtCommand.Name, "", "complete usage examples"),


### PR DESCRIPTION
The root command's `-v` option was added for display in help but never wired into the action handler, so `dotnet-inspect -v:q` still printed tips.

## Changes

**`CommandLineBuilder.cs`** — Store the root `-v` option in a variable and map `Verbosity.Quiet` → `TipLevel.Quiet`, matching the pattern already used by subcommands (`api`, `diff`, `find`, `package`).

**`CommandLineTests.cs`** — 5 new tests:
- Parse validation for root `-v:q`
- Integration: tips suppressed with `-v:q`, shown without
- `WriteTips` unit tests for `Quiet` and `Minimal` levels

## Before / After

```
# Before: -v:q still shows tips
$ dotnet-inspect -v:q
  ...help text...
Tip: package <package>   # inspect a NuGet package
Tip: llmstxt             # complete usage examples

# After: tips are suppressed
$ dotnet-inspect -v:q
  ...help text...
```