### PR TITLE
Add nullability annotations to API signatures

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -69,6 +69,9 @@ public static class ApiSurfaceExtractor
             // Check if this is an extension class (static class with [Extension] attribute)
             bool isExtensionClass = apiType.IsStatic && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes());
 
+            // Nullability context for annotated signatures
+            byte typeNullableContext = NullabilityReader.GetNullableContext(reader, typeDef.GetCustomAttributes());
+
             // Get type's generic context for resolving interface type parameters
             var typeContext = GenericContext.ForType(reader, typeDef);
 
@@ -158,7 +161,7 @@ public static class ApiSurfaceExtractor
                 if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
                     continue;
 
-                var signature = GetMethodSignature(reader, typeDef, method);
+                var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
                 var member = new ApiMember
                 {
                     Name = methodName,
@@ -211,7 +214,7 @@ public static class ApiSurfaceExtractor
                 {
                     Name = reader.GetString(prop.Name),
                     Kind = "property",
-                    Signature = GetPropertySignature(reader, typeDef, prop, accessors)
+                    Signature = GetPropertySignature(reader, typeDef, prop, accessors, typeNullableContext)
                 };
 
                 apiType.Members.Add(member);
@@ -239,7 +242,11 @@ public static class ApiSurfaceExtractor
                 if (!isEnum)
                 {
                     var context = GenericContext.ForType(reader, typeDef);
-                    fieldType = field.DecodeSignature(SignatureDecoder.Instance, context);
+                    var fieldNode = field.DecodeSignature(TypeNodeProvider.Instance, context);
+                    var fieldBytes = NullabilityReader.GetNullableBytes(reader, field.GetCustomAttributes());
+                    int pos = 0;
+                    fieldNode.ApplyNullability(fieldBytes, ref pos, typeNullableContext);
+                    fieldType = fieldNode.Render();
                 }
 
                 var member = new ApiMember
@@ -386,20 +393,34 @@ public static class ApiSurfaceExtractor
         }
     }
 
-    private static string GetMethodSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+    private static string GetMethodSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, byte typeNullableContext)
     {
         string name = reader.GetString(method.Name);
         var context = GenericContext.ForMethod(reader, typeDef, method);
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+        var treeSignature = method.DecodeSignature(TypeNodeProvider.Instance, context);
 
-        // Get parameter names from metadata
+        // Determine the effective nullable default: method overrides type
+        byte methodContext = NullabilityReader.GetNullableContext(reader, method.GetCustomAttributes());
+        byte nullableDefault = methodContext != 0 ? methodContext : typeNullableContext;
+
+        // Apply nullability to return type
         var paramHandles = method.GetParameters().ToList();
-        var paramTypes = signature.ParameterTypes;
+        var returnBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, 0);
+        int pos = 0;
+        treeSignature.ReturnType.ApplyNullability(returnBytes, ref pos, nullableDefault);
+
+        // Build parameter list with nullability
+        var paramTypes = treeSignature.ParameterTypes;
 
         List<string> parameters = [];
         for (int i = 0; i < paramTypes.Length; i++)
         {
-            string type = paramTypes[i];
+            // Apply nullability to this parameter's type tree
+            var paramBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, i + 1);
+            pos = 0;
+            paramTypes[i].ApplyNullability(paramBytes, ref pos, nullableDefault);
+            string type = paramTypes[i].Render();
+
             // Parameter handles may include return parameter at SequenceNumber 0
             // Actual parameters have SequenceNumber 1, 2, 3...
             var (paramName, isParams, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
@@ -416,7 +437,7 @@ public static class ApiSurfaceExtractor
         }
 
         string paramStr2 = string.Join(", ", parameters);
-        return $"{signature.ReturnType} {name}({paramStr2})";
+        return $"{treeSignature.ReturnType.Render()} {name}({paramStr2})";
     }
 
     private static (string? name, bool isParams, bool hasDefault, object? defaultValue) GetParameterInfo(
@@ -489,11 +510,16 @@ public static class ApiSurfaceExtractor
         };
     }
 
