### PR TITLE
Add ISectionDescriptor<T> and SectionPipeline<T> for library command

### DIFF
--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1,0 +1,237 @@
+using DotnetInspector.Metadata;
+using DotnetInspector.Models;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+public class SectionPipelineTests
+{
+    // Simple test model
+    private record TestModel(string? Name, int Count);
+
+    // Test descriptors
+    private sealed class AlwaysSection : ISectionDescriptor<TestModel>
+    {
+        public static string Name => "Always";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static bool CanRender(TestModel model) => true;
+    }
+
+    private sealed class DetailedSection : ISectionDescriptor<TestModel>
+    {
+        public static string Name => "Detailed";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(TestModel model) => model.Count > 0;
+    }
+
+    private sealed class NormalSection : ISectionDescriptor<TestModel>
+    {
+        public static string Name => "Normal";
+        public static Verbosity MinVerbosity => Verbosity.Normal;
+        public static bool CanRender(TestModel model) => model.Name != null;
+    }
+
+    private static SectionPipeline<TestModel> CreateTestPipeline() =>
+        new SectionPipeline<TestModel>()
+            .Add<AlwaysSection>()
+            .Add<NormalSection>()
+            .Add<DetailedSection>();
+
+    [Fact]
+    public void AllSectionNames_ReturnsRegisteredNames()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var names = pipeline.AllSectionNames;
+
+        Assert.Equal(["Always", "Normal", "Detailed"], names);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_MinimalVerbosity_ReturnsOnlyMinimalSections()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Equal(["Always"], effective);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_NormalVerbosity_ReturnsMinimalAndNormal()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Normal);
+
+        Assert.Equal(["Always", "Normal"], effective);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_DetailedVerbosity_ReturnsAll()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Equal(["Always", "Normal", "Detailed"], effective);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_CanRenderFalse_ExcludesSection()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel(null, 0); // NormalSection and DetailedSection CanRender = false
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Equal(["Always"], effective);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_IncludeOverridesVerbosity()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+        var include = new HashSet<string> { "Detailed" };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal, include);
+
+        Assert.Equal(["Detailed"], effective);
+    }
+
+    [Fact]
+    public void GetEffectiveSections_ExcludeRemovesSection()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+        var exclude = new HashSet<string> { "Always" };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed, exclude: exclude);
+
+        Assert.Equal(["Normal", "Detailed"], effective);
+    }
+
+    [Fact]
+    public void ComputeIncludeSections_AllEffective_ReturnsNull()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+
+        var result = pipeline.ComputeIncludeSections(model, Verbosity.Detailed);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ComputeIncludeSections_SubsetEffective_ReturnsHashSet()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+
+        var result = pipeline.ComputeIncludeSections(model, Verbosity.Minimal);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Always", result);
+    }
+
+    [Fact]
+    public void ComputeIncludeSections_WithIncludeFilter_ReturnsOnlyMatching()
+    {
+        var pipeline = CreateTestPipeline();
+        var model = new TestModel("test", 5);
+        var include = new HashSet<string> { "Detailed" };
+
+        var result = pipeline.ComputeIncludeSections(model, Verbosity.Minimal, include);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("Detailed", result);
+    }
+
+    [Fact]
+    public void GetRequiredVerbosity_NullInclude_ReturnsQuiet()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity(null);
+
+        Assert.Equal(Verbosity.Quiet, verbosity);
+    }
+
+    [Fact]
+    public void GetRequiredVerbosity_EmptyInclude_ReturnsQuiet()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity([]);
+
+        Assert.Equal(Verbosity.Quiet, verbosity);
+    }
+
+    [Fact]
+    public void GetRequiredVerbosity_MinimalSection_ReturnsMinimal()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity(new HashSet<string> { "Always" });
+
+        Assert.Equal(Verbosity.Minimal, verbosity);
+    }
+
+    [Fact]
+    public void GetRequiredVerbosity_DetailedSection_ReturnsDetailed()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity(new HashSet<string> { "Detailed" });
+
+        Assert.Equal(Verbosity.Detailed, verbosity);
+    }
+
+    [Fact]
+    public void GetRequiredVerbosity_MixedSections_ReturnsHighest()
+    {
+        var pipeline = CreateTestPipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity(new HashSet<string> { "Always", "Detailed" });
+
+        Assert.Equal(Verbosity.Detailed, verbosity);
+    }
+
+    // ===== Library pipeline integration tests =====
+
+    [Fact]
+    public void LibraryPipeline_HasExpectedSectionCount()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+
+        Assert.Equal(14, pipeline.AllSectionNames.Length);
+    }
+
+    [Fact]
+    public void LibraryPipeline_LibraryInfoIsMinimal()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection { AssemblyInfo = new AssemblyInfo() };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Contains("Library Info", effective);
+    }
+
+    [Fact]
+    public void LibraryPipeline_CustomAttributesRequiresDetailed()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+
+        var verbosity = pipeline.GetRequiredVerbosity(new HashSet<string> { "Custom Attributes" });
+
+        Assert.Equal(Verbosity.Detailed, verbosity);
+    }
+}

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 
@@ -16,24 +17,27 @@ public class AssemblyCommand
 {
     public static async Task<int> ExecuteAsync(string? assemblyPath, AssemblyOptions options)
     {
+        var pipeline = LibrarySections.CreatePipeline();
+
         // Validate section filters
         options = options with
         {
-            IncludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.IncludeSections, out var includeError),
-            ExcludeSections = SectionRegistry.Resolve(SectionRegistry.LibrarySections, options.ExcludeSections, out var excludeError),
+            IncludeSections = SectionRegistry.Resolve(pipeline.AllSectionNames, options.IncludeSections, out var includeError),
+            ExcludeSections = SectionRegistry.Resolve(pipeline.AllSectionNames, options.ExcludeSections, out var excludeError),
         };
         if (includeError || excludeError) return 1;
 
         // Bare -s: list available sections and exit
         if (options.IncludeSections is { Count: 0 })
         {
-            SectionRegistry.ListSections(SectionRegistry.LibrarySections);
+            SectionRegistry.ListSections(pipeline.AllSectionNames);
             return 0;
         }
 
-        // -s targeting specific sections: promote to detailed so data is collected
-        if (options.IncludeSections is { Count: > 0 })
-            options = options with { Verbosity = Verbosity.Detailed };
+        // -s targeting specific sections: promote verbosity to ensure data collection
+        var requiredVerbosity = pipeline.GetRequiredVerbosity(options.IncludeSections);
+        if (requiredVerbosity > options.Verbosity)
+            options = options with { Verbosity = requiredVerbosity };
 
         // Check for valid input source
         if (string.IsNullOrEmpty(assemblyPath) &&
@@ -83,7 +87,7 @@ public class AssemblyCommand
                     return 1;
                 }
 
-                OutputFormatter.WriteLibraryResult(inspection, options);
+                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 ExtractResourcesIfRequested(resolvedPath!, options, logger);
                 return 0;
             }
