### PR TITLE
Multi-target net10.0;net11.0 for NuGet compatibility

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.7.2</VersionPrefix>
+    <VersionPrefix>0.7.3</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Same pattern as richlander/dotnet-install#63: multi-target the exe csproj so the pointer package has `tools/net10.0/any/` (installable on .NET 10 SDK). AOT packs use net11.0 for runtime-async.

Changes:
- `dotnet-inspect.csproj`: `TargetFrameworks=net10.0;net11.0`
- `src/Directory.Build.props`: Remove `DefaultTargetFramework` override from `OfficialAotBuild`
- CI: Pointer/any pack with `-p:TargetFrameworks=net10.0`, AOT packs with `-p:TargetFrameworks=net11.0`
- Version bump to 0.7.3