### PR TITLE
Fix --source and --add-source for package command

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -174,7 +174,7 @@ public static class PackageExtractor
     /// <summary>
     /// Gets the download URL for a package from a specific source.
     /// </summary>
-    private static async Task<string?> GetPackageDownloadUrlAsync(
+    public static async Task<string?> GetPackageDownloadUrlAsync(
         HttpClient client,
         NuGetSource source,
         string packageName,
@@ -315,12 +315,18 @@ public static class PackageExtractor
     {
         string normalizedName = packageName.ToLowerInvariant();
 
-        // Check version cache first (1-hour TTL)
-        var cached = CoreCache.TryGet(VersionCacheCategory, normalizedName, VersionCacheTtl, extension: "txt");
-        if (cached != null)
+        // Only use version cache for default (nuget.org-only) sources;
+        // custom feeds may have different latest versions.
+        bool useCache = sources.Count == 1 && sources[0].IsNuGetOrg();
+
+        if (useCache)
         {
-            log?.Invoke($"Using cached version: {cached}");
-            return cached;
+            var cached = CoreCache.TryGet(VersionCacheCategory, normalizedName, VersionCacheTtl, extension: "txt");
+            if (cached != null)
+            {
+                log?.Invoke($"Using cached version: {cached}");
+                return cached;
+            }
         }
 
         foreach (var source in sources)
@@ -328,7 +334,8 @@ public static class PackageExtractor
             var version = await GetLatestVersionFromSourceAsync(client, normalizedName, source, log);
             if (version != null)
             {
-                CoreCache.Set(VersionCacheCategory, normalizedName, version, extension: "txt");
+                if (useCache)
+                    CoreCache.Set(VersionCacheCategory, normalizedName, version, extension: "txt");
                 return version;
             }
         }
@@ -425,20 +432,22 @@ public static class PackageExtractor
             var versions = doc.RootElement.GetProperty("versions");
             if (versions.GetArrayLength() > 0)
             {
-                // Get latest non-prerelease version, or latest overall
-                string? latestStable = null;
-                string? latestAny = null;
+                // Use NuGetVersion for proper comparison — feeds may return
+                // versions in any order (nuget.org ascending, Azure DevOps descending).
+                NuGet.Versioning.NuGetVersion? latestStable = null;
+                NuGet.Versioning.NuGetVersion? latestAny = null;
                 foreach (var v in versions.EnumerateArray())
                 {
                     var ver = v.GetString();
-                    if (ver != null)
+                    if (ver != null && NuGet.Versioning.NuGetVersion.TryParse(ver, out var parsed))
                     {
-                        latestAny = ver;
-                        if (!ver.Contains('-'))
-                            latestStable = ver;
+                        if (latestAny == null || parsed > latestAny)
+                            latestAny = parsed;
+                        if (!parsed.IsPrerelease && (latestStable == null || parsed > latestStable))
+                            latestStable = parsed;
                     }
                 }
-                return latestStable ?? latestAny;
+                return (latestStable ?? latestAny)?.OriginalVersion;
             }
         }
         catch (System.Text.Json.JsonException)

--- a/src/DotnetInspector.Services/PackageResolverService.cs
+++ b/src/DotnetInspector.Services/PackageResolverService.cs
@@ -29,7 +29,8 @@ public static class PackageResolverService
         string packageSource,
         string? version,
         Action<string>? log,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        NuGetSourceOptions? sourceOptions = null)
     {
         bool isLocalFile = packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
 
@@ -52,10 +53,21 @@ public static class PackageResolverService
             packageName = packageSource.ToLowerInvariant();
         }
 
