### PR TITLE
Add IsRawOutput for systematic tip suppression

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -306,7 +306,7 @@ public static class CommandLineBuilder
             var exitCode = await DiffCommand.ExecuteAsync(options);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
-            var tipLevel = verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
             if (exitCode == 0)
@@ -546,10 +546,10 @@ public static class CommandLineBuilder
             var exitCode = await FindCommand.ExecuteAsync(pattern!, options);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
-            var tipLevel = options.JsonOutput || verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
-            if (exitCode == 0 && !options.OneLine && !options.NameOnly)
+            if (exitCode == 0 && !options.IsRawOutput)
             {
                 var pkg = options.Packages.Length > 0 ? options.Packages[0] : null;
                 var sourceFlag = pkg != null ? $"--package {pkg}" : "--platform <library>";
@@ -920,9 +920,6 @@ public static class CommandLineBuilder
             var explicitVersion = parseResult.GetValue(versionOption);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
-            var jsonOutput = parseResult.GetValue(jsonOption);
-            var tipLevel = jsonOutput || verbosity == Verbosity.Quiet
-                ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
             var options = new InspectionOptions
             {
@@ -938,19 +935,21 @@ public static class CommandLineBuilder
                 ShowReadme = parseResult.GetValue(readmeOption),
                 OutputPath = parseResult.GetValue(outOption),
                 Limit = parseResult.GetValue(limitOption),
-                JsonOutput = jsonOutput,
+                JsonOutput = parseResult.GetValue(jsonOption),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = verbosity,
-                TipLevel = tipLevel,
                 IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
+            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
+                ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
+            options = options with { TipLevel = tipLevel };
+
             var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options, explicitVersion);
 
-            if (exitCode == 0 && packageArgs.Length > 0
-                && !options.ListVersions && !options.ListFiles && !options.ListLayout && !options.ListTfms && !options.ShowReadme)
+            if (exitCode == 0 && packageArgs.Length > 0 && !options.IsRawOutput)
             {
                 var pkg = packageArgs[0];
                 if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
@@ -1236,9 +1235,13 @@ public static class CommandLineBuilder
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption)),
-                TipLevel = parseResult.GetValue(verbosityOption)?.TrimStart(':').StartsWith("q", StringComparison.OrdinalIgnoreCase) == true
-                    ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
+            };
+
+            options = options with
+            {
+                TipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet
+                    ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
             };
 
             return await ApiCommand.ExecuteAsync(typeName, options);

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -260,4 +260,9 @@ public record DiffOptions
     public bool Breaking { get; init; }
     public bool Additive { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => Stat || NameOnly;
 }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -39,4 +39,9 @@ public record ApiOptions
     public HashSet<string>? ExcludeSections { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput || SignaturesOnly || ShapeOutput;
 }

--- a/src/dotnet-inspect/Options/AssemblyOptions.cs
+++ b/src/dotnet-inspect/Options/AssemblyOptions.cs
@@ -98,4 +98,9 @@ public record AssemblyOptions
     {
         IncludeSourcelinkAudit = true
     };
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput || ExtractResources != null;
 }

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -90,4 +90,9 @@ public record ExtensionsOptions : IAssemblySourceOptions
         Assemblies.Length > 0 ||
         PlatformAssemblies.Length > 0 ||
         PlatformFrameworks.Length > 0;
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput;
 }

--- a/src/dotnet-inspect/Options/FindOptions.cs
+++ b/src/dotnet-inspect/Options/FindOptions.cs
@@ -97,4 +97,9 @@ public record FindOptions : IAssemblySourceOptions
         PlatformFrameworks.Length > 0 ||
         Projects.Length > 0 ||
         BinPaths.Length > 0;
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput || OneLine || NameOnly;
 }

--- a/src/dotnet-inspect/Options/ImplementsOptions.cs
+++ b/src/dotnet-inspect/Options/ImplementsOptions.cs
@@ -75,4 +75,9 @@ public record ImplementsOptions : IAssemblySourceOptions
         Assemblies.Length > 0 ||
         PlatformAssemblies.Length > 0 ||
         PlatformFrameworks.Length > 0;
+
+    /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput;
 }

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -108,6 +108,11 @@ public record InspectionOptions
     public static InspectionOptions Default => new();
 
     /// <summary>
+    /// True when output is raw text (not rendered markdown). Tips should be suppressed.
+    /// </summary>
+    public bool IsRawOutput => JsonOutput || ListLayout || ListFiles || ListTfms || ListVersions || ShowReadme || ShowDependencies;
+
+    /// <summary>
     /// All inspection features enabled.
     /// </summary>
     public static InspectionOptions All => new();


### PR DESCRIPTION
## Problem


## Solution

Each options record now exposes a computed `IsRawOutput` property:

| Options | Raw when |
|---------|----------|
| `InspectionOptions` | JSON, --files, --layout, --tfms, --versions, --readme, --deps |
| `ApiOptions` | JSON, --signatures, --shape |
| `FindOptions` | JSON, --one-line, --name-only |
| `AssemblyOptions` | JSON, --extract-resources |
| `DiffOptions` | --stat, --name-only |
| `ExtensionsOptions` | JSON |
| `ImplementsOptions` | JSON |

`CommandLineBuilder` now uses `options.IsRawOutput` uniformly:
- `tipLevel` computation: `options.IsRawOutput || verbosity == Quiet → Quiet`

## Benefits

- **Self-maintaining**: Adding a new raw-text flag only requires updating the one `IsRawOutput` property
- **No missed cases**: diff --stat and --name-only now correctly suppress tips
- **Consistent pattern**: Same guard across all commands