### PR TITLE
Bound source fetch concurrency to 16 parallel requests

### DIFF
--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -282,18 +282,17 @@ internal static class SourceEnricher
         var urlList = allUrlsToFetch.OrderBy(u => u, StringComparer.OrdinalIgnoreCase).ToList();
         Dictionary<string, string?> contentCache = [];
 
-        logger.Log($"Phase 2: Fetching {urlList.Count} URLs in parallel");
-        var fetchTasks = urlList.Select(async url =>
-        {
-            var content = await fetcher.FetchSourceAsync(url);
-            return (Url: url, Content: content);
-        });
-
-        var results = await Task.WhenAll(fetchTasks);
-        foreach (var result in results)
-        {
-            contentCache[result.Url] = result.Content;
-        }
+        logger.Log($"Phase 2: Fetching {urlList.Count} URLs (max 16 concurrent)");
+        await Parallel.ForEachAsync(urlList,
+            new ParallelOptions { MaxDegreeOfParallelism = 16 },
+            async (url, ct) =>
+            {
+                var content = await fetcher.FetchSourceAsync(url);
+                lock (contentCache)
+                {
+                    contentCache[url] = content;
+                }
+            });
 
         logger.Log($"Phase 2: Fetched {contentCache.Count(kv => kv.Value != null)} of {contentCache.Count} URLs ({stopwatch.ElapsedMilliseconds}ms)");
 


### PR DESCRIPTION
## Summary

- Replace unbounded `Task.WhenAll` in `SourceEnricher.EnrichTypesWithSourceInfoBatchedAsync` with `Parallel.ForEachAsync` limited to 16 concurrent requests
- Prevents overwhelming GitHub raw content servers when inspecting assemblies with many source-linked types
- Consistent with the existing bounded pattern in `LibraryMetadataService.VerifySourceAccessibilityAsync`

## Test plan

- [ ] `dotnet run --project src/dotnet-inspect.Tests` passes (512 pass, 9 skip)
- [ ] `dotnet-inspect api Newtonsoft.Json --show-docs` still fetches source content correctly
- [ ] Verbose output shows "max 16 concurrent" log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)