### PR TITLE
Add NuGet source credential support and dual-purpose --version

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -111,3 +111,28 @@ Used in:
   Ported from src/coreclr/tools/Common/TypeSystem/IL/FlowGraph.cs
 - src/DotnetInspector.Decompiler/StackHeightCalculator.cs
   Ported from src/coreclr/tools/Common/TypeSystem/IL/ILStackHelper.cs
+
+License notice for NuGet.Client
+-------------------------------
+
+https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Used in:
+- src/DotnetInspector.Packages/EncryptionUtility.cs
+  DPAPI decryption forked from NuGet.Configuration/Utility/EncryptionUtility.cs

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Versioning" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/DotnetInspector.Packages/EncryptionUtility.cs
+++ b/src/DotnetInspector.Packages/EncryptionUtility.cs
@@ -1,0 +1,28 @@
+// Forked from NuGet.Client — src/NuGet.Core/NuGet.Configuration/Utility/EncryptionUtility.cs
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+//
+// Minimal fork: decrypt-only, for reading DPAPI-encrypted passwords from nuget.config.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>
+/// Decrypts DPAPI-encrypted passwords stored in nuget.config (Windows only).
+/// </summary>
+internal static class EncryptionUtility
+{
+    private static readonly byte[] EntropyBytes = Encoding.UTF8.GetBytes("NuGet");
+
+    public static string DecryptString(string encryptedString)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new NotSupportedException("Encrypted NuGet credentials are only supported on Windows. Use ClearTextPassword instead.");
+
+        var encryptedByteArray = Convert.FromBase64String(encryptedString);
+        var decryptedByteArray = ProtectedData.Unprotect(encryptedByteArray, EntropyBytes, DataProtectionScope.CurrentUser);
+        return Encoding.UTF8.GetString(decryptedByteArray);
+    }
+}

--- a/src/DotnetInspector.Packages/HttpRetryHelper.cs
+++ b/src/DotnetInspector.Packages/HttpRetryHelper.cs
@@ -6,6 +6,7 @@
 // Adapted for AOT compatibility and simplified for dotnet-inspect use case.
 
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Sockets;
 
 namespace DotnetInspector.Packages;
@@ -173,16 +174,24 @@ public static class HttpRetryHelper
     /// <param name="retryCount">Maximum number of retries (default: 3)</param>
     /// <param name="log">Optional logging callback</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="auth">Optional authentication header for authenticated feeds</param>
     /// <returns>Response if successful, null if failed or not found</returns>
     public static Task<HttpResponseMessage?> GetWithRetryAsync(
         HttpClient client,
         string url,
         int retryCount = DefaultRetryCount,
         Action<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        AuthenticationHeaderValue? auth = null)
     {
         return ExecuteWithRetryAsync(
-            ct => client.GetAsync(url, ct),
+            ct =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                if (auth != null)
+                    request.Headers.Authorization = auth;
+                return client.SendAsync(request, ct);
+            },
             url,
             "GET",
             retryCount,
@@ -198,15 +207,17 @@ public static class HttpRetryHelper
     /// <param name="retryCount">Maximum number of retries (default: 3)</param>
     /// <param name="log">Optional logging callback</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="auth">Optional authentication header for authenticated feeds</param>
     /// <returns>Response body as string, or null if failed</returns>
     public static async Task<string?> GetStringWithRetryAsync(
         HttpClient client,
         string url,
         int retryCount = DefaultRetryCount,
         Action<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        AuthenticationHeaderValue? auth = null)
     {
-        using var response = await GetWithRetryAsync(client, url, retryCount, log, cancellationToken).ConfigureAwait(false);
+        using var response = await GetWithRetryAsync(client, url, retryCount, log, cancellationToken, auth).ConfigureAwait(false);
         if (response == null)
             return null;
 
@@ -221,15 +232,17 @@ public static class HttpRetryHelper
     /// <param name="retryCount">Maximum number of retries (default: 3)</param>
     /// <param name="log">Optional logging callback</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="auth">Optional authentication header for authenticated feeds</param>
     /// <returns>Response body as byte array, or null if failed</returns>
     public static async Task<byte[]?> GetBytesWithRetryAsync(
         HttpClient client,
         string url,
         int retryCount = DefaultRetryCount,
         Action<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        AuthenticationHeaderValue? auth = null)
     {
-        using var response = await GetWithRetryAsync(client, url, retryCount, log, cancellationToken).ConfigureAwait(false);
+        using var response = await GetWithRetryAsync(client, url, retryCount, log, cancellationToken, auth).ConfigureAwait(false);
         if (response == null)
             return null;
 

--- a/src/DotnetInspector.Packages/NuGetSource.cs
+++ b/src/DotnetInspector.Packages/NuGetSource.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http.Headers;
+using System.Text;
+
 namespace DotnetInspector.Packages;
 
 /// <summary>
@@ -10,6 +13,11 @@ namespace DotnetInspector.Packages;
 /// <param name="Url">URL of the source (V3 feed URL)</param>
 public record NuGetSource(string Name, string Url)
 {
+    /// <summary>
+    /// Optional credentials for authenticated feeds.
+    /// </summary>
+    public NuGetSourceCredential? Credentials { get; init; }
+
     /// <summary>
     /// The default nuget.org source.
     /// </summary>
@@ -35,4 +43,21 @@ public record NuGetSource(string Name, string Url)
     /// Returns true if this source points to nuget.org.
     /// </summary>
     public bool IsNuGetOrg() => Url.Contains("api.nuget.org", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Creates an Authorization header value for this source, or null if no credentials.
+    /// </summary>
+    public AuthenticationHeaderValue? GetAuthHeader()
+    {
+        if (Credentials is null) return null;
+        var encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Credentials.Username}:{Credentials.Password}"));
+        return new AuthenticationHeaderValue("Basic", encoded);
+    }
 }
+
+/// <summary>
+/// Credentials for an authenticated NuGet source.
+/// </summary>
+/// <param name="Username">User name</param>
+/// <param name="Password">Password in clear text (decrypted if necessary)</param>
+public record NuGetSourceCredential(string Username, string Password);

--- a/src/DotnetInspector.Packages/NuGetSourceResolver.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceResolver.cs
@@ -222,5 +222,58 @@ public static class NuGetSourceResolver
                 }
             }
         }
