### PR TITLE
fix: add --prerelease option to router command

### DIFF
--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -45,10 +45,13 @@ public static class RouterCommandDefinition
         var routerVersionsOption = new Option<int?>("--versions") { Description = "List available versions (optionally limit count)", Arity = ArgumentArity.ZeroOrOne };
         routerVersionsOption.DefaultValueFactory = _ => null;
         routerCommand.Options.Add(routerVersionsOption);
+        var routerPrereleaseOption = new Option<bool>("--preview") { Description = "With --versions: include prerelease versions" };
+        routerPrereleaseOption.Aliases.Add("--prerelease");
+        routerCommand.Options.Add(routerPrereleaseOption);
 
         var commandArgs = new RouterOptionsParser.RouterCommandArgs(
             packageNameArg, routerVersionOption, routerLatestVersionOption, routerVersionsOption,
-            routerOneLineOption, routerNoHeaderOption);
+            routerPrereleaseOption, routerOneLineOption, routerNoHeaderOption);
 
         routerCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
@@ -20,6 +20,7 @@ public static class RouterOptionsParser
         Option<bool> VersionOption,
         Option<bool> LatestVersionOption,
         Option<int?> VersionsOption,
+        Option<bool> PrereleaseOption,
         Option<bool> OneLineOption,
         Option<bool> NoHeaderOption);
 
@@ -187,6 +188,7 @@ public static class RouterOptionsParser
         {
             PackageArgs = useBareName ? [bareName] : packageArgs,
             ListVersions = showLatestVersion || showVersions,
+            IncludePrerelease = parseResult.GetValue(args.PrereleaseOption),
             Limit = showLatestVersion ? 1 : routerVersionsValue,
             JsonOutput = parseResult.GetValue(opts.Json),
             OneLine = opts.ResolveOneLine(parseResult, args.OneLineOption),


### PR DESCRIPTION
## Problem

Running `dotnet-inspect System.CommandLine --versions --prerelease` through the router fails with:

```
Cannot parse argument '--prerelease' for option '--versions' as expected type 'System.Int32'.
```

The router command defined `--versions` (`Option<int?>` with `ZeroOrOne` arity) but not `--prerelease`. System.CommandLine tried to parse `--prerelease` as the int value argument for `--versions` since it wasn't a recognized option.

The explicit `package` subcommand worked because it defines both options.

## Fix

- Add `--preview`/`--prerelease` option to the router command definition
- Add `PrereleaseOption` to `RouterCommandArgs` record
- Propagate `IncludePrerelease` into the `InspectionOptions` for the package route

## Testing

- `dotnet-inspect System.CommandLine --versions --prerelease` now matches `dotnet-inspect package System.CommandLine --versions --prerelease`
- `dotnet-inspect System.CommandLine --versions` (without prerelease) still works
- All 143 services tests pass