### PR TITLE
Parse don't validate: non-nullable collections

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -16,7 +16,7 @@ public class DocComment
     /// <summary>
     /// Sample code references extracted from doc comments.
     /// </summary>
-    public List<SampleReference>? Samples { get; set; }
+    public List<SampleReference> Samples { get; set; } = [];
 }
 
 /// <summary>
@@ -180,19 +180,19 @@ public class ApiType
     public bool IsStatic { get; set; }
 
     public string? BaseType { get; set; }
-    public List<string>? Interfaces { get; set; }
+    public List<string> Interfaces { get; set; } = [];
 
     /// <summary>
     /// Known derived types within the same assembly.
     /// </summary>
-    public List<string>? DerivedTypes { get; set; }
+    public List<string> DerivedTypes { get; set; } = [];
 
     /// <summary>
     /// Generic type parameters with their constraints.
     /// </summary>
-    public List<TypeParameter>? TypeParameters { get; set; }
+    public List<TypeParameter> TypeParameters { get; set; } = [];
 
-    public List<ApiMember>? Members { get; set; }
+    public List<ApiMember> Members { get; set; } = [];
 
     // Source information (populated with --source-url)
     public string? SourceFilePath { get; set; }
@@ -211,12 +211,12 @@ public class ApiType
     /// <summary>
     /// Additional source files for partial types. Only populated when type spans multiple files.
     /// </summary>
-    public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
+    public List<PartialSourceFileInfo> AdditionalSourceFiles { get; set; } = [];
 
     /// <summary>
     /// Indicates whether this type is defined across multiple partial files.
     /// </summary>
-    public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
+    public bool IsPartialType => AdditionalSourceFiles.Count > 0;
 
     /// <summary>
     /// Full name of the type (Namespace.Name, or just Name if no namespace).
@@ -224,7 +224,7 @@ public class ApiType
     public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
 
     // Documentation (populated with --docs)
-    public DocComment? Documentation { get; set; }
+    public DocComment Documentation { get; set; } = new();
 }
 
 public class ApiMember
@@ -258,5 +258,5 @@ public class ApiMember
     public int? SourceLineNumber { get; set; }
 
     // Documentation (populated with --docs)
-    public DocComment? Documentation { get; set; }
+    public DocComment Documentation { get; set; } = new();
 }

--- a/src/DotnetInspector.Metadata/SourceLinkResolver.cs
+++ b/src/DotnetInspector.Metadata/SourceLinkResolver.cs
@@ -36,12 +36,12 @@ public class SourceLinkResolver
         /// Additional source files for partial types (e.g., JObject.Async.cs alongside JObject.cs).
         /// Only populated when type has multiple source files.
         /// </summary>
-        public List<PartialSourceFile>? AdditionalSourceFiles { get; init; }
+        public List<PartialSourceFile> AdditionalSourceFiles { get; init; } = [];
 
         /// <summary>
         /// Indicates whether this type is defined across multiple partial files.
         /// </summary>
-        public bool IsPartialType => AdditionalSourceFiles?.Count > 0;
+        public bool IsPartialType => AdditionalSourceFiles.Count > 0;
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ public class SourceLinkResolver
         var primaryFile = SelectPrimarySourceFile(allSourceFiles.Values.ToList(), typeName);
 
         // Build additional source files list (excluding primary)
-        List<PartialSourceFile>? additionalFiles = null;
+        List<PartialSourceFile> additionalFiles = [];
         if (allSourceFiles.Count > 1)
         {
             additionalFiles = allSourceFiles.Values

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -22,7 +22,7 @@ public class ApiSurfaceExtractorTests
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
         Assert.NotNull(testType);
 
-        var method = testType.Members?.FirstOrDefault(m => m.Name == "MethodWithParameters");
+        var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithParameters");
         Assert.NotNull(method);
 
         // Verify parameter names are included, not just types
@@ -42,7 +42,7 @@ public class ApiSurfaceExtractorTests
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
         Assert.NotNull(testType);
 
-        var method = testType.Members?.FirstOrDefault(m => m.Name == "MethodWithNoParameters");
+        var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithNoParameters");
         Assert.NotNull(method);
 
         Assert.Contains("()", method.Signature);
@@ -60,7 +60,7 @@ public class ApiSurfaceExtractorTests
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
         Assert.NotNull(testType);
 
-        var method = testType.Members?.FirstOrDefault(m => m.Name == "GenericMethod");
+        var method = testType.Members.FirstOrDefault(m => m.Name == "GenericMethod");
         Assert.NotNull(method);
 
         // Should have both the generic type and parameter name
@@ -235,7 +235,7 @@ public class ApiSurfaceExtractorTests
 
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
         Assert.NotNull(testType);
-        Assert.Null(testType.TypeParameters);
+        Assert.Empty(testType.TypeParameters);
     }
 
     [Fact]
