### PR TITLE
Standardize command signatures to options-only

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -19,6 +19,24 @@ var items = await MyService.LoadAsync();
 Console.WriteLine($"Found {items.Count} items");
 ```
 
+## Building and Testing
+
+Build the main project:
+
+```bash
+dotnet build src/dotnet-inspect -c Release
+```
+
+Tests use **xunit v3** with `OutputType Exe`. Run them with `dotnet run`, not `dotnet test`:
+
+```bash
+dotnet run --project src/dotnet-inspect.Tests -c Release
+dotnet run --project src/DotnetInspector.Services.Tests -c Release
+dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
+```
+
+Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if not installed.
+
 ## Branching
 
 The `main` branch is protected. All work must be done on a feature branch.

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -439,7 +439,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            return await ExtensionsCommand.ExecuteAsync(targetType!, options);
+            return await ExtensionsCommand.ExecuteAsync(options);
         });
 
         return extCommand;
@@ -530,6 +530,7 @@ public static class CommandLineBuilder
             var terse = parseResult.GetValue(terseOption);
             var options = new FindOptions
             {
+                Pattern = pattern!,
                 Packages = parseResult.GetValue(packageOption) ?? [],
                 Assemblies = parseResult.GetValue(assemblyOption) ?? [],
                 PlatformAssemblies = parseResult.GetValue(platformOption) ?? [],
@@ -548,7 +549,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            var exitCode = await FindCommand.ExecuteAsync(pattern!, options);
+            var exitCode = await FindCommand.ExecuteAsync(options);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
             var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
@@ -619,6 +620,7 @@ public static class CommandLineBuilder
             
             var options = new SamplesOptions
             {
+                TypeName = typeName,
                 PackagePath = parseResult.GetValue(packageOption),
                 AssemblyPath = parseResult.GetValue(assemblyOption),
                 PlatformAssembly = parseResult.GetValue(platformOption),
@@ -631,7 +633,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            return await SamplesCommand.ExecuteAsync(typeName, options);
+            return await SamplesCommand.ExecuteAsync(options);
         });
 
         return samplesCommand;
@@ -765,7 +767,7 @@ public static class CommandLineBuilder
                     ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption))
                 };
 
-                return await AssemblyCommand.ExecuteAsync(null, assemblyOptions);
+                return await AssemblyCommand.ExecuteAsync(assemblyOptions);
             }
 
             // No assembly specified: show help
@@ -853,7 +855,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            return await ImplementsCommand.ExecuteAsync(targetType!, options);
+            return await ImplementsCommand.ExecuteAsync(options);
         });
 
         return implCommand;
@@ -928,6 +930,8 @@ public static class CommandLineBuilder
 
             var options = new InspectionOptions
             {
+                PackageArgs = packageArgs,
+                ExplicitVersion = explicitVersion,
                 ShowDependencies = parseResult.GetValue(dependenciesOption),
                 Tfm = parseResult.GetValue(tfmOption),
                 ListLayout = parseResult.GetValue(layoutOption),
@@ -952,7 +956,7 @@ public static class CommandLineBuilder
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 
-            var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options, explicitVersion);
+            var exitCode = await PackageCommand.ExecuteAsync(options);
 
             if (exitCode == 0 && packageArgs.Length > 0 && !options.IsRawOutput)
             {
@@ -1051,13 +1055,14 @@ public static class CommandLineBuilder
                         ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption))
                     };
 
-                    return await AssemblyCommand.ExecuteAsync(null, assemblyOptions);
+                    return await AssemblyCommand.ExecuteAsync(assemblyOptions);
                 }
             }
 
             // Fall through to package command (NuGet resolution)
             var options = new InspectionOptions
             {
+                PackageArgs = packageArgs,
                 Limit = parseResult.GetValue(limitOption),
                 JsonOutput = parseResult.GetValue(jsonOption),
                 Verbose = parseResult.GetValue(verboseOption),
@@ -1071,7 +1076,7 @@ public static class CommandLineBuilder
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 
-            var exitCode = await PackageCommand.ExecuteAsync(packageArgs, options);
+            var exitCode = await PackageCommand.ExecuteAsync(options);
 
             if (exitCode == 0 && !options.IsRawOutput)
             {
@@ -1185,6 +1190,7 @@ public static class CommandLineBuilder
 
             var options = new AssemblyOptions
             {
+                AssemblyName = assemblyPath,
                 IncludeMetadata = true,
                 IncludeSourcelinkAudit = runSourcelinkAudit,
                 IncludeReferences = showReferences,
@@ -1202,7 +1208,7 @@ public static class CommandLineBuilder
                 ExtractResources = parseResult.GetValue(extractResourcesOption)
             };
 
-            return await AssemblyCommand.ExecuteAsync(assemblyPath, options);
+            return await AssemblyCommand.ExecuteAsync(options);
         });
 
         return assemblyCommand;
@@ -1366,6 +1372,7 @@ public static class CommandLineBuilder
 
             var options = new ApiOptions
             {
+                TypeName = typeName,
                 PackagePath = packagePath,
                 AssemblyPath = explicitAssembly,
                 PlatformAssembly = explicitPlatform,
@@ -1403,7 +1410,7 @@ public static class CommandLineBuilder
                     ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
             };
 
-            return await ApiCommand.ExecuteAsync(typeName, options);
+            return await ApiCommand.ExecuteAsync(options);
         });
 
         return apiCommand;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -18,8 +18,9 @@ namespace DotnetInspector.Commands;
 public class ApiCommand
 {
     public const string Name = "api";
-    public static async Task<int> ExecuteAsync(string? typeName, ApiOptions options)
+    public static async Task<int> ExecuteAsync(ApiOptions options)
     {
+        var typeName = options.TypeName;
         if (options.MemberFilter.Count > 0 && string.IsNullOrEmpty(typeName))
         {
             Console.Error.WriteLine("Error: --member requires a type argument.");

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -15,8 +15,9 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class AssemblyCommand
 {
-    public static async Task<int> ExecuteAsync(string? assemblyPath, AssemblyOptions options)
+    public static async Task<int> ExecuteAsync(AssemblyOptions options)
     {
+        var assemblyPath = options.AssemblyName;
         var pipeline = LibrarySections.CreatePipeline();
         var scannerRegistry = LibrarySections.CreateScannerRegistry();
 

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -13,11 +13,12 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class ExtensionsCommand
 {
-    public static async Task<int> ExecuteAsync(string targetType, ExtensionsOptions options)
+    public static async Task<int> ExecuteAsync(ExtensionsOptions options)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
         List<string> tempDirs = [];
+        var targetType = options.TargetType;
 
         try
         {

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -13,7 +13,7 @@ namespace DotnetInspector.Commands;
 public class FindCommand
 {
     public const string Name = "find";
-    public static async Task<int> ExecuteAsync(string patternInput, FindOptions options)
+    public static async Task<int> ExecuteAsync(FindOptions options)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
@@ -22,11 +22,18 @@ public class FindCommand
         try
         {
             // Split comma-separated patterns
-            var patterns = patternInput.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var patterns = options.Pattern.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             if (patterns.Length == 0)
             {
                 Console.Error.WriteLine("Error: No pattern specified.");
                 return 1;
+            }
+
+            // Default to runtime framework if no scope specified
+            if (!options.HasAnyScope)
+            {
+                logger.Log("No scope specified, defaulting to --framework runtime");
+                options = options with { PlatformFrameworks = ["runtime"] };
             }
 
             // For oneline/name-only/multi-pattern mode, collect results per pattern
@@ -46,13 +53,6 @@ public class FindCommand
 
     private static async Task<int> ExecuteMultiPatternAsync(string[] patterns, FindOptions options, VerboseLogger logger, List<string> tempDirs, HttpClient httpClient)
     {
-        // Default to runtime framework if no scope specified
-        if (!options.HasAnyScope)
-        {
-            logger.Log("No scope specified, defaulting to --framework runtime");
-            options = options with { PlatformFrameworks = ["runtime"] };
-        }
-
         // Collect all types first (without pattern filtering)
         var allTypes = await CollectAllTypesAsync(options, logger, tempDirs, httpClient);
 
@@ -102,13 +102,6 @@ public class FindCommand
 
     private static async Task<int> ExecuteSinglePatternAsync(string pattern, FindOptions options, VerboseLogger logger, List<string> tempDirs, HttpClient httpClient)
     {
-            // Default to runtime framework if no scope specified
-            if (!options.HasAnyScope)
-            {
-                logger.Log("No scope specified, defaulting to --framework runtime");
-                options = options with { PlatformFrameworks = ["runtime"] };
-            }
-
             var results = await TypeSearchService.CollectTypesAsync(options, pattern, logger, tempDirs, httpClient);
 
             // Apply limit

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -13,11 +13,12 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class ImplementsCommand
 {
-    public static async Task<int> ExecuteAsync(string targetType, ImplementsOptions options)
+    public static async Task<int> ExecuteAsync(ImplementsOptions options)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
         List<string> tempDirs = [];
+        var targetType = options.TargetType;
 
         try
         {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -18,8 +18,10 @@ namespace DotnetInspector.Commands;
 public class PackageCommand
 {
     public const string Name = "package";
-    public static async Task<int> ExecuteAsync(string[] packageArgs, InspectionOptions options, string? explicitVersion = null)
+    public static async Task<int> ExecuteAsync(InspectionOptions options)
     {
+        var packageArgs = options.PackageArgs;
+        var explicitVersion = options.ExplicitVersion;
         var pipeline = PackageSectionDescriptors.CreatePipeline();
         var sectionNames = pipeline.AllSectionNames;
 

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -14,11 +14,12 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class SamplesCommand
 {
-    public static async Task<int> ExecuteAsync(string? typeName, SamplesOptions options)
+    public static async Task<int> ExecuteAsync(SamplesOptions options)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        
+        var typeName = options.TypeName;
+
         // Get package info from options
         string? packageName = null;
         string? packageVersion = null;
@@ -289,6 +290,11 @@ public record TypedSample(string TypeName, string? TypeNamespace, SampleReferenc
 
 public record SamplesOptions
 {
+    /// <summary>
+    /// Type name to get samples for (positional argument). Null for library-wide samples.
+    /// </summary>
+    public string? TypeName { get; init; }
+
     public string? PackagePath { get; init; }
     public string? AssemblyPath { get; init; }
     public string? PlatformAssembly { get; init; }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -7,6 +7,11 @@ namespace DotnetInspector.Options;
 /// </summary>
 public record ApiOptions
 {
+    /// <summary>
+    /// Type name to inspect (positional argument). Null for full API listing.
+    /// </summary>
+    public string? TypeName { get; init; }
+
     public string? PackagePath { get; init; }
     public string? AssemblyPath { get; init; }
     public string? PlatformAssembly { get; init; }

--- a/src/dotnet-inspect/Options/AssemblyOptions.cs
+++ b/src/dotnet-inspect/Options/AssemblyOptions.cs
@@ -8,6 +8,12 @@ namespace DotnetInspector.Options;
 public record AssemblyOptions
 {
     /// <summary>
+    /// Assembly name within a package (positional argument).
+    /// Null when inspecting via --package, --platform, or direct file path.
+    /// </summary>
+    public string? AssemblyName { get; init; }
+
+    /// <summary>
     /// Show PE metadata (Assembly Info section: name, version, TFM, arch, signed, etc.).
     /// </summary>
     public bool IncludeMetadata { get; init; }

--- a/src/dotnet-inspect/Options/FindOptions.cs
+++ b/src/dotnet-inspect/Options/FindOptions.cs
@@ -8,6 +8,11 @@ namespace DotnetInspector.Options;
 public record FindOptions : IAssemblySourceOptions
 {
     /// <summary>
+    /// Type name or glob pattern (positional argument). Comma-separated for multiple.
+    /// </summary>
+    public string Pattern { get; init; } = "";
+
+    /// <summary>
     /// Packages to search (name or name@version). Can specify multiple.
     /// </summary>
     public string[] Packages { get; init; } = [];

--- a/src/dotnet-inspect/Options/IAssemblySourceOptions.cs
+++ b/src/dotnet-inspect/Options/IAssemblySourceOptions.cs
@@ -36,4 +36,9 @@ public interface IAssemblySourceOptions
     /// NuGet source configuration options.
     /// </summary>
     NuGetSourceOptions? SourceOptions { get; }
+
+    /// <summary>
+    /// Returns true if any search scope is specified.
+    /// </summary>
+    bool HasAnyScope { get; }
 }

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -8,6 +8,16 @@ namespace DotnetInspector.Options;
 public record InspectionOptions
 {
     /// <summary>
+    /// Package name/path arguments (positional). First element is package identifier.
+    /// </summary>
+    public string[] PackageArgs { get; init; } = [];
+
+    /// <summary>
+    /// Explicit version override (from --version option).
+    /// </summary>
+    public string? ExplicitVersion { get; init; }
+
+    /// <summary>
     /// Show package dependencies as a tree view with transitive resolution.
     /// </summary>
     public bool ShowDependencies { get; init; }


### PR DESCRIPTION
## Summary

- Unify all 7 command `ExecuteAsync` signatures to accept a single options record instead of a mix of positional args + options
- Move positional values (`pattern`, `typeName`, `packageArgs`, `assemblyPath`, `explicitVersion`) into their respective options types
- Add `HasAnyScope` to `IAssemblySourceOptions` interface, formalizing the contract already implemented by `FindOptions`, `ExtensionsOptions`, and `ImplementsOptions`
- Consolidate duplicate scope-defaulting logic in `FindCommand` from two locations to one
- Add Building and Testing section to AGENT.md documenting the xunit v3 `dotnet run --project` pattern

## Test plan

- [x] Build succeeds with 0 warnings, 0 errors
- [x] All 625 tests pass (472 + 122 + 31), 0 failures
- [x] CLI smoke tests: `find`, `api`, `implements`, `--help` all work correctly
- [x] No behavioral changes — pure internal refactor (positional args now flow through options instead of separate parameters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)