### PR TITLE
Add -m/--member option to source command

### DIFF
--- a/src/DotnetInspector.Services/GenericTypeNameConverter.cs
+++ b/src/DotnetInspector.Services/GenericTypeNameConverter.cs
@@ -21,7 +21,8 @@ public static class GenericTypeNameConverter
         string typeParamSection = typeName[(angleBracketStart + 1)..angleBracketEnd];
         int arity = CountTypeParameters(typeParamSection);
 
-        return $"{baseName}`{arity}";
+        string suffix = angleBracketEnd + 1 < typeName.Length ? typeName[(angleBracketEnd + 1)..] : "";
+        return $"{baseName}`{arity}{suffix}";
     }
 
     private static int CountTypeParameters(string typeParams)

--- a/src/dotnet-inspect/CommandLine/Commands/SourceCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SourceCommandDefinitions.cs
@@ -29,6 +29,8 @@ public static class SourceCommandDefinitions
         var frameworkOption = new Option<string?>("--framework") { Description = "Source: platform framework (runtime, aspnetcore, netstandard). @version for specific" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Source: select by TFM (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include hidden (EditorBrowsable.Never) and obsolete types" };
+        var memberOption = new Option<string?>("-m") { Description = "Member name to resolve (e.g., Clear, TryGetValue:2 for overload)" };
+        memberOption.Aliases.Add("--member");
         var typeFilterOption = new Option<string?>("-t") { Description = "Filter types by glob pattern (e.g., *Json*, Progress*)" };
         typeFilterOption.Aliases.Add("--type");
         var verifyOption = new Option<bool>("--verify") { Description = "Verify SourceLink URLs are accessible (HTTP HEAD)" };
@@ -45,6 +47,7 @@ public static class SourceCommandDefinitions
         sourceCommand.Options.Add(frameworkOption);
         sourceCommand.Options.Add(tfmOption);
         sourceCommand.Options.Add(allOption);
+        sourceCommand.Options.Add(memberOption);
         sourceCommand.Options.Add(typeFilterOption);
         sourceCommand.Options.Add(verifyOption);
         sourceCommand.Options.Add(auditOption);
@@ -61,7 +64,7 @@ public static class SourceCommandDefinitions
 
         var commandArgs = new SourceOptionsParser.SourceCommandArgs(
             argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
-            allOption, typeFilterOption, verifyOption, auditOption, browsableUrlsOption,
+            allOption, memberOption, typeFilterOption, verifyOption, auditOption, browsableUrlsOption,
             compactOption, oneLineOption, noHeaderOption);
 
         sourceCommand.SetAction(async (parseResult, ct) =>

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -22,6 +22,7 @@ public static class SourceOptionsParser
         Option<string?> FrameworkOption,
         Option<string?> TfmOption,
         Option<bool> AllOption,
+        Option<string?> MemberOption,
         Option<string?> TypeFilterOption,
         Option<bool> VerifyOption,
         Option<bool> AuditOption,
@@ -96,42 +97,44 @@ public static class SourceOptionsParser
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);
 
-        // Capture member name from extra positional args (after package + type)
-        // Pattern: source <package> <type> <member>  or  source <type> --package <pkg> <member>
-        string? memberName = null;
+        // Capture member name: -m/--member option, positional args, or Type.Member dot syntax
+        string? memberName = parseResult.GetValue(args.MemberOption);
         int? overloadIndex = null;
         {
-            var positionalMembers = new List<string>();
-            if (hasExplicitSource && argsValue.Length >= 2)
-                positionalMembers.AddRange(argsValue[1..]);
-            else if (!hasExplicitSource && argsValue.Length >= 3)
-                positionalMembers.AddRange(argsValue[2..]);
-
-            // Handle Type.Member dotted syntax
-            var typeName = source.TypeName;
-            if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
+            // Fall back to positional or dot syntax if -m not specified
+            if (memberName == null)
             {
-                var lastDot = typeName.LastIndexOf('.');
-                var rightPart = typeName[(lastDot + 1)..];
-                if (!rightPart.Contains('<'))
+                var positionalMembers = new List<string>();
+                if (hasExplicitSource && argsValue.Length >= 2)
+                    positionalMembers.AddRange(argsValue[1..]);
+                else if (!hasExplicitSource && argsValue.Length >= 3)
+                    positionalMembers.AddRange(argsValue[2..]);
+
+                // Handle Type.Member dotted syntax
+                var typeName = source.TypeName;
+                if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
                 {
-                    positionalMembers.Add(rightPart);
-                    source = source with { TypeName = typeName[..lastDot] };
+                    var lastDot = typeName.LastIndexOf('.');
+                    var rightPart = typeName[(lastDot + 1)..];
+                    if (!rightPart.Contains('<'))
+                    {
+                        positionalMembers.Add(rightPart);
+                        source = source with { TypeName = typeName[..lastDot] };
+                    }
                 }
+
+                if (positionalMembers.Count > 0)
+                    memberName = positionalMembers[0];
             }
 
-            if (positionalMembers.Count > 0)
+            // Parse overload index shorthand: GetValue:2
+            if (memberName != null && memberName.Contains(':'))
             {
-                memberName = positionalMembers[0];
-                // Parse overload index shorthand: GetValue:2
-                if (memberName.Contains(':'))
+                var colonIdx = memberName.LastIndexOf(':');
+                if (int.TryParse(memberName[(colonIdx + 1)..], out var idx))
                 {
-                    var colonIdx = memberName.LastIndexOf(':');
-                    if (int.TryParse(memberName[(colonIdx + 1)..], out var idx))
-                    {
-                        overloadIndex = idx;
-                        memberName = memberName[..colonIdx];
-                    }
+                    overloadIndex = idx;
+                    memberName = memberName[..colonIdx];
                 }
             }
         }

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.6.6</VersionPrefix>
+    <VersionPrefix>0.6.7</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Add `-m`/`--member` flag to the `source` command for unambiguous member-level source resolution
- Fix `GenericTypeNameConverter` dropping suffixes after `>` — `Dictionary<K,V>.Clear` was converted to `Dictionary`2` instead of `Dictionary`2.Clear`, losing the member name for dot notation
- Bump version to 0.6.7

**Before:**
```
$ source 'Dictionary<K,V>' Clear        # Error: Package 'Dictionary`2' not found.
$ source 'Dictionary<K,V>.Clear'        # URL without line numbers
```

**After:**
```
$ source 'Dictionary<K,V>' -m Clear     # URL with line numbers (#L282-L295)
$ source 'Dictionary<K,V>.Clear'        # URL with line numbers (#L282-L295)
$ source 'Dictionary<K,V>' -m TryGetValue:2  # overload index works
```

## Test plan

- [x] `source 'Dictionary<K,V>' -m Clear` — line-level URL
- [x] `source 'Dictionary<K,V>.Clear'` — line-level URL (dot notation fixed)
- [x] `source 'Dictionary<K,V>' --member Remove` — long form works
- [x] `source 'Dictionary<K,V>' -m 'TryGetValue:0'` — overload index works
- [x] `source 'Dictionary<K,V>' --platform System.Collections -m Clear` — explicit source + member
- [x] `source 'Dictionary<K,V>'` — bare type still works (no line numbers, as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)