### PR TITLE
Use collection expressions and record types

### DIFF
--- a/src/DotnetInspector.Metadata/ApiDiffAnalyzer.cs
+++ b/src/DotnetInspector.Metadata/ApiDiffAnalyzer.cs
@@ -104,7 +104,7 @@ public static class ApiDiffAnalyzer
         foreach (var key in oldTypes.Keys) allTypeNames.Add(key);
         foreach (var key in newTypes.Keys) allTypeNames.Add(key);
 
-        var typeDiffs = new List<TypeDiff>();
+        List<TypeDiff> typeDiffs = [];
         int totalBreaking = 0;
         int totalAdditive = 0;
         int totalPotentiallyBreaking = 0;
@@ -162,7 +162,7 @@ public static class ApiDiffAnalyzer
 
     private static List<ApiChange> CompareTypes(ApiType oldType, ApiType newType)
     {
-        var changes = new List<ApiChange>();
+        List<ApiChange> changes = [];
         CompareTypeMetadata(oldType, newType, changes);
         CompareTypeParameters(oldType, newType, changes);
         CompareMembers(oldType, newType, changes);
@@ -318,14 +318,14 @@ public static class ApiDiffAnalyzer
             }
         }
 
-        var unmatchedOld = new List<ApiMember>();
+        List<ApiMember> unmatchedOld = [];
         foreach (var kvp in oldBySignature)
         {
             if (!matchedOldKeys.Contains(kvp.Key))
                 unmatchedOld.Add(kvp.Value);
         }
 
