### PR TITLE
Consolidate library inspection and simplify command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Use `--layout` to see the full tree:
       └─ Microsoft.Azure.SignalR.dll
 ```
 
-Inspect or compare individual libraries using `package --metadata` with `--tfm`:
+Inspect or compare individual libraries using `library`:
 
 ```bash
-dotnet-inspect package Microsoft.Azure.SignalR --metadata                   # Primary library (highest TFM)
-dotnet-inspect package Microsoft.Azure.SignalR --metadata --tfm net8.0      # Specific TFM
-dotnet-inspect api Microsoft.Azure.SignalR                                  # API surface (all libraries)
+dotnet-inspect library Microsoft.Azure.SignalR                   # Primary library (highest TFM)
+dotnet-inspect library Microsoft.Azure.SignalR --tfm net8.0      # Specific TFM
+dotnet-inspect api Microsoft.Azure.SignalR                       # API surface (all libraries)
 ```
 
 ### platform

--- a/docs/design/command-model.md
+++ b/docs/design/command-model.md
@@ -132,5 +132,5 @@ Current deprecations:
 
 | Deprecated | Use Instead | Removal Target |
 |------------|-------------|----------------|
-| `library --package X` | `package X --library` | 0.3.0 |
+| `package X --metadata` | `library X` | 0.3.0 |
 | `--strict` | `--audit` (now always strict) | 0.3.0 |

--- a/docs/progression.md
+++ b/docs/progression.md
@@ -94,4 +94,4 @@ dotnet inspect library System.Text.Json --platform
 
 | Deprecated | Use Instead |
 |------------|-------------|
-| `library --package X` | `package X --library` |
+| `package X --metadata` | `library X` |

--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -92,6 +92,12 @@ public class ApiSurface
     public int PublicFieldCount { get; set; }
 
     /// <summary>
+    /// The assembly file name (e.g., "Foo.dll").
+    /// </summary>
+    [JsonIgnore]
+    public string? Library { get; set; }
+
+    /// <summary>
     /// Target framework moniker for the API surface.
     /// </summary>
     public string? Tfm { get; set; }

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -249,7 +249,7 @@ public class CommandLineTests
     [Fact]
     public void AssemblyCommand_WithPackage_ParsesCorrectly()
     {
-        var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "--package", "System.Text.Json"]);
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "System.Text.Json"]);
 
         Assert.Empty(result.Errors);
         Assert.Equal("library", result.CommandResult.Command.Name);
@@ -258,7 +258,7 @@ public class CommandLineTests
     [Fact]
     public void AssemblyCommand_WithTfm_ParsesCorrectly()
     {
-        var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "--package", "System.Text.Json", "--tfm", "net8.0"]);
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "System.Text.Json", "--tfm", "net8.0"]);
 
         Assert.Empty(result.Errors);
     }

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -2,6 +2,7 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
@@ -125,6 +126,119 @@ public class ExtensionsCommandTests
         Assert.Equal("String", UnwrapAsyncType("ValueTask<String>"));
         Assert.Equal("", UnwrapAsyncType("Task"));
         Assert.Equal("Int32", UnwrapAsyncType("Int32"));
+    }
+
+    [Fact]
+    public void FormatResults_NoDuplicateRowsForOverloads()
+    {
+        // Overloads with different signatures should be collapsed into a single row.
+        var results = CreateOverloadResults();
+        var collapsed = ExtensionsCommand.CollapseOverloads(results);
+
+        var output = ExtensionsOutputFormatter.FormatResults("IEnumerable<T>", collapsed);
+        var tableRows = output.Split('\n')
+            .Where(l => l.StartsWith("| ") && !l.StartsWith("| -") && !l.Contains("Name"))
+            .ToList();
+
+        // Should produce a single row, not 3 duplicate rows
+        Assert.Single(tableRows);
+        Assert.Contains("3 overloads", tableRows[0]);
+    }
+
+    [Fact]
+    public void CollapseOverloads_PreservesAllSignatures()
+    {
+        var results = CreateOverloadResults();
+        var collapsed = ExtensionsCommand.CollapseOverloads(results);
+
+        Assert.Single(collapsed);
+        var entry = collapsed[0];
+        Assert.Equal(3, entry.Overloads);
+        Assert.NotNull(entry.Signatures);
+        Assert.Equal(3, entry.Signatures!.Count);
+        Assert.Null(entry.Signature); // single signature cleared when multiple exist
+    }
+
+    [Fact]
+    public void CollapseOverloads_SingleMethod_NoOverloadFields()
+    {
+        var results = new List<ExtensionMethodResult>
+        {
+            new()
+            {
+                MethodName = "First",
+                Kind = "method",
+                ExtensionClass = "System.Linq.Enumerable",
+                Assembly = "System.Linq",
+                Signature = "TSource First(this IEnumerable<TSource> source)",
+                Source = "runtime",
+                SourceVersion = "10.0.0"
+            }
+        };
+
+        var collapsed = ExtensionsCommand.CollapseOverloads(results);
+
+        Assert.Single(collapsed);
+        var entry = collapsed[0];
+        Assert.Null(entry.Overloads);
+        Assert.Null(entry.Signatures);
+        Assert.Equal("TSource First(this IEnumerable<TSource> source)", entry.Signature);
+    }
+
+    private static List<ExtensionMethodResult> CreateOverloadResults() =>
+    [
+        new()
+        {
+            MethodName = "ToDictionary",
+            Kind = "method",
+            ExtensionClass = "System.Linq.Enumerable",
+            Assembly = "System.Linq",
+            Signature = "Dictionary<TKey, TSource> ToDictionary(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)",
+            Source = "runtime",
+            SourceVersion = "10.0.0"
+        },
+        new()
+        {
+            MethodName = "ToDictionary",
+            Kind = "method",
+            ExtensionClass = "System.Linq.Enumerable",
+            Assembly = "System.Linq",
+            Signature = "Dictionary<TKey, TValue> ToDictionary(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector)",
+            Source = "runtime",
+            SourceVersion = "10.0.0"
+        },
+        new()
+        {
+            MethodName = "ToDictionary",
+            Kind = "method",
+            ExtensionClass = "System.Linq.Enumerable",
+            Assembly = "System.Linq",
+            Signature = "Dictionary<TKey, TValue> ToDictionary(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, IEqualityComparer<TKey> comparer)",
+            Source = "runtime",
+            SourceVersion = "10.0.0"
+        }
+    ];
+
+    [Fact]
+    public void FormatResults_QuietMode_ShowsCountsTable()
+    {
+        var results = new List<ExtensionMethodResult>
+        {
+            new() { MethodName = "PostAsJson", Kind = "method", ExtensionClass = "JsonExtensions", Assembly = "System.Net.Http.Json" },
+            new() { MethodName = "GetFromJson", Kind = "method", ExtensionClass = "JsonExtensions", Assembly = "System.Net.Http.Json" },
+            new() { MethodName = "CopyToAsync", Kind = "method", ExtensionClass = "StreamExt", Assembly = "System.IO", ReachablePath = ".GetStreamAsync()", ReachableFromType = "Stream" },
+        };
+
+        var output = ExtensionsOutputFormatter.FormatResults("HttpClient", results, Verbosity.Quiet);
+
+        // Should have a counts table, not the full extension tables
+        Assert.Contains("| Type ", output);
+        Assert.Contains("| Extensions ", output);
+        Assert.Contains("| HttpClient | 2 |", output);
+        Assert.Contains("| Stream | 1 | .GetStreamAsync() |", output);
+        // Should NOT have the detailed columns
+        Assert.DoesNotContain("| Name ", output);
+        Assert.DoesNotContain("| Class ", output);
     }
 
     // Helper methods that mirror the logic in ExtensionsCommand

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -429,6 +429,7 @@ public static class CommandLineBuilder
                 JsonOutput = parseResult.GetValue(jsonOption),
                 CompactJson = parseResult.GetValue(compactOption),
                 Verbose = parseResult.GetValue(verboseOption),
+                Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
@@ -880,7 +881,6 @@ public static class CommandLineBuilder
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var depsOption = new Option<bool>("--deps") { Description = "Include dependency analysis" };
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree" };
         var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
         var filesOption = new Option<bool>("--files") { Description = "List files in the package (flat list, filterable with --tfm)" };
@@ -893,15 +893,10 @@ public static class CommandLineBuilder
         var readmeOption = new Option<bool>("--readme") { Description = "Show the README.md content from the package" };
         var outOption = new Option<string?>("--out") { Description = "Write output to file instead of stdout" };
         var discoverOption = new Option<bool>("--discover") { Description = "List available sections and exit" };
-        // New tiered flags
-        var metadataOption = new Option<bool>("--metadata") { Description = "Show library info (PE metadata: name, version, TFM, architecture)" };
-        var symbolsOption = new Option<bool>("--symbols") { Description = "Show Build Audit + PDB info (downloads PDB if needed)" };
-        var sourcelinkAuditOption = new Option<bool>("--sourcelink-audit") { Description = "Full provenance verification (parallel HTTP HEAD on all source files)" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
         var versionOption = new Option<string?>("--version") { Description = "Package version" };
 
         packageCommand.Arguments.Add(packageNameArg);
-        packageCommand.Options.Add(depsOption);
         packageCommand.Options.Add(dependenciesOption);
         packageCommand.Options.Add(layoutOption);
         packageCommand.Options.Add(filesOption);
@@ -911,9 +906,6 @@ public static class CommandLineBuilder
         packageCommand.Options.Add(versionsOption);
         packageCommand.Options.Add(prereleaseOption);
         packageCommand.Options.Add(readmeOption);
-        packageCommand.Options.Add(metadataOption);
-        packageCommand.Options.Add(symbolsOption);
-        packageCommand.Options.Add(sourcelinkAuditOption);
         packageCommand.Options.Add(tfmOption);
         packageCommand.Options.Add(versionOption);
         packageCommand.Options.Add(outOption);
@@ -935,40 +927,6 @@ public static class CommandLineBuilder
             var packageArgs = parseResult.GetValue(packageNameArg) ?? [];
             var explicitVersion = parseResult.GetValue(versionOption);
 
-            // New tiered flags
-            bool showMetadata = parseResult.GetValue(metadataOption);
-            bool showSymbols = parseResult.GetValue(symbolsOption);
-            bool runSourcelinkAudit = parseResult.GetValue(sourcelinkAuditOption);
-
-            // Handle --metadata, --symbols, --sourcelink-audit: delegate to AssemblyCommand
-            if (showMetadata || showSymbols || runSourcelinkAudit)
-            {
-                if (packageArgs.Length < 1)
-                {
-                    Console.Error.WriteLine("Error: Package name required.");
-                    return 1;
-                }
-
-                var assemblyOptions = new AssemblyOptions
-                {
-                    PackagePath = explicitVersion != null && !packageArgs[0].Contains('@')
-                        ? $"{packageArgs[0]}@{explicitVersion}"
-                        : packageArgs[0],
-                    Tfm = parseResult.GetValue(tfmOption),
-                    IncludeMetadata = showMetadata,
-                    IncludeSymbols = showSymbols,
-                    IncludeSourcelinkAudit = runSourcelinkAudit,
-                    JsonOutput = parseResult.GetValue(jsonOption),
-                    Verbose = parseResult.GetValue(verboseOption),
-                    Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
-                    IncludeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption)),
-                    ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
-                    SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
-                };
-
-                return await AssemblyCommand.ExecuteAsync(null, assemblyOptions);
-            }
-
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
             var jsonOutput = parseResult.GetValue(jsonOption);
             var tipLevel = jsonOutput || verbosity == Verbosity.Quiet
@@ -976,7 +934,6 @@ public static class CommandLineBuilder
 
             var options = new InspectionOptions
             {
-                IncludeDeps = parseResult.GetValue(depsOption),
                 ShowDependencies = parseResult.GetValue(dependenciesOption),
                 Tfm = parseResult.GetValue(tfmOption),
                 ListLayout = parseResult.GetValue(layoutOption),
@@ -1012,6 +969,7 @@ public static class CommandLineBuilder
                 if (options.Verbosity < Verbosity.Detailed)
                     tips.Add(new(PackageCommand.Name, $"{pkg} -v:d", "detailed metadata"));
 
+                tips.Add(new("library", pkg, "inspect library"));
                 tips.Add(new(ApiCommand.Name, $"--package {pkg}", "view public API surface"));
                 tips.Add(new(FindCommand.Name, $"<pattern> --package {pkg}", "search for types"));
                 tips.Add(new(DiffCommand.Name, $"--package {pkg}@<prev>..<cur>", "diff versions"));
@@ -1043,33 +1001,28 @@ public static class CommandLineBuilder
     {
         var assemblyCommand = new Command("library", "Inspect a .NET library file");
 
-        var assemblyPathArg = new Argument<string?>("path")
+        var assemblyPathArg = new Argument<string?>("source")
         {
-            Description = "Path to library file",
+            Description = "Library file path, NuGet package name (e.g., System.Text.Json), or package@version",
             Arity = ArgumentArity.ZeroOrOne
         };
         assemblyPathArg.DefaultValueFactory = _ => null;
 
-        // New tiered flags
-        var metadataOption = new Option<bool>("--metadata") { Description = "Show library info (PE metadata: name, version, TFM, architecture)" };
         var symbolsOption = new Option<bool>("--symbols") { Description = "Show Build Audit + PDB info (downloads PDB if needed)" };
         var sourcelinkAuditOption = new Option<bool>("--sourcelink-audit") { Description = "Full provenance verification (parallel HTTP HEAD on all source files)" };
         var referencesOption = new Option<bool>("--references") { Description = "Show library references" };
         var transitiveOption = new Option<bool>("--transitive") { Description = "[Deprecated: use --dependencies] Show transitive library references" };
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show library dependencies as a tree" };
-        var asmPackageOption = new Option<string?>("--package") { Description = "[Deprecated: use 'package X --metadata/--symbols/--sourcelink-audit'] Extract from package" };
         var asmPlatformOption = new Option<string?>("--platform") { Description = "Inspect platform library (e.g., System.Text.Json)" };
         var asmFrameworkOption = new Option<string?>("--framework") { Description = "Platform framework (runtime, aspnetcore). Use @version for specific version" };
         var asmTfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0, or 'all' for every TFM)" };
 
         assemblyCommand.Arguments.Add(assemblyPathArg);
-        assemblyCommand.Options.Add(metadataOption);
         assemblyCommand.Options.Add(symbolsOption);
         assemblyCommand.Options.Add(sourcelinkAuditOption);
         assemblyCommand.Options.Add(referencesOption);
         assemblyCommand.Options.Add(dependenciesOption);
         assemblyCommand.Options.Add(transitiveOption);
-        assemblyCommand.Options.Add(asmPackageOption);
         assemblyCommand.Options.Add(asmPlatformOption);
         assemblyCommand.Options.Add(asmFrameworkOption);
         assemblyCommand.Options.Add(asmTfmOption);
@@ -1086,17 +1039,19 @@ public static class CommandLineBuilder
 
         assemblyCommand.SetAction(async (parseResult, ct) =>
         {
-            var assemblyPath = parseResult.GetValue(assemblyPathArg);
-            var packagePath = parseResult.GetValue(asmPackageOption);
+            var source = parseResult.GetValue(assemblyPathArg);
 
-            // Emit deprecation warning for --package
-            if (!string.IsNullOrEmpty(packagePath))
+            // Disambiguate positional arg: local file vs package name
+            string? assemblyPath = null;
+            string? packagePath = null;
+            if (!string.IsNullOrEmpty(source) && string.IsNullOrEmpty(parseResult.GetValue(asmPlatformOption)))
             {
-                Console.Error.WriteLine("Warning: 'library --package X' is deprecated. Use 'package X --metadata' instead.");
+                if (File.Exists(source))
+                    assemblyPath = source;
+                else
+                    packagePath = source;
             }
 
-            // New tiered flags
-            bool showMetadata = parseResult.GetValue(metadataOption);
             bool showSymbols = parseResult.GetValue(symbolsOption);
             bool runSourcelinkAudit = parseResult.GetValue(sourcelinkAuditOption);
 
@@ -1112,7 +1067,7 @@ public static class CommandLineBuilder
 
             var options = new AssemblyOptions
             {
-                IncludeMetadata = showMetadata,
+                IncludeMetadata = true,
                 IncludeSymbols = showSymbols,
                 IncludeSourcelinkAudit = runSourcelinkAudit,
                 IncludeReferences = showReferences,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -187,6 +187,7 @@ public class ApiCommand
                 api.Tfm = selectedTfm;
                 api.Source = apiSource;
                 api.Version = apiVersion;
+                api.Library = apiDllPath != null ? Path.GetFileName(apiDllPath) : null;
 
                 if ((options.ShowDocs || options.ShowSamples || options.SourceLinkOnly) && pdbLookupPath != null)
                 {
@@ -280,6 +281,7 @@ public class ApiCommand
                         api.Tfm = selectedTfm;
                         api.Source = apiSource;
                         api.Version = apiVersion;
+                        api.Library = apiDllPath != null ? Path.GetFileName(apiDllPath) : null;
 
                         options = options with
                         {

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -20,7 +20,7 @@ public class AssemblyCommand
             string.IsNullOrEmpty(options.PackagePath) &&
             string.IsNullOrEmpty(options.PlatformAssembly))
         {
-            Console.Error.WriteLine("Error: Library path, --package, or --platform required.");
+            Console.Error.WriteLine("Error: Library path, package name, or --platform required.");
             Console.Error.WriteLine("Run 'dotnet-inspect library --help' for usage.");
             return 1;
         }

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -75,6 +75,9 @@ public class ExtensionsCommand
                 results = results.Take(options.Limit.Value).ToList();
             }
 
+            // Collapse overloads into single entries
+            results = CollapseOverloads(results);
+
             // Output results
             if (options.JsonOutput)
             {
@@ -82,7 +85,7 @@ public class ExtensionsCommand
             }
             else
             {
-                WriteMarkoutOutput(targetType, results);
+                WriteMarkoutOutput(targetType, results, options.Verbosity);
             }
 
             return 0;
@@ -135,9 +138,31 @@ public class ExtensionsCommand
         Console.WriteLine(JsonSerializer.Serialize(results, typeInfo));
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results)
+    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity)
     {
-        Console.WriteLine(ExtensionsOutputFormatter.FormatResults(targetType, results));
+        Console.WriteLine(ExtensionsOutputFormatter.FormatResults(targetType, results, verbosity));
+    }
+
+    /// <summary>
+    /// Collapses method overloads into a single result with an overload count and signatures list.
+    /// </summary>
+    internal static List<ExtensionMethodResult> CollapseOverloads(List<ExtensionMethodResult> results)
+    {
+        return results
+            .GroupBy(r => (r.MethodName, r.Kind, r.ExtensionClass, r.Assembly, r.Source, r.SourceVersion, r.ReachablePath, r.ReachableFromType))
+            .Select(g =>
+            {
+                var first = g.First();
+                var signatures = g.Select(r => r.Signature).Where(s => s != null).Distinct().Cast<string>().ToList();
+                var count = g.Count();
+                return first with
+                {
+                    Overloads = count > 1 ? count : null,
+                    Signatures = signatures.Count > 1 ? signatures : null,
+                    Signature = signatures.Count == 1 ? signatures[0] : null
+                };
+            })
+            .ToList();
     }
 }
 
@@ -160,6 +185,12 @@ public record class ExtensionMethodResult
 
     [JsonPropertyName("signature")]
     public string? Signature { get; set; }
+
+    [JsonPropertyName("signatures")]
+    public List<string>? Signatures { get; set; }
+
+    [JsonPropertyName("overloads")]
+    public int? Overloads { get; set; }
 
     [JsonPropertyName("kind")]
     public string Kind { get; set; } = "method";

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -196,7 +196,7 @@ public class PackageCommand
             var result = await PackageInspector.InspectAsync(
                 extractPath, packageName, version, isLocalFile,
                 isLocalFile ? packageArgs[0] : null,
-                options.IncludeDeps, nuspec, client, logger);
+                nuspec, client, logger);
 
             // Filter output based on options
             FilterResultForOutput(result, options);
@@ -258,12 +258,6 @@ public class PackageCommand
 
     private static void FilterResultForOutput(InspectionResult result, InspectionOptions options)
     {
-        // If deps is not requested, clear runtime dependencies
-        if (!options.IncludeDeps)
-        {
-            result.RuntimeDependencies = null;
-        }
-
         // Filter dependency groups and set TFM when --tfm is requested
         if (!string.IsNullOrEmpty(options.Tfm))
         {

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -16,7 +16,6 @@ internal static class PackageInspector
         string version,
         bool isLocalFile,
         string? localFilePath,
-        bool includeDeps,
         NuspecData? nuspec,
         HttpClient httpClient,
         VerboseLogger logger)
@@ -81,8 +80,7 @@ internal static class PackageInspector
         ToolsAnalyzer.AnalyzeContentDirectories(extractPath, result);
         result.AssemblyCount = ToolsAnalyzer.CountAssemblies(extractPath);
 
-        // Parse deps.json files if deps flag is set
-        if (includeDeps)
+        // Parse deps.json files (present in tool packages)
         {
             string[] depsFiles = Directory.GetFiles(extractPath, "*.deps.json", SearchOption.AllDirectories);
             foreach (string depsFile in depsFiles)

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -73,6 +73,11 @@ public record ExtensionsOptions : IAssemblySourceOptions
     public bool Verbose { get; init; }
 
     /// <summary>
+    /// Output verbosity level.
+    /// </summary>
+    public Verbosity Verbosity { get; init; } = Verbosity.Normal;
+
+    /// <summary>
     /// NuGet source configuration options.
     /// </summary>
     public NuGetSourceOptions? SourceOptions { get; init; }

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -8,11 +8,6 @@ namespace DotnetInspector.Options;
 public record InspectionOptions
 {
     /// <summary>
-    /// Include dependency analysis.
-    /// </summary>
-    public bool IncludeDeps { get; init; }
-
-    /// <summary>
     /// Show package dependencies as a tree view with transitive resolution.
     /// </summary>
     public bool ShowDependencies { get; init; }
@@ -120,8 +115,5 @@ public record InspectionOptions
     /// <summary>
     /// All inspection features enabled.
     /// </summary>
-    public static InspectionOptions All => new()
-    {
-        IncludeDeps = true
-    };
+    public static InspectionOptions All => new();
 }

--- a/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Options;
 using Markout;
 
 namespace DotnetInspector.Output;
@@ -8,7 +9,8 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class ExtensionsOutputFormatter
 {
-    public static string FormatResults(string targetType, List<ExtensionMethodResult> results)
+    public static string FormatResults(string targetType, List<ExtensionMethodResult> results,
+        Verbosity verbosity = Verbosity.Normal)
     {
         var writer = new MarkoutWriter();
 
@@ -19,6 +21,12 @@ public static class ExtensionsOutputFormatter
         var reachableExtensions = results.Where(r => r.ReachablePath != null)
             .GroupBy(r => r.ReachablePath)
             .ToList();
+
+        if (verbosity == Verbosity.Quiet)
+        {
+            WriteCountsTable(writer, targetType, directExtensions, reachableExtensions);
+            return writer.ToString();
+        }
 
         // Direct extensions (always shown)
         writer.WriteHeading(2, $"{targetType} Extensions ({directExtensions.Count})");
@@ -38,6 +46,25 @@ public static class ExtensionsOutputFormatter
         return writer.ToString();
     }
 
+    private static void WriteCountsTable(MarkoutWriter writer,
+        string targetType,
+        List<ExtensionMethodResult> directExtensions,
+        List<IGrouping<string?, ExtensionMethodResult>> reachableExtensions)
+    {
+        var headers = new[] { "Type", "Extensions", "Via" };
+        List<string[]> rows = [];
+
+        rows.Add([targetType, directExtensions.Count.ToString(), ""]);
+
+        foreach (var group in reachableExtensions)
+        {
+            var reachableType = group.First().ReachableFromType ?? "";
+            rows.Add([reachableType, group.Count().ToString(), group.Key ?? ""]);
+        }
+
+        writer.WriteTable(headers, rows);
+    }
+
     private static void WriteExtensionTable(MarkoutWriter writer, List<ExtensionMethodResult> results)
     {
         var byClass = results.GroupBy(r => r.ExtensionClass).ToList();
@@ -48,7 +75,10 @@ public static class ExtensionsOutputFormatter
             var sourceDisplay = ext.SourceVersion != null
                 ? $"{ext.Source}@{ext.SourceVersion}"
                 : ext.Source;
-            return new[] { ext.MethodName, ext.Kind, ext.ExtensionClass ?? "", ext.Assembly ?? "", sourceDisplay ?? "" };
+            var name = ext.Overloads > 1
+                ? $"{ext.MethodName} ({ext.Overloads} overloads)"
+                : ext.MethodName;
+            return new[] { name, ext.Kind, ext.ExtensionClass ?? "", ext.Assembly ?? "", sourceDisplay ?? "" };
         }));
         writer.WriteTable(headers, rows);
     }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -129,6 +129,9 @@ public class CliApiSurface
     [MarkoutIgnore]
     public string? Name => _inner.Name;
 
+    [MarkoutSkipNull]
+    public string? Library => _inner.Library;
+
     public int Types => _inner.PublicTypeCount;
     public int Methods => _inner.PublicMethodCount;
     public int Properties => _inner.PublicPropertyCount;


### PR DESCRIPTION
## Summary

Makes `library` the one-stop shop for library-level inspection and simplifies the command surface.

### Changes

**`library` command — now the canonical path for library inspection**
- Positional arg accepts package name, `package@version`, or local file path
  - `dotnet-inspect library System.Text.Json` (package)
  - `dotnet-inspect library MyLib.dll` (local file)
  - Disambiguation: if file exists on disk → local; otherwise → package name
- Metadata (Library Info) always shown — no `--metadata` flag needed
- Removed deprecated `--package` option (replaced by positional arg)

**`package` command — focused on package-level concerns**
- Removed `--metadata`, `--symbols`, `--sourcelink-audit` (use `library` instead)
- Removed `--deps` flag — runtime dependencies from `.deps.json` are now always shown when present
- Added `library X` tip to guide users

**`api` command**
- Added `Library` field to summary line showing which DLL is being read

### Before / After

| Before | After |
|--------|-------|
| `package X --metadata` | `library X` |
| `library --package X` | `library X` |
| `library --package X --metadata` | `library X` |
| `package X --deps` | `package X` (always included) |

### Tests

All 267 + 122 tests pass.