### PR TITLE
Add --mermaid flag for diagram output in depends command

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
-    <PackageVersion Include="Markout" Version="0.11.0" />
+    <PackageVersion Include="Markout" Version="0.12.0" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.1" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -374,6 +374,8 @@ public static class SearchCommandDefinitions
         dependsCommand.Options.Add(tfmOption);
         dependsCommand.Options.Add(opts.Json);
         dependsCommand.Options.Add(compactOption);
+        dependsCommand.Options.Add(opts.Mermaid);
+        dependsCommand.Options.Add(opts.Markdown);
         opts.AddOutputOptionsTo(dependsCommand);
         opts.AddNuGetOptionsTo(dependsCommand);
 
@@ -391,6 +393,8 @@ public static class SearchCommandDefinitions
                     Tfm = parseResult.GetValue(tfmOption),
                     JsonOutput = parseResult.GetValue(opts.Json),
                     CompactJson = parseResult.GetValue(compactOption),
+                    MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
+                    EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
                     Verbose = parseResult.GetValue(opts.Verbose),
                     SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
                 };
@@ -424,6 +428,8 @@ public static class SearchCommandDefinitions
                 Tfm = parseResult.GetValue(tfmOption),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 CompactJson = parseResult.GetValue(compactOption),
+                MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
+                EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
                 Verbose = parseResult.GetValue(opts.Verbose),
                 SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
             };
@@ -439,6 +445,8 @@ public static class SearchCommandDefinitions
                     Tfm = parseResult.GetValue(tfmOption),
                     JsonOutput = parseResult.GetValue(opts.Json),
                     CompactJson = parseResult.GetValue(compactOption),
+                    MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
+                    EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
                     Verbose = parseResult.GetValue(opts.Verbose),
                     SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
                 };

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -7,6 +7,7 @@ using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
+using Markout.Formatting;
 
 namespace DotnetInspector.Commands;
 
@@ -68,12 +69,25 @@ public class DependsCommand
             else
             {
                 var rootName = options.TargetType.Contains('<') ? options.TargetType : result.MatchedType!;
-                var view = new PackageDependenciesView
+                var treeNodes = ToTreeNodes(result.Tree);
+
+                if (options.MermaidOutput)
                 {
-                    Title = rootName,
-                    Dependencies = ToTreeNodes(result.Tree)
-                };
-                MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                    WriteMermaidTree(rootName, treeNodes);
+                }
+                else if (options.EmbeddedMermaid)
+                {
+                    WriteEmbeddedMermaidTree(rootName, treeNodes);
+                }
+                else
+                {
+                    var view = new PackageDependenciesView
+                    {
+                        Title = rootName,
+                        Dependencies = treeNodes
+                    };
+                    MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                }
             }
 
             return 0;
@@ -159,12 +173,23 @@ public class DependsCommand
 
             var treeNodes = BuildNestedDependencyTree(refNodes);
 
-            var view = new PackageDependenciesView
+            if (options.MermaidOutput)
             {
-                Title = assemblyName,
-                Dependencies = treeNodes
-            };
-            MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                WriteMermaidTree(assemblyName, treeNodes);
+            }
+            else if (options.EmbeddedMermaid)
+            {
+                WriteEmbeddedMermaidTree(assemblyName, treeNodes);
+            }
+            else
+            {
+                var view = new PackageDependenciesView
+                {
+                    Title = assemblyName,
+                    Dependencies = treeNodes
+                };
+                MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+            }
             return 0;
         }
         catch (Exception ex)
@@ -253,12 +278,26 @@ public class DependsCommand
             var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(
                 context.HttpClient, group.Dependencies, tfm, globalSeen, logger.Log);
 
-            var view = new PackageDependenciesView
+            var title = $"{packageName} ({version})";
+            var treeNodes = ToDependencyTreeNodes(depNodes);
+
+            if (options.MermaidOutput)
             {
-                Title = $"{packageName} ({version})",
-                Dependencies = ToDependencyTreeNodes(depNodes)
-            };
-            MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                WriteMermaidTree(title, treeNodes);
+            }
+            else if (options.EmbeddedMermaid)
+            {
+                WriteEmbeddedMermaidTree(title, treeNodes);
+            }
+            else
+            {
+                var view = new PackageDependenciesView
+                {
+                    Title = title,
+                    Dependencies = treeNodes
+                };
+                MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+            }
             return 0;
         }
         catch (Exception ex)
@@ -323,5 +362,37 @@ public class DependsCommand
 
             target.Add(children.Count > 0 ? new TreeNode(label) { Children = children } : new TreeNode(label));
         }
