### PR TITLE
Consolidate ref pack download into PlatformResolver.ResolveAssemblyAsync

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -376,7 +376,35 @@ public static class PlatformResolver
     }
 
     /// <summary>
+    /// Downloads ref packs if needed, then resolves an assembly name to a full path.
+    /// Prefer this over <see cref="ResolveAssembly"/> to avoid cache-miss races.
+    /// </summary>
+    public static async Task<(string? AssemblyPath, string? Framework, string? Version, string? Error)> ResolveAssemblyAsync(
+        string assemblyName,
+        HttpClient httpClient,
+        Action<string>? log = null,
+        string? frameworkSpec = null,
+        bool useRuntimeAssemblies = false)
+    {
+        if (!useRuntimeAssemblies)
+        {
+            // Parse explicit version from frameworkSpec (e.g., "runtime@9.0.12")
+            string? explicitVersion = null;
+            if (!string.IsNullOrEmpty(frameworkSpec) && frameworkSpec.Contains('@'))
+                explicitVersion = frameworkSpec[(frameworkSpec.LastIndexOf('@') + 1)..];
+
+            var requests = PlatformPackService.BuildPackRequests(assemblyName, explicitVersion);
+            await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, log))
+            {
+            }
+        }
+
+        return ResolveAssembly(assemblyName, frameworkSpec, useRuntimeAssemblies: useRuntimeAssemblies);
+    }
+
+    /// <summary>
     /// Resolves an assembly name to a full path within a framework.
+    /// Callers must ensure ref packs are already downloaded, or use <see cref="ResolveAssemblyAsync"/>.
     /// </summary>
     /// <param name="assemblyName">The assembly name (with or without .dll extension)</param>
     /// <param name="frameworkSpec">Optional framework specifier (e.g., "runtime", "runtime@9.0.12")</param>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1305,16 +1305,10 @@ public static class CommandLineBuilder
                     assemblyPath = source;
                 else if (!source.Contains('@') && PlatformResolver.IsPlatformCandidate(source))
                 {
-                    // Ensure ref packs are downloaded before resolving
+                    // Platform-preferred routing for System.*/Microsoft.* bare names
                     bool verbose = parseResult.GetValue(verboseOption);
                     Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
-                    var requests = PlatformPackService.BuildPackRequests(source, null);
-                    await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, HttpClientFactory.Shared, log))
-                    {
-                    }
-
-                    // Platform-preferred routing for System.*/Microsoft.* bare names
-                    var (asmPath, _, _, error) = PlatformResolver.ResolveAssembly(source);
+                    var (asmPath, _, _, error) = await PlatformResolver.ResolveAssemblyAsync(source, HttpClientFactory.Shared, log);
                     if (error == null && asmPath != null)
                         platformAssembly = source;
                     else

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -124,17 +124,11 @@ public class ApiCommand
             }
             else if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
