### PR TITLE
Add SDK packs as fallback search path for platform resolution

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -147,11 +147,64 @@ public static class PlatformResolver
 
     private static IEnumerable<string> GetPacksDirectoryCandidates()
     {
-        // Only use downloaded packs from the app cache
+        // App cache packs first (always preferred)
         var appCachePacks = PlatformPackService.GetPacksCachePath();
         if (appCachePacks != null)
         {
             yield return appCachePacks;
+        }
+
+        // SDK-installed packs (same paths as shared, but "packs" instead of "shared")
+        var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        if (!string.IsNullOrEmpty(dotnetRoot))
+        {
+            yield return Path.Combine(dotnetRoot, "packs");
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var installLocation = ReadInstallLocation();
+            if (!string.IsNullOrEmpty(installLocation))
+            {
+                yield return Path.Combine(installLocation, "packs");
+            }
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            yield return @"C:\Program Files\dotnet\packs";
+            yield return @"C:\Program Files (x86)\dotnet\packs";
+
+            var programFiles = Environment.GetEnvironmentVariable("ProgramFiles");
+            if (!string.IsNullOrEmpty(programFiles))
+            {
+                yield return Path.Combine(programFiles, "dotnet", "packs");
+            }
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            yield return "/usr/local/share/dotnet/packs";
+            yield return "/opt/homebrew/share/dotnet/packs";
+
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
+            {
+                yield return Path.Combine(home, ".dotnet", "packs");
+            }
+        }
+        else // Linux and others
+        {
+            yield return "/usr/lib/dotnet/packs";
+            yield return "/usr/share/dotnet/packs";
+            yield return "/usr/local/share/dotnet/packs";
+            yield return "/opt/dotnet/packs";
+
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
+            {
+                yield return Path.Combine(home, ".dotnet", "packs");
+                yield return Path.Combine(home, "dotnet", "packs");
+            }
         }
     }
 
@@ -196,7 +249,15 @@ public static class PlatformResolver
                     var allVersions = existing.AllVersions.Union(versions).Distinct()
                         .OrderByDescending(v => ParseVersion(v)).ToList();
                     existing.AllVersions = allVersions;
-                    existing.LatestVersion = allVersions[0];
+                    
+                    // Update path if the newest version comes from this directory
+                    if (allVersions[0] != existing.LatestVersion)
+                    {
+                        existing.LatestVersion = allVersions[0];
+                        existing.Path = refPackPath;
+                        var latestRefPath = GetRefAssemblyPath(refPackPath, existing.LatestVersion);
+                        existing.AssemblyCount = latestRefPath != null ? CountAssemblies(latestRefPath) : 0;
+                    }
                 }
                 else
                 {
@@ -386,6 +447,14 @@ public static class PlatformResolver
         string? frameworkSpec = null,
         bool useRuntimeAssemblies = false)
     {
+        // Try resolving from already-installed packs first (SDK + app cache, no network)
+        var local = ResolveAssembly(assemblyName, frameworkSpec, useRuntimeAssemblies: useRuntimeAssemblies);
+        if (local.AssemblyPath != null)
+        {
+            log?.Invoke($"Resolved from installed packs: {local.Framework} {local.Version}");
+            return local;
+        }
+
         if (!useRuntimeAssemblies)
         {
             // Parse explicit version from frameworkSpec (e.g., "runtime@9.0.12")

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -201,15 +201,15 @@ public class PlatformResolverTests
     /// Verifies GetPacksDirectory returns the app cache packs path.
     /// </summary>
     [Fact]
-    public void GetPacksDirectory_ReturnsAppCachePath()
+    public void GetPacksDirectory_ReturnsValidPath()
     {
         var result = PlatformResolver.GetPacksDirectory();
-        var expectedSuffix = Path.Combine("dotnet-inspect", "packs");
 
-        // App cache packs dir is the only candidate; it exists if we've downloaded packs
+        // Must return a packs directory (app cache or SDK-installed)
         if (result != null)
         {
-            Assert.EndsWith(expectedSuffix, result);
+            Assert.EndsWith("packs", result);
+            Assert.True(Directory.Exists(result), $"Packs directory should exist: {result}");
         }
     }
 


### PR DESCRIPTION
Search SDK-installed packs directories as a fallback after the app cache when resolving platform assemblies. This enables resolving assemblies like `System.Text.Json` without network calls when the SDK is installed locally.

## Changes

- **SDK packs discovery**: `GetPacksDirectoryCandidates` now yields platform-specific SDK packs paths (e.g., `/usr/local/share/dotnet/packs` on macOS) after the app cache
- **Version merge fix**: `GetInstalledFrameworks` now correctly updates `Path` and `AssemblyCount` when the newest version comes from a different packs directory (previously `Path` was stuck on the first directory, causing resolution failures when `LatestVersion` was from a different directory)
- **Local-first resolution**: `ResolveAssemblyAsync` tries `ResolveAssembly` from existing packs before calling `EnsurePacksAsync`, avoiding unnecessary network calls
- **Test update**: `GetPacksDirectory_ReturnsValidPath` accepts any valid packs directory (app cache or SDK-installed)

## Motivation

Previously, platform assembly resolution always required downloading ref packs to the app cache, even when the SDK already had them installed locally. This caused unnecessary network calls and latency. With this change, assemblies in SDK packs are discovered immediately without network access.