### PR TITLE
Preserve empty dependency groups for correct TFM selection

### DIFF
--- a/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
@@ -256,7 +256,7 @@ public class NuspecParserTests : IDisposable
     }
 
     [Fact]
-    public void Parse_EmptyDependencyGroup_IsNotAdded()
+    public void Parse_EmptyDependencyGroup_IsAdded()
     {
         var nuspec = WriteNuspec("""
             <?xml version="1.0" encoding="utf-8"?>
@@ -274,7 +274,10 @@ public class NuspecParserTests : IDisposable
 
         var result = NuspecParser.Parse(nuspec);
 
-        Assert.Null(result.DependencyGroups);
+        Assert.NotNull(result.DependencyGroups);
+        Assert.Single(result.DependencyGroups);
+        Assert.Equal("net8.0", result.DependencyGroups[0].TargetFramework);
+        Assert.Empty(result.DependencyGroups[0].Dependencies);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -94,11 +94,8 @@ public static class NuspecParser
                     });
                 }
 
-                if (depGroup.Dependencies.Count > 0)
-                {
-                    result.DependencyGroups ??= [];
-                    result.DependencyGroups.Add(depGroup);
-                }
+                result.DependencyGroups ??= [];
+                result.DependencyGroups.Add(depGroup);
             }
 
             // Handle dependencies without groups

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -484,6 +484,14 @@ public class PackageCommand
             tfm = group.TargetFramework;
         }
 
+        if (group.Dependencies.Count == 0)
+        {
+            Console.WriteLine($"# {result.PackageName} ({result.Version})");
+            Console.WriteLine();
+            Console.WriteLine($"No additional dependencies for {tfm}.");
+            return 0;
+        }
+
         // Resolve transitive dependencies
         var globalSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(


### PR DESCRIPTION
## Problem

`dotnet-inspect package System.Text.Json --dependencies` showed `TFM: net9.0` instead of `net10.0`. The `net10.0` dependency group has zero NuGet dependencies (everything is in the shared framework), and `NuspecParser` was dropping empty groups.

## Fix

- **`NuspecParser`**: Keep empty dependency groups — they signal TFM support even when no additional packages are needed
- **`PackageCommand`**: Show "No additional dependencies for net10.0" when the selected TFM's group is empty
- Updated test to match new behavior

### Before

```
$ dotnet-inspect package System.Text.Json --dependencies
Package: System.Text.Json | Version: 10.0.3 | TFM: net9.0
├─ System.IO.Pipelines 10.0.3 [Microsoft]
└─ System.Text.Encodings.Web 10.0.3 [Microsoft]
```

### After

```
$ dotnet-inspect package System.Text.Json --dependencies
# System.Text.Json (10.0.3)

No additional dependencies for net10.0.
```