-        var unmatchedNew = new List<ApiMember>();
+        List<ApiMember> unmatchedNew = [];
         foreach (var kvp in newBySignature)
         {
             if (!matchedNewKeys.Contains(kvp.Key))

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -346,7 +346,7 @@ public static class ApiSurfaceExtractor
             ? targetType.Name
             : $"{targetType.Namespace}.{targetType.Name}";
 
-        var derivedTypes = new List<string>();
+        List<string> derivedTypes = [];
 
         foreach (var type in surface.Types)
         {
@@ -393,7 +393,7 @@ public static class ApiSurfaceExtractor
         var paramHandles = method.GetParameters().ToList();
         var paramTypes = signature.ParameterTypes;
 
-        var parameters = new List<string>();
+        List<string> parameters = [];
         for (int i = 0; i < paramTypes.Length; i++)
         {
             string type = paramTypes[i];

--- a/src/DotnetInspector.Metadata/AssemblyInspector.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInspector.cs
@@ -392,7 +392,7 @@ public static class AssemblyInspector
 
     private static (bool isNormalized, List<string> nonNormalizedPaths) CheckSourceLinkPaths(string sourceLink)
     {
-        var nonNormalizedPaths = new List<string>();
+        List<string> nonNormalizedPaths = [];
         try
         {
             using var doc = System.Text.Json.JsonDocument.Parse(sourceLink);
@@ -497,7 +497,7 @@ public static class AssemblyInspector
 
     private static List<AssemblyReference>? ExtractReferences(MetadataReader metadataReader)
     {
-        var references = new List<AssemblyReference>();
+        List<AssemblyReference> references = [];
         foreach (var refHandle in metadataReader.AssemblyReferences)
         {
             var assemblyRef = metadataReader.GetAssemblyReference(refHandle);

--- a/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
@@ -150,7 +150,7 @@ public static class ExtensionMethodScanner
         IEnumerable<string> assemblyPaths,
         int maxDepth)
     {
-        var results = new List<(string Type, string Path)>();
+        List<(string Type, string Path)> results = [];
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var toProcess = new Queue<(string TypeName, string Path, int Depth)>();
 
@@ -300,7 +300,7 @@ public static class ExtensionMethodScanner
         var paramHandles = method.GetParameters().ToList();
         var paramTypes = signature.ParameterTypes;
 
-        var parameters = new List<string>();
+        List<string> parameters = [];
         for (int i = 0; i < paramTypes.Length; i++)
         {
             string type = paramTypes[i];

--- a/src/DotnetInspector.Metadata/SourceLinkResolver.cs
+++ b/src/DotnetInspector.Metadata/SourceLinkResolver.cs
@@ -223,7 +223,7 @@ public class SourceLinkResolver
     /// </summary>
     private List<PartialSourceFile> FindDocumentsMatchingTypeName(MetadataReader pdb, string typeName)
     {
-        var matches = new List<PartialSourceFile>();
+        List<PartialSourceFile> matches = [];
 
         foreach (var docHandle in pdb.Documents)
         {
@@ -387,7 +387,7 @@ public class SourceLinkResolver
 
     private static Dictionary<string, string> ParseSourceLinkMappings(string sourceLinkJson)
     {
-        var mappings = new Dictionary<string, string>();
+        Dictionary<string, string> mappings = [];
 
         try
         {

--- a/src/DotnetInspector.Metadata/TypeMatcher.cs
+++ b/src/DotnetInspector.Metadata/TypeMatcher.cs
@@ -130,7 +130,7 @@ public static class TypeMatcher
 
         var targetBase = GetBaseName(GetSimpleName(Normalize(target)));
 
-        var scored = new List<(string Name, double Similarity)>();
+        List<(string Name, double Similarity)> scored = [];
 
         foreach (var candidate in candidates)
         {

--- a/src/DotnetInspector.Packages/NuGetSourceResolver.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceResolver.cs
@@ -52,7 +52,7 @@ public static class NuGetSourceResolver
         }
 
         // Default: nuget.org plus any additional sources
-        var result = new List<NuGetSource> { NuGetSource.NuGetOrg };
+        List<NuGetSource> result = [NuGetSource.NuGetOrg];
 
         foreach (var additional in options.AdditionalSources)
         {
@@ -67,7 +67,7 @@ public static class NuGetSourceResolver
     /// </summary>
     private static List<NuGetSource> LoadSourcesFromConfig(string? explicitConfigPath, string workingDirectory)
     {
-        var configFiles = new List<string>();
+        List<string> configFiles = [];
 
         if (!string.IsNullOrEmpty(explicitConfigPath))
         {

--- a/src/DotnetInspector.Packages/TfmResolver.cs
+++ b/src/DotnetInspector.Packages/TfmResolver.cs
@@ -74,7 +74,7 @@ public static class TfmResolver
     /// </summary>
     public static List<string> GetPackageDlls(string extractPath)
     {
-        var result = new List<string>();
+        List<string> result = [];
         var libDir = Path.Combine(extractPath, "lib");
         var toolsDir = Path.Combine(extractPath, "tools");
 

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -133,7 +133,7 @@ public class ProjectAssetsParserTests
         """;
 
         var assetsPath = WriteTempFile(json);
-        var messages = new List<string>();
+        List<string> messages = [];
         try
         {
             var results = ProjectAssetsParser.Parse(assetsPath, "net8.0", s => messages.Add(s));
@@ -150,7 +150,7 @@ public class ProjectAssetsParserTests
     public void Parse_InvalidJson_ReturnsEmptyAndLogs()
     {
         var assetsPath = WriteTempFile("not valid json {{{");
-        var messages = new List<string>();
+        List<string> messages = [];
 
         try
         {
@@ -192,7 +192,7 @@ public class ProjectAssetsParserTests
         """;
 
         var assetsPath = WriteTempFile(json);
-        var messages = new List<string>();
+        List<string> messages = [];
         try
         {
             var results = ProjectAssetsParser.Parse(assetsPath, null, s => messages.Add(s));

--- a/src/DotnetInspector.Services/DependencyResolutionService.cs
+++ b/src/DotnetInspector.Services/DependencyResolutionService.cs
@@ -14,7 +14,7 @@ public static class DependencyResolutionService
         HttpClient client, List<PackageDependency> dependencies, string tfm,
         HashSet<string> globalSeen, Action<string>? log)
     {
-        var nodes = new List<DependencyNode>();
+        List<DependencyNode> nodes = [];
 
         foreach (var dep in dependencies.OrderBy(d => d.Id))
         {

--- a/src/DotnetInspector.Services/PackageCacheService.cs
+++ b/src/DotnetInspector.Services/PackageCacheService.cs
@@ -24,7 +24,7 @@ public static class PackageCacheService
     public static CacheInfo GetCacheInfo()
     {
         var basePath = NuGetCache.GetAppCacheBasePath();
-        var categories = new List<CacheCategoryInfo>();
+        List<CacheCategoryInfo> categories = [];
         long totalSize = 0;
 
         if (Directory.Exists(basePath))

--- a/src/DotnetInspector.Services/PackageMetadata.cs
+++ b/src/DotnetInspector.Services/PackageMetadata.cs
@@ -43,7 +43,7 @@ public class PackageDeprecation
     {
         get
         {
-            var parts = new List<string>();
+            List<string> parts = [];
             if (Reasons is { Count: > 0 })
                 parts.Add(string.Join(", ", Reasons));
             if (!string.IsNullOrEmpty(AlternatePackageId))

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -235,7 +235,7 @@ public static class PackageMetadataService
     private static async Task<List<PackageVulnerability>> GetPackageVulnerabilitiesAsync(
         HttpClient client, string packageName, string version, Action<string>? log)
     {
-        var result = new List<PackageVulnerability>();
+        List<PackageVulnerability> result = [];
 
         if (!NuGet.Versioning.NuGetVersion.TryParse(version, out var packageVersion))
         {

--- a/src/DotnetInspector.Services/PackageResolverService.cs
+++ b/src/DotnetInspector.Services/PackageResolverService.cs
@@ -134,7 +134,7 @@ public static class PackageResolverService
             : versions.Where(v => !v.Contains('-')).ToList();
 
         // Newest first, with optional limit
-        var result = new List<string>();
+        List<string> result = [];
         for (int i = filtered.Count - 1; i >= 0; i--)
         {
             result.Add(filtered[i]);

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -194,7 +194,7 @@ public static class PlatformResolver
             return [];
         }
 
-        var frameworks = new List<FrameworkInfo>();
+        List<FrameworkInfo> frameworks = [];
 
         foreach (var (shortName, refPackName) in FrameworkMappings)
         {

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -13,7 +13,7 @@ public static class ProjectAssetsParser
     /// </summary>
     public static List<(string Path, string PackageName, string Version)> Parse(string assetsPath, string? tfmFilter, Action<string>? log)
     {
-        var results = new List<(string Path, string PackageName, string Version)>();
+        List<(string Path, string PackageName, string Version)> results = [];
         var nugetCache = NuGetCache.GetNuGetCachePath();
 
         try

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -54,7 +54,7 @@ public class SourceFetcher(HttpClient httpClient)
     public static string? ExtractRegion(string content, string regionName)
     {
         var lines = content.Split('\n');
-        var regionLines = new List<string>();
+        List<string> regionLines = [];
         bool inRegion = false;
         int regionDepth = 0;
 
@@ -126,7 +126,7 @@ public class SourceFetcher(HttpClient httpClient)
             return string.Join('\n', lines).TrimEnd();
 
         // Remove common indentation
-        var result = new List<string>();
+        List<string> result = [];
         foreach (var line in lines)
         {
             if (string.IsNullOrWhiteSpace(line))

--- a/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
+++ b/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
@@ -79,7 +79,7 @@ public class HttpRetryHelperTests
     public void GetRetryDelay_IncludesJitter()
     {
         // Run multiple times and verify we get different values (jitter is random)
-        var delays = new HashSet<double>();
+        HashSet<double> delays = [];
         for (int i = 0; i < 20; i++)
         {
             delays.Add(HttpRetryHelper.GetRetryDelay(1).TotalMilliseconds);

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -310,7 +310,7 @@ public static class CommandLineBuilder
 
             if (exitCode == 0)
             {
-                var tips = new List<Tip>();
+                List<Tip> tips = [];
                 var versionRange = options.PackageVersionRange ?? options.PlatformVersionRange;
                 var sourceFlag = options.PackageVersionRange != null ? "--package" : "--platform";
 
@@ -1007,7 +1007,7 @@ public static class CommandLineBuilder
                 var pkg = packageArgs[0];
                 if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
 
-                var tips = new List<Tip>();
+                List<Tip> tips = [];
 
                 if (options.Verbosity < Verbosity.Detailed)
                     tips.Add(new(PackageCommand.Name, $"{pkg} -v:d", "detailed metadata"));

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -224,7 +224,7 @@ public class ApiCommand
                     if (options.MemberFilter?.Count > 0 && apiType.Members != null)
                     {
                         var memberNames = apiType.Members.Select(m => m.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-                        var missedFilters = new List<string>();
+                        List<string> missedFilters = [];
 
                         foreach (var filter in options.MemberFilter)
                         {

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -151,7 +151,7 @@ public class AssemblyCommand
         string? packageName, string? packageVersion, string extractPath,
         HttpClient httpClient, SignatureVerificationResult? signatureResult)
     {
-        var audits = new List<AssemblyAudit>();
+        List<AssemblyAudit> audits = [];
 
         foreach (var targetPath in assemblyPaths)
         {

--- a/src/dotnet-inspect/Commands/CliSchemaCommand.cs
+++ b/src/dotnet-inspect/Commands/CliSchemaCommand.cs
@@ -51,7 +51,7 @@ public class CliSchemaCommand
 
     private static TreeNode BuildCommandNode(Command command, Verbosity verbosity)
     {
-        var children = new List<TreeNode>();
+        List<TreeNode> children = [];
 
         // Minimal: command + description only, no children
         if (verbosity > Verbosity.Minimal)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -228,11 +228,11 @@ public class DiffCommand
         if (!options.Breaking && !options.Additive)
             return typeDiffs;
 
-        var allowed = new HashSet<ChangeClassification>();
+        HashSet<ChangeClassification> allowed = [];
         if (options.Breaking) allowed.Add(ChangeClassification.Breaking);
         if (options.Additive) allowed.Add(ChangeClassification.Additive);
 
-        var filtered = new List<TypeDiff>();
+        List<TypeDiff> filtered = [];
         foreach (var td in typeDiffs)
         {
             var changes = td.Changes.Where(c => allowed.Contains(c.Classification)).ToList();

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -17,7 +17,7 @@ public class ExtensionsCommand
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        var tempDirs = new List<string>();
+        List<string> tempDirs = [];
 
         try
         {
@@ -28,7 +28,7 @@ public class ExtensionsCommand
                 options = options with { PlatformFrameworks = ["runtime"] };
             }
 
-            var results = new List<ExtensionMethodResult>();
+            List<ExtensionMethodResult> results = [];
 
             // Collect all assembly paths from various sources
             var assemblyInfos = await AssemblyCollector.CollectAsync(context.HttpClient, options, tempDirs, logger, "inspect-ext");
@@ -99,7 +99,7 @@ public class ExtensionsCommand
         bool includeAll,
         VerboseLogger logger)
     {
-        var results = new List<ExtensionMethodResult>();
+        List<ExtensionMethodResult> results = [];
 
         try
         {
@@ -144,7 +144,7 @@ public class ExtensionsCommand
 /// <summary>
 /// Result of extension method search.
 /// </summary>
-public class ExtensionMethodResult
+public record class ExtensionMethodResult
 {
     [JsonPropertyName("method")]
     public string MethodName { get; set; } = "";

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -17,7 +17,7 @@ public class FindCommand
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        var tempDirs = new List<string>();
+        List<string> tempDirs = [];
 
         try
         {
@@ -57,10 +57,10 @@ public class FindCommand
         var allTypes = await CollectAllTypesAsync(options, logger, tempDirs, httpClient);
 
         // Match types against each pattern
-        var resultsByPattern = new Dictionary<string, List<TypeSearchResult>>();
+        Dictionary<string, List<TypeSearchResult>> resultsByPattern = [];
         foreach (var pattern in patterns)
         {
-            var matches = new List<TypeSearchResult>();
+            List<TypeSearchResult> matches = [];
             foreach (var type in allTypes)
             {
                 if (TypeMatcher.MatchesGlob(type.FullName, pattern) || TypeMatcher.MatchesGlob(type.TypeName, pattern))
@@ -148,7 +148,7 @@ public class FindCommand
 /// <summary>
 /// Represents a type found during search.
 /// </summary>
-public class TypeSearchResult
+public record class TypeSearchResult
 {
     [JsonPropertyName("type")]
     public string TypeName { get; set; } = "";

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -17,7 +17,7 @@ public class ImplementsCommand
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        var tempDirs = new List<string>();
+        List<string> tempDirs = [];
 
         try
         {
@@ -28,7 +28,7 @@ public class ImplementsCommand
                 options = options with { PlatformFrameworks = ["runtime"] };
             }
 
-            var results = new List<ImplementerResult>();
+            List<ImplementerResult> results = [];
 
             // Collect all assembly paths from various sources
             var assemblyInfos = await AssemblyCollector.CollectAsync(context.HttpClient, options, tempDirs, logger, "inspect-impl");
@@ -83,7 +83,7 @@ public class ImplementsCommand
         bool includeAll,
         VerboseLogger logger)
     {
-        var results = new List<ImplementerResult>();
+        List<ImplementerResult> results = [];
 
         try
         {
@@ -126,7 +126,7 @@ public class ImplementsCommand
 /// <summary>
 /// Result of implementer search.
 /// </summary>
-public class ImplementerResult
+public record class ImplementerResult
 {
     [JsonPropertyName("type")]
     public string TypeName { get; set; } = "";

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -394,7 +394,7 @@ public class PackageCommand
     {
         if (options.ScopeLib || options.ScopeTools || !string.IsNullOrEmpty(options.Tfm)) return;
 
-        var tips = new List<Tip>();
+        List<Tip> tips = [];
         var flag = isLayout ? "--layout" : "--files";
         var otherFlag = isLayout ? "--files" : "--layout";
         var otherDesc = isLayout ? "flat file list" : "file tree";

--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -154,7 +154,7 @@ public class PlatformCommand
     private static List<FrameworkAssemblyData> ResolveFrameworkAssemblies(
         List<FrameworkInfo> frameworks, string? requestedVersion, bool includeTypes, VerboseLogger logger)
     {
-        var result = new List<FrameworkAssemblyData>();
+        List<FrameworkAssemblyData> result = [];
 
         foreach (var framework in frameworks)
         {

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -115,7 +115,7 @@ public class SamplesCommand
         }
 
         // Collect all samples from all types
-        var allSamples = new List<TypedSample>();
+        List<TypedSample> allSamples = [];
         foreach (var type in api.Types)
         {
             if (type.Documentation?.Samples != null)

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -31,7 +31,7 @@ public static class AssemblyCollector
         VerboseLogger logger,
         string tempDirPrefix = "inspect")
     {
-        var assemblyPaths = new List<AssemblyInfo>();
+        List<AssemblyInfo> assemblyPaths = [];
 
         // 1. Packages
         foreach (var pkg in options.Packages)

--- a/src/dotnet-inspect/Inspectors/DocCommentParser.cs
+++ b/src/dotnet-inspect/Inspectors/DocCommentParser.cs
@@ -180,7 +180,7 @@ public partial class DocCommentParser
         if (currentIdx < 0) return null;
         
         // Search backwards to find /// comment lines
-        var lines = new List<string>();
+        List<string> lines = [];
         
         while (currentIdx >= 0)
         {
@@ -311,7 +311,7 @@ public partial class DocCommentParser
     /// </summary>
     private static List<SampleReference>? ExtractSampleReferences(XmlDocument doc)
     {
-        var samples = new List<SampleReference>();
+        List<SampleReference> samples = [];
 
         // Pattern 1: Sandcastle-style <code source="..." region="..." title="..."/>
         var codeNodes = doc.SelectNodes("//example/code[@source]");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -180,7 +180,7 @@ internal static class LibraryMetadataService
         int embeddedFiles = 0;
         int accessibleCount = 0;
         var missingFiles = new ConcurrentBag<string>();
-        var urlDocs = new List<SourceDocument>();
+        List<SourceDocument> urlDocs = [];
 
         foreach (var doc in documents)
         {
@@ -258,7 +258,7 @@ internal static class LibraryMetadataService
         Dictionary<string, int>? globalSeen = null)
     {
         globalSeen ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        var nodes = new List<AssemblyReferenceNode>();
+        List<AssemblyReferenceNode> nodes = [];
 
         foreach (var reference in references.OrderBy(r => r.Name))
         {

--- a/src/dotnet-inspect/Inspectors/SignatureParser.cs
+++ b/src/dotnet-inspect/Inspectors/SignatureParser.cs
@@ -53,7 +53,7 @@ internal static class SignatureParser
             return signature;
 
         // Split parameters respecting generic depth
-        var paramTypes = new List<string>();
+        List<string> paramTypes = [];
         int depth = 0;
         int lastSplit = 0;
         for (int i = 0; i < paramSection.Length; i++)
@@ -164,7 +164,7 @@ internal static class SignatureParser
     /// </summary>
     public static List<(string name, string type, bool hasDefault)> ExtractParameterInfo(string? signature)
     {
-        var result = new List<(string, string, bool)>();
+        List<(string, string, bool)> result = [];
         if (string.IsNullOrEmpty(signature))
             return result;
 
@@ -177,7 +177,7 @@ internal static class SignatureParser
         if (string.IsNullOrEmpty(paramSection))
             return result;
 
-        var params_ = new List<string>();
+        List<string> params_ = [];
         int depth = 0;
         int lastSplit = 0;
         for (int i = 0; i < paramSection.Length; i++)

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -139,10 +139,10 @@ internal static class SourceEnricher
                 var fetcher = new SourceFetcher(httpClient);
                 var parser = new DocCommentParser();
 
-                var sourceFilesToFetch = new List<(string Url, string FilePath)>
-                {
+                List<(string Url, string FilePath)> sourceFilesToFetch =
+                [
                     (sourceInfo.SourceUrl, sourceInfo.SourceFilePath ?? "")
-                };
+                ];
 
                 if (sourceInfo.AdditionalSourceFiles != null)
                 {
@@ -155,7 +155,7 @@ internal static class SourceEnricher
                     }
                 }
 
-                var allSourceContents = new List<(string Content, string Url, string FilePath)>();
+                List<(string Content, string Url, string FilePath)> allSourceContents = [];
                 string? primaryNamespace = null;
                 bool isPrimaryPartial = false;
 
@@ -254,8 +254,8 @@ internal static class SourceEnricher
             return;
         }
 
-        var typeSourceInfo = new List<(ApiType Type, string TypeName, SourceLinkResolver.TypeSourceInfo? SourceInfo)>();
-        var allUrlsToFetch = new HashSet<string>();
+        List<(ApiType Type, string TypeName, SourceLinkResolver.TypeSourceInfo? SourceInfo)> typeSourceInfo = [];
+        HashSet<string> allUrlsToFetch = [];
 
         foreach (var apiType in types)
         {
@@ -281,7 +281,7 @@ internal static class SourceEnricher
 
         var fetcher = new SourceFetcher(httpClient);
         var urlList = allUrlsToFetch.OrderBy(u => u, StringComparer.OrdinalIgnoreCase).ToList();
-        var contentCache = new Dictionary<string, string?>();
+        Dictionary<string, string?> contentCache = [];
 
         logger.Log($"Phase 2: Fetching {urlList.Count} URLs in parallel");
         var fetchTasks = urlList.Select(async url =>
@@ -324,7 +324,7 @@ internal static class SourceEnricher
 
             if ((options.ShowDocs || options.ShowSamples) && sourceInfo.SourceUrl != null)
             {
-                var sourceContents = new List<(string Content, string Url, string FilePath)>();
+                List<(string Content, string Url, string FilePath)> sourceContents = [];
 
                 if (contentCache.TryGetValue(sourceInfo.SourceUrl, out var primaryContent) && primaryContent != null)
                 {
@@ -479,7 +479,7 @@ internal static class SourceEnricher
         await Task.CompletedTask;
 
         DocComment? mergedTypeDoc = null;
-        var allSamples = new List<SampleReference>();
+        List<SampleReference> allSamples = [];
 
         foreach (var (content, url, filePath) in sourceContents)
         {

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -139,7 +139,7 @@ public static class ToolsAnalyzer
     public static void AnalyzeContentDirectories(string extractPath, InspectionResult result)
     {
         var standardDirs = new[] { "lib", "tools", "analyzers", "build", "buildTransitive", "contentFiles", "ref", "runtimes" };
-        var found = new List<string>();
+        List<string> found = [];
 
         foreach (var dir in standardDirs)
         {

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -24,7 +24,7 @@ internal static class TypeSearchService
         List<string> tempDirs,
         HttpClient httpClient)
     {
-        var results = new List<TypeSearchResult>();
+        List<TypeSearchResult> results = [];
 
         bool ReachedLimit() => pattern != null && options.Limit.HasValue && results.Count >= options.Limit.Value;
 
@@ -226,7 +226,7 @@ internal static class TypeSearchService
         }
         else if (Directory.Exists(path))
         {
-            var results = new List<TypeSearchResult>();
+            List<TypeSearchResult> results = [];
             var dlls = Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories);
             foreach (var dll in dlls)
             {
@@ -242,7 +242,7 @@ internal static class TypeSearchService
     /// </summary>
     public static List<TypeSearchResult> CollectFromAssembly(string assemblyPath, string? pattern, bool includeAll, VerboseLogger logger)
     {
-        var results = new List<TypeSearchResult>();
+        List<TypeSearchResult> results = [];
 
         try
         {

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -273,7 +273,7 @@ public partial class XmlDocFileParser
     /// </summary>
     private static List<DocCommentParser.SampleReference>? ExtractSampleReferences(XmlNode node)
     {
-        var samples = new List<DocCommentParser.SampleReference>();
+        List<DocCommentParser.SampleReference> samples = [];
 
         // Pattern: <example><code source="..." region="..." title="..."/></example>
         var codeNodes = node.SelectNodes("example/code[@source]");

--- a/src/dotnet-inspect/OptionParsers.cs
+++ b/src/dotnet-inspect/OptionParsers.cs
@@ -52,7 +52,7 @@ public static class OptionParsers
         if (string.IsNullOrEmpty(value)) return null;
 
         var v = value.TrimStart(':');
-        var sections = new HashSet<string>();
+        HashSet<string> sections = [];
         foreach (var part in v.Split(',', StringSplitOptions.RemoveEmptyEntries))
         {
             var trimmed = part.Trim();

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -203,7 +203,7 @@ public static class ApiOutputFormatter
             : packageName != null ? $" ({packageName})" : "";
 
         // Build modifiers
-        var modifiers = new List<string>();
+        List<string> modifiers = [];
         if (type.IsStatic) modifiers.Add("static");
         if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
         if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
@@ -282,7 +282,7 @@ public static class ApiOutputFormatter
 
     internal static TypeShapeView BuildShapeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string>? memberFilter)
     {
-        var nodes = new List<TreeNode>();
+        List<TreeNode> nodes = [];
 
         // Inheritance (always show)
         if (!string.IsNullOrEmpty(type.BaseType) && type.BaseType != "Object")
@@ -333,7 +333,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        var modifiers = new List<string>();
+        List<string> modifiers = [];
         if (type.IsStatic) modifiers.Add("static");
         if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
         if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
@@ -481,7 +481,7 @@ public static class ApiOutputFormatter
         bool isPartial = type.IsPartialType;
         int fileCount = 1 + (type.AdditionalSourceFiles?.Count ?? 0);
 
-        var rows = new List<string[]>();
+        List<string[]> rows = [];
         if (!string.IsNullOrEmpty(resolution))
             rows.Add(new[] { "Resolution", resolution });
         rows.Add(new[] { "Partial Type", isPartial ? "true" : "false" });
@@ -517,7 +517,7 @@ public static class ApiOutputFormatter
         if (resolution == null && string.IsNullOrEmpty(api.RepositoryUrl))
             return;
 
-        var rows = new List<string[]>();
+        List<string[]> rows = [];
         if (!string.IsNullOrEmpty(resolution))
             rows.Add(new[] { "Resolution", resolution });
         if (!string.IsNullOrEmpty(api.RepositoryUrl))

--- a/src/dotnet-inspect/Output/CacheOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/CacheOutputFormatter.cs
@@ -7,7 +7,7 @@ public static class CacheOutputFormatter
 {
     public static string FormatCacheInfo(string location, List<(string Name, long Size, int Count)> categories, long totalSize)
     {
-        var lines = new List<string>();
+        List<string> lines = [];
         lines.Add($"Cache location: {location}");
         lines.Add("");
 

--- a/src/dotnet-inspect/Output/FindOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/FindOutputFormatter.cs
@@ -13,7 +13,7 @@ public static class FindOutputFormatter
         if (grouped)
         {
             // Grouped: one line per pattern with matching type names
-            var lines = new List<string>();
+            List<string> lines = [];
             foreach (var (pattern, results) in resultsByPattern)
             {
                 var typeNames = results.Select(r => r.TypeName).Distinct().OrderBy(n => n);

--- a/src/dotnet-inspect/Output/MemberTableFormatter.cs
+++ b/src/dotnet-inspect/Output/MemberTableFormatter.cs
@@ -31,7 +31,7 @@ internal sealed class QuietMemberFormatter : MemberTableFormatter
         var byName = members.GroupBy(m => m.Name);
         bool hasOverloads = byName.Any(g => g.Count() > 1);
 
-        var headers = new List<string> { "Name" };
+        List<string> headers = ["Name"];
 
         switch (kind)
         {
@@ -70,7 +70,7 @@ internal sealed class QuietMemberFormatter : MemberTableFormatter
                 case "constructor":
                 case "method":
                 {
-                    var row = new List<string> { g.Key };
+                    List<string> row = [g.Key];
                     if (kind == "method")
                         row.Add(SignatureParser.ExtractReturnType(g.First().Signature));
                     if (hasOverloads)
@@ -82,26 +82,26 @@ internal sealed class QuietMemberFormatter : MemberTableFormatter
                 case "property":
                 {
                     var m = g.First();
-                    var row = new List<string>
-                    {
+                    List<string> row =
+                    [
                         g.Key,
                         SignatureParser.ExtractReturnType(m.Signature),
                         SignatureParser.ExtractAccessors(m.Signature)
-                    };
+                    ];
                     if (showDocs) row.Add(FirstDocSummary(g));
                     return row.ToArray();
                 }
                 case "event":
                 {
                     var m = g.First();
-                    var row = new List<string> { g.Key, m.ReturnType ?? m.Signature ?? "" };
+                    List<string> row = [g.Key, m.ReturnType ?? m.Signature ?? ""];
                     if (showDocs) row.Add(FirstDocSummary(g));
                     return row.ToArray();
                 }
                 default: // field
                 {
                     var m = g.First();
-                    var row = new List<string> { g.Key, m.ReturnType ?? "" };
+                    List<string> row = [g.Key, m.ReturnType ?? ""];
                     if (showDocs) row.Add(FirstDocSummary(g));
                     return row.ToArray();
                 }

--- a/src/dotnet-inspect/Output/PackageOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PackageOutputFormatter.cs
@@ -43,7 +43,7 @@ public static class PackageOutputFormatter
 
     private static List<TreeNode> BuildTreeNodes(Dictionary<string, object> dict)
     {
-        var nodes = new List<TreeNode>();
+        List<TreeNode> nodes = [];
 
         foreach (var kvp in dict.OrderBy(k => k.Key))
         {

--- a/src/dotnet-inspect/Views/AssemblyAuditView.cs
+++ b/src/dotnet-inspect/Views/AssemblyAuditView.cs
@@ -178,7 +178,7 @@ public class AssemblyAuditView
 
     private List<MarkoutField> GetAssemblyInfoFields()
     {
-        var fields = new List<MarkoutField>();
+        List<MarkoutField> fields = [];
         if (_data.AssemblyInfo is not { } info) return fields;
 
         if (!string.IsNullOrEmpty(info.AssemblyName))
@@ -211,11 +211,11 @@ public class AssemblyAuditView
 
     private List<MarkoutField> GetSymbolsFields()
     {
-        var fields = new List<MarkoutField>
-        {
+        List<MarkoutField> fields =
+        [
             new("PDB Format", _data.PdbFormat ?? "Unknown"),
             new("PDB Location", _data.PdbLocation ?? "Unknown")
-        };
+        ];
 
         if (!string.IsNullOrEmpty(_data.SymbolServer))
             fields.Add(new("Symbol Server", _data.SymbolServer));
@@ -253,7 +253,7 @@ public class AssemblyAuditView
 
     private List<MarkoutField> GetSourceCoverageFields()
     {
-        var fields = new List<MarkoutField>();
+        List<MarkoutField> fields = [];
         if (_data.TotalSourceFiles <= 0) return fields;
 
         int accessible = _data.AccessibleSourceFiles + _data.EmbeddedSourceFiles;
@@ -268,7 +268,7 @@ public class AssemblyAuditView
 
     private static List<TreeNode> BuildFlatTransitiveTree(List<AssemblyReferenceNode> nodes)
     {
-        var result = new List<TreeNode>();
+        List<TreeNode> result = [];
         foreach (var node in nodes)
         {
             var icon = node.ResolvedFrom switch
@@ -285,7 +285,7 @@ public class AssemblyAuditView
 
     private static List<TreeNode> BuildNestedDependencyTree(List<AssemblyReferenceNode> nodes)
     {
-        var result = new List<TreeNode>();
+        List<TreeNode> result = [];
         int i = 0;
         BuildNestedNodes(nodes, ref i, 0, result);
         return result;
@@ -301,7 +301,7 @@ public class AssemblyAuditView
                 : $"{node.Name} {node.Version}";
             index++;
 
-            var children = new List<TreeNode>();
+            List<TreeNode> children = [];
             if (index < nodes.Count && nodes[index].Depth > currentDepth)
             {
                 BuildNestedNodes(nodes, ref index, currentDepth + 1, children);

--- a/src/dotnet-inspect/Views/AssemblyDependenciesView.cs
+++ b/src/dotnet-inspect/Views/AssemblyDependenciesView.cs
@@ -31,7 +31,7 @@ public class AssemblyDependenciesView
 
     private List<MarkoutField> GetIdentityFields()
     {
-        var fields = new List<MarkoutField>();
+        List<MarkoutField> fields = [];
         if (!string.IsNullOrEmpty(AssemblyName))
             fields.Add(new("Library", AssemblyName));
         if (!string.IsNullOrEmpty(Version))

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -196,7 +196,7 @@ public class InspectionResultView
 
     private List<MarkoutField> GetCompactFields()
     {
-        var fields = new List<MarkoutField>();
+        List<MarkoutField> fields = [];
 
         fields.Add(new("Version", Version));
         fields.Add(new("Type", PackageType));
@@ -215,7 +215,7 @@ public class InspectionResultView
 
     private List<MarkoutField> GetMetadataFields()
     {
-        var fields = new List<MarkoutField>();
+        List<MarkoutField> fields = [];
 
         fields.Add(new("Version", Version));
         fields.Add(new("Type", PackageType));


### PR DESCRIPTION
## Summary

Modernize the codebase with C# 12 collection expressions and record types.

### Collection expressions (`[]` syntax)

Convert ~95 collection initializers across 46 files:
- `var x = new List<T>()` → `List<T> x = []`
- `var x = new List<T> { a, b }` → `List<T> x = [a, b]`

Instances with constructor arguments (comparers, capacity hints) are left as-is.

### Record types

Convert 3 command result DTOs from `class` to `record class`:
- `TypeSearchResult` (FindCommand.cs)
- `ImplementerResult` (ImplementsCommand.cs)
- `ExtensionMethodResult` (ExtensionsCommand.cs)

All three are pure DTOs — constructed via object initializers, never mutated after creation, serialized to JSON. The `record` declaration gives them structural equality, `ToString()`, and `with` expression support.

Net change: **+100 / -100 lines**. All 380 tests pass.