### PR TITLE
Disable tips for --files and --layout modes

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector;
+using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 
@@ -654,5 +655,50 @@ public class CommandLineTests
         var result = CommandLineBuilder.CreateRootCommand().Parse(["api", "Command", "--package", "System.CommandLine", "--interfaces", "--hierarchy"]);
 
         Assert.Empty(result.Errors);
+    }
+
+    [Theory]
+    [InlineData(false, false, null, false)]  // --files
+    [InlineData(false, false, null, true)]   // --layout
+    [InlineData(true, false, null, false)]   // --files --lib
+    [InlineData(true, false, null, true)]    // --layout --lib
+    [InlineData(false, true, null, false)]   // --files --tools
+    [InlineData(false, true, null, true)]    // --layout --tools
+    [InlineData(false, false, "net8.0", false)] // --files --tfm net8.0
+    [InlineData(false, false, "net8.0", true)]  // --layout --tfm net8.0
+    public void WriteFileLayoutTips_NeverWritesTips(bool scopeLib, bool scopeTools, string? tfm, bool isLayout)
+    {
+        var originalErr = Console.Error;
+        var originalTips = Environment.GetEnvironmentVariable("DOTNET_INSPECT_TIPS");
+        var errWriter = new System.IO.StringWriter();
+        Console.SetError(errWriter);
+        Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", null);
+        try
+        {
+            var options = new InspectionOptions
+            {
+                ScopeLib = scopeLib,
+                ScopeTools = scopeTools,
+                Tfm = tfm,
+                TipLevel = TipLevel.Detailed,
+            };
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(Path.Combine(tempDir, "lib"));
+            Directory.CreateDirectory(Path.Combine(tempDir, "tools"));
+            try
+            {
+                PackageCommand.WriteFileLayoutTips(tempDir, options, "TestPackage", TipLevel.Detailed, isLayout);
+                Assert.DoesNotContain("Tips:", errWriter.ToString());
+            }
+            finally
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", originalTips);
+            Console.SetError(originalErr);
+        }
     }
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -392,23 +392,9 @@ public class PackageCommand
         WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: false);
     }
 
-    private static void WriteFileLayoutTips(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel, bool isLayout)
+    internal static void WriteFileLayoutTips(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel, bool isLayout)
     {
-        if (options.ScopeLib || options.ScopeTools || !string.IsNullOrEmpty(options.Tfm)) return;
-
-        List<Tip> tips = [];
-        var flag = isLayout ? "--layout" : "--files";
-        var otherFlag = isLayout ? "--files" : "--layout";
-        var otherDesc = isLayout ? "flat file list" : "file tree";
-
-        tips.Add(new(PackageCommand.Name, $"{packageName} {otherFlag}", otherDesc));
-
-        if (Directory.Exists(Path.Combine(extractPath, "lib")))
-            tips.Add(new(PackageCommand.Name, $"{packageName} {flag} --lib", "lib/ folder only"));
-        if (Directory.Exists(Path.Combine(extractPath, "tools")))
-            tips.Add(new(PackageCommand.Name, $"{packageName} {flag} --tools", "tools/ folder only"));
-
-        Hints.WriteTips(tipLevel, [.. tips]);
+        // Tips are not shown for --files / --layout modes
     }
 
     private static (string path, string? error) ResolveScopedPath(string extractPath, InspectionOptions options)


### PR DESCRIPTION
## Summary

Tips were shown for bare `--files`/`--layout` but suppressed when combined with `--lib`, `--tools`, or `--tfm`. This was inconsistent — tips should never appear for file listing modes.

## Changes

- **PackageCommand.cs**: Clear `WriteFileLayoutTips` body so it never emits tips; change visibility to `internal` for testability
- **CommandLineTests.cs**: Add 8 test cases (Theory) covering all flag combinations (`--files`/`--layout` × `--lib`/`--tools`/`--tfm`/bare)