### PR TITLE
Add member index shorthand (Name:N) and improve api command UX

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -122,9 +122,9 @@ public static class CommandLineBuilder
         var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
         var markoutOption = new Option<bool>("--markout") { Description = "Output as Markout (default)" };
         var verboseOption = new Option<bool>("--verbose") { Description = "Show progress messages on stderr" };
-        var verbosityOption = new Option<string?>("-v") { Description = "Verbosity level: q(uiet), m(inimal), n(ormal), d(etailed)" };
-        var includeSectionsOption = new Option<string?>("-s") { Description = "Include only these sections (comma-separated, supports wildcards e.g. -s:Extension*).\nUse -s alone to list available sections.", Arity = ArgumentArity.ZeroOrOne };
-        var excludeSectionsOption = new Option<string?>("-x") { Description = "Exclude these sections by name (comma-separated, e.g., -x:Methods)" };
+        var verbosityOption = new Option<string?>("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)" };
+        var includeSectionsOption = new Option<string?>("-s") { Description = "Include sections by name (comma-separated, supports wildcards). Use -s alone to list.", Arity = ArgumentArity.ZeroOrOne };
+        var excludeSectionsOption = new Option<string?>("-x") { Description = "Exclude sections by name (comma-separated, e.g., -x:Methods)" };
         var limitOption = new Option<int?>("-n") { Description = "Limit number of results" };
         var tipsOption = new Option<string?>("--tips") { Description = "Tip verbosity: q(uiet), m(inimal), d(etailed)", Arity = ArgumentArity.ZeroOrOne };
         tipsOption.Aliases.Add("-T");
@@ -137,7 +137,7 @@ public static class CommandLineBuilder
         };
         var addSourceOption = new Option<string[]>("--add-source")
         {
-            Description = "Additional NuGet source URL (can repeat)",
+            Description = "NuGet source URL to add (can repeat)",
             AllowMultipleArgumentsPerToken = true
         };
         var nugetConfigOption = new Option<string?>("--nugetconfig")
@@ -1430,34 +1430,34 @@ public static class CommandLineBuilder
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var apiPackageOption = new Option<string?>("--package") { Description = "Extract from package (file, name, or name@version)" };
-        var apiAssemblyOption = new Option<string?>("--library") { Description = "Library path (local file, or relative path within package)" };
-        var apiPlatformOption = new Option<string?>("--platform") { Description = "Extract from platform library (e.g., System.Text.Json)" };
-        var apiFrameworkOption = new Option<string?>("--framework") { Description = "Platform framework (runtime, aspnetcore, netstandard). Use @version for specific version" };
-        var apiTfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
+        var apiPackageOption = new Option<string?>("--package") { Description = "Source: package (file, name, or name@version)" };
+        var apiAssemblyOption = new Option<string?>("--library") { Description = "Source: library path (local file, or relative within package)" };
+        var apiPlatformOption = new Option<string?>("--platform") { Description = "Source: platform library (e.g., System.Text.Json)" };
+        var apiFrameworkOption = new Option<string?>("--framework") { Description = "Source: platform framework (runtime, aspnetcore, netstandard). @version for specific" };
+        var apiTfmOption = new Option<string?>("--tfm") { Description = "Source: select by TFM (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include hidden (EditorBrowsable.Never) and obsolete members" };
-        var typeFilterOption = new Option<string?>("-t") { Description = "Filter to types by glob pattern (e.g., *Json*, Progress*)" };
+        var typeFilterOption = new Option<string?>("-t") { Description = "Filter types by glob pattern (e.g., *Json*, Progress*)" };
         typeFilterOption.Aliases.Add("--type");
         var memberOption = new Option<string[]>("-m")
         {
-            Description = "Filter to specific member(s)",
+            Description = "Filter members by name (supports globs)",
             AllowMultipleArgumentsPerToken = true
         };
         memberOption.Aliases.Add("--member");
