### PR TITLE
Update docs for member verbosity refinement

### DIFF
--- a/docs/workflows/core/member-lookup-docs-code.md
+++ b/docs/workflows/core/member-lookup-docs-code.md
@@ -64,7 +64,7 @@ Tips:
 grep -c '| ---- |'
 ```
 
-### 1b. Quiet mode (summary only)
+### 1b. Quiet mode (summary tables)
 
 ```bash
 dotnet-inspect member --package System.CommandLine Command -v:q
@@ -73,16 +73,17 @@ dotnet-inspect member --package System.CommandLine Command -v:q
 ```expect
 # System.CommandLine.Command
 Kind: class
-Properties: 8
-Methods: 10
+## Constructors
+## Properties
+## Methods
 ```
 
 ```expect-not
-## Constructors
+| Signature |
 Tips:
 ```
 
-### 1c. Detailed verbosity (with descriptions)
+### 1c. Detailed verbosity (with source/IL)
 
 ```bash
 dotnet-inspect member --package System.CommandLine Command -v:d
@@ -92,6 +93,7 @@ dotnet-inspect member --package System.CommandLine Command -v:d
 | Name | Signature | Description |
 Represents a specific action
 Initializes a new instance
+## Source
 ```
 
 ```expect-not
@@ -132,10 +134,12 @@ dotnet-inspect member System.Text.Json JsonSerializer -m 'Deseri*' -v:q
 
 ```expect
 # System.Text.Json.JsonSerializer
-Methods: 1
+## Methods
+| Name |
 ```
 
 ```expect-not
+| Signature |
 Serialize
 Tips:
 ```
@@ -247,7 +251,8 @@ dotnet-inspect member --package System.CommandLine Command --ctor -v:q
 
 ```expect
 # System.CommandLine.Command
-Constructors: 1
+## Constructors
+| Name |
 ```
 
 ```expect-not
@@ -269,7 +274,7 @@ dotnet-inspect member System.Text.Json JsonSerializer -v:q
 # System.Text.Json.JsonSerializer
 Kind: class
 Source: Platform
-Methods: 103
+## Methods
 ```
 
 ### 6b. Filter to specific method

--- a/docs/workflows/getting-started/type-and-member-addressability.md
+++ b/docs/workflows/getting-started/type-and-member-addressability.md
@@ -203,8 +203,8 @@ dotnet-inspect member System.Text.Json JsonSerializer -v:q
 
 ```expect
 # System.Text.Json.JsonSerializer
-Properties: 1
-Methods: 103
+## Properties
+## Methods
 ```
 
 ## Address a specific member by name
@@ -221,7 +221,7 @@ dotnet-inspect member System.Text.Json JsonSerializer Deserialize -v:q
 
 ```expect
 # System.Text.Json.JsonSerializer
-Methods: 1
+## Methods
 ```
 
 ## Member select mode

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -17,6 +17,8 @@ Verbosity levels:
 | Minimal (default) | (none) | H1, description, oneline field list, one section table | Yes |
 | Detailed | `-v:d` | H1, description, oneline field list, all sections | No |
 
+The `member` command has its own scale: quiet shows summary tables (Name + Return Type), default shows full signatures with docs, detailed adds Source/Lowered C#/IL.
+
 Section selection (`-s`) lists available sections or filters to specific ones. Tips are suppressed when sections are selected.
 
 ## Preconditions

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -11,8 +11,8 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 
 - **Code broken?** → `diff --package Foo@old..new` first, then `member --oneline`
 - **Need API surface?** → `member Type --package Foo --oneline` (token-efficient)
-- **Need signatures?** → `member Type --package Foo -m Method` (default verbosity)
-- **Need source/IL?** → `member Type --package Foo -m Method -v:d` (verbose, one overload at a time)
+- **Need signatures?** → `member Type --package Foo -m Method` (default shows full signatures + docs)
+- **Need source/IL?** → `member Type --package Foo -m Method -v:d` (adds Source, Lowered C#, IL)
 - **Need constructors?** → `member 'Type<T>' --package Foo -m .ctor` (use `<T>` not `<>`)
 - **Need all overloads?** → `member Type --package Foo --select` (shows `Name:N` indices)
 

--- a/src/dotnet-inspect/SKILL.md
+++ b/src/dotnet-inspect/SKILL.md
@@ -11,8 +11,8 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 
 - **Code broken?** → `diff --package Foo@old..new` first, then `member --oneline`
 - **Need API surface?** → `member Type --package Foo --oneline` (token-efficient)
-- **Need signatures?** → `member Type --package Foo -m Method` (default verbosity)
-- **Need source/IL?** → `member Type --package Foo -m Method -v:d` (verbose, one overload at a time)
+- **Need signatures?** → `member Type --package Foo -m Method` (default shows full signatures + docs)
+- **Need source/IL?** → `member Type --package Foo -m Method -v:d` (adds Source, Lowered C#, IL)
 - **Need constructors?** → `member 'Type<T>' --package Foo -m .ctor` (use `<T>` not `<>`)
 - **Need all overloads?** → `member Type --package Foo --select` (shows `Name:N` indices)
 

--- a/src/dotnet-inspect/llms.txt
+++ b/src/dotnet-inspect/llms.txt
@@ -345,6 +345,14 @@ dotnet-inspect cli type                             # Explore args for specific 
 | `-v:n` | Normal | + metadata table, type parameters |
 | `-v:d` | Detailed | + all sections, full signatures |
 
+The `member` command has its own verbosity scale (it's a deep-dive, not an entry point):
+
+| Flag | Level | Member output |
+| ---- | ----- | ------------- |
+| `-v:q` | Quiet | Summary tables (Name + Return Type) |
+| (default) | Minimal | Full signature tables with docs |
+| `-v:d` | Detailed | + Source, Lowered C#, IL, IL (Annotated) |
+
 Every verbosity level includes a **compact summary line**:
 
 ```text
