### PR TITLE
Add PDB cache check to symbol server fallback path

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -177,6 +177,19 @@ Needs investigation:
 - Determine the right mechanism (FD3, temp file, named pipe)
 - Consider how LLM tooling would consume the secondary channel
 
+## Platform Assembly Resolution
+
+When a user queries a `System.*` or `Microsoft.*` assembly name that exists as a platform assembly (e.g., `System.Runtime`, `System.Text.RegularExpressions`), the tool currently resolves it via NuGet, finding ancient netstandard1.6/net462 shim packages instead of the modern platform assembly.
+
+The tool should detect platform assembly names and resolve from the installed runtime (e.g., `/usr/share/dotnet/shared/Microsoft.NETCore.App/{version}/`) instead of NuGet. On Ubuntu, platform assemblies come from the distro package and don't have PDBs — source resolution should be skipped or handled via MSDL.
+
+Considerations:
+
+- Need a reliable heuristic for "is this a platform assembly?" vs a genuine NuGet package (e.g., `System.Text.Json` exists as both)
+- Should support `--framework` to pick a specific runtime version
+- Falls back to NuGet if the assembly isn't found locally
+- Related to the "On-Demand Ref Pack Downloads" item below
+
 ## On-Demand Ref Pack Downloads
 
 Download reference packs from NuGet on-demand, similar to how regular packages are handled.

--- a/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
+++ b/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
@@ -389,6 +389,20 @@ public class SymbolPackageDownloader(HttpClient client)
     {
         bool windowsPdbDetected = false;
 
+        // Check cache before hitting the network
+        var cachePath = GetSymbolServerCachePath(pdbFileName, symbolKey);
+        if (File.Exists(cachePath))
+        {
+            var cachedCheck = CheckPdbHeader(cachePath);
+            if (cachedCheck == PdbHeaderKind.Portable)
+            {
+                log?.Invoke("Using cached PDB from symbol server");
+                return new PdbDownloadResult(cachePath, SymbolServer: "cached");
+            }
+            if (cachedCheck == PdbHeaderKind.Windows)
+                windowsPdbDetected = true;
+        }
+
         var symbolServers = new[]
         {
             "https://symbols.nuget.org/download/symbols",
@@ -406,7 +420,6 @@ public class SymbolPackageDownloader(HttpClient client)
                 if (response == null || !response.IsSuccessStatusCode)
                     continue;
 
-                var cachePath = GetSymbolServerCachePath(pdbFileName, symbolKey);
                 Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
 
                 using (var fs = File.Create(cachePath))


### PR DESCRIPTION
## Problem

When loading an assembly from a filesystem path (e.g. `library /path/to/System.Text.Json.dll --source-link-audit`), the PDB was re-downloaded from the symbol server on every invocation even though it was already cached on disk.

Root cause: `TryLocateFromSymbolServerAsync` (the fallback path for non-package assemblies) **wrote** to the PDB cache but never **read** from it. The MSDL-specific method had a cache check, but the generic symbol server method did not.

## Fix

Add a cache lookup at the top of `TryLocateFromSymbolServerAsync` using the same `GetSymbolServerCachePath` + `CheckPdbHeader` pattern already used in `TryLocateFromMsdlAsync`.

## Performance (NAOT, library command with source-link-audit)

| Scenario | Before | After |
|----------|--------|-------|
| Warm (PDB cached) | 1.27s | **0.44s** |

Also adds a Platform Assembly Resolution item to backlog.md.

## Tests

All 454 tests pass.