### PR TITLE
Add SectionRegistry for -s/-x validation, wildcards, and case-insensitive matching

### DIFF
--- a/src/dotnet-inspect.Tests/SectionRegistryTests.cs
+++ b/src/dotnet-inspect.Tests/SectionRegistryTests.cs
@@ -1,0 +1,170 @@
+using DotnetInspector.Views;
+
+namespace DotnetInspector.Tests;
+
+public class SectionRegistryTests
+{
+    private static readonly string[] TestSections =
+    [
+        "Library Info",
+        "Symbols",
+        "Extension Methods",
+        "Custom Attributes",
+    ];
+
+    [Fact]
+    public void Resolve_NullRequested_ReturnsNull()
+    {
+        var result = SectionRegistry.Resolve(TestSections, null, out var hasError);
+
+        Assert.Null(result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_EmptySet_ReturnsEmpty()
+    {
+        var requested = new HashSet<string>();
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_ExactMatch_ReturnsOriginalCasing()
+    {
+        var requested = new HashSet<string> { "Symbols" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Symbols", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_CaseInsensitive_ReturnsOriginalCasing()
+    {
+        var requested = new HashSet<string> { "extension methods" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Extension Methods", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_Wildcard_MatchesPrefix()
+    {
+        var requested = new HashSet<string> { "Extension*" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Extension Methods", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_Wildcard_MatchesMultiple()
+    {
+        var requested = new HashSet<string> { "Custom*" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Custom Attributes", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_WildcardCaseInsensitive_Matches()
+    {
+        var requested = new HashSet<string> { "extension*" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Contains("Extension Methods", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void Resolve_UnknownSection_ReturnsNullWithError()
+    {
+        var requested = new HashSet<string> { "NotReal" };
+
+        var stderr = new StringWriter();
+        Console.SetError(stderr);
+        try
+        {
+            var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+            Assert.Null(result);
+            Assert.True(hasError);
+
+            var output = stderr.ToString();
+            Assert.Contains("Unknown section: NotReal", output);
+            Assert.Contains("Available sections:", output);
+            Assert.Contains("Library Info", output);
+        }
+        finally
+        {
+            Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+        }
+    }
+
+    [Fact]
+    public void Resolve_MixedValidAndInvalid_ReportsOnlyInvalid()
+    {
+        var requested = new HashSet<string> { "Symbols", "FakeSection" };
+
+        var stderr = new StringWriter();
+        Console.SetError(stderr);
+        try
+        {
+            var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+            Assert.Null(result);
+            Assert.True(hasError);
+            Assert.Contains("FakeSection", stderr.ToString());
+        }
+        finally
+        {
+            Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+        }
+    }
+
+    [Fact]
+    public void Resolve_MultipleValidSections_ReturnsAll()
+    {
+        var requested = new HashSet<string> { "Symbols", "Library Info" };
+        var result = SectionRegistry.Resolve(TestSections, requested, out var hasError);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Contains("Symbols", result);
+        Assert.Contains("Library Info", result);
+        Assert.False(hasError);
+    }
+
+    [Fact]
+    public void LibrarySections_ContainsExpectedSections()
+    {
+        Assert.Contains("Library Info", SectionRegistry.LibrarySections);
+        Assert.Contains("Symbols", SectionRegistry.LibrarySections);
+        Assert.Contains("Extension Methods", SectionRegistry.LibrarySections);
+        Assert.Contains("Custom Attributes", SectionRegistry.LibrarySections);
+        Assert.Contains("Type Forwarders", SectionRegistry.LibrarySections);
+    }
+
+    [Fact]
+    public void PackageCommandSections_ContainsExpectedSections()
+    {
+        Assert.Contains("Package", SectionRegistry.PackageCommandSections);
+        Assert.Contains("Statistics", SectionRegistry.PackageCommandSections);
+        Assert.Contains("Files", SectionRegistry.PackageCommandSections);
+    }
+}

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -26,6 +26,15 @@ public class ApiCommand
             return 1;
         }
 
+        // Validate section filters against all known api sections
+        var allApiSections = SectionRegistry.ApiTypeSections.Concat(SectionRegistry.ApiMemberSections).Distinct().ToArray();
+        options = options with
+        {
+            IncludeSections = SectionRegistry.Resolve(allApiSections, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(allApiSections, options.ExcludeSections, out var excludeError),
+        };
+        if (includeError || excludeError) return 1;
+
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
         string? tempDir = null;

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -5,6 +5,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
+using DotnetInspector.Views;
 
 namespace DotnetInspector.Commands;
 
@@ -24,6 +25,14 @@ public class AssemblyCommand
             Console.Error.WriteLine("Run 'dotnet-inspect library --help' for usage.");
             return 1;
         }
+
+        // Validate section filters
+        options = options with
+        {
+            IncludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.ExcludeSections, out var excludeError),
+        };
+        if (includeError || excludeError) return 1;
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -22,8 +22,7 @@ public class PackageCommand
         // Handle --discover mode: list sections and exit early
         if (options.Discover)
         {
-            string[] sectionNames = [PackageSections.Package, PackageSections.Statistics, PackageSections.PackageDependencies, PackageSections.Files, PackageSections.Vulnerabilities, PackageSections.RidPackages, PackageSections.RuntimeDependencies];
-            foreach (var name in sectionNames)
+            foreach (var name in SectionRegistry.PackageCommandSections)
             {
                 Console.WriteLine(name);
             }
@@ -36,6 +35,14 @@ public class PackageCommand
             Console.Error.WriteLine("Run 'dotnet-inspect package --help' for usage.");
             return 1;
         }
+
+        // Validate section filters
+        options = options with
+        {
+            IncludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.ExcludeSections, out var excludeError),
+        };
+        if (includeError || excludeError) return 1;
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;

--- a/src/dotnet-inspect/Views/SectionRegistry.cs
+++ b/src/dotnet-inspect/Views/SectionRegistry.cs
@@ -1,0 +1,139 @@
+namespace DotnetInspector.Views;
+
+/// <summary>
+/// Registry of known section names per command. Provides case-insensitive
+/// matching and wildcard resolution for <c>-s</c> and <c>-x</c> options.
+/// </summary>
+public static class SectionRegistry
+{
+    /// <summary>Sections available in the library command.</summary>
+    public static readonly string[] LibrarySections =
+    [
+        "Library Info",
+        "Symbols",
+        "Source Coverage",
+        "Library References",
+        "Library References (Transitive)",
+        "Dependencies",
+        "Extension Methods",
+        "Unsafe Methods",
+        "P/Invoke Methods",
+        "Resources",
+        "Custom Attributes",
+        "Type Forwarders",
+        "Non-normalized Paths",
+        "Missing Sources",
+    ];
+
+    /// <summary>Sections available in the package command.</summary>
+    public static readonly string[] PackageCommandSections =
+    [
+        PackageSections.Package,
+        PackageSections.Statistics,
+        PackageSections.PackageDependencies,
+        PackageSections.Files,
+        PackageSections.Vulnerabilities,
+        PackageSections.RidPackages,
+        PackageSections.RuntimeDependencies,
+    ];
+
+    /// <summary>Sections available in the api type-list view.</summary>
+    public static readonly string[] ApiTypeSections =
+    [
+        "Classes",
+        "Structs",
+        "Interfaces",
+        "Enums",
+        "Delegates",
+    ];
+
+    /// <summary>Sections available in the api type-detail view.</summary>
+    public static readonly string[] ApiMemberSections =
+    [
+        "Values",
+        "Type Parameters",
+        "Interfaces",
+        "Baseclass",
+        "Sources",
+        "Constructors",
+        "Fields",
+        "Properties",
+        "Methods",
+        "Events",
+    ];
+
+    /// <summary>
+    /// Resolves user-supplied section names against known sections.
+    /// Supports case-insensitive matching and trailing <c>*</c> wildcards.
+    /// </summary>
+    /// <param name="knownSections">The set of valid section names.</param>
+    /// <param name="requested">User-supplied section names (from <c>-s</c> or <c>-x</c>). Null means no filter.</param>
+    /// <returns>
+    /// A <see cref="HashSet{String}"/> with original-cased names for Markout,
+    /// or <c>null</c> if <paramref name="requested"/> was null (no filter).
+    /// Returns an empty set if the user specified <c>-s</c> with no value (header only).
+    /// On unresolvable names, writes an error to stderr and returns <c>null</c> with
+    /// <paramref name="hasError"/> set to <c>true</c>.
+    /// </returns>
+    public static HashSet<string>? Resolve(string[] knownSections, HashSet<string>? requested, out bool hasError)
+    {
+        hasError = false;
+        if (requested == null)
+            return null;
+
+        // Empty set means "header only" (-s with no value)
+        if (requested.Count == 0)
+            return [];
+
+        HashSet<string> resolved = new(StringComparer.Ordinal);
+        List<string> unmatched = [];
+
+        foreach (var term in requested)
+        {
+            bool matched = false;
+
+            if (term.EndsWith('*'))
+            {
+                // Wildcard: match any section starting with the prefix
+                var prefix = term[..^1];
+                foreach (var section in knownSections)
+                {
+                    if (section.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        resolved.Add(section);
+                        matched = true;
+                    }
+                }
+            }
+            else
+            {
+                // Exact case-insensitive match
+                foreach (var section in knownSections)
+                {
+                    if (section.Equals(term, StringComparison.OrdinalIgnoreCase))
+                    {
+                        resolved.Add(section);
+                        matched = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!matched)
+                unmatched.Add(term);
+        }
+
+        if (unmatched.Count > 0)
+        {
+            hasError = true;
+            Console.Error.WriteLine($"Error: Unknown section{(unmatched.Count > 1 ? "s" : "")}: {string.Join(", ", unmatched)}");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Available sections:");
+            foreach (var section in knownSections)
+                Console.Error.WriteLine($"  {section}");
+            return null;
+        }
+
+        return resolved;
+    }
+}


### PR DESCRIPTION
## Problem
`-s notarealsection` silently produced empty output with no indication of what went wrong. Section names were case-sensitive, and there was no wildcard support.

## Changes

### SectionRegistry (`Views/SectionRegistry.cs`)
- Per-command section name arrays: `LibrarySections`, `PackageCommandSections`, `ApiTypeSections`, `ApiMemberSections`
- `Resolve()` method with:
  - **Case-insensitive matching** — `-s "extension methods"` matches `Extension Methods`
  - **Trailing `*` wildcards** — `-s Extension*` matches `Extension Methods`
  - **Error on no match** — prints available sections to stderr, exits with code 1

### Command wiring
- **library**: Validates `-s`/`-x` early in `AssemblyCommand.ExecuteAsync` before any downloads
- **package**: Validates early in `PackageCommand.ExecuteAsync`; `--discover` now uses `SectionRegistry.PackageCommandSections`
- **api**: Validates against combined type + member sections

### Tests
- 12 new tests covering exact match, case-insensitive, wildcards, error output, and registry contents
- All 289 tests pass

## Examples
```
$ dotnet-inspect library System.Text.Json -s NotReal
Error: Unknown section: NotReal

Available sections:
  Library Info
  Symbols
  ...

$ dotnet-inspect library System.Text.Json -v:d -s Extension*
# System.Text.Json.dll (net10.0)
## Extension Methods
...

$ dotnet-inspect library System.Text.Json -v:d -s "extension methods"
# System.Text.Json.dll (net10.0)
## Extension Methods
...
```