### PR TITLE
Bump upload-artifact from v5 to v6 for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -p:OfficialBuild=true
 
       - name: Upload pointer package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: package-pointer
           path: artifacts/package/release/*.nupkg
@@ -160,7 +160,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
 
       - name: Upload any package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: package-any
           path: artifacts/package/release/*.nupkg
@@ -170,7 +170,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r linux-x64 -p:OfficialAotBuild=true
 
       - name: Upload linux-x64 package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: package-linux-x64
           path: artifacts/package/release/*.nupkg
@@ -278,7 +278,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
 
       - name: Upload RID package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: package-${{ matrix.rid }}
           path: artifacts/package/release/*.nupkg


### PR DESCRIPTION
Updates all 4 `actions/upload-artifact` references in `ci.yml` from `@v5` to `@v6`.

**Why:** v5 runs on Node.js 20, which GitHub will force-migrate to Node.js 24 on **June 2, 2026**. v6 runs on Node.js 24 natively, eliminating the deprecation warnings on `pack` and `pack-rid` jobs.