### PR TITLE
Reorder demos by command, simplify UX, fix prefix bug (0.4.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotnet-inspect",
   "description": "Inspect .NET assemblies and NuGet packages",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Rich"
   },

--- a/docs/demo-queries.md
+++ b/docs/demo-queries.md
@@ -19,80 +19,7 @@ with varying type parameter combinations (`IAdditionOperators<TSelf, TSelf, TSel
 `IComparisonOperators<TSelf, TSelf, bool>`), and operator methods make this the
 ultimate showcase for `--shape` on an interface.
 
-## 2. Extensions for IServiceCollection
-
-```bash
-dotnet-inspect extensions IServiceCollection
-```
-
-Finds 120+ extension methods targeting `IServiceCollection` across both the
-runtime platform and ASP.NET Core. This is the canonical "extension method
-explosion" in .NET — every middleware and service registration shows up here.
-Demonstrates cross-scope search with no explicit `--package` flag.
-
-## 3. Implements Stream
-
-```bash
-dotnet-inspect implements Stream
-```
-
-Finds every concrete type that extends `Stream` across all platform frameworks.
-Results include `FileStream`, `MemoryStream`, `CryptoStream`, `NetworkStream`,
-`QuicStream`, and ASP.NET Core buffered streams. A good showcase of the
-`implements` command's ability to search across multiple frameworks at once.
-
-## 4. Diff: System.CommandLine breaking changes
-
-```bash
-dotnet-inspect diff System.CommandLine@2.0.0-beta4.22272.1..2.0.3 -v:q
-```
-
-Shows 134 breaking changes, 81 additive changes across 83 types between the
-beta and the stable release of System.CommandLine. Dramatic API churn that
-makes a compelling case for the `diff` command during migrations.
-
-## 5. API: JsonSerializer members
-
-```bash
-dotnet-inspect api System.Text.Json JsonSerializer
-```
-
-Lists all public members of `JsonSerializer` — one of the most-used types in
-modern .NET. Shows overload grouping, return types, and parameter signatures.
-Good intro to the `api` command at member granularity.
-
-## 6. Find: Chat\* types
-
-```bash
-dotnet-inspect find "Chat*"
-```
-
-Searches the default scope (platform + curated packages) for types matching
-`Chat*`. Finds AI-related types from `Microsoft.Extensions.AI` — a timely
-result that shows the tool keeps pace with the latest .NET ecosystem additions.
-
-## 7. Package: System.Text.Json@8.0.0 vulnerabilities
-
-```bash
-dotnet-inspect package System.Text.Json@8.0.0 -s Vulnerabilities
-```
-
-Shows known security vulnerabilities for an older version of System.Text.Json.
-The `-s Vulnerabilities` section filter zeroes in on the security data. A
-practical demo of the tool's value for security auditing.
-
-## 8. Library: dependency tree
-
-```bash
-dotnet-inspect library Microsoft.Extensions.AI.OpenAI --dependencies
-```
-
-Renders a visual dependency tree for the OpenAI integration library, showing
-transitive dependencies like `System.ClientModel`, `System.Text.Json`, and
-`System.Text.RegularExpressions`. The ASCII tree format makes it easy to
-understand the full dependency graph at a glance.
-
-## 9. Shape: Int128 — generic math concrete type
+## 2. Shape: Int128 — generic math concrete type
 
 ```bash
 dotnet-inspect api System.Runtime Int128 --shape
@@ -104,32 +31,17 @@ and implicit/explicit conversion operators. The interface list shows the full
 generic math hierarchy resolved with concrete types
 (`IShiftOperators<Int128, int, Int128>` — three different types in one interface).
 
-## 10. Find: Chat\*/Converse\*/Message\* across OpenAI, Azure, AWS, Anthropic
+## 3. API: JsonSerializer members
 
 ```bash
-dotnet-inspect find "Chat*,Converse*,Message*" --package OpenAI --package Azure.AI.OpenAI --package AWSSDK.BedrockRuntime --package Anthropic
+dotnet-inspect api System.Text.Json JsonSerializer
 ```
 
-Pairs with demo #6 to show scope expansion. The default scope finds AI types
-in curated packages; this demo adds four vendor SDK packages and searches
-across all of them. The multi-glob catches each vendor's naming convention
-(OpenAI/Azure use "Chat", AWS uses "Converse", Anthropic uses "Message").
-Results span 118 types across four packages.
+Lists all public members of `JsonSerializer` — one of the most-used types in
+modern .NET. Shows overload grouping, return types, and parameter signatures.
+Good intro to the `api` command at member granularity.
 
-## 11. Depends: IFloatingPointIeee754 interface hierarchy
-
-```bash
-dotnet-inspect depends "IFloatingPointIeee754<TSelf>"
-```
-
-Walks the interface dependency DAG upward from `IFloatingPointIeee754<TSelf>`,
-showing the full generic math hierarchy as a tree. Fans out into
-`IFloatingPoint`, `INumber`, `INumberBase`, and then all the operator and
-function interfaces (`IExponentialFunctions`, `ITrigonometricFunctions`, etc.).
-The tree de-duplicates nodes at their shallowest introduction, revealing the
-diamond inheritance pattern in the generic math design.
-
-## 12. Code: OptionsFactory.Create — source, lowered C#, and IL
+## 4. Code: OptionsFactory.Create — source, lowered C#, and IL
 
 ```bash
 dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory Create
@@ -142,20 +54,63 @@ goto-based control flow), raw IL disassembly, and annotated IL with
 pre-execution stack state at each instruction. A showcase of the tool's
 decompilation pipeline on a real, well-known method.
 
-## 13. Package search: Azure AI ecosystem
+## 5. Depends: IFloatingPointIeee754 interface hierarchy
 
 ```bash
-dotnet-inspect package search "Azure.AI"
+dotnet-inspect depends "IFloatingPointIeee754<TSelf>"
 ```
 
-Searches NuGet for packages matching "Azure.AI" and displays them in a
-formatted table with version, download counts, and descriptions. Discovers
-14 Azure AI packages (OpenAI, FormRecognizer, DocumentIntelligence,
-Translation, Vision, ContentSafety, etc.) without needing to know their
-exact names. A showcase of the `package search` subcommand for NuGet
-package discovery.
+Walks the interface dependency DAG upward from `IFloatingPointIeee754<TSelf>`,
+showing the full generic math hierarchy as a tree. Fans out into
+`IFloatingPoint`, `INumber`, `INumberBase`, and then all the operator and
+function interfaces (`IExponentialFunctions`, `ITrigonometricFunctions`, etc.).
+The tree de-duplicates nodes at their shallowest introduction, revealing the
+diamond inheritance pattern in the generic math design.
 
-## 14. Find: Chat\* across Azure AI packages (prefix search)
+## 6. Diff: System.CommandLine breaking changes
+
+```bash
+dotnet-inspect diff System.CommandLine@2.0.0-beta4.22272.1..2.0.3 -v:q
+```
+
+Shows 134 breaking changes, 81 additive changes across 83 types between the
+beta and the stable release of System.CommandLine. Dramatic API churn that
+makes a compelling case for the `diff` command during migrations.
+
+## 7. Extensions for IServiceCollection
+
+```bash
+dotnet-inspect extensions IServiceCollection
+```
+
+Finds 120+ extension methods targeting `IServiceCollection` across both the
+runtime platform and ASP.NET Core. This is the canonical "extension method
+explosion" in .NET — every middleware and service registration shows up here.
+Demonstrates cross-scope search with no explicit `--package` flag.
+
+## 8. Find: Chat\* types
+
+```bash
+dotnet-inspect find "Chat*"
+```
+
+Searches the default scope (platform + curated packages) for types matching
+`Chat*`. Finds AI-related types from `Microsoft.Extensions.AI` — a timely
+result that shows the tool keeps pace with the latest .NET ecosystem additions.
+
+## 9. Find: Chat\*/Converse\*/Message\* across OpenAI, Azure, AWS, Anthropic
+
+```bash
+dotnet-inspect find "Chat*,Converse*,Message*" --package OpenAI --package Azure.AI.OpenAI --package AWSSDK.BedrockRuntime --package Anthropic
+```
+
+Pairs with demo #8 to show scope expansion. The default scope finds AI types
+in curated packages; this demo adds four vendor SDK packages and searches
+across all of them. The multi-glob catches each vendor's naming convention
+(OpenAI/Azure use "Chat", AWS uses "Converse", Anthropic uses "Message").
+Results span 118 types across four packages.
+
+## 10. Find: Chat\* across Azure AI packages (prefix search)
 
 ```bash
 dotnet-inspect find "Chat*" --package-prefix Azure.AI
@@ -167,3 +122,48 @@ search API, discovering 14 packages and downloading each to search for
 types matching `Chat*`. This is a powerful combo — prefix-based scoping
 removes the need to know exact package names when exploring a vendor's
 SDK ecosystem.
+
+## 11. Implements Stream
+
+```bash
+dotnet-inspect implements Stream
+```
+
+Finds every concrete type that extends `Stream` across all platform frameworks.
+Results include `FileStream`, `MemoryStream`, `CryptoStream`, `NetworkStream`,
+`QuicStream`, and ASP.NET Core buffered streams. A good showcase of the
+`implements` command's ability to search across multiple frameworks at once.
+
+## 12. Library: dependency tree
+
+```bash
+dotnet-inspect library Microsoft.Extensions.AI.OpenAI --dependencies
+```
+
+Renders a visual dependency tree for the OpenAI integration library, showing
+transitive dependencies like `System.ClientModel`, `System.Text.Json`, and
+`System.Text.RegularExpressions`. The ASCII tree format makes it easy to
+understand the full dependency graph at a glance.
+
+## 13. Package: System.Text.Json@8.0.0 vulnerabilities
+
+```bash
+dotnet-inspect package System.Text.Json@8.0.0 -s Vulnerabilities
+```
+
+Shows known security vulnerabilities for an older version of System.Text.Json.
+The `-s Vulnerabilities` section filter zeroes in on the security data. A
+practical demo of the tool's value for security auditing.
+
+## 14. Package search: Azure AI ecosystem
+
+```bash
+dotnet-inspect package search "Azure.AI"
+```
+
+Searches NuGet for packages matching "Azure.AI" and displays them in a
+formatted table with version, download counts, and descriptions. Discovers
+14 Azure AI packages (OpenAI, FormRecognizer, DocumentIntelligence,
+Translation, Vision, ContentSafety, etc.) without needing to know their
+exact names. A showcase of the `package search` subcommand for NuGet
+package discovery.

--- a/docs/lap-around.md
+++ b/docs/lap-around.md
@@ -1006,31 +1006,31 @@ $ dotnet-inspect demo list
 # Demo Queries
 
    1. [api] Shape: INumber<TSelf> — generic math interface
-      dotnet-inspect api System.Runtime INumber<TSelf> --shape
-   2. [extensions] Extensions for IServiceCollection
-      dotnet-inspect extensions IServiceCollection
-   3. [implements] Implements Stream
-      dotnet-inspect implements Stream
-   4. [diff] Diff: System.CommandLine breaking changes (beta→stable)
-      dotnet-inspect diff System.CommandLine@2.0.0-beta4.22272.1..2.0.3 -v:q
-   5. [api] API: JsonSerializer members
-      dotnet-inspect api System.Text.Json JsonSerializer
-   6. [find] Find: Chat* types
-      dotnet-inspect find "Chat*"
-   7. [package] Package: System.Text.Json@8.0.0 vulnerabilities
-      dotnet-inspect package System.Text.Json@8.0.0 -s Vulnerabilities
-   8. [library] Library: Microsoft.Extensions.AI.OpenAI dependency tree
-      dotnet-inspect library Microsoft.Extensions.AI.OpenAI --dependencies
-   9. [api] Shape: Int128 — generic math concrete type
+      dotnet-inspect api System.Runtime "INumber<TSelf>" --shape
+   2. [api] Shape: Int128 — generic math concrete type
       dotnet-inspect api System.Runtime Int128 --shape
-  10. [find] Find: Chat*/Converse*/Message* across OpenAI, Azure, AWS, Anthropic
-      dotnet-inspect find "Chat*,Converse*,Message*" --package OpenAI --package Azure.AI.OpenAI --package AWSSDK.BedrockRuntime --package Anthropic
-  11. [depends] Depends: IFloatingPointIeee754 interface hierarchy
-      dotnet-inspect depends IFloatingPointIeee754<TSelf>
-  12. [api] Code: OptionsFactory.Create — source, lowered C#, and IL
+   3. [api] API: JsonSerializer members
+      dotnet-inspect api System.Text.Json JsonSerializer
+   4. [api] Code: OptionsFactory.Create — source, lowered C#, and IL
       dotnet-inspect api --package Microsoft.Extensions.Options OptionsFactory Create
-  13. [search] Package search: Azure AI ecosystem
-      dotnet-inspect package search "Azure.AI"
-  14. [find] Find: Chat* across Azure AI packages (prefix search)
+   5. [depends] Depends: IFloatingPointIeee754 interface hierarchy
+      dotnet-inspect depends "IFloatingPointIeee754<TSelf>"
+   6. [diff] Diff: System.CommandLine breaking changes (beta→stable)
+      dotnet-inspect diff System.CommandLine@2.0.0-beta4.22272.1..2.0.3 -v:q
+   7. [extensions] Extensions for IServiceCollection
+      dotnet-inspect extensions IServiceCollection
+   8. [find] Find: Chat* types
+      dotnet-inspect find "Chat*"
+   9. [find] Find: Chat*/Converse*/Message* across OpenAI, Azure, AWS, Anthropic
+      dotnet-inspect find "Chat*,Converse*,Message*" --package OpenAI --package Azure.AI.OpenAI --package AWSSDK.BedrockRuntime --package Anthropic
+  10. [find] Find: Chat* across Azure AI packages (prefix search)
       dotnet-inspect find "Chat*" --package-prefix Azure.AI
+  11. [implements] Implements Stream
+      dotnet-inspect implements Stream
+  12. [library] Library: Microsoft.Extensions.AI.OpenAI dependency tree
+      dotnet-inspect library Microsoft.Extensions.AI.OpenAI --dependencies
+  13. [package] Package: System.Text.Json@8.0.0 vulnerabilities
+      dotnet-inspect package System.Text.Json@8.0.0 -s Vulnerabilities
+  14. [search] Package search: Azure AI ecosystem
+      dotnet-inspect package search "Azure.AI"
 ```

--- a/src/dotnet-inspect/Commands/DemoCommand.cs
+++ b/src/dotnet-inspect/Commands/DemoCommand.cs
@@ -21,47 +21,55 @@ public class DemoCommand
     /// </summary>
     public static readonly DemoEntry[] Demos =
     [
+        // api (4)
         new("Shape: INumber<TSelf> — generic math interface", "api",
             ["api", "System.Runtime", "INumber<TSelf>", "--shape"]),
-
-        new("Extensions for IServiceCollection", "extensions",
-            ["extensions", "IServiceCollection"]),
-
-        new("Implements Stream", "implements",
-            ["implements", "Stream"]),
-
-        new("Diff: System.CommandLine breaking changes (beta→stable)", "diff",
-            ["diff", "System.CommandLine@2.0.0-beta4.22272.1..2.0.3", "-v:q"]),
-
-        new("API: JsonSerializer members", "api",
-            ["api", "System.Text.Json", "JsonSerializer"]),
-
-        new("Find: Chat* types", "find",
-            ["find", "Chat*"]),
-
-        new("Package: System.Text.Json@8.0.0 vulnerabilities", "package",
-            ["package", "System.Text.Json@8.0.0", "-s", "Vulnerabilities"]),
-
-        new("Library: Microsoft.Extensions.AI.OpenAI dependency tree", "library",
-            ["library", "Microsoft.Extensions.AI.OpenAI", "--dependencies"]),
 
         new("Shape: Int128 — generic math concrete type", "api",
             ["api", "System.Runtime", "Int128", "--shape"]),
 
-        new("Find: Chat*/Converse*/Message* across OpenAI, Azure, AWS, Anthropic", "find",
-            ["find", "Chat*,Converse*,Message*", "--package", "OpenAI", "--package", "Azure.AI.OpenAI", "--package", "AWSSDK.BedrockRuntime", "--package", "Anthropic"]),
-
-        new("Depends: IFloatingPointIeee754 interface hierarchy", "depends",
-            ["depends", "IFloatingPointIeee754<TSelf>"]),
+        new("API: JsonSerializer members", "api",
+            ["api", "System.Text.Json", "JsonSerializer"]),
 
         new("Code: OptionsFactory.Create — source, lowered C#, and IL", "api",
             ["api", "--package", "Microsoft.Extensions.Options", "OptionsFactory", "Create"]),
 
-        new("Package search: Azure AI ecosystem", "search",
-            ["package", "search", "Azure.AI"]),
+        // depends (1)
+        new("Depends: IFloatingPointIeee754 interface hierarchy", "depends",
+            ["depends", "IFloatingPointIeee754<TSelf>"]),
+
+        // diff (1)
+        new("Diff: System.CommandLine breaking changes (beta→stable)", "diff",
+            ["diff", "System.CommandLine@2.0.0-beta4.22272.1..2.0.3", "-v:q"]),
+
+        // extensions (1)
+        new("Extensions for IServiceCollection", "extensions",
+            ["extensions", "IServiceCollection"]),
+
+        // find (3)
+        new("Find: Chat* types", "find",
+            ["find", "Chat*"]),
+
+        new("Find: Chat*/Converse*/Message* across OpenAI, Azure, AWS, Anthropic", "find",
+            ["find", "Chat*,Converse*,Message*", "--package", "OpenAI", "--package", "Azure.AI.OpenAI", "--package", "AWSSDK.BedrockRuntime", "--package", "Anthropic"]),
 
         new("Find: Chat* across Azure AI packages (prefix search)", "find",
             ["find", "Chat*", "--package-prefix", "Azure.AI"]),
+
+        // implements (1)
+        new("Implements Stream", "implements",
+            ["implements", "Stream"]),
+
+        // library (1)
+        new("Library: Microsoft.Extensions.AI.OpenAI dependency tree", "library",
+            ["library", "Microsoft.Extensions.AI.OpenAI", "--dependencies"]),
+
+        // package (2)
+        new("Package: System.Text.Json@8.0.0 vulnerabilities", "package",
+            ["package", "System.Text.Json@8.0.0", "-s", "Vulnerabilities"]),
+
+        new("Package search: Azure AI ecosystem", "search",
+            ["package", "search", "Azure.AI"]),
     ];
 
     public static async Task<int> ExecuteListAsync()

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Changes

- **Demo reorder**: Sort all 14 demos alphabetically by command (api×4, depends, diff, extensions, find×3, implements, library, package×2)
- **Simplified UX**: `demo <index>` replaces `demo invoke <index>`; bare `demo` shows help + 3 random demo tips
- **Copy-paste friendly**: Generic type args in demo list output are now quoted (`"INumber<TSelf>"`)
- **Randomized tips**: `Hints.WriteTips` gains a `randomize` parameter for picking a random subset
- **Prefix bug fix**: `--package-prefix` now uses keyword search instead of `packageid:` qualifier (which only did exact match)
- **Docs**: Updated demo-queries.md and lap-around.md to match new ordering
- **Version**: 0.4.1