### PR TITLE
Remove redundant MarkoutValueMap for type Kind

### DIFF
--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -13,7 +13,6 @@ public class ApiTypeView
     [MarkoutIgnore] public string Title { get; set; } = "";
     [MarkoutIgnore] public string? Description { get; set; }
 
-    [MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     public string Kind { get; set; } = "";
 
     [MarkoutSkipNull]
@@ -399,7 +398,6 @@ public class TypeShapeView
     [MarkoutIgnore]
     public string FullName { get; set; } = "";
 
-    [MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     public string Kind { get; set; } = "";
 
     [MarkoutSkipNull]

--- a/src/dotnet-inspect/Views/FindViews.cs
+++ b/src/dotnet-inspect/Views/FindViews.cs
@@ -25,7 +25,6 @@ public record FindRow(
     string Pattern,
     string Type,
     string Namespace,
-    [property: MarkoutValueMap("class=cls", "struct=str", "interface=ifc", "enum=enm", "delegate=del")]
     string Kind,
     string Library,
     string Source);


### PR DESCRIPTION
Follow-up to #211. The Kind values (class, struct, interface, enum, delegate) are already the desired display text — the abbreviation mapping (cls/str/ifc/enm/del) was not useful. Remove the MarkoutValueMap attributes entirely so raw values pass through.