### PR TITLE
Resolve newest platform version across ref packs and runtime

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -420,10 +420,25 @@ public static class PlatformResolver
                 ? frameworkSpec[..frameworkSpec.LastIndexOf('@')] 
                 : frameworkSpec;
 
+            // For unversioned specs, prefer runtime when it has an equal or newer version
+            if (!frameworkSpec.Contains('@'))
+            {
+                var rt = ResolveRuntimeAssembly(assemblyName, frameworkName);
+                if (rt.AssemblyPath != null && rt.Version != null)
+                {
+                    var rtVer = ParseVersion(rt.Version);
+                    var refVer = ParseVersion(version!);
+                    if (rtVer >= refVer)
+                        return (rt.AssemblyPath, rt.Framework, rt.Version, null);
+                }
+            }
+
             return (assemblyPath, frameworkName, version, null);
         }
 
-        // Search all frameworks across all packs dirs, prefer runtime
+        // Search all frameworks across all packs dirs and runtime,
+        // returning the assembly from whichever source has the newest version.
+        // When versions are equal, runtime wins (has debug info for SourceLink).
         var frameworks = GetInstalledFrameworks(packsDirectory);
         var searchOrder = new[] { "runtime", "aspnetcore", "netstandard" };
 
@@ -438,10 +453,20 @@ public static class PlatformResolver
                 continue;
 
             var assemblyPath = Path.Combine(refPath, assemblyName);
-            if (File.Exists(assemblyPath))
+            if (!File.Exists(assemblyPath))
+                continue;
+
+            // Check if the runtime has a newer (or equal) version
+            var rt = ResolveRuntimeAssembly(assemblyName, shortName);
+            if (rt.AssemblyPath != null && rt.Version != null)
             {
-                return (assemblyPath, framework.ShortName, framework.LatestVersion, null);
+                var rtVer = ParseVersion(rt.Version);
+                var refVer = ParseVersion(framework.LatestVersion);
+                if (rtVer >= refVer)
+                    return (rt.AssemblyPath, rt.Framework, rt.Version, null);
             }
+
+            return (assemblyPath, framework.ShortName, framework.LatestVersion, null);
         }
 
         return (null, null, null, $"Library '{assemblyName}' not found in any installed framework");

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -79,22 +79,9 @@ public class AssemblyCommand
 
             if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
-                // Try runtime assemblies first (has debug info for SourceLink)
                 var (resolvedPath, framework, version, error) = PlatformResolver.ResolveAssembly(
                     options.PlatformAssembly,
-                    options.PlatformFramework,
-                    packsDirectory: null,
-                    useRuntimeAssemblies: true);
-
-                // Fall back to ref assemblies if runtime not available (e.g., downloaded packs)
-                if (error != null)
-                {
-                    (resolvedPath, framework, version, error) = PlatformResolver.ResolveAssembly(
-                        options.PlatformAssembly,
-                        options.PlatformFramework,
-                        packsDirectory: null,
-                        useRuntimeAssemblies: false);
-                }
+                    options.PlatformFramework);
 
                 if (error != null)
                 {


### PR DESCRIPTION
## Problem

When running `dotnet-inspect System.Text.Json`, the tool showed version **10.0.1** (the locally installed runtime) even though the latest ref pack (**10.0.3**) had been downloaded from NuGet. The router correctly downloaded the newest ref pack, but `AssemblyCommand` independently re-resolved using the local runtime first and only fell back to ref packs on error — so a stale-but-present runtime always won.

## Fix

`PlatformResolver.ResolveAssembly` now compares versions from both ref packs and the local runtime, returning whichever is newest. Runtime wins on equal versions (it has debug info for SourceLink/PDB lookup).

### Changes

- **`PlatformResolver.ResolveAssembly`**: The default resolution path (both unversioned `frameworkSpec` and no-spec search) now checks the runtime version against the ref pack version before choosing the assembly source.
- **`AssemblyCommand`**: Simplified from a two-call fallback pattern to a single `ResolveAssembly` call. The resolver itself now picks the best source.
- Versioned specs (e.g., `runtime@9.0.6`) are unchanged — explicit versions are always honored.

### Before

```
$ dotnet-inspect System.Text.Json
Name: System.Text.Json | Version: 10.0.1 | Source: Platform (runtime)
```

### After

```
$ dotnet-inspect System.Text.Json
Name: System.Text.Json | Version: 10.0.3 | Source: Platform (runtime)
```