### PR TITLE
Log swallowed exceptions in InspectAsync and ResolveMethodSourceAsync

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -650,8 +650,9 @@ public class ApiCommand
 
             return new MethodSourceContext(sourceCode, methodInfo.SourceUrl);
         }
-        catch
+        catch (Exception ex)
         {
+            logger.Log($"Warning: Failed to resolve method source for {typeName}.{methodName}: {ex.Message}");
             return null;
         }
     }

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -126,8 +126,9 @@ internal static class LibraryMetadataService
 
             return inspection;
         }
-        catch
+        catch (Exception ex)
         {
+            logger.Log($"Warning: Failed to inspect {Path.GetFileName(path)}: {ex.Message}");
             return null;
         }
     }


### PR DESCRIPTION
## Summary

- Add verbose logging to two bare `catch { return null; }` blocks that had a logger in scope but weren't using it
- `LibraryMetadataService.InspectAsync` — now logs which assembly failed inspection and why
- `ApiCommand.ResolveMethodSourceAsync` — now logs which method's source resolution failed and why
- Both only emit in verbose mode (`-v`), so normal output is unchanged

## Test plan

- [ ] `dotnet run --project src/dotnet-inspect.Tests` passes (512 pass, 9 skip)
- [ ] `dotnet-inspect api System.Runtime -v` shows verbose log lines without spurious warnings
- [ ] Behavior unchanged without `-v` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)