### PR TITLE
Lightweight presence flags for fast -s discovery

### DIFF
--- a/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
@@ -176,4 +176,116 @@ public static class AssemblyDetailScanner
             return null;
         }
     }
+
+    /// <summary>
+    /// Cheap presence flags for section discovery. Single MetadataReader pass,
+    /// short-circuits at first match for each flag.
+    /// </summary>
+    public static PresenceFlags ScanPresenceFlags(PEReader peReader)
+    {
+        var reader = peReader.GetMetadataReader();
+        var flags = new PresenceFlags();
+
+        // Resources: cheapest check — just a count
+        flags.HasManifestResources = reader.GetTableRowCount(TableIndex.ManifestResource) > 0;
+
+        // Type forwarders: iterate ExportedTypes, stop at first forwarder
+        foreach (var handle in reader.ExportedTypes)
+        {
+            if (reader.GetExportedType(handle).IsForwarder)
+            {
+                flags.HasTypeForwarders = true;
+                break;
+            }
+        }
+
+        // Custom attributes: check assembly + module level for non-well-known
+        if (reader.IsAssembly)
+        {
+            foreach (var attrHandle in reader.GetAssemblyDefinition().GetCustomAttributes())
+            {
+                var name = AssemblyInspector.GetAttributeName(reader, reader.GetCustomAttribute(attrHandle));
+                if (name != null && !IsWellKnownMetadataAttribute(name))
+                {
+                    flags.HasAssemblyAttributes = true;
+                    break;
+                }
+            }
+        }
+
+        if (!flags.HasAssemblyAttributes)
+        {
+            foreach (var attrHandle in reader.GetModuleDefinition().GetCustomAttributes())
+            {
+                var name = AssemblyInspector.GetAttributeName(reader, reader.GetCustomAttribute(attrHandle));
+                if (name != null && !IsWellKnownMetadataAttribute(name))
+                {
+                    flags.HasAssemblyAttributes = true;
+                    break;
+                }
+            }
+        }
+
+        // Extension types, P/Invoke, unsafe: iterate TypeDefs once
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            if (flags.HasExtensionTypes && flags.HasPInvokeImports && flags.HasUnsafeCode)
+                break;
+
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+            // Extension types: static class with [Extension] attribute
+            if (!flags.HasExtensionTypes)
+            {
+                var attrs = typeDef.Attributes;
+                bool isStatic = (attrs & TypeAttributes.Sealed) != 0
+                             && (attrs & TypeAttributes.Abstract) != 0;
+                if (isStatic && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes()))
+                    flags.HasExtensionTypes = true;
+            }
+
+            // P/Invoke and unsafe: check methods
+            if (!flags.HasPInvokeImports || !flags.HasUnsafeCode)
+            {
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    if (flags.HasPInvokeImports && flags.HasUnsafeCode)
+                        break;
+
+                    var method = reader.GetMethodDefinition(methodHandle);
+
+                    if (!flags.HasPInvokeImports
+                        && (method.Attributes & MethodAttributes.PinvokeImpl) != 0)
+                        flags.HasPInvokeImports = true;
+
+                    if (!flags.HasUnsafeCode)
+                    {
+                        try
+                        {
+                            var sig = method.DecodeSignature(SignatureDecoder.Instance, null);
+                            if (sig.ReturnType.Contains('*')
+                                || sig.ParameterTypes.Any(p => p.Contains('*')))
+                                flags.HasUnsafeCode = true;
+                        }
+                        catch { }
+                    }
+                }
+            }
+        }
+
+        return flags;
+    }
+}
+
+/// <summary>
+/// Lightweight presence flags populated from a single MetadataReader pass.
+/// </summary>
+public class PresenceFlags
+{
+    public bool HasExtensionTypes { get; set; }
+    public bool HasPInvokeImports { get; set; }
+    public bool HasUnsafeCode { get; set; }
+    public bool HasManifestResources { get; set; }
+    public bool HasAssemblyAttributes { get; set; }
+    public bool HasTypeForwarders { get; set; }
 }

--- a/src/DotnetInspector.Metadata/PdbContext.cs
+++ b/src/DotnetInspector.Metadata/PdbContext.cs
@@ -257,6 +257,12 @@ public class PdbContext : IDisposable
     internal MetadataReader? GetMetadataReader()
         => _peReader.HasMetadata ? _peReader.GetMetadataReader() : null;
 
