### PR TITLE
Capitalize api Source labels and fix -v:q verbosity

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -45,7 +45,7 @@ public class ApiCommand
                 if (extracted == null)
                     return 1;
                 (searchPath, tempDir, packageName, packageVersion) = (extracted.ExtractPath, extracted.TempDir, extracted.PackageName, extracted.Version);
-                apiSource = "nuget";
+                apiSource = "NuGet";
                 apiVersion = packageVersion;
 
                 if (!string.IsNullOrEmpty(options.Tfm))
@@ -78,7 +78,7 @@ public class ApiCommand
                     return 1;
                 }
                 searchPath = options.AssemblyPath;
-                apiSource = "local";
+                apiSource = "Library";
             }
             else if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
@@ -95,7 +95,7 @@ public class ApiCommand
                 }
 
                 searchPath = assemblyPath!;
-                apiSource = $"platform ({framework})";
+                apiSource = $"Platform ({framework})";
                 apiVersion = version;
                 logger.Log($"Using platform ref library: {framework} {version}");
 
@@ -122,7 +122,7 @@ public class ApiCommand
             string? selectedTfm = null;
 
             // Derive TFM for platform assemblies from the version
-            if (apiSource?.StartsWith("platform") == true && apiVersion != null)
+            if (apiSource?.StartsWith("Platform") == true && apiVersion != null)
             {
                 var dotIndex = apiVersion.IndexOf('.');
                 if (dotIndex > 0)
@@ -133,29 +133,30 @@ public class ApiCommand
                 }
             }
 
+            // Auto-select TFM when searchPath is a directory with multiple DLLs
+            if (Directory.Exists(searchPath))
+            {
+                var dlls = TfmSelector.GetPackageDlls(searchPath);
+                if (dlls.Count > 1)
+                {
+                    var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath);
+                    if (selectedPath != null)
+                    {
+                        searchPath = selectedPath;
+                        selectedTfm = tfm;
+                        logger.Log($"Auto-selected TFM: {tfm}");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: Multiple libraries found. Please specify one with --library or --tfm.");
+                        return 1;
+                    }
+                }
+            }
+
             if (string.IsNullOrEmpty(typeName))
             {
                 // No type specified - list all types
-                if (Directory.Exists(searchPath))
-                {
-                    var dlls = TfmSelector.GetPackageDlls(searchPath);
-                    if (dlls.Count > 1)
-                    {
-                        var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath);
-                        if (selectedPath != null)
-                        {
-                            searchPath = selectedPath;
-                            selectedTfm = tfm;
-                            logger.Log($"Auto-selected TFM: {tfm}");
-                        }
-                        else
-                        {
-                            Console.Error.WriteLine("Error: Multiple libraries found. Please specify one with --library or --tfm.");
-                            return 1;
-                        }
-                    }
-                }
-
                 var (api, apiDllPath) = ApiServices.ExtractFullApi(searchPath, logger, options.IncludeAll);
                 if (api == null)
                 {
@@ -259,7 +260,7 @@ public class ApiCommand
                             await SourceEnricher.EnrichTypeWithSourceInfoAsync(apiType, typeName, pdbLookupPath, options, logger, context.HttpClient);
                     }
 
-                    WriteTypeOutput(apiType, foundIn, packageName, packageVersion, options);
+                    WriteTypeOutput(apiType, foundIn, packageName, packageVersion, apiSource, selectedTfm, options);
                 }
                 else if (lookupResult.Suggestions.Count > 0)
                 {
@@ -368,7 +369,7 @@ public class ApiCommand
 
     // ===== Single Type Rendering =====
 
-    private static void WriteTypeOutput(ApiType type, string? foundIn, string? packageName, string? packageVersion, ApiOptions options)
+    private static void WriteTypeOutput(ApiType type, string? foundIn, string? packageName, string? packageVersion, string? apiSource, string? selectedTfm, ApiOptions options)
     {
         if (options.ShapeOutput)
         {
@@ -380,7 +381,7 @@ public class ApiCommand
         }
         else
         {
-            Console.WriteLine(ApiOutputFormatter.RenderTypeMarkdown(type, foundIn, packageName, packageVersion, options));
+            Console.WriteLine(ApiOutputFormatter.RenderTypeMarkdown(type, foundIn, packageName, packageVersion, apiSource, selectedTfm, options));
         }
     }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -57,14 +57,14 @@ public static class ApiOutputFormatter
                     byAssembly.Select(g => new[] { g.Key, g.Count().ToString() }));
             }
         }