@@ -338,7 +338,7 @@ public class ApiSurfaceExtractorTests
 
         ApiSurfaceExtractor.PopulateDerivedTypes(surface, leafType);
 
-        Assert.Null(leafType.DerivedTypes);
+        Assert.Empty(leafType.DerivedTypes);
     }
 }
 

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -26,7 +26,7 @@ public class ExtensionsCommandTests
         Assert.True(extClass.IsStatic);
 
         // Find extension methods
-        var extMethod = extClass.Members?.FirstOrDefault(m => m.Name == "ToUpperCase" && m.IsExtension);
+        var extMethod = extClass.Members.FirstOrDefault(m => m.Name == "ToUpperCase" && m.IsExtension);
         Assert.NotNull(extMethod);
         Assert.True(extMethod.IsExtension);
         Assert.NotNull(extMethod.ExtendedType);
@@ -46,7 +46,7 @@ public class ExtensionsCommandTests
         Assert.NotNull(extClass);
 
         // Find generic extension method
-        var extMethod = extClass.Members?.FirstOrDefault(m => m.Name == "FirstOrNull");
+        var extMethod = extClass.Members.FirstOrDefault(m => m.Name == "FirstOrNull");
         Assert.NotNull(extMethod);
         Assert.True(extMethod.IsExtension);
         Assert.Contains("IEnumerable", extMethod.ExtendedType);
@@ -65,7 +65,7 @@ public class ExtensionsCommandTests
         Assert.NotNull(extClass);
 
         // Regular static method (not an extension)
-        var staticMethod = extClass.Members?.FirstOrDefault(m => m.Name == "RegularStaticMethod");
+        var staticMethod = extClass.Members.FirstOrDefault(m => m.Name == "RegularStaticMethod");
         Assert.NotNull(staticMethod);
         Assert.False(staticMethod.IsExtension);
         Assert.Null(staticMethod.ExtendedType);
@@ -84,7 +84,7 @@ public class ExtensionsCommandTests
         var normalClass = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
         Assert.NotNull(normalClass);
         
-        var anyExtensions = normalClass.Members?.Any(m => m.IsExtension) ?? false;
+        var anyExtensions = normalClass.Members.Any(m => m.IsExtension);
         Assert.False(anyExtensions);
     }
 

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -274,7 +274,7 @@ public static class CommandLineBuilder
             var typeFilterValues = parseResult.GetValue(typeFilterOption);
 
             // Merge positional type name with -t filter
-            HashSet<string>? typeFilter = null;
+            HashSet<string> typeFilter = [];
             if (typeFilterValues?.Length > 0 || !string.IsNullOrEmpty(typeName))
             {
                 typeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1198,7 +1198,7 @@ public static class CommandLineBuilder
             var allMembers = members.Concat(positionalMembers).ToArray();
             var ctorOnly = parseResult.GetValue(ctorOption);
 
-            HashSet<string>? memberFilter = null;
+            HashSet<string> memberFilter = [];
             if (ctorOnly)
             {
                 memberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".ctor" };

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -20,7 +20,7 @@ public class ApiCommand
     public const string Name = "api";
     public static async Task<int> ExecuteAsync(string? typeName, ApiOptions options)
     {
-        if (options.MemberFilter?.Count > 0 && string.IsNullOrEmpty(typeName))
+        if (options.MemberFilter.Count > 0 && string.IsNullOrEmpty(typeName))
         {
             Console.Error.WriteLine("Error: --member requires a type argument.");
             Console.Error.WriteLine("Usage: dotnet-inspect api <type> --package <pkg> --member <name>");
@@ -247,7 +247,7 @@ public class ApiCommand
                     var apiType = api.Types.First(t => t.FullName == lookupResult.Match);
 
                     // Check each member filter before producing output
-                    if (options.MemberFilter?.Count > 0 && apiType.Members != null)
+                    if (options.MemberFilter.Count > 0)
                     {
                         var memberNames = apiType.Members.Select(m => m.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
                         List<string> missedFilters = [];
@@ -373,10 +373,10 @@ public class ApiCommand
         {
             api.Types = api.Types.Where(t => !string.IsNullOrEmpty(t.SourceUrl)).ToList();
             api.PublicTypeCount = api.Types.Count;
-            api.PublicMethodCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind is "method" or "constructor") ?? 0);
-            api.PublicPropertyCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "property") ?? 0);
-            api.PublicFieldCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "field") ?? 0);
-            api.PublicEventCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "event") ?? 0);
+            api.PublicMethodCount = api.Types.Sum(t => t.Members.Count(m => m.Kind is "method" or "constructor"));
+            api.PublicPropertyCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "property"));
+            api.PublicFieldCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "field"));
+            api.PublicEventCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "event"));
         }
 
         // Apply unsafe filter