+
+        // Parse packageSourceCredentials
+        var credentialsSection = configuration.Element("packageSourceCredentials");
+        if (credentialsSection != null)
+        {
+            foreach (var sourceElement in credentialsSection.Elements())
+            {
+                // Element name is the source name (XML-encoded: spaces become _x0020_, etc.)
+                var sourceName = System.Xml.XmlConvert.DecodeName(sourceElement.Name.LocalName);
+                if (sourceName == null || !sources.ContainsKey(sourceName))
+                    continue;
+
+                string? username = null;
+                string? password = null;
+                bool isClearText = false;
+
+                foreach (var add in sourceElement.Elements("add"))
+                {
+                    var key = add.Attribute("key")?.Value;
+                    var value = add.Attribute("value")?.Value;
+
+                    if (string.Equals(key, "Username", StringComparison.OrdinalIgnoreCase))
+                        username = value;
+                    else if (string.Equals(key, "ClearTextPassword", StringComparison.OrdinalIgnoreCase))
+                        { password = value; isClearText = true; }
+                    else if (string.Equals(key, "Password", StringComparison.OrdinalIgnoreCase))
+                        { password = value; isClearText = false; }
+                }
+
+                if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+                {
+                    string clearPassword;
+                    if (isClearText)
+                    {
+                        clearPassword = password!;
+                    }
+                    else
+                    {
+                        try { clearPassword = EncryptionUtility.DecryptString(password!); }
+                        catch (Exception ex)
+                        {
+                            Console.Error.WriteLine($"Warning: Could not decrypt password for source '{sourceName}': {ex.Message}");
+                            continue;
+                        }
+                    }
+
+                    sources[sourceName] = sources[sourceName] with
+                    {
+                        Credentials = new NuGetSourceCredential(username!, clearPassword)
+                    };
+                }
+            }
+        }
     }
 }

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Compression;
+using System.Net.Http.Headers;
 using DotnetInspector.Core;
 
 namespace DotnetInspector.Packages;
