### PR TITLE
Change default output format from oneline to markdown

### DIFF
--- a/src/dotnet-inspect/Options/OutputFormat.cs
+++ b/src/dotnet-inspect/Options/OutputFormat.cs
@@ -57,7 +57,7 @@ public static class OutputFormatResolver
             return envFormat;
 
         // Default
-        return OutputFormat.OneLine;
+        return OutputFormat.Markdown;
     }
 
     /// <summary>


### PR DESCRIPTION
Changes the default output format from `OneLine` to `Markdown` in `OutputFormatResolver.Resolve()`.

This is a single-line change to the fallback in the centralized format resolver. All commands flow through this resolver, so the change applies globally.

**Overrides still work as before:**
- `--oneline` flag
- `--json`, `--markdown`, `--plaintext` flags
- `-v` (any verbosity level)
- `DOTNET_INSPECT_FORMAT` environment variable

Tree defaults are unchanged.