### PR TITLE
Report error when package not found or download fails

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -91,6 +91,7 @@ public static class PackageExtractor
             version = await GetLatestVersionAsync(client, packageName, sources, log);
             if (version == null)
             {
+                Console.Error.WriteLine($"Error: Package '{packageName}' not found.");
                 return null;
             }
         }
@@ -144,6 +145,7 @@ public static class PackageExtractor
         if (packageBytes == null)
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { }
+            Console.Error.WriteLine($"Error: Failed to download package '{packageName}@{version}'.");
             return null;
         }
 


### PR DESCRIPTION
## Summary

- Add stderr error messages to `PackageExtractor` when package lookup or download fails
- Fixes: `dotnet-inspect api NonExistentPackage` exits 1 with zero output — user gets no feedback
- Now prints `Error: Package 'NonExistentPackage' not found.` or `Error: Failed to download package 'name@version'.`
- All callers (api, package, assembly, find, implements, extensions) benefit from this fix

## Test plan

- [ ] `dotnet run --project src/dotnet-inspect.Tests` passes
- [ ] `dotnet-inspect api NonExistentPackage` now shows error on stderr
- [ ] `dotnet-inspect api System.Text.Json` still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)