### PR TITLE
Reject option-like tokens in positional args

### DIFF
--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -76,16 +76,29 @@ public static class PackageCommandDefinitions
         {
             var result = PackageOptionsParser.Parse(parseResult, opts, commandArgs);
 
-            var exitCode = await PackageCommand.ExecuteAsync(result.Options);
-
-            if (exitCode == 0 && result.Options.PackageArgs.Length > 0 && !result.Options.IsRawOutput)
+            switch (result)
             {
-                var pkg = result.Options.PackageArgs[0];
-                if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
-                TipWriter.WritePackageTips(pkg, result.Options.TipLevel, result.Verbosity);
-            }
+                case PackageOptionsParser.UnrecognizedOption error:
+                    Console.Error.WriteLine($"Error: Unrecognized option '{error.Option}'.");
+                    return 1;
 
-            return exitCode;
+                case PackageOptionsParser.Success success:
+                {
+                    var exitCode = await PackageCommand.ExecuteAsync(success.Options);
+
+                    if (exitCode == 0 && success.Options.PackageArgs.Length > 0 && !success.Options.IsRawOutput)
+                    {
+                        var pkg = success.Options.PackageArgs[0];
+                        if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
+                        TipWriter.WritePackageTips(pkg, success.Options.TipLevel, success.Verbosity);
+                    }
+
+                    return exitCode;
+                }
+
+                default:
+                    return 1;
+            }
         });
 
         return packageCommand;

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -69,6 +69,10 @@ public static class RouterCommandDefinition
                     Console.Error.WriteLine(error.Message);
                     return 1;
 
+                case RouterOptionsParser.UnrecognizedOption error:
+                    Console.Error.WriteLine($"Error: Unrecognized option '{error.Option}'.");
+                    return 1;
+
                 case RouterOptionsParser.RouteToAssemblyFile route:
                     return await AssemblyCommand.ExecuteAsync(route.Options);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -150,7 +150,7 @@ public static class MemberOptionsParser
         }
 
         // Check for unrecognized options in positional args
-        var badOption = positionalMembers.FirstOrDefault(m => m.StartsWith("--"));
+        var badOption = positionalMembers.FirstOrDefault(m => m.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -34,7 +34,17 @@ public static class PackageOptionsParser
     /// <summary>
     /// Result of parsing package command options.
     /// </summary>
-    public record PackageParseResult(InspectionOptions Options, Verbosity Verbosity);
+    public abstract record PackageParseResult;
+
+    /// <summary>
+    /// Indicates an unrecognized option was found in positional args.
+    /// </summary>
+    public record UnrecognizedOption(string Option) : PackageParseResult;
+
+    /// <summary>
+    /// Successfully parsed options ready for execution.
+    /// </summary>
+    public record Success(InspectionOptions Options, Verbosity Verbosity) : PackageParseResult;
 
     /// <summary>
     /// Parses package command options.
@@ -45,6 +55,12 @@ public static class PackageOptionsParser
         PackageCommandArgs args)
     {
         var packageArgs = parseResult.GetValue(args.PackageNameArg) ?? [];
+
+        // Check for unrecognized options in positional args
+        var badOption = packageArgs.FirstOrDefault(a => a.StartsWith('-'));
+        if (badOption != null)
+            return new UnrecognizedOption(badOption);
+
         var explicitVersion = parseResult.GetValue(args.VersionOption);
 
         // Bare --version (no value): treat as --versions 1
@@ -90,6 +106,6 @@ public static class PackageOptionsParser
             ? TipLevel.Quiet : opts.ParseTipLevel(parseResult);
         options = options with { TipLevel = tipLevel };
 
-        return new PackageParseResult(options, verbosity);
+        return new Success(options, verbosity);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
@@ -44,6 +44,11 @@ public static class RouterOptionsParser
     public record ParseError(string Message) : RouterParseResult;
 
     /// <summary>
+    /// Indicates an unrecognized option was found in positional args.
+    /// </summary>
+    public record UnrecognizedOption(string Option) : RouterParseResult;
+
+    /// <summary>
     /// Route to assembly command for a .dll file.
     /// </summary>
     public record RouteToAssemblyFile(AssemblyOptions Options) : RouterParseResult;
@@ -91,6 +96,11 @@ public static class RouterOptionsParser
                 return new Discovery(opts.ParseDiscover(parseResult), parseResult.GetValue(opts.Tree));
             return new ShowHelp();
         }
+
+        // Check for unrecognized options in positional args
+        var badOption = packageArgs.FirstOrDefault(a => a.StartsWith('-'));
+        if (badOption != null)
+            return new UnrecognizedOption(badOption);
 
         var name = packageArgs[0];
 

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -91,7 +91,7 @@ public static class TypeOptionsParser
         }
 
         // Check for unrecognized options in positional args
-        var badOption = argsValue.FirstOrDefault(a => a.StartsWith("--"));
+        var badOption = argsValue.FirstOrDefault(a => a.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -22,7 +22,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.6.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Problem

Running `dotnet-inspect --package FooPackage` treats `--package` as the positional package name argument, producing:

```
Error: Package '--package' not found.
```

System.CommandLine absorbs unknown `--` and `-` tokens into `ZeroOrMore` positional arguments instead of rejecting them.

## Fix

All four option parsers now check positional args for option-like tokens (starting with `-`) before processing:

- **RouterOptionsParser** — new `UnrecognizedOption` result + guard (primary path for the reported bug)
- **PackageOptionsParser** — converted to discriminated union (`Success`/`UnrecognizedOption`) + guard
- **TypeOptionsParser** — widened existing `--` check to also catch single-dash `-`
- **MemberOptionsParser** — same widening

Now produces:
```
Error: Unrecognized option '--package'.
```

## Testing

- 143 service tests pass
- Manual: `--package Foo`, `-p Foo`, `--unknown Foo`, `package --unknown Foo` all rejected
- Normal usage (`Humanizer`, `package Humanizer`) unaffected

Bumps version to 0.6.1.