### PR TITLE
fix: Show all overloads when member filter matches multiple

### DIFF
--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1855,9 +1855,8 @@ public static class CommandLineBuilder
                 }
             }
 
-            // Parse Name:N shorthand
+            // Parse Name:N shorthand for explicit overload selection
             int? shorthandIndex = null;
-            bool hasExplicitIndex = false;
             for (int i = 0; i < allMembers.Length; i++)
             {
                 var colonIdx = allMembers[i].LastIndexOf(':');
@@ -1865,12 +1864,11 @@ public static class CommandLineBuilder
                 {
                     allMembers[i] = allMembers[i][..colonIdx];
                     shorthandIndex = idx;
-                    hasExplicitIndex = true;
                 }
             }
-
-            if (!hasExplicitIndex && allMembers.Length == 1)
-                shorthandIndex = 1;
+            // Note: We don't auto-select overload 1 when a single member is filtered.
+            // This allows seeing all overloads when e.g. `-m GetValue` matches multiple.
+            // Use explicit Name:1 syntax to select a specific overload.
 
             HashSet<string> memberFilter = [];
             int? memberLimit = null;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -364,7 +364,7 @@ public class ApiCommand
                         int idx = options.OverloadIndex.Value;
                         if (idx < 1 || idx > overloads.Count)
                         {
-                            Console.Error.WriteLine($"Error: {memberName}:{idx} is out of range. {memberName} has {overloads.Count} overload(s).");
+                            Console.Error.WriteLine($"Error: {memberName}:{idx} is out of range. Use {memberName}:1 through {memberName}:{overloads.Count}.");
                             return 1;
                         }
 


### PR DESCRIPTION
## Summary
- **Fix:** `-m GetValue` now shows all matching overloads instead of auto-selecting the first one
- **Fix:** Improved overload index error message for 1-based index clarity

## Root Cause
At `CommandLineBuilder.cs:1872-1873`, when a single member filter was provided without an explicit index, the code auto-set `shorthandIndex = 1`, causing:
1. Only 1 row in Methods table (selected overload)
2. Source/IL sections to appear (because OverloadIndex was set)

## Changes
1. Removed auto-selection of first overload - users now see all matching overloads
2. Error message now shows valid range: "Use SetAction:1 through SetAction:4"

## Before/After

**Before:**
```
$ member ParseResult --package System.CommandLine -m GetValue
## Methods
| Name | Signature |
| GetValue | `T? GetValue(System.CommandLine.Argument<T> argument)` |  ← Only 1 shown!

## Source
...  ← Source/IL auto-shown for first overload
```

**After:**
```
$ member ParseResult --package System.CommandLine -m GetValue
## Methods
| Name | Signature |
| GetValue | `T? GetValue(System.CommandLine.Argument<T> argument)` |
| GetValue | `T? GetValue(System.CommandLine.Option<T> option)` |
| GetValue | `T? GetValue(string name)` |  ← All 3 shown!

Tips:
member ParseResult --package System.CommandLine GetResult:1   # view member detail
```

## Test plan
- [x] All 558 tests pass
- [x] `-m GetValue` shows all 3 overloads
- [x] `GetValue:2` explicit selection still works
- [x] Error message shows valid index range

🤖 Generated with [Claude Code](https://claude.com/claude-code)