### PR TITLE
Ensure ref packs are downloaded for api command platform routing

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1432,11 +1432,23 @@ public static class CommandLineBuilder
                 if (packagePath != null && !packagePath.Contains('@') &&
                     PlatformResolver.IsPlatformCandidate(packagePath))
                 {
-                    var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(packagePath);
-                    if (error == null && asmPath != null)
+                    // Ensure ref packs are downloaded before resolving
+                    var client = HttpClientFactory.Shared;
+                    bool verbose = parseResult.GetValue(verboseOption);
+                    Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+                    var requests = PlatformPackService.BuildPackRequests(packagePath, null);
+                    await foreach (var pack in PlatformPackService.EnsurePacksAsync(requests, client, log))
                     {
-                        explicitPlatform = packagePath;
-                        packagePath = null;
+                        if (PlatformPackService.ContainsAssembly(pack.PackDir, packagePath))
+                        {
+                            var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(packagePath);
+                            if (error == null && asmPath != null)
+                            {
+                                explicitPlatform = packagePath;
+                                packagePath = null;
+                                break;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The api command's platform-preferred routing for `System.*`/`Microsoft.*` bare names called `PlatformResolver.ResolveAssembly` without first downloading ref packs via `PlatformPackService.EnsurePacksAsync`. When packs weren't already cached, resolution failed silently and fell through to NuGet package download.

**Before:** `api System.Text.Json` → `Source: NuGet` (version 10.0.3 from nuget.org)
**After:** `api System.Text.Json` → `Source: Platform (runtime)` (version 10.0.3 from ref packs)

Now matches the router command behavior — ensures packs are downloaded before attempting platform resolution.