### PR TITLE
Make cli quiet output symmetric for filtered commands

### DIFF
--- a/src/dotnet-inspect/Commands/CliSchemaCommand.cs
+++ b/src/dotnet-inspect/Commands/CliSchemaCommand.cs
@@ -24,14 +24,33 @@ public class CliSchemaCommand
                 return 1;
             }
             commands = [match];
-            // Single command always shows full detail
-            verbosity = Verbosity.Detailed;
+            // Default to full detail unless quiet was explicitly requested
+            if (verbosity != Verbosity.Quiet)
+                verbosity = Verbosity.Detailed;
         }
 
-        // Quiet: command names only, space-separated
+        // Quiet: single command shows description + flags, all commands shows space-separated names
         if (verbosity == Verbosity.Quiet)
         {
-            Console.WriteLine(string.Join(" ", commands.Select(c => c.Name)));
+            if (!string.IsNullOrEmpty(commandFilter))
+            {
+                var cmd = commands[0];
+                var label = cmd.Name;
+                if (!string.IsNullOrEmpty(cmd.Description))
+                    label += $"  {cmd.Description}";
+                Console.WriteLine(label);
+
+                var flags = cmd.Options
+                    .Where(o => !o.Hidden && o is not HelpOption)
+                    .Select(o => o.Name)
+                    .ToList();
+                if (flags.Count > 0)
+                    Console.WriteLine(string.Join(" ", flags));
+            }
+            else
+            {
+                Console.WriteLine(string.Join(" ", commands.Select(c => c.Name)));
+            }
             return 0;
         }
 


### PR DESCRIPTION
## Summary

`cli -v:q` and `cli <command> -v:q` now have symmetric compact output styles.

## Before

```
$ dotnet-inspect cli -v:q
api cache cli diff extensions find implements library llmstxt package platform samples skill

$ dotnet-inspect cli api -v:q
# dotnet-inspect 0.2.0
...
└─ api  Extract public API surface
   ├─ <args>  Package and type name...
   ├─ --package <package>  Extract from package...
   ...                                            (36 lines)
```

## After

```
$ dotnet-inspect cli -v:q
api cache cli diff extensions find implements library llmstxt package platform samples skill

$ dotnet-inspect cli api -v:q
api  Extract public API surface
--package --library --platform --framework --tfm --all -t -m --ctor -n --docs ...
```

## Changes

Single file: `CliSchemaCommand.cs`
- Respect `-v:q` when a command filter is provided (was always forcing detailed)
- Filtered quiet mode shows command description on line 1, flags on line 2
- Unfiltered quiet mode unchanged (space-separated command names)
- Default verbosity for filtered commands remains detailed (full tree)

## Testing

289 tests pass.