### PR TITLE
Refine member command verbosity levels and hide source at minimal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ rm -rf "$PACK_OUTPUT"
 
 # Pack
 echo "Packing..."
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT"
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT" --ucr
+dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -bl:"$PACK_OUTPUT/pack.binlog"
+dotnet pack "$PROJECT" -o "$PACK_OUTPUT" --ucr -bl:"$PACK_OUTPUT/pack-ucr.binlog"
 
 # Install from local packages
 echo "Installing..."

--- a/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
+++ b/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
@@ -115,8 +115,8 @@ public class OfflineVerbosityTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.Contains("Serialize", output);
-        // No documentation at minimal
-        Assert.DoesNotContain("Converts the provided value", output);
+        // Minimal now shows full signatures with docs
+        Assert.Contains("Signature", output);
     }
 
     // ── router -> qualified type name ─────────────────────────────────

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -1926,7 +1926,8 @@ public static class CommandLineBuilder
                 ExcludeSections = opts.ParseExcludeSections(parseResult),
                 Verbose = parseResult.GetValue(opts.Verbose),
                 Verbosity = opts.ParseVerbosity(parseResult),
-                SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
+                SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
+                IsMemberCommand = true
             };
 
             options = options with

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -779,7 +779,9 @@ public class ApiCommand
             ApiOutputFormatter.PopulateEnumValues(view, type, options);
 
         // Determine if we can use the full serializer for member tables
-        bool fullSerializer = options.Verbosity != Verbosity.Quiet;
+        // Member command always shows tables: quiet gets summary, minimal+ gets full signatures
+        // Type command: quiet gets no tables, minimal gets summary, normal+ gets full
+        bool fullSerializer = options.IsMemberCommand || options.Verbosity != Verbosity.Quiet;
 
         int truncatedCount = 0;
         string truncatedNoun = "";
@@ -791,7 +793,11 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateConstructorOverloads(view, type, options);
             }
-            else if (options.Verbosity == Verbosity.Minimal)
+            else if (options.IsMemberCommand && options.Verbosity == Verbosity.Quiet)
+            {
+                (truncatedCount, truncatedNoun) = ApiOutputFormatter.PopulateMemberSummarySections(view, type, options);
+            }
+            else if (options.Verbosity == Verbosity.Minimal && !options.IsMemberCommand)
             {
                 (truncatedCount, truncatedNoun) = ApiOutputFormatter.PopulateMemberSummarySections(view, type, options);
             }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -53,6 +53,11 @@ public record ApiOptions
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 
     /// <summary>
+    /// True when invoked via the member command. Member always shows tables (quiet gets summary, minimal+ gets full).
+    /// </summary>
+    public bool IsMemberCommand { get; init; }
+
+    /// <summary>
     /// True when output is raw text (not rendered markdown). Tips should be suppressed.
     /// </summary>
     public bool IsRawOutput => JsonOutput || OneLine || ShapeOutput;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -146,7 +146,7 @@ public static class ApiOutputFormatter
         string truncatedNoun = "";
 
         // Populate member sections declaratively (unless quiet or enum)
-        bool fullSerializer = options.Verbosity != Verbosity.Quiet;
+        bool fullSerializer = options.IsMemberCommand || options.Verbosity != Verbosity.Quiet;
 
         if (fullSerializer && view.EnumValues == null && view.EnumValuesWithDocs == null)
         {
@@ -155,7 +155,11 @@ public static class ApiOutputFormatter
             {
                 PopulateConstructorOverloads(view, type, options);
             }
-            else if (options.Verbosity == Verbosity.Minimal)
+            else if (options.IsMemberCommand && options.Verbosity == Verbosity.Quiet)
+            {
+                (truncatedCount, truncatedNoun) = PopulateMemberSummarySections(view, type, options);
+            }
+            else if (options.Verbosity == Verbosity.Minimal && !options.IsMemberCommand)
             {
                 (truncatedCount, truncatedNoun) = PopulateMemberSummarySections(view, type, options);
             }
@@ -175,14 +179,18 @@ public static class ApiOutputFormatter
 
     internal static MarkoutWriterOptions BuildTypeWriterOptions(ApiType type, ApiOptions options)
     {
+        // Member command at quiet still needs sections rendered (summary tables)
+        var effectiveVerbosity = options.IsMemberCommand && options.Verbosity == Verbosity.Quiet
+            ? Verbosity.Minimal : options.Verbosity;
+
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
         var includeSections = pipeline.ComputeIncludeSections(
-            type, options.Verbosity, options.IncludeSections, options.ExcludeSections);
+            type, effectiveVerbosity, options.IncludeSections, options.ExcludeSections);
 
         return new MarkoutWriterOptions
         {
             IncludeSections = includeSections,
-            IncludeDescription = options.Verbosity != Verbosity.Quiet
+            IncludeDescription = effectiveVerbosity != Verbosity.Quiet
         };
     }
 
