### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` from `0.3.0` to `0.3.1` for patch release

## Changes since 0.3.0

- #164 Fix resource leak in PdbContext.Open()
- #165 Remove ~450 lines unused GetPdbReaderAsync legacy code
- #166 Add error handling to commands that could crash on failure
- #167 Bound source fetch concurrency to 16 parallel requests
- #168 Standardize .TrimEnd() on all MarkoutWriter output
- #169 Log swallowed exceptions in InspectAsync and ResolveMethodSourceAsync

🤖 Generated with [Claude Code](https://claude.com/claude-code)