@@ -119,9 +123,9 @@ public class AssemblyCommand
                 }
 
                 if (inspections.Count == 1)
-                    OutputFormatter.WriteLibraryResult(inspections[0], options);
+                    OutputFormatter.WriteLibraryResult(inspections[0], options, pipeline);
                 else
-                    OutputFormatter.WriteLibraryResults(inspections, options);
+                    OutputFormatter.WriteLibraryResults(inspections, options, pipeline);
 
                 if (assemblyPaths.Count > 0)
                     ExtractResourcesIfRequested(assemblyPaths[0], options, logger);
@@ -144,7 +148,7 @@ public class AssemblyCommand
                     return 1;
                 }
 
-                OutputFormatter.WriteLibraryResult(inspection, options);
+                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 ExtractResourcesIfRequested(assemblyPath!, options, logger);
                 return 0;
             }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Models;
 using DotnetInspector.Views;
 using System.Text.Json;
 using DotnetInspector.Options;
+using DotnetInspector.Sections;
 using Markout;
 
 namespace DotnetInspector.Output;
@@ -58,7 +59,8 @@ public static class OutputFormatter
         };
     }
 
-    public static void WriteLibraryResult(LibraryInspection inspection, AssemblyOptions options)
+    public static void WriteLibraryResult(LibraryInspection inspection, AssemblyOptions options,
+        SectionPipeline<LibraryInspection>? pipeline = null)
     {
         if (inspection.UseDependenciesView)
         {
@@ -74,16 +76,23 @@ public static class OutputFormatter
         else
         {
             var auditView = new LibraryInspectionView(inspection);
-            var context = new MarkoutContext(new MarkoutWriterOptions
-            {
-                IncludeSections = options.IncludeSections,
-                ExcludeSections = GetLibraryExcludeSections(options)
-            });
+            var includeSections = pipeline?.ComputeIncludeSections(
+                inspection, options.Verbosity, options.IncludeSections, options.ExcludeSections);
+
+            var writerOptions = pipeline != null
+                ? new MarkoutWriterOptions { IncludeSections = includeSections }
+                : new MarkoutWriterOptions
+                {
+                    IncludeSections = options.IncludeSections,
+                    ExcludeSections = GetLibraryExcludeSections(options)
+                };
+            var context = new MarkoutContext(writerOptions);
             Console.WriteLine(context.Serialize(auditView).TrimEnd());
         }
     }
 
-    public static void WriteLibraryResults(List<LibraryInspection> inspections, AssemblyOptions options)
+    public static void WriteLibraryResults(List<LibraryInspection> inspections, AssemblyOptions options,
+        SectionPipeline<LibraryInspection>? pipeline = null)
     {
         if (options.JsonOutput)
         {
@@ -96,11 +105,18 @@ public static class OutputFormatter
                 Title = Path.GetFileNameWithoutExtension(inspections[0].FileName),
                 Assemblies = inspections.Select(a => new LibraryInspectionView(a)).ToList()
             };
-            var context = new MarkoutContext(new MarkoutWriterOptions
-            {
-                IncludeSections = options.IncludeSections,
-                ExcludeSections = GetLibraryExcludeSections(options)
-            });
+            var writerOptions = pipeline != null
+                ? new MarkoutWriterOptions
+                {
+                    IncludeSections = pipeline.ComputeIncludeSections(
+                        inspections[0], options.Verbosity, options.IncludeSections, options.ExcludeSections)
+                }
+                : new MarkoutWriterOptions
+                {
+                    IncludeSections = options.IncludeSections,
+                    ExcludeSections = GetLibraryExcludeSections(options)
+                };
+            var context = new MarkoutContext(writerOptions);
             Console.WriteLine(context.Serialize(report).TrimEnd());
         }
     }