@@ -155,7 +156,7 @@ public static class PackageExtractor
 
             try
             {
-                packageBytes = await HttpRetryHelper.GetBytesWithRetryAsync(client, nupkgUrl).ConfigureAwait(false);
+                packageBytes = await HttpRetryHelper.GetBytesWithRetryAsync(client, nupkgUrl, auth: source.GetAuthHeader()).ConfigureAwait(false);
                 if (packageBytes != null)
                 {
                     successfulSource = source.Name;
@@ -251,7 +252,7 @@ public static class PackageExtractor
 
         log?.Invoke($"Querying service index: {indexUrl}");
 
-        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl).ConfigureAwait(false);
+        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl, auth: source.GetAuthHeader()).ConfigureAwait(false);
         if (json == null)
             return null;
 
@@ -425,12 +426,14 @@ public static class PackageExtractor
         NuGetSource source,
         Action<string>? log)
     {
+        var auth = source.GetAuthHeader();
+
         // Try flat-container index first
         var flatContainerUrl = source.GetFlatContainerUrl();
         if (flatContainerUrl != null)
         {
             string indexUrl = $"{flatContainerUrl}/{packageName}/index.json";
-            var versions = await FetchVersionListAsync(client, indexUrl, log).ConfigureAwait(false);
+            var versions = await FetchVersionListAsync(client, indexUrl, log, auth).ConfigureAwait(false);
             if (versions != null)
                 return versions;
         }
@@ -443,7 +446,7 @@ public static class PackageExtractor
                 baseAddress += "/";
 
             string indexUrl = $"{baseAddress}{packageName}/index.json";
-            var versions = await FetchVersionListAsync(client, indexUrl, log).ConfigureAwait(false);
+            var versions = await FetchVersionListAsync(client, indexUrl, log, auth).ConfigureAwait(false);
             if (versions != null)
                 return versions;
         }
@@ -452,10 +455,11 @@ public static class PackageExtractor
     }
 
     private static async Task<List<string>?> FetchVersionListAsync(
-        HttpClient client, string indexUrl, Action<string>? log)
+        HttpClient client, string indexUrl, Action<string>? log,
+        AuthenticationHeaderValue? auth = null)
     {
         log?.Invoke($"Fetching versions from: {indexUrl}");
-        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl).ConfigureAwait(false);
+        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl, auth: auth).ConfigureAwait(false);
         if (json == null) return null;
 
         try
@@ -484,6 +488,8 @@ public static class PackageExtractor
         NuGetSource source,
         Action<string>? log)
     {
+        var auth = source.GetAuthHeader();
+
         // For nuget.org, use the search API — returns latest version directly without listing all versions
         if (source.IsNuGetOrg())
         {
@@ -499,7 +505,7 @@ public static class PackageExtractor
             string indexUrl = $"{flatContainerUrl}/{packageName}/index.json";
             log?.Invoke($"Fetching versions from: {indexUrl}");
 
-            var version = await ParseVersionIndexAsync(client, indexUrl).ConfigureAwait(false);
+            var version = await ParseVersionIndexAsync(client, indexUrl, auth).ConfigureAwait(false);
             if (version != null)
                 return version;
         }
@@ -514,7 +520,7 @@ public static class PackageExtractor
             string indexUrl = $"{baseAddress}{packageName}/index.json";
             log?.Invoke($"Fetching versions from: {indexUrl}");
 
-            var version = await ParseVersionIndexAsync(client, indexUrl).ConfigureAwait(false);
+            var version = await ParseVersionIndexAsync(client, indexUrl, auth).ConfigureAwait(false);
             if (version != null)
                 return version;
         }
@@ -555,9 +561,11 @@ public static class PackageExtractor
         return null;
     }
 
-    private static async Task<string?> ParseVersionIndexAsync(HttpClient client, string indexUrl)
+    private static async Task<string?> ParseVersionIndexAsync(
+        HttpClient client, string indexUrl,
+        AuthenticationHeaderValue? auth = null)
     {
-        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl).ConfigureAwait(false);
+        string? json = await HttpRetryHelper.GetStringWithRetryAsync(client, indexUrl, auth: auth).ConfigureAwait(false);
         if (json == null)
             return null;
 

--- a/src/dotnet-inspect.Tests/NuGetSourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSourceResolverTests.cs
@@ -314,4 +314,136 @@ public class NuGetSourceResolverTests
             Directory.Delete(rootDir, recursive: true);
         }
     }
