### PR TITLE
Show vulnerabilities only in detailed view; add blank line before tips

### DIFF
--- a/src/dotnet-inspect/Output/Hints.cs
+++ b/src/dotnet-inspect/Output/Hints.cs
@@ -19,6 +19,7 @@ public static class Hints
         var visible = tips.Take(max).ToList();
         int commentColumn = visible.Max(t => t.CommandText.Length) + 3;
         Console.Out.Flush();
+        Console.Error.WriteLine();
         foreach (var tip in visible)
             Console.Error.WriteLine($"Tip: {tip.CommandText.PadRight(commentColumn)}# {tip.Comment}");
     }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -49,10 +49,10 @@ public static class OutputFormatter
         {
             // Quiet: exclude all sections (just title + compact line)
             Verbosity.Quiet => ["Package", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"],
-            // Minimal: show Metadata, exclude Statistics, Package Dependencies, Files
-            Verbosity.Minimal => ["Statistics", "Package Dependencies", "Files"],
-            // Normal and Detailed: show everything
-            Verbosity.Normal => null,
+            // Minimal: show Metadata, exclude Statistics, Package Dependencies, Files, Vulnerabilities
+            Verbosity.Minimal => ["Statistics", "Package Dependencies", "Files", "Vulnerabilities"],
+            // Normal: show most sections, exclude Vulnerabilities (use -v:d to see them)
+            Verbosity.Normal => ["Vulnerabilities"],
             Verbosity.Detailed => ["Files"],
             _ => null
         };


### PR DESCRIPTION
Two small output changes:

- **Vulnerabilities section**: now excluded from Normal and Minimal verbosity levels. Use `-v:d` to see vulnerabilities. They were previously shown at all non-quiet verbosity levels.
- **Tips blank line**: tips now have a leading blank line for visual separation from the preceding output.