### PR TITLE
Update docs for v0.7.0 markdown-default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ dnx dotnet-inspect -y -- <command>
 | `implements X` | Find types implementing an interface or extending a class |
 | `find X` | Search for types across packages, frameworks, and local assets |
 | `source X` | SourceLink URLs — type or member level, `--cat` to fetch content |
-| `platform` | List installed frameworks |
 
 ### Bare Names
 
@@ -38,6 +37,7 @@ A bare name like `dotnet-inspect System.Text.Json` uses a router to pick the bes
 | Flag | Description |
 | ------ | ------------- |
 | `-v:q/m/n/d` | Verbosity: quiet, minimal (default), normal, detailed |
+| `--oneline` | Compact columnar output, one result per line |
 | `--platform` | Search all platform frameworks (find, extensions, implements) |
 | `--json` | JSON output |
 | `-s Name` | Include section (glob-capable: `-s Ext*`) |
@@ -160,7 +160,7 @@ dotnet-inspect diff System.CommandLine@2.0.0-beta4.22272.1..2.0.3 -v:q  # Full p
 dotnet-inspect diff JsonSerializer --package System.Text.Json@9.0.0..10.0.2  # Single type
 dotnet-inspect diff "*Writer*" --package Markout@0.1.8..0.2.0            # Glob filter
 dotnet-inspect diff --platform System.Text.Json@8.0.23..10.0.2           # Platform versions
-dotnet-inspect diff System.Text.Json@9.0.0..10.0.2 --oneline            # One change per line
+dotnet-inspect diff System.Text.Json@9.0.0..10.0.2 --oneline            # Compact columnar output
 dotnet-inspect diff System.Text.Json@9.0.0..10.0.2 --breaking           # Breaking only
 ```
 
@@ -172,7 +172,7 @@ Search for types across packages, frameworks, and local assets.
 dotnet-inspect find HttpClient                           # Runtime (default scope)
 dotnet-inspect find "*Stream*" -n 10                     # Glob, limit results
 dotnet-inspect find "*Json*" --package System.Text.Json  # Search in package
-dotnet-inspect find "ChatClient*" --oneline                # Columnar output
+dotnet-inspect find "ChatClient*" --oneline                # Compact columnar output
 dotnet-inspect find ILogger --aspnetcore                 # ASP.NET Core packages
 dotnet-inspect find "*Command*" --project ./MyApp.csproj # Project dependencies
 ```
@@ -197,16 +197,6 @@ Find types implementing an interface or extending a base class.
 dotnet-inspect implements Stream                             # Default scope
 dotnet-inspect implements IDisposable --platform             # All platform frameworks
 dotnet-inspect implements IJsonTypeInfoResolver --package System.Text.Json
-```
-
-### platform
-
-List installed frameworks.
-
-```bash
-dotnet-inspect platform                             # List frameworks
-dotnet-inspect platform --framework runtime         # List runtime libraries
-dotnet-inspect platform --list-versions             # Installed SDK versions
 ```
 
 ### source
@@ -238,13 +228,9 @@ dotnet-inspect -v:q                                 # Command names only (onelin
 
 ## Output Control
 
-**Verbosity** (`-v`): q(uiet) → m(inimal) → n(ormal) → d(etailed)
+**Format**: Default is **markdown** (headings, tables, field lists). Use `--oneline` for compact columnar output, `--plaintext` for plain text, or `--json` for JSON.
 
-Each level includes a **compact summary line** with key metadata:
-
-```text
-Version: 8.0.0 | Type: Library | TFM: net8.0 | Updated: 2023-11-14 | Vulnerabilities: 2
-```
+**Verbosity** (`-v`): q(uiet) → m(inimal) → n(ormal) → d(etailed). Controls which sections are included.
 
 **Sections**: Use `-s Name` to include or `-x Name` to exclude sections by name. Bare `-s` lists available sections. Supports glob patterns (`-s Ext*`).
 

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -38,7 +38,8 @@
 | `-x` section exclusion | 9a9f154 | 0.2.x | Exclude sections by name |
 | `--compact` JSON | e7297bb | 0.1.0 | Minified JSON output |
 | `--json` output | e7297bb | 0.1.0 | JSON output format |
-| `--oneline` output | — | 0.1.x | One result per line, columnar |
+| `--oneline` output | — | 0.1.x | One result per line, columnar (opt-in since 0.7.0) |
+| Markdown default | 2c6e9e0 | 0.7.0 | Markdown is the default output format |
 | `--no-header` | — | 0.2.x | Suppress column headers |
 | `--signatures-only` | d718525 | 0.1.3 | Minimal output with signatures only |
 | `--out` file output | 627a0a0 | 0.2.x | Write output to file |
@@ -281,3 +282,4 @@ The `--fields-only` flag was replaced by section filtering:
 | 0.3.1 | — | Name:N shorthand for member targeting |
 | 0.4.0 | — | `demo`, `depends` commands, removed `platform` command |
 | 0.5.0 | — | Split `api` into `type`/`member`, nullability, `@latest`, `-n`/`-t`/`-m` redesign |
+| 0.7.0 | — | Markdown default output, removed `llmstxt` command, removed `dotnet-inspect-find`, NuGetFetch library, XDG cache dirs |

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -13,9 +13,9 @@ Verbosity levels:
 
 | Level | Flag | Content | Tips |
 | ----- | ---- | ------- | ---- |
-| Quiet | `-v:q` | H1 + oneline field list | No |
-| Minimal (default) | (none) | H1, description, oneline field list, one section table | Yes |
-| Detailed | `-v:d` | H1, description, oneline field list, all sections | No |
+| Quiet | `-v:q` | H1 + metadata field list | No |
+| Minimal (default) | (none) | H1, description, metadata field list, one section table | Yes |
+| Detailed | `-v:d` | H1, description, metadata field list, all sections | No |
 
 The `member` command follows the same scale: quiet shows the heading-only summary, default shows full signatures with docs, detailed adds Source/Lowered C#/IL.
 
@@ -53,9 +53,9 @@ dotnet-inspect System.CommandLine
 
 ```expect
 # System.CommandLine
