### PR TITLE
Bump checkout and download-artifact to v6 for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -64,7 +64,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v19
@@ -89,7 +89,7 @@ jobs:
     env:
       DOTNET_INSPECT_TIPS: q
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -138,7 +138,7 @@ jobs:
     env:
       DOTNET_INSPECT_TIPS: q
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -266,7 +266,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     environment: nuget-publish
     
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Download all packages from CI run
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: packages
           pattern: package-*


### PR DESCRIPTION
Bumps `actions/checkout` (5 refs in ci.yml, 1 in release.yml) and `actions/download-artifact` (1 in release.yml) from `@v5` to `@v6`.

**Why:**
- v5 runs on Node.js 20, deprecated June 2, 2026
- v6 runs on Node.js 24 natively — eliminates deprecation warnings
- Fixes the Publish workflow failure where `download-artifact@v5` found 0 artifacts uploaded by `upload-artifact@v6` (version mismatch)

`actions/setup-dotnet@v5` already supports Node.js 24, no bump needed.