### PR TITLE
Consolidate JSON serialization contexts and add shared helper

### DIFF
--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -1,5 +1,4 @@
 using DotnetInspector.Packages;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -133,10 +132,7 @@ public class ExtensionsCommand
 
     private static void WriteJsonOutput(List<ExtensionMethodResult> results, bool compact)
     {
-        var typeInfo = compact
-            ? ExtensionsCompactJsonContext.Default.ListExtensionMethodResult
-            : ExtensionsJsonContext.Default.ListExtensionMethodResult;
-        Console.WriteLine(JsonSerializer.Serialize(results, typeInfo));
+        JsonOutputHelper.Write(results, ExtensionsJsonContext.Default.ListExtensionMethodResult, ExtensionsCompactJsonContext.Default.ListExtensionMethodResult, compact);
     }
 
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity)
@@ -209,10 +205,3 @@ public record class ExtensionMethodResult
     public string? ReachableFromType { get; set; }
 }
 
-[JsonSerializable(typeof(List<ExtensionMethodResult>))]
-[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-internal partial class ExtensionsJsonContext : JsonSerializerContext { }
-
-[JsonSerializable(typeof(List<ExtensionMethodResult>))]
-[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-internal partial class ExtensionsCompactJsonContext : JsonSerializerContext { }

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -131,10 +130,7 @@ public class FindCommand
 
     private static void WriteJsonOutput(List<TypeSearchResult> results, bool compact)
     {
-        var typeInfo = compact
-            ? FindCompactJsonContext.Default.ListTypeSearchResult
-            : FindJsonContext.Default.ListTypeSearchResult;
-        Console.WriteLine(JsonSerializer.Serialize(results, typeInfo));
+        JsonOutputHelper.Write(results, FindJsonContext.Default.ListTypeSearchResult, FindCompactJsonContext.Default.ListTypeSearchResult, compact);
     }
 }
 
@@ -165,10 +161,3 @@ public record class TypeSearchResult
     public string? SourceVersion { get; set; }
 }
 
-[JsonSerializable(typeof(List<TypeSearchResult>))]
-[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
-internal partial class FindJsonContext : JsonSerializerContext { }
-
-[JsonSerializable(typeof(List<TypeSearchResult>))]
-[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
-internal partial class FindCompactJsonContext : JsonSerializerContext { }

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -1,5 +1,4 @@
 using DotnetInspector.Packages;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -112,10 +111,7 @@ public class ImplementsCommand
 
     private static void WriteJsonOutput(List<ImplementerResult> results, bool compact)
     {
-        var typeInfo = compact
-            ? ImplementsCompactJsonContext.Default.ListImplementerResult
-            : ImplementsJsonContext.Default.ListImplementerResult;
-        Console.WriteLine(JsonSerializer.Serialize(results, typeInfo));
+        JsonOutputHelper.Write(results, ImplementsJsonContext.Default.ListImplementerResult, ImplementsCompactJsonContext.Default.ListImplementerResult, compact);
     }
 
     private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results)
@@ -151,10 +147,3 @@ public record class ImplementerResult
     public string? SourceVersion { get; set; }
 }
 
-[JsonSerializable(typeof(List<ImplementerResult>))]
-[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-internal partial class ImplementsJsonContext : JsonSerializerContext { }
-
-[JsonSerializable(typeof(List<ImplementerResult>))]
-[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-internal partial class ImplementsCompactJsonContext : JsonSerializerContext { }

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using DotnetInspector.Commands;
+using DotnetInspector.Metadata;
 using DotnetInspector.Models;
 using DotnetInspector.Views;
-using System.Text.Json.Serialization;
-using DotnetInspector.Metadata;
 
 namespace DotnetInspector;
 
@@ -79,4 +82,58 @@ public partial class PlatformJsonContext : JsonSerializerContext
 [JsonSerializable(typeof(List<PlatformAssembliesJson>))]
 public partial class PlatformCompactJsonContext : JsonSerializerContext
 {
+}
+
+// Find command JSON contexts
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<TypeSearchResult>))]
+internal partial class FindJsonContext : JsonSerializerContext { }
+
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<TypeSearchResult>))]
+internal partial class FindCompactJsonContext : JsonSerializerContext { }
+
+// Extensions command JSON contexts
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<ExtensionMethodResult>))]
+internal partial class ExtensionsJsonContext : JsonSerializerContext { }
+
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<ExtensionMethodResult>))]
+internal partial class ExtensionsCompactJsonContext : JsonSerializerContext { }
+
+// Implements command JSON contexts
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<ImplementerResult>))]
+internal partial class ImplementsJsonContext : JsonSerializerContext { }
+
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(List<ImplementerResult>))]
+internal partial class ImplementsCompactJsonContext : JsonSerializerContext { }
+
+static class JsonOutputHelper
+{
+    public static void Write<T>(T data, JsonTypeInfo<T> indented, JsonTypeInfo<T> compact, bool useCompact)
+    {
+        var typeInfo = useCompact ? compact : indented;
+        Console.WriteLine(JsonSerializer.Serialize(data, typeInfo));
+    }
 }


### PR DESCRIPTION
## Summary

- Move 3 inline `JsonSerializerContext` pairs (find, extensions, implements) from command files into `JsonContext.cs` with unified `SnakeCaseLower` + `WhenWritingNull` settings
- Add generic `JsonOutputHelper.Write<T>` to replace identical `WriteJsonOutput` methods in each command
- Fix `FindJsonContext` missing `WhenWritingNull` (was inconsistent with extensions/implements)
- Policy change from `CamelCase` to `SnakeCaseLower` is a no-op since all result types use explicit `[JsonPropertyName]` attributes

## Test plan

- [x] `dotnet build src/dotnet-inspect -c Release` — 0 warnings, 0 errors
- [x] `find --json` and `find --json --compact` produce valid JSON
- [x] `extensions --json` produces valid JSON
- [x] `implements --json` produces valid JSON
- [x] `dotnet run --project src/dotnet-inspect.Tests -c Release` — 482 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)