### PR TITLE
fix: Target net10.0 for tool install compatibility

### DIFF
--- a/src/DotnetInspector.Core/DotnetInspector.Core.csproj
+++ b/src/DotnetInspector.Core/DotnetInspector.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Decompiler.Tests/DotnetInspector.Decompiler.Tests.csproj
+++ b/src/DotnetInspector.Decompiler.Tests/DotnetInspector.Decompiler.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Decompiler.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/DotnetInspector.Decompiler/DotnetInspector.Decompiler.csproj
+++ b/src/DotnetInspector.Decompiler/DotnetInspector.Decompiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -23,6 +23,6 @@
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
   </ItemGroup>
 
-  <!-- System.Reflection.Metadata is part of net11.0 BCL -->
+  <!-- System.Reflection.Metadata is part of net10.0 BCL -->
 
 </Project>

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
+++ b/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Services.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/dotnet-inspect-find/dotnet-inspect-find.csproj
+++ b/src/dotnet-inspect-find/dotnet-inspect-find.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Problem

v0.5.0 changed the `TargetFramework` from `net10.0` to `net11.0`. This means the pointer package places `DotnetToolSettings.xml` under `tools/net11.0/any/`, but users with a .NET 10 SDK look for it under `tools/net10.0/any/` — resulting in:

> Settings file 'DotnetToolSettings.xml' was not found in the package.

Since .NET 11 is still in preview, most users hit this on install/update.

## Fix

- Target `net10.0` across all projects so the pointer and `any` packages are installable by .NET 10+ SDKs
- NativeAOT RID-specific packages still compile with `net11.0` via `-p:TargetFramework=net11.0` in CI (their layout is `tools/any/{rid}/`, which is TFM-independent)
- Bump version to 0.5.1

Fixes #240