### PR TITLE
Fix -s discovery for --platform path

### DIFF
--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -95,6 +95,12 @@ public class AssemblyCommand
                     return 1;
                 }
 
+                if (discoverSections)
+                {
+                    ListEffectiveSections(pipeline, inspection);
+                    return 0;
+                }
+
                 OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 ExtractResourcesIfRequested(resolvedPath!, options, logger);
                 return 0;


### PR DESCRIPTION
The `discoverSections` intercept was missing from the platform assembly code path, causing `--platform ... -s` to render full output instead of listing effective sections.

```
$ dotnet-inspect library --platform System.Collections -s
Library Info
Symbols
Resources
Custom Attributes
Type Forwarders
```