### PR TITLE
Fix CI change detection for shallow push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Detect changes
         id: filter
@@ -26,7 +28,11 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
           else
-            FILES=$(git diff --name-only ${{ github.event.before }}...${{ github.sha }})
+            BEFORE=${{ github.event.before }}
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              BEFORE=HEAD~1
+            fi
+            FILES=$(git diff --name-only "$BEFORE"..."${{ github.sha }}")
           fi
           CODE=false
           DOCS=false


### PR DESCRIPTION
The change detection script fails on push events when the shallow checkout (depth 1) doesn't have the parent commit for `git diff`.

- `fetch-depth: 2` ensures parent commit is available
- Falls back to `HEAD~1` when `github.event.before` is the zero SHA (force push/new branch)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>