### PR TITLE
fix: Prefer generic types with matching arity in TypeMatcher.Lookup

### DIFF
--- a/src/DotnetInspector.Metadata/TypeMatcher.cs
+++ b/src/DotnetInspector.Metadata/TypeMatcher.cs
@@ -179,6 +179,41 @@ public static class TypeMatcher
     }
 
     /// <summary>
+    /// Gets the expected generic arity from a search pattern.
+    /// Supports both C# notation and CLR backtick notation.
+    /// "Option&lt;T&gt;" → 1, "Dictionary&lt;K,V&gt;" → 2, "Option`1" → 1, "Option" → -1 (unspecified)
+    /// </summary>
+    public static int GetPatternArity(string pattern)
+    {
+        // First check for CLR backtick notation (Option`1, Dictionary`2)
+        var backtickArity = GetGenericArity(pattern);
+        if (backtickArity > 0)
+            return backtickArity;
+
+        // Then check for C# angle bracket notation (Option<T>, Dictionary<K,V>)
+        var startIdx = pattern.IndexOf('<');
+        var endIdx = pattern.LastIndexOf('>');
+        if (startIdx < 0 || endIdx <= startIdx)
+            return -1; // No generic notation, arity unspecified
+
+        var typeArgs = pattern[(startIdx + 1)..endIdx];
+        if (string.IsNullOrWhiteSpace(typeArgs))
+            return -1;
+
+        // Count type parameters by counting commas + 1
+        // Handle nested generics by tracking angle bracket depth
+        int arity = 1;
+        int depth = 0;
+        foreach (var c in typeArgs)
+        {
+            if (c == '<') depth++;
+            else if (c == '>') depth--;
+            else if (c == ',' && depth == 0) arity++;
+        }
+        return arity;
+    }
+
+    /// <summary>
     /// Tests whether <paramref name="text"/> matches a glob pattern (* and ? wildcards).
     /// Case-insensitive.
     /// </summary>
@@ -264,9 +299,22 @@ public static class TypeMatcher
         }
 
         // Exact match via Matches (handles namespace prefix, generic arity, case-insensitive)
-        var exact = list.FirstOrDefault(c => Matches(c, pattern));
-        if (exact != null)
-            return new LookupResult(exact, []);
+        // When pattern has generic notation (e.g., Option<T>), prefer matching arity
+        var patternArity = GetPatternArity(pattern);
+        var matches = list.Where(c => Matches(c, pattern)).ToList();
+
+        if (matches.Count > 0)
+        {
+            // If pattern specified arity (e.g., Option<T>), prefer candidate with matching arity
+            if (patternArity >= 0)
+            {
+                var arityMatch = matches.FirstOrDefault(c => GetGenericArity(c) == patternArity);
+                if (arityMatch != null)
+                    return new LookupResult(arityMatch, []);
+            }
+            // Otherwise return first match (existing behavior for non-generic patterns)
+            return new LookupResult(matches[0], []);
+        }
 
         // Fuzzy fallback
         var suggestions = FindClosest(list, pattern, maxResults: maxSuggestions)

