### PR TITLE
Add Custom Attributes section to --index detail view

### DIFF
--- a/src/DotnetInspector.Metadata/AttributeReader.cs
+++ b/src/DotnetInspector.Metadata/AttributeReader.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace DotnetInspector.Metadata;
 
@@ -88,5 +90,113 @@ public static class AttributeReader
             return TypeResolver.GetFullName(reader, typeDef);
         }
         return null;
+    }
+
+    /// <summary>
+    /// Gets custom attributes for a specific method, identified by type name, method name, and overload index.
+    /// Returns short attribute names with optional display values. Filters out compiler-generated noise.
+    /// </summary>
+    public static List<(string Name, string? Value)> GetMethodAttributes(
+        PEReader peReader, string fullTypeName, string methodName, int overloadIndex, bool publicOnly = true)
+    {
+        List<(string Name, string? Value)> results = [];
+        if (!peReader.HasMetadata) return results;
+
+        var reader = peReader.GetMetadataReader();
+        var methodHandle = FindMethodHandle(reader, fullTypeName, methodName, overloadIndex, publicOnly);
+        if (methodHandle.IsNil) return results;
+
+        var method = reader.GetMethodDefinition(methodHandle);
+        foreach (var attrHandle in method.GetCustomAttributes())
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName == null || IsMethodNoiseAttribute(attrTypeName))
+                continue;
+
+            var shortName = GetShortAttributeName(attrTypeName);
+            var value = TryGetAttributeDisplayValue(reader, attr);
+            results.Add((shortName, value));
+        }
+
+        return results;
+    }
+
+    private static MethodDefinitionHandle FindMethodHandle(
+        MetadataReader reader, string fullTypeName, string methodName, int overloadIndex, bool publicOnly)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var name = TypeResolver.GetFullName(reader, typeDef);
+            if (name != fullTypeName) continue;
+
+            int matchIndex = 0;
+            foreach (var mHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(mHandle);
+                if (publicOnly && (method.Attributes & MethodAttributes.Public) == 0)
+                    continue;
+                if (reader.GetString(method.Name) != methodName)
+                    continue;
+
+                if (matchIndex == overloadIndex)
+                    return mHandle;
+                matchIndex++;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Compiler-generated attributes that are noise for method-level display.
+    /// </summary>
+    private static bool IsMethodNoiseAttribute(string name) => name switch
+    {
+        ExtensionAttributeName => true,
+        "System.Runtime.CompilerServices.NullableContextAttribute" => true,
+        "System.Runtime.CompilerServices.NullableAttribute" => true,
+        "System.Runtime.CompilerServices.CompilerGeneratedAttribute" => true,
+        "System.Runtime.CompilerServices.AsyncStateMachineAttribute" => true,
+        "System.Runtime.CompilerServices.IteratorStateMachineAttribute" => true,
+        "System.Diagnostics.DebuggerStepThroughAttribute" => true,
+        "System.Diagnostics.DebuggerHiddenAttribute" => true,
+        "System.Runtime.CompilerServices.MethodImplAttribute" => false, // interesting to see
+        _ => false
+    };
+
+    private static string GetShortAttributeName(string fullName)
+    {
+        var name = fullName;
+        if (name.EndsWith("Attribute", StringComparison.Ordinal))
+            name = name[..^9];
+        var lastDot = name.LastIndexOf('.');
+        return lastDot >= 0 ? name[(lastDot + 1)..] : name;
+    }
+
+    private static string? TryGetAttributeDisplayValue(MetadataReader reader, CustomAttribute attr)
+    {
+        try
+        {
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.Length < 2) return null;
+            blob.ReadUInt16(); // prolog
+
+            var value = blob.ReadSerializedString();
+            if (value == null) return null;
+
+            foreach (char c in value)
+            {
+                if (char.IsControl(c) && c != '\t' && c != '\n' && c != '\r')
+                    return null;
+            }
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -802,7 +802,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(12, pipeline.AllSectionNames.Length);
+        Assert.Equal(13, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -823,6 +823,7 @@ public class SectionPipelineTests
         Assert.Contains("Events", names);
         Assert.Contains("IL Body", names);
         Assert.Contains("Source", names);
+        Assert.Contains("Custom Attributes", names);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -497,6 +497,14 @@ public static class ApiOutputFormatter
             writer.WriteCodeBlockEnd();
         }
 
+        // Custom attributes (when --index selects a single member)
+        if (options.DllPath != null && options.OverloadIndex.HasValue)
+        {
+            var methods = allMembers.Where(m => m.Kind is "method" or "constructor" && !m.IsAbstract).ToList();
+            if (methods.Count > 0)
+                RenderMethodAttributes(writer, type, methods, options.DllPath, options.OverloadIndex.Value - 1);
+        }
+
         // IL method body (when --index selects a single member)
         if (options.DllPath != null && options.OverloadIndex.HasValue)
         {
@@ -526,6 +534,26 @@ public static class ApiOutputFormatter
             writer.WriteCodeBlockStart("il");
             writer.WriteParagraph(ilText);
             writer.WriteCodeBlockEnd();
+        }
+    }
+
+    private static void RenderMethodAttributes(MarkoutWriter writer, ApiType type, List<ApiMember> methods, string dllPath, int overloadIndex)
+    {
+        using var stream = File.OpenRead(dllPath);
+        using var peReader = new PEReader(stream);
+
+        foreach (var method in methods)
+        {
+            var attributes = AttributeReader.GetMethodAttributes(
+                peReader, type.FullName, method.Name, overloadIndex, publicOnly: true);
+
+            if (attributes.Count == 0)
+                continue;
+
+            writer.WriteHeading(2, "Custom Attributes");
+            writer.WriteTable(
+                ["Name", "Value"],
+                attributes.Select(a => new[] { a.Name, a.Value ?? "" }));
         }
     }
 

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -86,6 +86,7 @@ public static class ApiMemberSectionDescriptors
             .Add<Properties>()
             .Add<Methods>()
             .Add<Events>()
+            .Add<MethodAttributes>()
             .Add<MethodSource>()
             .Add<ILBody>();
     }
