### PR TITLE
Add C# 14 extension members for MetadataReader

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -20,10 +20,7 @@ public static class ApiSurfaceExtractor
             var attributes = typeDef.Attributes;
 
             // Only include public types
-            bool isPublic = (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.Public ||
-                            (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic;
-
-            if (!isPublic)
+            if (!typeDef.IsPublic)
                 continue;
 
             string typeName = reader.GetString(typeDef.Name);
@@ -320,9 +317,7 @@ public static class ApiSurfaceExtractor
             if (!exportedType.IsForwarder)
                 continue;
 
-            var eTypeName = reader.GetString(exportedType.Name);
-            var ns = reader.GetString(exportedType.Namespace);
-            var fullName = string.IsNullOrEmpty(ns) ? eTypeName : $"{ns}.{eTypeName}";
+            var fullName = reader.GetFullTypeName(exportedType);
 
             // Get the target assembly
             string targetAssembly = "";

--- a/src/DotnetInspector.Metadata/AssemblyInspector.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInspector.cs
@@ -573,28 +573,7 @@ public static class AssemblyInspector
     }
 
     internal static string? GetAttributeName(MetadataReader reader, CustomAttribute attr)
-    {
-        if (attr.Constructor.Kind == HandleKind.MemberReference)
-        {
-            var memberRef = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
-            if (memberRef.Parent.Kind == HandleKind.TypeReference)
-            {
-                var typeRef = reader.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
-                string ns = reader.GetString(typeRef.Namespace);
-                string name = reader.GetString(typeRef.Name);
-                return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-            }
-        }
-        else if (attr.Constructor.Kind == HandleKind.MethodDefinition)
-        {
-            var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)attr.Constructor);
-            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
-            string ns = reader.GetString(typeDef.Namespace);
-            string name = reader.GetString(typeDef.Name);
-            return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-        }
-        return null;
-    }
+        => AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
 
     internal static string? GetAttributeStringValue(MetadataReader reader, CustomAttribute attr)
     {

--- a/src/DotnetInspector.Metadata/AssemblyReader.cs
+++ b/src/DotnetInspector.Metadata/AssemblyReader.cs
@@ -86,12 +86,8 @@ public static class AssemblyReader
             foreach (var typeDefHandle in reader.TypeDefinitions)
             {
                 var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                var attributes = typeDef.Attributes;
 
-                bool isPublic = (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.Public ||
-                                (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic;
-
-                if (isPublic)
+                if (typeDef.IsPublic)
                 {
                     var name = reader.GetString(typeDef.Name);
                     if (!name.StartsWith("<") && !name.StartsWith("__"))

--- a/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
@@ -50,9 +50,8 @@ public static class ExtensionMethodScanner
             if (!includeAll && AttributeReader.HasHiddenAttribute(reader, typeDef.GetCustomAttributes()))
                 continue;
 
-            string className = reader.GetString(typeDef.Name);
             string classNs = reader.GetString(typeDef.Namespace);
-            string fullClassName = string.IsNullOrEmpty(classNs) ? className : $"{classNs}.{className}";
+            string fullClassName = reader.GetFullTypeName(typeDef);
 
             // Track property accessors seen (for deduplication of get_/set_ pairs)
             var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
@@ -178,8 +177,7 @@ public static class ExtensionMethodScanner
                     {
                         var typeDef = reader.GetTypeDefinition(typeDefHandle);
                         string typeName = reader.GetString(typeDef.Name);
-                        string typeNs = reader.GetString(typeDef.Namespace);
-                        string fullName = string.IsNullOrEmpty(typeNs) ? typeName : $"{typeNs}.{typeName}";
+                        string fullName = reader.GetFullTypeName(typeDef);
 
                         // Match by simple name or full name
                         if (!typeName.Equals(currentType, StringComparison.OrdinalIgnoreCase) &&

--- a/src/DotnetInspector.Metadata/GenericContext.cs
+++ b/src/DotnetInspector.Metadata/GenericContext.cs
@@ -22,7 +22,7 @@ public class GenericContext
     public static GenericContext ForType(MetadataReader reader, TypeDefinition typeDef)
     {
         var typeParams = typeDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
+            .Select(h => reader.GetGenericParameterName(h))
             .ToList();
         return new GenericContext(typeParams, []);
     }
@@ -33,10 +33,10 @@ public class GenericContext
     public static GenericContext ForMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition methodDef)
     {
         var typeParams = typeDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
+            .Select(h => reader.GetGenericParameterName(h))
             .ToList();
         var methodParams = methodDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
+            .Select(h => reader.GetGenericParameterName(h))
             .ToList();
         return new GenericContext(typeParams, methodParams);
     }

--- a/src/DotnetInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/DotnetInspector.Metadata/MetadataReaderExtensions.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Extension members for <see cref="MetadataReader"/> and related metadata types,
+/// reducing boilerplate around common name-resolution patterns.
+/// </summary>
+public static class MetadataReaderExtensions
+{
+    /// <summary>
+    /// Extensions for resolving fully-qualified names from metadata handles.
+    /// </summary>
+    extension(MetadataReader reader)
+    {
+        /// <summary>
+        /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeDefinition"/>.
+        /// </summary>
+        public string GetFullTypeName(TypeDefinition typeDef)
+        {
+            string ns = reader.GetString(typeDef.Namespace);
+            string name = reader.GetString(typeDef.Name);
+            return TypeResolver.GetFullName(ns, name);
+        }
+
+        /// <summary>
+        /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeReference"/>.
+        /// </summary>
+        public string GetFullTypeName(TypeReference typeRef)
+        {
+            string ns = reader.GetString(typeRef.Namespace);
+            string name = reader.GetString(typeRef.Name);
+            return TypeResolver.GetFullName(ns, name);
+        }
+
+        /// <summary>
+        /// Gets the fully qualified name (Namespace.Name) of an <see cref="ExportedType"/>.
+        /// </summary>
+        public string GetFullTypeName(ExportedType exportedType)
+        {
+            string ns = reader.GetString(exportedType.Namespace);
+            string name = reader.GetString(exportedType.Name);
+            return TypeResolver.GetFullName(ns, name);
+        }
+
+        /// <summary>
+        /// Gets the name of a generic parameter from its handle.
+        /// </summary>
+        public string GetGenericParameterName(GenericParameterHandle handle)
+            => reader.GetString(reader.GetGenericParameter(handle).Name);
+    }
+
+    /// <summary>
+    /// Extensions for common <see cref="TypeDefinition"/> attribute checks.
+    /// </summary>
+    extension(TypeDefinition typeDef)
+    {
+        /// <summary>
+        /// True when the type has Public or NestedPublic visibility.
+        /// </summary>
+        public bool IsPublic
+            => (typeDef.Attributes & TypeAttributes.VisibilityMask) is
+                TypeAttributes.Public or TypeAttributes.NestedPublic;
+    }
+}

--- a/src/DotnetInspector.Metadata/PdbContext.cs
+++ b/src/DotnetInspector.Metadata/PdbContext.cs
@@ -178,9 +178,7 @@ public class PdbContext : IDisposable
             if (!exportedType.IsForwarder)
                 continue;
 
-            var name = reader.GetString(exportedType.Name);
-            var ns = reader.GetString(exportedType.Namespace);
-            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+            var fullName = reader.GetFullTypeName(exportedType);
 
             if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DotnetInspector.Metadata/SignatureDecoder.cs
+++ b/src/DotnetInspector.Metadata/SignatureDecoder.cs
@@ -40,17 +40,13 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
     {
         var typeDef = reader.GetTypeDefinition(handle);
-        string ns = reader.GetString(typeDef.Namespace);
-        string name = reader.GetString(typeDef.Name);
-        return TypeResolver.GetFullName(ns, name);
+        return reader.GetFullTypeName(typeDef);
     }
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
     {
         var typeRef = reader.GetTypeReference(handle);
-        string ns = reader.GetString(typeRef.Namespace);
-        string name = reader.GetString(typeRef.Name);
-        return TypeResolver.GetFullName(ns, name);
+        return reader.GetFullTypeName(typeRef);
     }
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)

--- a/src/DotnetInspector.Metadata/SourceLinkResolver.cs
+++ b/src/DotnetInspector.Metadata/SourceLinkResolver.cs
@@ -178,8 +178,7 @@ public class SourceLinkResolver
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
             string name = reader.GetString(typeDef.Name);
-            string ns = reader.GetString(typeDef.Namespace);
-            string fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+            string fullName = reader.GetFullTypeName(typeDef);
 
             if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
                 name.Equals(typeName, StringComparison.OrdinalIgnoreCase))

--- a/src/DotnetInspector.Metadata/TypeHierarchyScanner.cs
+++ b/src/DotnetInspector.Metadata/TypeHierarchyScanner.cs
@@ -57,12 +57,8 @@ public static class TypeHierarchyScanner
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
-            var attributes = typeDef.Attributes;
-
             // Only public types
-            bool isPublic = (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.Public ||
-                           (attributes & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic;
-            if (!isPublic)
+            if (!typeDef.IsPublic)
                 continue;
 
             string typeName = reader.GetString(typeDef.Name);

--- a/src/DotnetInspector.Metadata/TypeResolver.cs
+++ b/src/DotnetInspector.Metadata/TypeResolver.cs
@@ -31,9 +31,7 @@ public static class TypeResolver
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
     {
         var typeRef = reader.GetTypeReference(handle);
-        string ns = reader.GetString(typeRef.Namespace);
-        string name = reader.GetString(typeRef.Name);
-        return GetFullName(ns, name);
+        return reader.GetFullTypeName(typeRef);
     }
 
     /// <summary>
@@ -42,9 +40,7 @@ public static class TypeResolver
     public static string GetTypeNameFromDefinition(MetadataReader reader, TypeDefinitionHandle handle)
     {
         var typeDef = reader.GetTypeDefinition(handle);
-        string ns = reader.GetString(typeDef.Namespace);
-        string name = reader.GetString(typeDef.Name);
-        return GetFullName(ns, name);
+        return reader.GetFullTypeName(typeDef);
     }
 
     /// <summary>
@@ -61,9 +57,7 @@ public static class TypeResolver
     /// </summary>
     public static string GetFullName(MetadataReader reader, TypeDefinition typeDef)
     {
-        string ns = reader.GetString(typeDef.Namespace);
-        string name = reader.GetString(typeDef.Name);
-        return GetFullName(ns, name);
+        return reader.GetFullTypeName(typeDef);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Introduces `MetadataReaderExtensions.cs` using C# 14 `extension` block syntax to reduce repetitive `MetadataReader` patterns across `DotnetInspector.Metadata`.

## New extension members

**`extension(MetadataReader reader)`** — 4 methods:
- `GetFullTypeName(TypeDefinition)` — replaces the 3-line ns/name/combine pattern (used in 6 call sites)
- `GetFullTypeName(TypeReference)` — same pattern for type references
- `GetFullTypeName(ExportedType)` — same pattern for exported types
- `GetGenericParameterName(GenericParameterHandle)` — replaces `reader.GetString(reader.GetGenericParameter(h).Name)`

**`extension(TypeDefinition typeDef)`** — 1 property:
- `IsPublic` — replaces the 2-line `VisibilityMask` bitmask check (used in 3 call sites)

## Other cleanup

`AssemblyInspector.GetAttributeName` was a 22-line method that duplicated the logic of `AttributeReader.GetAttributeTypeName`. Replaced with a one-line delegation.

## What changed

| File | Change |
|---|---|
| `MetadataReaderExtensions.cs` | New file with extension blocks |
| `TypeResolver.cs` | 3 methods delegate to extensions |
| `SignatureDecoder.cs` | 2 methods simplified |
| `GenericContext.cs` | 3 lambda expressions simplified |
| `AssemblyInspector.cs` | Duplicated `GetAttributeName` consolidated |
| `ApiSurfaceExtractor.cs` | `IsPublic` property + `GetFullTypeName` for exported types |
| `AssemblyReader.cs` | `IsPublic` property |
| `TypeHierarchyScanner.cs` | `IsPublic` property |
| `ExtensionMethodScanner.cs` | `GetFullTypeName`, removed unused local |
| `SourceLinkResolver.cs` | `GetFullTypeName` |
| `PdbContext.cs` | `GetFullTypeName` for exported types |

Net: **+83 / -66 lines** across 11 files. All 380 tests pass.