@@ -384,15 +384,14 @@ public class ApiCommand
         {
             foreach (var type in api.Types)
             {
-                if (type.Members != null)
-                    type.Members = type.Members.Where(m => m.IsUnsafe).ToList();
+                type.Members = type.Members.Where(m => m.IsUnsafe).ToList();
             }
-            api.Types = api.Types.Where(t => t.Members?.Count > 0).ToList();
+            api.Types = api.Types.Where(t => t.Members.Count > 0).ToList();
             api.PublicTypeCount = api.Types.Count;
-            api.PublicMethodCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind is "method" or "constructor") ?? 0);
-            api.PublicPropertyCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "property") ?? 0);
-            api.PublicFieldCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "field") ?? 0);
-            api.PublicEventCount = api.Types.Sum(t => t.Members?.Count(m => m.Kind == "event") ?? 0);
+            api.PublicMethodCount = api.Types.Sum(t => t.Members.Count(m => m.Kind is "method" or "constructor"));
+            api.PublicPropertyCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "property"));
+            api.PublicFieldCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "field"));
+            api.PublicEventCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "event"));
         }
 
         if (options.JsonOutput)
@@ -428,13 +427,13 @@ public class ApiCommand
         var outputType = type;
         var members = type.Members;
 
-        if (options.MemberFilter?.Count > 0 && members != null)
+        if (options.MemberFilter.Count > 0)
             members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, options.MemberFilter)).ToList();
 
-        if (options.UnsafeOnly && members != null)
+        if (options.UnsafeOnly)
             members = members.Where(m => m.IsUnsafe).ToList();
 
-        if (options.Limit.HasValue && members != null && members.Count > options.Limit.Value)
+        if (options.Limit.HasValue && members.Count > options.Limit.Value)
             members = members.Take(options.Limit.Value).ToList();
 
         if (members != type.Members)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -204,7 +204,7 @@ public class DiffCommand
         var typeDiffs = diff.TypeDiffs;
 
         // Apply type filter post-Compare
-        if (options.TypeFilter?.Count > 0)
+        if (options.TypeFilter.Count > 0)
         {
             typeDiffs = typeDiffs
                 .Where(td => TypeMatcher.MatchesAnyTypeFilter(td.TypeFullName, options.TypeFilter))
@@ -254,7 +254,7 @@ public record DiffOptions
     public string? Tfm { get; init; }
     public bool IncludeAll { get; init; }
     public bool Verbose { get; init; }
-    public HashSet<string>? TypeFilter { get; init; }
+    public HashSet<string> TypeFilter { get; init; } = [];
     public bool Stat { get; init; }
     public bool NameOnly { get; init; }
     public bool Breaking { get; init; }

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -69,7 +69,7 @@ public class SamplesCommand
             return 1;
         }
 