+    }
+
+    /// <summary>
+    /// Writes standalone mermaid output using the MermaidFormatter.
+    /// </summary>
+    private static void WriteMermaidTree(string title, List<TreeNode> treeNodes)
+    {
+        var writer = MarkoutWriter.Create(Console.Out, new MermaidFormatter());
+        writer.WriteHeading(1, title);
+        writer.WriteTree([.. treeNodes]);
+        writer.Flush();
+    }
+
+    /// <summary>
+    /// Writes mermaid embedded in a markdown document (```mermaid code block).
+    /// </summary>
+    private static void WriteEmbeddedMermaidTree(string title, List<TreeNode> treeNodes)
+    {
+        var mdWriter = MarkoutWriter.Create(Console.Out, new MarkdownFormatter());
+        mdWriter.WriteHeading(1, title);
+
+        // Render the mermaid content to a string
+        var mermaidWriter = MarkoutWriter.Create(new MermaidFormatter());
+        mermaidWriter.WriteTree([.. treeNodes]);
+        var mermaidContent = mermaidWriter.ToString();
+
+        mdWriter.WriteCodeStart("mermaid");
+        Console.Out.Write(mermaidContent);
+        if (!mermaidContent.EndsWith('\n'))
+            Console.Out.WriteLine();
+        mdWriter.WriteCodeEnd();
+        mdWriter.Flush();
     }
 }

--- a/src/dotnet-inspect/Options/DependsOptions.cs
+++ b/src/dotnet-inspect/Options/DependsOptions.cs
@@ -58,6 +58,16 @@ public record DependsOptions : IAssemblySourceOptions
     public bool CompactJson { get; init; }
 
     /// <summary>
+    /// Output as standalone Mermaid diagram.
+    /// </summary>
+    public bool MermaidOutput { get; init; }
+
+    /// <summary>
+    /// Embed mermaid diagrams in markdown output (--markdown --mermaid).
+    /// </summary>
+    public bool EmbeddedMermaid { get; init; }
+
+    /// <summary>
     /// Show progress messages on stderr.
     /// </summary>
     public bool Verbose { get; init; }

--- a/src/dotnet-inspect/Options/OutputFormat.cs
+++ b/src/dotnet-inspect/Options/OutputFormat.cs
@@ -24,7 +24,13 @@ public enum OutputFormat
     /// <summary>
     /// JSON output.
     /// </summary>
-    Json
+    Json,
+
+    /// <summary>
+    /// Standalone Mermaid diagram syntax (graph TD, classDiagram, etc.).
+    /// Only works for commands that produce graph/tree data.
+    /// </summary>
+    Mermaid
 }
 
 /// <summary>
@@ -40,11 +46,13 @@ public static class OutputFormatResolver
     /// Resolves format. Any -v flag implies Markdown. --json implies Json. --markdown implies Markdown.
     /// Commands may supply a <paramref name="defaultFormat"/> to override the global default (Markdown).
     /// </summary>
-    public static OutputFormat Resolve(bool jsonFlag, bool markdownFlag, Verbosity? verbosity, bool plainTextFlag = false, OutputFormat defaultFormat = OutputFormat.Markdown)
+    public static OutputFormat Resolve(bool jsonFlag, bool markdownFlag, Verbosity? verbosity, bool plainTextFlag = false, bool mermaidFlag = false, OutputFormat defaultFormat = OutputFormat.Markdown)
     {
         // Explicit CLI flags win
         if (jsonFlag)
             return OutputFormat.Json;
+        if (mermaidFlag && !markdownFlag)
+            return OutputFormat.Mermaid;
         if (markdownFlag)
             return OutputFormat.Markdown;
         if (plainTextFlag)
@@ -59,6 +67,13 @@ public static class OutputFormatResolver
         // Command-specific or global default
         return defaultFormat;
     }
+
+    /// <summary>
+    /// Returns true when --mermaid is combined with --markdown (embedded mermaid mode).
+    /// In this mode, the output is still markdown but tree/graph sections render as mermaid code blocks.
+    /// </summary>
+    public static bool IsEmbeddedMermaid(bool markdownFlag, bool mermaidFlag)
+        => markdownFlag && mermaidFlag;
 
     /// <summary>
     /// Warns when --oneline is combined with a verbosity that produces multiple sections
@@ -85,6 +100,7 @@ public static class OutputFormatResolver
                 "markdown" or "md" => OutputFormat.Markdown,
                 "plaintext" or "plain-text" or "plain" or "text" => OutputFormat.PlainText,
                 "json" => OutputFormat.Json,