-        var docsOption = new Option<bool>("--docs") { Description = "Fetch and display XML doc comments from source" };
-        var useLocalDocsOption = new Option<bool>("--use-local-docs") { Description = "Use XML doc files from packs directory (offline, implies --docs)" };
-        var samplesOption = new Option<bool>("--samples") { Description = "Fetch and display code samples from source" };
-        var sourcelinkOnlyOption = new Option<bool>("--sourcelink-only") { Description = "Filter to types with sourcelink resolution" };
-        var browsableUrlsOption = new Option<bool>("--browsable-urls") { Description = "Use /blob/ URLs for browser viewing instead of /raw/ URLs (default is /raw/ for LLM consumption)" };
-        var compactOption = new Option<bool>("--compact") { Description = "Minified JSON (use with --json)" };
-        var signaturesOnlyOption = new Option<bool>("--signatures-only") { Description = "Output only method signatures (no table formatting)" };
-        var shapeOption = new Option<bool>("--shape") { Description = "View type shape (inheritance, interfaces, members)" };
-        var unsafeOption = new Option<bool>("--unsafe") { Description = "Filter to methods with unsafe signatures (pointers)" };
-        var ctorOption = new Option<bool>("--ctor") { Description = "Show constructors only (shorthand for -m .ctor)" };
-        var indexOption = new Option<int?>("--index") { Description = "Select a specific overload by 1-based index (use with -m)" };
-        var paramsOption = new Option<string>("--params") { Description = "Select overload by comma-separated simple parameter type names (use with -m)" };
-        var ofOption = new Option<string>("-of") { Description = "Select overload by first parameter simple type name (use with -m)" };
-        var selectOption = new Option<bool>("--select") { Description = "Add a column showing -m/--params values to target each member" };
+        var docsOption = new Option<bool>("--docs") { Description = "Include XML doc comments from source" };
+        var useLocalDocsOption = new Option<bool>("--use-local-docs") { Description = "Include XML docs from local packs directory (offline, implies --docs)" };
+        var samplesOption = new Option<bool>("--samples") { Description = "Include code samples from source" };
+        var sourcelinkOnlyOption = new Option<bool>("--sourcelink-only") { Description = "Filter types to those with SourceLink resolution" };
+        var browsableUrlsOption = new Option<bool>("--browsable-urls") { Description = "Use /blob/ URLs for browser viewing (default: /raw/ for LLM consumption)" };
+        var compactOption = new Option<bool>("--compact") { Description = "Output as minified JSON (use with --json)" };
+        var signaturesOnlyOption = new Option<bool>("--signatures-only") { Description = "Output member signatures only (plain text, no table)" };
+        var shapeOption = new Option<bool>("--shape") { Description = "Output type shape (inheritance, interfaces, members)" };
+        var unsafeOption = new Option<bool>("--unsafe") { Description = "Filter members to unsafe signatures (pointers)" };
+        var ctorOption = new Option<bool>("--ctor") { Description = "Filter members to constructors (shorthand for -m .ctor)" };
+        var indexOption = new Option<int?>("--index") { Description = "Select member overload by index (or use Name:N shorthand)" };
+        var paramsOption = new Option<string>("--params") { Description = "Select member overload by parameter types (comma-separated)" };
+        var ofOption = new Option<string>("-of") { Description = "Select member overload by first parameter type" };
+        var selectOption = new Option<bool>("--select") { Description = "Show member overload index (Name:N) column" };
 
         apiCommand.Arguments.Add(argsArg);
         apiCommand.Options.Add(apiPackageOption);
@@ -1592,6 +1592,24 @@ public static class CommandLineBuilder
             var allMembers = members.Concat(positionalMembers).ToArray();
             var ctorOnly = parseResult.GetValue(ctorOption);
 
