### PR TITLE
Redesign tips UI: single header with aligned entries

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -40,7 +40,7 @@ public class CommandLineTests
             var root = CommandLineBuilder.CreateRootCommand();
             await root.Parse(["-v:q"]).InvokeAsync(null, TestContext.Current.CancellationToken);
             var stderr = errWriter.ToString();
-            Assert.DoesNotContain("Tip:", stderr);
+            Assert.DoesNotContain("Tips:", stderr);
         }
         finally
         {
@@ -64,7 +64,7 @@ public class CommandLineTests
             var root = CommandLineBuilder.CreateRootCommand();
             await root.Parse([]).InvokeAsync(null, TestContext.Current.CancellationToken);
             var stderr = errWriter.ToString();
-            Assert.Contains("Tip:", stderr);
+            Assert.Contains("Tips:", stderr);
         }
         finally
         {
@@ -100,7 +100,7 @@ public class CommandLineTests
         try
         {
             Hints.WriteTips(TipLevel.Minimal, new Tip("package", "Foo", "inspect"));
-            Assert.Contains("Tip:", errWriter.ToString());
+            Assert.Contains("Tips:", errWriter.ToString());
         }
         finally
         {

--- a/src/dotnet-inspect/Output/Hints.cs
+++ b/src/dotnet-inspect/Output/Hints.cs
@@ -20,7 +20,8 @@ public static class Hints
         int commentColumn = visible.Max(t => t.CommandText.Length) + 3;
         Console.Out.Flush();
         Console.Error.WriteLine();
+        Console.Error.WriteLine("Tips:");
         foreach (var tip in visible)
-            Console.Error.WriteLine($"Tip: {tip.CommandText.PadRight(commentColumn)}# {tip.Comment}");
+            Console.Error.WriteLine($"{tip.CommandText.PadRight(commentColumn)}# {tip.Comment}");
     }
 }


### PR DESCRIPTION
## Summary

Redesign the tips output format for better readability and copy/paste friendliness.

## Before

```
Tip: package System.Text.Json -v:d    # detailed metadata
Tip: library System.Text.Json         # inspect library
Tip: api --package System.Text.Json   # view public API surface
```

## After

```
Tips:
package System.Text.Json -v:d    # detailed metadata
library System.Text.Json         # inspect library
api --package System.Text.Json   # view public API surface
```

## Changes

- `Hints.WriteTips`: Replace per-line `Tip:` prefix with a single `Tips:` header
- Updated test assertions to match new format