-        if (apiType.Documentation?.Samples == null || apiType.Documentation.Samples.Count == 0)
+        if (apiType.Documentation.Samples.Count == 0)
         {
             Console.Error.WriteLine($"No samples found for type '{typeName}'.");
             return 0;
@@ -118,12 +118,9 @@ public class SamplesCommand
         List<TypedSample> allSamples = [];
         foreach (var type in api.Types)
         {
-            if (type.Documentation?.Samples != null)
+            foreach (var sample in type.Documentation.Samples)
             {
-                foreach (var sample in type.Documentation.Samples)
-                {
-                    allSamples.Add(new TypedSample(type.Name, type.Namespace, sample));
-                }
+                allSamples.Add(new TypedSample(type.Name, type.Namespace, sample));
             }
         }
 
@@ -133,7 +130,7 @@ public class SamplesCommand
             return 0;
         }
 
-        logger.Log($"Found {allSamples.Count} samples across {api.Types.Count(t => t.Documentation?.Samples?.Count > 0)} types");
+        logger.Log($"Found {allSamples.Count} samples across {api.Types.Count(t => t.Documentation.Samples.Count > 0)} types");
 
         return await ProcessSamplesAsync(allSamples, options, packageName, packageVersion, api.Name, logger, httpClient);
     }

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -309,10 +309,10 @@ internal static class ApiServices
                     if (forwardedTypeNames.Contains(type.FullName))
                     {
                         api.Types.Add(type);
-                        api.PublicMethodCount += type.Members?.Count(m => m.Kind == "method" || m.Kind == "constructor") ?? 0;
-                        api.PublicPropertyCount += type.Members?.Count(m => m.Kind == "property") ?? 0;
-                        api.PublicEventCount += type.Members?.Count(m => m.Kind == "event") ?? 0;
-                        api.PublicFieldCount += type.Members?.Count(m => m.Kind == "field") ?? 0;
+                        api.PublicMethodCount += type.Members.Count(m => m.Kind == "method" || m.Kind == "constructor");
+                        api.PublicPropertyCount += type.Members.Count(m => m.Kind == "property");
+                        api.PublicEventCount += type.Members.Count(m => m.Kind == "event");
+                        api.PublicFieldCount += type.Members.Count(m => m.Kind == "field");
                     }
                 }
             }

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -119,7 +119,7 @@ internal static class SourceEnricher
                 apiType.SourceLineNumber = sourceInfo.LineNumber;
                 apiType.SourceResolution = sourceInfo.ResolutionMethod.ToString();
 
-                if (sourceInfo.AdditionalSourceFiles?.Count > 0)
+                if (sourceInfo.AdditionalSourceFiles.Count > 0)
                 {
                     apiType.AdditionalSourceFiles = sourceInfo.AdditionalSourceFiles
                         .Select(f => new PartialSourceFileInfo
@@ -145,14 +145,11 @@ internal static class SourceEnricher
                     (sourceInfo.SourceUrl, sourceInfo.SourceFilePath ?? "")
                 ];
 
-                if (sourceInfo.AdditionalSourceFiles != null)
+                foreach (var additionalFile in sourceInfo.AdditionalSourceFiles)
                 {
-                    foreach (var additionalFile in sourceInfo.AdditionalSourceFiles)
+                    if (additionalFile.SourceUrl != null)
                     {
-                        if (additionalFile.SourceUrl != null)
-                        {
-                            sourceFilesToFetch.Add((additionalFile.SourceUrl, additionalFile.FilePath));
-                        }
+                        sourceFilesToFetch.Add((additionalFile.SourceUrl, additionalFile.FilePath));
                     }
                 }
 
@@ -450,7 +447,7 @@ internal static class SourceEnricher
             logger.Log($"Found type documentation for {apiType.FullName}");
         }
 
-        if (options.ShowDocs && apiType.Members != null)
+        if (options.ShowDocs)
         {
             foreach (var member in apiType.Members)
             {
@@ -528,34 +525,31 @@ internal static class SourceEnricher
                 }
             }
 
