### PR TITLE
Update install.sh and --flavor to target .NET 11

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ rm -rf "$PACK_OUTPUT"
 
 # Pack
 echo "Packing..."
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -bl:"$PACK_OUTPUT/pack.binlog"
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT" --ucr -bl:"$PACK_OUTPUT/pack-ucr.binlog"
+dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -p:OfficialBuild=true -bl:"$PACK_OUTPUT/pack.binlog"
+dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -p:OfficialAotBuild=true --ucr -bl:"$PACK_OUTPUT/pack-ucr.binlog"
 
 # Install from local packages
 echo "Installing..."

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -60,7 +60,7 @@ if (args.Length == 1 && args[0] == "--version")
 // Handle --flavor to show build type (CoreCLR or NativeAOT)
 if (args.Length == 1 && args[0] == "--flavor")
 {
-    Console.WriteLine(VersionInfo.Flavor);
+    Console.WriteLine(VersionInfo.FlavorVersion);
     return 0;
 }
 

--- a/src/dotnet-inspect/VersionInfo.cs
+++ b/src/dotnet-inspect/VersionInfo.cs
@@ -25,6 +25,12 @@ public static class VersionInfo
     public static string Flavor =>
         string.IsNullOrEmpty(typeof(object).Assembly.Location) ? "NativeAOT" : "CoreCLR";
 
+    /// <summary>
+    /// Gets the runtime flavor and .NET version (e.g., "CoreCLR; .NET 10.0").
+    /// </summary>
+    public static string FlavorVersion =>
+        $"{Flavor}; .NET {Environment.Version.Major}.{Environment.Version.Minor}";
+
     private static string GetVersion()
     {
         var assembly = typeof(VersionInfo).Assembly;


### PR DESCRIPTION
- Pass `-p:DefaultTargetFramework=net11.0` in `install.sh` pack commands so local installs build against .NET 11
- Add `VersionInfo.FlavorVersion` property (`CoreCLR; .NET 11.0` / `NativeAOT; .NET 11.0`)
- Use `FlavorVersion` in `--flavor` output