### PR TITLE
Fix --docs performance for platform assemblies (1.5s → 27ms)

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -230,9 +230,16 @@ public class ApiCommand
                 if ((options.ShowDocs || options.ShowSamples || options.SourceLinkOnly) && pdbLookupPath != null)
                 {
                     logger.Log("Enriching types with source info...");
-                    foreach (var type in api.Types)
+                    if (!string.IsNullOrEmpty(options.PlatformAssembly) && options.ShowDocs)
                     {
-                        await SourceEnricher.EnrichTypeWithSourceInfoAsync(type, type.FullName, pdbLookupPath, options, logger, context.HttpClient);
+                        SourceEnricher.EnrichTypesFromXmlDoc(api.Types, options, logger);
+                    }
+                    else
+                    {
+                        foreach (var type in api.Types)
+                        {
+                            await SourceEnricher.EnrichTypeWithSourceInfoAsync(type, type.FullName, pdbLookupPath, options, logger, context.HttpClient);
+                        }
                     }
                 }
 

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -41,7 +41,7 @@ internal static class SourceEnricher
 
     internal static async Task EnrichTypeWithSourceInfoAsync(ApiType apiType, string typeName, string dllPath, ApiOptions options, VerboseLogger logger, HttpClient httpClient)
     {
-        if (options.UseLocalDocs && !string.IsNullOrEmpty(options.PlatformAssembly))
+        if (!string.IsNullOrEmpty(options.PlatformAssembly) && (options.UseLocalDocs || options.ShowDocs))
         {
             await EnrichFromXmlDocFileAsync(apiType, typeName, options, logger);
             return;
@@ -401,6 +401,81 @@ internal static class SourceEnricher
         return (packageName, packageVersion);
     }
 
+    /// <summary>
+    /// Enriches multiple types from a single XML doc file (loaded once).
+    /// </summary>
+    internal static void EnrichTypesFromXmlDoc(IEnumerable<ApiType> types, ApiOptions options, VerboseLogger logger)
+    {
+        if (string.IsNullOrEmpty(options.PlatformAssembly))
+        {
+            logger.Log("XML doc fallback only available for platform libraries");
+            return;
+        }
+
+        var (refPath, version, error) = PlatformResolver.ResolveFramework(
+            options.PlatformFramework ?? "runtime");
+
+        if (error != null || refPath == null)
+        {
+            logger.Log($"Could not resolve framework for XML docs: {error}");
+            return;
+        }
+
+        var xmlDocPath = Path.Combine(refPath, $"{options.PlatformAssembly}.xml");
+        if (!File.Exists(xmlDocPath))
+        {
+            logger.Log($"XML doc file not found: {xmlDocPath}");
+            return;
+        }
+
+        logger.Log($"Loading XML documentation from: {xmlDocPath}");
+
+        var xmlParser = new XmlDocFileParser();
+        if (!xmlParser.Load(xmlDocPath))
+        {
+            logger.Log("Failed to load XML documentation file");
+            return;
+        }
+
+        foreach (var apiType in types)
+        {
+            EnrichTypeFromXmlDoc(apiType, xmlParser, options, logger);
+        }
+    }
+
+    private static void EnrichTypeFromXmlDoc(ApiType apiType, XmlDocFileParser xmlParser, ApiOptions options, VerboseLogger logger)
+    {
+        var typeDoc = xmlParser.GetTypeDocumentation(apiType.FullName);
+        if (typeDoc != null)
+        {
+            apiType.Documentation = new DocComment
+            {
+                Summary = typeDoc.Summary,
+                Remarks = typeDoc.Remarks
+            };
+        }
+
+        if (options.ShowDocs)
+        {
+            foreach (var member in apiType.Members)
+            {
+                var memberDoc = xmlParser.GetMemberDocumentation(apiType.FullName, member.Name, member.Kind);
+                if (memberDoc != null)
+                {
+                    member.Documentation = new DocComment
+                    {
+                        Summary = memberDoc.Summary,
+                        Remarks = memberDoc.Remarks,
+                        Parameters = memberDoc.Parameters,
+                        Returns = memberDoc.Returns
+                    };
+                }
+            }
+        }
+
+        apiType.SourceResolution = "XmlDoc";
+    }
+
     private static async Task EnrichFromXmlDocFileAsync(ApiType apiType, string typeName, ApiOptions options, VerboseLogger logger)
     {
         await Task.CompletedTask;
@@ -436,37 +511,7 @@ internal static class SourceEnricher
             return;
         }
 
-        var typeDoc = xmlParser.GetTypeDocumentation(apiType.FullName);
-        if (typeDoc != null)
-        {
-            apiType.Documentation = new DocComment
-            {
-                Summary = typeDoc.Summary,
-                Remarks = typeDoc.Remarks
-            };
-            logger.Log($"Found type documentation for {apiType.FullName}");
-        }
-
-        if (options.ShowDocs)
-        {
-            foreach (var member in apiType.Members)
-            {
-                var memberDoc = xmlParser.GetMemberDocumentation(apiType.FullName, member.Name, member.Kind);
-                if (memberDoc != null)
-                {
-                    member.Documentation = new DocComment
-                    {
-                        Summary = memberDoc.Summary,
-                        Remarks = memberDoc.Remarks,
-                        Parameters = memberDoc.Parameters,
-                        Returns = memberDoc.Returns
-                    };
-                }
-            }
-            logger.Log($"Enriched {apiType.Members.Count} members with documentation");
-        }
-
-        apiType.SourceResolution = "XmlDoc";
+        EnrichTypeFromXmlDoc(apiType, xmlParser, options, logger);
     }
 
     private static async Task MergePartialTypeDocumentation(


### PR DESCRIPTION
## Problem

`dotnet-inspect api System.Text.Json --docs` took ~1.5s (NativeAOT) despite all data being local. Two issues:

1. **Unnecessary PDB download**: For platform assemblies, the code tried downloading a PDB from the symbol server, failed, then fell back to local XML docs — adding ~1.3s of network latency per invocation.

2. **XML file re-parsed per type**: `EnrichFromXmlDocFileAsync` was called once per type in a loop, re-opening and re-parsing the same XML doc file each time (78 opens for System.Text.Json).

## Fix

1. **Auto-shortcut for platform assemblies**: When a platform assembly is used with `--docs`, go directly to the local XML doc path — no PDB download attempt needed.

2. **Batch XML enrichment**: New `EnrichTypesFromXmlDoc` method loads and parses the XML file once, then iterates over all types using the pre-loaded parser.

## Results (NativeAOT)

| Command | Before | After |
|---------|--------|-------|
| `api System.Text.Json` | 7ms | 7ms |
| `api System.Text.Json --docs` | 1,500ms | 27ms |

- Network calls: 1 HTTPS connection → 0
- XML file opens: 78 → 1
- All 504 tests pass