### PR TITLE
Remove all emoji and non-ASCII from tool output

### DIFF
--- a/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
+++ b/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
@@ -119,7 +119,7 @@ public class OfflineVerbosityTests : IDisposable
         Assert.DoesNotContain("Converts the provided value", output);
     }
 
-    // ── router → qualified type name ─────────────────────────────────
+    // ── router -> qualified type name ─────────────────────────────────
 
     [Fact]
     public async Task Router_QualifiedType_Quiet_Offline_Succeeds()

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1643,7 +1643,7 @@ public static class CommandLineBuilder
                 }
             }
 
-            // Qualified type name: e.g., System.Text.Json.JsonSerializer → type JsonSerializer --platform System.Text.Json
+            // Qualified type name: e.g., System.Text.Json.JsonSerializer -> type JsonSerializer --platform System.Text.Json
             if (!isVersionQuery && PlatformResolver.IsPlatformCandidate(bareName)
                 && PlatformResolver.TryParseQualifiedTypeName(bareName, out var qtAssembly, out var qtType))
             {

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -107,7 +107,7 @@ public class DiffCommand
             return (null, null, null, null, null, "Error: Invalid version range. Use format: Package@v1..v2");
         }
 
-        logger.Log($"Comparing {packageName} v{fromVersion} → v{toVersion}");
+        logger.Log($"Comparing {packageName} v{fromVersion} -> v{toVersion}");
 
         var fromOptions = new ApiOptions
         {
@@ -146,7 +146,7 @@ public class DiffCommand
         }
 
         var framework = options.Framework ?? "runtime";
-        logger.Log($"Comparing {assemblyName} in {framework} v{fromVersion} → v{toVersion}");
+        logger.Log($"Comparing {assemblyName} in {framework} v{fromVersion} -> v{toVersion}");
 
         // Resolve assemblies for both versions (downloads ref packs as needed)
         var (fromPath, _, _, fromError) = await PlatformResolver.ResolveAssemblyAsync(

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -44,7 +44,7 @@ public static class DiffOutputFormatter
             }
             else if (td.BreakingCount > 0)
             {
-                symbol = "\u2717"; // ✗
+                symbol = "x";
                 detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
             }
             else
@@ -59,7 +59,7 @@ public static class DiffOutputFormatter
         return new DiffOneLineView
         {
             Title = $"API Diff: {name}",
-            Versions = $"{fromVersion} → {toVersion}",
+            Versions = $"{fromVersion} -> {toVersion}",
             Summary = FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking),
             Rows = rows.Count > 0 ? rows : null
         };
@@ -70,7 +70,7 @@ public static class DiffOutputFormatter
         var view = new DiffFullView
         {
             Title = $"API Diff: {name}",
-            Versions = $"**{fromVersion}** → **{toVersion}**",
+            Versions = $"**{fromVersion}** -> **{toVersion}**",
         };
 
         if (typeDiffs.Count == 0)
@@ -126,7 +126,7 @@ public static class DiffOutputFormatter
                 if (change.Kind == ChangeKind.MemberSignatureChanged &&
                     change.OldValue != null && change.NewValue != null)
                 {
-                    message += $": `{change.OldValue}` → `{change.NewValue}`";
+                    message += $": `{change.OldValue}` -> `{change.NewValue}`";
                 }
                 rows.Add(new DiffChangeRow(typeName, message));
             }

--- a/src/dotnet-inspect/Output/PackageSearchOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/PackageSearchOutputFormatter.cs
@@ -21,11 +21,11 @@ public static class PackageSearchOutputFormatter
         maxId = Math.Min(maxId, 50);
 
         sb.AppendLine($"{"Package".PadRight(maxId)}  {"Version".PadRight(maxVer)}  {"Downloads".PadLeft(12)}  Description");
-        sb.AppendLine($"{new string('─', maxId)}  {new string('─', maxVer)}  {new string('─', 12)}  {new string('─', 40)}");
+        sb.AppendLine($"{new string('-', maxId)}  {new string('-', maxVer)}  {new string('-', 12)}  {new string('-', 40)}");
 
         foreach (var r in results)
         {
-            string id = r.PackageId.Length > maxId ? r.PackageId[..(maxId - 1)] + "…" : r.PackageId;
+            string id = r.PackageId.Length > maxId ? r.PackageId[..(maxId - 1)] + "..." : r.PackageId;
             string downloads = FormatDownloads(r.TotalDownloads);
             string desc = TruncateDescription(r.Description, 60);
 
@@ -60,6 +60,6 @@ public static class PackageSearchOutputFormatter
         if (description.Length <= maxLength)
             return description;
 
-        return description[..(maxLength - 1)] + "…";
+        return description[..(maxLength - 1)] + "...";
     }
 }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -13,7 +13,7 @@ public class ApiTypeView
     [MarkoutIgnore] public string Title { get; set; } = "";
     [MarkoutIgnore] public string? Description { get; set; }
 