-Version: 2.0.3
+Version: 2.0.2
 ## Package
-| Property | Value |
+| Field | Value |
 ```
 
 ```query
@@ -70,7 +70,7 @@ Tips:
 
 ## 2. Default verbosity (platform library)
 
-> Goal: Platform library default shows H1, oneline fields, Library Info section table, and no tips.
+> Goal: Platform library default shows H1, metadata fields, Library Info section table, and no tips.
 
 ```prompt
 Tell me about the System.Text.Json library.
@@ -82,14 +82,12 @@ dotnet-inspect System.Text.Json
 
 ```expect
 # System.Text.Json.dll
-Source: Platform
 ## Library Info
-| Property | Value |
+| Field | Value |
 ```
 
 ```query
 grep '^# '
-grep -o 'Source: [A-Za-z]*'
 grep '^## '
 ```
 
@@ -107,7 +105,7 @@ dotnet-inspect System.CommandLine -v:q
 
 ```expect
 # System.CommandLine
-Version: 2.0.3
+Version: 2.0.2
 ```
 
 ```expect-not
@@ -267,7 +265,7 @@ dotnet-inspect System.CommandLine -s Package
 
 ```expect
 ## Package
-| Property | Value |
+| Field | Value |
 ```
 
 ```expect-not
@@ -277,7 +275,7 @@ Tips:
 
 ```query
 grep '^## '
-grep '| Property'
+grep '| Field'
 ```
 
 ### 8b. Platform library section

--- a/docs/workflows/output/cli-introspection.md
+++ b/docs/workflows/output/cli-introspection.md
@@ -32,7 +32,7 @@ dotnet-inspect -v:n
 ├─ library
 ├─ member
 ├─ package
-├─ samples
+├─ source
 └─ type
 ```
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.6.9
+version: 0.7.0
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 
@@ -46,7 +46,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 
 ## Key Patterns
 
-Default output is compact columnar tables (like `docker images` or `git log --oneline`). No flags needed for scanning:
+Default output is **markdown** — headings, tables, and field lists that render well in terminals, editors, and LLM contexts. No flags needed:
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json    # scan members
@@ -54,12 +54,12 @@ dnx dotnet-inspect -y -- type --package System.Text.Json                     # s
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # triage changes
 ```
 
-Four formatters: **oneline** (default), **plaintext**, **markdown** (`-v` or `--markdown`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
+Four formatters: **markdown** (default), **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
 
 ```bash
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:m  # markdown with docs
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:d  # detailed (source/IL)
 dnx dotnet-inspect -y -- System.Text.Json -v:n --plaintext                      # all local sections, plaintext
+dnx dotnet-inspect -y -- type --package System.Text.Json --oneline              # compact columnar output
 ```
 
 Use `diff` first when fixing broken code — triage changes, then drill into specifics:


### PR DESCRIPTION
## Summary

- **README.md**: Remove stale `platform` command section, add `--oneline` to Common Flags, update Output Control to reflect markdown as default format
- **SKILL.md**: Bump version to 0.7.0, update Key Patterns to describe markdown as default with `--oneline` as opt-in
- **Workflow docs**: Fix `| Property | Value |` → `| Field | Value |`, update System.CommandLine version (2.0.3 → 2.0.2), fix `samples` → `source` in CLI introspection, add 0.7.0 to feature history

## Test plan

- [x] Verbosity workflow scenarios: 10/10 pass
- [x] Oneline workflow scenarios: 9/9 pass
- [x] Bare-name routing + type query spot checks: 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)