--- a/tests/DotnetInspector.Metadata.Tests/TypeMatcherTests.cs
+++ b/tests/DotnetInspector.Metadata.Tests/TypeMatcherTests.cs
@@ -1,0 +1,152 @@
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Metadata.Tests;
+
+public class TypeMatcherTests
+{
+    [Theory]
+    [InlineData("Option<T>", 1)]
+    [InlineData("Dictionary<K,V>", 2)]
+    [InlineData("Action<T1,T2,T3>", 3)]
+    [InlineData("Func<T1,T2,T3,TResult>", 4)]
+    public void GetPatternArity_returns_correct_arity_for_generic_patterns(string pattern, int expected)
+        => Assert.Equal(expected, TypeMatcher.GetPatternArity(pattern));
+
+    [Theory]
+    [InlineData("Option")]
+    [InlineData("String")]
+    [InlineData("List")]
+    public void GetPatternArity_returns_negative_one_for_non_generic_patterns(string pattern)
+        => Assert.Equal(-1, TypeMatcher.GetPatternArity(pattern));
+
+    [Theory]
+    [InlineData("Option`1", 1)]
+    [InlineData("Dictionary`2", 2)]
+    [InlineData("Action`3", 3)]
+    [InlineData("Func`4", 4)]
+    public void GetPatternArity_returns_correct_arity_for_clr_backtick_notation(string pattern, int expected)
+        => Assert.Equal(expected, TypeMatcher.GetPatternArity(pattern));
+
+    [Theory]
+    [InlineData("Option<>")]
+    [InlineData("Option<  >")]
+    public void GetPatternArity_returns_negative_one_for_empty_type_args(string pattern)
+        => Assert.Equal(-1, TypeMatcher.GetPatternArity(pattern));
+
+    [Theory]
+    [InlineData("Func<Tuple<int,int>,string>", 2)]
+    [InlineData("Dictionary<List<T>,Action<T1,T2>>", 2)]
+    public void GetPatternArity_handles_nested_generics(string pattern, int expected)
+        => Assert.Equal(expected, TypeMatcher.GetPatternArity(pattern));
+
+    [Fact]
+    public void Lookup_prefers_generic_type_when_pattern_has_generic_notation()
+    {
+        var candidates = new[]
+        {
+            "System.CommandLine.Option",      // Non-generic base class
+            "System.CommandLine.Option`1"     // Generic Option<T>
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "Option<T>");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.CommandLine.Option`1", result.Match);
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public void Lookup_prefers_non_generic_type_when_pattern_has_no_generic_notation()
+    {
+        var candidates = new[]
+        {
+            "System.CommandLine.Option",      // Non-generic base class
+            "System.CommandLine.Option`1"     // Generic Option<T>
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "Option");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.CommandLine.Option", result.Match);
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public void Lookup_returns_generic_with_matching_arity_for_multi_param_pattern()
+    {
+        var candidates = new[]
+        {
+            "System.Collections.Generic.Dictionary`2",
+            "System.Collections.Generic.KeyValuePair`2"
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "Dictionary<K,V>");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.Collections.Generic.Dictionary`2", result.Match);
+    }
+
+    [Fact]
+    public void Lookup_falls_back_to_first_match_when_no_arity_matches()
+    {
+        var candidates = new[]
+        {
+            "MyNamespace.Option`2",  // Two type params
+            "MyNamespace.Option`3"   // Three type params
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "Option<T>");  // Expects arity 1
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("MyNamespace.Option`2", result.Match);
+    }
+
+    [Fact]
+    public void Lookup_handles_namespace_qualified_pattern()
+    {
+        var candidates = new[]
+        {
+            "System.CommandLine.Argument",
+            "System.CommandLine.Argument`1"
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "System.CommandLine.Argument<T>");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.CommandLine.Argument`1", result.Match);
+    }
+
+    [Fact]
+    public void Lookup_prefers_generic_type_when_pattern_uses_clr_backtick_notation()
+    {
+        var candidates = new[]
+        {
+            "System.CommandLine.Option",      // Non-generic base class
+            "System.CommandLine.Option`1"     // Generic Option<T>
+        };
+
+        // This is the pattern after GenericTypeNameConverter.Convert("Option<T>")
+        var result = TypeMatcher.Lookup(candidates, "Option`1");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.CommandLine.Option`1", result.Match);
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public void Lookup_with_clr_notation_matches_correct_arity()
+    {
+        var candidates = new[]
+        {
+            "System.Action",
+            "System.Action`1",
+            "System.Action`2",
+            "System.Action`3"
+        };
+
+        var result = TypeMatcher.Lookup(candidates, "Action`2");
+
+        Assert.NotNull(result.Match);
+        Assert.Equal("System.Action`2", result.Match);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes bug where `type System.CommandLine Option<T>` returned non-generic `Option` instead of `Option<T>`
- `TypeMatcher.Lookup` now prefers candidates with matching generic arity when search pattern includes arity notation
- Supports both C# (`Option<T>`) and CLR (`Option`1`) notation

## Root Cause
- `TypeMatcher.Normalize()` strips generic type arguments: `Option<T>` → `Option`
- Both `Option` (non-generic) and `Option`1` (generic) normalize to `Option`
- `FirstOrDefault` returned whichever came first (the non-generic base class)

## Fix
- Added `GetPatternArity()` to extract expected arity from patterns
- Modified `Lookup()` to prefer arity-matching candidates when pattern specifies arity
- Added comprehensive test coverage in `TypeMatcherTests.cs`

## Test plan
- [x] All 123 Metadata tests pass
- [x] All 558 main tests pass
- [x] All 143 Services tests pass
- [x] `type System.CommandLine Option<T> -s Constructors` now shows generic type with constructors
- [x] `type System.CommandLine Argument<T> -s Constructors` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)