### PR TITLE
Change release environment to nuget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
-    environment: nuget-publish
+    environment: nuget
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     


### PR DESCRIPTION
Renames the release workflow environment from `nuget-publish` to `nuget`.