+            // Parse Name:N shorthand (e.g., "Deserialize:6")
+            // A bare member name without :N auto-selects overload 1 (detail page)
+            int? shorthandIndex = null;
+            bool hasExplicitIndex = false;
+            for (int i = 0; i < allMembers.Length; i++)
+            {
+                var colonIdx = allMembers[i].LastIndexOf(':');
+                if (colonIdx > 0 && int.TryParse(allMembers[i][(colonIdx + 1)..], out var idx))
+                {
+                    allMembers[i] = allMembers[i][..colonIdx];
+                    shorthandIndex = idx;
+                    hasExplicitIndex = true;
+                }
+            }
+
+            if (!hasExplicitIndex && allMembers.Length == 1)
+                shorthandIndex = 1;
+
             HashSet<string> memberFilter = [];
             if (ctorOnly)
             {
@@ -1626,7 +1644,7 @@ public static class CommandLineBuilder
                 ShapeOutput = parseResult.GetValue(shapeOption),
                 UnsafeOnly = parseResult.GetValue(unsafeOption),
                 CtorOnly = ctorOnly,
-                OverloadIndex = parseResult.GetValue(indexOption),
+                OverloadIndex = parseResult.GetValue(indexOption) ?? shorthandIndex,
                 ParamTypes = parseResult.GetValue(paramsOption)?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
                 FirstParamType = parseResult.GetValue(ofOption),
                 ShowSelect = parseResult.GetValue(selectOption),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -250,6 +250,35 @@ public class ApiCommand
                 }
 
                 WriteFullApiOutput(api, options, selectedTfm);
+
+                if (!options.IsRawOutput)
+                {
+                    var sourceFlag = !string.IsNullOrEmpty(options.PlatformAssembly) ? $"--platform {options.PlatformAssembly}"
+                        : !string.IsNullOrEmpty(options.PackagePath) ? $"--package {packageName ?? options.PackagePath}"
+                        : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
+                        : "";
+
+                    // Pick a representative type: prefer the one with most members
+                    var exampleType = api.Types
+                        .Where(t => !options.SourceLinkOnly || !string.IsNullOrEmpty(t.SourceUrl))
+                        .OrderByDescending(t => t.Members.Count)
+                        .FirstOrDefault();
+
+                    if (exampleType != null)
+                    {
+                        var simpleName = exampleType.FullName.Contains('.')
+                            ? exampleType.FullName[(exampleType.FullName.LastIndexOf('.') + 1)..] : exampleType.FullName;
+
+                        List<Tip> tips =
+                        [
+                            new(ApiCommand.Name, $"{simpleName} {sourceFlag}", "view type members"),
+                            new(ApiCommand.Name, $"{simpleName} {sourceFlag} --shape", "view type shape"),
+                            new(ApiCommand.Name, $"-t \"*Writer*\" {sourceFlag}", "filter types by pattern"),
+                        ];
+
+                        Hints.WriteTips(options.TipLevel, [.. tips]);
+                    }
+                }
             }
             else
             {
@@ -316,7 +345,7 @@ public class ApiCommand
                     {
                         if (options.MemberFilter.Count != 1)
                         {
-                            Console.Error.WriteLine("Error: --index requires exactly one member name via -m.");
+                            Console.Error.WriteLine("Error: --index/Name:N requires exactly one member name.");
                             return 1;
                         }
 
@@ -328,7 +357,7 @@ public class ApiCommand
                         int idx = options.OverloadIndex.Value;
                         if (idx < 1 || idx > overloads.Count)
                         {
-                            Console.Error.WriteLine($"Error: --index {idx} is out of range. {memberName} has {overloads.Count} overload(s).");
+                            Console.Error.WriteLine($"Error: {memberName}:{idx} is out of range. {memberName} has {overloads.Count} overload(s).");
                             return 1;
                         }
 
@@ -430,6 +459,41 @@ public class ApiCommand
                     }
 
                     WriteTypeOutput(apiType, foundIn, packageName, packageVersion, apiSource, selectedTfm, effectiveOptions);
+
+                    if (!effectiveOptions.IsRawOutput && !effectiveOptions.OverloadIndex.HasValue)
+                    {
+                        var sourceFlag = !string.IsNullOrEmpty(options.PlatformAssembly) ? $"--platform {options.PlatformAssembly}"
+                            : !string.IsNullOrEmpty(options.PackagePath) ? $"--package {packageName ?? options.PackagePath}"
+                            : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
+                            : "";
+
+                        var simpleName = apiType.FullName.Contains('.')
+                            ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
+
+                        // Pick a member with overloads for the Name:N example, or fall back to any method
+                        var overloadGroups = apiType.Members
+                            .Where(m => m.Kind is "method" or "constructor")
+                            .GroupBy(m => m.Name)
+                            .OrderByDescending(g => g.Count())
+                            .ToList();
+                        var exampleGroup = overloadGroups.FirstOrDefault();
+
+                        List<Tip> tips = [];
+
+                        if (exampleGroup != null)
+                        {
+                            var memberName = exampleGroup.Key == ".ctor" ? ".ctor" : exampleGroup.Key;
+                            tips.Add(new(ApiCommand.Name, $"{simpleName} {sourceFlag} {memberName}:1", "view member detail (source, IL)"));
+                        }
+
+                        if (overloadGroups.Any(g => g.Count() > 1))
+                            tips.Add(new(ApiCommand.Name, $"{simpleName} {sourceFlag} --select", "show Name:N overload index"));
+
+                        tips.Add(new(ApiCommand.Name, $"{simpleName} {sourceFlag} --shape", "view type shape"));
+                        tips.Add(new(ApiCommand.Name, $"{simpleName} {sourceFlag} --docs", "include XML documentation"));
+
+                        Hints.WriteTips(effectiveOptions.TipLevel, [.. tips]);
+                    }
                 }
                 else if (lookupResult.Suggestions.Count > 0)
                 {

--- a/src/dotnet-inspect/Output/MemberTableFormatter.cs
+++ b/src/dotnet-inspect/Output/MemberTableFormatter.cs
@@ -21,41 +21,13 @@ internal abstract class MemberTableFormatter
     };
 
     /// <summary>
