### PR TITLE
Add --params and -of options for overload selection by parameter types

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1249,6 +1249,8 @@ public static class CommandLineBuilder
         var unsafeOption = new Option<bool>("--unsafe") { Description = "Filter to methods with unsafe signatures (pointers)" };
         var ctorOption = new Option<bool>("--ctor") { Description = "Show constructors only (shorthand for -m .ctor)" };
         var indexOption = new Option<int?>("--index") { Description = "Select a specific overload by 1-based index (use with -m)" };
+        var paramsOption = new Option<string>("--params") { Description = "Select overload by comma-separated simple parameter type names (use with -m)" };
+        var ofOption = new Option<string>("-of") { Description = "Select overload by first parameter simple type name (use with -m)" };
 
         apiCommand.Arguments.Add(argsArg);
         apiCommand.Options.Add(apiPackageOption);
@@ -1272,6 +1274,8 @@ public static class CommandLineBuilder
         apiCommand.Options.Add(shapeOption);
         apiCommand.Options.Add(unsafeOption);
         apiCommand.Options.Add(indexOption);
+        apiCommand.Options.Add(paramsOption);
+        apiCommand.Options.Add(ofOption);
         apiCommand.Options.Add(includeSectionsOption);
         apiCommand.Options.Add(excludeSectionsOption);
         apiCommand.Options.Add(markoutOption);
@@ -1379,6 +1383,8 @@ public static class CommandLineBuilder
                 UnsafeOnly = parseResult.GetValue(unsafeOption),
                 CtorOnly = ctorOnly,
                 OverloadIndex = parseResult.GetValue(indexOption),
+                ParamTypes = parseResult.GetValue(paramsOption)?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                FirstParamType = parseResult.GetValue(ofOption),
                 IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                 ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
                 Verbose = parseResult.GetValue(verboseOption),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -313,6 +313,68 @@ public class ApiCommand
                         effectiveOptions = effectiveOptions with { DllPath = apiDllPath, ExcludeSections = exclude };
                     }
 
