### PR TITLE
Document --mermaid in SKILL.md and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ dnx dotnet-inspect -y -- <command>
 | `diff X` | Compare versions with breaking/additive classification |
 | `extensions X` | Find extension methods/properties for a type |
 | `implements X` | Find types implementing an interface or extending a class |
+| `depends X` | Walk dependency graphs — type hierarchy, package deps, library refs (`--mermaid` for diagrams) |
 | `find X` | Search for types across packages, frameworks, and local assets |
 | `source X` | SourceLink URLs — type or member level, `--cat` to fetch content |
 
@@ -40,6 +41,7 @@ A bare name like `dotnet-inspect System.Text.Json` uses a router to pick the bes
 | `--oneline` | Compact columnar output, one result per line |
 | `--platform` | Search all platform frameworks (find, extensions, implements) |
 | `--json` | JSON output |
+| `--mermaid` | Mermaid diagram output (`depends` command) |
 | `-s Name` | Include section (glob-capable: `-s Ext*`) |
 | `-x Name` | Exclude section |
 | `--shape` | Type shape diagram (hierarchy + members) — `type` command |
@@ -199,6 +201,20 @@ dotnet-inspect implements IDisposable --platform             # All platform fram
 dotnet-inspect implements IJsonTypeInfoResolver --package System.Text.Json
 ```
 
+### depends
+
+Walk dependency graphs — type hierarchy, library references, or package dependencies. Supports `--mermaid` for diagram output.
+
+```bash
+dotnet-inspect depends Stream                                    # Type hierarchy (markdown tree)
+dotnet-inspect depends 'INumber<TSelf>'                          # Deep interface hierarchy
+dotnet-inspect depends Command --package System.CommandLine       # NuGet package type
+dotnet-inspect depends --library System.Text.Json                # Assembly reference graph
+dotnet-inspect depends --package Markout                         # Package dependency graph
+dotnet-inspect depends Stream --mermaid                          # Standalone mermaid diagram
+dotnet-inspect depends Stream --markdown --mermaid               # Mermaid embedded in markdown
+```
+
 ### source
 
 SourceLink URLs for type source files. Supports member-level resolution with line numbers.
@@ -228,13 +244,15 @@ dotnet-inspect -v:q                                 # Command names only (onelin
 
 ## Output Control
 
-**Format**: Default is **markdown** (headings, tables, field lists). Use `--oneline` for compact columnar output, `--plaintext` for plain text, or `--json` for JSON.
+**Format**: Default is **markdown** (headings, tables, field lists). Use `--oneline` for compact columnar output, `--plaintext` for plain text, `--json` for JSON, or `--mermaid` for Mermaid diagrams.
 
 **Verbosity** (`-v`): q(uiet) → m(inimal) → n(ormal) → d(etailed). Controls which sections are included.
 
 **Sections**: Use `-s Name` to include or `-x Name` to exclude sections by name. Bare `-s` lists available sections. Supports glob patterns (`-s Ext*`).
 
 **JSON**: `--json` for full JSON, `--json --compact` for minified.
+
+**Mermaid**: `--mermaid` for standalone mermaid (`graph TD`), `--markdown --mermaid` for mermaid fenced blocks inside markdown. Currently supported on the `depends` command.
 
 ## LLM Integration
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.7.2
+version: 0.7.4
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 
@@ -23,6 +23,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **How many overloads?** → `member Type --package Foo --show-index` (shows `Name:N` indices)
 - **What does this package depend on?** → `depends --package Foo`
 - **What does this type inherit?** → `depends 'INumber<TSelf>'`
+- **Want a dependency diagram?** → `depends --mermaid` (standalone) or `depends --markdown --mermaid` (embedded)
 - **What metadata fields exist?** → `-S Section --fields "PDB*"` (structured query, no DSL)
 - **What version is available?** → `Foo --version` (cache-first), `Foo --latest-version` (always NuGet), `Foo --versions` (list all)
 
@@ -36,6 +37,7 @@ Query .NET library APIs — the same commands work across NuGet packages, platfo
 - **"What extends this type?"** — `extensions` finds extension methods/properties (`--reachable` for transitive)
 - **"What implements this interface?"** — `implements` finds concrete types
 - **"What does this type depend on?"** — `depends` walks type hierarchy, package deps, or library refs
+- **"Show dependencies as a diagram"** — `depends --mermaid` for standalone mermaid, `--markdown --mermaid` for embedded
 - **"Where is the source code?"** — `source` returns SourceLink URLs; add member name for line numbers
 - **"What version/metadata does this have?"** — `package` and `library` inspect metadata
 - **"What version is available?"** — `Foo --version` (fast, cache-first — like `docker run`)
@@ -56,12 +58,14 @@ dnx dotnet-inspect -y -- type --package System.Text.Json                     # s
 dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # triage changes
 ```
 
