### PR TITLE
List only sections with content for bare -s with input

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -39,12 +39,18 @@ public class ApiCommand
         };
         if (includeError || excludeError) return 1;
 
-        // Bare -s: list available sections and exit
-        if (options.IncludeSections is { Count: 0 })
+        // Bare -s without input: list all potential sections and exit
+        if (options.IncludeSections is { Count: 0 } &&
+            string.IsNullOrEmpty(options.PackagePath) &&
+            string.IsNullOrEmpty(options.AssemblyPath) &&
+            string.IsNullOrEmpty(options.PlatformAssembly))
         {
             SectionRegistry.ListSections(allApiSections);
             return 0;
         }
+
+        // Bare -s with input: discover which sections have data (set flag for later)
+        bool discoverSections = options.IncludeSections is { Count: 0 };
 
         // Auto-promote verbosity when -s targets specific sections
         if (options.IncludeSections is { Count: > 0 })
@@ -224,6 +230,12 @@ public class ApiCommand
                     }
                 }
 
+                if (discoverSections)
+                {
+                    typePipeline.ListEffectiveSections(api);
+                    return 0;
+                }
+
                 WriteFullApiOutput(api, options, selectedTfm);
             }
             else
@@ -398,6 +410,12 @@ public class ApiCommand
                             effectiveOptions = effectiveOptions with { MethodSource = methodSource };
                     }
 
+                    if (discoverSections)
+                    {
+                        memberPipeline.ListEffectiveSections(apiType);
+                        return 0;
+                    }
+
                     WriteTypeOutput(apiType, foundIn, packageName, packageVersion, apiSource, selectedTfm, effectiveOptions);
                 }
                 else if (lookupResult.Suggestions.Count > 0)
@@ -425,6 +443,12 @@ public class ApiCommand
                             TypeFilter = typeName,
                             Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
                         };
+                        if (discoverSections)
+                        {
+                            typePipeline.ListEffectiveSections(api);
+                            return 0;
+                        }
+
                         WriteFullApiOutput(api, options, selectedTfm);
                     }
                     else

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -104,7 +104,7 @@ public class AssemblyCommand
 
                 if (discoverSections)
                 {
-                    ListEffectiveSections(pipeline, inspection);
+                    pipeline.ListEffectiveSections(inspection);
                     return 0;
                 }
 
@@ -148,7 +148,7 @@ public class AssemblyCommand
 
                 if (discoverSections)
                 {
-                    ListEffectiveSections(pipeline, inspections[0]);
+                    pipeline.ListEffectiveSections(inspections[0]);
                     return 0;
                 }
 
@@ -182,7 +182,7 @@ public class AssemblyCommand
 
                 if (discoverSections)
                 {
-                    ListEffectiveSections(pipeline, inspection);
+                    pipeline.ListEffectiveSections(inspection);
                     return 0;
                 }
 
@@ -432,12 +432,5 @@ public class AssemblyCommand
         }
 
         return null;
-    }
-
-    private static void ListEffectiveSections(SectionPipeline<LibraryInspection> pipeline, LibraryInspection inspection)
-    {
-        var effective = pipeline.GetEffectiveSections(inspection, Verbosity.Detailed);
-        foreach (var name in effective)
-            Console.WriteLine(name);
     }
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -33,12 +33,15 @@ public class PackageCommand
         };
         if (includeError || excludeError) return 1;
 
-        // Bare -s: list available sections and exit
-        if (options.IncludeSections is { Count: 0 })
+        // Bare -s without input: list all potential sections and exit
+        if (options.IncludeSections is { Count: 0 } && packageArgs.Length < 1)
         {
             SectionRegistry.ListSections(sectionNames);
             return 0;
         }
+
+        // Bare -s with input: discover which sections have data (set flag for later)
+        bool discoverSections = options.IncludeSections is { Count: 0 };
 
         // Auto-promote verbosity when -s targets specific sections
         if (options.IncludeSections is { Count: > 0 })
@@ -222,6 +225,13 @@ public class PackageCommand
 
             // Filter output based on options
             FilterResultForOutput(result, options);
+
+            // Bare -s with input: list sections that have content and exit
+            if (discoverSections)
+            {
+                pipeline.ListEffectiveSections(result);
+                return 0;
+            }
 
             // Output results
             var output = OutputFormatter.FormatResult(result, options, pipeline);

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -60,6 +60,16 @@ public sealed class SectionPipeline<TModel>
     }
 
     /// <summary>
+    /// Lists sections that have content at <see cref="Verbosity.Detailed"/>.
+    /// Used by bare <c>-s</c> with input to discover which sections have data.
+    /// </summary>
+    public void ListEffectiveSections(TModel model)
+    {
+        foreach (var name in GetEffectiveSections(model, Verbosity.Detailed))
+            Console.WriteLine(name);
+    }
+
+    /// <summary>
     /// Computes the <see cref="HashSet{String}"/> to pass as
     /// <c>MarkoutWriterOptions.IncludeSections</c>. Returns <c>null</c> when
     /// all sections should be rendered (no filtering needed).


### PR DESCRIPTION
## Problem

`dotnet-inspect package System.Text.Json -s` listed all registered sections including ones with no data (e.g., `Vulnerabilities` when the package has none). Selecting such a section produced no output.

## Fix

When `-s` is used with a package/library/type argument, only sections that actually have content are now listed. Bare `-s` without input continues to list all potential section names.

### Changes

- **`SectionPipeline<T>.ListEffectiveSections()`** — new shared helper that prints sections with content at Detailed verbosity
- **`PackageCommand`** — discover sections after inspection, before rendering
- **`ApiCommand`** — discover sections at all three output points (full API, single type, glob match)
- **`AssemblyCommand`** — replaced private helper with shared pipeline method (already had the correct behavior)

### Before

```
$ dotnet-inspect package System.Text.Json -s -T:q
Package
Statistics
Package Dependencies
Vulnerabilities        ← no data
RID Packages           ← no data
Runtime Dependencies   ← no data
Files                  ← no data
```

### After

```
$ dotnet-inspect package System.Text.Json -s -T:q
Package
Statistics
Package Dependencies
```