### PR TITLE
Switch metadata cache from JSON to markdown field format

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -87,6 +87,28 @@ public static class CoreCache
     }
 
     /// <summary>
+    /// Tries to read cached content as raw bytes with a maximum age.
+    /// Returns null if the entry is missing or older than <paramref name="maxAge"/>.
+    /// </summary>
+    public static byte[]? TryGetBytes(string category, string key, TimeSpan maxAge, string extension = "json")
+    {
+        var path = GetFilePath(category, key, extension);
+        try
+        {
+            var info = new FileInfo(path);
+            if (info.Exists && (DateTime.UtcNow - info.LastWriteTimeUtc) < maxAge)
+            {
+                return File.ReadAllBytes(path);
+            }
+        }
+        catch
+        {
+            // Best-effort
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Tries to read cached content with a maximum age. Returns null if the entry
     /// is missing or older than <paramref name="maxAge"/>.
     /// </summary>

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="../DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MarkdownTable.Formatting" Version="0.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/DotnetInspector.Services/MetadataFieldCache.cs
+++ b/src/DotnetInspector.Services/MetadataFieldCache.cs
@@ -1,0 +1,192 @@
+using System.Buffers;
+using System.Text;
+using DotnetInspector.Core;
+using MarkdownTable.Formatting;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Reads and writes <see cref="PackageMetadata"/> as markdown field documents.
+/// Replaces the previous JSON-based metadata cache with zero-string byte-level parsing.
+/// </summary>
+internal static class MetadataFieldCache
+{
+    private const string Category = "metadata";
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Tries to load cached metadata. Returns null on cache miss or expiry.
+    /// </summary>
+    public static PackageMetadata? TryGet(string cacheKey)
+    {
+        var bytes = CoreCache.TryGetBytes(Category, cacheKey, Ttl, extension: "md");
+        if (bytes is null) return null;
+
+        try
+        {
+            using var doc = FieldDocument.Parse(bytes);
+            var metadata = new PackageMetadata
+            {
+                IsVerified = doc.GetBool("isVerified") ? true : null,
+                VersionCount = doc.GetInt32("versionCount") is > 0 and var vc ? vc : null,
+            };
+
+            if (doc.GetString("published") is string pub
+                && DateTimeOffset.TryParse(pub, out var published))
+                metadata.Published = published;
+
+            if (doc.GetString("totalDownloads") is string td
+                && long.TryParse(td, out var totalDl))
+                metadata.TotalDownloads = totalDl;
+
+            if (doc.GetString("versionDownloads") is string vd
+                && long.TryParse(vd, out var verDl))
+                metadata.VersionDownloads = verDl;
+
+            if (doc.GetString("packageSize") is string ps
+                && long.TryParse(ps, out var size))
+                metadata.PackageSize = size;
+
+            var owners = doc.GetArrayList("owners");
+            if (owners is { Count: > 0 })
+                metadata.Owners = owners;
+
+            // Deprecation: flattened fields
+            var reasons = doc.GetString("deprecationReasons");
+            var message = doc.GetString("deprecationMessage");
+            var altPkg = doc.GetString("deprecationAlternate");
+            if (reasons is not null || message is not null)
+            {
+                metadata.Deprecation = new PackageDeprecation
+                {
+                    Reasons = reasons?.Split(", ").ToList(),
+                    Message = message,
+                    AlternatePackageId = altPkg,
+                };
+            }
+
+            // Vulnerabilities: pipe-delimited compact strings
+            var vulnItems = doc.GetArrayList("vulnerabilities");
+            if (vulnItems is { Count: > 0 })
+            {
+                metadata.Vulnerabilities = vulnItems.Select(ParseVulnerability).ToList();
+            }
+
+            return metadata;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Caches metadata as a markdown field document.
+    /// </summary>
+    public static void Set(string cacheKey, PackageMetadata metadata)
+    {
+        try
+        {
+            var buf = new ArrayBufferWriter<byte>(512);
+
+            // Scalars
+            if (metadata.Published.HasValue)
+                WriteField(buf, "published"u8, metadata.Published.Value.ToString("o"));
+            if (metadata.TotalDownloads.HasValue)
+                WriteField(buf, "totalDownloads"u8, metadata.TotalDownloads.Value.ToString());
+            if (metadata.VersionDownloads.HasValue)
+                WriteField(buf, "versionDownloads"u8, metadata.VersionDownloads.Value.ToString());
+            if (metadata.VersionCount.HasValue)
+                WriteField(buf, "versionCount"u8, metadata.VersionCount.Value.ToString());
+            if (metadata.PackageSize.HasValue)
+                WriteField(buf, "packageSize"u8, metadata.PackageSize.Value.ToString());
+            if (metadata.IsVerified == true)
+                WriteField(buf, "isVerified"u8, "true");
+
+            // Deprecation: flattened
+            if (metadata.Deprecation is { } dep)
+            {
+                if (dep.Reasons is { Count: > 0 })
+                    WriteField(buf, "deprecationReasons"u8, string.Join(", ", dep.Reasons));
+                if (!string.IsNullOrEmpty(dep.Message))
+                    WriteField(buf, "deprecationMessage"u8, dep.Message);
+                if (!string.IsNullOrEmpty(dep.AlternatePackageId))
+                    WriteField(buf, "deprecationAlternate"u8, dep.AlternatePackageId);
+            }
+
+            // Arrays
+            WriteArray(buf, "owners"u8, metadata.Owners);
+
+            // Vulnerabilities: compact pipe-delimited
+            if (metadata.Vulnerabilities is { Count: > 0 })
+            {
+                var items = metadata.Vulnerabilities.Select(FormatVulnerability).ToList();
+                WriteArray(buf, "vulnerabilities"u8, items);
+            }
+
+            CoreCache.SetBytes(Category, cacheKey, buf.WrittenSpan.ToArray(), extension: "md");
+        }
+        catch
+        {
+            // Best-effort caching
+        }
+    }
+
+    // ── Vulnerability compact format: "Severity|CveId|GhsaId|Summary" ──
+
+    private static string FormatVulnerability(PackageVulnerability v)
+    {
+        return $"{v.Severity}|{v.CveId ?? ""}|{v.GhsaId ?? ""}|{v.Summary ?? ""}";
+    }
+
+    private static PackageVulnerability ParseVulnerability(string raw)
+    {
+        var parts = raw.Split('|', 4);
+        return new PackageVulnerability
+        {
+            Severity = parts.Length > 0 ? parts[0] : "",
+            CveId = parts.Length > 1 && parts[1].Length > 0 ? parts[1] : null,
+            GhsaId = parts.Length > 2 && parts[2].Length > 0 ? parts[2] : null,
+            Summary = parts.Length > 3 && parts[3].Length > 0 ? parts[3] : null,
+        };
+    }
+
+    // ── Field serialization (UTF-8 bytes) ──
+
+    private static void WriteField(ArrayBufferWriter<byte> buf, ReadOnlySpan<byte> key, string? value)
+    {
+        if (value is null) return;
+        Write(buf, key);
+        Write(buf, ": "u8);
+        Write(buf, value);
+        Write(buf, "\n"u8);
+    }
+
+    private static void WriteArray(ArrayBufferWriter<byte> buf, ReadOnlySpan<byte> key, List<string>? items)
+    {
+        if (items is not { Count: > 0 }) return;
+        Write(buf, "\n"u8);
+        Write(buf, key);
+        Write(buf, ":\n"u8);
+        foreach (var item in items)
+        {
+            Write(buf, "- "u8);
+            Write(buf, item);
+            Write(buf, "\n"u8);
+        }
+    }
+
+    private static void Write(ArrayBufferWriter<byte> buf, ReadOnlySpan<byte> utf8)
+    {
+        utf8.CopyTo(buf.GetSpan(utf8.Length));
+        buf.Advance(utf8.Length);
+    }
+
+    private static void Write(ArrayBufferWriter<byte> buf, string text)
+    {
+        var maxBytes = Encoding.UTF8.GetMaxByteCount(text.Length);
+        var span = buf.GetSpan(maxBytes);
+        int written = Encoding.UTF8.GetBytes(text, span);
+        buf.Advance(written);
+    }
+}

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -5,19 +5,11 @@ using DotnetInspector.Packages;
 namespace DotnetInspector.Services;
 
 /// <summary>
-/// JSON source generation context for metadata caching (NativeAOT-safe).
-/// </summary>
-[System.Text.Json.Serialization.JsonSerializable(typeof(PackageMetadata))]
-internal partial class MetadataJsonContext : System.Text.Json.Serialization.JsonSerializerContext;
-
-/// <summary>
 /// Fetches NuGet metadata: publish date, downloads, deprecation, vulnerabilities, and package size.
 /// Results are cached on disk with a 1-hour TTL for the default (bare name) case.
 /// </summary>
 public static class PackageMetadataService
 {
-    private const string MetadataCacheCategory = "metadata";
-    private static readonly TimeSpan MetadataCacheTtl = TimeSpan.FromHours(1);
     /// <summary>
     /// Gets the published date for a specific package version.
     /// </summary>
@@ -63,37 +55,18 @@ public static class PackageMetadataService
         // Try cache first (unless @latest forces refresh)
         if (!forceLatest)
         {
-            var cached = CoreCache.TryGet(MetadataCacheCategory, cacheKey, MetadataCacheTtl);
-            if (cached != null)
+            var fromCache = MetadataFieldCache.TryGet(cacheKey);
+            if (fromCache != null)
             {
-                try
-                {
-                    var fromCache = JsonSerializer.Deserialize(cached, MetadataJsonContext.Default.PackageMetadata);
-                    if (fromCache != null)
-                    {
-                        log?.Invoke("Using cached metadata");
-                        return fromCache;
-                    }
-                }
-                catch
-                {
-                    // Corrupted cache entry — fall through to fetch
-                }
+                log?.Invoke("Using cached metadata");
+                return fromCache;
             }
         }
 
         var metadata = await FetchAllMetadataFromNetworkAsync(client, normalizedName, version, log).ConfigureAwait(false);
 
         // Cache the result
-        try
-        {
-            var json = JsonSerializer.Serialize(metadata, MetadataJsonContext.Default.PackageMetadata);
-            CoreCache.Set(MetadataCacheCategory, cacheKey, json);
-        }
-        catch
-        {
-            // Best-effort caching
-        }
+        MetadataFieldCache.Set(cacheKey, metadata);
 
         return metadata;
     }


### PR DESCRIPTION
Replaces `JsonSerializer` with `FieldDocument` for the metadata cache (`PackageMetadata` — published date, downloads, deprecation, vulnerabilities).

### Changes
- **New**: `MetadataFieldCache` — reads/writes `PackageMetadata` as markdown field documents using `ArrayBufferWriter<byte>` + `FieldDocument.Parse`
- **New**: `CoreCache.TryGetBytes(category, key, maxAge, extension)` — byte read with TTL support
- **Removed**: `MetadataJsonContext` source-gen context (no longer needed)
- **Simplified**: `PackageMetadataService.FetchAllMetadataAsync` cache logic

### Format
Nested objects are flattened:
- **Deprecation** → `deprecationReasons`, `deprecationMessage`, `deprecationAlternate` scalar fields
- **Vulnerabilities** → pipe-delimited compact strings: `Severity|CveId|GhsaId|Summary`

### Validated
- Newtonsoft.Json@13.0.3 (simple metadata) ✅
- System.Text.Json@8.0.0 (2 vulnerabilities) ✅  
- System.Text.Json@5.0.0 (deprecated) ✅
- Cache hit round-trip verified for all three
- 693 tests passing (143 Services + 550 main)