### PR TITLE
Standardize .TrimEnd() on all MarkoutWriter output

### DIFF
--- a/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
@@ -25,7 +25,7 @@ public static class ExtensionsOutputFormatter
         if (verbosity == Verbosity.Quiet)
         {
             WriteCountsTable(writer, targetType, directExtensions, reachableExtensions);
-            return writer.ToString();
+            return writer.ToString().TrimEnd();
         }
 
         // Direct extensions (always shown)
@@ -43,7 +43,7 @@ public static class ExtensionsOutputFormatter
             WriteExtensionTable(writer, group.ToList());
         }
 
-        return writer.ToString();
+        return writer.ToString().TrimEnd();
     }
 
     private static void WriteCountsTable(MarkoutWriter writer,

--- a/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
@@ -17,7 +17,7 @@ public static class ImplementsOutputFormatter
         if (results.Count == 0)
         {
             writer.WriteParagraph("No implementing types found.");
-            return writer.ToString();
+            return writer.ToString().TrimEnd();
         }
 
         writer.WriteField("Matches", results.Count);
@@ -39,6 +39,6 @@ public static class ImplementsOutputFormatter
             writer.WriteTable(headers, rows);
         }
 
-        return writer.ToString();
+        return writer.ToString().TrimEnd();
     }
 }

--- a/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PlatformOutputFormatter.cs
@@ -47,7 +47,7 @@ public static class PlatformOutputFormatter
         var rows = frameworks.Select(f => new[] { f.ShortName, f.LatestVersion, f.AssemblyCount.ToString() });
         writer.WriteTable(headers, rows);
 
-        return writer.ToString();
+        return writer.ToString().TrimEnd();
     }
 
     public static string FormatVersions(List<FrameworkInfo> frameworks, int? limit)
@@ -73,7 +73,7 @@ public static class PlatformOutputFormatter
             }
         }
 
-        return writer.ToString();
+        return writer.ToString().TrimEnd();
     }
 
     public static string FormatAssemblies(List<FrameworkAssemblyData> frameworkData, bool includeTypes,
@@ -116,6 +116,6 @@ public static class PlatformOutputFormatter
             }
         }
 
-        return writer.ToString();
+        return writer.ToString().TrimEnd();
     }
 }


### PR DESCRIPTION
## Summary

- Add missing `.TrimEnd()` to `PlatformOutputFormatter`, `ImplementsOutputFormatter`, and `ExtensionsOutputFormatter`
- These three formatters returned `writer.ToString()` without `TrimEnd()`, while all other formatters (Api, Diff, Find, Samples) consistently called `.TrimEnd()`
- Since all callers use `Console.WriteLine()`, the missing `TrimEnd()` caused trailing blank lines in output

## Test plan

- [ ] `dotnet run --project src/dotnet-inspect.Tests` passes (512 pass, 9 skip)
- [ ] `dotnet-inspect platform` output has no trailing blank line
- [ ] `dotnet-inspect implements IDisposable` output has no trailing blank line
- [ ] `dotnet-inspect extensions IEnumerable` output has no trailing blank line

🤖 Generated with [Claude Code](https://claude.com/claude-code)