-    private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors)
+    private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext)
     {
         string name = reader.GetString(prop.Name);
         var context = GenericContext.ForType(reader, typeDef);
-        var signature = prop.DecodeSignature(SignatureDecoder.Instance, context);
+        var treeSignature = prop.DecodeSignature(TypeNodeProvider.Instance, context);
+
+        // Apply nullability to the property type
+        var propBytes = NullabilityReader.GetNullableBytes(reader, prop.GetCustomAttributes());
+        int pos = 0;
+        treeSignature.ReturnType.ApplyNullability(propBytes, ref pos, typeNullableContext);
 
         // Determine accessor visibility
         bool hasPublicGetter = false;
@@ -526,7 +552,7 @@ public static class ApiSurfaceExtractor
         else
             accessorStr = "{ get; }"; // Fallback
 
-        return $"{signature.ReturnType} {name} {accessorStr}";
+        return $"{treeSignature.ReturnType.Render()} {name} {accessorStr}";
     }
 
     /// <summary>

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-inspect" />
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
+    <InternalsVisibleTo Include="DotnetInspector.Metadata.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotnetInspector.Metadata/NullabilityReader.cs
+++ b/src/DotnetInspector.Metadata/NullabilityReader.cs
@@ -1,0 +1,87 @@
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Reads nullability annotation metadata (NullableAttribute and NullableContextAttribute)
+/// from assembly custom attribute collections.
+/// </summary>
+public static class NullabilityReader
+{
+    private const string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
+    private const string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+    /// <summary>
+    /// Gets the NullableContextAttribute default byte from custom attributes.
+    /// Returns 0 (oblivious) if not found.
+    /// </summary>
+    public static byte GetNullableContext(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName != NullableContextAttributeName) continue;
+
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.Length < 3) continue;
+            blob.ReadUInt16(); // prolog
+            return blob.ReadByte();
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Gets the NullableAttribute byte array from custom attributes.
+    /// Returns null if the attribute is not present.
+    /// Single-byte constructor returns a one-element array.
+    /// </summary>
+    public static byte[]? GetNullableBytes(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName != NullableAttributeName) continue;
+
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.Length < 3) return null;
+            blob.ReadUInt16(); // prolog
+
+            // NullableAttribute(byte):   prolog(2) + byte(1) + namedArgs(2) = 5
+            // NullableAttribute(byte[]): prolog(2) + count(4) + N bytes + namedArgs(2) = 8+N
+            if (blob.RemainingBytes == 3)
+            {
+                return [blob.ReadByte()];
+            }
+            else if (blob.RemainingBytes >= 6)
+            {
+                int count = blob.ReadInt32();
+                if (count < 0 || count > blob.RemainingBytes - 2) return null;
+                var bytes = new byte[count];
+                for (int i = 0; i < count; i++)
+                    bytes[i] = blob.ReadByte();
+                return bytes;
+            }
+
+            return null;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Gets NullableAttribute bytes for a specific parameter by sequence number.
+    /// Sequence 0 = return type, 1+ = parameters.
+    /// </summary>
+    public static byte[]? GetParameterNullableBytes(
+        MetadataReader reader, List<ParameterHandle> paramHandles, int sequenceNumber)
+    {
+        foreach (var handle in paramHandles)
+        {
+            var param = reader.GetParameter(handle);
+            if (param.SequenceNumber == sequenceNumber)
+                return GetNullableBytes(reader, param.GetCustomAttributes());
+        }
+        return null;
+    }
+}

