### PR TITLE
Update install.sh to match dotnet-install conventions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,31 @@
-#!/bin/bash
+#!/bin/sh
 # Installs dotnet-inspect from local source using dotnet-install.
 # Usage: ./install.sh
 #
-# Installs dotnet-install as a global tool if not already available,
-# then uses it to build and install dotnet-inspect to ~/.dotnet/bin/.
+# Uses an existing dotnet-install (if available) or installs it as a
+# temporary global tool, then builds dotnet-inspect from the local
+# source tree into ~/.dotnet/bin/.
 
-set -e
+set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "=== Installing dotnet-inspect from source ==="
 
-# Ensure dotnet-install is available
-if ! command -v dotnet-install &> /dev/null; then
+_used_global_tool=no
+
+# Use existing dotnet-install if available; otherwise install the global tool temporarily
+if ! command -v dotnet-install > /dev/null 2>&1; then
     echo "Installing dotnet-install global tool..."
     dotnet tool install -g dotnet-install
+    _used_global_tool=yes
 fi
 
 # Install dotnet-inspect from local source
 dotnet-install "$SCRIPT_DIR/src/dotnet-inspect"
+
+# Remove the temporary global tool if we installed it
+if [ "$_used_global_tool" = "yes" ]; then
+    echo "Removing temporary global tool..."
+    dotnet tool uninstall -g dotnet-install
+fi


### PR DESCRIPTION
Aligns install.sh with the pattern from dotnet-install:

- Use `/bin/sh` instead of `/bin/bash` for portability
- Use POSIX-compatible command checks (no bash-specific `&>`)
- Clean up the temporary dotnet-install global tool after use
- Use `set -eu` for stricter error handling