### PR TITLE
Add positional routing to samples command

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -631,10 +631,10 @@ public static class CommandLineBuilder
     {
         var samplesCommand = new Command("samples", "Show sample code references for a type or library");
 
-        var typeNameArg = new Argument<string?>("type")
+        var argsArg = new Argument<string[]>("args")
         {
-            Description = "Type name to get samples for (omit for library-wide samples)",
-            Arity = ArgumentArity.ZeroOrOne
+            Description = "Package and type name. When no --package/--library/--platform is given, first arg is the package.",
+            Arity = ArgumentArity.ZeroOrMore
         };
 
         var packageOption = new Option<string?>("--package") { Description = "Extract from package (name or name@version)" };
@@ -646,7 +646,7 @@ public static class CommandLineBuilder
         var listOption = new Option<bool>("--list") { Description = "List samples only (don't fetch content)" };
         var printOption = new Option<int?>("--print") { Description = "Print specific sample by number (raw code, no markdown)", Arity = ArgumentArity.ExactlyOne };
 
-        samplesCommand.Arguments.Add(typeNameArg);
+        samplesCommand.Arguments.Add(argsArg);
         samplesCommand.Options.Add(packageOption);
         samplesCommand.Options.Add(assemblyOption);
         samplesCommand.Options.Add(platformOption);
@@ -664,14 +664,38 @@ public static class CommandLineBuilder
 
         samplesCommand.SetAction(async (parseResult, ct) =>
         {
-            var typeName = parseResult.GetValue(typeNameArg);
-            
+            var args = parseResult.GetValue(argsArg) ?? [];
+            var explicitPackage = parseResult.GetValue(packageOption);
+            var explicitAssembly = parseResult.GetValue(assemblyOption);
+            var explicitPlatform = parseResult.GetValue(platformOption);
+            bool hasExplicitSource = explicitPackage != null || explicitAssembly != null || explicitPlatform != null;
+
+            string? packagePath = explicitPackage;
+            string? typeName = null;
+
+            if (hasExplicitSource)
+            {
+                if (args.Length >= 1) typeName = args[0];
+            }
+            else
+            {
+                if (args.Length >= 1) packagePath = args[0];
+                if (args.Length >= 2) typeName = args[1];
+
+                // Route file paths (.dll → --library, .nupkg stays as package path)
+                if (TryClassifyAsFilePath(packagePath, out var dllPath, out var nupkgPath))
+                {
+                    if (dllPath != null) { explicitAssembly = dllPath; packagePath = null; }
+                    else if (nupkgPath != null) { packagePath = nupkgPath; }
+                }
+            }
+
             var options = new SamplesOptions
             {
                 TypeName = typeName,
-                PackagePath = parseResult.GetValue(packageOption),
-                AssemblyPath = parseResult.GetValue(assemblyOption),
-                PlatformAssembly = parseResult.GetValue(platformOption),
+                PackagePath = packagePath,
+                AssemblyPath = explicitAssembly,
+                PlatformAssembly = explicitPlatform,
                 PlatformFramework = parseResult.GetValue(frameworkOption),
                 Tfm = parseResult.GetValue(tfmOption),
                 BrowsableUrls = parseResult.GetValue(browsableUrlsOption),


### PR DESCRIPTION
## Problem

The `samples` command required `--package` to specify the source:

```bash
dotnet-inspect samples --package Markout MarkoutWriter    # worked
dotnet-inspect samples Markout MarkoutWriter              # failed: 'MarkoutWriter' unrecognized
```

Every other command (`api`, `router`, etc.) supports positional routing where the first arg is the package and the second is the type/filter.

## Fix

Replaces the single `typeNameArg` with the same `argsArg` + positional routing pattern used by `api`:

- First positional → package
- Second positional → type name
- `TryClassifyAsFilePath` for `.dll`/`.nupkg` detection
- `--package` flag continues to work

```bash
# All work now
dotnet-inspect samples Markout MarkoutWriter --list
dotnet-inspect samples Newtonsoft.Json JObject
dotnet-inspect samples --package Markout MarkoutWriter
```

Also includes the `--library` selector fix from #148 (bare DLL name as library selector within packages).

All 512 tests pass.