### PR TITLE
Fix publish order: RID-specific → any → pointer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,26 @@ jobs:
         with:
           dotnet-version: '10.0.x'
       
-      # Publish RID-specific packages first, then pointer package last
+      # Publish RID-specific packages first, then any package, then pointer package last
       - name: Publish packages
         run: |
-          # Publish RID-specific packages first (any package with a RID in the name)
-          for pkg in packages/dotnet-inspect.win-*.nupkg packages/dotnet-inspect.linux-*.nupkg packages/dotnet-inspect.osx-*.nupkg packages/dotnet-inspect.any.*.nupkg; do
+          # 1. Publish RID-specific AOT packages first
+          for pkg in packages/dotnet-inspect.win-*.nupkg packages/dotnet-inspect.linux-*.nupkg packages/dotnet-inspect.osx-*.nupkg; do
             if [[ -f "$pkg" ]]; then
               echo "Publishing $pkg"
               dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
             fi
           done
           
-          # Publish pointer package last (the one without a RID, just version number)
+          # 2. Publish any (non-AOT) package
+          for pkg in packages/dotnet-inspect.any.*.nupkg; do
+            if [[ -f "$pkg" ]]; then
+              echo "Publishing any package: $pkg"
+              dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            fi
+          done
+          
+          # 3. Publish pointer package last (references all RID-specific packages)
           for pkg in packages/dotnet-inspect.[0-9]*.nupkg; do
             if [[ -f "$pkg" ]]; then
               echo "Publishing pointer package: $pkg"


### PR DESCRIPTION
The `any` (non-AOT) package was grouped with RID-specific AOT packages in the publish loop, but NuGet requires dependencies to exist before the referencing package is pushed.

**New order:**
1. RID-specific AOT packages (win-x64, linux-x64, osx-arm64)
2. `any` (non-AOT) package
3. Pointer package (references all of the above)