### PR TITLE
Don't report 'any' as TFM for RID-specific binary packages

### DIFF
--- a/src/dotnet-inspect.Tests/ToolsAnalyzerTests.cs
+++ b/src/dotnet-inspect.Tests/ToolsAnalyzerTests.cs
@@ -272,4 +272,31 @@ public class ToolsAnalyzerTests : IDisposable
         Assert.False(result.IsFrameworkDependent);
         Assert.True(result.IsRidSpecificPointerPackage);
     }
+
+    [Fact]
+    public void AnalyzeToolsDirectory_RidSpecificBinaryPackage_DoesNotAddAnyAsTfm()
+    {
+        // RID-specific binary packages use tools/any/{rid}/ layout where "any" means
+        // framework-agnostic, not a TFM. It should not appear in TargetFrameworks.
+        var toolsDir = Path.Combine(_tempDir, "tools");
+        var ridDir = Path.Combine(toolsDir, "any", "linux-x64");
+        Directory.CreateDirectory(ridDir);
+
+        var settingsXml = """
+            <DotNetCliTool Version="2">
+              <Commands>
+                <Command Name="mytool" EntryPoint="mytool" Runner="executable" />
+              </Commands>
+            </DotNetCliTool>
+            """;
+        File.WriteAllText(Path.Combine(ridDir, "DotnetToolSettings.xml"), settingsXml);
+
+        var result = new InspectionResult();
+        ToolsAnalyzer.AnalyzeToolsDirectory(toolsDir, result);
+
+        Assert.True(result.TargetFrameworks is null or { Count: 0 });
+        Assert.NotNull(result.SupportedRids);
+        Assert.Contains("linux-x64", result.SupportedRids);
+        Assert.DoesNotContain("any", result.SupportedRids);
+    }
 }

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -82,13 +82,17 @@ public static class ToolsAnalyzer
         }
 
         // Tools directory structure: tools/{tfm}/{rid}/ or tools/{tfm}/any/
+        // RID-specific binary packages use tools/any/{rid}/ where "any" means any framework
         foreach (string tfmDir in Directory.GetDirectories(toolsDir))
         {
             string tfm = Path.GetFileName(tfmDir);
-            result.TargetFrameworks ??= [];
-            if (!result.TargetFrameworks.Contains(tfm))
+            if (!tfm.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
-                result.TargetFrameworks.Add(tfm);
+                result.TargetFrameworks ??= [];
+                if (!result.TargetFrameworks.Contains(tfm))
+                {
+                    result.TargetFrameworks.Add(tfm);
+                }
             }
 
             foreach (string ridDir in Directory.GetDirectories(tfmDir))


### PR DESCRIPTION
## Problem

RID-specific binary packages (e.g. `dotnet-inspect.linux-x64.0.2.0.nupkg`) use a `tools/any/{rid}/` layout where `any` at the TFM directory level means "framework-agnostic". The code was treating all first-level directory names under `tools/` as target frameworks, resulting in `TFM: any` being displayed:

```
# dotnet-inspect.linux-x64 (0.2.0)
Version: 0.2.0 | Type: Tool v2 | TFM: any
```

## Fix

Skip `any` when populating `TargetFrameworks` from `tools/` subdirectories in `ToolsAnalyzer`. This is consistent with the [RID-specific tools packaging convention](https://github.com/dotnet/docs/blob/main/docs/core/tools/rid-specific-tools.md) where `any` at the TFM level is a framework-agnostic placeholder, not a real TFM.

## After

```
# dotnet-inspect.linux-x64 (0.2.0)
Version: 0.2.0 | Type: Tool v2
```

The regular pointer package is unaffected (`tools/net10.0/any/` → `TFM: net10.0`).