+
+    [Fact]
+    public void ResolveSources_WithClearTextCredentials_ParsesCredentials()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"nuget-cred-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var configPath = Path.Combine(tempDir, "nuget.config");
+            File.WriteAllText(configPath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="MyPrivateFeed" value="https://private.example.com/v3/index.json" />
+                  </packageSources>
+                  <packageSourceCredentials>
+                    <MyPrivateFeed>
+                      <add key="Username" value="myuser" />
+                      <add key="ClearTextPassword" value="mypassword" />
+                    </MyPrivateFeed>
+                  </packageSourceCredentials>
+                </configuration>
+                """);
+
+            var options = new NuGetSourceOptions { ConfigFile = configPath };
+            var sources = NuGetSourceResolver.ResolveSources(options);
+
+            Assert.Single(sources);
+            Assert.NotNull(sources[0].Credentials);
+            Assert.Equal("myuser", sources[0].Credentials!.Username);
+            Assert.Equal("mypassword", sources[0].Credentials!.Password);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSources_WithEncodedSourceName_ParsesCredentials()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"nuget-cred-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var configPath = Path.Combine(tempDir, "nuget.config");
+            // Spaces in source names are encoded as _x0020_ in the XML element name
+            File.WriteAllText(configPath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="My Private Feed" value="https://private.example.com/v3/index.json" />
+                  </packageSources>
+                  <packageSourceCredentials>
+                    <My_x0020_Private_x0020_Feed>
+                      <add key="Username" value="spaceuser" />
+                      <add key="ClearTextPassword" value="spacepass" />
+                    </My_x0020_Private_x0020_Feed>
+                  </packageSourceCredentials>
+                </configuration>
+                """);
+
+            var options = new NuGetSourceOptions { ConfigFile = configPath };
+            var sources = NuGetSourceResolver.ResolveSources(options);
+
+            Assert.Single(sources);
+            Assert.NotNull(sources[0].Credentials);
+            Assert.Equal("spaceuser", sources[0].Credentials!.Username);
+            Assert.Equal("spacepass", sources[0].Credentials!.Password);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSources_WithNoCredentials_LeavesCredentialsNull()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"nuget-cred-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var configPath = Path.Combine(tempDir, "nuget.config");
+            File.WriteAllText(configPath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="PublicFeed" value="https://public.example.com/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """);
+
+            var options = new NuGetSourceOptions { ConfigFile = configPath };
+            var sources = NuGetSourceResolver.ResolveSources(options);
+
+            Assert.Single(sources);
+            Assert.Null(sources[0].Credentials);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NuGetSource_GetAuthHeader_ReturnsBasicAuth()
+    {
+        var source = new NuGetSource("test", "https://test.example.com/v3/index.json")
+        {
+            Credentials = new NuGetSourceCredential("user", "pass")
+        };
+
+        var header = source.GetAuthHeader();
+
+        Assert.NotNull(header);
+        Assert.Equal("Basic", header!.Scheme);
+        // "user:pass" base64
+        var decoded = System.Text.Encoding.ASCII.GetString(Convert.FromBase64String(header.Parameter!));
+        Assert.Equal("user:pass", decoded);
+    }
+
+    [Fact]
+    public void NuGetSource_GetAuthHeader_ReturnsNullWithoutCredentials()
+    {
+        var source = new NuGetSource("test", "https://test.example.com/v3/index.json");
+
+        Assert.Null(source.GetAuthHeader());
+    }
 }

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1228,7 +1228,7 @@ public static class CommandLineBuilder
         var readmeOption = new Option<bool>("--readme") { Description = "Show the README.md content from the package" };
         var outOption = new Option<string?>("--out") { Description = "Write output to file instead of stdout" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
-        var versionOption = new Option<string?>("--version") { Description = "Package version" };
+        var versionOption = new Option<string?>("--version") { Description = "Package version (or use alone to show latest)", Arity = ArgumentArity.ZeroOrOne };
 
         packageCommand.Arguments.Add(packageNameArg);
         packageCommand.Options.Add(dependenciesOption);
@@ -1264,6 +1264,9 @@ public static class CommandLineBuilder
             var packageArgs = parseResult.GetValue(packageNameArg) ?? [];
             var explicitVersion = parseResult.GetValue(versionOption);
 
+            // Bare --version (no value): treat as --versions -n 1
+            bool bareVersion = explicitVersion == null && parseResult.GetResult(versionOption) is { Implicit: false };
+
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
 
             var options = new InspectionOptions
@@ -1277,11 +1280,11 @@ public static class CommandLineBuilder
                 ListTfms = parseResult.GetValue(tfmsOption),
                 ScopeLib = parseResult.GetValue(libOption),
                 ScopeTools = parseResult.GetValue(toolsOption),
-                ListVersions = parseResult.GetValue(versionsOption),
+                ListVersions = bareVersion || parseResult.GetValue(versionsOption),
                 IncludePrerelease = parseResult.GetValue(prereleaseOption),
                 ShowReadme = parseResult.GetValue(readmeOption),
                 OutputPath = parseResult.GetValue(outOption),
-                Limit = parseResult.GetValue(limitOption),
+                Limit = bareVersion ? 1 : parseResult.GetValue(limitOption),
                 JsonOutput = parseResult.GetValue(jsonOption),
                 Verbose = parseResult.GetValue(verboseOption),
                 Verbosity = verbosity,

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -53,6 +53,7 @@ dnx dotnet-inspect -y -- implements Stream
 # Package metadata and versions
 dnx dotnet-inspect -y -- package System.Text.Json -v:d
 dnx dotnet-inspect -y -- package System.Text.Json --versions
+dnx dotnet-inspect -y -- package System.Text.Json --version
 
 # Library metadata, SourceLink audit, dependency tree
 dnx dotnet-inspect -y -- library --package System.Text.Json --source-link-audit

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -51,6 +51,7 @@ Package data:
 
 ```bash
 dotnet-inspect package System.Text.Json --versions          # List available versions
+dotnet-inspect package System.Text.Json --version           # Show latest version
 dotnet-inspect package System.Text.Json --version 11.0.0-preview*  # Wildcard version
 dotnet-inspect package System.Text.Json --files             # File listing
 dotnet-inspect package System.Text.Json --tfms              # TFM list
@@ -399,7 +400,7 @@ DOTNET_INSPECT_TIPS=quiet            # ENV-based silencing
 | `--source-link-audit` | SourceLink/determinism audit | library |
 | `--extract-resources dir/` | Extract embedded resources | library |
 | `--versions` | List available versions | package |
-| `--version VER` | Specific version (supports wildcards) | package |
+| `--version` | Show latest version (or specify version) | package |
 | `--files` | List files | package |
 | `--tfms` | List target frameworks | package |
 | `--layout` | File tree view | package |


### PR DESCRIPTION
## Summary

Adds support for authenticated NuGet feeds (fixes #190) and a dual-purpose `--version` flag.

### Credential support
- Parses `<packageSourceCredentials>` from nuget.config with `ClearTextPassword` and DPAPI-encrypted `Password`
- Handles XML-encoded source names (spaces → `_x0020_`) via `XmlConvert.DecodeName`
- Threads `Authorization: Basic` headers through `HttpRetryHelper` → `PackageExtractor` for all HTTP calls against authenticated sources
- Forks `EncryptionUtility` from NuGet.Client (Apache 2.0) for DPAPI decryption on Windows

### Dual-purpose `--version`
- `--version` (bare, no value): shows latest version — equivalent to `--versions -n 1`
- `--version 8.0.5`: specifies package version (existing behavior, unchanged)
- Uses `ArgumentArity.ZeroOrOne` with `parseResult.GetResult()` to distinguish bare from value

### Tests
- 5 new tests: ClearTextPassword parsing, encoded source names, no-credentials null check, Basic auth header encoding, auth header null without credentials
- All 527 CLI tests pass, 130 services tests pass

### Files changed
- `EncryptionUtility.cs` (new) — DPAPI decrypt fork from NuGet.Client
- `NuGetSource.cs` — `Credentials` property, `NuGetSourceCredential` record, `GetAuthHeader()`
- `NuGetSourceResolver.cs` — credential parsing from nuget.config
- `HttpRetryHelper.cs` — optional `auth` parameter on all public methods
- `PackageExtractor.cs` — passes source auth through all HTTP calls
- `CommandLineBuilder.cs` — `--version` dual-purpose with ZeroOrOne arity
- `THIRD-PARTY-NOTICES.TXT` — Apache 2.0 notice for NuGet.Client fork
- `llms.txt`, `SKILL.md` — docs for `--version`