-            if (apiType.Members != null)
-            {
-                var membersToDocument = options.MemberFilter?.Count > 0
-                    ? apiType.Members.Where(m => options.MemberFilter.Contains(m.Name))
-                    : apiType.Members;
+            var membersToDocument = options.MemberFilter.Count > 0
+                ? apiType.Members.Where(m => options.MemberFilter.Contains(m.Name))
+                : apiType.Members;
 
-                foreach (var member in membersToDocument)
+            foreach (var member in membersToDocument)
+            {
+                if (member.Documentation.Summary == null)
                 {
-                    if (member.Documentation == null)
+                    var memberDoc = parser.ExtractMemberDocComment(content, apiType.Name, member.Name);
+                    if (memberDoc != null)
                     {
-                        var memberDoc = parser.ExtractMemberDocComment(content, apiType.Name, member.Name);
-                        if (memberDoc != null)
+                        member.Documentation = new DocComment
                         {
-                            member.Documentation = new DocComment
+                            Summary = memberDoc.Summary,
+                            Remarks = memberDoc.Remarks,
+                            Parameters = memberDoc.Parameters,
+                            Returns = memberDoc.Returns,
+                            Samples = memberDoc.Samples?.Select(s => new SampleReference
                             {
-                                Summary = memberDoc.Summary,
-                                Remarks = memberDoc.Remarks,
-                                Parameters = memberDoc.Parameters,
-                                Returns = memberDoc.Returns,
-                                Samples = memberDoc.Samples?.Select(s => new SampleReference
-                                {
-                                    RelativePath = s.RelativePath,
-                                    Description = s.Description,
-                                    Region = s.Region,
-                                    ResolvedUrl = GitHubUrlResolver.ResolveSampleUrl(url, s.RelativePath)
-                                }).ToList()
-                            };
-                        }
+                                RelativePath = s.RelativePath,
+                                Description = s.Description,
+                                Region = s.Region,
+                                ResolvedUrl = GitHubUrlResolver.ResolveSampleUrl(url, s.RelativePath)
+                            }).ToList() ?? []
+                        };
                     }
                 }
             }
@@ -563,7 +557,7 @@ internal static class SourceEnricher
 
         if (mergedTypeDoc != null)
         {
-            mergedTypeDoc.Samples = allSamples.Count > 0 ? allSamples : null;
+            mergedTypeDoc.Samples = allSamples;
             apiType.Documentation = mergedTypeDoc;
         }
     }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -17,7 +17,7 @@ public record ApiOptions
     public bool Verbose { get; init; }
     public int? Limit { get; init; }
     public Verbosity Verbosity { get; init; } = Verbosity.Minimal;
