### PR TITLE
Support @version syntax in api command platform routing

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1414,6 +1414,7 @@ public static class CommandLineBuilder
             string? packagePath = explicitPackage;
             string? typeName = null;
             List<string> positionalMembers = [];
+            string? apiFrameworkOverride = null;
 
             if (hasExplicitSource)
             {
@@ -1429,23 +1430,35 @@ public static class CommandLineBuilder
                 if (args.Length >= 3) positionalMembers.AddRange(args[2..]);
 
                 // Platform-preferred routing for System.*/Microsoft.* bare names
-                if (packagePath != null && !packagePath.Contains('@') &&
-                    PlatformResolver.IsPlatformCandidate(packagePath))
+                if (packagePath != null && PlatformResolver.IsPlatformCandidate(
+                    packagePath.Contains('@') ? packagePath[..packagePath.IndexOf('@')] : packagePath))
                 {
+                    var bareName = packagePath.Contains('@') ? packagePath[..packagePath.IndexOf('@')] : packagePath;
+                    var explicitVersion = packagePath.Contains('@') ? packagePath[(packagePath.IndexOf('@') + 1)..] : null;
+
                     // Ensure ref packs are downloaded before resolving
                     var client = HttpClientFactory.Shared;
                     bool verbose = parseResult.GetValue(verboseOption);
                     Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
-                    var requests = PlatformPackService.BuildPackRequests(packagePath, null);
+                    var requests = PlatformPackService.BuildPackRequests(bareName, explicitVersion);
                     await foreach (var pack in PlatformPackService.EnsurePacksAsync(requests, client, log))
                     {
-                        if (PlatformPackService.ContainsAssembly(pack.PackDir, packagePath))
+                        if (PlatformPackService.ContainsAssembly(pack.PackDir, bareName))
                         {
-                            var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(packagePath);
+                            string? frameworkSpec = null;
+                            var (asmPath, framework, _, error) = PlatformResolver.ResolveAssembly(bareName);
+
+                            if (asmPath != null && explicitVersion != null)
+                            {
+                                frameworkSpec = $"{framework}@{explicitVersion}";
+                                (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(bareName, frameworkSpec);
+                            }
+
                             if (error == null && asmPath != null)
                             {
-                                explicitPlatform = packagePath;
+                                explicitPlatform = bareName;
                                 packagePath = null;
+                                apiFrameworkOverride = frameworkSpec;
                                 break;
                             }
                         }
@@ -1480,7 +1493,7 @@ public static class CommandLineBuilder
                 PackagePath = packagePath,
                 AssemblyPath = explicitAssembly,
                 PlatformAssembly = explicitPlatform,
-                PlatformFramework = parseResult.GetValue(apiFrameworkOption),
+                PlatformFramework = apiFrameworkOverride ?? parseResult.GetValue(apiFrameworkOption),
                 Tfm = parseResult.GetValue(apiTfmOption),
                 IncludeAll = parseResult.GetValue(allOption),
                 TypeFilter = parseResult.GetValue(typeFilterOption),

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -70,7 +70,19 @@ public static class AssemblyCollector
             assemblyPaths.Add(new AssemblyInfo(asmPath, Path.GetFileName(asmPath), null));
         }
 
-        // 3. Platform assemblies
+        // 3. Platform assemblies (ensure ref packs are downloaded first)
+        if (options.PlatformAssemblies.Length > 0)
+        {
+            // Download packs for all requested platform assemblies
+            foreach (var platformAsm in options.PlatformAssemblies)
+            {
+                var requests = PlatformPackService.BuildPackRequests(platformAsm, null);
+                await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, logger.Log))
+                {
+                }
+            }
+        }
+
         foreach (var platformAsm in options.PlatformAssemblies)
         {
             var (assemblyPath, version, resolvedFramework, error) = PlatformResolver.ResolveAssembly(platformAsm);
@@ -82,7 +94,23 @@ public static class AssemblyCollector
             assemblyPaths.Add(new AssemblyInfo(assemblyPath!, resolvedFramework ?? "platform", version));
         }
 
-        // 4. Platform frameworks
+        // 4. Platform frameworks (ensure ref packs are downloaded first)
+        if (options.PlatformFrameworks.Length > 0)
+        {
+            List<PlatformPackService.PackRequest> requests = [];
+            foreach (var fw in options.PlatformFrameworks)
+            {
+                var fwName = fw.Contains('@') ? fw[..fw.IndexOf('@')] : fw;
+                var fwVersion = fw.Contains('@') ? fw[(fw.IndexOf('@') + 1)..] : null;
+                if (PlatformResolver.FrameworkMappings.TryGetValue(fwName, out var packName))
+                    requests.Add(new PlatformPackService.PackRequest(packName, fwVersion));
+            }
+
+            await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, logger.Log))
+            {
+            }
+        }
+
         foreach (var framework in options.PlatformFrameworks)
         {
             var (refPath, resolvedVersion, error) = PlatformResolver.ResolveFramework(framework);


### PR DESCRIPTION
`api System.Text.Json@10.0.3` skipped platform routing because the `@` character triggered the NuGet package path instead. Now parses the bare name and version, downloads the correct ref packs, and resolves via platform.

**Before:** `api System.Text.Json@10.0.3` → `Source: NuGet`
**After:** `api System.Text.Json@10.0.3` → `Source: Platform (runtime)`