### PR TITLE
Auto-promote to detailed verbosity when -s targets specific sections

### DIFF
--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -31,6 +31,10 @@ public class AssemblyCommand
             return 0;
         }
 
+        // -s targeting specific sections: promote to detailed so data is collected
+        if (options.IncludeSections is { Count: > 0 })
+            options = options with { Verbosity = Verbosity.Detailed };
+
         // Check for valid input source
         if (string.IsNullOrEmpty(assemblyPath) &&
             string.IsNullOrEmpty(options.PackagePath) &&


### PR DESCRIPTION
Fixes the issue where `-s Cust*` shows nothing because data collection only runs at detailed verbosity.

When `-s` selects specific sections, verbosity is auto-promoted to Detailed so all section data is collected. This is a simple stopgap until the full section service with per-section verbosity tiers.

```
# Before: empty output
dotnet-inspect library Microsoft.Extensions.AI.OpenAI -s Cust*

# After: works without -v:d
dotnet-inspect library Microsoft.Extensions.AI.OpenAI -s Cust*
## Custom Attributes
| Name | Target | Value |
| Extension | Assembly | |
| UnverifiableCode | Module | |
```

289 tests pass.