### PR TITLE
Bump NuGetFetch to 0.2.0

### DIFF
--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
-    <PackageReference Include="NuGetFetch" Version="0.1.0" />
+    <PackageReference Include="NuGetFetch" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -7,6 +7,7 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using NuGetFetch;
 using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
+using SignatureVerificationResult = DotnetInspector.Services.SignatureVerificationResult;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;


### PR DESCRIPTION
Updates NuGetFetch PackageReference from 0.1.0 to 0.2.0.

Adds a using alias for `SignatureVerificationResult` in AssemblyCommand.cs to resolve ambiguity with the new `NuGetFetch.SignatureVerificationResult` type added in 0.2.0.