### PR TITLE
Decompiler: improve high-level C# output quality

### DIFF
--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -17,17 +17,19 @@ public static class CSharpEmitter
         var cfg = ControlFlowGraph.Create(context);
         var simResult = StackSimulator.Simulate(context, cfg);
         var ast = ILAstBuilder.Build(context, cfg, simResult);
+        var inliner = new ExpressionInliner();
+        var inlinedLocals = inliner.Inline(ast);
         var structure = StructuredControlFlow.Analyze(context, cfg);
-        return Emit(ast, structure, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames);
+        return Emit(ast, structure, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, inlinedLocals);
     }
 
     /// <summary>
     /// Emit C# source from pre-computed ILAst and control flow structure.
     /// </summary>
-    public static string Emit(ILAstMethod ast, StructuredControlFlow structure, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null)
+    public static string Emit(ILAstMethod ast, StructuredControlFlow structure, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
     {
         var sb = new StringBuilder();
-        var emitter = new EmitterContext(ast, structure, sb, reader, hasThis, returnType, parameterNames);
+        var emitter = new EmitterContext(ast, structure, sb, reader, hasThis, returnType, parameterNames, inlinedLocals);
         emitter.EmitMethod();
         return sb.ToString();
     }
@@ -93,7 +95,13 @@ public static class CSharpEmitter
         // IL offset labels consumed by while-loop conditions (body entry points from header branch)
         readonly HashSet<string> _loopConsumedLabels;
 
-        public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null)
+        // Synthetic variable substitutions (e.g., S_in_0 → "x > 0 && y > 0")
+        readonly Dictionary<string, string> _syntheticSubstitutions = [];
+
+        // Variables inlined by ExpressionInliner (suppress declarations)
+        readonly HashSet<string> _inlinedLocals;
+
+        public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
         {
             _ast = ast;
             _structure = structure;
@@ -102,6 +110,7 @@ public static class CSharpEmitter
             _hasThis = hasThis;
             _returnsBool = returnType is "bool" or "System.Boolean";
             _paramNames = parameterNames;
+            _inlinedLocals = inlinedLocals ?? [];
 
             _blockMap = [];
             for (int i = 0; i < ast.Blocks.Count; i++)
@@ -428,6 +437,8 @@ public static class CSharpEmitter
                         continue;
                     if (_suppressedLocals.Contains(local.Name))
                         continue;
+                    if (_inlinedLocals.Contains(local.Name))
+                        continue;
                     string typeName = SimplifyTypeName(local.TypeName ?? "var");
                     // Skip compiler-generated closure variable declarations
                     if (typeName.Contains("/* closure */", StringComparison.Ordinal))
@@ -519,6 +530,10 @@ public static class CSharpEmitter
             if (blockIndex < 0 || !_blockMap.TryGetValue(blockIndex, out var astBlock))
                 return;
 
+            // Skip blocks already consumed by structured constructs
+            if (_consumedBlocks.Contains(blockIndex))
+                return;
+
             // Suppress return-only blocks whose gotos were all inlined
             if (astBlock.Nodes.Count == 1
                 && astBlock.Nodes[0] is ILAstStatement { Expression.OpCode: ILOpCode.Ret }
@@ -543,6 +558,14 @@ public static class CSharpEmitter
                     continue;
 
                 var node = astBlock.Nodes[nodeIdx];
+
+                // Peephole: stloc V_x = expr; ret(ldloc V_x) → return expr;
+                if (TryEmitStoreReturn(astBlock, nodeIdx, indent))
+                {
+                    nodeIdx++; // skip the ret node
+                    continue;
+                }
+
                 switch (node)
                 {
                     case ILAstAssignment assign:
@@ -611,26 +634,55 @@ public static class CSharpEmitter
                 var elseValue = TryExtractTernaryValue(block.ElseBlock);
                 if (thenValue is not null && elseValue is not null)
                 {
-                    // Apply negation if the conditional detector swapped then/else
                     if (block.NegateCondition)
                         condition = NegateConditionString(condition);
 
-                    // Emit as: S_in_0 = cond ? thenValue : elseValue
-                    // The follow block's S_in_0 references will resolve naturally
-                    WriteIndent(indent);
-                    _sb.Append("S_in_0 = ");
-                    _sb.Append(condition);
-                    _sb.Append(" ? ");
-                    _sb.Append(ExpressionToString(thenValue));
-                    _sb.Append(" : ");
-                    _sb.Append(ExpressionToString(elseValue));
-                    _sb.AppendLine(";");
+                    string? shortCircuit = TryBuildShortCircuit(condition, thenValue, elseValue);
+                    string resultExpr = shortCircuit
+                        ?? $"{condition} ? {ExpressionToString(thenValue)} : {ExpressionToString(elseValue)}";
 
-                    // Mark then/else blocks as consumed
+                    _syntheticSubstitutions["S_in_0"] = resultExpr;
+
                     if (block.ThenBlock.BlockIndex >= 0)
+                    {
                         _consumedBlocks.Add(block.ThenBlock.BlockIndex);
+                        RemoveGotoTargetsForConsumedBlock(block.ThenBlock.BlockIndex);
+                    }
                     if (block.ElseBlock.BlockIndex >= 0)
+                    {
                         _consumedBlocks.Add(block.ElseBlock.BlockIndex);
+                        RemoveGotoTargetsForConsumedBlock(block.ElseBlock.BlockIndex);
+                    }
+                    return;
+                }
+            }
+
+            // Detect ternary/short-circuit with no else but follow block assigns S_0
+            if (block.ThenBlock is not null && block.ElseBlock is null)
+            {
+                var thenValue = TryExtractTernaryValue(block.ThenBlock);
+                var followValue = TryExtractFollowTernaryValue(block);
+                if (thenValue is not null && followValue.expr is not null)
+                {
+                    if (block.NegateCondition)
+                        condition = NegateConditionString(condition);
+
+                    string? shortCircuit = TryBuildShortCircuit(condition, thenValue, followValue.expr);
+                    string resultExpr = shortCircuit
+                        ?? $"{condition} ? {ExpressionToString(thenValue)} : {ExpressionToString(followValue.expr)}";
+
+                    _syntheticSubstitutions["S_in_0"] = resultExpr;
+
+                    if (block.ThenBlock.BlockIndex >= 0)
+                    {
+                        _consumedBlocks.Add(block.ThenBlock.BlockIndex);
+                        RemoveGotoTargetsForConsumedBlock(block.ThenBlock.BlockIndex);
+                    }
+                    if (followValue.blockIdx >= 0)
+                    {
+                        _consumedBlocks.Add(followValue.blockIdx);
+                        RemoveGotoTargetsForConsumedBlock(followValue.blockIdx);
+                    }
                     return;
                 }
             }
@@ -760,6 +812,112 @@ public static class CSharpEmitter
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// For a no-else conditional, look at the next sibling block in the parent
+        /// sequence for an S_0 assignment that serves as the "else" value.
+        /// </summary>
+        (ILAstExpression? expr, int blockIdx) TryExtractFollowTernaryValue(StructuredBlock ifBlock)
+        {
+            var parent = FindParentSequence(ifBlock);
+            if (parent is null) return (null, -1);
+
+            int myIndex = -1;
+            for (int i = 0; i < parent.Children.Count; i++)
+            {
+                if (ReferenceEquals(parent.Children[i], ifBlock))
+                { myIndex = i; break; }
+            }
+
+            if (myIndex < 0 || myIndex + 1 >= parent.Children.Count)
+                return (null, -1);
+
+            var followBlock = parent.Children[myIndex + 1];
+            if (followBlock.BlockIndex < 0 || !_blockMap.TryGetValue(followBlock.BlockIndex, out var astBlock))
+                return (null, -1);
+
+            ILAstExpression? value = null;
+            foreach (var node in astBlock.Nodes)
+            {
+                if (node is ILAstAssignment assign && assign.Variable.Kind == ILVariableKind.StackSlot)
+                {
+                    if (value is not null) return (null, -1);
+                    value = assign.Value;
+                }
+                else if (node is ILAstStatement stmt)
+                {
+                    var op = stmt.Expression.OpCode;
+                    if (op is not (ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Nop
+                        or ILOpCode.Leave or ILOpCode.Leave_s))
+                        return (null, -1);
+                }
+                else return (null, -1);
+            }
+            return (value, followBlock.BlockIndex);
+        }
+
+        /// <summary>
+        /// Detect short-circuit &amp;&amp; and || patterns from ternary values.
+        /// </summary>
+        string? TryBuildShortCircuit(string condition, ILAstExpression thenExpr, ILAstExpression elseExpr)
+        {
+            bool thenIsTrue = IsTrueLiteral(thenExpr);
+            bool thenIsFalse = IsFalseLiteral(thenExpr);
+            bool elseIsTrue = IsTrueLiteral(elseExpr);
+            bool elseIsFalse = IsFalseLiteral(elseExpr);
+
+            string thenStr = ExpressionToString(thenExpr);
+            string elseStr = ExpressionToString(elseExpr);
+
+            if (elseIsFalse && !thenIsFalse && !thenIsTrue)
+                return $"{condition} && {thenStr}";
+            if (thenIsTrue && !elseIsTrue && !elseIsFalse)
+                return $"{condition} || {elseStr}";
+            if (elseIsTrue && !thenIsTrue && !thenIsFalse)
+                return $"{NegateConditionString(condition)} || {thenStr}";
+            if (thenIsFalse && !elseIsFalse && !elseIsTrue)
+                return $"{NegateConditionString(condition)} && {elseStr}";
+
+            return null;
+        }
+
+        static bool IsTrueLiteral(ILAstExpression expr) =>
+            expr.OpCode == ILOpCode.Ldc_i4_1 || (expr.OpCode == ILOpCode.Ldc_i4_s && expr.Operand == "1");
+
+        static bool IsFalseLiteral(ILAstExpression expr) =>
+            expr.OpCode == ILOpCode.Ldc_i4_0;
+
+        /// <summary>
+        /// Remove goto targets that only originated from the specified consumed block.
+        /// </summary>
+        void RemoveGotoTargetsForConsumedBlock(int blockIndex)
+        {
+            if (blockIndex < 0 || !_blockMap.TryGetValue(blockIndex, out var block))
+                return;
+
+            foreach (var node in block.Nodes)
+            {
+                if (node is ILAstStatement { Expression: var expr }
+                    && expr.OpCode is ILOpCode.Br or ILOpCode.Br_s
+                    && expr.Operand is string target)
+                {
+                    bool otherRef = false;
+                    foreach (var (otherIdx, otherBlock) in _blockMap)
+                    {
+                        if (otherIdx == blockIndex || _consumedBlocks.Contains(otherIdx))
+                            continue;
+                        foreach (var otherNode in otherBlock.Nodes)
+                        {
+                            if (otherNode is ILAstStatement { Expression: var otherExpr }
+                                && otherExpr.Operand is string otherTarget && otherTarget == target)
+                            { otherRef = true; break; }
+                        }
+                        if (otherRef) break;
+                    }
+                    if (!otherRef) _gotoTargets.Remove(target);
+                }
+            }
         }
 
         void EmitLoop(StructuredBlock block, int indent)
@@ -1148,7 +1306,11 @@ public static class CSharpEmitter
                 if (retExpr.Arguments.Count > 0)
                 {
                     _sb.Append("return ");
+                    bool wasBool = _emitBoolContext;
+                    if (_returnsBool)
+                        _emitBoolContext = true;
                     EmitExpression(retExpr.Arguments[0]);
+                    _emitBoolContext = wasBool;
                     _sb.AppendLine(";");
                 }
                 else
@@ -1158,6 +1320,51 @@ public static class CSharpEmitter
                 return true;
             }
             return false;
+        }
+
+        /// <summary>
+        /// Peephole: stloc V_x = expr; ret(ldloc V_x) → return expr;
+        /// </summary>
+        bool TryEmitStoreReturn(ILAstBlock block, int nodeIdx, int indent)
+        {
+            if (nodeIdx + 1 >= block.Nodes.Count) return false;
+
+            var nextNode = block.Nodes[nodeIdx + 1];
+            if (nextNode is not ILAstStatement { Expression: var retExpr }) return false;
+            if (retExpr.OpCode != ILOpCode.Ret || retExpr.Arguments.Count == 0) return false;
+
+            var retArg = retExpr.Arguments[0];
+            string? retVarName = retArg.OpCode switch
+            {
+                ILOpCode.Ldloc_0 => "V_0", ILOpCode.Ldloc_1 => "V_1",
+                ILOpCode.Ldloc_2 => "V_2", ILOpCode.Ldloc_3 => "V_3",
+                ILOpCode.Ldloc_s or ILOpCode.Ldloc => retArg.Operand,
+                _ => null
+            };
+            if (retVarName is null) return false;
+
+            ILAstExpression? valueExpr = null;
+            var curNode = block.Nodes[nodeIdx];
+            if (curNode is ILAstStatement { Expression: var stExpr }
+                && stExpr.OpCode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2
+                    or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc
+                && stExpr.Arguments.Count > 0)
+            {
+                string? storeVar = stExpr.Operand ?? GetLocalName(stExpr.OpCode);
+                if (storeVar == retVarName)
+                    valueExpr = stExpr.Arguments[0];
+            }
+
+            if (valueExpr is null) return false;
+
+            WriteIndent(indent);
+            _sb.Append("return ");
+            bool wasBool = _emitBoolContext;
+            if (_returnsBool) _emitBoolContext = true;
+            EmitExpression(valueExpr);
+            _emitBoolContext = wasBool;
+            _sb.AppendLine(";");
+            return true;
         }
 
         void EmitTryCatchFinally(StructuredBlock block, int indent)