@@ -186,6 +187,15 @@ public static class ApiMemberSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind == "event");
+    }
+
+    public sealed class MethodAttributes : ISectionDescriptor<ApiType>
+    {
+        public static string Name => "Custom Attributes";
+        public static Verbosity MinVerbosity => Verbosity.Quiet;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind is "method" or "constructor");
     }
 
     public sealed class MethodSource : ISectionDescriptor<ApiType>


### PR DESCRIPTION
## Summary

Shows method-level custom attributes in the `--index` / `--params` / `-of` single-overload detail view. Attributes like `RequiresUnreferencedCode`, `RequiresDynamicCode`, `Obsolete`, and `MethodImpl` are surfaced; compiler noise (`NullableContext`, `Extension`, `CompilerGenerated`, etc.) is filtered out.

## Example

```
api JsonSerializer -m Deserialize --params "JsonDocument,JsonSerializerOptions" --package System.Text.Json
```

```
## Custom Attributes

| Name | Value |
| ---- | ----- |
| RequiresUnreferencedCode | JSON serialization and deserialization might require types... |
| RequiresDynamicCode | JSON serialization and deserialization might require types... |
```

The section is omitted when a method has no interesting attributes.

## View structure (with `--index`)

```
## Methods (filtered to selected overload)
## Source (C# from SourceLink)
## Custom Attributes (new)
## IL Body
```

## Files changed (4 files, +150/-1)

| File | Change |
|------|--------|
| `AttributeReader.cs` | `GetMethodAttributes` + helper methods for method-level attribute extraction |
| `ApiOutputFormatter.cs` | `RenderMethodAttributes` rendering |
| `ApiSectionDescriptors.cs` | `MethodAttributes` section descriptor, pipeline 12→13 |
| `SectionPipelineTests.cs` | Updated count and assertions |

## Testing

- 462 tests pass (0 failures)
- E2E: `JsonSerializer.Deserialize(JsonDocument,JsonSerializerOptions)` shows 2 trim/AOT attributes
- E2E: `JsonSerializer.Deserialize(JsonDocument,JsonTypeInfo)` has no attributes → section omitted