### PR TITLE
Upgrade to xUnit v3

### DIFF
--- a/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
+++ b/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
@@ -8,13 +8,11 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -35,7 +35,7 @@ public class CommandLineTests
         try
         {
             var root = CommandLineBuilder.CreateRootCommand();
-            await root.Parse(["-v:q"]).InvokeAsync();
+            await root.Parse(["-v:q"]).InvokeAsync(null, TestContext.Current.CancellationToken);
             var stderr = errWriter.ToString();
             Assert.DoesNotContain("Tip:", stderr);
         }
@@ -57,7 +57,7 @@ public class CommandLineTests
         try
         {
             var root = CommandLineBuilder.CreateRootCommand();
-            await root.Parse([]).InvokeAsync();
+            await root.Parse([]).InvokeAsync(null, TestContext.Current.CancellationToken);
             var stderr = errWriter.ToString();
             Assert.Contains("Tip:", stderr);
         }

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -9,13 +9,11 @@
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotnetInspector.Metadata.Tests/DotnetInspector.Metadata.Tests.csproj
+++ b/tests/DotnetInspector.Metadata.Tests/DotnetInspector.Metadata.Tests.csproj
@@ -7,13 +7,11 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Upgrade all test projects from xUnit v2 (2.9.3) to xUnit v3 (3.2.2).

## Changes

- Replace `xunit` 2.9.3 with `xunit.v3` 3.2.2 in all 3 test projects
- Remove packages no longer needed with xUnit v3's in-process runner:
  - `Microsoft.NET.Test.Sdk`
  - `xunit.runner.visualstudio`
  - `coverlet.collector`
- Add `<OutputType>Exe</OutputType>` to test projects (xUnit v3 projects are standalone executables)
- Pass `CancellationToken` to `InvokeAsync` calls to satisfy xUnit1051 analyzer

## Testing

All 464 tests pass across all 3 test projects:
- `dotnet-inspect.Tests`: 311 passed
- `DotnetInspector.Services.Tests`: 122 passed
- `DotnetInspector.Metadata.Tests`: 31 passed