### PR TITLE
Add backlog items and tweak SKILL.md description

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,1 +1,13 @@
 # Backlog
+
+## Smarter defaults for agent and human users
+
+The tool's defaults were designed for human terminal use, but most callers are now agents. Two ideas to reduce guidance overhead by making the defaults better:
+
+### Auto-detect agent context and default to oneline
+
+If the tool detects it's being called by an agent (piped output, non-TTY, or an env var), default to `--oneline` output. Humans at a terminal keep the current full output. This matches how agents actually work — scan a compact list first, then drill into specific items. Every agent transcript shows this pattern. The win: shorter SKILL.md/llms.txt guidance because the tool does the right thing by default.
+
+### Make `--shape` more visible on `type`
+
+A human user was shown `type` output and liked it, but was wowed by `--shape` and said "this should be the default." Consider making `--shape` the default for `type`, or at least more prominent. The shape view (showing inheritance, interfaces, member categories) gives an immediate structural understanding that the flat type list doesn't. This parallels the oneline discussion — the best default is the one that answers the most common first question.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
+description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, diff/compare versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 
 # dotnet-inspect


### PR DESCRIPTION
- **backlog.md**: Two items around smarter defaults — auto-detect agent context for oneline, make `--shape` more visible on `type`
- **SKILL.md**: Add "diff/compare" to skill description