+                "mermaid" => OutputFormat.Mermaid,
                 _ => null
             };
             _envParsed = true;

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -15,6 +15,7 @@ public class SharedOptions
     public Option<bool> Json { get; } = new("--json") { Description = "Output as JSON" };
     public Option<bool> Markdown { get; } = new("--markdown") { Description = "Output as markdown" };
     public Option<bool> PlainText { get; } = new("--plaintext") { Description = "Output as plain text" };
+    public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
 
     // Verbosity options
     public Option<bool> Verbose { get; } = new("--verbose") { Description = "Show progress messages on stderr" };
@@ -147,6 +148,7 @@ public class SharedOptions
         command.Options.Add(Json);
         command.Options.Add(Markdown);
         command.Options.Add(PlainText);
+        command.Options.Add(Mermaid);
         AddOutputOptionsTo(command);
         AddSectionOptionsTo(command);
         AddNuGetOptionsTo(command);
@@ -195,10 +197,17 @@ public class SharedOptions
         bool jsonFlag = parseResult.GetValue(Json);
         bool markdownFlag = parseResult.GetValue(Markdown);
         bool plainTextFlag = parseResult.GetValue(PlainText);
+        bool mermaidFlag = parseResult.GetValue(Mermaid);
         bool hasVerbosity = parseResult.GetResult(Verbosity) is { Implicit: false };
         Verbosity? verbosity = hasVerbosity ? ParseVerbosity(parseResult) : null;
-        return OutputFormatResolver.Resolve(jsonFlag, markdownFlag, verbosity, plainTextFlag, defaultFormat);
+        return OutputFormatResolver.Resolve(jsonFlag, markdownFlag, verbosity, plainTextFlag, mermaidFlag, defaultFormat);
     }
+
+    /// <summary>
+    /// Returns true when --mermaid is combined with --markdown (embedded mermaid in markdown).
+    /// </summary>
+    public bool IsEmbeddedMermaid(ParseResult parseResult)
+        => OutputFormatResolver.IsEmbeddedMermaid(parseResult.GetValue(Markdown), parseResult.GetValue(Mermaid));
 
     /// <summary>
     /// Resolves whether oneline output should be used, considering the --oneline flag and format resolution.
@@ -234,6 +243,7 @@ public class SharedOptions
         if (parseResult.GetResult(Json) is { Implicit: false }) return true;
         if (parseResult.GetResult(Markdown) is { Implicit: false }) return true;
         if (parseResult.GetResult(PlainText) is { Implicit: false }) return true;
+        if (parseResult.GetResult(Mermaid) is { Implicit: false }) return true;
         if (parseResult.GetResult(Verbosity) is { Implicit: false }) return true;
         return false;
     }


### PR DESCRIPTION
## Summary

Add `--mermaid` flag to the `depends` command, enabling Mermaid diagram output for type hierarchies, library references, and package dependencies.

### Two modes

| Flags | Output | Use case |
|-------|--------|----------|
| `--mermaid` | Standalone mermaid (`graph TD`) | Pipe to `mmdc`, embed in tooling |
| `--markdown --mermaid` | Mermaid fenced blocks inside markdown | Render in GitHub, VS Code, etc. |

### Examples

```bash
# Standalone mermaid
dotnet-inspect depends 'INumber<TSelf>' --mermaid

# Embedded in markdown
dotnet-inspect depends 'INumber<TSelf>' --markdown --mermaid

# Package dependencies as mermaid
dotnet-inspect depends --package System.Text.Json --mermaid
```

### Changes

- **OutputFormat.cs** — Added `Mermaid` enum value, `IsEmbeddedMermaid()` helper, env var support (`DOTNET_INSPECT_FORMAT=mermaid`)
- **SharedOptions.cs** — Added `--mermaid` CLI option, wired into format resolution
- **DependsOptions.cs** — Added `MermaidOutput` and `EmbeddedMermaid` properties
- **SearchCommandDefinitions.cs** — Wired flags into all 3 depends subcommands (type/library/package)
- **DependsCommand.cs** — Added `WriteMermaidTree()` and `WriteEmbeddedMermaidTree()` helpers, mermaid branches in all 3 Execute methods
- **Directory.Packages.props** — Updated Markout to 0.12.0 (adds `MermaidFormatter`)

### Dependencies

Requires [Markout 0.12.0](https://github.com/richlander/markout/pull/97) which adds `MermaidFormatter`.