### PR TITLE
Add --file and --region options to samples command

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -956,6 +956,8 @@ public static class CommandLineBuilder
         var browsableUrlsOption = new Option<bool>("--browsable-urls") { Description = "Use /blob/ URLs for browser viewing instead of /raw/ URLs" };
         var listOption = new Option<bool>("--list") { Description = "List samples only (don't fetch content)" };
         var printOption = new Option<int?>("--print") { Description = "Print specific sample by number (raw code, no markdown)", Arity = ArgumentArity.ExactlyOne };
+        var fileOption = new Option<string?>("--file") { Description = "Read a local .cs file directly (skips SourceLink/PDB)" };
+        var regionOption = new Option<string?>("--region") { Description = "Extract a specific #region from the file (used with --file)" };
 
         samplesCommand.Arguments.Add(argsArg);
         samplesCommand.Options.Add(packageOption);
@@ -966,6 +968,8 @@ public static class CommandLineBuilder
         samplesCommand.Options.Add(browsableUrlsOption);
         samplesCommand.Options.Add(listOption);
         samplesCommand.Options.Add(printOption);
+        samplesCommand.Options.Add(fileOption);
+        samplesCommand.Options.Add(regionOption);
         samplesCommand.Options.Add(verboseOption);
         samplesCommand.Options.Add(verbosityOption);
         samplesCommand.Options.Add(sourceOption);
@@ -1013,6 +1017,8 @@ public static class CommandLineBuilder
                 Verbose = parseResult.GetValue(verboseOption),
                 ListOnly = parseResult.GetValue(listOption),
                 PrintSample = parseResult.GetValue(printOption),
+                FilePath = parseResult.GetValue(fileOption),
+                Region = parseResult.GetValue(regionOption),
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 

--- a/src/dotnet-inspect/Commands/SamplesCommand.cs
+++ b/src/dotnet-inspect/Commands/SamplesCommand.cs
@@ -22,6 +22,12 @@ public class SamplesCommand
 
         try
         {
+            // Local .cs file mode: read file directly, skip SourceLink/PDB
+            if (!string.IsNullOrEmpty(options.FilePath))
+            {
+                return ExecuteForLocalFile(options.FilePath, options.Region);
+            }
+
             // Get package info from options
             string? packageName = null;
             string? packageVersion = null;
@@ -44,6 +50,31 @@ public class SamplesCommand
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 1;
         }
+    }
+
+    private static int ExecuteForLocalFile(string filePath, string? region)
+    {
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"Error: File not found: {filePath}");
+            return 1;
+        }
+
+        var content = File.ReadAllText(filePath);
+
+        if (!string.IsNullOrEmpty(region))
+        {
+            var regionContent = SourceFetcher.ExtractRegion(content, region);
+            if (regionContent == null)
+            {
+                Console.Error.WriteLine($"Error: Region '{region}' not found in {filePath}");
+                return 1;
+            }
+            content = regionContent;
+        }
+
+        Console.Write(content);
+        return 0;
     }
 
     private static async Task<int> ExecuteForTypeAsync(
@@ -302,6 +333,16 @@ public record SamplesOptions
     /// Type name to get samples for (positional argument). Null for library-wide samples.
     /// </summary>
     public string? TypeName { get; init; }
+
+    /// <summary>
+    /// Local .cs file path to read directly (skips SourceLink/PDB).
+    /// </summary>
+    public string? FilePath { get; init; }
+
+    /// <summary>
+    /// Optional region name to extract from a local file (used with --file).
+    /// </summary>
+    public string? Region { get; init; }
 
     public string? PackagePath { get; init; }
     public string? AssemblyPath { get; init; }


### PR DESCRIPTION
Add support for reading a local `.cs` file directly in the `samples` command, bypassing the SourceLink/PDB pipeline. Useful for local testing.

### Usage

```
dotnet-inspect samples --file path/to/sample.cs
dotnet-inspect samples --file path/to/sample.cs --region RegionName
```

### Changes

- **CommandLineBuilder.cs** — Added `--file` and `--region` options to the samples command
- **SamplesCommand.cs** — Added `ExecuteForLocalFile` method that reads the file from disk with optional `#region` extraction; added `FilePath` and `Region` properties to `SamplesOptions`