### PR TITLE
Centralize package section names into PackageSections constants

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -22,7 +22,7 @@ public class PackageCommand
         // Handle --discover mode: list sections and exit early
         if (options.Discover)
         {
-            string[] sectionNames = ["Package", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"];
+            string[] sectionNames = [PackageSections.Package, PackageSections.Statistics, PackageSections.PackageDependencies, PackageSections.Files, PackageSections.Vulnerabilities, PackageSections.RidPackages, PackageSections.RuntimeDependencies];
             foreach (var name in sectionNames)
             {
                 Console.WriteLine(name);

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -48,12 +48,12 @@ public static class OutputFormatter
         return options.Verbosity switch
         {
             // Quiet: exclude all sections (just title + compact line)
-            Verbosity.Quiet => ["Package", "Statistics", "Package Dependencies", "Files", "Vulnerabilities", "RID Packages", "Runtime Dependencies"],
+            Verbosity.Quiet => [PackageSections.Package, PackageSections.Statistics, PackageSections.PackageDependencies, PackageSections.Files, PackageSections.Vulnerabilities, PackageSections.RidPackages, PackageSections.RuntimeDependencies],
             // Minimal: show Metadata, exclude Statistics, Package Dependencies, Files, Vulnerabilities
-            Verbosity.Minimal => ["Statistics", "Package Dependencies", "Files", "Vulnerabilities"],
+            Verbosity.Minimal => [PackageSections.Statistics, PackageSections.PackageDependencies, PackageSections.Files, PackageSections.Vulnerabilities],
             // Normal: show most sections, exclude Vulnerabilities (use -v:d to see them)
-            Verbosity.Normal => ["Vulnerabilities"],
-            Verbosity.Detailed => ["Files"],
+            Verbosity.Normal => [PackageSections.Vulnerabilities],
+            Verbosity.Detailed => [PackageSections.Files],
             _ => null
         };
     }

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -32,7 +32,7 @@ public class InspectionResultView
     [MarkoutIgnoreInTable]
     public List<MarkoutField> Summary => GetCompactFields();
 
-    [MarkoutSection(Name = "Package")]
+    [MarkoutSection(Name = PackageSections.Package)]
     public List<MarkoutField> Metadata => GetMetadataFields();
 
     public string? Authors => _data.Authors;
@@ -43,24 +43,24 @@ public class InspectionResultView
     [MarkoutPropertyName("Updated")]
     public DateTimeOffset? Published => _data.Published;
 
-    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSection(Name = PackageSections.Statistics)]
     [MarkoutSkipNull]
     [MarkoutValueFormatter(typeof(CompactNumberFormatter))]
     [MarkoutPropertyName("Downloads")]
     public long? TotalDownloads => _data.TotalDownloads;
 
-    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSection(Name = PackageSections.Statistics)]
     [MarkoutSkipNull]
     [MarkoutValueFormatter(typeof(CompactNumberFormatter))]
     [MarkoutPropertyName("Version Downloads")]
     public long? VersionDownloads => _data.VersionDownloads;
 
-    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSection(Name = PackageSections.Statistics)]
     [MarkoutSkipNull]
     [MarkoutPropertyName("Version Count")]
     public int? VersionCount => _data.VersionCount;
 
-    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSection(Name = PackageSections.Statistics)]
     [MarkoutSkipNull]
     [MarkoutValueFormatter(typeof(ByteSizeFormatter))]
     [MarkoutPropertyName("Package Size")]
@@ -75,7 +75,7 @@ public class InspectionResultView
     [MarkoutIgnoreInTable]
     public PackageDeprecation? Deprecation => _data.Deprecation;
 
-    [MarkoutSection(Name = "Vulnerabilities")]
+    [MarkoutSection(Name = PackageSections.Vulnerabilities)]
     [MarkoutIgnoreInTable]
     public List<PackageVulnerability>? Vulnerabilities => _data.Vulnerabilities;
 
@@ -146,7 +146,7 @@ public class InspectionResultView
     [MarkoutPropertyName("Tool Commands")]
     public List<string>? ToolCommands => _data.ToolCommands;
 
-    [MarkoutSection(Name = "RID Packages")]
+    [MarkoutSection(Name = PackageSections.RidPackages)]
     public List<RidPackageReferenceView>? RuntimeIdentifierPackages => _data.RuntimeIdentifierPackages?
         .Select(r => new RidPackageReferenceView(r))
         .ToList();
@@ -161,7 +161,7 @@ public class InspectionResultView
     [MarkoutIgnoreInTable]
     public List<DependencyGroup>? DependencyGroups => _data.DependencyGroups;
 
-    [MarkoutSection(Name = "Package Dependencies")]
+    [MarkoutSection(Name = PackageSections.PackageDependencies)]
     public List<FlatDependency>? FlatDependencies => _data.DependencyGroups?
         .OrderBy(g => GetTfmSortOrder(g.TargetFramework))
         .ThenBy(g => g.TargetFramework)
@@ -188,10 +188,10 @@ public class InspectionResultView
         return 3;
     }
 
-    [MarkoutSection(Name = "Runtime Dependencies")]
+    [MarkoutSection(Name = PackageSections.RuntimeDependencies)]
     public List<PackageDependency>? RuntimeDependencies => _data.RuntimeDependencies;
 
-    [MarkoutSection(Name = "Files")]
+    [MarkoutSection(Name = PackageSections.Files)]
     public List<string>? Files => _data.Files;
 
     private List<MarkoutField> GetCompactFields()

--- a/src/dotnet-inspect/Views/PackageSections.cs
+++ b/src/dotnet-inspect/Views/PackageSections.cs
@@ -1,0 +1,16 @@
+namespace DotnetInspector.Views;
+
+/// <summary>
+/// Section names for package inspection results.
+/// Used by <see cref="InspectionResultView"/> attributes, verbosity filtering, and --discover output.
+/// </summary>
+public static class PackageSections
+{
+    public const string Package = "Package";
+    public const string Statistics = "Statistics";
+    public const string PackageDependencies = "Package Dependencies";
+    public const string Files = "Files";
+    public const string Vulnerabilities = "Vulnerabilities";
+    public const string RidPackages = "RID Packages";
+    public const string RuntimeDependencies = "Runtime Dependencies";
+}


### PR DESCRIPTION
## Summary

Introduces a `PackageSections` static class with `const` fields for the 7 package section names used across the codebase.

## Motivation

The `assembly → library` rename in #84 highlighted that these section names were duplicated across 3 locations that must stay in sync:

1. **`InspectionResultView.cs`** — `[MarkoutSection(Name = "...")]` attributes (authoritative schema)
2. **`OutputFormatter.cs`** — verbosity-based section exclusion lists  
3. **`PackageCommand.cs`** — `--discover` output

A rename or addition required manual edits in all 3 files with no compiler help to catch drift.

## Changes

- **New:** `Views/PackageSections.cs` — 7 `const string` fields (`Package`, `Statistics`, `PackageDependencies`, `Files`, `Vulnerabilities`, `RidPackages`, `RuntimeDependencies`)
- **Updated:** All 3 consuming files now reference `PackageSections.*` constants instead of string literals

## What this doesn't do

Intentionally scoped to the one real sync problem. Strings that are contextually unique (table headers, `[JsonPropertyName]`, CLI help text) remain inline — centralizing those would add indirection without reducing bugs.