### PR TITLE
Ensure ref packs are downloaded before platform resolution in all commands

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -118,6 +118,12 @@ public class ApiCommand
             }
             else if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
+                // Ensure ref packs are downloaded before resolving
+                var packRequests = PlatformPackService.BuildPackRequests(options.PlatformAssembly, null);
+                await foreach (var _ in PlatformPackService.EnsurePacksAsync(packRequests, context.HttpClient, logger.Log))
+                {
+                }
+
                 var (assemblyPath, framework, version, error) = PlatformResolver.ResolveAssembly(
                     options.PlatformAssembly,
                     options.PlatformFramework,

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -79,6 +79,12 @@ public class AssemblyCommand
 
             if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
+                // Ensure ref packs are downloaded before resolving
+                var packRequests = PlatformPackService.BuildPackRequests(options.PlatformAssembly, null);
+                await foreach (var _ in PlatformPackService.EnsurePacksAsync(packRequests, context.HttpClient, logger.Log))
+                {
+                }
+
                 var (resolvedPath, framework, version, error) = PlatformResolver.ResolveAssembly(
                     options.PlatformAssembly,
                     options.PlatformFramework);

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -136,6 +136,14 @@ public class DiffCommand
         var framework = options.Framework ?? "runtime";
         logger.Log($"Comparing {assemblyName} in {framework} v{fromVersion} → v{toVersion}");
 
+        // Ensure ref packs are downloaded for both versions
+        var fromRequests = PlatformPackService.BuildPackRequests(assemblyName, fromVersion);
+        var toRequests = PlatformPackService.BuildPackRequests(assemblyName, toVersion);
+        var allRequests = fromRequests.Concat(toRequests).ToList();
+        await foreach (var _ in PlatformPackService.EnsurePacksAsync(allRequests, httpClient, logger.Log))
+        {
+        }
+
         // Resolve assemblies for both versions
         var (fromPath, _, _, fromError) = PlatformResolver.ResolveAssembly(
             assemblyName,


### PR DESCRIPTION
Completes the pack download fix from #142 and #143. Three more commands called `PlatformResolver.ResolveAssembly` without downloading ref packs first:

- **`api --platform`**: `api --platform System.Text.Json` → "not found in any installed framework"
- **`assembly --platform`** (via `dotnet-inspect library --platform`): same failure
- **`diff`**: platform version range diffs failed when packs weren't cached

All now call `EnsurePacksAsync` before resolving, matching the router pattern.