### PR TITLE
Follow type forwarders unconditionally (curl -L for types)

### DIFF
--- a/docs/workflows/output/cli-introspection.md
+++ b/docs/workflows/output/cli-introspection.md
@@ -34,7 +34,7 @@ dotnet-inspect cli
 ├─ member
 ├─ package
 ├─ samples
-├─ type
+└─ type
 ```
 
 ## 2. Inspect a specific command

--- a/docs/workflows/output/oneline-output.md
+++ b/docs/workflows/output/oneline-output.md
@@ -51,7 +51,7 @@ dotnet-inspect type System.Text.Json JsonSerializer --oneline -m 3
 ```
 
 ```expect
-Kind
+KIND
 property
 method
 ```

--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -219,6 +219,11 @@ public class ApiType
     public bool IsPartialType => AdditionalSourceFiles.Count > 0;
 
     /// <summary>
+    /// True if this type was resolved from a type forwarder in another assembly.
+    /// </summary>
+    public bool IsForwarded { get; set; }
+
+    /// <summary>
     /// Full name of the type (Namespace.Name, or just Name if no namespace).
     /// </summary>
     public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";

--- a/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
+++ b/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
@@ -141,4 +141,50 @@ public class OfflineVerbosityTests : IDisposable
         Assert.Contains("Deserialize", output);
         Assert.Contains("Overloads", output);
     }
+
+    // ── type forwarder following ─────────────────────────────────────
+
+    [Fact]
+    public async Task TypeListing_FollowsForwarders_Offline()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "type", "--platform", "System.Collections", "-v:q", "--offline");
+
+        Assert.Equal(0, exit);
+        // Native types (e.g., SortedSet) + forwarded types (e.g., HashSet)
+        Assert.Contains("System.Collections", output);
+    }
+
+    [Fact]
+    public async Task TypeListing_ForwardedTypeMatchesFilter_Offline()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "type", "--platform", "System.Collections", "-t", "HashSet*", "-v:q", "--offline");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Types: 1", output);
+    }
+
+    [Fact]
+    public async Task TypeListing_NativeAndForwardedTypes_Offline()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "type", "--platform", "System.Collections", "-v:m", "--offline");
+
+        Assert.Equal(0, exit);
+        // Forwarded type
+        Assert.Contains("HashSet", output);
+        // Native type
+        Assert.Contains("SortedSet", output);
+    }
+
+    [Fact]
+    public async Task SingleType_ForwardedType_Offline()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "type", "HashSet", "--platform", "System.Collections", "-v:q", "--offline");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("HashSet", output);
+    }
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -213,10 +213,8 @@ public class ApiCommand
                     return 1;
                 }
 
-                if (api.Types.Count == 0 && api.TypeForwarders.Count > 0 && apiDllPath != null)
-                {
+                if (apiDllPath != null)
                     ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
-                }
 
                 if (!string.IsNullOrEmpty(options.PackagePath))
                 {
@@ -298,7 +296,7 @@ public class ApiCommand
                     return 1;
                 }
 
-                if (api.Types.Count == 0 && api.TypeForwarders.Count > 0 && apiDllPath != null)
+                if (apiDllPath != null)
                     ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
 
                 var allTypeNames = api.Types.Select(t => t.FullName).ToList();

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -280,11 +280,12 @@ internal static class ApiServices
     // ===== Type Forwarder Resolution =====
 
     /// <summary>
-    /// Resolves types from forwarded assemblies when the primary assembly is a type-forwarding assembly.
+    /// Resolves types from forwarded assemblies and merges them into the API surface.
+    /// Like curl -L, this follows type forwarders to their target assemblies.
     /// </summary>
     internal static void ResolveForwardedTypes(ApiSurface api, string dllPath, VerboseLogger logger, bool includeAll)
     {
-        if (api.Types.Count > 0 || api.TypeForwarders.Count == 0)
+        if (api.TypeForwarders.Count == 0)
             return;
 
         var assemblyDir = Path.GetDirectoryName(dllPath);
@@ -296,6 +297,8 @@ internal static class ApiServices
             .ToDictionary(g => g.Key, g => g.Select(f => f.TypeName).ToHashSet(StringComparer.OrdinalIgnoreCase));
 
         logger.Log($"Resolving {api.TypeForwarders.Count} forwarded types from {byAssembly.Count} libraries...");
+
+        int resolvedCount = 0;
 
         foreach (var (targetAssembly, forwardedTypeNames) in byAssembly)
         {
@@ -316,11 +319,13 @@ internal static class ApiServices
                 {
                     if (forwardedTypeNames.Contains(type.FullName))
                     {
+                        type.IsForwarded = true;
                         api.Types.Add(type);
                         api.PublicMethodCount += type.Members.Count(m => m.Kind == "method" || m.Kind == "constructor");
                         api.PublicPropertyCount += type.Members.Count(m => m.Kind == "property");
                         api.PublicEventCount += type.Members.Count(m => m.Kind == "event");
                         api.PublicFieldCount += type.Members.Count(m => m.Kind == "field");
+                        resolvedCount++;
                     }
                 }
             }
@@ -330,12 +335,12 @@ internal static class ApiServices
             }
         }
 
-        if (api.Types.Count > 0)
+        if (resolvedCount > 0)
         {
             api.IsTypeForwardingAssembly = true;
             api.PublicTypeCount = api.Types.Count;
             api.Types = api.Types.OrderBy(t => t.FullName).ToList();
-            logger.Log($"Resolved {api.Types.Count} types from forwarded libraries.");
+            logger.Log($"Resolved {resolvedCount} types from forwarded libraries.");
         }
     }
 }


### PR DESCRIPTION
## Summary

Assemblies like `System.Collections` have both native types (28) and type forwarders (e.g., `HashSet<T>` → `System.Private.CoreLib`). Previously, forwarders were only resolved when an assembly had **zero** native types, so `type System.Collections -t 'HashSet*'` returned 0 types.

Now `ResolveForwardedTypes` always merges forwarded types into the API surface — analogous to `curl -L` following HTTP redirects.

### Changes

| File | Change |
|------|--------|
| `ApiSurface.cs` | New `ApiType.IsForwarded` flag to distinguish forwarded vs native types |
| `ApiServices.cs` | `ResolveForwardedTypes` removes `Types.Count==0` guard, marks resolved types |
| `ApiCommand.cs` | Call sites no longer gate on `Types.Count==0` |

### Before / After

```
# Before
$ dotnet-inspect type System.Collections -t 'HashSet*' -v:q
Types: 0

# After
$ dotnet-inspect type System.Collections -t 'HashSet*' -v:q
Types: 1
```

### Testing

589 tests pass (0 failures, 31 skipped)