-    public HashSet<string>? MemberFilter { get; init; }
+    public HashSet<string> MemberFilter { get; init; } = [];
     public bool ShowDocs { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -119,7 +119,7 @@ public static class ApiOutputFormatter
         if (view.EnumValues == null && view.EnumValuesWithDocs == null)
         {
             if (options.CtorOnly && options.Verbosity >= Verbosity.Normal &&
-                type.Members?.Any(m => m.Kind == "constructor") == true)
+                type.Members.Any(m => m.Kind == "constructor"))
             {
                 // --ctor emphasis mode
                 var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly);
@@ -145,7 +145,7 @@ public static class ApiOutputFormatter
 
     // ===== Shape Output (--shape) =====
 
-    public static void WriteShapeOutput(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string>? memberFilter)
+    public static void WriteShapeOutput(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string> memberFilter)
     {
         var view = BuildShapeView(type, foundIn, packageName, packageVersion, memberFilter);
         MarkoutSerializer.Serialize(view, Console.Out, TypeViewContext.Default);
@@ -155,13 +155,13 @@ public static class ApiOutputFormatter
 
     public static string RenderSignaturesOnly(ApiType type, ApiOptions options)
     {
-        var members = type.Members?
+        var members = type.Members
             .Where(m => !IsCompilerGenerated(m.Name))
             .OrderBy(m => GetMemberSortOrder(m.Kind))
             .ThenBy(m => m.Name)
-            .ToList() ?? [];
+            .ToList();
 
-        if (options.MemberFilter?.Count > 0)
+        if (options.MemberFilter.Count > 0)
             members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, options.MemberFilter)).ToList();
 
         if (options.UnsafeOnly)
@@ -216,7 +216,7 @@ public static class ApiOutputFormatter
 
         // Type parameters inline (for quiet/minimal only)
         string? typeParamsInline = null;
-        if (type.TypeParameters is { Count: > 0 } &&
+        if (type.TypeParameters.Count > 0 &&
             (options.Verbosity == Verbosity.Quiet || options.Verbosity == Verbosity.Minimal))
         {
             var paramDescriptions = type.TypeParameters
@@ -228,17 +228,17 @@ public static class ApiOutputFormatter
 
         // Description (from docs)
         string? description = null;
-        if (options.ShowDocs && type.Documentation?.Summary != null)
+        if (options.ShowDocs && type.Documentation.Summary != null)
             description = type.Documentation.Summary;
 
         // Samples info (only with --docs/--samples)
         string? samplesInfo = null;
-        if ((options.ShowDocs || options.ShowSamples) && type.Documentation?.Samples?.Count > 0)
+        if ((options.ShowDocs || options.ShowSamples) && type.Documentation.Samples.Count > 0)
             samplesInfo = $"{type.Documentation.Samples.Count} available";
 
         // Type parameters table (Normal+)
         List<TypeParameterRow>? typeParameterRows = null;
-        if (type.TypeParameters is { Count: > 0 } && options.Verbosity >= Verbosity.Normal)
+        if (type.TypeParameters.Count > 0 && options.Verbosity >= Verbosity.Normal)
         {
             typeParameterRows = type.TypeParameters
                 .Select(tp => new TypeParameterRow { Parameter = tp.DisplayName, Constraints = tp.ConstraintsSummary ?? "" })
@@ -247,7 +247,7 @@ public static class ApiOutputFormatter
 
         // Interfaces (Detailed+)
         List<InterfaceRow>? interfaceRows = null;
-        if (type.Interfaces is { Count: > 0 } && options.Verbosity >= Verbosity.Detailed)
+        if (type.Interfaces.Count > 0 && options.Verbosity >= Verbosity.Detailed)
         {
             interfaceRows = type.Interfaces.Order()
                 .Select(i => new InterfaceRow { Interface = i })
@@ -271,16 +271,13 @@ public static class ApiOutputFormatter
                 Url = type.GitHubBrowseUrl
             }];
 
-            if (type.AdditionalSourceFiles != null)
+            foreach (var f in type.AdditionalSourceFiles)
             {
-                foreach (var f in type.AdditionalSourceFiles)
+                sourceRows.Add(new SourceRow
                 {
-                    sourceRows.Add(new SourceRow
-                    {
-                        File = Path.GetFileName(f.FilePath ?? ""),
-                        Url = f.GitHubBrowseUrl
-                    });
-                }
+                    File = Path.GetFileName(f.FilePath ?? ""),
+                    Url = f.GitHubBrowseUrl
+                });
             }
         }
 
@@ -305,7 +302,7 @@ public static class ApiOutputFormatter
         };
     }
 
-    internal static TypeShapeView BuildShapeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string>? memberFilter)
+    internal static TypeShapeView BuildShapeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string> memberFilter)
     {
         List<TreeNode> nodes = [];
 
@@ -316,13 +313,13 @@ public static class ApiOutputFormatter
         }
 
         // Interfaces (always show)
-        if (type.Interfaces is { Count: > 0 })
+        if (type.Interfaces.Count > 0)
         {
             nodes.Add(new TreeNode("Implements", type.Interfaces));
         }
 
         // Type parameters with constraints (always show)
-        if (type.TypeParameters is { Count: > 0 })
+        if (type.TypeParameters.Count > 0)
         {
             var typeParamDescriptions = type.TypeParameters
                 .Select(tp => tp.Constraints.Count > 0
@@ -333,11 +330,11 @@ public static class ApiOutputFormatter
         }
 
         // Group members by kind
-        if (type.Members is { Count: > 0 })
+        if (type.Members.Count > 0)
         {
             var members = type.Members.Where(m => !IsCompilerGenerated(m.Name));
 
-            if (memberFilter?.Count > 0)
+            if (memberFilter.Count > 0)
             {
                 members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, memberFilter));
             }
