### PR TITLE
Add Extension Methods section to library detailed view

### DIFF
--- a/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
@@ -131,6 +131,104 @@ public static class ExtensionMethodScanner
     }
 
     /// <summary>
+    /// Finds all extension methods in an assembly (no target type filter).
+    /// </summary>
+    public static IEnumerable<ExtensionMethodInfo> FindAllExtensions(
+        Stream peStream, bool includeAll = false)
+    {
+        using var peReader = new PEReader(peStream);
+        return FindAllExtensions(peReader, includeAll).ToList();
+    }
+
+    /// <summary>
+    /// Finds all extension methods in an assembly (no target type filter).
+    /// </summary>
+    public static IEnumerable<ExtensionMethodInfo> FindAllExtensions(
+        PEReader peReader, bool includeAll = false)
+    {
+        if (!peReader.HasMetadata)
+            yield break;
+
+        var reader = peReader.GetMetadataReader();
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            var typeAttrs = typeDef.Attributes;
+
+            bool isStatic = (typeAttrs & TypeAttributes.Sealed) != 0 &&
+                           (typeAttrs & TypeAttributes.Abstract) != 0;
+            if (!isStatic) continue;
+
+            if (!AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())) continue;
+
+            if (!includeAll && AttributeReader.HasHiddenAttribute(reader, typeDef.GetCustomAttributes()))
+                continue;
+
+            string classNs = reader.GetString(typeDef.Namespace);
+            string fullClassName = reader.GetFullTypeName(typeDef);
+
+            var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+                if ((method.Attributes & MethodAttributes.Static) == 0) continue;
+
+                string methodName = reader.GetString(method.Name);
+
+                bool hasExtension = AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
+                if (!hasExtension &&
+                    (methodName.StartsWith("get_", StringComparison.Ordinal) ||
+                     methodName.StartsWith("set_", StringComparison.Ordinal)))
+                {
+                    if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
+                        continue;
+
+                    var context = GenericContext.ForMethod(reader, typeDef, method);
+                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    if (signature.ParameterTypes.Length == 0) continue;
+
+                    var extendedType = signature.ParameterTypes[0];
+                    string propertyName = methodName.Substring(4);
+                    if (!seenPropertyNames.Add(propertyName)) continue;
+
+                    var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
+                    yield return new ExtensionMethodInfo(
+                        MethodName: propertyName,
+                        ExtensionClass: fullClassName,
+                        Namespace: classNs,
+                        ExtendedType: extendedType,
+                        Signature: propSignature,
+                        Kind: "property");
+                    continue;
+                }
+
+                if (!hasExtension) continue;
+
+                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
+                    continue;
+
+                {
+                    var context = GenericContext.ForMethod(reader, typeDef, method);
+                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    if (signature.ParameterTypes.Length == 0) continue;
+
+                    var extendedType = signature.ParameterTypes[0];
+
+                    yield return new ExtensionMethodInfo(
+                        MethodName: methodName,
+                        ExtensionClass: fullClassName,
+                        Namespace: classNs,
+                        ExtendedType: extendedType,
+                        Signature: FormatMethodSignature(reader, typeDef, method, context));
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Finds extension methods in a stream containing a PE image.
     /// </summary>
     public static IEnumerable<ExtensionMethodInfo> FindExtensions(

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -89,6 +89,51 @@ public class ExtensionsCommandTests
     }
 
     [Fact]
+    public void FindAllExtensions_ReturnsAllExtensionsFromAssembly()
+    {
+        var assemblyPath = typeof(ExtensionsCommandTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+
+        var extensions = ExtensionMethodScanner.FindAllExtensions(stream, includeAll: true).ToList();
+
+        // Should find our sample extensions (ToUpperCase, Repeat, FirstOrNull, GetInfo)
+        Assert.True(extensions.Count >= 4);
+        Assert.Contains(extensions, e => e.MethodName == "ToUpperCase");
+        Assert.Contains(extensions, e => e.MethodName == "FirstOrNull");
+        Assert.Contains(extensions, e => e.MethodName == "GetInfo");
+
+        // Each result should have an extended type
+        Assert.All(extensions, e => Assert.False(string.IsNullOrEmpty(e.ExtendedType)));
+    }
+
+    [Fact]
+    public void FindAllExtensions_FindsCSharp14ExtensionBlockMembers()
+    {
+        // MetadataReaderExtensions uses C# 14 extension blocks:
+        //   extension(MetadataReader reader) { GetFullTypeName (3 overloads), GetGenericParameterName }
+        //   extension(TypeDefinition typeDef) { IsPublic (property) }
+        var testDir = Path.GetDirectoryName(typeof(ExtensionsCommandTests).Assembly.Location)!;
+        var targetPath = Path.Combine(testDir, "DotnetInspector.Metadata.dll");
+        Assert.True(File.Exists(targetPath), $"DotnetInspector.Metadata.dll not found at {targetPath}");
+
+        using var stream = File.OpenRead(targetPath);
+        var extensions = ExtensionMethodScanner.FindAllExtensions(stream).ToList();
+
+        // C# 14 extension methods on MetadataReader
+        var readerExtensions = extensions.Where(e =>
+            e.ExtendedType.Contains("MetadataReader") &&
+            !e.ExtendedType.Contains("TypeDefinition")).ToList();
+        Assert.Contains(readerExtensions, e => e.MethodName == "GetFullTypeName");
+        Assert.Equal(3, readerExtensions.Count(e => e.MethodName == "GetFullTypeName"));
+        Assert.Contains(readerExtensions, e => e.MethodName == "GetGenericParameterName");
+
+        // C# 14 extension property on TypeDefinition
+        var typeDefExtensions = extensions.Where(e =>
+            e.ExtendedType.Contains("TypeDefinition")).ToList();
+        Assert.Contains(typeDefExtensions, e => e.MethodName == "IsPublic" && e.Kind == "property");
+    }
+
+    [Fact]
     public void MatchesTargetType_ExactMatch()
     {
         // Test exact matching logic

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -78,6 +78,12 @@ internal static class LibraryMetadataService
                     deduplicate: options.IncludeDependencies);
             }
 
+            // Scan for extension methods in detailed mode
+            if (options.Verbosity == Options.Verbosity.Detailed)
+            {
+                audit.ExtensionMethods = ScanExtensionMethods(path, logger);
+            }
+
             if (options.HasAuditTier)
             {
                 await AuditAsync(pdbContext, audit, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, options.IncludeSourcelinkAudit);
@@ -340,5 +346,42 @@ internal static class LibraryMetadataService
         }
 
         return nodes;
+    }
+
+    /// <summary>
+    /// Scans an assembly for all extension methods and returns collapsed summaries.
+    /// </summary>
+    private static List<ExtensionMethodSummary>? ScanExtensionMethods(string path, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var extensions = ExtensionMethodScanner.FindAllExtensions(stream);
+
+            var collapsed = extensions
+                .GroupBy(e => (e.MethodName, e.Kind, e.ExtensionClass, e.ExtendedType))
+                .Select(g =>
+                {
+                    var count = g.Count();
+                    return new ExtensionMethodSummary
+                    {
+                        MethodName = g.Key.MethodName,
+                        ExtendedType = g.Key.ExtendedType,
+                        ExtensionClass = g.Key.ExtensionClass,
+                        Kind = g.Key.Kind,
+                        Overloads = count > 1 ? count : null
+                    };
+                })
+                .OrderBy(e => e.ExtendedType)
+                .ThenBy(e => e.MethodName)
+                .ToList();
+
+            return collapsed.Count > 0 ? collapsed : null;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning extensions in {path}: {ex.Message}");
+            return null;
+        }
     }
 }

