### PR TITLE
Ensure ref packs are downloaded before library command platform routing

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1305,6 +1305,14 @@ public static class CommandLineBuilder
                     assemblyPath = source;
                 else if (!source.Contains('@') && PlatformResolver.IsPlatformCandidate(source))
                 {
+                    // Ensure ref packs are downloaded before resolving
+                    bool verbose = parseResult.GetValue(verboseOption);
+                    Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+                    var requests = PlatformPackService.BuildPackRequests(source, null);
+                    await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, HttpClientFactory.Shared, log))
+                    {
+                    }
+
                     // Platform-preferred routing for System.*/Microsoft.* bare names
                     var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(source);
                     if (error == null && asmPath != null)


### PR DESCRIPTION
After `cache --clean`, `dotnet-inspect library System.Text.Json` resolved from NuGet instead of Platform (runtime).

### Root cause

The library command's positional arg routing called `PlatformResolver.ResolveAssembly` without first downloading ref packs. With an empty cache, `GetInstalledFrameworks()` returned nothing — the loop that also checks runtime assemblies never executed — and the command fell through to NuGet.

### Fix

Download ref packs before the routing decision, matching the behavior already present in the router command.

### Before (after `cache --clean`)
```
dotnet-inspect library System.Text.Json -v:q
# System.Text.Json.dll (net10.0)
Name: System.Text.Json | Source: NuGet
```

### After
```
dotnet-inspect library System.Text.Json -v:q
# System.Text.Json.dll
Name: System.Text.Json | Source: Platform (runtime)
```

Closes #1