### PR TITLE
Replace --discover with bare -s for section discovery

### DIFF
--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -95,7 +95,7 @@ Type: Library | TFM: net10.0 | Updated: 2026-01-13 | Vulnerabilities: 1
 For detailed output, you can include or exclude specific sections:
 
 ```bash
-dotnet-inspect package --discover                        # List available sections
+dotnet-inspect package -s                                # List available sections
 dotnet-inspect System.Text.Json -v:d -x:Statistics,Files # Exclude sections by name
 dotnet-inspect System.Text.Json -v:d -s:Metadata         # Include only named sections
 ```

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Views;
 
 namespace DotnetInspector;
 
@@ -46,7 +47,7 @@ public static class CommandLineBuilder
         var markoutOption = new Option<bool>("--markout") { Description = "Output as Markout (default)" };
         var verboseOption = new Option<bool>("--verbose") { Description = "Show progress messages on stderr" };
         var verbosityOption = new Option<string?>("-v") { Description = "Verbosity level: q(uiet), m(inimal), n(ormal), d(etailed)" };
-        var includeSectionsOption = new Option<string?>("-s") { Description = "Include only these sections by name (comma-separated, e.g., -s:Methods,Properties).\nUse -s alone for header only.", Arity = ArgumentArity.ZeroOrOne };
+        var includeSectionsOption = new Option<string?>("-s") { Description = "Include only these sections (comma-separated, supports wildcards e.g. -s:Extension*).\nUse -s alone to list available sections.", Arity = ArgumentArity.ZeroOrOne };
         var excludeSectionsOption = new Option<string?>("-x") { Description = "Exclude these sections by name (comma-separated, e.g., -x:Methods)" };
         var limitOption = new Option<int?>("-n") { Description = "Limit number of results" };
         var tipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)", Arity = ArgumentArity.ZeroOrOne };
@@ -755,7 +756,7 @@ public static class CommandLineBuilder
                     JsonOutput = parseResult.GetValue(jsonOption),
                     Verbose = parseResult.GetValue(verboseOption),
                     Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
-                    IncludeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption)),
+                    IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                     ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption))
                 };
 
@@ -885,7 +886,6 @@ public static class CommandLineBuilder
         prereleaseOption.Aliases.Add("--prerelease");
         var readmeOption = new Option<bool>("--readme") { Description = "Show the README.md content from the package" };
         var outOption = new Option<string?>("--out") { Description = "Write output to file instead of stdout" };
-        var discoverOption = new Option<bool>("--discover") { Description = "List available sections and exit" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
         var versionOption = new Option<string?>("--version") { Description = "Package version" };
 
@@ -902,7 +902,6 @@ public static class CommandLineBuilder
         packageCommand.Options.Add(tfmOption);
         packageCommand.Options.Add(versionOption);
         packageCommand.Options.Add(outOption);
-        packageCommand.Options.Add(discoverOption);
         packageCommand.Options.Add(limitOption);
         packageCommand.Options.Add(jsonOption);
         packageCommand.Options.Add(markoutOption);
@@ -938,13 +937,12 @@ public static class CommandLineBuilder
                 IncludePrerelease = parseResult.GetValue(prereleaseOption),
                 ShowReadme = parseResult.GetValue(readmeOption),
                 OutputPath = parseResult.GetValue(outOption),
-                Discover = parseResult.GetValue(discoverOption),
                 Limit = parseResult.GetValue(limitOption),
                 JsonOutput = jsonOutput,
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = verbosity,
                 TipLevel = tipLevel,
-                IncludeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption)),
+                IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
@@ -952,7 +950,7 @@ public static class CommandLineBuilder
             var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options, explicitVersion);
 
             if (exitCode == 0 && packageArgs.Length > 0
-                && !options.ListVersions && !options.ListFiles && !options.ListLayout && !options.ListTfms && !options.Discover && !options.ShowReadme)
+                && !options.ListVersions && !options.ListFiles && !options.ListLayout && !options.ListTfms && !options.ShowReadme)
             {
                 var pkg = packageArgs[0];
                 if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
@@ -1061,7 +1059,7 @@ public static class CommandLineBuilder
                 JsonOutput = parseResult.GetValue(jsonOption),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
-                IncludeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption)),
+                IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption),
                 ExtractResources = parseResult.GetValue(extractResourcesOption)