-    [MarkoutValueMap("class=📦", "struct=🔲", "interface=🔌", "enum=🔢", "delegate=⚡")]
+    [MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     public string Kind { get; set; } = "";
 
     [MarkoutSkipNull]
@@ -399,7 +399,7 @@ public class TypeShapeView
     [MarkoutIgnore]
     public string FullName { get; set; } = "";
 
-    [MarkoutValueMap("class=📦", "struct=🔲", "interface=🔌", "enum=🔢", "delegate=⚡")]
+    [MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     public string Kind { get; set; } = "";
 
     [MarkoutSkipNull]

--- a/src/dotnet-inspect/Views/FindViews.cs
+++ b/src/dotnet-inspect/Views/FindViews.cs
@@ -25,7 +25,7 @@ public record FindRow(
     string Pattern,
     string Type,
     string Namespace,
-    [property: MarkoutValueMap("class=📦", "struct=🔲", "interface=🔌", "enum=🔢", "delegate=⚡")]
+    [property: MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     string Kind,
     string Library,
     string Source);

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -33,18 +33,18 @@ public class LibraryInspectionView
     public string? PdbPath => _data.PdbPath;
 
     [MarkoutPropertyName("Embedded PDB")]
-    [MarkoutBoolFormat("✓", "✗")]
+    [MarkoutBoolFormat("Yes", "No")]
     public bool HasEmbeddedPdb => _data.HasEmbeddedPdb;
 
     [MarkoutPropertyName("Reproducible Flag")]
-    [MarkoutBoolFormat("✓", "✗")]
+    [MarkoutBoolFormat("Yes", "No")]
     public bool HasReproducibleFlag => _data.HasReproducibleFlag;
 
     [MarkoutIgnore]
     public bool? HasNormalizedPaths => _data.HasNormalizedPaths;
 
     [MarkoutPropertyName("SourceLink")]
-    [MarkoutBoolFormat("✓", "✗")]
+    [MarkoutBoolFormat("Yes", "No")]
     public bool HasSourceLink => _data.HasSourceLink;
 
     [MarkoutIgnore]
@@ -52,12 +52,12 @@ public class LibraryInspectionView
 
     [MarkoutPropertyName("SourceLink Status")]
     public string SourceLinkStatus => _data.HasSourceLink
-        ? "✓"
+        ? "Yes"
         : _data.SourceLinkUnavailableReason != null
-            ? $"✗ ({_data.SourceLinkUnavailableReason})"
-            : "✗";
+            ? $"No ({_data.SourceLinkUnavailableReason})"
+            : "No";
 
-    [MarkoutBoolFormat("✓", "✗")]
+    [MarkoutBoolFormat("Yes", "No")]
     public bool IsDeterministic => _data.IsDeterministic;
 
     [MarkoutPropertyName("Repository URL")]
@@ -301,8 +301,8 @@ public class LibraryInspectionView
             fields.Add(new("Signed", "Yes"));
         if (!string.IsNullOrEmpty(info.PublicKeyToken))
             fields.Add(new("Public Key Token", info.PublicKeyToken));
-        fields.Add(new("Deterministic", _data.IsDeterministic ? "✓" : "✗"));
-        fields.Add(new("Reproducible", _data.HasReproducibleFlag ? "✓" : "✗"));
+        fields.Add(new("Deterministic", _data.IsDeterministic ? "Yes" : "No"));
+        fields.Add(new("Reproducible", _data.HasReproducibleFlag ? "Yes" : "No"));
         if (_data.FileSize > 0)
             fields.Add(new("File Size", FormatFileSize(_data.FileSize)));
         if (info.TypeDefinitionCount > 0)
@@ -363,7 +363,7 @@ public class LibraryInspectionView
         if (_data.TotalSourceFiles <= 0) return fields;
 
         int accessible = _data.AccessibleSourceFiles + _data.EmbeddedSourceFiles;
-        string status = _data.AllSourcesAccessible == true ? "✓" : "✗";
+        string status = _data.AllSourcesAccessible == true ? "Yes" : "No";
         fields.Add(new("Status", $"{status} {accessible}/{_data.TotalSourceFiles} files accessible"));
 
         if (_data.EmbeddedSourceFiles > 0)
@@ -400,9 +400,9 @@ public class LibraryInspectionView
         {
             var badge = node.ResolvedFrom switch
             {
-                "local" => "📁",
-                "platform" => "🚢",
-                _ => "❓"
+                "local" => "local",
+                "platform" => "platform",
+                _ => "?"
             };
             var suffix = node.IsCyclic ? " (circular)" : "";
             result.Add(new TreeNode($"{node.Name} {node.Version}{suffix}", badge));
@@ -468,7 +468,6 @@ public record PInvokeMethodRow(
 [MarkoutSerializable]
 public record ResourceRow(
     string Name,
-    [property: MarkoutValueMap("public=🔓", "private=🔒")]
     string Visibility,
     string Size);
 


### PR DESCRIPTION
Replace all emoji and non-ASCII characters in tool output with plain ASCII text to make output grep-friendly.

### Replacements
| Before | After | Where |
|--------|-------|-------|
| 📦🔲🔌🔢⚡ | cls/str/ifc/enm/del | Type kind column |
| ✓ / ✗ | Yes / No | Boolean fields (SourceLink, Deterministic, etc.) |
| 📁🚢❓ | local/platform/? | Transitive reference badges |
| 🔓🔒 | (removed identity map) | Resource visibility |
| → | -> | Diff version arrows, change descriptions |
| … | ... | Package search truncation |
| ─ | - | Package search separator line |
| ✗ (U+2717) | x | Diff breaking-change symbol |

All 558 tests pass.