### PR TITLE
Disable tips when line or result limiting is used

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -306,7 +306,7 @@ public static class CommandLineBuilder
             Console.WriteLine(sw.ToString().TrimEnd());
 
             var verbosity = ParseVerbosity(parseResult.GetValue(rootVerbosityOption));
-            var tipLevel = verbosity == Verbosity.Quiet
+            var tipLevel = verbosity == Verbosity.Quiet || HeadLines != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(rootTipsOption), parseResult.GetResult(rootTipsOption) != null);
             Hints.WriteTips(tipLevel,
                 new Tip(PackageCommand.Name, "<package>", "inspect a NuGet package"),
@@ -522,7 +522,7 @@ public static class CommandLineBuilder
             var exitCode = await DiffCommand.ExecuteAsync(options);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
-            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet || HeadLines != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
             if (exitCode == 0)
@@ -1003,7 +1003,7 @@ public static class CommandLineBuilder
             var exitCode = await FindCommand.ExecuteAsync(options);
 
             var verbosity = ParseVerbosity(parseResult.GetValue(verbosityOption));
-            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet
+            var tipLevel = options.IsRawOutput || verbosity == Verbosity.Quiet || HeadLines != null || options.Limit != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
             if (exitCode == 0 && !options.IsRawOutput)
@@ -1374,7 +1374,7 @@ public static class CommandLineBuilder
                 SourceOptions = ParseNuGetSourceOptions(parseResult, sourceOption, addSourceOption, nugetConfigOption)
             };
 
-            var tipLevel = options.IsRawOutput || verbosity != Verbosity.Minimal || options.IncludeSections != null
+            var tipLevel = options.IsRawOutput || verbosity != Verbosity.Minimal || options.IncludeSections != null || HeadLines != null || options.Limit != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 
@@ -1621,7 +1621,7 @@ public static class CommandLineBuilder
 
                             if (assemblyExitCode == 0 && !assemblyOptions.JsonOutput)
                             {
-                                var platformTipLevel = verbosity != Verbosity.Minimal || includeSections != null
+                                var platformTipLevel = verbosity != Verbosity.Minimal || includeSections != null || HeadLines != null
                                     ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
 
                                 List<Tip> tips = [];
@@ -1657,7 +1657,7 @@ public static class CommandLineBuilder
                     Verbosity = verbosity,
                     IncludeSections = ParseIncludeSections(parseResult, includeSectionsOption),
                     ExcludeSections = ParseSectionList(parseResult.GetValue(excludeSectionsOption)),
-                    TipLevel = ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
+                    TipLevel = HeadLines != null ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
                 };
 
                 return await ApiCommand.ExecuteAsync(typeOptions);
@@ -1726,7 +1726,7 @@ public static class CommandLineBuilder
                 ForceLatest = forceLatest || showLatestVersion
             };
 
-            var tipLevel = options.IsRawOutput || options.Verbosity != Verbosity.Minimal || options.IncludeSections != null
+            var tipLevel = options.IsRawOutput || options.Verbosity != Verbosity.Minimal || options.IncludeSections != null || HeadLines != null
                 ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null);
             options = options with { TipLevel = tipLevel };
 
@@ -2093,7 +2093,7 @@ public static class CommandLineBuilder
 
             options = options with
             {
-                TipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet
+                TipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet || HeadLines != null || typeLimit != null
                     ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
             };
 
@@ -2383,7 +2383,7 @@ public static class CommandLineBuilder
 
             options = options with
             {
-                TipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet
+                TipLevel = options.IsRawOutput || options.Verbosity == Verbosity.Quiet || HeadLines != null || memberLimit != null
                     ? TipLevel.Quiet : ParseTipLevel(parseResult.GetValue(tipsOption), parseResult.GetResult(tipsOption) != null)
             };
 


### PR DESCRIPTION
## Summary

- Tips are now automatically suppressed when limiting options are used (`-n`, `-t N`, `-m N`, `--versions N`)
- This provides cleaner, more predictable output for agent usage where compact results are desired
- Applies to all commands that support tips: root, diff, find, package, router, type, and member

## Test plan

- [ ] Run `dotnet-inspect System.Text.Json -n 4` and verify no tips appear
- [ ] Run `dotnet-inspect type System.Text.Json -t 3` and verify no tips appear
- [ ] Run `dotnet-inspect member System.Text.Json JsonSerializer -m 3` and verify no tips appear
- [ ] Run `dotnet-inspect System.Text.Json --versions 3` and verify no tips appear
- [ ] Run `dotnet-inspect System.Text.Json` (no limiting) and verify tips still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)