### PR TITLE
Extend platform routing to api/library and add Source display

### DIFF
--- a/src/DotnetInspector.Metadata/AssemblyInspector.cs
+++ b/src/DotnetInspector.Metadata/AssemblyInspector.cs
@@ -55,7 +55,7 @@ public static class AssemblyInspector
             Machine.Amd64 => "x64",
             Machine.Arm => "ARM",
             Machine.Arm64 => "ARM64",
-            _ => coffHeader.Machine.ToString()
+            _ => null // Ref assemblies may have placeholder machine headers
         };
 
         info.IsAnyCpu = coffHeader.Machine == Machine.I386 &&

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1155,10 +1155,20 @@ public static class CommandLineBuilder
             // Disambiguate positional arg: local file vs package name
             string? assemblyPath = null;
             string? packagePath = null;
+            string? platformAssembly = null;
             if (!string.IsNullOrEmpty(source) && string.IsNullOrEmpty(parseResult.GetValue(asmPlatformOption)))
             {
                 if (File.Exists(source))
                     assemblyPath = source;
+                else if (!source.Contains('@') && PlatformResolver.IsPlatformCandidate(source))
+                {
+                    // Platform-preferred routing for System.*/Microsoft.* bare names
+                    var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(source);
+                    if (error == null && asmPath != null)
+                        platformAssembly = source;
+                    else
+                        packagePath = source;
+                }
                 else
                     packagePath = source;
             }
@@ -1175,7 +1185,7 @@ public static class CommandLineBuilder
                 IncludeReferences = showReferences,
                 IncludeDependencies = showDependencies,
                 PackagePath = packagePath,
-                PlatformAssembly = parseResult.GetValue(asmPlatformOption),
+                PlatformAssembly = platformAssembly ?? parseResult.GetValue(asmPlatformOption),
                 PlatformFramework = parseResult.GetValue(asmFrameworkOption),
                 Tfm = parseResult.GetValue(asmTfmOption),
                 JsonOutput = parseResult.GetValue(jsonOption),
@@ -1306,10 +1316,22 @@ public static class CommandLineBuilder
             }
             else
             {
-                // First positional is the package
+                // First positional is the package (or platform candidate)
                 if (args.Length >= 1) packagePath = args[0];
                 if (args.Length >= 2) typeName = args[1];
                 if (args.Length >= 3) positionalMembers.AddRange(args[2..]);
+
+                // Platform-preferred routing for System.*/Microsoft.* bare names
+                if (packagePath != null && !packagePath.Contains('@') &&
+                    PlatformResolver.IsPlatformCandidate(packagePath))
+                {
+                    var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(packagePath);
+                    if (error == null && asmPath != null)
+                    {
+                        explicitPlatform = packagePath;
+                        packagePath = null;
+                    }
+                }
             }
 
             var badOption = positionalMembers.FirstOrDefault(m => m.StartsWith("--"));

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -100,6 +100,8 @@ public class AssemblyCommand
                     return 1;
                 }
 
+                inspection.Source = $"Platform ({framework})";
+
                 if (discoverSections)
                 {
                     ListEffectiveSections(pipeline, inspection);
@@ -140,6 +142,9 @@ public class AssemblyCommand
                     Console.Error.WriteLine("Error: No libraries could be read from the package.");
                     return 1;
                 }
+
+                foreach (var insp in inspections)
+                    insp.Source = "NuGet";
 
                 if (discoverSections)
                 {

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -60,6 +60,12 @@ public class LibraryInspection
     public string? Builder { get; set; }
 
     /// <summary>
+    /// Where the assembly was resolved from: "Platform (runtime)", "NuGet", or null for local files.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Source { get; set; }
+
+    /// <summary>
     /// Publisher identity from NuGet package author signature (CN).
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -240,6 +240,8 @@ public class LibraryInspectionView
             fields.Add(new("Arch", info.Architecture));
         if (_data.FileSize > 0)
             fields.Add(new("Size", FormatFileSize(_data.FileSize)));
+        if (!string.IsNullOrEmpty(_data.Source))
+            fields.Add(new("Source", _data.Source));
 
         return fields;
     }
@@ -279,6 +281,8 @@ public class LibraryInspectionView
             fields.Add(new("Types", info.TypeDefinitionCount.ToString("N0")));
         if (info.MethodDefinitionCount > 0)
             fields.Add(new("Methods", info.MethodDefinitionCount.ToString("N0")));
+        if (!string.IsNullOrEmpty(_data.Source))
+            fields.Add(new("Source", _data.Source));
 
         return fields;
     }


### PR DESCRIPTION
## Summary

Follow-up to #123. Extends platform-preferred routing to the `api` and `library` commands, adds Source display to library output, and fixes the Arch display bug for ref assemblies.

## Changes

### Platform routing for `api` and `library` bare names

When `api` or `library` receives a bare positional name (no `--package`/`--platform` flag), it now checks `IsPlatformCandidate` before defaulting to NuGet:

| Before | After |
|---|---|
| `api System.Text.Json` → NuGet (Source: NuGet) | `api System.Text.Json` → Platform (Source: Platform (runtime)) |
| `library System.Text.Json` → NuGet | `library System.Text.Json` → Platform (Source: Platform (runtime)) |

Explicit flags unchanged: `api --package System.Text.Json` → always NuGet, `api --platform System.Text.Json` → always Platform.

### Source field in library output

Added `Source` to `LibraryInspection` model, displayed in both compact (one-liner) and detailed views:

```
# System.Text.Json.dll
Name: System.Text.Json | Version: 10.0.0.0 | TFM: .NETCoreApp,Version=v10.0 | Size: 1.5 MB | Source: Platform (runtime)
```

### Arch bug fix

Ref assemblies may have non-standard PE Machine header values (e.g., `0xFD1D`). Previously displayed as raw int (`Arch: 64797`). Now returns null for unrecognized values, omitting the field instead of showing a meaningless number.

## Motivation

Continues the `.NET 10 PrunePackageReference` alignment from #123. All command entry points now consistently prefer platform assemblies for `System.*`/`Microsoft.*` bare names.