--- a/src/DotnetInspector.Metadata/TypeNode.cs
+++ b/src/DotnetInspector.Metadata/TypeNode.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Represents a type as a tree structure for applying nullability annotations.
+/// Built by <see cref="TypeNodeProvider"/> during signature decoding, then
+/// nullability bytes are applied via <see cref="ApplyNullability"/> before
+/// rendering to a C# string with <see cref="Render"/>.
+/// </summary>
+internal abstract class TypeNode
+{
+    /// <summary>Whether this node is a reference type (can be annotated with ?).</summary>
+    public abstract bool IsReferenceType { get; }
+
+    /// <summary>Set to true when nullability byte is 2.</summary>
+    public bool IsNullableAnnotated { get; set; }
+
+    /// <summary>Renders this type to a C# type string with nullability annotations.</summary>
+    public abstract string Render();
+
+    /// <summary>
+    /// Walks the type tree in preorder, consuming bytes from the NullableAttribute array
+    /// and setting <see cref="IsNullableAnnotated"/> where byte == 2.
+    /// </summary>
+    public abstract void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte);
+
+    protected static byte ConsumeByte(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        if (bytes == null) return defaultByte;
+        // Single-byte attribute: all positions use the same value
+        if (bytes.Length == 1) { position++; return bytes[0]; }
+        return position < bytes.Length ? bytes[position++] : defaultByte;
+    }
+}
+
+/// <summary>C# primitive types (int, string, object, etc.).</summary>
+internal sealed class PrimitiveTypeNode(string name, bool isReferenceType) : TypeNode
+{
+    public override bool IsReferenceType => isReferenceType;
+
+    public override string Render() => IsReferenceType && IsNullableAnnotated ? $"{name}?" : name;
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (IsReferenceType && b == 2) IsNullableAnnotated = true;
+    }
+}
+
+/// <summary>Non-generic named types (JsonSerializer, Stream, etc.).</summary>
+internal sealed class NamedTypeNode(string name, bool isReferenceType) : TypeNode
+{
+    public string Name => name;
+    public override bool IsReferenceType => isReferenceType;
+
+    public override string Render() => IsReferenceType && IsNullableAnnotated ? $"{name}?" : name;
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (IsReferenceType && b == 2) IsNullableAnnotated = true;
+    }
+}
+
+/// <summary>Generic instantiations (Dictionary&lt;K,V&gt;, Task&lt;T&gt;, etc.).</summary>
+internal sealed class GenericTypeNode(string baseName, bool isReferenceType, ImmutableArray<TypeNode> arguments) : TypeNode
+{
+    public override bool IsReferenceType => isReferenceType;
+
+    public override string Render()
+    {
+        var argsStr = string.Join(", ", arguments.Select(a => a.Render()));
+        var result = $"{baseName}<{argsStr}>";
+        return IsReferenceType && IsNullableAnnotated ? $"{result}?" : result;
+    }
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (IsReferenceType && b == 2) IsNullableAnnotated = true;
+        foreach (var arg in arguments)
+            arg.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>Single-dimensional arrays (string[], int[], etc.).</summary>
+internal sealed class SZArrayTypeNode(TypeNode elementType) : TypeNode
+{
+    public override bool IsReferenceType => true;
+
+    public override string Render()
+    {
+        var result = $"{elementType.Render()}[]";
+        return IsNullableAnnotated ? $"{result}?" : result;
+    }
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (b == 2) IsNullableAnnotated = true;
+        elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>Multi-dimensional arrays (int[,], etc.).</summary>
+internal sealed class MDArrayTypeNode(TypeNode elementType, int rank) : TypeNode
+{
+    public override bool IsReferenceType => true;
+
+    public override string Render()
+    {
+        var result = $"{elementType.Render()}[{new string(',', rank - 1)}]";
+        return IsNullableAnnotated ? $"{result}?" : result;
+    }
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (b == 2) IsNullableAnnotated = true;
+        elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>Pointer types (int*, void*, etc.).</summary>
+internal sealed class PointerTypeNode(TypeNode elementType) : TypeNode
+{
+    public override bool IsReferenceType => false;
+
+    public override string Render() => $"{elementType.Render()}*";
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        ConsumeByte(bytes, ref position, defaultByte);
+        elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>By-reference types (ref T, out T, in T). Does not consume a nullability byte.</summary>
+internal sealed class ByRefTypeNode(TypeNode elementType) : TypeNode
+{
+    public override bool IsReferenceType => false;
+
+    public override string Render() => $"ref {elementType.Render()}";
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        // ByRef is a modifier, not a type—does not consume a nullability byte.
+        elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>Generic type or method parameters (T, TKey, etc.).</summary>
+internal sealed class GenericParameterNode(string name) : TypeNode
+{
+    public override bool IsReferenceType => false; // unknown; annotation still applies
+
+    public override string Render() => IsNullableAnnotated ? $"{name}?" : name;
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        byte b = ConsumeByte(bytes, ref position, defaultByte);
+        if (b == 2) IsNullableAnnotated = true;
+    }
+}
+
+/// <summary>Function pointer types (delegate*).</summary>
+internal sealed class FunctionPointerTypeNode : TypeNode
+{
+    public override bool IsReferenceType => false;
+
+    public override string Render() => "delegate*";
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        ConsumeByte(bytes, ref position, defaultByte);
+    }
+}
+
+/// <summary>Modified or pinned types—pass through to the underlying type.</summary>
+internal sealed class PassthroughTypeNode(TypeNode inner) : TypeNode
+{
+    public override bool IsReferenceType => inner.IsReferenceType;
+
+    public override string Render() => inner.Render();
+
+    public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
+    {
+        inner.ApplyNullability(bytes, ref position, defaultByte);
+    }
+}

--- a/src/DotnetInspector.Metadata/TypeNodeProvider.cs
+++ b/src/DotnetInspector.Metadata/TypeNodeProvider.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Decodes type signatures from metadata into <see cref="TypeNode"/> trees.
+/// The tree can then have nullability annotations applied before rendering.
+/// </summary>
+internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, GenericContext?>
+{
+    public static TypeNodeProvider Instance { get; } = new();
+
+    // Delegate to existing SignatureDecoder for name resolution to avoid duplication.
+    private static readonly SignatureDecoder NameDecoder = SignatureDecoder.Instance;
+
+    public TypeNode GetPrimitiveType(PrimitiveTypeCode typeCode)
+    {
+        string name = NameDecoder.GetPrimitiveType(typeCode);
+        bool isRef = typeCode is PrimitiveTypeCode.String or PrimitiveTypeCode.Object;
+        return new PrimitiveTypeNode(name, isRef);
+    }
+
+    public TypeNode GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        string name = NameDecoder.GetTypeFromDefinition(reader, handle, rawTypeKind);
+        bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
+        return new NamedTypeNode(name, isRef);
+    }
+
+    public TypeNode GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        string name = NameDecoder.GetTypeFromReference(reader, handle, rawTypeKind);
+        bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
+        return new NamedTypeNode(name, isRef);
+    }
+
+    public TypeNode GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+    {
+        var typeSpec = reader.GetTypeSpecification(handle);
+        return typeSpec.DecodeSignature(this, context);
+    }
+
+    public TypeNode GetSZArrayType(TypeNode elementType) => new SZArrayTypeNode(elementType);
+
+    public TypeNode GetArrayType(TypeNode elementType, ArrayShape shape) => new MDArrayTypeNode(elementType, shape.Rank);
+
+    public TypeNode GetByReferenceType(TypeNode elementType) => new ByRefTypeNode(elementType);
+
+    public TypeNode GetPointerType(TypeNode elementType) => new PointerTypeNode(elementType);
+
+    public TypeNode GetGenericInstantiation(TypeNode genericType, ImmutableArray<TypeNode> typeArguments)
+    {
+        // Strip .NET arity suffix (e.g., List`1 -> List)
+        string rawName = genericType is NamedTypeNode n ? n.Name : genericType.Render();
+        var backtickIndex = rawName.IndexOf('`');
+        var baseName = backtickIndex >= 0 ? rawName[..backtickIndex] : rawName;
+        return new GenericTypeNode(baseName, genericType.IsReferenceType, typeArguments);
+    }
+
+    public TypeNode GetGenericMethodParameter(GenericContext? context, int index)
+    {
+        string name = NameDecoder.GetGenericMethodParameter(context, index);
+        return new GenericParameterNode(name);
+    }
+
+    public TypeNode GetGenericTypeParameter(GenericContext? context, int index)
+    {
+        string name = NameDecoder.GetGenericTypeParameter(context, index);
+        return new GenericParameterNode(name);
+    }
+
+    public TypeNode GetFunctionPointerType(MethodSignature<TypeNode> signature) => new FunctionPointerTypeNode();
+
+    public TypeNode GetModifiedType(TypeNode modifier, TypeNode unmodifiedType, bool isRequired) => new PassthroughTypeNode(unmodifiedType);
+
+    public TypeNode GetPinnedType(TypeNode elementType) => new PassthroughTypeNode(elementType);
+}

--- a/tests/DotnetInspector.Metadata.Tests/NullabilityTests.cs
+++ b/tests/DotnetInspector.Metadata.Tests/NullabilityTests.cs
@@ -1,0 +1,283 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Metadata.Tests;
+
+#nullable enable
+
+/// <summary>
+/// Tests for nullability annotation reading and rendering in API signatures.
+/// Uses the test assembly itself (compiled with nullable enabled) as the test subject.
+/// </summary>
+public class NullabilityTests
+{
+    private static readonly ApiSurface Surface;
+
+    static NullabilityTests()
+    {
+        var assemblyPath = typeof(NullabilityTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    private static ApiType GetType(string name) =>
+        Surface.Types.First(t => t.Name == name);
+
+    private static ApiMember GetMethod(string typeName, string methodName) =>
+        GetType(typeName).Members.First(m => m.Name == methodName);
+
+    private static ApiMember GetProperty(string typeName, string propName) =>
+        GetType(typeName).Members.First(m => m.Name == propName && m.Kind == "property");
+
+    private static ApiMember GetField(string typeName, string fieldName) =>
+        GetType(typeName).Members.First(m => m.Name == fieldName && m.Kind == "field");
+
+    // --- NullabilityReader unit tests ---
+
+    [Fact]
+    public void GetNullableContext_ReturnsDefault_WhenNotPresent()
+    {
+        // Value types typically don't have NullableContextAttribute
+        var reader = GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(typeDef.Name) == "Int32")
+            {
+                // System.Int32 doesn't have a NullableContext attribute
+                var context = NullabilityReader.GetNullableContext(reader, typeDef.GetCustomAttributes());
+                Assert.Equal(0, context);
+                return;
+            }
+        }
+    }
+
+    [Fact]
+    public void GetNullableContext_ReadsValue_WhenPresent()
+    {
+        // This test assembly has nullable=enable, so types should have NullableContextAttribute
+        var reader = GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(typeDef.Name) == nameof(NullableSampleClass))
+            {
+                var context = NullabilityReader.GetNullableContext(reader, typeDef.GetCustomAttributes());
+                // Should be 1 (not annotated) or 2 (annotated) — non-zero for nullable-enabled types
+                Assert.NotEqual(0, context);
+                return;
+            }
+        }
+    }
+
+    // --- TypeNode tree + rendering tests ---
+
+    [Fact]
+    public void PrimitiveNode_String_RendersNullable()
+    {
+        var node = new PrimitiveTypeNode("string", isReferenceType: true);
+        byte[] bytes = [2];
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("string?", node.Render());
+        Assert.Equal(1, pos);
+    }
+
+    [Fact]
+    public void PrimitiveNode_Int_IgnoresNullability()
+    {
+        var node = new PrimitiveTypeNode("int", isReferenceType: false);
+        byte[] bytes = [2]; // even if byte says 2, value types don't render ?
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("int", node.Render());
+        Assert.Equal(1, pos); // byte still consumed
+    }
+
+    [Fact]
+    public void GenericNode_NullableArgs()
+    {
+        // Dictionary<string?, int> where Dictionary is not nullable
+        var node = new GenericTypeNode("Dictionary", isReferenceType: true,
+            [new PrimitiveTypeNode("string", true), new PrimitiveTypeNode("int", false)]);
+        byte[] bytes = [1, 2, 0]; // Dict=not null, string=nullable, int=oblivious
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("Dictionary<string?, int>", node.Render());
+    }
+
+    [Fact]
+    public void GenericNode_NullableOuter()
+    {
+        // Task<string>? where Task is nullable, string is not
+        var node = new GenericTypeNode("Task", isReferenceType: true,
+            [new PrimitiveTypeNode("string", true)]);
+        byte[] bytes = [2, 1]; // Task=nullable, string=not null
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("Task<string>?", node.Render());
+    }
+
+    [Fact]
+    public void ArrayNode_NullableElement()
+    {
+        // string?[] where array is not nullable, string is
+        var node = new SZArrayTypeNode(new PrimitiveTypeNode("string", true));
+        byte[] bytes = [1, 2]; // array=not null, string=nullable
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("string?[]", node.Render());
+    }
+
+    [Fact]
+    public void ArrayNode_NullableArray()
+    {
+        // string[]? where array is nullable, string is not
+        var node = new SZArrayTypeNode(new PrimitiveTypeNode("string", true));
+        byte[] bytes = [2, 1]; // array=nullable, string=not null
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("string[]?", node.Render());
+    }
+
+    [Fact]
+    public void ByRefNode_DoesNotConsumeByte()
+    {
+        // ref string? — ByRef doesn't consume a byte
+        var inner = new PrimitiveTypeNode("string", true);
+        var node = new ByRefTypeNode(inner);
+        byte[] bytes = [2]; // only the string's byte
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("ref string?", node.Render());
+        Assert.Equal(1, pos); // only inner consumed
+    }
+
+    [Fact]
+    public void SingleByteAttribute_AppliesUniformly()
+    {
+        // NullableAttribute(byte) applies to all positions
+        var node = new GenericTypeNode("Task", isReferenceType: true,
+            [new PrimitiveTypeNode("string", true)]);
+        byte[] bytes = [2]; // single byte = all positions nullable
+        int pos = 0;
+        node.ApplyNullability(bytes, ref pos, 0);
+        Assert.Equal("Task<string?>?", node.Render());
+    }
+
+    [Fact]
+    public void DefaultByte_UsedWhenNoAttribute()
+    {
+        var node = new PrimitiveTypeNode("string", isReferenceType: true);
+        int pos = 0;
+        node.ApplyNullability(null, ref pos, defaultByte: 2);
+        Assert.Equal("string?", node.Render());
+    }
+
+    [Fact]
+    public void DefaultByte_NotAnnotated()
+    {
+        var node = new PrimitiveTypeNode("string", isReferenceType: true);
+        int pos = 0;
+        node.ApplyNullability(null, ref pos, defaultByte: 1);
+        Assert.Equal("string", node.Render());
+    }
+
+    // --- End-to-end: signatures extracted from this assembly ---
+
+    [Fact]
+    public void Method_NullableStringParam()
+    {
+        var member = GetMethod(nameof(NullableSampleClass), nameof(NullableSampleClass.TakesNullableString));
+        Assert.Contains("string?", member.Signature);
+        Assert.Contains("string? value", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NonNullableStringParam()
+    {
+        var member = GetMethod(nameof(NullableSampleClass), nameof(NullableSampleClass.TakesNonNullableString));
+        // Should contain "string value" without ?
+        Assert.Contains("string value", member.Signature);
+        Assert.DoesNotContain("string?", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NullableReturnType()
+    {
+        var member = GetMethod(nameof(NullableSampleClass), nameof(NullableSampleClass.ReturnsNullableString));
+        Assert.NotNull(member.Signature);
+        Assert.StartsWith("string?", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NonNullableReturnType()
+    {
+        var member = GetMethod(nameof(NullableSampleClass), nameof(NullableSampleClass.ReturnsNonNullableString));
+        Assert.NotNull(member.Signature);
+        Assert.StartsWith("string ", member.Signature);
+    }
+
+    [Fact]
+    public void Property_NullableType()
+    {
+        var member = GetProperty(nameof(NullableSampleClass), nameof(NullableSampleClass.NullableProp));
+        Assert.Contains("string?", member.Signature);
+    }
+
+    [Fact]
+    public void Property_NonNullableType()
+    {
+        var member = GetProperty(nameof(NullableSampleClass), nameof(NullableSampleClass.NonNullableProp));
+        Assert.DoesNotContain("string?", member.Signature);
+        Assert.Contains("string ", member.Signature);
+    }
+
+    [Fact]
+    public void Field_NullableType()
+    {
+        var member = GetField(nameof(NullableSampleClass), nameof(NullableSampleClass.NullableField));
+        Assert.Contains("?", member.ReturnType);
+    }
+
+    [Fact]
+    public void Method_GenericNullableArg()
+    {
+        var member = GetMethod(nameof(NullableSampleClass), nameof(NullableSampleClass.TakesNullableList));
+        // Should show List<string?> or similar nullable inner arg
+        Assert.Contains("string?", member.Signature);
+    }
+
+    private static MetadataReader GetMetadataReader()
+    {
+        var path = typeof(NullabilityTests).Assembly.Location;
+        var stream = File.OpenRead(path);
+        var peReader = new PEReader(stream);
+        return peReader.GetMetadataReader();
+    }
+}
+
+// ===== Test fixture types compiled with #nullable enable =====
+
+/// <summary>Sample class for testing nullable signature extraction.</summary>
+public class NullableSampleClass
+{
+    public string? NullableField;
+    public string NonNullableField = "";
+
+    public string? NullableProp { get; set; }
+    public string NonNullableProp { get; set; } = "";
+
+    public void TakesNullableString(string? value) { }
+    public void TakesNonNullableString(string value) { }
+
+    public string? ReturnsNullableString() => null;
+    public string ReturnsNonNullableString() => "";
+
+    public void TakesNullableList(List<string?> items) { }
+    public void TakesNonNullableList(List<string> items) { }
+
+    public Dictionary<string, object?> MixedGeneric() => new();
+}


### PR DESCRIPTION
## Nullability annotations in API signatures

Reads `NullableAttribute` and `NullableContextAttribute` from assembly metadata and applies `?` annotations to reference types in method, property, and field signatures.

### Before

```
Deserialize  `TValue Deserialize(string, System.Text.Json.JsonSerializerOptions)`
```

### After

```
Deserialize  `TValue? Deserialize(string, System.Text.Json.JsonSerializerOptions?)`
```

### Design

Uses a tree-based type representation (`TypeNode`) to correctly handle the byte ordering difference between `NullableAttribute`'s preorder traversal and SRM's bottom-up decoding order:

1. Decode signature into `TypeNode` tree via `TypeNodeProvider` (`ISignatureTypeProvider<TypeNode, GenericContext?>`)
2. Walk tree in preorder, consuming nullability bytes and setting `IsNullableAnnotated` flags
3. Render to C# string with `?` annotations

Always-on — no flag needed. Assemblies without nullable annotations produce byte 0 (oblivious) and render identically to before.

### New files

| File | Purpose |
|------|---------|
| `NullabilityReader.cs` | Reads `NullableAttribute` (byte or byte[]) and `NullableContextAttribute` default from metadata |
| `TypeNode.cs` | Type tree hierarchy with `ApplyNullability()` preorder walk and `Render()` |
| `TypeNodeProvider.cs` | Builds `TypeNode` trees from SRM signature decoding |
| `NullabilityTests.cs` | 20 unit + integration tests |

### Modified files

- `ApiSurfaceExtractor.cs` — method, property, and field signatures flow through the nullable pipeline
- `DotnetInspector.Metadata.csproj` — `InternalsVisibleTo` for test project

### Test results

- 522 CLI tests ✅
- 148 decompiler tests ✅
- 130 services tests ✅
- 101 metadata tests (20 new nullability tests ✅, 8 pre-existing TypeDependencyScanner failures unchanged)