### PR TITLE
Suppress tips for detailed verbosity and section selection

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1317,7 +1317,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || verbosity != Verbosity.Minimal || options.IncludeSections != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 
@@ -1624,7 +1624,7 @@ public static class CommandLineBuilder
                 ForceLatest = forceLatest || showLatestVersion
             };
 
-            var tipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || options.Verbosity != Verbosity.Minimal || options.IncludeSections != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 


### PR DESCRIPTION
## Problem

Tips were appearing on stderr in three scenarios where the [verbosity workflow spec](docs/workflows/verbosity-and-tips.md) says they should be suppressed:

| Scenario | Command | Expected | Actual |
|----------|---------|----------|--------|
| Detailed verbosity | `dotnet-inspect System.CommandLine -v:d` | No tips | Tips shown |
| List sections | `dotnet-inspect System.CommandLine -s` | No tips | Tips shown |
| Select section | `dotnet-inspect System.CommandLine -s Package` | No tips | Tips shown |

## Root Cause

The tip suppression condition in `CommandLineBuilder.cs` (both the router and explicit package command handlers) only checked for `Verbosity.Quiet`:

```csharp
var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
    ? TipLevel.Quiet : ...
```

Per the workflow spec, tips should only display at **Minimal** (default) verbosity and never when sections are selected.

## Fix

Changed the condition to suppress tips when verbosity is anything other than Minimal, and when `-s` is present:

```csharp
var tipLevel = options.IsRawOutput || verbosity != Verbosity.Minimal || options.IncludeSections != null
    ? TipLevel.Quiet : ...
```

Two-line change in `CommandLineBuilder.cs` — one for the package command handler, one for the router command handler.

## Testing

- All 10 verbosity workflow scenarios pass (5 package + 5 platform)
- 550 existing tests pass (0 failures)