--- a/src/dotnet-inspect/MarkoutContext.cs
+++ b/src/dotnet-inspect/MarkoutContext.cs
@@ -10,6 +10,7 @@ namespace DotnetInspector;
 [MarkoutContext(typeof(AssemblyAuditView))]
 [MarkoutContext(typeof(AssemblyAuditReport))]
 [MarkoutContext(typeof(ReferenceRow))]
+[MarkoutContext(typeof(ExtensionMethodRow))]
 [MarkoutContext(typeof(CliApiSurface))]
 [MarkoutContext(typeof(ApiTypeView))]
 [MarkoutContext(typeof(EnumValueRow))]

--- a/src/dotnet-inspect/Models/AssemblyAudit.cs
+++ b/src/dotnet-inspect/Models/AssemblyAudit.cs
@@ -125,8 +125,26 @@ public class AssemblyAudit
     public ApiSurface? ApiSurface { get; set; }
 
     /// <summary>
+    /// Extension methods defined in this assembly, grouped by extended type.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ExtensionMethodSummary>? ExtensionMethods { get; set; }
+
+    /// <summary>
     /// View routing flag: when true, show nested dependency tree instead of flat references.
     /// </summary>
     [JsonIgnore]
     public bool UseDependenciesView { get; set; }
+}
+
+/// <summary>
+/// Summary of an extension method defined in a library.
+/// </summary>
+public record class ExtensionMethodSummary
+{
+    public string MethodName { get; init; } = "";
+    public string ExtendedType { get; init; } = "";
+    public string ExtensionClass { get; init; } = "";
+    public string Kind { get; init; } = "method";
+    public int? Overloads { get; init; }
 }

