### PR TITLE
Fix resource leak in PdbContext.Open()

### DIFF
--- a/src/DotnetInspector.Metadata/PdbContext.cs
+++ b/src/DotnetInspector.Metadata/PdbContext.cs
@@ -74,7 +74,17 @@ public class PdbContext : IDisposable
     public static PdbContext Open(string assemblyPath, Action<string>? log = null)
     {
         var stream = File.OpenRead(assemblyPath);
-        var peReader = new PEReader(stream);
+        PEReader peReader;
+        try
+        {
+            peReader = new PEReader(stream);
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+
         var context = new PdbContext(stream, peReader, assemblyPath, log);
 
         if (!peReader.HasMetadata)


### PR DESCRIPTION
## Summary
- If `PEReader` constructor throws after `File.OpenRead()` succeeds, the `FileStream` was never disposed
- Wrap in try/catch to ensure the stream is disposed on failure before re-throwing

## Test plan
- [x] Builds successfully
- [ ] Verify with corrupted PE file that stream is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)