+                    // --params / -of: select overload by parameter type matching
+                    if (!options.OverloadIndex.HasValue && (options.ParamTypes != null || options.FirstParamType != null))
+                    {
+                        if (options.MemberFilter.Count != 1)
+                        {
+                            Console.Error.WriteLine("Error: --params/-of requires exactly one member name via -m.");
+                            return 1;
+                        }
+
+                        var memberName = options.MemberFilter.First();
+                        var overloads = apiType.Members
+                            .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+
+                        var matches = new List<(ApiMember member, int index)>();
+                        for (int i = 0; i < overloads.Count; i++)
+                        {
+                            var sig = overloads[i].Signature;
+                            if (sig == null) continue;
+                            var paramTypes = ExtractParameterTypes(sig);
+
+                            if (options.ParamTypes != null)
+                            {
+                                if (MatchesParamTypes(paramTypes, options.ParamTypes))
+                                    matches.Add((overloads[i], i));
+                            }
+                            else if (options.FirstParamType != null)
+                            {
+                                if (paramTypes.Count > 0 && SimpleNameMatches(paramTypes[0], options.FirstParamType))
+                                    matches.Add((overloads[i], i));
+                            }
+                        }
+
+                        if (matches.Count == 0)
+                        {
+                            var filter = options.ParamTypes != null
+                                ? $"--params \"{string.Join(",", options.ParamTypes)}\""
+                                : $"-of \"{options.FirstParamType}\"";
+                            Console.Error.WriteLine($"Error: No overload of {memberName} matches {filter}.");
+                            return 1;
+                        }
+
+                        if (matches.Count > 1)
+                        {
+                            Console.Error.WriteLine($"Error: Multiple overloads of {memberName} match. Use --params with more specific types to disambiguate:");
+                            foreach (var (m, _) in matches)
+                                Console.Error.WriteLine($"  {m.Signature}");
+                            return 1;
+                        }
+
+                        var (selected, overloadIdx) = matches[0];
+                        apiType.Members = [selected];
+                        var exclude = effectiveOptions.ExcludeSections ?? [];
+                        exclude.Add("Remote Source");
+                        effectiveOptions = effectiveOptions with
+                        {
+                            DllPath = apiDllPath,
+                            ExcludeSections = exclude,
+                            OverloadIndex = overloadIdx + 1
+                        };
+                    }
+
                     // Always enrich with SourceLink info for single-type view (Sources section).
                     // Doc comment fetching is gated by ShowDocs inside the enricher.
                     {
@@ -603,6 +665,119 @@ public class ApiCommand
             Console.WriteLine(JsonSerializer.Serialize(outputType, ApiTypeCompactJsonContext.Default.ApiType));
         else
             Console.WriteLine(JsonSerializer.Serialize(outputType, ApiTypeJsonContext.Default.ApiType));
+    }
+
+    /// <summary>
+    /// Extracts parameter type names from a signature string like "TValue Method(System.IO.Stream s, int count)".
+    /// Returns fully qualified type names without parameter names or default values.
+    /// </summary>
+    static List<string> ExtractParameterTypes(string signature)
+    {
+        List<string> types = [];
+        int parenStart = signature.IndexOf('(');
+        if (parenStart < 0) return types;
+        int parenEnd = signature.LastIndexOf(')');
+        if (parenEnd <= parenStart + 1) return types;
+
+        var paramSection = signature.AsSpan((parenStart + 1)..(parenEnd));
+        int depth = 0;
+        int segStart = 0;
+
+        for (int i = 0; i <= paramSection.Length; i++)
+        {
+            char c = i < paramSection.Length ? paramSection[i] : ',';
+            if (c == '<') depth++;
+            else if (c == '>') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                var seg = paramSection[segStart..i].Trim();
+                if (seg.Length > 0)
+                    types.Add(ExtractTypeFromParam(seg));
+                segStart = i + 1;
+            }
+        }
+
+        return types;
+    }
+
+    /// <summary>
+    /// Extracts the type portion from a single parameter like "System.IO.Stream utf8Json" or "int count = 0".
+    /// Handles ref/out/in/params modifiers and generic types.
+    /// </summary>
+    static string ExtractTypeFromParam(ReadOnlySpan<char> param)
+    {
+        // Strip modifiers: ref, out, in, params, this (extension)
+        var s = param.ToString();
+        foreach (var mod in (ReadOnlySpan<string>)["ref ", "out ", "in ", "params ", "this "])
+        {
+            if (s.StartsWith(mod))
+            {
+                s = s[mod.Length..];
+                break;
+            }
+        }
+
+        // Strip default value: "Type name = default"
+        int eqIdx = s.IndexOf(" = ");
+        if (eqIdx > 0)
+            s = s[..eqIdx];
+
+        // The type is everything before the last space (the parameter name).
+        // But generic types can have spaces inside <>, so find last space outside angle brackets.
+        int depth = 0;
+        int lastSpace = -1;
+        for (int i = 0; i < s.Length; i++)
+        {
+            if (s[i] == '<') depth++;
+            else if (s[i] == '>') depth--;
+            else if (s[i] == ' ' && depth == 0) lastSpace = i;
+        }
+
+        return lastSpace > 0 ? s[..lastSpace] : s;
+    }
+
+    /// <summary>
+    /// Checks if a fully qualified type name matches a simple (unqualified) type name.
+    /// "System.Text.Json.JsonDocument" matches "JsonDocument".
+    /// Also matches if the user provides the full name.
+    /// </summary>
+    static bool SimpleNameMatches(string fullTypeName, string simpleName)
+    {
+        if (string.Equals(fullTypeName, simpleName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Match simple name: extract after last '.' that is outside angle brackets
+        int depth = 0;
+        int lastDot = -1;
+        for (int i = 0; i < fullTypeName.Length; i++)
+        {
+            if (fullTypeName[i] == '<') depth++;
+            else if (fullTypeName[i] == '>') depth--;
+            else if (fullTypeName[i] == '.' && depth == 0) lastDot = i;
+        }
+
+        if (lastDot > 0)
+        {
+            var simple = fullTypeName[(lastDot + 1)..];
+            return string.Equals(simple, simpleName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if extracted parameter types match the user-specified type list.
+    /// Each entry is matched by simple name. Parameter count must match exactly.
+    /// </summary>
+    static bool MatchesParamTypes(List<string> extractedTypes, string[] requestedTypes)
+    {
+        if (extractedTypes.Count != requestedTypes.Length) return false;
+        for (int i = 0; i < extractedTypes.Count; i++)
+        {
+            if (!SimpleNameMatches(extractedTypes[i], requestedTypes[i]))
+                return false;
+        }
+        return true;
     }
 
 }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -36,6 +36,8 @@ public record ApiOptions
     public bool UnsafeOnly { get; init; }
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }
+    public string[]? ParamTypes { get; init; }
+    public string? FirstParamType { get; init; }
     public string? DllPath { get; init; }
     public MethodSourceContext? MethodSource { get; init; }
     public HashSet<string>? IncludeSections { get; init; }


### PR DESCRIPTION
## Summary

Adds two new options to the `api` command for selecting overloads by parameter types instead of positional index. Designed for deterministic LLM usage — an LLM that knows the API signature can select the right overload in one shot without counting.

## New Options

| Option | Example | Behavior |
|--------|---------|----------|
| `--params` | `--params "JsonDocument,JsonSerializerOptions"` | Exact match on full parameter list by simple type names |
| `-of` | `-of JsonDocument` | Match on first parameter type only |

Both require `-m` with exactly one member name (same as `--index`). On match, they trigger the same IL/Source display view.

## Matching Rules

- **Simple name matching**: `JsonDocument` matches `System.Text.Json.JsonDocument` (case-insensitive)
- **`--params`**: Parameter count must match exactly, each type matched by simple name
- **`-of`**: Matches any overload whose first parameter has the given simple type name
- **Ambiguity**: If multiple overloads match, shows all matching signatures with guidance to use `--params`
- **No match**: Clear error message

## Examples

```bash
# Exact match — one result
api JsonSerializer -m Deserialize --params "JsonDocument,JsonSerializerOptions" --package System.Text.Json

# First param match — may need disambiguation
api JsonSerializer -m Deserialize -of Stream --package System.Text.Json
# Error: Multiple overloads match. Use --params to disambiguate:
#   TValue Deserialize(System.IO.Stream, JsonSerializerOptions)
#   object Deserialize(System.IO.Stream, Type, JsonSerializerOptions)
#   ...
```

## Files changed (3 files, +183/-0)

| File | Change |
|------|--------|
| `CommandLineBuilder.cs` | Define `--params` and `-of` options, wire to `ApiOptions` |
| `ApiCommand.cs` | Parameter matching logic + 4 helper methods (`ExtractParameterTypes`, `ExtractTypeFromParam`, `SimpleNameMatches`, `MatchesParamTypes`) |
| `ApiOptions.cs` | `ParamTypes` and `FirstParamType` properties |

## Testing

- 462 tests pass (0 failures)
- E2E validated with `System.Text.Json JsonSerializer.Deserialize` (40 overloads)