### PR TITLE
Simplify install.sh to use dotnet-install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,21 @@
 #!/bin/bash
-# Packs and installs dotnet-inspect as a global tool from local source.
+# Installs dotnet-inspect from local source using dotnet-install.
 # Usage: ./install.sh
+#
+# Installs dotnet-install as a global tool if not already available,
+# then uses it to build and install dotnet-inspect to ~/.dotnet/bin/.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT="$SCRIPT_DIR/src/dotnet-inspect/dotnet-inspect.csproj"
-PACK_OUTPUT="$SCRIPT_DIR/artifacts/packages"
 
 echo "=== Installing dotnet-inspect from source ==="
 
-# Uninstall if already installed
-if dotnet tool list -g | grep -q dotnet-inspect; then
-    echo "Uninstalling existing dotnet-inspect..."
-    dotnet tool uninstall -g dotnet-inspect
+# Ensure dotnet-install is available
+if ! command -v dotnet-install &> /dev/null; then
+    echo "Installing dotnet-install global tool..."
+    dotnet tool install -g dotnet-install
 fi
 
-# Clean previous packages
-rm -rf "$PACK_OUTPUT"
-
-# Pack
-echo "Packing..."
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -p:OfficialBuild=true -bl:"$PACK_OUTPUT/pack.binlog"
-dotnet pack "$PROJECT" -o "$PACK_OUTPUT" -p:OfficialAotBuild=true --ucr -bl:"$PACK_OUTPUT/pack-ucr.binlog"
-
-# Install from local packages
-echo "Installing..."
-dotnet tool install -g dotnet-inspect --add-source "$PACK_OUTPUT"
-
-echo ""
-echo "Done. Run 'dotnet-inspect --version' to verify."
+# Install dotnet-inspect from local source
+dotnet-install "$SCRIPT_DIR/src/dotnet-inspect"


### PR DESCRIPTION
Replaces the 33-line pack + global tool install flow with a simple `dotnet-install` call:

```bash
dotnet-install src/dotnet-inspect
```

The script installs `dotnet-install` as a global tool if not already available, then uses it to build and install dotnet-inspect from local source to `~/.dotnet/bin/`.