@@ -1856,6 +2063,9 @@ public static class CSharpEmitter
                 case ILOpCode.Endfinally:
                     break;
 
+                case ILOpCode.Nop when expr.Operand is null:
+                    break;
+
                 default:
                     WriteIndent(indent);
                     _sb.Append("/* ");
@@ -1942,7 +2152,10 @@ public static class CSharpEmitter
                     EmitBinary(expr, ">>"); break;
 
                 // Comparison operators
-                case ILOpCode.Ceq: EmitBinary(expr, expr.Operand ?? "=="); break;
+                case ILOpCode.Ceq:
+                    if (!TryEmitNegatedComparisonZero(expr))
+                        EmitBinary(expr, expr.Operand ?? "==");
+                    break;
                 case ILOpCode.Cgt or ILOpCode.Cgt_un: EmitBinary(expr, ">"); break;
                 case ILOpCode.Clt or ILOpCode.Clt_un: EmitBinary(expr, "<"); break;
 
@@ -2161,6 +2374,8 @@ public static class CSharpEmitter
                     if (_nullConditionalReceiver is not null
                         && expr.Operand.StartsWith("S_in_", StringComparison.Ordinal))
                         _sb.Append(_nullConditionalReceiver);
+                    else if (_syntheticSubstitutions.TryGetValue(expr.Operand, out var subst))
+                        _sb.Append(subst);
                     else
                         _sb.Append(expr.Operand);
                     break;