+        var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        bool isDefaultSource = sources.Count == 1 && sources[0].IsNuGetOrg();
+
         // Discover latest version if not specified
         if (string.IsNullOrEmpty(version))
         {
-            version = await GetLatestVersionAsync(httpClient, packageName, log);
+            if (isDefaultSource)
+            {
+                version = await GetLatestVersionAsync(httpClient, packageName, log);
+            }
+            else
+            {
+                version = await PackageExtractor.GetLatestVersionAsync(httpClient, packageName, sources, log);
+            }
+
             if (version == null)
             {
                 return null;
@@ -77,10 +89,23 @@ public static class PackageResolverService
         string extractPath = Path.Combine(tempDir, "extracted");
         Directory.CreateDirectory(tempDir);
 
-        string nupkgUrl = $"https://api.nuget.org/v3-flatcontainer/{packageName}/{version}/{packageName}.{version}.nupkg";
-        log?.Invoke($"Downloading: {nupkgUrl}");
+        byte[]? packageBytes = null;
+        foreach (var source in sources)
+        {
+            var nupkgUrl = await PackageExtractor.GetPackageDownloadUrlAsync(httpClient, source, packageName, version, log);
+            if (nupkgUrl == null) continue;
 
-        byte[]? packageBytes = await HttpRetryHelper.GetBytesWithRetryAsync(httpClient, nupkgUrl);
+            log?.Invoke($"Downloading: {packageName} {version} from {source.Name}");
+            try
+            {
+                packageBytes = await HttpRetryHelper.GetBytesWithRetryAsync(httpClient, nupkgUrl);
+                if (packageBytes != null) break;
+            }
+            catch (HttpRequestException)
+            {
+                continue;
+            }
+        }
         if (packageBytes == null)
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -130,18 +130,11 @@ public class PackageCommand
             else
             {
                 packageName = packageArg.ToLowerInvariant();
-                // Auto-discover latest version
-                string? latestVersion = await PackageResolverService.GetLatestVersionAsync(client, packageName, logger.Log);
-                if (latestVersion == null)
-                {
-                    Console.Error.WriteLine($"Error: Package '{packageArg}' not found on nuget.org");
-                    return 1;
-                }
-                version = latestVersion;
+                version = "";
             }
 
             // Validate version looks like a NuGet version
-            if (!NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+            if (version.Length > 0 && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
             {
                 string badVersion = packageArgs.Length >= 2 ? packageArgs[1] : version;
                 Console.Error.WriteLine($"Error: '{badVersion}' is not a valid package version.");
@@ -158,20 +151,25 @@ public class PackageCommand
         {
             resolution = await PackageResolverService.ResolvePackageAsync(
                 isLocalFile ? packageArgs[0] : packageName,
-                isLocalFile ? null : version,
+                isLocalFile ? null : (version.Length > 0 ? version : null),
                 logger.Log,
-                client);
+                client,
+                options.SourceOptions);
 
             if (resolution == null)
             {
                 if (isLocalFile)
                     Console.Error.WriteLine($"Error: File not found: {packageArgs[0]}");
-                else
+                else if (version.Length > 0)
                     Console.Error.WriteLine($"Error: Package '{packageName}' version '{version}' not found or download failed.");
+                else
+                    Console.Error.WriteLine($"Error: Package '{packageName}' not found.");
                 return 1;
             }
 
             extractPath = resolution.ExtractPath;
+            // Update version from resolution (may have been auto-discovered)
+            version = resolution.Version;
 
             // Handle --layout mode: show file tree and exit early
             if (options.ListLayout)


### PR DESCRIPTION
Fixes the custom NuGet source support that was added in PR #4 (resolving #1). The `--source` and `--add-source` options were accepted but ignored — `PackageCommand` and `PackageResolverService` hardcoded nuget.org for both version resolution and package download.

## Changes

- **PackageCommand**: Defer version discovery to `ResolvePackageAsync` instead of calling the nuget.org-only `GetLatestVersionAsync` directly
- **PackageResolverService**: Accept `NuGetSourceOptions`, use source-aware `PackageExtractor` methods for version resolution and download
- **PackageExtractor**: Skip version cache for non-default sources; fix `ParseVersionIndexAsync` to use `NuGetVersion` comparison instead of assuming array order (Azure DevOps feeds return versions descending, nuget.org ascending)

## Example

```
$ dotnet-inspect package System.Text.Json --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
# System.Text.Json (11.0.0-preview.2.26110.116)
...
Version: 11.0.0-preview.2.26110.116 | Type: Library | TFM: net11.0
```

Previously this returned `10.0.3` from nuget.org, ignoring the custom source entirely.