### PR TITLE
Add stats view for single-type quiet mode

### DIFF
--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -113,6 +113,10 @@ public static class ApiOutputFormatter
         // Serialize title + description + identity fields + enum values + type params + interfaces + baseclass
         new MarkoutContext().Serialize(view, writer);
 
+        // Quiet: just title + stats line, no member tables
+        if (options.Verbosity == Verbosity.Quiet)
+            return writer.ToString().TrimEnd();
+
         // Imperative rendering for member tables and source info
         int truncatedCount = 0;
         string truncatedNoun = "";
@@ -296,11 +300,19 @@ public static class ApiOutputFormatter
             Source = apiSource,
             Tfm = selectedTfm,
             SamplesInfo = samplesInfo,
+            // Member stats for quiet verbosity
+            Constructors = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "constructor")) : null,
+            Fields = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
+            Properties = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
+            Methods = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
+            Events = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
             BaseclassRows = baseclassRows,
             SourceRows = sourceRows
         };
+
+        static int? NullIfZero(int count) => count > 0 ? count : null;
     }
 
     internal static TypeShapeView BuildShapeView(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string> memberFilter)

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -49,6 +49,13 @@ public class ApiTypeView
     [MarkoutPropertyName("Samples")]
     public string? SamplesInfo { get; set; }
 
+    // Member stats (quiet verbosity only)
+    [MarkoutSkipNull] public int? Constructors { get; set; }
+    [MarkoutSkipNull] public int? Fields { get; set; }
+    [MarkoutSkipNull] public int? Properties { get; set; }
+    [MarkoutSkipNull] public int? Methods { get; set; }
+    [MarkoutSkipNull] public int? Events { get; set; }
+
     /// <summary>
     /// Enum values without Description column (default).
     /// </summary>


### PR DESCRIPTION
## Problem

Library-level quiet gives a compact stats line:

```
dotnet-inspect api Markout -v:q
# Markout
Library: Markout.dll | Types: 32 | Methods: 98 | Properties: 57 | Source: NuGet | Version: 0.5.1
```

But single-type quiet still rendered full member tables — no way to get a quick summary.

## Fix

Single-type quiet now mirrors the library-level pattern:

```
dotnet-inspect api Markout MarkoutWriter -v:q
# Markout.MarkoutWriter (Markout 0.5.1)
Kind: class | Modifiers: sealed | Library: Markout | Package: Markout | Version: 0.5.1 | Source: NuGet | Constructors: 6 | Properties: 6 | Methods: 27
```

With `--samples`:

```
dotnet-inspect api Markout MarkoutWriter --samples -v:q
# Markout.MarkoutWriter (Markout 0.5.1)
Kind: class | Modifiers: sealed | ... | Samples: 5 available | Constructors: 6 | Properties: 6 | Methods: 27
```

Member counts (Constructors, Fields, Properties, Methods, Events) are shown inline with zero-count categories omitted. All 512 tests pass.