### PR TITLE
Add Source field to package inspection output

### DIFF
--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -225,6 +225,8 @@ public class PackageCommand
             if (packageSize.HasValue)
                 result.PackageSize = packageSize;
 
+            result.Source = isLocalFile ? SourceKind.File : SourceKind.NuGet;
+
             // Filter output based on options
             FilterResultForOutput(result, options);
 

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -10,6 +10,11 @@ public class InspectionResult
 
     public string Version { get; set; } = "";
 
+    /// <summary>
+    /// Where this package was resolved from (e.g., NuGet, Platform, File).
+    /// </summary>
+    public string? Source { get; set; }
+
     public string? Description { get; set; }
 
     public string? Authors { get; set; }

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -206,6 +206,8 @@ public class InspectionResultView
             fields.Add(new("Built", _data.BuiltDate.Value.ToString("yyyy-MM-dd")));
         else if (_data.Published.HasValue)
             fields.Add(new("Published", _data.Published.Value.ToString("yyyy-MM-dd")));
+        if (!string.IsNullOrEmpty(_data.Source))
+            fields.Add(new("Source", _data.Source));
         if (_data.Deprecation != null)
             fields.Add(new("Deprecated", "Yes"));
         if (_data.Vulnerabilities is { Count: > 0 })
@@ -228,6 +230,8 @@ public class InspectionResultView
             fields.Add(new("Built", _data.BuiltDate.Value.ToString("yyyy-MM-dd")));
         if (_data.Published.HasValue)
             fields.Add(new("Published", _data.Published.Value.ToString("yyyy-MM-dd")));
+        if (!string.IsNullOrEmpty(_data.Source))
+            fields.Add(new("Source", _data.Source));
 
         if (_data.Deprecation?.Summary != null)
             fields.Add(new("Deprecated Note", _data.Deprecation.Summary));


### PR DESCRIPTION
The `package` command was missing the Source field that the `library` command shows. Now displays `Source: NuGet` (or `File` for local .nupkg) in both the compact header and metadata table.

```
Version: 10.0.0 | Type: Library | TFM: net10.0 | Built: 2025-10-24 | Source: NuGet

| Property | Value |
| Source | NuGet |
```

Uses the `SourceKind` constants from PR #201.