### PR TITLE
Cache version resolution with 1-hour TTL

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -66,6 +66,28 @@ public static class CoreCache
     }
 
     /// <summary>
+    /// Tries to read cached content with a maximum age. Returns null if the entry
+    /// is missing or older than <paramref name="maxAge"/>.
+    /// </summary>
+    public static string? TryGet(string category, string key, TimeSpan maxAge, string extension = "json")
+    {
+        var path = GetFilePath(category, key, extension);
+        try
+        {
+            var info = new FileInfo(path);
+            if (info.Exists && (DateTime.UtcNow - info.LastWriteTimeUtc) < maxAge)
+            {
+                return File.ReadAllText(path);
+            }
+        }
+        catch
+        {
+            // Best-effort
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Stores content in the cache under the given category and key.
     /// Best-effort — failures are silently ignored.
     /// </summary>

--- a/src/DotnetInspector.Packages/NuGetSource.cs
+++ b/src/DotnetInspector.Packages/NuGetSource.cs
@@ -23,11 +23,16 @@ public record NuGetSource(string Name, string Url)
     public string? GetFlatContainerUrl()
     {
         // nuget.org has a well-known flat-container URL
-        if (Url.Contains("api.nuget.org", StringComparison.OrdinalIgnoreCase))
+        if (IsNuGetOrg())
         {
             return "https://api.nuget.org/v3-flatcontainer";
         }
 
         return null;
     }
+
+    /// <summary>
+    /// Returns true if this source points to nuget.org.
+    /// </summary>
+    public bool IsNuGetOrg() => Url.Contains("api.nuget.org", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Compression;
+using DotnetInspector.Core;
 
 namespace DotnetInspector.Packages;
 
@@ -303,6 +304,9 @@ public static class PackageExtractor
         return (packageSource, null);
     }
 
+    private static readonly TimeSpan VersionCacheTtl = TimeSpan.FromHours(1);
+    private const string VersionCacheCategory = "versions";
+
     private static async Task<string?> GetLatestVersionAsync(
         HttpClient client,
         string packageName,
@@ -311,11 +315,22 @@ public static class PackageExtractor
     {
         string normalizedName = packageName.ToLowerInvariant();
 
+        // Check version cache first (1-hour TTL)
+        var cached = CoreCache.TryGet(VersionCacheCategory, normalizedName, VersionCacheTtl, extension: "txt");
+        if (cached != null)
+        {
+            log?.Invoke($"Using cached version: {cached}");
+            return cached;
+        }
+
         foreach (var source in sources)
         {
             var version = await GetLatestVersionFromSourceAsync(client, normalizedName, source, log);
             if (version != null)
+            {
+                CoreCache.Set(VersionCacheCategory, normalizedName, version, extension: "txt");
                 return version;
+            }
         }
 
         return null;
@@ -327,7 +342,15 @@ public static class PackageExtractor
         NuGetSource source,
         Action<string>? log)
     {
-        // Try flat-container index first (faster)
+        // For nuget.org, use the search API — returns latest version directly without listing all versions
+        if (source.IsNuGetOrg())
+        {
+            var version = await GetLatestVersionFromSearchAsync(client, packageName, log);
+            if (version != null)
+                return version;
+        }
+
+        // Fall back to flat-container index (enumerates all versions)
         var flatContainerUrl = source.GetFlatContainerUrl();
         if (flatContainerUrl != null)
         {
@@ -352,6 +375,39 @@ public static class PackageExtractor
             var version = await ParseVersionIndexAsync(client, indexUrl);
             if (version != null)
                 return version;
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> GetLatestVersionFromSearchAsync(
+        HttpClient client,
+        string packageName,
+        Action<string>? log)
+    {
+        string searchUrl = $"https://azuresearch-usnc.nuget.org/query?q=packageid:{packageName}&take=1&prerelease=false";
+        log?.Invoke($"Fetching latest version from: {searchUrl}");
+
+        try
+        {
+            string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, searchUrl);
+            if (json == null)
+                return null;
+
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("data", out var data) &&
+                data.GetArrayLength() > 0)
+            {
+                var package = data[0];
+                if (package.TryGetProperty("version", out var version))
+                {
+                    return version.GetString();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Search API failed: {ex.Message}");
         }
 
         return null;

--- a/src/DotnetInspector.Services/PackageResolverService.cs
+++ b/src/DotnetInspector.Services/PackageResolverService.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text.Json;
+using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services;
@@ -103,19 +104,73 @@ public static class PackageResolverService
 
     /// <summary>
     /// Gets the latest version of a package from NuGet. Prefers stable versions.
+    /// Uses a 1-hour disk cache to avoid network calls on repeated invocations.
     /// </summary>
     public static async Task<string?> GetLatestVersionAsync(
+        HttpClient client, string packageName, Action<string>? log)
+    {
+        string normalizedName = packageName.ToLowerInvariant();
+
+        // Check version cache first (1-hour TTL)
+        var cached = CoreCache.TryGet("versions", normalizedName, TimeSpan.FromHours(1), extension: "txt");
+        if (cached != null)
+        {
+            log?.Invoke($"Using cached version: {cached}");
+            return cached;
+        }
+
+        // Use the search API — returns latest stable version directly
+        var version = await GetLatestVersionFromSearchAsync(client, normalizedName, log);
+
+        // Fall back to flat-container index
+        version ??= await GetLatestVersionFromIndexAsync(client, normalizedName, log);
+
+        if (version != null)
+        {
+            CoreCache.Set("versions", normalizedName, version, extension: "txt");
+            log?.Invoke($"Latest version: {version}");
+        }
+
+        return version;
+    }
+
+    private static async Task<string?> GetLatestVersionFromSearchAsync(
+        HttpClient client, string packageName, Action<string>? log)
+    {
+        string searchUrl = $"https://azuresearch-usnc.nuget.org/query?q=packageid:{packageName}&take=1&prerelease=false";
+        log?.Invoke($"Fetching latest version from: {searchUrl}");
+
+        try
+        {
+            string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, searchUrl);
+            if (json == null)
+                return null;
+
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("data", out var data) &&
+                data.GetArrayLength() > 0 &&
+                data[0].TryGetProperty("version", out var version))
+            {
+                return version.GetString();
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Search API failed: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> GetLatestVersionFromIndexAsync(
         HttpClient client, string packageName, Action<string>? log)
     {
         var versions = await FetchVersionIndexAsync(client, packageName, log);
         if (versions == null || versions.Count == 0)
             return null;
 
-        // Prefer stable versions (those without a hyphen)
         var stableVersions = versions.Where(v => !v.Contains('-')).ToList();
-        string latest = stableVersions.Count > 0 ? stableVersions[^1] : versions[^1];
-        log?.Invoke($"Latest version: {latest}");
-        return latest;
+        return stableVersions.Count > 0 ? stableVersions[^1] : versions[^1];
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

Every invocation without an explicit version (e.g. `api System.Text.Json JsonSerializer`) called the NuGet API to resolve the latest version, even when the package was already cached locally. This added ~140-200ms of network latency to every warm run.

## Changes

- **CoreCache TTL support**: New `TryGet(category, key, maxAge)` overload that checks file write time against a TTL
- **Version caching**: Resolved latest version is cached to `~/.local/share/dotnet-inspect/versions/` with a 1-hour TTL
- **Search API**: For nuget.org, use the search API (`azuresearch-usnc.nuget.org/query`) which returns the latest stable version directly, instead of the flat-container `index.json` which returns all ~158 versions
- **Fallback preserved**: Flat-container index remains as fallback for non-nuget.org feeds and if the search API fails
- **NuGetSource.IsNuGetOrg()**: Extracted from `GetFlatContainerUrl()` for reuse

Both `PackageExtractor` and `PackageResolverService` version resolution paths are updated.

## Performance (NAOT)

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Cold (no caches) | 469ms | 330ms | 30% faster |
| Warm (all cached) | 195ms | **14ms** | **14× faster** |

## Tests

All 576 tests pass (454 + 122).