### PR TITLE
Add section pipeline for api command

### DIFF
--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -729,4 +729,213 @@ public class SectionPipelineTests
 
         Assert.Null(include);
     }
+
+    // ===== API type-list pipeline tests =====
+
+    [Fact]
+    public void ApiTypePipeline_HasExpectedSectionCount()
+    {
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        Assert.Equal(5, pipeline.AllSectionNames.Length);
+    }
+
+    [Fact]
+    public void ApiTypePipeline_SectionNamesMatchExpected()
+    {
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var names = pipeline.AllSectionNames;
+
+        Assert.Contains("Classes", names);
+        Assert.Contains("Structs", names);
+        Assert.Contains("Interfaces", names);
+        Assert.Contains("Enums", names);
+        Assert.Contains("Delegates", names);
+    }
+
+    [Fact]
+    public void ApiTypePipeline_ShowsClassesWhenPresent()
+    {
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var model = new ApiSurface { Types = [new ApiType { Name = "Foo", Kind = "class" }] };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Contains("Classes", effective);
+        Assert.DoesNotContain("Structs", effective);
+    }
+
+    [Fact]
+    public void ApiTypePipeline_EmptyTypes_NoSections()
+    {
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var model = new ApiSurface { Types = [] };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.Empty(effective);
+    }
+
+    [Fact]
+    public void ApiTypePipeline_AllKindsPresent()
+    {
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var model = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { Name = "C", Kind = "class" },
+                new ApiType { Name = "S", Kind = "struct" },
+                new ApiType { Name = "I", Kind = "interface" },
+                new ApiType { Name = "E", Kind = "enum" },
+                new ApiType { Name = "D", Kind = "delegate" },
+            ]
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Equal(5, effective.Count);
+    }
+
+    // ===== API member pipeline tests =====
+
+    [Fact]
+    public void ApiMemberPipeline_HasExpectedSectionCount()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        Assert.Equal(10, pipeline.AllSectionNames.Length);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_SectionNamesMatchExpected()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var names = pipeline.AllSectionNames;
+
+        Assert.Contains("Values", names);
+        Assert.Contains("Type Parameters", names);
+        Assert.Contains("Interfaces", names);
+        Assert.Contains("Baseclass", names);
+        Assert.Contains("Sources", names);
+        Assert.Contains("Constructors", names);
+        Assert.Contains("Fields", names);
+        Assert.Contains("Properties", names);
+        Assert.Contains("Methods", names);
+        Assert.Contains("Events", names);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_EnumValues_RequiresNormalVerbosity()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "Color", Kind = "enum",
+            Members = [new ApiMember { Name = "Red", Kind = "field", EnumValue = 0 }]
+        };
+
+        var atMinimal = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+        var atNormal = pipeline.GetEffectiveSections(model, Verbosity.Normal);
+
+        Assert.DoesNotContain("Values", atMinimal);
+        Assert.Contains("Values", atNormal);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_TypeParameters_RequiresNormalVerbosity()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "List", Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "T" }]
+        };
+
+        var atMinimal = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+        var atNormal = pipeline.GetEffectiveSections(model, Verbosity.Normal);
+
+        Assert.DoesNotContain("Type Parameters", atMinimal);
+        Assert.Contains("Type Parameters", atNormal);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_Interfaces_RequiresDetailedVerbosity()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "Foo", Kind = "class",
+            Interfaces = ["IDisposable"]
+        };
+
+        var atNormal = pipeline.GetEffectiveSections(model, Verbosity.Normal);
+        var atDetailed = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+
+        Assert.DoesNotContain("Interfaces", atNormal);
+        Assert.Contains("Interfaces", atDetailed);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_Baseclass_RequiresDetailedAndNonTrivial()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+
+        // Trivial base (System.Object) should not render
+        var trivialModel = new ApiType { Name = "Foo", Kind = "class", BaseType = "System.Object" };
+        var trivialEffective = pipeline.GetEffectiveSections(trivialModel, Verbosity.Detailed);
+        Assert.DoesNotContain("Baseclass", trivialEffective);
+
+        // Real base should render at Detailed
+        var realModel = new ApiType { Name = "Foo", Kind = "class", BaseType = "MyBase" };
+        var realEffective = pipeline.GetEffectiveSections(realModel, Verbosity.Detailed);
+        Assert.Contains("Baseclass", realEffective);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_MemberSections_AtMinimal()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "Foo", Kind = "class",
+            Members =
+            [
+                new ApiMember { Name = ".ctor", Kind = "constructor" },
+                new ApiMember { Name = "Count", Kind = "property" },
+                new ApiMember { Name = "GetValue", Kind = "method" },
+            ]
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Contains("Constructors", effective);
+        Assert.Contains("Properties", effective);
+        Assert.Contains("Methods", effective);
+        Assert.DoesNotContain("Fields", effective);
+        Assert.DoesNotContain("Events", effective);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_VerbosityAutoPromote_ForInterfaces()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+
+        var required = pipeline.GetRequiredVerbosity(new HashSet<string> { "Interfaces" });
+
+        Assert.Equal(Verbosity.Detailed, required);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_Sources_AtMinimal()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "Foo", Kind = "class",
+            SourceFilePath = "src/Foo.cs"
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Minimal);
+
+        Assert.Contains("Sources", effective);
+    }
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -5,6 +5,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 
@@ -27,7 +28,9 @@ public class ApiCommand
         }
 
         // Validate section filters against all known api sections
