### PR TITLE
feat: Add diff tip when viewing package types

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -506,6 +506,10 @@ public class ApiCommand
                         tips.Add(new(TypeCommand.Name, $"{simpleName} {sourceFlag} --shape", "view type shape"));
                         tips.Add(new(MemberCommand.Name, $"-m {simpleName}.{(exampleGroup?.Key ?? "Method")} {sourceFlag}", "dotted member syntax"));
 
+                        // Suggest diff for package sources when version is known
+                        if (!string.IsNullOrEmpty(packageName) && !string.IsNullOrEmpty(packageVersion))
+                            tips.Add(new(DiffCommand.Name, $"--package {packageName}@<prev>..{packageVersion} -t {simpleName}", "compare API changes"));
+
                         Hints.WriteTips(effectiveOptions.TipLevel, [.. tips]);
                     }
                 }


### PR DESCRIPTION
## Summary
- When inspecting a type from a NuGet package, suggest using `diff` to compare API changes across versions
- This helps users discover the version comparison feature during migration scenarios

## Context
From user feedback in a migration scenario (System.CommandLine beta → stable), the `diff` command existed but wasn't easily discoverable when viewing types.

## Example
```bash
$ dotnet-inspect type System.CommandLine "Option<T>" -T:d

Tips:
member Option`1 --package System.CommandLine .ctor:1          # view member detail
type Option`1 --package System.CommandLine --shape            # view type shape
member -m Option`1..ctor --package System.CommandLine         # dotted member syntax
diff --package System.CommandLine@<prev>..2.0.3 -t Option`1   # compare API changes  <-- NEW
```

## Test plan
- [x] All 558 tests pass
- [x] Tip appears when viewing types from packages with known versions
- [x] Tip doesn't appear for platform or local library sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)