--- a/src/dotnet-inspect/Sections/ISectionDescriptor.cs
+++ b/src/dotnet-inspect/Sections/ISectionDescriptor.cs
@@ -1,0 +1,24 @@
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Metadata descriptor for a named section. Declares the section's name,
+/// minimum verbosity tier, and a static check for whether the model has
+/// data that the section can render.
+/// </summary>
+/// <typeparam name="TModel">The model type this section inspects.</typeparam>
+public interface ISectionDescriptor<TModel>
+{
+    /// <summary>Section display name (must match the MarkoutSection Name).</summary>
+    static abstract string Name { get; }
+
+    /// <summary>Minimum verbosity at which this section is shown by default.</summary>
+    static abstract Verbosity MinVerbosity { get; }
+
+    /// <summary>
+    /// Returns <c>true</c> if the model contains data this section can render.
+    /// Called without allocating a renderer instance.
+    /// </summary>
+    static abstract bool CanRender(TModel model);
+}

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -1,0 +1,146 @@
+using DotnetInspector.Models;
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Section descriptors for the library command.
+/// Each descriptor declares its name, minimum verbosity, and a
+/// <c>CanRender</c> check against <see cref="LibraryInspection"/>.
+/// </summary>
+public static class LibrarySections
+{
+    /// <summary>Builds the section pipeline with all library sections registered.</summary>
+    public static SectionPipeline<LibraryInspection> CreatePipeline()
+    {
+        return new SectionPipeline<LibraryInspection>()
+            .Add<LibraryInfo>()
+            .Add<Symbols>()
+            .Add<SourceCoverage>()
+            .Add<LibraryReferences>()
+            .Add<LibraryReferencesTransitive>()
+            .Add<Dependencies>()
+            .Add<ExtensionMethods>()
+            .Add<UnsafeMethods>()
+            .Add<PInvokeMethods>()
+            .Add<Resources>()
+            .Add<CustomAttributes>()
+            .Add<TypeForwarders>()
+            .Add<NonNormalizedPaths>()
+            .Add<MissingSources>();
+    }
+
+    // ===== Always-on sections (Normal verbosity) =====
+
+    public sealed class LibraryInfo : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Library Info";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static bool CanRender(LibraryInspection model) => model.AssemblyInfo != null;
+    }
+
+    public sealed class Symbols : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Symbols";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => true;
+    }
+
+    // ===== Source-link audit sections =====
+
+    public sealed class SourceCoverage : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Source Coverage";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.TotalSourceFiles > 0;
+    }
+
+    // ===== Reference sections (Normal verbosity) =====
+
+    public sealed class LibraryReferences : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Library References";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static bool CanRender(LibraryInspection model)
+            => model.AssemblyInfo?.References is { Count: > 0 }
+               && model.AssemblyInfo?.TransitiveReferences is not { Count: > 0 };
+    }
+
+    public sealed class LibraryReferencesTransitive : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Library References (Transitive)";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static bool CanRender(LibraryInspection model)
+            => !model.UseDependenciesView
+               && model.AssemblyInfo?.TransitiveReferences is { Count: > 0 };
+    }
+
+    public sealed class Dependencies : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Dependencies";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static bool CanRender(LibraryInspection model)
+            => model.UseDependenciesView
+               && model.AssemblyInfo?.TransitiveReferences is { Count: > 0 };
+    }
+
+    // ===== Detailed sections =====
+
+    public sealed class ExtensionMethods : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Extension Methods";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.ExtensionMethods is { Count: > 0 };
+    }
+
+    public sealed class UnsafeMethods : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Unsafe Methods";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.UnsafeMethods is { Count: > 0 };
+    }
+
+    public sealed class PInvokeMethods : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "P/Invoke Methods";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.PInvokeMethods is { Count: > 0 };
+    }
+
+    public sealed class Resources : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Resources";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.Resources is { Count: > 0 };
+    }
+
+    public sealed class CustomAttributes : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Custom Attributes";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.CustomAttributes is { Count: > 0 };
+    }
+
+    public sealed class TypeForwarders : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Type Forwarders";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.TypeForwarders is { Count: > 0 };
+    }
+
+    // ===== Source-link audit detail sections =====
+
+    public sealed class NonNormalizedPaths : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Non-normalized Paths";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.NonNormalizedPaths is { Count: > 0 };
+    }
+
+    public sealed class MissingSources : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Missing Sources";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static bool CanRender(LibraryInspection model) => model.MissingSourceFiles is { Count: > 0 };
+    }
+}

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -1,0 +1,110 @@
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Non-generic descriptor for storage in collections.
+/// Created from <see cref="ISectionDescriptor{TModel}"/> implementations.
+/// </summary>
+public sealed class SectionEntry<TModel>
+{
+    public required string Name { get; init; }
+    public required Verbosity MinVerbosity { get; init; }
+    public required Func<TModel, bool> CanRender { get; init; }
+}
+
+/// <summary>
+/// Pipeline that computes the effective set of sections to render
+/// based on registered descriptors, verbosity, and <c>-s</c>/<c>-x</c> filters.
+/// </summary>
+public sealed class SectionPipeline<TModel>
+{
+    private readonly List<SectionEntry<TModel>> _entries = [];
+
+    /// <summary>
+    /// Registers a section descriptor. The descriptor type is never instantiated —
+    /// only its static members are accessed.
+    /// </summary>
+    public SectionPipeline<TModel> Add<TDescriptor>() where TDescriptor : ISectionDescriptor<TModel>
+    {
+        _entries.Add(new SectionEntry<TModel>
+        {
+            Name = TDescriptor.Name,
+            MinVerbosity = TDescriptor.MinVerbosity,
+            CanRender = TDescriptor.CanRender,
+        });
+        return this;
+    }
+
+    /// <summary>All registered section names, in registration order.</summary>
+    public string[] AllSectionNames => _entries.Select(e => e.Name).ToArray();
+
+    /// <summary>
+    /// Returns the names of sections that would produce output for the given model,
+    /// filtered by verbosity and <c>-s</c>/<c>-x</c>.
+    /// </summary>
+    public List<string> GetEffectiveSections(TModel model, Verbosity verbosity,
+        HashSet<string>? include = null, HashSet<string>? exclude = null)
+    {
+        List<string> result = [];
+        foreach (var entry in _entries)
+        {
+            if (!IsRequested(entry, verbosity, include, exclude))
+                continue;
+            if (entry.CanRender(model))
+                result.Add(entry.Name);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Computes the <see cref="HashSet{String}"/> to pass as
+    /// <c>MarkoutWriterOptions.IncludeSections</c>. Returns <c>null</c> when
+    /// all sections should be rendered (no filtering needed).
+    /// </summary>
+    public HashSet<string>? ComputeIncludeSections(TModel model, Verbosity verbosity,
+        HashSet<string>? include = null, HashSet<string>? exclude = null)
+    {
+        var effective = GetEffectiveSections(model, verbosity, include, exclude);
+
+        // If all registered sections are effective, no filter needed
+        if (effective.Count == _entries.Count)
+            return null;
+
+        return [.. effective];
+    }
+
+    /// <summary>
+    /// Returns the minimum verbosity needed to show all sections in the
+    /// <paramref name="include"/> set. Used to auto-promote verbosity when
+    /// <c>-s</c> targets specific sections.
+    /// </summary>
+    public Verbosity GetRequiredVerbosity(HashSet<string>? include)
+    {
+        if (include == null || include.Count == 0)
+            return Verbosity.Quiet;
+
+        var maxVerbosity = Verbosity.Quiet;
+        foreach (var entry in _entries)
+        {
+            if (include.Contains(entry.Name) && entry.MinVerbosity > maxVerbosity)
+                maxVerbosity = entry.MinVerbosity;
+        }
+        return maxVerbosity;
+    }
+
+    private static bool IsRequested(SectionEntry<TModel> entry, Verbosity verbosity,
+        HashSet<string>? include, HashSet<string>? exclude)
+    {
+        // Explicit include overrides verbosity
+        if (include is { Count: > 0 })
+            return include.Contains(entry.Name);
+
+        // Explicit exclude
+        if (exclude?.Contains(entry.Name) == true)
+            return false;
+
+        // Verbosity gate
+        return verbosity >= entry.MinVerbosity;
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a declarative section pipeline architecture that replaces scattered verbosity/exclude logic with centralized section metadata using static abstract interfaces.

## Core Types

- **`ISectionDescriptor<T>`** — static abstract interface with `Name`, `MinVerbosity`, `CanRender`. Zero allocation: all members are static, no renderer instances created.
- **`SectionPipeline<T>`** — computes effective sections based on registered descriptors, verbosity tier, and `-s`/`-x` filters. Methods: `ComputeIncludeSections()`, `GetEffectiveSections()`, `GetRequiredVerbosity()`.
- **`LibrarySections`** — 14 descriptors for all library sections with `CreatePipeline()` factory.

## Verbosity Tiers

| Tier | Sections |
|------|----------|
| Minimal (default) | Library Info, Library References, Dependencies |
| Detailed (`-v:d`) | Symbols, Source Coverage, Extensions, Unsafe, P/Invoke, Resources, Custom Attributes, Type Forwarders, Non-normalized Paths, Missing Sources |

## What the Pipeline Replaces

- Hardcoded `GetLibraryExcludeSections` in OutputFormatter (kept as fallback)
- Manual verbosity auto-promote hack in AssemblyCommand
- `SectionRegistry.LibrarySections` array (`pipeline.AllSectionNames` used instead)

## Output Parity

Output is identical before and after — only internal plumbing changes. The pipeline computes an `IncludeSections` set that Markout's serializer uses for filtering.

## Tests

18 new `SectionPipelineTests` covering:
- Verbosity gating (Minimal/Normal/Detailed)
- `CanRender` filtering
- `-s` include overrides verbosity
- `-x` exclude removes sections
- `GetRequiredVerbosity` for auto-promotion
- Library pipeline integration (section count, tiers)

All 307 tests pass.