### PR TITLE
Update NuGetFetch to 0.5.0

### DIFF
--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
-    <PackageReference Include="NuGetFetch" Version="0.4.0" />
+    <PackageReference Include="NuGetFetch" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps NuGetFetch from 0.4.0 to 0.5.0.

### What's in 0.5.0
- **Security**: zip-slip defense-in-depth, signature content hash, IsNuGetOrg host validation, credential masking
- **Protocol**: version normalization, config merge order, TFM cross-family compatibility
- **Reliability**: service index caching, atomic cache writes, auth for version resolution

No API changes required — all new parameters are optional with defaults matching 0.4.0 behavior.