-Default format is **markdown** — no flags needed. Optional formats: **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
+Default format is **markdown** — no flags needed. Optional formats: **oneline** (`--oneline`), **plaintext** (`--plaintext`), **json** (`--json`), **mermaid** (`--mermaid`). Verbosity (`-v:q/m/n/d`) controls which sections are included; formatter controls how they render. They compose freely — except `--oneline` and `-v` cannot be combined.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:d  # detailed (source/IL)
 dnx dotnet-inspect -y -- System.Text.Json -v:n --plaintext                      # all local sections, plaintext
 dnx dotnet-inspect -y -- type --package System.Text.Json --oneline              # compact columnar output
+dnx dotnet-inspect -y -- depends Stream --mermaid                               # standalone mermaid diagram
+dnx dotnet-inspect -y -- depends Stream --markdown --mermaid                    # mermaid embedded in markdown
 ```
 
 Use `diff` first when fixing broken code — triage changes, then drill into specifics:
@@ -143,6 +147,22 @@ dnx dotnet-inspect -y -- library System.Text.Json -D --tree           # full sch
 dnx dotnet-inspect -y -- System.Text.Json -S Symbols                  # render one section
 dnx dotnet-inspect -y -- System.Text.Json -S Symbols --fields "PDB*"  # project specific fields
 dnx dotnet-inspect -y -- type System.Text.Json --columns Kind,Type    # project specific columns
+```
+
+## Mermaid Diagrams
+
+The `depends` command supports `--mermaid` for Mermaid diagram output. Two modes:
+
+| Flags | Output | Use case |
+| ----- | ------ | -------- |
+| `--mermaid` | Standalone mermaid (`graph TD`) | Pipe to `mmdc`, embed in tooling |
+| `--markdown --mermaid` | Mermaid fenced blocks inside markdown | Render in GitHub, VS Code, docs |
+
+```bash
+dnx dotnet-inspect -y -- depends Stream --mermaid                               # type hierarchy as mermaid
+dnx dotnet-inspect -y -- depends Stream --markdown --mermaid                    # embedded in markdown
+dnx dotnet-inspect -y -- depends --library System.Text.Json --mermaid           # assembly reference graph
+dnx dotnet-inspect -y -- depends --package Markout --mermaid                    # package dependency graph
 ```
 
 ## Search Scope

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.7.4
+version: 0.7.5
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents.
 ---
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.7.4</VersionPrefix>
+    <VersionPrefix>0.7.5</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Document the new `--mermaid` flag across SKILL.md and README.md.

### SKILL.md
- Added mermaid to Quick Decision Tree
- Added "Show dependencies as a diagram" to When to Use
- Added `--mermaid` examples to format description
- Added **Mermaid Diagrams** section (two-mode table + examples)
- Bumped version to 0.7.4

### README.md
- Added `depends` to Quick Reference table
- Added `--mermaid` to Common Flags table
- Added `depends` command section with 7 examples (tree, library, package, mermaid modes)
- Added **Mermaid** paragraph to Output Control section