-        var allApiSections = SectionRegistry.ApiTypeSections.Concat(SectionRegistry.ApiMemberSections).Distinct().ToArray();
+        var typePipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var memberPipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var allApiSections = typePipeline.AllSectionNames.Concat(memberPipeline.AllSectionNames).Distinct().ToArray();
         options = options with
         {
             IncludeSections = SectionRegistry.Resolve(allApiSections, options.IncludeSections, out var includeError),
@@ -40,6 +43,16 @@ public class ApiCommand
         {
             SectionRegistry.ListSections(allApiSections);
             return 0;
+        }
+
+        // Auto-promote verbosity when -s targets specific sections
+        if (options.IncludeSections is { Count: > 0 })
+        {
+            var typeVerbosity = typePipeline.GetRequiredVerbosity(options.IncludeSections);
+            var memberVerbosity = memberPipeline.GetRequiredVerbosity(options.IncludeSections);
+            var requiredVerbosity = typeVerbosity > memberVerbosity ? typeVerbosity : memberVerbosity;
+            if (requiredVerbosity > options.Verbosity)
+                options = options with { Verbosity = requiredVerbosity };
         }
 
         var context = new CommandContext(options.Verbose);

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2,6 +2,7 @@ using System.Text;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
@@ -27,11 +28,15 @@ public static class ApiOutputFormatter
             api.Types = api.Types.Take(options.Limit.Value).ToList();
         }
 
+        // Compute effective sections via pipeline
+        var pipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var includeSections = pipeline.ComputeIncludeSections(
+            api, options.Verbosity, options.IncludeSections, options.ExcludeSections);
+
         // Single writer with section filtering
         var writerOptions = new MarkoutWriterOptions
         {
-            IncludeSections = options.IncludeSections,
-            ExcludeSections = options.ExcludeSections,
+            IncludeSections = includeSections,
             IncludeDescription = options.Verbosity != Verbosity.Quiet
         };
         var writer = new MarkoutWriter(writerOptions);
@@ -91,11 +96,15 @@ public static class ApiOutputFormatter
         if (type.Kind == "enum" && options.Verbosity >= Verbosity.Normal)
             PopulateEnumValues(view, type, options);
 