+    /// <summary>
+    /// Cheap presence flags for section discovery, using the already-open PEReader.
+    /// </summary>
+    public PresenceFlags ScanPresenceFlags()
+        => AssemblyDetailScanner.ScanPresenceFlags(_peReader);
+
     public void Dispose()
     {
         foreach (var d in _disposables)

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -385,4 +385,131 @@ public class SectionPipelineTests
         // (we can't easily inspect the registry, but we can verify it runs)
         Assert.NotEmpty(detailedScanners);
     }
+
+    // ===== Presence flag / CanRender discovery tests =====
+
+    [Fact]
+    public void CanRender_ExtensionMethods_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        // No scanner has run (ExtensionMethods list is null), but flag is set
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasExtensionTypes = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("Extension Methods", effective);
+    }
+
+    [Fact]
+    public void CanRender_ExtensionMethods_FalseWhenNoFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasExtensionTypes = false
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.DoesNotContain("Extension Methods", effective);
+    }
+
+    [Fact]
+    public void CanRender_UnsafeMethods_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasUnsafeCode = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("Unsafe Methods", effective);
+    }
+
+    [Fact]
+    public void CanRender_PInvokeMethods_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasPInvokeImports = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("P/Invoke Methods", effective);
+    }
+
+    [Fact]
+    public void CanRender_Resources_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasManifestResources = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("Resources", effective);
+    }
+
+    [Fact]
+    public void CanRender_CustomAttributes_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasAssemblyAttributes = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("Custom Attributes", effective);
+    }
+
+    [Fact]
+    public void CanRender_TypeForwarders_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasExportedTypeForwarders = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Contains("Type Forwarders", effective);
+    }
+
+    [Fact]
+    public void CanRender_AllFlagsFalse_OnlyAlwaysOnSections()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection { AssemblyInfo = new AssemblyInfo() };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        // Only sections that don't depend on scanners or presence flags
+        Assert.Contains("Library Info", effective);
+        Assert.Contains("Symbols", effective);
+        Assert.DoesNotContain("Extension Methods", effective);
+        Assert.DoesNotContain("Unsafe Methods", effective);
+        Assert.DoesNotContain("P/Invoke Methods", effective);
+        Assert.DoesNotContain("Resources", effective);
+        Assert.DoesNotContain("Custom Attributes", effective);
+        Assert.DoesNotContain("Type Forwarders", effective);
+    }
 }

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -38,10 +38,10 @@ public class AssemblyCommand
             return 0;
         }
 
-        // Bare -s with input: promote to Detailed to collect all data for discovery
+        // Bare -s with input: discover which sections have data.
+        // Presence flags are populated cheaply during initial metadata load,
+        // so we don't need to promote verbosity or run scanners.
         bool discoverSections = options.IncludeSections is { Count: 0 };
-        if (discoverSections)
-            options = options with { Verbosity = Verbosity.Detailed };
 
         // -s targeting specific sections: promote verbosity to ensure data collection
         var requiredVerbosity = pipeline.GetRequiredVerbosity(options.IncludeSections);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -66,6 +66,15 @@ internal static class LibraryMetadataService
 
             inspection.AssemblyInfo = pdbContext.ExtractAssemblyInfo(options.IncludeReferences || options.IncludeDependencies);
 
+            // Populate cheap presence flags for fast -s discovery
+            var presenceFlags = pdbContext.ScanPresenceFlags();
+            inspection.HasExtensionTypes = presenceFlags.HasExtensionTypes;
+            inspection.HasPInvokeImports = presenceFlags.HasPInvokeImports;
+            inspection.HasUnsafeCode = presenceFlags.HasUnsafeCode;
+            inspection.HasManifestResources = presenceFlags.HasManifestResources;
+            inspection.HasAssemblyAttributes = presenceFlags.HasAssemblyAttributes;
+            inspection.HasExportedTypeForwarders = presenceFlags.HasTypeForwarders;
+
             // PE debug directory fields
             inspection.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
             inspection.HasEmbeddedPdb = pdbContext.HasEmbeddedPdb;

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -166,6 +166,33 @@ public class LibraryInspection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<TypeForwarderSummary>? TypeForwarders { get; set; }
 
