### PR TITLE
Add --flavor flag to report CoreCLR or NativeAOT

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -25,7 +25,7 @@ public static class CommandLineBuilder
     /// </summary>
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
-        "package", "library", "api", "type", "member", "diff", "find", "search", "samples", "list", "ls", "llmstxt", "skill", "extensions", "implements", "depends", "cache", "cli", "demo", "perf", "perf-test", "help", "--help", "-h", "-?", "--version"
+        "package", "library", "api", "type", "member", "diff", "find", "search", "samples", "list", "ls", "llmstxt", "skill", "extensions", "implements", "depends", "cache", "cli", "demo", "perf", "perf-test", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -57,6 +57,13 @@ if (args.Length == 1 && args[0] == "--version")
     return 0;
 }
 
+// Handle --flavor to show build type (CoreCLR or NativeAOT)
+if (args.Length == 1 && args[0] == "--flavor")
+{
+    Console.WriteLine(VersionInfo.Flavor);
+    return 0;
+}
+
 // Pre-process args for implicit package command (also expands -NN → -n NN)
 args = CommandLineBuilder.PreprocessArgs(args);
 

--- a/src/dotnet-inspect/VersionInfo.cs
+++ b/src/dotnet-inspect/VersionInfo.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace DotnetInspector;
@@ -15,6 +16,14 @@ public static class VersionInfo
     /// Gets the version string with short commit hash (e.g., "0.1.11+abc1234").
     /// </summary>
     public static string Version => _version ??= GetVersion();
+
+    /// <summary>
+    /// Gets the runtime flavor: "NativeAOT" or "CoreCLR".
+    /// </summary>
+    [UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Assembly.Location is intentionally used to detect NativeAOT (returns empty).")]
+    public static string Flavor =>
+        string.IsNullOrEmpty(typeof(object).Assembly.Location) ? "NativeAOT" : "CoreCLR";
 
     private static string GetVersion()
     {


### PR DESCRIPTION
Returns the runtime flavor for the current build, making it easy to verify which runtime is being tested during performance work. Uses Assembly.Location to detect NativeAOT (returns empty in AOT builds).