@@ -226,9 +234,9 @@ public static class ApiOutputFormatter
             typeParamsInline = string.Join(", ", paramDescriptions);
         }
 
-        // Description (from docs)
+        // Description (from docs) — suppressed at quiet
         string? description = null;
-        if (options.ShowDocs && type.Documentation.Summary != null)
+        if (options.Verbosity != Verbosity.Quiet && options.ShowDocs && type.Documentation.Summary != null)
             description = type.Documentation.Summary;
 
         // Samples info (only with --docs/--samples)
@@ -295,12 +303,12 @@ public static class ApiOutputFormatter
             Source = apiSource,
             Tfm = selectedTfm,
             SamplesInfo = samplesInfo,
-            // Member stats for quiet verbosity
-            Constructors = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "constructor")) : null,
-            Fields = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
-            Properties = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
-            Methods = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
-            Events = options.Verbosity == Verbosity.Quiet ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
+            // Member stats for quiet verbosity (non-member commands only; member command shows tables)
+            Constructors = options.Verbosity == Verbosity.Quiet && !options.IsMemberCommand ? NullIfZero(type.Members.Count(m => m.Kind == "constructor")) : null,
+            Fields = options.Verbosity == Verbosity.Quiet && !options.IsMemberCommand ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
+            Properties = options.Verbosity == Verbosity.Quiet && !options.IsMemberCommand ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
+            Methods = options.Verbosity == Verbosity.Quiet && !options.IsMemberCommand ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
+            Events = options.Verbosity == Verbosity.Quiet && !options.IsMemberCommand ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
             BaseclassRows = baseclassRows,

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -203,7 +203,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class MethodSource : ISectionDescriptor<ApiType>
     {
         public static string Name => "Source";
-        public static Verbosity MinVerbosity => Verbosity.Quiet;
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind is "method" or "constructor");
@@ -212,7 +212,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class ILBody : ISectionDescriptor<ApiType>
     {
         public static string Name => "IL";
-        public static Verbosity MinVerbosity => Verbosity.Quiet;
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind is "method" or "constructor");
@@ -221,7 +221,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class AnnotatedIL : ISectionDescriptor<ApiType>
     {
         public static string Name => "IL (Annotated)";
-        public static Verbosity MinVerbosity => Verbosity.Quiet;
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind is "method" or "constructor");
@@ -230,7 +230,7 @@ public static class ApiMemberSectionDescriptors
     public sealed class LoweredCSharp : ISectionDescriptor<ApiType>
     {
         public static string Name => "Lowered C#";
-        public static Verbosity MinVerbosity => Verbosity.Quiet;
+        public static Verbosity MinVerbosity => Verbosity.Detailed;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(m => m.Kind is "method" or "constructor");


### PR DESCRIPTION
## Summary

Member is a deep-dive command, not an entry-point like package/library/router. This PR adjusts verbosity so each level provides progressively more detail:

| Level | Member output |
|-------|--------------|
| **Quiet** (`-v:q`) | Summary table (Name + Return Type) — replaces inline counts |
| **Minimal** (default) | Full signature table with docs |
| **Detailed** (`-v:d`) | Full signatures + Source, Lowered C#, IL, IL (Annotated), Interfaces, Baseclass, Remote Source |

Source code sections (Source, Lowered C#, IL, IL Annotated) are moved from `Quiet` to `Detailed` MinVerbosity so they no longer appear at default verbosity.

Type and package commands are **unchanged**.

### Other
- `install.sh` now generates binlogs for each pack call.

### Testing
- All 558 tests pass (0 failures, 31 skipped)