### PR TITLE
Add file size, metadata counts, custom attributes, type forwarders, and CLI cleanup

### DIFF
--- a/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
@@ -1,0 +1,179 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Information about an assembly-level or module-level custom attribute.
+/// </summary>
+public record AssemblyAttributeInfo(
+    string Name,
+    string Target,
+    string? Value);
+
+/// <summary>
+/// Information about a type forwarder.
+/// </summary>
+public record TypeForwarderInfo(
+    string TypeName,
+    string TargetAssembly);
+
+/// <summary>
+/// Scans assemblies for custom attributes and type forwarders.
+/// </summary>
+public static class AssemblyDetailScanner
+{
+    /// <summary>
+    /// Extracts assembly-level and module-level custom attributes.
+    /// Skips well-known metadata attributes that are already surfaced elsewhere.
+    /// </summary>
+    public static List<AssemblyAttributeInfo> ScanCustomAttributes(PEReader peReader)
+    {
+        List<AssemblyAttributeInfo> results = [];
+
+        if (!peReader.HasMetadata)
+            return results;
+
+        var reader = peReader.GetMetadataReader();
+
+        // Assembly-level attributes
+        if (reader.IsAssembly)
+        {
+            var assemblyDef = reader.GetAssemblyDefinition();
+            foreach (var attrHandle in assemblyDef.GetCustomAttributes())
+            {
+                var attr = reader.GetCustomAttribute(attrHandle);
+                string? name = AssemblyInspector.GetAttributeName(reader, attr);
+                if (name == null || IsWellKnownMetadataAttribute(name))
+                    continue;
+
+                string shortName = GetShortAttributeName(name);
+                string? value = TryGetAttributeDisplayValue(reader, attr);
+                results.Add(new AssemblyAttributeInfo(shortName, "Assembly", value));
+            }
+        }
+
+        // Module-level attributes
+        var moduleDef = reader.GetModuleDefinition();
+        foreach (var attrHandle in moduleDef.GetCustomAttributes())
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            string? name = AssemblyInspector.GetAttributeName(reader, attr);
+            if (name == null || IsWellKnownMetadataAttribute(name))
+                continue;
+
+            string shortName = GetShortAttributeName(name);
+            string? value = TryGetAttributeDisplayValue(reader, attr);
+            results.Add(new AssemblyAttributeInfo(shortName, "Module", value));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Extracts type forwarders from the ExportedTypes table.
+    /// </summary>
+    public static List<TypeForwarderInfo> ScanTypeForwarders(PEReader peReader)
+    {
+        List<TypeForwarderInfo> results = [];
+
+        if (!peReader.HasMetadata)
+            return results;
+
+        var reader = peReader.GetMetadataReader();
+
+        foreach (var handle in reader.ExportedTypes)
+        {
+            var exportedType = reader.GetExportedType(handle);
+
+            if (!exportedType.IsForwarder)
+                continue;
+
+            var ns = reader.GetString(exportedType.Namespace);
+            var name = reader.GetString(exportedType.Name);
+            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+
+            string targetAssembly = "";
+            if (exportedType.Implementation.Kind == HandleKind.AssemblyReference)
+            {
+                var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)exportedType.Implementation);
+                targetAssembly = reader.GetString(assemblyRef.Name);
+            }
+
+            results.Add(new TypeForwarderInfo(fullName, targetAssembly));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Gets the file size of an assembly.
+    /// </summary>
+    public static long GetFileSize(string path) => new FileInfo(path).Length;
+
+    /// <summary>
+    /// Attributes already surfaced in Library Info — skip in custom attributes section.
+    /// </summary>
+    private static bool IsWellKnownMetadataAttribute(string name) => name switch
+    {
+        "System.Runtime.Versioning.TargetFrameworkAttribute" => true,
+        "System.Reflection.AssemblyFileVersionAttribute" => true,
+        "System.Reflection.AssemblyInformationalVersionAttribute" => true,
+        "System.Reflection.AssemblyProductAttribute" => true,
+        "System.Reflection.AssemblyCompanyAttribute" => true,
+        "System.Reflection.AssemblyCopyrightAttribute" => true,
+        "System.Reflection.AssemblyDescriptionAttribute" => true,
+        "System.Reflection.AssemblyConfigurationAttribute" => true,
+        "System.Reflection.AssemblyTitleAttribute" => true,
+        "System.Reflection.AssemblyMetadataAttribute" => true,
+        // Compiler-generated noise
+        "System.Runtime.CompilerServices.CompilationRelaxationsAttribute" => true,
+        "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" => true,
+        "System.Diagnostics.DebuggableAttribute" => true,
+        "System.Runtime.CompilerServices.RefSafetyRulesAttribute" => true,
+        "System.Runtime.CompilerServices.NullablePublicOnlyAttribute" => true,
+        "System.Runtime.CompilerServices.NullableContextAttribute" => true,
+        "System.Runtime.CompilerServices.NullableAttribute" => true,
+        _ => false
+    };
+
+    private static string GetShortAttributeName(string fullName)
+    {
+        // Remove "Attribute" suffix and namespace
+        var name = fullName;
+        if (name.EndsWith("Attribute", StringComparison.Ordinal))
+            name = name[..^9];
+
+        var lastDot = name.LastIndexOf('.');
+        return lastDot >= 0 ? name[(lastDot + 1)..] : name;
+    }
+
+    private static string? TryGetAttributeDisplayValue(MetadataReader reader, CustomAttribute attr)
+    {
+        try
+        {
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.Length < 2) return null;
+            blob.ReadUInt16(); // prolog
+
+            // Try reading a single string argument
+            var value = blob.ReadSerializedString();
+            if (value == null) return null;
+
+            // Filter out binary/control character values
+            foreach (char c in value)
+            {
+                if (char.IsControl(c) && c != '\t' && c != '\n' && c != '\r')
+                    return null;
+            }
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/DotnetInspector.Metadata/AssemblyInfo.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInfo.cs
@@ -82,6 +82,10 @@ public class AssemblyInfo
     public bool HasCorHeader { get; set; }
     public bool HasILCode { get; set; }
 
+    // Metadata statistics
+    public int TypeDefinitionCount { get; set; }
+    public int MethodDefinitionCount { get; set; }
+
     /// <summary>
     /// List of assemblies referenced by this assembly.
     /// </summary>

--- a/src/DotnetInspector.Metadata/AssemblyInspector.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInspector.cs
@@ -89,6 +89,9 @@ public static class AssemblyInspector
 
             ExtractCustomAttributes(metadataReader, info);
 
+            info.TypeDefinitionCount = metadataReader.GetTableRowCount(TableIndex.TypeDef);
+            info.MethodDefinitionCount = metadataReader.GetTableRowCount(TableIndex.MethodDef);
+
             if (includeReferences)
             {
                 info.References = ExtractReferences(metadataReader);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Models;
 using System.Collections.Concurrent;
+using System.Reflection.PortableExecutable;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
@@ -38,12 +39,18 @@ internal static class LibraryMetadataService
             {
                 var nativeInfo = pdbContext.CreateNativeInfo();
 
-                return new AssemblyAudit
+                var nativeAudit = new AssemblyAudit
                 {
                     FileName = Path.GetFileName(path),
                     FileType = "native",
-                    AssemblyInfo = nativeInfo
+                    AssemblyInfo = nativeInfo,
+                    FileSize = AssemblyDetailScanner.GetFileSize(path)
                 };
+
+                nativeAudit.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
+                nativeAudit.IsDeterministic = pdbContext.HasReproducibleFlag;
+
+                return nativeAudit;
             }
 
             var audit = new AssemblyAudit
@@ -84,7 +91,11 @@ internal static class LibraryMetadataService
                 audit.ExtensionMethods = ScanExtensionMethods(path, logger);
                 ScanClassifiedMethods(path, audit, logger);
                 audit.Resources = ScanResources(path, logger);
+                ScanCustomAttributes(path, audit, logger);
+                ScanTypeForwarders(path, audit, logger);
             }
+
+            audit.FileSize = AssemblyDetailScanner.GetFileSize(path);
 
             await AuditAsync(pdbContext, audit, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, options.IncludeSourcelinkAudit);
 
@@ -454,6 +465,62 @@ internal static class LibraryMetadataService
         {
             logger.Log($"Warning: Error scanning resources in {path}: {ex.Message}");
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Scans an assembly for custom attributes (assembly-level and module-level).
+    /// </summary>
+    private static void ScanCustomAttributes(string path, AssemblyAudit audit, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var attrs = AssemblyDetailScanner.ScanCustomAttributes(peReader);
+            if (attrs.Count > 0)
+            {
+                audit.CustomAttributes = attrs
+                    .Select(a => new CustomAttributeSummary
+                    {
+                        Name = a.Name,
+                        Target = a.Target,
+                        Value = a.Value
+                    })
+                    .ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Scans an assembly for type forwarders.
+    /// </summary>
+    private static void ScanTypeForwarders(string path, AssemblyAudit audit, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var forwarders = AssemblyDetailScanner.ScanTypeForwarders(peReader);
+            if (forwarders.Count > 0)
+            {
+                audit.TypeForwarders = forwarders
+                    .Select(f => new TypeForwarderSummary
+                    {
+                        TypeName = f.TypeName,
+                        TargetAssembly = f.TargetAssembly
+                    })
+                    .OrderBy(f => f.TypeName)
+                    .ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning type forwarders in {path}: {ex.Message}");
         }
     }
 }

--- a/src/dotnet-inspect/MarkoutContext.cs
+++ b/src/dotnet-inspect/MarkoutContext.cs
@@ -14,6 +14,8 @@ namespace DotnetInspector;
 [MarkoutContext(typeof(ClassifiedMethodRow))]
 [MarkoutContext(typeof(PInvokeMethodRow))]
 [MarkoutContext(typeof(ResourceRow))]
+[MarkoutContext(typeof(CustomAttributeRow))]
+[MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(CliApiSurface))]
 [MarkoutContext(typeof(ApiTypeView))]
 [MarkoutContext(typeof(EnumValueRow))]

--- a/src/dotnet-inspect/Models/AssemblyAudit.cs
+++ b/src/dotnet-inspect/Models/AssemblyAudit.cs
@@ -149,6 +149,24 @@ public class AssemblyAudit
     public List<ResourceSummary>? Resources { get; set; }
 
     /// <summary>
+    /// File size of the assembly in bytes.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public long FileSize { get; set; }
+
+    /// <summary>
+    /// Assembly-level and module-level custom attributes.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<CustomAttributeSummary>? CustomAttributes { get; set; }
+
+    /// <summary>
+    /// Type forwarders defined in this assembly.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<TypeForwarderSummary>? TypeForwarders { get; set; }
+
+    /// <summary>
     /// View routing flag: when true, show nested dependency tree instead of flat references.
     /// </summary>
     [JsonIgnore]
@@ -187,4 +205,24 @@ public record class ResourceSummary
     public string Name { get; init; } = "";
     public string Visibility { get; init; } = "";
     public int Size { get; init; }
+}
+
+/// <summary>
+/// Summary of a custom attribute on the assembly or module.
+/// </summary>
+public record class CustomAttributeSummary
+{
+    public string Name { get; init; } = "";
+    public string Target { get; init; } = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Value { get; init; }
+}
+
+/// <summary>
+/// Summary of a type forwarder in a library.
+/// </summary>
+public record class TypeForwarderSummary
+{
+    public string TypeName { get; init; } = "";
+    public string TargetAssembly { get; init; } = "";
 }

--- a/src/dotnet-inspect/Views/AssemblyAuditView.cs
+++ b/src/dotnet-inspect/Views/AssemblyAuditView.cs
@@ -195,6 +195,20 @@ public class AssemblyAuditView
         _data.Resources?.Select(r => new ResourceRow(r.Name, r.Visibility, FormatSize(r.Size))).ToList();
 
     [MarkoutIgnore]
+    public bool HasCustomAttributes => _data.CustomAttributes is { Count: > 0 };
+
+    [MarkoutSection(Name = "Custom Attributes", ShowWhenProperty = nameof(HasCustomAttributes))]
+    public List<CustomAttributeRow>? CustomAttributesSection =>
+        _data.CustomAttributes?.Select(a => new CustomAttributeRow(a.Name, a.Target, a.Value ?? "")).ToList();
+
+    [MarkoutIgnore]
+    public bool HasTypeForwarders => _data.TypeForwarders is { Count: > 0 };
+
+    [MarkoutSection(Name = "Type Forwarders", ShowWhenProperty = nameof(HasTypeForwarders))]
+    public List<TypeForwarderRow>? TypeForwardersSection =>
+        _data.TypeForwarders?.Select(f => new TypeForwarderRow(f.TypeName, f.TargetAssembly)).ToList();
+
+    [MarkoutIgnore]
     public bool HasNonNormalizedPaths => _data.NonNormalizedPaths is { Count: > 0 };
 
     [MarkoutSection(Name = "Non-normalized Paths", ShowWhenProperty = nameof(HasNonNormalizedPaths))]
@@ -237,6 +251,12 @@ public class AssemblyAuditView
             fields.Add(new("Public Key Token", info.PublicKeyToken));
         fields.Add(new("Deterministic", _data.IsDeterministic ? "✓" : "✗"));
         fields.Add(new("Reproducible", _data.HasReproducibleFlag ? "✓" : "✗"));
+        if (_data.FileSize > 0)
+            fields.Add(new("File Size", FormatFileSize(_data.FileSize)));
+        if (info.TypeDefinitionCount > 0)
+            fields.Add(new("Types", info.TypeDefinitionCount.ToString("N0")));
+        if (info.MethodDefinitionCount > 0)
+            fields.Add(new("Methods", info.MethodDefinitionCount.ToString("N0")));
 
         return fields;
     }
@@ -253,8 +273,6 @@ public class AssemblyAuditView
             fields.Add(new("Symbol Server", _data.SymbolServer));
         if (!string.IsNullOrEmpty(_data.PdbPath))
             fields.Add(new("PDB Path", _data.PdbPath));
-        if (_data.PdbLocation == null && !string.IsNullOrEmpty(_data.PdbPath))
-            fields.Add(new("Note", "Path is from the CodeView record; actual PDB location is unknown"));
 
         fields.Add(new("SourceLink", SourceLinkStatus));
 
@@ -301,6 +319,13 @@ public class AssemblyAuditView
     private static string FormatSize(int bytes) => bytes switch
     {
         0 => "",
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+    };
+
+    private static string FormatFileSize(long bytes) => bytes switch
+    {
         < 1024 => $"{bytes} B",
         < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
         _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
@@ -383,3 +408,14 @@ public record ResourceRow(
     string Name,
     string Visibility,
     string Size);
+
+[MarkoutSerializable]
+public record CustomAttributeRow(
+    string Name,
+    string Target,
+    string Value);
+
+[MarkoutSerializable]
+public record TypeForwarderRow(
+    [property: MarkoutPropertyName("Type")] string TypeName,
+    [property: MarkoutPropertyName("Target Assembly")] string TargetAssembly);


### PR DESCRIPTION
## Summary

Adds new metadata sections to the library detailed view (`-v:d`) and cleans up deprecated CLI flags.

### Library Info enhancements
- **File Size** — human-readable formatting (e.g., "1.5 MB")
- **Types** / **Methods** — definition counts from metadata tables

### New detailed sections (`-v:d`)
- **Custom Attributes** — assembly-level and module-level attributes, with noise filtering (compiler-generated attributes like `CompilationRelaxations`, `RuntimeCompatibility`, `Debuggable`, `RefSafetyRules`, `NullablePublicOnly` are excluded, as are attributes already surfaced in Library Info)
- **Type Forwarders** — types forwarded to other assemblies (e.g., System.Runtime forwards ~460 types to System.Private.CoreLib)

### CLI cleanup
- Remove `--symbols` flag — symbols/PDB section is now always shown
- Remove `--transitive` flag — fully deprecated, use `--dependencies`
- Rename `--sourcelink-audit` → `--source-link-audit` (Source Link is two words)
- Remove confusing PDB "Note" field from Symbols section

### Infrastructure
- `AssemblyDetailScanner` in `DotnetInspector.Metadata` — scans custom attributes and type forwarders
- `TypeDefinitionCount` / `MethodDefinitionCount` on `AssemblyInfo`
- `FileSize`, `CustomAttributes`, `TypeForwarders` on `AssemblyAudit`
- `CustomAttributeRow`, `TypeForwarderRow` view records
- Native binary path enhanced with file size and reproducible flag

### Tests
All 276 tests pass.