-        else
+        else if (options.Verbosity != Verbosity.Quiet)
         {
             if (api.IsTypeForwardingAssembly)
             {
                 writer.WriteParagraph("*This is a type-forwarding library. Types shown are resolved from target libraries.*");
             }
 
-            // Per-kind type sections (verbosity-independent)
+            // Per-kind type sections
             RenderTypesPerKind(writer, api.Types, options);
 
             if (truncatedCount.HasValue)
@@ -82,14 +82,14 @@ public static class ApiOutputFormatter
 
     // ===== Single Type Rendering =====
 
-    public static string RenderTypeMarkdown(ApiType type, string? foundIn, string? packageName, string? packageVersion, ApiOptions options)
+    public static string RenderTypeMarkdown(ApiType type, string? foundIn, string? packageName, string? packageVersion, string? apiSource, string? selectedTfm, ApiOptions options)
     {
         // Signatures-only: plain text, no serializer
         if (options.SignaturesOnly)
             return RenderSignaturesOnly(type, options);
 
         // Build the view model
-        var view = BuildApiTypeView(type, foundIn, packageName, packageVersion, options);
+        var view = BuildApiTypeView(type, foundIn, packageName, packageVersion, apiSource, selectedTfm, options);
 
         // Populate enum values declaratively for Normal+ enums
         if (type.Kind == "enum" && options.Verbosity >= Verbosity.Normal)
@@ -195,7 +195,7 @@ public static class ApiOutputFormatter
 
     // ===== View Model Factories =====
 
-    internal static ApiTypeView BuildApiTypeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, ApiOptions options)
+    internal static ApiTypeView BuildApiTypeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, string? apiSource, string? selectedTfm, ApiOptions options)
     {
         // Build title with package context
         var packageInfo = packageName != null && packageVersion != null
@@ -271,6 +271,8 @@ public static class ApiOutputFormatter
             Assembly = foundIn,
             Package = packageName,
             Version = packageVersion,
+            Source = apiSource,
+            Tfm = selectedTfm,
             SamplesInfo = samplesInfo,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -39,6 +39,13 @@ public class ApiTypeView
     public string? Version { get; set; }
 
     [MarkoutSkipNull]
+    public string? Source { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("TFM")]
+    public string? Tfm { get; set; }
+
+    [MarkoutSkipNull]
     [MarkoutPropertyName("Samples")]
     public string? SamplesInfo { get; set; }
 


### PR DESCRIPTION
## Changes

- **Capitalize Source field values**: `nuget` → `NuGet`, `local` → `Library`, `platform` → `Platform`
- **Fix `-v:q` for api command**: Suppress per-kind type tables in quiet mode, matching `package` command behavior
- **Add Source and TFM to single-type view**: `ApiTypeView` now includes Source and TFM fields so they appear in type-level output at all verbosity levels
- **Hoist TFM auto-selection**: Moved TFM selection before the type/no-type branch so both paths resolve the TFM

## Examples

```
$ dotnet-inspect api System.Text.Json -v:q
# System.Text.Json
Types: 80 | Methods: 555 | Properties: 187 | Source: NuGet | Version: 10.0.2 | TFM: net10.0

$ dotnet-inspect api System.Text.Json JsonSerializer -v:q
# System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
Kind: class | ... | Source: NuGet | TFM: net10.0

$ dotnet-inspect api --library path/to/lib.dll -v:q
# MyLib
Types: 43 | Methods: 200 | Properties: 186 | Source: Library
```