### PR TITLE
feat: Support split TFM for AOT and non-AOT packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           if-no-files-found: error
 
       - name: Pack linux-x64 AOT package
-        run: dotnet pack src/dotnet-inspect -c Release -r linux-x64 -p:PublishAot=true -p:OfficialBuild=true
+        run: dotnet pack src/dotnet-inspect -c Release -r linux-x64 -p:OfficialAotBuild=true
 
       - name: Upload linux-x64 package
         uses: actions/upload-artifact@v4
@@ -262,7 +262,7 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Pack RID-specific package
-        run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:PublishAot=true -p:OfficialBuild=true
+        run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
 
       - name: Upload RID package
         uses: actions/upload-artifact@v4

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,11 +1,18 @@
 <Project>
 
   <PropertyGroup>
+    <DefaultTargetFramework Condition="'$(DefaultTargetFramework)' == ''">net10.0</DefaultTargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
     <IncludeProjectNameInArtifactsPaths>true</IncludeProjectNameInArtifactsPaths>
     <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OfficialAotBuild)' == 'true'">
+    <OfficialBuild>true</OfficialBuild>
+    <PublishAot>true</PublishAot>
+    <DefaultTargetFramework>net11.0</DefaultTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/DotnetInspector.Core/DotnetInspector.Core.csproj
+++ b/src/DotnetInspector.Core/DotnetInspector.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Decompiler.Tests/DotnetInspector.Decompiler.Tests.csproj
+++ b/src/DotnetInspector.Decompiler.Tests/DotnetInspector.Decompiler.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Decompiler.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/DotnetInspector.Decompiler/DotnetInspector.Decompiler.csproj
+++ b/src/DotnetInspector.Decompiler/DotnetInspector.Decompiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
+++ b/src/DotnetInspector.Metadata/DotnetInspector.Metadata.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
+++ b/src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Services.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/dotnet-inspect-find/dotnet-inspect-find.csproj
+++ b/src/dotnet-inspect-find/dotnet-inspect-find.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DotnetInspector.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.5.2</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Enables targeting different TFMs for AOT vs non-AOT packages. The pointer and `any` packages stay on `net10.0` for broad SDK compatibility, while RID-specific NativeAOT packages can target `net11.0` (or any newer TFM).

## How it works

- `DefaultTargetFramework` property defined in `src/Directory.Build.props` (defaults to `net10.0`)
- All csproj files use `<TargetFramework>$(DefaultTargetFramework)</TargetFramework>`
- CI AOT pack commands pass `-p:DefaultTargetFramework=net11.0`

The custom property propagates through the entire project graph (unlike `-p:TargetFramework` which MSBuild treats specially), so restore and build stay consistent across all projects.

## Future use

This pattern supports scenarios like keeping the `any` package on .NET LTS for maximum reach while building AOT binaries with the latest runtime features — e.g., `any` = net10.0, RID-specific = net12.0.