### PR TITLE
Fix quiet mode hiding member sections in api command

### DIFF
--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -144,7 +144,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class Constructors : ISectionDescriptor<ApiType>
     {
         public static string Name => "Constructors";
-        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "constructor");
@@ -153,7 +153,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class Fields : ISectionDescriptor<ApiType>
     {
         public static string Name => "Fields";
-        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "field" && !m.EnumValue.HasValue);
@@ -162,7 +162,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class Properties : ISectionDescriptor<ApiType>
     {
         public static string Name => "Properties";
-        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "property");
@@ -171,7 +171,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class Methods : ISectionDescriptor<ApiType>
     {
         public static string Name => "Methods";
-        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "method");
@@ -180,7 +180,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class Events : ISectionDescriptor<ApiType>
     {
         public static string Name => "Events";
-        public static Verbosity MinVerbosity => Verbosity.Minimal;
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "event");


### PR DESCRIPTION
## Problem

`api JsonSerializer -v:q` showed no members, and `api JsonSerializer -m Deserialize -v:q` showed full per-overload signatures instead of a collapsed overload count.

## Cause

The API pipeline migration (PR #115) set member section descriptors to `MinVerbosity = Minimal`. Since Quiet < Minimal, the pipeline excluded all member sections at quiet verbosity. The `QuietMemberFormatter` — which collapses overloads into a single row with an overload count — never got a chance to run.

## Fix

Change `MinVerbosity` from `Minimal` to `Quiet` for all 5 member section descriptors (Constructors, Fields, Properties, Methods, Events). The formatter handles the display style at each verbosity level.

## Before / After

```
# Before (-v:q)
Kind: class | ...
(no members shown)

# After (-v:q)  
Kind: class | ...
## Methods
| Name | Return Type | Overloads |
| Deserialize | TValue | 40 |
| Serialize | void | 15 |
...
```

NAOT timings confirm caching works correctly:
- Cold (no source/symbol cache): **469ms**
- Warm (cached): **195ms**