### PR TITLE
Fix --library as DLL selector within packages

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1414,7 +1414,11 @@ public static class CommandLineBuilder
             var explicitPackage = parseResult.GetValue(apiPackageOption);
             var explicitAssembly = parseResult.GetValue(apiAssemblyOption);
             var explicitPlatform = parseResult.GetValue(apiPlatformOption);
-            bool hasExplicitSource = explicitPackage != null || explicitAssembly != null || explicitPlatform != null;
+            // A bare DLL name in --library (no path separators) is a selector within a package, not a standalone source
+            bool isLibrarySelector = explicitAssembly != null && explicitPackage == null
+                && !explicitAssembly.Contains('/') && !explicitAssembly.Contains('\\')
+                && explicitAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
+            bool hasExplicitSource = explicitPackage != null || (explicitAssembly != null && !isLibrarySelector) || explicitPlatform != null;
 
             // No args and no explicit source: show help (unless bare -s for section discovery)
             if (args.Length == 0 && !hasExplicitSource)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -98,6 +98,12 @@ public class ApiCommand
                 else if (!string.IsNullOrEmpty(options.AssemblyPath))
                 {
                     var targetPath = Path.Combine(searchPath, options.AssemblyPath.Replace('\\', '/'));
+                    // If it's a bare filename, search for it within the package
+                    if (!File.Exists(targetPath) && !options.AssemblyPath.Contains('/') && !options.AssemblyPath.Contains('\\'))
+                    {
+                        var found = Directory.EnumerateFiles(searchPath, options.AssemblyPath, SearchOption.AllDirectories).FirstOrDefault();
+                        if (found != null) targetPath = found;
+                    }
                     if (!File.Exists(targetPath))
                     {
                         Console.Error.WriteLine($"Error: Library '{options.AssemblyPath}' not found in package.");


### PR DESCRIPTION
## Problem

`api Microsoft.Azure.SignalR --library Microsoft.Azure.SignalR.Common.dll` failed with:

```
Error: File not found: Microsoft.Azure.SignalR.Common.dll
```

Two issues:

1. **CommandLineBuilder**: `--library` with a bare DLL name was treated as an explicit source, so the positional arg (`Microsoft.Azure.SignalR`) became a type filter instead of the package name.
2. **ApiCommand**: Even within the package path, `Path.Combine(extractRoot, "Common.dll")` doesn't find a file nested under `lib/net8.0/`.

## Fix

- A bare DLL name in `--library` (no path separators) without `--package` is now treated as a library *selector* within a package, not a standalone file source. The positional arg correctly routes as the package name.
- When `--library` is a bare filename, searches within the extracted package tree instead of requiring the full relative path.

```bash
# Now works
dotnet-inspect api Microsoft.Azure.SignalR --library Microsoft.Azure.SignalR.Common.dll
# → Library: Microsoft.Azure.SignalR.Common.dll | Types: 38

# Still works — default picks package-named DLL
dotnet-inspect api Microsoft.Azure.SignalR
# → Library: Microsoft.Azure.SignalR.dll | Types: 9

# Still works — local file path
dotnet-inspect api --library ./path/to/foo.dll
```

All 512 tests pass.