### PR TITLE
Add 'cache clear' subcommand, deprecate --clean/--clear flags

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -325,7 +325,7 @@ public static class CommandLineBuilder
     {
         var cacheCommand = new Command("cache", "Manage the dotnet-inspect cache");
 
-        var cleanOption = new Option<bool>("--clean") { Description = "Clear the cache" };
+        var cleanOption = new Option<bool>("--clean", "--clear") { Hidden = true };
 
         cacheCommand.Options.Add(cleanOption);
         cacheCommand.Options.Add(verboseOption);
@@ -333,11 +333,26 @@ public static class CommandLineBuilder
         cacheCommand.Options.Add(tipsOption);
         cacheCommand.Options.Add(limitOption);
 
+        // Subcommand: clear
+        var clearCommand = new Command("clear", "Clear the cache");
+        clearCommand.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var options = new CacheOptions(Clean: true, Verbose: false);
+            return await CacheCommand.ExecuteAsync(options);
+        });
+        cacheCommand.Subcommands.Add(clearCommand);
+
         cacheCommand.SetAction(async (parseResult, cancellationToken) =>
         {
+            var clean = parseResult.GetValue(cleanOption);
+            if (clean)
+            {
+                Console.Error.WriteLine("hint: use 'dotnet-inspect cache clear' instead of --clean/--clear");
+            }
+
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
             var options = new CacheOptions(
-                Clean: parseResult.GetValue(cleanOption),
+                Clean: clean,
                 Verbose: parseResult.GetValue(verboseOption) || verbosity >= Verbosity.Detailed);
 
             return await CacheCommand.ExecuteAsync(options);


### PR DESCRIPTION
Add `clear` as the primary subcommand for clearing the cache, matching CLI conventions (`git stash clear`, `npm cache clean`, `docker builder prune`).

### Usage

```
dotnet-inspect cache clear      # primary (new)
dotnet-inspect cache --clean    # hidden alias (backwards compat)
dotnet-inspect cache --clear    # hidden alias (backwards compat)
```

### Changes

- Added `clear` subcommand to `cache` command
- `--clean` and `--clear` flags are now hidden from help output but still work for backwards compatibility
- Using the deprecated flags prints a hint to stderr: `hint: use 'dotnet-inspect cache clear' instead of --clean/--clear`