### PR TITLE
Fix options before bare name breaking routing

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -43,9 +43,20 @@ public static class CommandLineBuilder
     /// </summary>
     public static string[] PreprocessArgs(string[] args)
     {
-        if (args.Length > 0 && !args[0].StartsWith('-') && !KnownCommands.Contains(args[0]))
+        // Find the first positional argument, skipping any leading options
+        int firstPositional = -1;
+        for (int i = 0; i < args.Length; i++)
         {
-            if (TryClassifyAsFilePath(args[0], out var dllPath, out var nupkgPath))
+            if (!args[i].StartsWith('-'))
+            {
+                firstPositional = i;
+                break;
+            }
+        }
+
+        if (firstPositional >= 0 && !KnownCommands.Contains(args[firstPositional]))
+        {
+            if (TryClassifyAsFilePath(args[firstPositional], out var dllPath, out var nupkgPath))
             {
                 if (dllPath != null) return ["library", .. args];
                 if (nupkgPath != null) return ["package", .. args];


### PR DESCRIPTION
## Summary

- Fix `dotnet-inspect -T:d System.Text.Json` failing with "Unrecognized command or argument"
- `PreprocessArgs` only checked `args[0]` — when it was an option like `-T:d`, bare-name routing was skipped
- Now scans past leading options to find the first positional argument before applying routing
- `dotnet-inspect -T:d`, `-v:q`, etc. without a bare name still work as before

## Test plan

- [ ] `dotnet run --project src/dotnet-inspect.Tests` passes (512 pass, 9 skip)
- [ ] `dotnet-inspect -T:d System.Text.Json` now works (was broken)
- [ ] `dotnet-inspect System.Text.Json -T:d` still works (was already working)
- [ ] `dotnet-inspect -v:q System.Text.Json` works
- [ ] `dotnet-inspect -T:d` alone still shows help
- [ ] `dotnet-inspect --help` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)