### PR TITLE
Route .dll positional to --library in api command

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1429,6 +1429,14 @@ public static class CommandLineBuilder
                 if (args.Length >= 2) typeName = args[1];
                 if (args.Length >= 3) positionalMembers.AddRange(args[2..]);
 
+                // Route .dll files to --library, .nupkg stays as package path
+                if (packagePath != null && packagePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    explicitAssembly = packagePath;
+                    packagePath = null;
+                    hasExplicitSource = true;
+                }
+
                 // Platform-preferred routing for System.*/Microsoft.* bare names
                 if (packagePath != null && PlatformResolver.IsPlatformCandidate(
                     packagePath.Contains('@') ? packagePath[..packagePath.IndexOf('@')] : packagePath))


### PR DESCRIPTION
## Problem

`dotnet-inspect api foo.dll` silently produced no output because the `.dll` path was treated as a package name and fell through to NuGet resolution (which found nothing). Users had to use `api --library foo.dll` explicitly.

The root-level `PreprocessArgs` already routes bare `foo.dll` → `library foo.dll`, but when prefixed with `api`, the positional was interpreted as a package path inside the api command's action handler.

## Fix

Detect `.dll` extension in the first positional argument within the api command and route it to `--library`, matching the root-level behavior.

```bash
# Before: silent no-op
dotnet-inspect api artifacts/bin/Foo/debug/Foo.dll

# After: works like --library
dotnet-inspect api artifacts/bin/Foo/debug/Foo.dll
```