-    /// Builds the -m/--params string needed to target a specific member.
-    /// When the member name is unique (no overloads), returns just "-m Name".
-    /// When overloads exist, appends "--params type1,type2" using simple type names.
+    /// Builds the Name:N shorthand string for the Select column.
     /// </summary>
     protected static string BuildSelectString(ApiMember member, bool hasOverloads, int overloadIndex = 0)
     {
-        var name = member.Name;
-        if (!hasOverloads || member.Kind is "property" or "field" or "event")
-            return $"-m {name} --index {overloadIndex}";
-
-        var paramTypes = SignatureParser.ExtractParamTypes(member.Signature);
-        if (paramTypes.Count == 0)
-            return $"-m {name} --params \"\" --index {overloadIndex}";
-
-        var simpleTypes = paramTypes.Select(SimplifyTypeName).ToList();
-        return $"-m {name} --params {string.Join(",", simpleTypes)} --index {overloadIndex}";
+        return hasOverloads ? $"{member.Name}:{overloadIndex}" : member.Name;
     }
 
-    /// <summary>
-    /// Extracts the simple (unqualified) name from a fully-qualified type name.
-    /// "System.Text.Json.JsonDocument" → "JsonDocument". Preserves generic suffixes.
-    /// </summary>
-    private static string SimplifyTypeName(string fullTypeName)
-    {
-        int depth = 0;
-        int lastDot = -1;
-        for (int i = 0; i < fullTypeName.Length; i++)
-        {
-            if (fullTypeName[i] == '<') depth++;
-            else if (fullTypeName[i] == '>') depth--;
-            else if (fullTypeName[i] == '.' && depth == 0) lastDot = i;
-        }
-
-        return lastDot > 0 ? fullTypeName[(lastDot + 1)..] : fullTypeName;
-    }
 }
 
 /// <summary>
