### PR TITLE
Improve member index page documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,33 @@ dotnet-inspect api 'Option<T>' --package System.CommandLine      # Generic types
 dotnet-inspect api Markout MarkoutWriter --samples -v:q          # Code samples
 ```
 
-Member selection and decompilation:
+Member selection and decompilation — use `--select` to see addressing hints, then drill in:
 
 ```bash
-dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory --select  # Show Select column
-dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1  # Member doc
+$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory --select
+## Constructors
+
+| Name | Signature | Select |
+| ---- | --------- | ------ |
+| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ...)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...> --index 1` |
+| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ..., IEnumerable<IValidateOptions<TOptions>>)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...>,IEnumerable<...> --index 2` |
+
+## Methods
+
+| Name | Signature | Select |
+| ---- | --------- | ------ |
+| Create | `TOptions Create(string)` | `-m Create --index 1` |
 ```
 
-Targeting a member with `--index` or `--params` produces four sections: **Source** (original C#), **Lowered C#** (decompiled), **IL** (disassembly), and **Annotated IL** (with stack state).
+Then target a member to get source, decompiled C#, and IL:
+
+```bash
+$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1
+## Source                          # Original C# (via SourceLink)
+## Lowered C#                     # Decompiled C# faithful to IL semantics
+## IL                             # Raw IL disassembly with resolved tokens
+## IL (Annotated)                 # IL with pre-execution stack state at each instruction
+```
 
 ### diff
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -55,6 +55,10 @@ dnx dotnet-inspect -y -- package System.Text.Json --versions
 
 # Get XML documentation for a type
 dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
+
+# Drill into a specific method — get source, decompiled C#, and IL
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory --select  # See Select column
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1  # Member doc
 ```
 
 ## Key Flags
@@ -64,6 +68,8 @@ dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
 | `-v:d` | Detailed output (full signatures, more info) | all commands |
 | `--docs` | Include XML documentation from source | `api` |
 | `-m Name` | Filter to specific member(s) | `api` |
+| `--select` | Show Select column for member addressing | `api` |
+| `--index N` | Target Nth overload for decompiled member doc | `api` |
 | `-t Name` | Filter to specific type(s), supports globs | `diff` |
 | `-n 10` | Limit results | `find`, `extensions`, `package --versions` |
 | `--terse` | Compact output (alias for --oneline --grouped) | `find` |
@@ -114,3 +120,4 @@ dnx dotnet-inspect -y -- llmstxt
 - Auditing libraries for SourceLink and determinism
 - Finding types matching a pattern (`--filter "Progress*"`)
 - Getting documentation from source (`--docs`)
+- Viewing decompiled source, IL, and annotated IL for methods

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -63,6 +63,10 @@ dnx dotnet-inspect -y -- samples Markout MarkoutWriter --list
 
 # Get XML documentation for a type
 dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
+
+# Drill into a specific method — get source, decompiled C#, and IL
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory --select  # See Select column
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1  # Member doc
 ```
 
 ## Key Flags

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -127,20 +127,40 @@ dotnet-inspect api System.Text.Json JsonSerializer -s                     # Head
 dotnet-inspect api System.Text.Json -s "Classes"                          # Type-level section filter
 ```
 
-Member selection and decompilation:
+Member selection and decompilation — use `--select` to see addressing hints, then drill in:
 
 ```bash
-dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory --select  # Show Select column
-dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1  # Member doc
+$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory --select
+## Constructors
+
+| Name | Signature | Select |
+| ---- | --------- | ------ |
+| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ...)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...> --index 1` |
+| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ..., IEnumerable<IValidateOptions<TOptions>>)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...>,IEnumerable<...> --index 2` |
+
+## Methods
+
+| Name | Signature | Select |
+| ---- | --------- | ------ |
+| Create | `TOptions Create(string)` | `-m Create --index 1` |
+```
+
+Then target a member to get source, decompiled C#, and IL:
+
+```bash
+$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1
+## Source                          # Original C# (via SourceLink)
+## Lowered C#                     # Decompiled C# faithful to IL semantics
+## IL                             # Raw IL disassembly with resolved tokens
+## IL (Annotated)                 # IL with pre-execution stack state at each instruction
+```
+
+For constructors with overloads, use `--params` to disambiguate:
+
+```bash
 dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory \
   -m .ctor --params "IEnumerable<...>,IEnumerable<...>"                   # Overload by params
 ```
-
-When `--index` or `--params` targets a member, output includes four sections:
-- **Source** — original C# source (when PDB with SourceLink is available)
-- **Lowered C#** — decompiled C# faithful to IL semantics, goto-with-labels control flow
-- **IL** — raw IL disassembly with resolved tokens
-- **Annotated IL** — IL with pre-execution stack state at each instruction
 
 Multi-library packages:
 


### PR DESCRIPTION
Adds example output for the `--select`/`--index`/`--params` workflow across all doc files. The previous docs showed the commands but not the output, making the two-step workflow harder to grasp.

### Changes

- **README.md** — Replace terse command listing with example output showing the Select column and the four output sections (Source, Lowered C#, IL, Annotated IL)
- **llms.txt** — Same example output plus separate `--params` example for constructor overload disambiguation
- **SKILL.md** (both copies) — Add `--select`/`--index` examples to Quick Patterns, add flags to Key Flags table, add decompilation to "When to Use" list

### Motivation

The member index page feature (`--select` → `--index`) is one of the most powerful capabilities — producing original source, decompiled C#, raw IL, and annotated IL for any method. Showing the actual output makes the workflow self-explanatory.