### PR TITLE
Route .dll and .nupkg files directly to library/package commands

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -340,6 +340,24 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PreprocessArgs_WithDllFile_PrependsLibrary()
+    {
+        var args = new[] { "artifacts/bin/Foo/debug/Foo.dll", "--json" };
+        var result = CommandLineBuilder.PreprocessArgs(args);
+
+        Assert.Equal(["library", "artifacts/bin/Foo/debug/Foo.dll", "--json"], result);
+    }
+
+    [Fact]
+    public void PreprocessArgs_WithNupkgFile_PrependsPackage()
+    {
+        var args = new[] { "Foo.1.0.0.nupkg" };
+        var result = CommandLineBuilder.PreprocessArgs(args);
+
+        Assert.Equal(["package", "Foo.1.0.0.nupkg"], result);
+    }
+
+    [Fact]
     public void PreprocessArgs_WithHelpFlag_ReturnsUnchanged()
     {
         var args = new[] { "--help" };

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -29,6 +29,14 @@ public static class CommandLineBuilder
     {
         if (args.Length > 0 && !args[0].StartsWith('-') && !KnownCommands.Contains(args[0]))
         {
+            // Route .dll files directly to the library command
+            if (args[0].EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                return ["library", .. args];
+
+            // Route .nupkg files directly to the package command
+            if (args[0].EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+                return ["package", .. args];
+
             // Route bare names through the router command (platform-preferred, NuGet fallback)
             return ["router", .. args];
         }


### PR DESCRIPTION
## Summary

`PreprocessArgs` now detects `.dll` and `.nupkg` file extensions before falling through to the router command.

- `dotnet-inspect path/to/Foo.dll` → routes to `library` command
- `dotnet-inspect Foo.1.0.0.nupkg` → routes to `package` command

Previously these paths were sent to the `router` command which tried to interpret them as NuGet package names or platform candidates, failing to resolve them.

## Changes

- **`CommandLineBuilder.PreprocessArgs`** — added `.dll` → `library` and `.nupkg` → `package` routing before the existing `router` fallback
- **`CommandLineTests`** — two new tests for the file extension routing