### PR TITLE
Use XDG-appropriate cache directories per platform

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -42,13 +42,47 @@ public static class CoreCache
 
     /// <summary>
     /// Gets the default (non-overridden) base path for caches.
-    /// Always returns the platform-default local application data directory,
-    /// ignoring any base path override.
+    /// Uses XDG-appropriate directories per platform:
+    /// Linux: <c>$XDG_CACHE_HOME/appName</c> (defaults to <c>~/.cache/appName</c>),
+    /// macOS: <c>~/Library/Caches/appName</c>,
+    /// Windows: <c>%LOCALAPPDATA%\appName</c>.
     /// </summary>
     public static string GetDefaultBasePath()
     {
+        if (OperatingSystem.IsLinux())
+        {
+            var xdgCache = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+            if (!string.IsNullOrEmpty(xdgCache))
+                return Path.Combine(xdgCache, AppName);
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, ".cache", AppName);
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, "Library", "Caches", AppName);
+        }
+
+        // Windows: %LOCALAPPDATA%
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return Path.Combine(localAppData, AppName);
+    }
+
+    /// <summary>
+    /// Returns the pre-XDG cache path (<c>~/.local/share/appName</c>) on Linux/macOS
+    /// if it differs from the current default path, or <c>null</c> on Windows.
+    /// Used by cache-clear to clean up the old location.
+    /// </summary>
+    public static string? GetLegacyBasePath()
+    {
+        if (OperatingSystem.IsWindows())
+            return null;
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var legacyPath = Path.Combine(localAppData, AppName);
+
+        return legacyPath != GetDefaultBasePath() ? legacyPath : null;
     }
 
     /// <summary>

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -4,7 +4,7 @@ namespace DotnetInspector.Packages;
 
 /// <summary>
 /// Utilities for working with NuGet package caches.
-/// Uses cross-platform paths via Environment.SpecialFolder.
+/// Uses platform-appropriate cache directories (XDG on Linux, ~/Library/Caches on macOS).
 /// Never writes to ~/.nuget/packages (read-only).
 /// Call <see cref="Initialize"/> before using app cache methods.
 /// Source content caching is delegated to <see cref="CoreCache"/>.

--- a/src/DotnetInspector.Services/PackageCacheService.cs
+++ b/src/DotnetInspector.Services/PackageCacheService.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services;
@@ -47,17 +48,30 @@ public static class PackageCacheService
 
     /// <summary>
     /// Clears the active app cache (session cache if isolated, default otherwise).
+    /// Also clears the legacy cache location (pre-XDG) if it exists.
     /// Returns the number of bytes freed.
     /// </summary>
     public static long ClearCache()
     {
-        var basePath = NuGetCache.GetAppCacheBasePath();
+        long totalFreed = 0;
 
-        if (!Directory.Exists(basePath))
+        totalFreed += DeleteCacheDirectory(NuGetCache.GetAppCacheBasePath());
+
+        // Clean up legacy cache location (pre-XDG: ~/.local/share/dotnet-inspect)
+        var legacyPath = CoreCache.GetLegacyBasePath();
+        if (legacyPath != null)
+            totalFreed += DeleteCacheDirectory(legacyPath);
+
+        return totalFreed;
+    }
+
+    private static long DeleteCacheDirectory(string path)
+    {
+        if (!Directory.Exists(path))
             return 0;
 
-        var (size, _) = GetDirectoryStats(basePath);
-        Directory.Delete(basePath, recursive: true);
+        var (size, _) = GetDirectoryStats(path);
+        Directory.Delete(path, recursive: true);
         return size;
     }
 

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -6,7 +6,7 @@ namespace DotnetInspector.Services;
 /// <summary>
 /// Downloads and caches .NET platform ref/runtime packs from NuGet.
 /// Packs are cached in the app cache directory mirroring the SDK packs layout:
-/// ~/.local/share/dotnet-inspect/packs/{PackName}/{Version}/ref/net{TFM}/*.dll
+/// {cache}/dotnet-inspect/packs/{PackName}/{Version}/ref/net{TFM}/*.dll
 /// </summary>
 public static class PlatformPackService
 {


### PR DESCRIPTION
## Summary

- **Linux**: cache moves from `~/.local/share/dotnet-inspect` to `~/.cache/dotnet-inspect` (respects `XDG_CACHE_HOME`)
- **macOS**: cache moves from `~/.local/share/dotnet-inspect` to `~/Library/Caches/dotnet-inspect`
- **Windows**: unchanged (`%LOCALAPPDATA%`)
- **Cache clear** also deletes the legacy `~/.local/share/dotnet-inspect` directory to avoid leaking data on existing installations
- `DOTNET_INSPECT_CACHE_DIR` override still works and takes precedence

## Test plan

- [x] 639 CLI tests pass, 143 services tests pass (1 pre-existing failure unrelated)
- [x] Verified default path resolves to `~/.cache/dotnet-inspect` on Linux
- [x] Verified `XDG_CACHE_HOME` override is respected
- [x] Verified legacy path is reported for cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)