@@ -158,8 +130,9 @@ internal sealed class MinimalMemberFormatter : MemberTableFormatter
 {
     public override string[] GetHeaders(string kind, List<ApiMember> members, bool showDocs, bool showSelect)
     {
-        List<string> headers = ["Name", "Signature"];
+        List<string> headers = [];
         if (showSelect) headers.Add("Select");
+        headers.AddRange(["Name", "Signature"]);
         if (showDocs) headers.Add("Description");
         return headers.ToArray();
     }
@@ -178,8 +151,9 @@ internal sealed class MinimalMemberFormatter : MemberTableFormatter
                 idx++;
                 overloadIndices[m.Name] = idx;
                 var sig = SignatureParser.AbbreviateSignature(m.Signature ?? m.ReturnType ?? "");
-                List<string> row = [m.Name, $"`{sig}`"];
+                List<string> row = [];
                 if (showSelect) row.Add($"`{BuildSelectString(m, overloadCounts[m.Name] > 1, idx)}`");
+                row.AddRange([m.Name, $"`{sig}`"]);
                 if (showDocs) row.Add(m.Documentation.Summary ?? "");
                 return row.ToArray();
             });
@@ -193,8 +167,9 @@ internal sealed class DetailedMemberFormatter : MemberTableFormatter
 {
     public override string[] GetHeaders(string kind, List<ApiMember> members, bool showDocs, bool showSelect)
     {
-        List<string> headers = ["Name", "Signature"];
+        List<string> headers = [];
         if (showSelect) headers.Add("Select");
+        headers.AddRange(["Name", "Signature"]);
         if (showDocs) headers.Add("Description");
         return headers.ToArray();
     }
@@ -213,8 +188,9 @@ internal sealed class DetailedMemberFormatter : MemberTableFormatter
                 idx++;
                 overloadIndices[m.Name] = idx;
                 var sig = m.Signature ?? m.ReturnType ?? "";
-                List<string> row = [m.Name, $"`{sig}`"];
+                List<string> row = [];
                 if (showSelect) row.Add($"`{BuildSelectString(m, overloadCounts[m.Name] > 1, idx)}`");
+                row.AddRange([m.Name, $"`{sig}`"]);
                 if (showDocs) row.Add(m.Documentation.Summary ?? "");
                 return row.ToArray();
             });

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -65,8 +65,8 @@ dnx dotnet-inspect -y -- samples Markout MarkoutWriter --list
 dnx dotnet-inspect -y -- api Option --package System.CommandLine --docs
 
 # Drill into a specific method — get source, decompiled C#, and IL
-dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory --select  # See Select column
-dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1  # Member doc
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory --select  # See Name:N shorthand
+dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFactory Create:1  # Member doc
 ```
 
 ## Key Flags
@@ -77,8 +77,8 @@ dnx dotnet-inspect -y -- api --package Microsoft.Extensions.Options OptionsFacto
 | `--shape` | Type shape diagram (hierarchy + members) | `api` |
 | `--docs` | Include XML documentation | `api` |
 | `-m Name` | Filter to specific member(s), supports globs | `api` |
-| `--select` | Show Select column for member addressing | `api` |
-| `--index N` | Target Nth overload for decompiled member doc | `api` |
+| `--select` | Show Select column with Name:N shorthand | `api` |
+| `--index N` | Target Nth overload (or use Name:N shorthand) | `api` |
 | `-n 10` | Limit results | `find`, `extensions`, `package --versions` |
 | `--dotnet` | runtime + aspnetcore + curated Microsoft packages | `find`, `extensions`, `implements` |
 | `--terse` | Compact output (alias for --oneline --grouped) | `find` |

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -127,35 +127,35 @@ dotnet-inspect api System.Text.Json JsonSerializer -s                     # Head
 dotnet-inspect api System.Text.Json -s "Classes"                          # Type-level section filter
 ```
 
-Member selection and decompilation — use `--select` to see addressing hints, then drill in:
+Member selection and decompilation — use `--select` to see `Name:N` addressing hints, then drill in:
 
 ```bash
 $ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory --select
 ## Constructors
 
-| Name | Signature | Select |
-| ---- | --------- | ------ |
-| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ...)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...> --index 1` |
-| .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ..., IEnumerable<IValidateOptions<TOptions>>)` | `-m .ctor --params IEnumerable<...>,IEnumerable<...>,IEnumerable<...> --index 2` |
+| Select | Name | Signature |
+| ------ | ---- | --------- |
+| `.ctor:1` | .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ...)` |
+| `.ctor:2` | .ctor | `void .ctor(IEnumerable<IConfigureOptions<TOptions>>, ..., IEnumerable<IValidateOptions<TOptions>>)` |
 
 ## Methods
 