+        // Compute effective sections via pipeline
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var includeSections = pipeline.ComputeIncludeSections(
+            type, options.Verbosity, options.IncludeSections, options.ExcludeSections);
+
         // Single writer with section filtering via MarkoutWriterOptions
         var writerOptions = new MarkoutWriterOptions
         {
-            IncludeSections = options.IncludeSections,
-            ExcludeSections = options.ExcludeSections,
+            IncludeSections = includeSections,
             IncludeDescription = options.Verbosity != Verbosity.Quiet
         };
         var writer = new MarkoutWriter(writerOptions);

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -1,0 +1,188 @@
+using DotnetInspector.Metadata;
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Section descriptors for the api command type-list view (all types in an assembly).
+/// Sections correspond to type-kind groupings: Classes, Structs, Interfaces, Enums, Delegates.
+/// </summary>
+public static class ApiTypeSectionDescriptors
+{
+    /// <summary>Builds the section pipeline for the type-list view.</summary>
+    public static SectionPipeline<ApiSurface> CreatePipeline()
+    {
+        return new SectionPipeline<ApiSurface>()
+            .Add<Classes>()
+            .Add<Structs>()
+            .Add<Interfaces>()
+            .Add<Enums>()
+            .Add<Delegates>();
+    }
+
+    public sealed class Classes : ISectionDescriptor<ApiSurface>
+    {
+        public static string Name => "Classes";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiSurface model)
+            => model.Types.Any(t => t.Kind == "class");
+    }
+
+    public sealed class Structs : ISectionDescriptor<ApiSurface>
+    {
+        public static string Name => "Structs";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiSurface model)
+            => model.Types.Any(t => t.Kind == "struct");
+    }
+
+    public sealed class Interfaces : ISectionDescriptor<ApiSurface>
+    {
+        public static string Name => "Interfaces";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiSurface model)
+            => model.Types.Any(t => t.Kind == "interface");
+    }
+
+    public sealed class Enums : ISectionDescriptor<ApiSurface>
+    {
+        public static string Name => "Enums";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiSurface model)
+            => model.Types.Any(t => t.Kind == "enum");
+    }
+
+    public sealed class Delegates : ISectionDescriptor<ApiSurface>
+    {
+        public static string Name => "Delegates";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiSurface model)
+            => model.Types.Any(t => t.Kind == "delegate");
+    }
+}
+
+/// <summary>
+/// Section descriptors for the api command type-detail view (single type with members).
+/// Sections correspond to <see cref="Views.ApiTypeView"/> sections and member-kind groupings.
+/// </summary>
+public static class ApiMemberSectionDescriptors
+{
+    /// <summary>Builds the section pipeline for the type-detail view.</summary>
+    public static SectionPipeline<ApiType> CreatePipeline()
+    {
+        return new SectionPipeline<ApiType>()
+            .Add<Values>()
+            .Add<TypeParameters>()
+            .Add<TypeInterfaces>()
+            .Add<Baseclass>()
+            .Add<Sources>()
+            .Add<Constructors>()
+            .Add<Fields>()
+            .Add<Properties>()
+            .Add<Methods>()
+            .Add<Events>();
+    }
+
+    // ===== Declarative sections (rendered via Markout [MarkoutSection]) =====
+
+    public sealed class Values : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Values";
+        public static Verbosity MinVerbosity => Verbosity.Normal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Kind == "enum"
+               && model.Members?.Any(m => m.Kind == "field" && m.EnumValue.HasValue) == true;
+    }
+
+    public sealed class TypeParameters : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Type Parameters";
+        public static Verbosity MinVerbosity => Verbosity.Normal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.TypeParameters is { Count: > 0 };
+    }
+
+    public sealed class TypeInterfaces : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Interfaces";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Interfaces is { Count: > 0 };
+    }
+
+    public sealed class Baseclass : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Baseclass";
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => !string.IsNullOrEmpty(model.BaseType)
+               && model.BaseType != "System.Object"
+               && model.BaseType != "System.ValueType"
+               && model.BaseType != "System.Enum";
+    }
+
+    public sealed class Sources : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Sources";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.SourceFilePath != null;
+    }
+
+    // ===== Imperative sections (rendered via RenderMembersPerKind) =====
+
+    public sealed class Constructors : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Constructors";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members?.Any(m => m.Kind == "constructor") == true;
+    }
+
+    public sealed class Fields : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Fields";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members?.Any(m => m.Kind == "field" && !m.EnumValue.HasValue) == true;
+    }
+
+    public sealed class Properties : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Properties";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members?.Any(m => m.Kind == "property") == true;
+    }
+
+    public sealed class Methods : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Methods";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members?.Any(m => m.Kind == "method") == true;
+    }
+
+    public sealed class Events : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Events";
+        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members?.Any(m => m.Kind == "event") == true;
+    }
+}


### PR DESCRIPTION
## Summary

Completes the section pipeline migration across all three commands (library ✅, package ✅, api ✅). The api command has two distinct modes with separate pipelines.

## Two Pipelines

**`ApiTypeSectionDescriptors`** — type-list view (all types in assembly):

| Section | Min Verbosity | CanRender |
|---------|--------------|-----------|
| Classes | Minimal | Has class types |
| Structs | Minimal | Has struct types |
| Interfaces | Minimal | Has interface types |
| Enums | Minimal | Has enum types |
| Delegates | Minimal | Has delegate types |

**`ApiMemberSectionDescriptors`** — type-detail view (single type):

| Section | Min Verbosity | CanRender |
|---------|--------------|-----------|
| Values | Normal | Enum with enum values |
| Type Parameters | Normal | Has type parameters |
| Interfaces | Detailed | Has implemented interfaces |
| Baseclass | Detailed | Has non-trivial base type |
| Sources | Minimal | Has SourceLink data |
| Constructors | Minimal | Has constructor members |
| Fields | Minimal | Has field members |
| Properties | Minimal | Has property members |
| Methods | Minimal | Has method members |
| Events | Minimal | Has event members |

## Changes

- **`ApiSectionDescriptors.cs`**: 15 descriptor classes across two pipeline factories
- **`ApiCommand.cs`**: Section names from pipeline, verbosity auto-promotion for `-s`
- **`ApiOutputFormatter.cs`**: `ComputeIncludeSections` replaces raw include/exclude pass-through
- **22 new tests** for both pipelines

## Pipeline Migration Complete

All three commands now use the declarative `SectionPipeline<T>` + `ISectionDescriptor<T>` pattern:
- `library`: `SectionPipeline<LibraryInspection>` (14 sections + scanner registry)
- `package`: `SectionPipeline<InspectionResult>` (7 sections)
- `api`: `SectionPipeline<ApiSurface>` + `SectionPipeline<ApiType>` (5 + 10 sections)