@@ -403,11 +400,11 @@ public static class ApiOutputFormatter
             {
                 var displayName = FormatGenericTypeName(t.Name, t.TypeParameters);
                 var fullName = string.IsNullOrEmpty(t.Namespace) ? displayName : $"{t.Namespace}.{displayName}";
-                var members = (t.Members?.Count ?? 0).ToString();
+                var members = t.Members.Count.ToString();
 
                 if (showDocs)
                 {
-                    var desc = t.Documentation?.Summary ?? "";
+                    var desc = t.Documentation.Summary ?? "";
                     desc = desc.ReplaceLineEndings(" ");
                     if (desc.Length > 80)
                         desc = desc[..77] + "...";
@@ -423,7 +420,7 @@ public static class ApiOutputFormatter
 
     private static void PopulateEnumValues(ApiTypeView view, ApiType type, ApiOptions options)
     {
-        var enumMembers = (type.Members ?? [])
+        var enumMembers = type.Members
             .Where(m => m.Kind == "field" && m.EnumValue.HasValue && !IsCompilerGenerated(m.Name))
             .OrderBy(m => m.EnumValue)
             .ToList();
@@ -434,13 +431,13 @@ public static class ApiOutputFormatter
         if (options.Limit.HasValue && options.Limit.Value < enumMembers.Count)
             enumMembers = enumMembers.Take(options.Limit.Value).ToList();
 
-        bool hasAnyDocs = options.ShowDocs && enumMembers.Any(m => m.Documentation?.Summary != null);
+        bool hasAnyDocs = options.ShowDocs && enumMembers.Any(m => m.Documentation.Summary != null);
 
         var rows = enumMembers.Select(m => new EnumValueRow
         {
             Name = m.Name,
             Value = m.EnumValue.ToString()!,
-            Description = hasAnyDocs ? (m.Documentation?.Summary ?? "") : null
+            Description = hasAnyDocs ? (m.Documentation.Summary ?? "") : null
         }).ToList();
 
         if (hasAnyDocs)
@@ -475,7 +472,7 @@ public static class ApiOutputFormatter
             .OrderBy(g => GetMemberSortOrder(g.Key))
             .ToList();
 
-        bool hasDocs = options.ShowDocs && allMembers.Any(m => m.Documentation?.Summary != null);
+        bool hasDocs = options.ShowDocs && allMembers.Any(m => m.Documentation.Summary != null);
         var formatter = MemberTableFormatter.Create(options.Verbosity);
 
         foreach (var group in kindGroups)
@@ -526,9 +523,9 @@ public static class ApiOutputFormatter
 
     internal static Dictionary<string, List<ApiMember>> GroupMembersByKind(ApiType type, HashSet<string>? memberFilter = null, bool unsafeOnly = false)
     {
-        var members = type.Members?
+        var members = type.Members
             .Where(m => !IsCompilerGenerated(m.Name))
-            .ToList() ?? [];
+            .ToList();
 
         if (memberFilter?.Count > 0)
             members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, memberFilter)).ToList();

--- a/src/dotnet-inspect/Output/MemberTableFormatter.cs
+++ b/src/dotnet-inspect/Output/MemberTableFormatter.cs
@@ -110,7 +110,7 @@ internal sealed class QuietMemberFormatter : MemberTableFormatter
     }
 
     private static string FirstDocSummary(IGrouping<string, ApiMember> group) =>
-        group.Select(m => m.Documentation?.Summary).FirstOrDefault(s => s != null) ?? "";
+        group.Select(m => m.Documentation.Summary).FirstOrDefault(s => s != null) ?? "";
 }
 
 /// <summary>
@@ -132,7 +132,7 @@ internal sealed class MinimalMemberFormatter : MemberTableFormatter
             {
                 var sig = SignatureParser.AbbreviateSignature(m.Signature ?? m.ReturnType ?? "");
                 return showDocs
-                    ? new[] { m.Name, $"`{sig}`", m.Documentation?.Summary ?? "" }
+                    ? new[] { m.Name, $"`{sig}`", m.Documentation.Summary ?? "" }
                     : new[] { m.Name, $"`{sig}`" };
             });
     }
@@ -157,7 +157,7 @@ internal sealed class DetailedMemberFormatter : MemberTableFormatter
             {
                 var sig = m.Signature ?? m.ReturnType ?? "";
                 return showDocs
-                    ? new[] { m.Name, $"`{sig}`", m.Documentation?.Summary ?? "" }
+                    ? new[] { m.Name, $"`{sig}`", m.Documentation.Summary ?? "" }
                     : new[] { m.Name, $"`{sig}`" };
             });
     }

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -97,7 +97,7 @@ public static class ApiMemberSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Kind == "enum"
-               && model.Members?.Any(m => m.Kind == "field" && m.EnumValue.HasValue) == true;
+               && model.Members.Any(m => m.Kind == "field" && m.EnumValue.HasValue);
     }
 
     public sealed class TypeParameters : ISectionDescriptor<ApiType>
