### PR TITLE
Opt publish workflow into Node.js 24 for JS actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
     environment: nuget-publish
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning on the publish workflow by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the job level.

Affected actions:
- `NuGet/login@v1` — no v2 available yet; env var is the recommended fix
- `softprops/action-gh-release@v2` — already supports Node 24 since v2.3.0, but the env var ensures the runner uses it

Node.js 20 actions will be forced to Node.js 24 by default starting June 2nd, 2026. This opts in early.