--- a/src/dotnet-inspect/Views/AssemblyAuditView.cs
+++ b/src/dotnet-inspect/Views/AssemblyAuditView.cs
@@ -163,6 +163,17 @@ public class AssemblyAuditView
         BuildNestedDependencyTree(_data.AssemblyInfo.TransitiveReferences);
 
     [MarkoutIgnore]
+    public bool HasExtensionMethods => _data.ExtensionMethods is { Count: > 0 };
+
+    [MarkoutSection(Name = "Extension Methods", ShowWhenProperty = nameof(HasExtensionMethods))]
+    public List<ExtensionMethodRow>? ExtensionMethodsSection =>
+        _data.ExtensionMethods?.Select(e =>
+        {
+            var name = e.Overloads > 1 ? $"{e.MethodName} ({e.Overloads} overloads)" : e.MethodName;
+            return new ExtensionMethodRow(name, e.Kind, e.ExtendedType, e.ExtensionClass);
+        }).ToList();
+
+    [MarkoutIgnore]
     public bool HasNonNormalizedPaths => _data.NonNormalizedPaths is { Count: > 0 };
 
     [MarkoutSection(Name = "Non-normalized Paths", ShowWhenProperty = nameof(HasNonNormalizedPaths))]
@@ -317,3 +328,10 @@ public record ReferenceRow(
     string Name,
     string Version,
     [property: MarkoutPropertyName("Public Key Token")] string PublicKeyToken);
+
+[MarkoutSerializable]
+public record ExtensionMethodRow(
+    string Name,
+    string Kind,
+    [property: MarkoutPropertyName("Extended Type")] string ExtendedType,
+    string Class);


### PR DESCRIPTION
## Summary

Add a new **Extension Methods** section to the `library` command's detailed view (`-v:d`) that lists all extension methods defined in an assembly — the inverse of what the `extensions` command does.

### Example

```
$ dotnet-inspect library --platform System.Linq -v:d
```

Shows a new section:

| Name | Kind | Extended Type | Class |
| ---- | ---- | ------------- | ----- |
| Aggregate (3 overloads) | method | IEnumerable\<TSource\> | System.Linq.Enumerable |
| ToList | method | IEnumerable\<TSource\> | System.Linq.Enumerable |
| Cast | method | IEnumerable | System.Linq.Enumerable |
| IsPublic | property | TypeDefinition | MetadataReaderExtensions |
| ... | | | |

### Changes

- **ExtensionMethodScanner** — add `FindAllExtensions` (PEReader + Stream overloads) that returns all extension methods without target type filtering
- **AssemblyAudit** — add `ExtensionMethods` property and `ExtensionMethodSummary` record with overload collapsing
- **LibraryMetadataService** — scan for extensions when `Verbosity == Detailed`
- **AssemblyAuditView** — add `Extension Methods` section with `ExtensionMethodRow` table (Name, Kind, Extended Type, Class), gated by `ShowWhenProperty`
- **MarkoutContext** — register `ExtensionMethodRow`

### Testing

- `FindAllExtensions_ReturnsAllExtensionsFromAssembly` — verifies traditional `this`-style extensions
- `FindAllExtensions_FindsCSharp14ExtensionBlockMembers` — verifies C# 14 `extension(T)` block syntax: discovers `GetFullTypeName` (3 overloads), `GetGenericParameterName`, and `IsPublic` (property) from `MetadataReaderExtensions.cs`

All 270 tests pass.