### PR TITLE
fix: Use correct view type in OneLineWriter empty results test

### DIFF
--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Services;
+using DotnetInspector.Views;
 using Markout;
 
 namespace DotnetInspector.Tests;
@@ -40,9 +41,8 @@ public class FindCommandTests
     [Fact]
     public void OneLineWriter_EmptyResults_NoOutput()
     {
-        var results = new Dictionary<string, List<TypeSearchResult>>();
-
-        var view = FindOutputFormatter.BuildMultiPatternView(results);
+        // One-line output uses FindOneLineView, not FindResultView
+        var view = new FindOneLineView { Results = [] };
         var sw = new StringWriter();
         var writer = new OneLineWriter(sw, showHeader: false);
         new MarkoutContext().Serialize(view, writer);


### PR DESCRIPTION
## Summary
- Fix failing test `OneLineWriter_EmptyResults_NoOutput` on macOS
- The test was using `FindResultView` which includes a `Description` property that `OneLineWriter` cannot render (it tries to write a paragraph which throws `ObjectDisposedException`)
- Use `FindOneLineView` instead, which matches the actual command behavior

## Test plan
- [x] Run tests locally - all 621 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)