-                // Ensure ref packs are downloaded before resolving
-                var packRequests = PlatformPackService.BuildPackRequests(options.PlatformAssembly, null);
-                await foreach (var _ in PlatformPackService.EnsurePacksAsync(packRequests, context.HttpClient, logger.Log))
-                {
-                }
-
-                var (assemblyPath, framework, version, error) = PlatformResolver.ResolveAssembly(
+                var (assemblyPath, framework, version, error) = await PlatformResolver.ResolveAssemblyAsync(
                     options.PlatformAssembly,
-                    options.PlatformFramework,
-                    packsDirectory: null,
-                    useRuntimeAssemblies: false);
+                    context.HttpClient,
+                    logger.Log,
+                    options.PlatformFramework);
 
                 if (error != null)
                 {

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -79,14 +79,10 @@ public class AssemblyCommand
 
             if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
-                // Ensure ref packs are downloaded before resolving
-                var packRequests = PlatformPackService.BuildPackRequests(options.PlatformAssembly, null);
-                await foreach (var _ in PlatformPackService.EnsurePacksAsync(packRequests, context.HttpClient, logger.Log))
-                {
-                }
-
-                var (resolvedPath, framework, version, error) = PlatformResolver.ResolveAssembly(
+                var (resolvedPath, framework, version, error) = await PlatformResolver.ResolveAssemblyAsync(
                     options.PlatformAssembly,
+                    context.HttpClient,
+                    logger.Log,
                     options.PlatformFramework);
 
                 if (error != null)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -136,31 +136,23 @@ public class DiffCommand
         var framework = options.Framework ?? "runtime";
         logger.Log($"Comparing {assemblyName} in {framework} v{fromVersion} → v{toVersion}");
 
-        // Ensure ref packs are downloaded for both versions
-        var fromRequests = PlatformPackService.BuildPackRequests(assemblyName, fromVersion);
-        var toRequests = PlatformPackService.BuildPackRequests(assemblyName, toVersion);
-        var allRequests = fromRequests.Concat(toRequests).ToList();
-        await foreach (var _ in PlatformPackService.EnsurePacksAsync(allRequests, httpClient, logger.Log))
-        {
-        }
-
-        // Resolve assemblies for both versions
-        var (fromPath, _, _, fromError) = PlatformResolver.ResolveAssembly(
+        // Resolve assemblies for both versions (downloads ref packs as needed)
+        var (fromPath, _, _, fromError) = await PlatformResolver.ResolveAssemblyAsync(
             assemblyName,
-            $"{framework}@{fromVersion}",
-            packsDirectory: null,
-            useRuntimeAssemblies: false);
+            httpClient,
+            logger.Log,
+            $"{framework}@{fromVersion}");
 
         if (fromError != null)
         {
             return (null, null, null, null, null, $"Error resolving v{fromVersion}: {fromError}");
         }
 
-        var (toPath, _, _, toError) = PlatformResolver.ResolveAssembly(
+        var (toPath, _, _, toError) = await PlatformResolver.ResolveAssemblyAsync(
             assemblyName,
-            $"{framework}@{toVersion}",
-            packsDirectory: null,
-            useRuntimeAssemblies: false);
+            httpClient,
+            logger.Log,
+            $"{framework}@{toVersion}");
 
         if (toError != null)
         {

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -70,22 +70,10 @@ public static class AssemblyCollector
             assemblyPaths.Add(new AssemblyInfo(asmPath, Path.GetFileName(asmPath), null));
         }
 
-        // 3. Platform assemblies (ensure ref packs are downloaded first)
-        if (options.PlatformAssemblies.Length > 0)
-        {
-            // Download packs for all requested platform assemblies
-            foreach (var platformAsm in options.PlatformAssemblies)
-            {
-                var requests = PlatformPackService.BuildPackRequests(platformAsm, null);
-                await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, logger.Log))
-                {
-                }
-            }
-        }
-
+        // 3. Platform assemblies
         foreach (var platformAsm in options.PlatformAssemblies)
         {
-            var (assemblyPath, version, resolvedFramework, error) = PlatformResolver.ResolveAssembly(platformAsm);
+            var (assemblyPath, version, resolvedFramework, error) = await PlatformResolver.ResolveAssemblyAsync(platformAsm, httpClient, logger.Log);
             if (error != null)
             {
                 Console.Error.WriteLine($"Warning: {error}, skipping.");


### PR DESCRIPTION
Five callers duplicated the pattern of downloading ref packs via `PlatformPackService.EnsurePacksAsync`, then calling `ResolveAssembly`. Missing the download step (as the library command did before #152) caused platform resolution to silently fall through to NuGet after `cache --clean`.

### Change

Add `ResolveAssemblyAsync` to `PlatformResolver` that handles both steps atomically:

```csharp
var (path, framework, version, error) = await PlatformResolver.ResolveAssemblyAsync(
    assemblyName, httpClient, log, frameworkSpec);
```

### Updated callers

| File | Before | After |
|------|--------|-------|
| `CommandLineBuilder.cs` (library routing) | 8 lines ensure+resolve | 1 call |
| `AssemblyCommand.cs` | 7 lines ensure+resolve | 1 call |
| `ApiCommand.cs` | 7 lines ensure+resolve | 1 call |
| `DiffCommand.cs` | 10 lines ensure+resolve×2 | 2 calls |
| `AssemblyCollector.cs` | 10 lines batch ensure+resolve | 1 call per assembly |

Callers that use streaming `EnsurePacksAsync` for early-exit optimization (router command, api positional routing) are left unchanged — they intentionally check each pack as it lands.

Net: **-8 lines** (48 added, 56 removed).

Closes #1