### PR TITLE
Add cache isolation and offline mode via environment variables

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -11,15 +11,17 @@ namespace DotnetInspector.Core;
 public static class CoreCache
 {
     private static string? _appName;
+    private static string? _basePathOverride;
 
     /// <summary>
     /// Initializes the cache with the application name used for the cache directory.
     /// Must be called before any cache operations.
     /// </summary>
-    public static void Initialize(string appName)
+    public static void Initialize(string appName, string? basePath = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(appName);
         _appName = appName;
+        _basePathOverride = basePath;
     }
 
     private static string AppName => _appName
@@ -27,11 +29,14 @@ public static class CoreCache
 
     /// <summary>
     /// Gets the base path for all caches.
-    /// Windows: %LOCALAPPDATA%\{appName}
-    /// macOS/Linux: ~/.local/share/{appName}
+    /// Returns the override path if set via <see cref="Initialize"/>,
+    /// otherwise uses the platform-default local application data directory.
     /// </summary>
     public static string GetBasePath()
     {
+        if (_basePathOverride != null)
+            return _basePathOverride;
+
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return Path.Combine(localAppData, AppName);
     }

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -14,6 +14,7 @@ namespace DotnetInspector.Packages;
 public static class NuGetCache
 {
     private static string? _appName;
+    private static bool _skipNuGetCache;
 
     /// <summary>
     /// Initializes the cache with the application name used for the cache directory.
@@ -21,11 +22,14 @@ public static class NuGetCache
     /// Also initializes <see cref="CoreCache"/> with the same app name.
     /// </summary>
     /// <param name="appName">Application name used as the cache subdirectory (e.g., "dotnet-inspect")</param>
-    public static void Initialize(string appName)
+    /// <param name="basePath">Optional override for the cache base directory</param>
+    /// <param name="skipNuGetCache">When true, skip the NuGet global cache (~/.nuget/packages)</param>
+    public static void Initialize(string appName, string? basePath = null, bool skipNuGetCache = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(appName);
         _appName = appName;
-        CoreCache.Initialize(appName);
+        _skipNuGetCache = skipNuGetCache;
+        CoreCache.Initialize(appName, basePath);
     }
 
     private static string AppName => _appName
@@ -95,14 +99,17 @@ public static class NuGetCache
         var normalizedName = packageName.ToLowerInvariant();
         var normalizedVersion = version.ToLowerInvariant();
 
-        // Check NuGet cache first (more likely to have packages)
-        var nugetCachePath = GetNuGetCachePath();
-        if (Directory.Exists(nugetCachePath))
+        // Check NuGet cache first (more likely to have packages) — skip in isolated mode
+        if (!_skipNuGetCache)
         {
-            var nugetPackageDir = Path.Combine(nugetCachePath, normalizedName, normalizedVersion);
-            if (Directory.Exists(nugetPackageDir) && IsCachedPackageValid(nugetPackageDir, normalizedName))
+            var nugetCachePath = GetNuGetCachePath();
+            if (Directory.Exists(nugetCachePath))
             {
-                return nugetPackageDir;
+                var nugetPackageDir = Path.Combine(nugetCachePath, normalizedName, normalizedVersion);
+                if (Directory.Exists(nugetPackageDir) && IsCachedPackageValid(nugetPackageDir, normalizedName))
+                {
+                    return nugetPackageDir;
+                }
             }
         }
 
@@ -192,8 +199,11 @@ public static class NuGetCache
         NuGet.Versioning.NuGetVersion? best = null;
         string? bestOriginal = null;
 
-        // Check NuGet global cache
-        ScanCacheDir(Path.Combine(GetNuGetCachePath(), normalizedName), normalizedName, ref best, ref bestOriginal);
+        // Check NuGet global cache — skip in isolated mode
+        if (!_skipNuGetCache)
+        {
+            ScanCacheDir(Path.Combine(GetNuGetCachePath(), normalizedName), normalizedName, ref best, ref bestOriginal);
+        }
 
         // Check app cache
         try

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -3,13 +3,33 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 // Parse --offline early (before command parsing) to configure HttpClientFactory
-bool offline = args.Contains("--offline");
+bool offline = args.Contains("--offline")
+    || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1");
 if (offline)
     args = args.Where(a => a != "--offline").ToArray();
 
+// Parse --isolated and --no-nuget-cache early
+bool isolated = args.Contains("--isolated")
+    || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_ISOLATED"), "1");
+if (isolated)
+    args = args.Where(a => a != "--isolated").ToArray();
+
+bool noNuGetCache = args.Contains("--no-nuget-cache") || isolated;
+if (args.Contains("--no-nuget-cache"))
+    args = args.Where(a => a != "--no-nuget-cache").ToArray();
+
+// Resolve cache base path: explicit env var > isolated temp dir > default
+string? cacheBasePath = Environment.GetEnvironmentVariable("DOTNET_INSPECT_CACHE_DIR");
+string? isolatedTempDir = null;
+if (isolated && cacheBasePath == null)
+{
+    isolatedTempDir = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-{Path.GetRandomFileName()}");
+    cacheBasePath = isolatedTempDir;
+}
+
 // Initialize library configuration
 DotnetInspector.Core.HttpClientFactory.Initialize(offline);
-NuGetCache.Initialize("dotnet-inspect");
+NuGetCache.Initialize("dotnet-inspect", basePath: cacheBasePath, skipNuGetCache: noNuGetCache);
 
 // Handle --version explicitly to show short commit hash
 if (args.Length == 1 && args[0] == "--version")
@@ -28,4 +48,12 @@ if (CommandLineBuilder.HeadLines is int headLines)
 // Create and invoke command
 var rootCommand = CommandLineBuilder.CreateRootCommand();
 var result = rootCommand.Parse(args);
-return await result.InvokeAsync();
+var exitCode = await result.InvokeAsync();
+
+// Clean up isolated temp dir
+if (isolatedTempDir != null && Directory.Exists(isolatedTempDir))
+{
+    try { Directory.Delete(isolatedTempDir, recursive: true); } catch { }
+}
+
+return exitCode;


### PR DESCRIPTION
## Summary

Support deterministic, isolated cache behavior for CI/test workflows.

### Environment Variables

| Variable | Effect |
|---|---|
| `DOTNET_INSPECT_CACHE_DIR` | Override app cache location |
| `DOTNET_INSPECT_ISOLATED=1` | Use temp cache dir + skip NuGet cache |
| `DOTNET_INSPECT_OFFLINE=1` | Disable all network access |

### CLI Flags

| Flag | Equivalent |
|---|---|
| `--isolated` | `DOTNET_INSPECT_ISOLATED=1` |
| `--no-nuget-cache` | Skip `~/.nuget/packages` (standalone or part of isolated) |
| `--offline` | `DOTNET_INSPECT_OFFLINE=1` (already existed as flag) |

### Behavior

When `DOTNET_INSPECT_ISOLATED=1`:
- If `CACHE_DIR` is set → use that directory, skip NuGet cache
- If `CACHE_DIR` is not set → auto-create temp directory, skip NuGet cache
- Temp directory is cleaned up on exit

### Examples

```bash
# Simple isolated test
DOTNET_INSPECT_ISOLATED=1 dotnet-inspect System.CommandLine@2.0.2 -v:q

# Isolated + offline (fully deterministic)
DOTNET_INSPECT_ISOLATED=1 DOTNET_INSPECT_OFFLINE=1 dotnet-inspect ...

# Explicit cache dir (for inspection after test)
DOTNET_INSPECT_ISOLATED=1 DOTNET_INSPECT_CACHE_DIR=/tmp/my-test dotnet-inspect ...

# Just override cache location (still reads NuGet cache)
DOTNET_INSPECT_CACHE_DIR=/tmp/my-cache dotnet-inspect ...
```

### Changes

- `CoreCache.Initialize`: optional `basePath` override parameter
- `NuGetCache.Initialize`: optional `basePath` + `skipNuGetCache` parameters
- `Program.cs`: early-parse env vars and CLI flags, wire into initialization