### PR TITLE
Fix Library Info not showing at quiet verbosity

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -4,6 +4,7 @@ using DotnetInspector;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Sections;
 using Markout;
 
 namespace DotnetInspector.Tests;
@@ -284,5 +285,85 @@ public class OutputFormatterTests
 
         Assert.DoesNotContain("Source:", output);
         Assert.DoesNotContain("TFM:", output);
+    }
+
+    // ===== Quiet Output Tests =====
+
+    [Fact]
+    public void LibraryQuiet_ThreeLines()
+    {
+        var inspection = CreateTestAudit("Test.dll", "net9.0");
+        var pipeline = LibrarySections.CreatePipeline();
+        var includeSections = pipeline.ComputeIncludeSections(
+            inspection, Verbosity.Quiet);
+        var output = SerializeWithInclude(inspection, includeSections);
+        var lines = output.Split('\n', StringSplitOptions.None);
+
+        Assert.Equal(3, lines.Length);
+        Assert.StartsWith("# ", lines[0]);
+        Assert.Equal("", lines[1]);
+        Assert.Contains("Name: ", lines[2]);
+        Assert.Contains(" | ", lines[2]);
+        Assert.DoesNotContain("## ", output);
+    }
+
+    [Fact]
+    public void PackageQuiet_ThreeLines()
+    {
+        var result = CreateTestPackageResult();
+        var view = new InspectionResultView(result);
+        var context = new MarkoutContext(new MarkoutWriterOptions
+        {
+            ExcludeSections = [PackageSections.Package, PackageSections.Statistics,
+                PackageSections.PackageDependencies, PackageSections.Files,
+                PackageSections.Vulnerabilities, PackageSections.RidPackages,
+                PackageSections.RuntimeDependencies],
+            IncludeDescription = false
+        });
+        var output = context.Serialize(view).TrimEnd();
+        var lines = output.Split('\n', StringSplitOptions.None);
+
+        Assert.Equal(3, lines.Length);
+        Assert.StartsWith("# ", lines[0]);
+        Assert.Equal("", lines[1]);
+        Assert.Contains(" | ", lines[2]);
+        Assert.DoesNotContain("## ", output);
+    }
+
+    [Fact]
+    public void ApiQuiet_ThreeLines()
+    {
+        var api = CreateTestApiSurface();
+        var options = new ApiOptions { Verbosity = Verbosity.Quiet };
+
+        var output = ApiOutputFormatter.RenderFullApiMarkdown(api, options).TrimEnd();
+        var lines = output.Split('\n', StringSplitOptions.None);
+
+        Assert.Equal(3, lines.Length);
+        Assert.StartsWith("# ", lines[0]);
+        Assert.Equal("", lines[1]);
+        Assert.Contains(" | ", lines[2]);
+        Assert.DoesNotContain("## ", output);
+    }
+
+    private static string SerializeWithInclude(LibraryInspection inspection, HashSet<string>? includeSections)
+    {
+        var view = new LibraryInspectionView(inspection);
+        var context = new MarkoutContext(new MarkoutWriterOptions
+        {
+            IncludeSections = includeSections
+        });
+        return context.Serialize(view).TrimEnd();
+    }
+
+    private static InspectionResult CreateTestPackageResult()
+    {
+        return new InspectionResult
+        {
+            PackageName = "TestPackage",
+            Version = "1.0.0",
+            PackageTypes = ["Library"],
+            Published = DateTimeOffset.Parse("2025-01-15"),
+        };
     }
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -215,7 +215,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_LibraryInfoIsMinimal()
+    public void LibraryPipeline_LibraryInfoShowsAtMinimal()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var model = new LibraryInspection { AssemblyInfo = new AssemblyInfo() };
@@ -223,6 +223,17 @@ public class SectionPipelineTests
         var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
 
         Assert.Contains("Library Info", effective);
+    }
+
+    [Fact]
+    public void LibraryPipeline_QuietShowsNoSections()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection { AssemblyInfo = new AssemblyInfo() };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Quiet);
+
+        Assert.Empty(effective);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -111,6 +111,9 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public ApiSurface? ApiSurface => _data.ApiSurface;
 
+    [MarkoutIgnoreInTable]
+    public List<MarkoutField> Summary => GetCompactFields();
+
     [MarkoutPropertyName("Library")]
     public string? AssemblySummary => _data.AssemblyInfo switch
     {
@@ -221,6 +224,25 @@ public class LibraryInspectionView
     [MarkoutMaxItems(10)]
     public List<string>? MissingSourcesSection =>
         _data.MissingSourceFiles?.Select(f => $"`{f}`").ToList();
+
+    private List<MarkoutField> GetCompactFields()
+    {
+        List<MarkoutField> fields = [];
+        if (_data.AssemblyInfo is not { } info) return fields;
+
+        if (!string.IsNullOrEmpty(info.AssemblyName))
+            fields.Add(new("Name", info.AssemblyName));
+        if (!string.IsNullOrEmpty(info.AssemblyVersion))
+            fields.Add(new("Version", info.AssemblyVersion));
+        if (!string.IsNullOrEmpty(info.TargetFramework))
+            fields.Add(new("TFM", info.TargetFramework));
+        if (!string.IsNullOrEmpty(info.Architecture))
+            fields.Add(new("Arch", info.Architecture));
+        if (_data.FileSize > 0)
+            fields.Add(new("Size", FormatFileSize(_data.FileSize)));
+
+        return fields;
+    }
 
     private List<MarkoutField> GetAssemblyInfoFields()
     {


### PR DESCRIPTION
Library Info's `MinVerbosity` was `Minimal`, but `-v:q` maps to `Quiet` which is below `Minimal`. This caused `-v:q` to show only the title heading with no content.

**Fix**: Set Library Info's `MinVerbosity` to `Quiet` so it always renders.

**Before**: `-v:q` showed only `# System.Text.Json.dll (net10.0)`
**After**: `-v:q` shows the title + Library Info table (same as default)

Added `LibraryPipeline_LibraryInfoShowsAtQuiet` test.