+    // Presence flags — populated cheaply from MetadataReader before scanners run.
+    // Used by CanRender for fast -s discovery without full scanning.
+
+    /// <summary>Whether the assembly contains any static classes with [Extension] attribute.</summary>
+    [JsonIgnore]
+    public bool HasExtensionTypes { get; set; }
+
+    /// <summary>Whether the assembly contains any methods with PInvokeImpl flag.</summary>
+    [JsonIgnore]
+    public bool HasPInvokeImports { get; set; }
+
+    /// <summary>Whether the assembly contains any methods with unsafe (pointer) signatures.</summary>
+    [JsonIgnore]
+    public bool HasUnsafeCode { get; set; }
+
+    /// <summary>Whether the assembly has manifest resources.</summary>
+    [JsonIgnore]
+    public bool HasManifestResources { get; set; }
+
+    /// <summary>Whether the assembly has non-well-known custom attributes.</summary>
+    [JsonIgnore]
+    public bool HasAssemblyAttributes { get; set; }
+
+    /// <summary>Whether the assembly has type forwarders.</summary>
+    [JsonIgnore]
+    public bool HasExportedTypeForwarders { get; set; }
+
     /// <summary>
     /// View routing flag: when true, show nested dependency tree instead of flat references.
     /// </summary>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -124,7 +124,8 @@ public static class LibrarySections
         public static string Name => "Extension Methods";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerExtensionMethods;
-        public static bool CanRender(LibraryInspection model) => model.ExtensionMethods is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.ExtensionMethods is { Count: > 0 } || model.HasExtensionTypes;
     }
 
     public sealed class UnsafeMethods : ISectionDescriptor<LibraryInspection>
@@ -132,7 +133,8 @@ public static class LibrarySections
         public static string Name => "Unsafe Methods";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerClassifiedMethods;
-        public static bool CanRender(LibraryInspection model) => model.UnsafeMethods is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.UnsafeMethods is { Count: > 0 } || model.HasUnsafeCode;
     }
 
     public sealed class PInvokeMethods : ISectionDescriptor<LibraryInspection>
@@ -140,7 +142,8 @@ public static class LibrarySections
         public static string Name => "P/Invoke Methods";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerClassifiedMethods;
-        public static bool CanRender(LibraryInspection model) => model.PInvokeMethods is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.PInvokeMethods is { Count: > 0 } || model.HasPInvokeImports;
     }
 
     public sealed class Resources : ISectionDescriptor<LibraryInspection>
@@ -148,7 +151,8 @@ public static class LibrarySections
         public static string Name => "Resources";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerResources;
-        public static bool CanRender(LibraryInspection model) => model.Resources is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.Resources is { Count: > 0 } || model.HasManifestResources;
     }
 
     public sealed class CustomAttributes : ISectionDescriptor<LibraryInspection>
@@ -156,7 +160,8 @@ public static class LibrarySections
         public static string Name => "Custom Attributes";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerCustomAttributes;
-        public static bool CanRender(LibraryInspection model) => model.CustomAttributes is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.CustomAttributes is { Count: > 0 } || model.HasAssemblyAttributes;
     }
 
     public sealed class TypeForwarders : ISectionDescriptor<LibraryInspection>
@@ -164,7 +169,8 @@ public static class LibrarySections
         public static string Name => "Type Forwarders";
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => ScannerTypeForwarders;
-        public static bool CanRender(LibraryInspection model) => model.TypeForwarders is { Count: > 0 };
+        public static bool CanRender(LibraryInspection model)
+            => model.TypeForwarders is { Count: > 0 } || model.HasExportedTypeForwarders;
     }
 
     // ===== Source-link audit detail sections =====


### PR DESCRIPTION
## Summary

Adds cheap boolean presence flags populated during initial MetadataReader extraction, enabling `-s` discovery to skip full scanner execution entirely.

## Changes

**New: `PresenceFlags` + `ScanPresenceFlags()`** in `AssemblyDetailScanner`
- Single MetadataReader pass with short-circuit logic for each flag
- Checks: extension types, P/Invoke, unsafe code, manifest resources, custom attributes, type forwarders

**Updated: `LibraryInspection` model**
- 6 new `[JsonIgnore]` boolean properties for presence flags
- Populated during `InspectAsync` before scanners run

**Updated: `CanRender` in `LibrarySections`**
- Checks presence flag OR populated collection: `model.ExtensionMethods is { Count: > 0 } || model.HasExtensionTypes`
- Works for both discovery (flags only) and full render (collection populated)

**Updated: `AssemblyCommand` discovery path**
- Bare `-s` with input no longer promotes to Detailed verbosity
- No scanners run — discovery uses only presence flags

## Performance

Before: `-s` discovery promoted to Detailed, ran ALL scanners (extension methods, classified methods, resources, custom attributes, type forwarders, audit, sourcelink audit)

After: `-s` discovery runs at default verbosity with zero scanner execution. Only the cheap MetadataReader pass runs.

## Tests

8 new tests verify presence flag-based CanRender for all 6 section types plus negative cases. All 329 tests pass.