### PR TITLE
Support wildcard version patterns (e.g., 8.0.*, 11.0.0-preview*)

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -343,6 +343,111 @@ public static class PackageExtractor
         return null;
     }
 
+    /// <summary>
+    /// Resolves a wildcard version pattern (e.g., "11.0.0-preview*") to the latest matching version.
+    /// </summary>
+    public static async Task<string?> ResolveVersionPatternAsync(
+        HttpClient client,
+        string packageName,
+        string pattern,
+        List<NuGetSource> sources,
+        Action<string>? log)
+    {
+        string normalizedName = packageName.ToLowerInvariant();
+        string prefix = pattern.Replace("*", "");
+
+        log?.Invoke($"Resolving version pattern: {pattern}");
+
+        NuGet.Versioning.NuGetVersion? best = null;
+        string? bestOriginal = null;
+
+        foreach (var source in sources)
+        {
+            var versions = await FetchAllVersionsFromSourceAsync(client, normalizedName, source, log);
+            if (versions == null) continue;
+
+            foreach (var ver in versions)
+            {
+                if (ver.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                    && NuGet.Versioning.NuGetVersion.TryParse(ver, out var parsed)
+                    && (best == null || parsed > best))
+                {
+                    best = parsed;
+                    bestOriginal = ver;
+                }
+            }
+        }
+
+        if (bestOriginal != null)
+        {
+            log?.Invoke($"Resolved pattern '{pattern}' to version: {bestOriginal}");
+        }
+
+        return bestOriginal;
+    }
+
+    /// <summary>
+    /// Fetches all version strings for a package from a single source.
+    /// </summary>
+    private static async Task<List<string>?> FetchAllVersionsFromSourceAsync(
+        HttpClient client,
+        string packageName,
+        NuGetSource source,
+        Action<string>? log)
+    {
+        // Try flat-container index first
+        var flatContainerUrl = source.GetFlatContainerUrl();
+        if (flatContainerUrl != null)
+        {
+            string indexUrl = $"{flatContainerUrl}/{packageName}/index.json";
+            var versions = await FetchVersionListAsync(client, indexUrl, log);
+            if (versions != null)
+                return versions;
+        }
+
+        // Fall back to V3 service index discovery
+        var baseAddress = await GetPackageBaseAddressAsync(client, source, log);
+        if (baseAddress != null)
+        {
+            if (!baseAddress.EndsWith('/'))
+                baseAddress += "/";
+
+            string indexUrl = $"{baseAddress}{packageName}/index.json";
+            var versions = await FetchVersionListAsync(client, indexUrl, log);
+            if (versions != null)
+                return versions;
+        }
+
+        return null;
+    }
+
+    private static async Task<List<string>?> FetchVersionListAsync(
+        HttpClient client, string indexUrl, Action<string>? log)
+    {
+        log?.Invoke($"Fetching versions from: {indexUrl}");
+        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl);
+        if (json == null) return null;
+
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("versions", out var versions))
+            {
+                return versions.EnumerateArray()
+                    .Select(v => v.GetString())
+                    .Where(v => v != null)
+                    .Cast<string>()
+                    .ToList();
+            }
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Ignore parse errors
+        }
+
+        return null;
+    }
+
     private static async Task<string?> GetLatestVersionFromSourceAsync(
         HttpClient client,
         string packageName,

--- a/src/DotnetInspector.Services/PackageResolverService.cs
+++ b/src/DotnetInspector.Services/PackageResolverService.cs
@@ -56,8 +56,17 @@ public static class PackageResolverService
         var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
         bool isDefaultSource = sources.Count == 1 && sources[0].IsNuGetOrg();
 
+        // Resolve wildcard version patterns (e.g., 11.0.0-preview*)
+        if (version != null && version.Contains('*'))
+        {
+            version = await PackageExtractor.ResolveVersionPatternAsync(httpClient, packageName, version, sources, log);
+            if (version == null)
+            {
+                return null;
+            }
+        }
         // Discover latest version if not specified
-        if (string.IsNullOrEmpty(version))
+        else if (string.IsNullOrEmpty(version))
         {
             if (isDefaultSource)
             {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -133,12 +133,12 @@ public class PackageCommand
                 version = "";
             }
 
-            // Validate version looks like a NuGet version
-            if (version.Length > 0 && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+            // Validate version looks like a NuGet version (allow wildcard patterns like 11.0.0-preview*)
+            if (version.Length > 0 && !version.Contains('*') && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
             {
                 string badVersion = packageArgs.Length >= 2 ? packageArgs[1] : version;
                 Console.Error.WriteLine($"Error: '{badVersion}' is not a valid package version.");
-                Console.Error.WriteLine("Versions look like: 1.0.0, 8.0.5, 13.0.3-beta1");
+                Console.Error.WriteLine("Versions look like: 1.0.0, 8.0.5, 13.0.3-beta1, 11.0.0-preview*");
                 Console.Error.WriteLine($"To list available versions: dotnet-inspect package {packageName} --versions");
                 return 1;
             }


### PR DESCRIPTION
Adds NuGet-style floating version resolution for the package command. When a version contains `*`, all sources are queried for their version indices and the latest matching version is selected.

Works with `--version`, `@`-syntax, and across `--source`/`--add-source` feeds.

### Examples

```
dotnet-inspect package System.Text.Json@8.0.*
# System.Text.Json (8.0.6)

dotnet-inspect package System.Text.Json@9.*
# System.Text.Json (9.0.13)

dotnet-inspect package System.Text.Json --version 11.0.0-preview* --add-source <dotnet11-feed>
# System.Text.Json (11.0.0-preview.2.26110.125)
```

### Changes

- **PackageCommand.cs**: Allow `*` in version validation
- **PackageResolverService.cs**: Detect wildcard and delegate to pattern resolver before normal resolution
- **PackageExtractor.cs**: Add `ResolveVersionPatternAsync` — queries version indices from all configured sources, filters by prefix, picks the latest match

Closes #1