@@ -1158,9 +1156,16 @@ public static class CommandLineBuilder
             var explicitPlatform = parseResult.GetValue(apiPlatformOption);
             bool hasExplicitSource = explicitPackage != null || explicitAssembly != null || explicitPlatform != null;
 
-            // No args and no explicit source: show help
+            // No args and no explicit source: show help (unless bare -s for section discovery)
             if (args.Length == 0 && !hasExplicitSource)
             {
+                if (parseResult.GetResult(includeSectionsOption) != null && parseResult.GetValue(includeSectionsOption) == null)
+                {
+                    var allApiSections = SectionRegistry.ApiTypeSections.Concat(SectionRegistry.ApiMemberSections).Distinct().ToArray();
+                    SectionRegistry.ListSections(allApiSections);
+                    return 0;
+                }
+
                 new HelpAction().Invoke(parseResult);
                 return 0;
             }
@@ -1204,11 +1209,6 @@ public static class CommandLineBuilder
                 memberFilter = new HashSet<string>(allMembers, StringComparer.OrdinalIgnoreCase);
             }
 
-            var includeSections = ParseSectionList(parseResult.GetValue(includeSectionsOption));
-            // Bare -s with no value means "header only" (empty set excludes all sections)
-            if (includeSections == null && parseResult.GetResult(includeSectionsOption) != null)
-                includeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
             var options = new ApiOptions
             {
                 PackagePath = packagePath,
@@ -1232,7 +1232,7 @@ public static class CommandLineBuilder
                 ShapeOutput = parseResult.GetValue(shapeOption),
                 UnsafeOnly = parseResult.GetValue(unsafeOption),
                 CtorOnly = ctorOnly,
-                IncludeSections = includeSections,
+                IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
@@ -1251,6 +1251,8 @@ public static class CommandLineBuilder
     public static Verbosity ParseVerbosity(string? value) => OptionParsers.ParseVerbosity(value);
     public static TipLevel ParseTipLevel(string? value, bool optionPresent) => OptionParsers.ParseTipLevel(value, optionPresent);
     public static HashSet<string>? ParseSectionList(string? value) => OptionParsers.ParseSectionList(value);
+    public static HashSet<string>? ParseIncludeSections(ParseResult parseResult, Option<string?> option)
+        => OptionParsers.ParseIncludeSections(parseResult, option);
     public static NuGetSourceOptions ParseNuGetSourceOptions(
         ParseResult parseResult, Option<string[]> sourceOption,
         Option<string[]> addSourceOption, Option<string?> nugetConfigOption)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -35,6 +35,13 @@ public class ApiCommand
         };
         if (includeError || excludeError) return 1;
 
+        // Bare -s: list available sections and exit
+        if (options.IncludeSections is { Count: 0 })
+        {
+            SectionRegistry.ListSections(allApiSections);
+            return 0;
+        }
+
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
         string? tempDir = null;

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -16,6 +16,21 @@ public class AssemblyCommand
 {
     public static async Task<int> ExecuteAsync(string? assemblyPath, AssemblyOptions options)
     {
+        // Validate section filters
+        options = options with
+        {
+            IncludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.ExcludeSections, out var excludeError),
+        };
+        if (includeError || excludeError) return 1;
+
+        // Bare -s: list available sections and exit
+        if (options.IncludeSections is { Count: 0 })
+        {
+            SectionRegistry.ListSections(SectionRegistry.LibrarySections);
+            return 0;
+        }
+
         // Check for valid input source
         if (string.IsNullOrEmpty(assemblyPath) &&
             string.IsNullOrEmpty(options.PackagePath) &&
@@ -25,14 +40,6 @@ public class AssemblyCommand
             Console.Error.WriteLine("Run 'dotnet-inspect library --help' for usage.");
             return 1;
         }
-
-        // Validate section filters
-        options = options with
-        {
-            IncludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.IncludeSections, out var includeError),
-            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.ExcludeSections, out var excludeError),
-        };
-        if (includeError || excludeError) return 1;
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -19,13 +19,18 @@ public class PackageCommand
     public const string Name = "package";
     public static async Task<int> ExecuteAsync(string[] packageArgs, InspectionOptions options, string? explicitVersion = null)
     {
-        // Handle --discover mode: list sections and exit early
-        if (options.Discover)
+        // Validate section filters
+        options = options with
         {
-            foreach (var name in SectionRegistry.PackageCommandSections)
-            {
-                Console.WriteLine(name);
-            }
+            IncludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.ExcludeSections, out var excludeError),
+        };
+        if (includeError || excludeError) return 1;
+
+        // Bare -s: list available sections and exit
+        if (options.IncludeSections is { Count: 0 })
+        {
+            SectionRegistry.ListSections(SectionRegistry.PackageCommandSections);
             return 0;
         }
 
