### PR TITLE
Fix ConsoleCapture race condition in parallel tests

### DIFF
--- a/src/dotnet-inspect.Tests/ConsoleCapture.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCapture.cs
@@ -2,8 +2,12 @@ namespace DotnetInspector.Tests;
 
 static class ConsoleCapture
 {
+    // Serialize access to Console.Out/Error to prevent parallel test interference
+    private static readonly SemaphoreSlim _lock = new(1, 1);
+
     public static async Task<(int ExitCode, string Output, string Error)> RunAsync(Func<Task<int>> action)
     {
+        await _lock.WaitAsync();
         var origOut = Console.Out;
         var origErr = Console.Error;
         using var outWriter = new StringWriter();
@@ -19,6 +23,7 @@ static class ConsoleCapture
         {
             Console.SetOut(origOut);
             Console.SetError(origErr);
+            _lock.Release();
         }
     }
 }


### PR DESCRIPTION
Fixes `Package_NonexistentPackage_ShowsError` failure on Linux CI.

**Root cause**: xunit v3 runs test classes in parallel by default. Multiple test classes (`CommandExecutionTests`, `RouterVersionTests`, `CacheCommandTests`) use `ConsoleCapture` which redirects `Console.Out`/`Console.Error`. When two classes run concurrently, one class can restore the original writers while another class's action is still running, causing output to escape to the test runner's stderr instead of being captured.

**Fix**: Add a `SemaphoreSlim` to serialize access to `Console.SetOut`/`Console.SetError` across all `ConsoleCapture.RunAsync` calls.