### PR TITLE
Add Size to package metadata section

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -198,6 +198,10 @@ public class PackageCommand
                 isLocalFile ? packageArgs[0] : null,
                 nuspec, client, logger);
 
+            // Set package size from local .nupkg file
+            if (resolution.NupkgPath != null && File.Exists(resolution.NupkgPath))
+                result.PackageSize = new FileInfo(resolution.NupkgPath).Length;
+
             // Filter output based on options
             FilterResultForOutput(result, options);
 

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -60,12 +60,6 @@ public class InspectionResultView
     [MarkoutPropertyName("Version Count")]
     public int? VersionCount => _data.VersionCount;
 
-    [MarkoutSection(Name = PackageSections.Statistics)]
-    [MarkoutSkipNull]
-    [MarkoutValueFormatter(typeof(ByteSizeFormatter))]
-    [MarkoutPropertyName("Package Size")]
-    public long? PackageSize => _data.PackageSize;
-
     public bool? IsVerified => _data.IsVerified;
 
     [MarkoutJoin(", ")]
@@ -219,6 +213,8 @@ public class InspectionResultView
 
         fields.Add(new("Version", Version));
         fields.Add(new("Type", PackageType));
+        if (_data.PackageSize.HasValue)
+            fields.Add(new("Size", new ByteSizeFormatter().Format(_data.PackageSize.Value)));
         if (!string.IsNullOrEmpty(Tfm))
             fields.Add(new("TFM", Tfm));
         if (_data.Published.HasValue)


### PR DESCRIPTION
## Summary

Adds package size to the Package metadata section, calculated locally from the `.nupkg` file.

### Changes

- **PackageCommand**: Set `PackageSize` from local `.nupkg` file after inspection (works for both cached and downloaded packages)
- **InspectionResultView**: Move Size from Statistics section to Package metadata table, displayed after Type

### Before

Size was in the Statistics section (requires API call, only for remote packages).

### After

Size appears in the Package section as a metadata field, sourced locally from the `.nupkg` file. Works for local files too.

All 276 tests pass.