### PR TITLE
Always show Sources section in single-type api view

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1221,7 +1221,7 @@ public static class CommandLineBuilder
                 MemberFilter = memberFilter,
                 Limit = parseResult.GetValue(limitOption),
                 ShowDocs = parseResult.GetValue(docsOption) || parseResult.GetValue(useLocalDocsOption),
-                DocsExplicitlySet = parseResult.GetResult(docsOption) != null || parseResult.GetResult(useLocalDocsOption) != null,
+                DocsExplicitlySet = parseResult.GetResult(docsOption) is { Implicit: false } || parseResult.GetResult(useLocalDocsOption) is { Implicit: false },
                 UseLocalDocs = parseResult.GetValue(useLocalDocsOption),
                 ShowSamples = parseResult.GetValue(samplesOption),
                 SourceLinkOnly = parseResult.GetValue(sourcelinkOnlyOption),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -256,7 +256,8 @@ public class ApiCommand
                     if (!options.DocsExplicitlySet)
                         effectiveOptions = options with { ShowDocs = true };
 
-                    if (effectiveOptions.ShowDocs || effectiveOptions.ShowSamples || effectiveOptions.SourceLinkOnly)
+                    // Always enrich with SourceLink info for single-type view (Sources section).
+                    // Doc comment fetching is gated by ShowDocs inside the enricher.
                     {
                         var pdbLookupPath = runtimeAssemblyPath ?? apiDllPath;
                         if (pdbLookupPath != null)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -252,6 +252,29 @@ public static class ApiOutputFormatter
             baseclassRows = [new BaseclassRow { Type = baseType }];
         }
 
+        // Source files (when SourceLink data is available)
+        List<SourceRow>? sourceRows = null;
+        if (type.SourceFilePath != null)
+        {
+            sourceRows = [new SourceRow
+            {
+                File = Path.GetFileName(type.SourceFilePath),
+                Url = type.GitHubBrowseUrl
+            }];
+
+            if (type.AdditionalSourceFiles != null)
+            {
+                foreach (var f in type.AdditionalSourceFiles)
+                {
+                    sourceRows.Add(new SourceRow
+                    {
+                        File = Path.GetFileName(f.FilePath ?? ""),
+                        Url = f.GitHubBrowseUrl
+                    });
+                }
+            }
+        }
+
         return new ApiTypeView
         {
             Title = $"{type.FullName}{packageInfo}",
@@ -268,7 +291,8 @@ public static class ApiOutputFormatter
             SamplesInfo = samplesInfo,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
-            BaseclassRows = baseclassRows
+            BaseclassRows = baseclassRows,
+            SourceRows = sourceRows
         };
     }
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -84,6 +84,13 @@ public class ApiTypeView
     [JsonIgnore]
     public List<BaseclassRow>? BaseclassRows { get; set; }
 
+    /// <summary>
+    /// Source files (populated via SourceLink). Null → section skipped.
+    /// </summary>
+    [MarkoutSection(Name = "Sources")]
+    [JsonIgnore]
+    public List<SourceRow>? SourceRows { get; set; }
+
 }
 
 [MarkoutSerializable]
@@ -111,6 +118,15 @@ public class InterfaceRow
 public class BaseclassRow
 {
     public string Type { get; set; } = "";
+}
+
+[MarkoutSerializable]
+public class SourceRow
+{
+    public string File { get; set; } = "";
+
+    [MarkoutSkipNull]
+    public string? Url { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

The `api` single-type member view now always shows a **Sources** section listing the source files for the type (via SourceLink), without requiring `--docs`. The `-s Sources` section filter also works correctly.

## Changes

- **`ApiViews.cs`** — Added `SourceRow` class and `SourceRows` property on `ApiTypeView` with `[MarkoutSection(Name = "Sources")]` for declarative rendering
- **`ApiOutputFormatter.cs`** — Populates source rows from `SourceFilePath` and `AdditionalSourceFiles` in `BuildApiTypeView`
- **`ApiCommand.cs`** — Always runs `SourceEnricher` in single-type view (removed `ShowDocs` gate); doc comment fetching is still gated by `ShowDocs` inside the enricher
- **`CommandLineBuilder.cs`** — Fixed `DocsExplicitlySet` parsing: `GetResult(option) != null` was always true for `Option<bool>` with defaults in System.CommandLine 2.0.2; now uses `is { Implicit: false }` to detect explicit user input

## Bug fix

`DocsExplicitlySet` was always `true` even when `--docs` was not passed, because `parseResult.GetResult(docsOption)` returns a non-null `OptionResult` for boolean options with implicit defaults. This prevented the `--docs` defaulting logic from activating in single-type view, meaning doc comments and descriptions were not shown unless `--docs` was explicitly passed.

## Before / After

**Before** (no `--docs`):
```
# System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)

Kind: class | Modifiers: static, abstract, sealed | ...
```

**After** (no `--docs`):
```
# System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)

Provides functionality to serialize objects or value types to JSON and ...

Kind: class | Modifiers: static, abstract, sealed | ...

## Sources

| File | Url |
| ---- | --- |
| JsonSerializer.Helpers.cs | https://github.com/... |
| JsonSerializer.Read.Document.cs | https://github.com/... |
...
```

## Testing

- 276 tests pass
- Smoke tested: `api System.Text.Json JsonSerializer -v:d`, `-v:q`, `--docs`, `-s Sources`, `-s` (bare)