@@ -35,14 +40,6 @@ public class PackageCommand
             Console.Error.WriteLine("Run 'dotnet-inspect package --help' for usage.");
             return 1;
         }
-
-        // Validate section filters
-        options = options with
-        {
-            IncludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.IncludeSections, out var includeError),
-            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.PackageCommandSections, options.ExcludeSections, out var excludeError),
-        };
-        if (includeError || excludeError) return 1;
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;

--- a/src/dotnet-inspect/OptionParsers.cs
+++ b/src/dotnet-inspect/OptionParsers.cs
@@ -63,6 +63,18 @@ public static class OptionParsers
     }
 
     /// <summary>
+    /// Parses -s option, distinguishing "not specified" (null) from bare "-s" (empty set).
+    /// </summary>
+    public static HashSet<string>? ParseIncludeSections(ParseResult parseResult, Option<string?> option)
+    {
+        var sections = ParseSectionList(parseResult.GetValue(option));
+        // Bare -s with no value: return empty set (signals "list sections")
+        if (sections == null && parseResult.GetResult(option) != null)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return sections;
+    }
+
+    /// <summary>
     /// Creates NuGetSourceOptions from parsed command line values.
     /// </summary>
     public static NuGetSourceOptions ParseNuGetSourceOptions(

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -73,11 +73,6 @@ public record InspectionOptions
     public bool JsonOutput { get; init; }
 
     /// <summary>
-    /// Discover available sections and exit.
-    /// </summary>
-    public bool Discover { get; init; }
-
-    /// <summary>
     /// Show progress messages on stderr.
     /// </summary>
     public bool Verbose { get; init; }

--- a/src/dotnet-inspect/Views/SectionRegistry.cs
+++ b/src/dotnet-inspect/Views/SectionRegistry.cs
@@ -63,6 +63,15 @@ public static class SectionRegistry
     ];
 
     /// <summary>
+    /// Prints available section names to stdout.
+    /// </summary>
+    public static void ListSections(string[] knownSections)
+    {
+        foreach (var section in knownSections)
+            Console.WriteLine(section);
+    }
+
+    /// <summary>
     /// Resolves user-supplied section names against known sections.
     /// Supports case-insensitive matching and trailing <c>*</c> wildcards.
     /// </summary>

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -260,7 +260,7 @@ Type: Library | TFM: net10.0 | Updated: 2026-01-13 | Vulnerabilities: 1
 
 Section filtering:
 ```bash
-dotnet-inspect package --discover                            # List available section names
+dotnet-inspect package -s                                     # List available section names
 dotnet-inspect System.Text.Json -v:d -x:Statistics,Files     # Exclude sections by name
 dotnet-inspect System.Text.Json -v:d -s:Metadata             # Include only named sections
 ```


### PR DESCRIPTION
## Changes

Bare `-s` (with no value) now lists available sections for the current command, replacing the package-only `--discover` flag with a unified pattern across all commands.

### Before
- `dotnet-inspect package --discover` listed sections (package only)
- `dotnet-inspect library -s` showed header + Library Info (broken)

### After
```
$ dotnet-inspect library -s
Library Info
Symbols
Source Coverage
...

$ dotnet-inspect package -s
Package
Statistics
Package Dependencies
...

$ dotnet-inspect api -s
Classes
Structs
Interfaces
...
```

### Implementation
- `SectionRegistry.ListSections()` prints section names to stdout
- `ParseIncludeSections()` helper consistently detects bare `-s` across all commands
- Section validation runs before input source validation so `-s` works without arguments
- Removed `--discover` option and `Discover` property from `InspectionOptions`
- Updated llms.txt and docs

### Testing
- 289 tests pass
- Verified bare `-s` on all three commands