-| Name | Signature | Select |
-| ---- | --------- | ------ |
-| Create | `TOptions Create(string)` | `-m Create --index 1` |
+| Select | Name | Signature |
+| ------ | ---- | --------- |
+| `Create:1` | Create | `TOptions Create(string)` |
 ```
 
-Then target a member to get source, decompiled C#, and IL:
+Then target a member using the `Name:N` shorthand to get source, decompiled C#, and IL:
 
 ```bash
-$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory -m Create --index 1
+$ dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory Create:1
 ## Source                          # Original C# (via SourceLink)
 ## Lowered C#                     # Decompiled C# faithful to IL semantics
 ## IL                             # Raw IL disassembly with resolved tokens
 ## IL (Annotated)                 # IL with pre-execution stack state at each instruction
 ```
 
-For constructors with overloads, use `--params` to disambiguate:
+For constructors with overloads, `--params` can also disambiguate:
 
 ```bash
 dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory \
@@ -361,8 +361,8 @@ DOTNET_INSPECT_TIPS=quiet            # ENV-based silencing
 | `--tfm net8.0` | Select target framework | package, library, api, extensions |
 | `-m Name` | Filter to member (supports globs) | api |
 | `--shape` | Type shape diagram (hierarchy + members) | api |
-| `--select` | Show Select column for member addressing | api |
-| `--index N` | Target Nth overload for member doc | api |
+| `--select` | Show Select column with Name:N shorthand | api |
+| `--index N` | Target Nth overload (or use Name:N shorthand) | api |
 | `--params "..."` | Target overload by parameter types | api |
 | `--docs` | Include XML documentation | api |
 | `--samples` | Fetch code samples | api |
@@ -485,7 +485,7 @@ dotnet-inspect api JsonSerializer --platform System.Text.Json --shape
 dotnet-inspect api JsonSerializer --platform System.Text.Json -m Serialize -v:d
 
 # Step 4: View decompiled source for a specific overload
-dotnet-inspect api JsonSerializer --package System.Text.Json -m Serialize --index 1
+dotnet-inspect api JsonSerializer --package System.Text.Json Serialize:1
 ```
 
 ### Test Packages


### PR DESCRIPTION
## Summary

- **Name:N shorthand** — `Deserialize:6` as a positional arg replaces the 3-step `--select` → copy → `--index` workflow
- **Bare member name** auto-selects first overload → detail page (source, lowered C#, IL)
- **Select column** shows compact `Name:N` (or just `Name` for non-overloaded), moved to first column
- **Contextual tips** on library view and type member view guide the drill-in progression
- **Option descriptions** revised for consistency (`Source:`, `Filter`, `Include`, `Output`, `Select` verbs)
- **llms.txt / SKILL.md** updated with new shorthand syntax
- **Version bump** to 0.3.2

## Drill-in progression (all bare names)

```
api Markout                              → library view (+ tips)
api Markout MarkoutWriter                → type members (+ tips)
api Markout MarkoutWriter Flush          → detail page (source, IL)
api Markout MarkoutWriter WriteField:2   → specific overload detail
```

## Test plan

- [ ] `api Markout` — library view with tips showing type drill-in
- [ ] `api Markout MarkoutWriter` — type member view with tips showing `Name:N`
- [ ] `api Markout MarkoutWriter Flush` — bare name → detail page
- [ ] `api Markout MarkoutWriter WriteField:2` — specific overload detail
- [ ] `api Markout MarkoutWriter --select` — Select as first column, compact format
- [ ] `api Markout MarkoutWriter WriteField:99` — clear out-of-range error
- [ ] `api System.Text.Json JsonSerializer Deserialize:6` — platform source works
- [ ] `api Markout MarkoutWriter --ctor` — constructor list (no auto-drill)
- [ ] `api --help` — option descriptions show Source:/Filter/Include/Output grouping
- [ ] `api Markout -T:q` — tips suppressed at quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)