### PR TITLE
Add error handling to commands that could crash on failure

### DIFF
--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -90,6 +90,11 @@ public class ExtensionsCommand
 
             return 0;
         }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
         finally
         {
             AssemblyCollector.CleanupTempDirs(tempDirs);

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -44,6 +44,11 @@ public class FindCommand
             // Single pattern - use original logic
             return await ExecuteSinglePatternAsync(patterns[0], options, logger, tempDirs, context.HttpClient);
         }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
         finally
         {
             AssemblyCollector.CleanupTempDirs(tempDirs);

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -71,6 +71,11 @@ public class ImplementsCommand
 
             return 0;
         }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
         finally
         {
             AssemblyCollector.CleanupTempDirs(tempDirs);

--- a/src/dotnet-inspect/Commands/PlatformCommand.cs
+++ b/src/dotnet-inspect/Commands/PlatformCommand.cs
@@ -17,30 +17,38 @@ public class PlatformCommand
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
 
-        var packsDir = PlatformResolver.GetPacksDirectory();
-        if (packsDir == null)
+        try
         {
-            Console.Error.WriteLine("Error: Could not locate .NET SDK packs directory.");
-            Console.Error.WriteLine("Ensure .NET SDK is installed and DOTNET_ROOT is set if using a non-standard location.");
+            var packsDir = PlatformResolver.GetPacksDirectory();
+            if (packsDir == null)
+            {
+                Console.Error.WriteLine("Error: Could not locate .NET SDK packs directory.");
+                Console.Error.WriteLine("Ensure .NET SDK is installed and DOTNET_ROOT is set if using a non-standard location.");
+                return Task.FromResult(1);
+            }
+
+            logger.Log($"Using packs directory: {packsDir}");
+
+            // Handle --list-versions
+            if (options.ListVersions)
+            {
+                return Task.FromResult(ListVersions(packsDir, options));
+            }
+
+            // If --framework specified, list assemblies for that framework
+            if (!string.IsNullOrEmpty(options.Framework))
+            {
+                return Task.FromResult(ListAssemblies(packsDir, options, logger));
+            }
+
+            // Default: list frameworks (consistent with api/samples requiring explicit source)
+            return Task.FromResult(ListFrameworks(packsDir, options));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
             return Task.FromResult(1);
         }
-
-        logger.Log($"Using packs directory: {packsDir}");
-
-        // Handle --list-versions
-        if (options.ListVersions)
-        {
-            return Task.FromResult(ListVersions(packsDir, options));
-        }
-
-        // If --framework specified, list assemblies for that framework
-        if (!string.IsNullOrEmpty(options.Framework))
-        {
-            return Task.FromResult(ListAssemblies(packsDir, options, logger));
-        }
-
-        // Default: list frameworks (consistent with api/samples requiring explicit source)
-        return Task.FromResult(ListFrameworks(packsDir, options));
     }
 
     private static int ListFrameworks(string packsDir, PlatformOptions options)

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -20,22 +20,30 @@ public class SamplesCommand
         var logger = context.Logger;
         var typeName = options.TypeName;
 
-        // Get package info from options
-        string? packageName = null;
-        string? packageVersion = null;
-        if (!string.IsNullOrEmpty(options.PackagePath))
+        try
         {
-            (packageName, packageVersion) = PackageReferenceParser.ParsePackageReference(options.PackagePath);
-        }
+            // Get package info from options
+            string? packageName = null;
+            string? packageVersion = null;
+            if (!string.IsNullOrEmpty(options.PackagePath))
+            {
+                (packageName, packageVersion) = PackageReferenceParser.ParsePackageReference(options.PackagePath);
+            }
 
-        // If type name is specified, get samples for that type only
-        if (!string.IsNullOrEmpty(typeName))
+            // If type name is specified, get samples for that type only
+            if (!string.IsNullOrEmpty(typeName))
+            {
+                return await ExecuteForTypeAsync(typeName, options, packageName, packageVersion, logger, context.HttpClient);
+            }
+
+            // No type specified - get samples for entire assembly
+            return await ExecuteForAssemblyAsync(options, packageName, packageVersion, logger, context.HttpClient);
+        }
+        catch (Exception ex)
         {
-            return await ExecuteForTypeAsync(typeName, options, packageName, packageVersion, logger, context.HttpClient);
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
         }
-
-        // No type specified - get samples for entire assembly
-        return await ExecuteForAssemblyAsync(options, packageName, packageVersion, logger, context.HttpClient);
     }
 
     private static async Task<int> ExecuteForTypeAsync(


### PR DESCRIPTION
## Summary
- `SamplesCommand` and `PlatformCommand` had zero try/catch — network or file I/O errors would crash with unhandled exceptions
- `FindCommand`, `ExtensionsCommand`, and `ImplementsCommand` had try/finally for temp dir cleanup but no catch block
- All five now follow the same pattern as `ApiCommand`/`AssemblyCommand`/`DiffCommand`: catch, write to stderr, return exit code 1

## Test plan
- [x] Full CLI builds
- [ ] Verify with invalid package name that error is reported gracefully (not a stack trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)