@@ -106,7 +106,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Normal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.TypeParameters is { Count: > 0 };
+            => model.TypeParameters.Count > 0;
     }
 
     public sealed class TypeInterfaces : ISectionDescriptor<ApiType>
@@ -115,7 +115,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Interfaces is { Count: > 0 };
+            => model.Interfaces.Count > 0;
     }
 
     public sealed class Baseclass : ISectionDescriptor<ApiType>
@@ -147,7 +147,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Minimal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members?.Any(m => m.Kind == "constructor") == true;
+            => model.Members.Any(m => m.Kind == "constructor");
     }
 
     public sealed class Fields : ISectionDescriptor<ApiType>
@@ -156,7 +156,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Minimal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members?.Any(m => m.Kind == "field" && !m.EnumValue.HasValue) == true;
+            => model.Members.Any(m => m.Kind == "field" && !m.EnumValue.HasValue);
     }
 
     public sealed class Properties : ISectionDescriptor<ApiType>
@@ -165,7 +165,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Minimal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members?.Any(m => m.Kind == "property") == true;
+            => model.Members.Any(m => m.Kind == "property");
     }
 
     public sealed class Methods : ISectionDescriptor<ApiType>
@@ -174,7 +174,7 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Minimal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members?.Any(m => m.Kind == "method") == true;
+            => model.Members.Any(m => m.Kind == "method");
     }
 
     public sealed class Events : ISectionDescriptor<ApiType>
@@ -183,6 +183,6 @@ public static class ApiMemberSectionDescriptors
         public static Verbosity MinVerbosity => Verbosity.Minimal;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members?.Any(m => m.Kind == "event") == true;
+            => model.Members.Any(m => m.Kind == "event");
     }
 }


### PR DESCRIPTION
## Problem

`ApiType`, `DocComment`, and filter options use nullable collections (`List<T>?`, `HashSet<string>?`) that are always initialized before consumers access them. This leads to ~55 defensive null guards:

- `Members?.Any(m => ...) == true`
- `Members?.Count(m => ...) ?? 0`
- `Documentation?.Summary ?? ""`
- `MemberFilter?.Count > 0`
- `type.Members is { Count: > 0 }`

These runtime checks mask the invariant that the data is always present (possibly empty) by the time it reaches formatters and section descriptors.

## Solution

Initialize collections to empty defaults, making the type system prove they're non-null:

| Property | Before | After |
|----------|--------|-------|
| `ApiType.Members` | `List<ApiMember>?` | `List<ApiMember> = []` |
| `ApiType.Interfaces` | `List<string>?` | `List<string> = []` |
| `ApiType.TypeParameters` | `List<TypeParameter>?` | `List<TypeParameter> = []` |
| `ApiType.DerivedTypes` | `List<string>?` | `List<string> = []` |
| `ApiType.AdditionalSourceFiles` | `List<PartialSourceFileInfo>?` | `List<PartialSourceFileInfo> = []` |
| `ApiType.Documentation` | `DocComment?` | `DocComment = new()` |
| `ApiMember.Documentation` | `DocComment?` | `DocComment = new()` |
| `DocComment.Samples` | `List<SampleReference>?` | `List<SampleReference> = []` |
| `ApiOptions.MemberFilter` | `HashSet<string>?` | `HashSet<string> = []` |
| `DiffOptions.TypeFilter` | `HashSet<string>?` | `HashSet<string> = []` |

## What's NOT changed

`IncludeSections`/`ExcludeSections` remain `HashSet<string>?` — null means "not specified", empty means "bare `-s`", non-empty means specific sections. The three-state nullable semantics are intentional.

`LibraryInspection` collections remain nullable — they use `JsonIgnoreCondition.WhenWritingNull` to omit empty collections from JSON output, and the `HasXxx` presence flags already serve as parsed presence signals.

## Impact

- **14 files changed**, net -13 lines
- **~55 null guards eliminated** across ApiCommand, ApiOutputFormatter, ApiSectionDescriptors, SourceEnricher, MemberTableFormatter, SamplesCommand, ApiServices
- All 576 tests pass (454 + 122)