@@ -2473,9 +2688,47 @@ public static class CSharpEmitter
         }
 
         /// <summary>
-        /// Returns true if the expression produces a numeric (non-boolean) Int32 value.
-        /// Conservative: only returns true for known numeric patterns (lengths, counts, arithmetic).
+        /// Handle ceq(comparison, 0) → negated comparison.
+        /// E.g., ceq(clt(value, 0), 0) → value >= 0 instead of (value &lt; 0) == 0.
         /// </summary>
+        bool TryEmitNegatedComparisonZero(ILAstExpression ceqExpr)
+        {
+            if (ceqExpr.Arguments.Count < 2) return false;
+
+            var lhs = ceqExpr.Arguments[0];
+            var rhs = ceqExpr.Arguments[1];
+
+            ILAstExpression? comparison = null;
+            if (IsZeroLiteral(rhs) && IsComparisonOp(lhs))
+                comparison = lhs;
+            else if (IsZeroLiteral(lhs) && IsComparisonOp(rhs))
+                comparison = rhs;
+
+            if (comparison is null || comparison.Arguments.Count < 2) return false;
+
+            string negatedOp = comparison.OpCode switch
+            {
+                ILOpCode.Clt or ILOpCode.Clt_un => ">=",
+                ILOpCode.Cgt or ILOpCode.Cgt_un => "<=",
+                ILOpCode.Ceq => "!=",
+                _ => ""
+            };
+            if (negatedOp == "") return false;
+
+            EmitExpression(comparison.Arguments[0]);
+            _sb.Append($" {negatedOp} ");
+            EmitExpression(comparison.Arguments[1]);
+            return true;
+        }
+
+        static bool IsZeroLiteral(ILAstExpression expr) =>
+            expr.OpCode is ILOpCode.Ldc_i4_0;
+
+        static bool IsComparisonOp(ILAstExpression expr) =>
+            expr.OpCode is ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Clt
+                or ILOpCode.Cgt_un or ILOpCode.Clt_un;
+
+        /// <summary>
         static bool IsBoolContext(ILAstExpression expr, bool parentBoolContext)
         {
             if (parentBoolContext)

--- a/src/DotnetInspector.Decompiler/ExpressionInliner.cs
+++ b/src/DotnetInspector.Decompiler/ExpressionInliner.cs
@@ -1,0 +1,316 @@
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Decompiler;
+
+/// <summary>
+/// Eliminates single-use temporary variables by inlining their assigned
+/// expression directly at the use site. Operates on the ILAst before emission.
+/// </summary>
+sealed class ExpressionInliner
+{
+    /// <summary>
+    /// Run inlining passes on <paramref name="method"/>. Returns the set of
+    /// local variable names that were successfully inlined (and whose declarations
+    /// should be suppressed).
+    /// </summary>
+    public HashSet<string> Inline(ILAstMethod method)
+    {
+        HashSet<string> inlinedLocals = [];
+
+        // Pass 1: within-block inlining (single block, store → load adjacency)
+        foreach (var block in method.Blocks)
+            InlineBlock(block, inlinedLocals);
+
+        // Pass 2: cross-block inlining (exactly 1 def + 1 use across entire method)
+        InlineCrossBlock(method, inlinedLocals);
+
+        return inlinedLocals;
+    }
+
+    /// <summary>
+    /// Within a single block, find stloc patterns where the stored value is used
+    /// exactly once in a subsequent node, with no intervening redefinition.
+    /// Replace the use with the stored expression and nop-out the store.
+    /// </summary>
+    static void InlineBlock(ILAstBlock block, HashSet<string> inlinedLocals)
+    {
+        for (int i = 0; i < block.Nodes.Count; i++)
+        {
+            // Match: stloc V_x = expr (as ILAstStatement wrapping a stloc expression)
+            if (block.Nodes[i] is not ILAstStatement { Expression: var storeExpr })
+                continue;
+
+            if (storeExpr.OpCode is not (ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or
+                ILOpCode.Stloc_2 or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc))
+                continue;
+
+            string? varName = storeExpr.Operand ?? GetLocalNameFromOp(storeExpr.OpCode);
+            if (varName is null || storeExpr.Arguments.Count == 0)
+                continue;
+
+            var valueExpr = storeExpr.Arguments[0];
+
+            // Don't inline side-effecting expressions (calls, newobj) — preserves
+            // using/foreach pattern detection which requires named variable stores
+            if (IsSideEffecting(valueExpr))
+                continue;
+
+            // Don't inline self-referential stores like V_0 = V_0 + 1 (mutations)
+            if (ExprReferencesVar(valueExpr, varName))
+                continue;
+
+            // Scan forward for a single use of this variable before any redefinition
+            for (int j = i + 1; j < block.Nodes.Count; j++)
+            {
+                var candidate = block.Nodes[j];
+
+                // Check if this node redefines the variable — stop scanning
+                if (IsStoreToVar(candidate, varName))
+                    break;
+
+                // Count references to this variable in the candidate node
+                int refCount = CountReferences(candidate, varName);
+                if (refCount == 0)
+                    continue;
+                if (refCount > 1)
+                    break; // multiple uses — can't inline
+
+                // Exactly one reference — inline it
+                if (ReplaceReference(candidate, varName, valueExpr))
+                {
+                    // Nop-out the original store by replacing with a nop statement
+                    storeExpr = new ILAstExpression { OpCode = ILOpCode.Nop, Offset = storeExpr.Offset };
+                    block.Nodes[i] = new ILAstStatement { Expression = storeExpr };
+                    inlinedLocals.Add(varName);
+                }
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Cross-block inlining: for variables with exactly 1 definition and 1 use
+    /// across the entire method, inline the definition at the use site.
+    /// </summary>
+    static void InlineCrossBlock(ILAstMethod method, HashSet<string> inlinedLocals)
+    {
+        // Count definitions and uses per variable across all blocks
+        Dictionary<string, int> defCount = [];
+        Dictionary<string, int> useCount = [];
+        Dictionary<string, (ILAstBlock block, int nodeIdx, ILAstExpression storeExpr)> defSites = [];
+
+        for (int blockIdx = 0; blockIdx < method.Blocks.Count; blockIdx++)
+        {
+            var block = method.Blocks[blockIdx];
+            for (int nodeIdx = 0; nodeIdx < block.Nodes.Count; nodeIdx++)
+            {
+                var node = block.Nodes[nodeIdx];
+
+                // Count definitions (stloc statements)
+                if (node is ILAstStatement { Expression: var expr }
+                    && expr.OpCode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or
+                       ILOpCode.Stloc_2 or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc)
+                {
+                    string? vn = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
+                    if (vn is not null)
+                    {
+                        defCount[vn] = defCount.GetValueOrDefault(vn) + 1;
+                        defSites[vn] = (block, nodeIdx, expr);
+                    }
+                }
+
+                // Count uses (references in expressions)
+                CountReferencesInNode(node, useCount);
+            }
+        }
+
+        // Inline variables with exactly 1 def and 1 use
+        foreach (var (varName, defs) in defCount)
+        {
+            if (defs != 1 || useCount.GetValueOrDefault(varName) != 1)
+                continue;
+            if (inlinedLocals.Contains(varName))
+                continue;
+            if (!defSites.TryGetValue(varName, out var site))
+                continue;
+
+            var storeExpr = site.storeExpr;
+            if (storeExpr.Arguments.Count == 0)
+                continue;
+
+            var valueExpr = storeExpr.Arguments[0];
+
+            // Don't inline side-effecting expressions across blocks
+            if (IsSideEffecting(valueExpr))
+                continue;
+
+            // Don't inline self-referential stores
+            if (ExprReferencesVar(valueExpr, varName))
+                continue;
+
+            // Find and replace the single use
+            bool replaced = false;
+            foreach (var block in method.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (ReplaceReference(node, varName, valueExpr))
+                    {
+                        replaced = true;
+                        break;
+                    }
+                }
+                if (replaced) break;
+            }
+
+            if (replaced)
+            {
+                // Nop-out the definition
+                var nopExpr = new ILAstExpression { OpCode = ILOpCode.Nop, Offset = storeExpr.Offset };
+                site.block.Nodes[site.nodeIdx] = new ILAstStatement { Expression = nopExpr };
+                inlinedLocals.Add(varName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Count all references to a variable in a node's expression tree.
+    /// Does NOT count the variable in its own definition (stloc operand).
+    /// </summary>
+    static void CountReferencesInNode(ILAstNode node, Dictionary<string, int> counts)
+    {
+        switch (node)
+        {
+            case ILAstStatement { Expression: var expr }:
+                // For stloc, count references in the value expression only (not the operand)
+                if (expr.OpCode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2
+                    or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc)
+                {
+                    foreach (var arg in expr.Arguments)
+                        CountExprRefs(arg, counts);
+                }
+                else
+                {
+                    CountExprRefs(expr, counts);
+                }
+                break;
+            case ILAstAssignment { Value: var val }:
+                CountExprRefs(val, counts);
+                break;
+        }
+    }
+
+    static void CountExprRefs(ILAstExpression expr, Dictionary<string, int> counts)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc)
+        {
+            string? vn = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
+            if (vn is not null)
+                counts[vn] = counts.GetValueOrDefault(vn) + 1;
+        }
+        foreach (var arg in expr.Arguments)
+            CountExprRefs(arg, counts);
+    }
+
+    static int CountReferences(ILAstNode node, string varName)
+    {
+        return node switch
+        {
+            ILAstStatement { Expression: var expr } => CountExprRefs(expr, varName),
+            ILAstAssignment { Value: var val } => CountExprRefs(val, varName),
+            _ => 0
+        };
+    }
+
+    static int CountExprRefs(ILAstExpression expr, string varName)
+    {
+        int count = 0;
+        if (IsLoadOf(expr, varName))
+            count++;
+        foreach (var arg in expr.Arguments)
+            count += CountExprRefs(arg, varName);
+        return count;
+    }
+
+    /// <summary>
+    /// Replace the first reference to <paramref name="varName"/> in a node
+    /// with <paramref name="valueExpr"/>. Returns true if replaced.
+    /// </summary>
+    static bool ReplaceReference(ILAstNode node, string varName, ILAstExpression valueExpr)
+    {
+        return node switch
+        {
+            ILAstStatement { Expression: var expr } => ReplaceInExpr(expr, varName, valueExpr),
+            ILAstAssignment assign => ReplaceInExpr(assign.Value, varName, valueExpr),
+            _ => false
+        };
+    }
+
+    static bool ReplaceInExpr(ILAstExpression expr, string varName, ILAstExpression valueExpr)
+    {
+        for (int i = 0; i < expr.Arguments.Count; i++)
+        {
+            if (IsLoadOf(expr.Arguments[i], varName))
+            {
+                expr.Arguments[i] = valueExpr;
+                return true;
+            }
+            if (ReplaceInExpr(expr.Arguments[i], varName, valueExpr))
+                return true;
+        }
+        return false;
+    }
+
+    static bool IsLoadOf(ILAstExpression expr, string varName)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc)
+        {
+            string? name = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
+            return name == varName;
+        }
+        return false;
+    }
+
+    static bool IsStoreToVar(ILAstNode node, string varName)
+    {
+        if (node is ILAstStatement { Expression: var expr }
+            && expr.OpCode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2
+               or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc)
+        {
+            string? name = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
+            return name == varName;
+        }
+        return false;
+    }
+
+    static bool ExprReferencesVar(ILAstExpression expr, string varName)
+    {
+        if (IsLoadOf(expr, varName))
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (ExprReferencesVar(arg, varName))
+                return true;
+        return false;
+    }
+
+    static bool IsSideEffecting(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj or ILOpCode.Calli)
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (IsSideEffecting(arg))
+                return true;
+        return false;
+    }
+
+    static string? GetLocalNameFromOp(ILOpCode op) => op switch
+    {
+        ILOpCode.Stloc_0 or ILOpCode.Ldloc_0 => "V_0",
+        ILOpCode.Stloc_1 or ILOpCode.Ldloc_1 => "V_1",
+        ILOpCode.Stloc_2 or ILOpCode.Ldloc_2 => "V_2",
+        ILOpCode.Stloc_3 or ILOpCode.Ldloc_3 => "V_3",
+        _ => null
+    };
+}


### PR DESCRIPTION
## Summary

Six improvements to the C# decompiler for more realistic high-level output.

### Changes

1. **Expression inlining** (`ExpressionInliner.cs`) — eliminates single-use temporary variables by inlining their definitions at the use site. Within-block and cross-block passes. Preserves using/foreach patterns by skipping side-effecting expressions.

2. **Nop suppression** — suppresses `/* nop */` comments from debug builds.

3. **Boolean condition cleanup** — `ceq(clt(value, 0), 0)` → `value >= 0` instead of `(value < 0) == 0`. Fixes `TryEmitInlinedReturn` to propagate bool context for `true`/`false` literal emission.

4. **Short-circuit &&/|| detection** — recognizes IL patterns for `&&` and `||` and emits clean short-circuit expressions with synthetic variable substitution.

5. **Ternary substitution** — stores ternary/short-circuit results in a substitution dictionary instead of emitting `S_in_0` assignments. Cleans up leftover labels from consumed blocks.

6. **Store-return peephole** — folds `V_x = expr; return V_x;` into `return expr;` at emission time.

### Before / After examples

| Method | Before | After |
|--------|--------|-------|
| BoolAnd | `if (x > 0) { goto IL_000C; S_0 = y > 0; } S_0 = 0; IL_000C: V_0 = S_in_0; return V_0;` | `return x > 0 && y > 0;` |
| IsPositiveOrZero | `V_0 = (value < 0) == 0; return V_0;` | `return value >= 0;` |
| AlwaysTrue | `V_0 = true; return V_0;` | `return true;` |
| LoopSum | `V_2 = V_1 < n; while (V_2 != 0) { ... }` | `for (; V_1 < n; ...) { ... }` |

### Test results

- 162 total, 3 pre-existing failures (unchanged), 0 regressions
- **5 previously-failing tests now pass**: WhileLoop, NestedLoops, LoopSum, BoolLiteral_AlwaysTrue, BoolLiteral_AlwaysFalse