### PR TITLE
Add SourceKind constants for Source field

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -395,7 +395,7 @@ public class OutputFormatterTests
             FileType = "dll",
             AssemblyInfo = assemblyInfo,
             FileSize = 1024,
-            Source = "Platform (runtime)",
+            Source = SourceKind.Platform,
             PlatformVersion = "10.0.1",
             LastModified = modified
         };

--- a/src/dotnet-inspect.Tests/VersionDisplayTests.cs
+++ b/src/dotnet-inspect.Tests/VersionDisplayTests.cs
@@ -161,7 +161,7 @@ public class VersionDisplayTests
         var inspection = new LibraryInspection
         {
             FileName = "System.Text.Json.dll", FileType = "dll", FileSize = 1024,
-            Source = "Platform (runtime)",
+            Source = SourceKind.Platform,
             PlatformVersion = version,
             AssemblyInfo = new AssemblyInfo
             {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
+using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -85,7 +86,7 @@ public class ApiCommand
                 }
                 var extracted = outcome.Result!;
                 (searchPath, tempDir, packageName, packageVersion) = (extracted.ExtractPath, extracted.TempDir, extracted.PackageName, extracted.Version);
-                apiSource = "NuGet";
+                apiSource = SourceKind.NuGet;
                 apiVersion = packageVersion;
 
                 if (!string.IsNullOrEmpty(options.Tfm))
@@ -124,7 +125,7 @@ public class ApiCommand
                     return 1;
                 }
                 searchPath = options.AssemblyPath;
-                apiSource = "Library";
+                apiSource = SourceKind.Library;
             }
             else if (!string.IsNullOrEmpty(options.PlatformAssembly))
             {
@@ -141,7 +142,7 @@ public class ApiCommand
                 }
 
                 searchPath = assemblyPath!;
-                apiSource = $"Platform ({framework})";
+                apiSource = SourceKind.Platform;
                 apiVersion = version;
                 logger.Log($"Using platform ref library: {framework} {version}");
 
@@ -170,7 +171,7 @@ public class ApiCommand
             string? selectedTfm = null;
 
             // Derive TFM for platform assemblies from the version
-            if (apiSource?.StartsWith("Platform") == true && apiVersion != null)
+            if (apiSource == SourceKind.Platform && apiVersion != null)
             {
                 var dotIndex = apiVersion.IndexOf('.');
                 if (dotIndex > 0)

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -106,7 +106,7 @@ public class AssemblyCommand
                     return 1;
                 }
 
-                inspection.Source = $"Platform ({framework})";
+                inspection.Source = SourceKind.Platform;
                 inspection.PlatformVersion = version;
                 inspection.LastModified = File.GetLastWriteTimeUtc(resolvedPath!);
 
@@ -152,7 +152,7 @@ public class AssemblyCommand
                 }
 
                 foreach (var insp in inspections)
-                    insp.Source = "NuGet";
+                    insp.Source = SourceKind.NuGet;
 
                 if (discoverSections)
                 {
@@ -186,7 +186,7 @@ public class AssemblyCommand
                     return 1;
                 }
 
-                inspection.Source = "File";
+                inspection.Source = SourceKind.File;
 
                 if (discoverSections)
                 {

--- a/src/dotnet-inspect/Models/SourceKind.cs
+++ b/src/dotnet-inspect/Models/SourceKind.cs
@@ -1,0 +1,12 @@
+namespace DotnetInspector.Models;
+
+/// <summary>
+/// Constant values for the Source field, identifying where content was resolved from.
+/// </summary>
+public static class SourceKind
+{
+    public const string Platform = "Platform";
+    public const string NuGet = "NuGet";
+    public const string File = "File";
+    public const string Library = "Library";
+}


### PR DESCRIPTION
Introduces `SourceKind` class with constant values for the Source field:

- `Platform` (was `Platform (runtime)`, `Platform (aspnetcore)`, etc.)
- `NuGet`
- `File`
- `Library`

Replaces all string literals in ApiCommand, AssemblyCommand, and test files with the constants.