### PR TITLE
ci: bump upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -p:OfficialBuild=true
 
       - name: Upload pointer package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: package-pointer
           path: artifacts/package/release/*.nupkg
@@ -160,7 +160,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
 
       - name: Upload any package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: package-any
           path: artifacts/package/release/*.nupkg
@@ -170,7 +170,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r linux-x64 -p:OfficialAotBuild=true
 
       - name: Upload linux-x64 package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: package-linux-x64
           path: artifacts/package/release/*.nupkg
@@ -278,7 +278,7 @@ jobs:
         run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
 
       - name: Upload RID package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: package-${{ matrix.rid }}
           path: artifacts/package/release/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Download all packages from CI run
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: packages
           pattern: package-*


### PR DESCRIPTION
Bump GitHub Actions artifact actions to latest versions for Node.js 24 compatibility.

- `actions/upload-artifact` v6 → v7 (4 instances in ci.yml)
- `actions/download-artifact` v6 → v8 (1 instance in release.yml)