@@ -435,10 +443,10 @@ Use `--oneline` as the default format for scanning APIs. It is far more token-ef
 ```bash
 dotnet-inspect member Command --package System.CommandLine --oneline       # scan all members
 dotnet-inspect type --package System.CommandLine --oneline                  # scan all types
-dotnet-inspect member Command --package System.CommandLine -m SetAction -v:d  # then drill in
+dotnet-inspect member Command --package System.CommandLine -m SetAction     # then drill in (full signatures + docs)
 ```
 
-Only switch to `-v:d` when you need full signatures, docs, or source for a specific member.
+Default `member` output shows full signatures with docs. Use `-v:d` only when you need source code or IL. Use `-v:q` for compact summary tables (Name + Return Type).
 
 ### Migration Workflow (fixing build errors from API changes)
 
@@ -462,7 +470,7 @@ dotnet-inspect member Command --package System.CommandLine@2.0.2 -m SetAction:3 
 
 Start with `diff` — it immediately shows all removed/changed/added members. This avoids guessing which APIs changed.
 
-**Verbosity tip:** Default verbosity is usually sufficient for migration. Use `-v:d` only when you need source code or IL — it shows one overload at a time and generates much more output. Use `--select` or overload index (`SetAction:2`) to see all overloads efficiently.
+**Verbosity tip:** Default `member` output shows full signatures with docs — usually sufficient for migration. Use `-v:d` only when you need source code or IL. Use `-v:q` for compact summary tables. Use `--select` or overload index (`SetAction:2`) to enumerate overloads efficiently.
 
 ### Important: New type and member Commands
 
@@ -482,17 +490,18 @@ dotnet-inspect member -m JsonSerializer.Deserialize --package System.Text.Json  
 ### Common Mistakes to Avoid
 
 ```bash
-# WRONG: Using -v:d for initial scanning (wastes tokens)
+# WRONG: Using -v:d for initial scanning (wastes tokens with source/IL)
 dotnet-inspect member Command --package System.CommandLine -v:d              # ✗
-# CORRECT: Use --oneline for scanning, -v:d only for specific members
+# CORRECT: Use --oneline for scanning, default for signatures+docs, -v:d only for source/IL
 dotnet-inspect member Command --package System.CommandLine --oneline         # ✓
-dotnet-inspect member Command --package System.CommandLine -m SetAction -v:d # ✓ (drill in)
+dotnet-inspect member Command --package System.CommandLine -m SetAction      # ✓ (full signatures + docs)
+dotnet-inspect member Command --package System.CommandLine -m SetAction -v:d # ✓ (source/IL)
 
-# WRONG: Using -v:d to see all overloads (only shows one at a time)
-dotnet-inspect member Command --package System.CommandLine -m SetAction -v:d # ✗ (shows first overload only)
-# CORRECT: Use --select to see overload indices, then drill into specific ones
+# WRONG: Using -v:d just to see all overloads
+dotnet-inspect member Command --package System.CommandLine -m SetAction -v:d # ✗ (default already shows all)
+# CORRECT: Default member shows all overloads with full signatures; use --select for indices
+dotnet-inspect member Command --package System.CommandLine -m SetAction      # ✓ (all overloads, full sigs)
 dotnet-inspect member Command --package System.CommandLine --select          # ✓ (shows Name:N for each)
-dotnet-inspect member Command --package System.CommandLine -m SetAction:3    # ✓ (async overload)
 
 # WRONG: Not using diff when fixing API migration errors
 # CORRECT: Start with diff to see all changes at once


### PR DESCRIPTION
Updates SKILL.md, llms.txt, and workflows to reflect the member command's new verbosity behavior from PR #229.

### Key change

Member command now has its own verbosity scale:

| Level | Output |
|-------|--------|
| `-v:q` | Summary tables (Name + Return Type) |
| default | Full signature tables with docs |
| `-v:d` | + Source, Lowered C#, IL, IL (Annotated) |

### Files changed

- **SKILL.md** (both copies): Decision tree updated — signatures at default, source/IL at `-v:d`
- **llms.txt**: Member-specific verbosity table, updated --oneline/migration/common-mistakes sections
- **member-lookup-docs-code.md**: Quiet expects summary tables not inline counts; detailed expects Source section
- **type-and-member-addressability.md**: Quiet expects section headers not inline counts
- **verbosity-and-tips.md**: Note about member's different verbosity scale