### PR TITLE
Move PlatformResolver to DotnetInspector.Services

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspector.Services;
 
 /// <summary>
 /// Resolves .NET platform/framework installation paths and discovers available assemblies.

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-using DotnetInspector.Inspectors;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Tests;
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -82,7 +82,7 @@ public class ApiCommand
             }
             else if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
-                var (assemblyPath, framework, version, error) = Inspectors.PlatformResolver.ResolveAssembly(
+                var (assemblyPath, framework, version, error) = PlatformResolver.ResolveAssembly(
                     options.PlatformAssembly,
                     options.PlatformFramework,
                     packsDirectory: null,
@@ -99,7 +99,7 @@ public class ApiCommand
                 apiVersion = version;
                 logger.Log($"Using platform ref assembly: {framework} {version}");
 
-                var (runtimePath, _, _, runtimeError) = Inspectors.PlatformResolver.ResolveAssembly(
+                var (runtimePath, _, _, runtimeError) = PlatformResolver.ResolveAssembly(
                     options.PlatformAssembly,
                     options.PlatformFramework,
                     packsDirectory: null,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 

--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -1,8 +1,8 @@
 using System.Text;
-using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Commands;
 

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
 

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -5,6 +5,7 @@ using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 using AssemblyReference = DotnetInspector.Metadata.AssemblyReference;
 
 namespace DotnetInspector.Inspectors;
@@ -306,7 +307,7 @@ internal static class LibraryMetadataService
 
             if (resolvedPath == null)
             {
-                var (platformPath, _, _, error) = Inspectors.PlatformResolver.ResolveAssembly(reference.Name);
+                var (platformPath, _, _, error) = PlatformResolver.ResolveAssembly(reference.Name);
                 if (error == null && platformPath != null)
                 {
                     resolvedPath = platformPath;

--- a/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
@@ -1,5 +1,5 @@
-using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
+using DotnetInspector.Services;
 using Markout;
 
 namespace DotnetInspector.Output;


### PR DESCRIPTION
PlatformResolver is a pure static class (599 lines) with zero CLI dependencies — just `Path`, `Directory`, `Environment`, and `RuntimeInformation`. It provides cross-platform .NET SDK discovery, framework resolution, and assembly enumeration.

**Why move it:** It currently lives in `dotnet-inspect/Inspectors/`, making it inaccessible to other tools without depending on the entire CLI project. dotnet-scope needs this for platform assembly resolution (currently has a hardcoded 4-assembly fallback with basic SDK path discovery). Moving it to the shared Services library makes it available to any consumer of `DotnetInspector.Services`.

**What moved:**
- `PlatformResolver.cs` → `DotnetInspector.Services/PlatformResolver.cs`
- Namespace: `DotnetInspector.Inspectors` → `DotnetInspector.Services`
- Includes `FrameworkInfo` and `AssemblyRefInfo` types

**Cleanup:**
- Removed stale `using DotnetInspector.Inspectors` from PlatformCommand and PlatformOutputFormatter
- Removed fully-qualified `Inspectors.PlatformResolver` references in ApiCommand and LibraryMetadataService

All 380 tests pass (258 app + 122 service).