### PR TITLE
Surface [Obsolete] members in listings (#316)

### DIFF
--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -257,6 +257,17 @@ public class ApiMember
     public bool IsExtension { get; set; }
 
     /// <summary>
+    /// True if the member carries an [Obsolete] attribute.
+    /// </summary>
+    public bool IsObsolete { get; set; }
+
+    /// <summary>
+    /// Optional deprecation message from [Obsolete("...")]. Null when the
+    /// attribute is missing or has no message argument.
+    /// </summary>
+    public string? ObsoleteMessage { get; set; }
+
+    /// <summary>
     /// The type that this extension method extends (first parameter type).
     /// Only populated when IsExtension is true.
     /// </summary>

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -162,9 +162,11 @@ public static class ApiSurfaceExtractor
                 if (methodName.StartsWith("<"))
                     continue;
 
-                // Skip EditorBrowsable(Never) and Obsolete methods unless --all
-                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
+                // Skip EditorBrowsable(Never) methods unless --all; obsolete are surfaced with marker.
+                if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
                     continue;
+
+                var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, method.GetCustomAttributes(), out var obsoleteMessage);
 
                 var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
                 var member = new ApiMember
@@ -176,7 +178,9 @@ public static class ApiSurfaceExtractor
                     IsAbstract = (method.Attributes & MethodAttributes.Abstract) != 0,
                     Signature = signature,
                     IsUnsafe = HasUnsafeSignature(signature),
-                    Accessibility = GetAccessibility(methodAccess)
+                    Accessibility = GetAccessibility(methodAccess),
+                    IsObsolete = isObsolete,
+                    ObsoleteMessage = obsoleteMessage
                 };
 
                 // Check for extension method
@@ -215,16 +219,20 @@ public static class ApiSurfaceExtractor
                 if (!isPublicProp && !includeAll)
                     continue;
 
-                // Skip EditorBrowsable(Never) and Obsolete properties unless --all
-                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, prop.GetCustomAttributes()))
+                // Skip EditorBrowsable(Never) properties unless --all; obsolete are surfaced with marker.
+                if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, prop.GetCustomAttributes()))
                     continue;
+
+                var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, prop.GetCustomAttributes(), out var obsoleteMessage);
 
                 var member = new ApiMember
                 {
                     Name = reader.GetString(prop.Name),
                     Kind = "property",
                     Signature = GetPropertySignature(reader, typeDef, prop, accessors, typeNullableContext, includeAll),
-                    Accessibility = GetAccessibility(bestAccess)
+                    Accessibility = GetAccessibility(bestAccess),
+                    IsObsolete = isObsolete,
+                    ObsoleteMessage = obsoleteMessage
                 };
 
                 apiType.Members.Add(member);
@@ -244,9 +252,11 @@ public static class ApiSurfaceExtractor
                 if (fieldName.StartsWith("<"))
                     continue; // Skip backing fields
 
-                // Skip EditorBrowsable(Never) and Obsolete fields unless --all
-                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, field.GetCustomAttributes()))
+                // Skip EditorBrowsable(Never) fields unless --all; obsolete are surfaced with marker.
+                if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, field.GetCustomAttributes()))
                     continue;
+
+                var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, field.GetCustomAttributes(), out var obsoleteMessage);
 
                 // Decode field type
                 string? fieldType = null;
@@ -266,7 +276,9 @@ public static class ApiSurfaceExtractor
                     Kind = "field",
                     ReturnType = fieldType,
                     IsStatic = (field.Attributes & FieldAttributes.Static) != 0,
-                    Accessibility = GetFieldAccessibility(fieldAccess)
+                    Accessibility = GetFieldAccessibility(fieldAccess),
+                    IsObsolete = isObsolete,
+                    ObsoleteMessage = obsoleteMessage
                 };
 
                 // Read enum constant value
@@ -311,16 +323,20 @@ public static class ApiSurfaceExtractor
                 if (adderAccess != MethodAttributes.Public && !includeAll)
                     continue;
 
-                // Skip EditorBrowsable(Never) and Obsolete events unless --all
-                if (!includeAll && AttributeReader.HasHiddenAttribute(reader, evt.GetCustomAttributes()))
+                // Skip EditorBrowsable(Never) events unless --all; obsolete are surfaced with marker.
+                if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, evt.GetCustomAttributes()))
                     continue;
+
+                var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, evt.GetCustomAttributes(), out var obsoleteMessage);
 
                 var member = new ApiMember
                 {
                     Name = reader.GetString(evt.Name),
                     Kind = "event",
                     IsStatic = (adder.Attributes & MethodAttributes.Static) != 0,
-                    Accessibility = GetAccessibility(adderAccess)
+                    Accessibility = GetAccessibility(adderAccess),
+                    IsObsolete = isObsolete,
+                    ObsoleteMessage = obsoleteMessage
                 };
 
                 apiType.Members.Add(member);

--- a/src/DotnetInspector.Metadata/AttributeReader.cs
+++ b/src/DotnetInspector.Metadata/AttributeReader.cs
@@ -40,20 +40,60 @@ public static class AttributeReader
 
             if (attrTypeName == EditorBrowsableAttributeName)
             {
-                // Check if the value is EditorBrowsableState.Never (value = 1)
-                var value = reader.GetBlobBytes(attr.Value);
-                // Attribute blob format: 2-byte prolog (0x0001), then the enum value as int32
-                if (value.Length >= 6)
-                {
-                    int enumValue = value[2] | (value[3] << 8) | (value[4] << 16) | (value[5] << 24);
-                    if (enumValue == 1) // EditorBrowsableState.Never
-                        return true;
-                }
+                if (IsEditorBrowsableNever(reader, attr))
+                    return true;
             }
             else if (attrTypeName == ObsoleteAttributeName)
             {
                 return true;
             }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if the member has the [EditorBrowsable(Never)] attribute.
+    /// </summary>
+    public static bool HasEditorBrowsableNeverAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName == EditorBrowsableAttributeName && IsEditorBrowsableNever(reader, attr))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if the member has the [Obsolete] attribute, returning the optional message.
+    /// </summary>
+    public static bool TryGetObsoleteAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes, out string? message)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName == ObsoleteAttributeName)
+            {
+                message = TryGetAttributeDisplayValue(reader, attr);
+                return true;
+            }
+        }
+        message = null;
+        return false;
+    }
+
+    private static bool IsEditorBrowsableNever(MetadataReader reader, CustomAttribute attr)
+    {
+        // Check if the value is EditorBrowsableState.Never (value = 1)
+        var value = reader.GetBlobBytes(attr.Value);
+        // Attribute blob format: 2-byte prolog (0x0001), then the enum value as int32
+        if (value.Length >= 6)
+        {
+            int enumValue = value[2] | (value[3] << 8) | (value[4] << 16) | (value[5] << 24);
+            return enumValue == 1; // EditorBrowsableState.Never
         }
         return false;
     }

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -340,6 +340,69 @@ public class ApiSurfaceExtractorTests
 
         Assert.Empty(leafType.DerivedTypes);
     }
+    [Fact]
+    public void Extract_ObsoleteMethod_VisibleByDefault_WithMessage()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        // includeAll: false — obsolete should still appear, but EditorBrowsable(Never) should not.
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: false);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleObsoleteHost");
+        Assert.NotNull(testType);
+
+        var obsoleteMethod = testType.Members.FirstOrDefault(m => m.Name == "OldMethod");
+        Assert.NotNull(obsoleteMethod);
+        Assert.True(obsoleteMethod.IsObsolete);
+        Assert.Equal("Use NewMethod instead.", obsoleteMethod.ObsoleteMessage);
+
+        var newMethod = testType.Members.FirstOrDefault(m => m.Name == "NewMethod");
+        Assert.NotNull(newMethod);
+        Assert.False(newMethod.IsObsolete);
+        Assert.Null(newMethod.ObsoleteMessage);
+
+        // EditorBrowsable(Never) is still filtered out by default.
+        var hidden = testType.Members.FirstOrDefault(m => m.Name == "HiddenMethod");
+        Assert.Null(hidden);
+    }
+
+    [Fact]
+    public void Extract_ObsoleteMethodWithoutMessage_HasIsObsoleteTrue()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: false);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleObsoleteHost");
+        Assert.NotNull(testType);
+
+        var method = testType.Members.FirstOrDefault(m => m.Name == "OldMethodNoMessage");
+        Assert.NotNull(method);
+        Assert.True(method.IsObsolete);
+        Assert.Null(method.ObsoleteMessage);
+    }
+
+    [Fact]
+    public void Extract_EditorBrowsableNever_StillVisibleWithIncludeAll()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleObsoleteHost");
+        Assert.NotNull(testType);
+
+        var hidden = testType.Members.FirstOrDefault(m => m.Name == "HiddenMethod");
+        Assert.NotNull(hidden);
+        Assert.False(hidden.IsObsolete);
+    }
+
 }
 
 /// <summary>
@@ -350,6 +413,23 @@ public class SampleClassForTesting
     public void MethodWithParameters(int count, string name) { }
     public void MethodWithNoParameters() { }
     public void GenericMethod<T>(T item) { }
+}
+
+/// <summary>
+/// Sample class hosting Obsolete and EditorBrowsable(Never) members for testing.
+/// </summary>
+public class SampleObsoleteHost
+{
+    [Obsolete("Use NewMethod instead.")]
+    public void OldMethod() { }
+
+    [Obsolete]
+    public void OldMethodNoMessage() { }
+
+    public void NewMethod() { }
+
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public void HiddenMethod() { }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -444,7 +444,14 @@ public static class ApiOutputFormatter
                 }
 
                 var sigDisplay = m.Accessibility != null ? $"{m.Accessibility} {sig}" : sig;
-                return new MemberRow(select, OperatorNames.FormatDisplayName(m.Name), $"`{sigDisplay}`", hasDocs ? (m.Documentation.Summary ?? "") : null);
+                string? obsoleteCell = null;
+                if (m.IsObsolete)
+                {
+                    obsoleteCell = string.IsNullOrWhiteSpace(m.ObsoleteMessage)
+                        ? "⚠ Obsolete"
+                        : $"⚠ Obsolete — {m.ObsoleteMessage}";
+                }
+                return new MemberRow(select, OperatorNames.FormatDisplayName(m.Name), $"`{sigDisplay}`", obsoleteCell, hasDocs ? (m.Documentation.Summary ?? "") : null);
             }).ToList();
 
             switch (kind)

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -88,75 +88,98 @@ public class TypeView
     // Member sections (populated by ApiOutputFormatter.PopulateMemberSections)
     // Without --show-index: hide Select column
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorRows { get; set; }
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldRows { get; set; }
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertyRows { get; set; }
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertyRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? MethodRows { get; set; }
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? MethodRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Events", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? EventRows { get; set; }
     [MarkoutSection(Name = "Events", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? EventRowsWithDocs { get; set; }
 
     // With --show-index: show Select column
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorSelectRows { get; set; }
     [MarkoutSection(Name = "Constructors")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorSelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldSelectRows { get; set; }
     [MarkoutSection(Name = "Fields")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldSelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertySelectRows { get; set; }
     [MarkoutSection(Name = "Properties")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertySelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? MethodSelectRows { get; set; }
     [MarkoutSection(Name = "Methods")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? MethodSelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Events", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? EventSelectRows { get; set; }
     [MarkoutSection(Name = "Events")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? EventSelectRowsWithDocs { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
 
     // Constructor emphasis (--ctor mode, Normal+ verbosity)
     [MarkoutSection(Name = "Constructors")]

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -295,13 +295,14 @@ public record MemberRow(
     [property: MarkoutSkipNull] string? Select,
     string Name,
     string Signature,
+    [property: MarkoutSkipNull] string? Obsolete,
     string? Description)
 {
     /// <summary>
-    /// Creates a MemberRow without a Select column.
+    /// Creates a MemberRow without Select or Obsolete columns.
     /// </summary>
     public MemberRow(string name, string signature, string? description)
-        : this(null, name, signature, description) { }
+        : this(null, name, signature, null, description) { }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.7.7</VersionPrefix>
+    <VersionPrefix>0.7.8</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Fixes #316.

## Problem

Member listings rendered `[Obsolete]` overloads identically to non-obsolete ones, and `[Obsolete]` members were silently filtered out unless `--all` was passed. The deprecation only became visible by drilling into a single overload with `--index`. Tools auditing deprecated APIs (e.g. AI migration agents) would silently miss obsolete overloads — the issue's reporter hit exactly this with `WorkflowBuilder.AddFanInBarrierEdge`.

## Fix

Split `[Obsolete]` handling out of `HasHiddenAttribute` so members with `[Obsolete]` are visible by default with a new ``Obsolete`` column showing ``⚠ Obsolete`` plus the deprecation message. `[EditorBrowsable(Never)]` continues to be hidden by default.

The new column uses ``[MarkoutSkipNull]``, so non-obsolete listings render unchanged. ``ApiMember`` gains ``IsObsolete`` and ``ObsoleteMessage`` so structured output (JSON, etc.) exposes the data programmatically.

Type-level filtering of obsolete types and the scanner/hierarchy code paths are intentionally left unchanged.

## Verified with the issue's reproduction

\`\`\`
dotnet-inspect member WorkflowBuilder --package Microsoft.Agents.AI.Workflows@1.3.0
\`\`\`

Now shows the deprecated overload by default with the marker:

\`\`\`
| AddFanInBarrierEdge | \`...AddFanInBarrierEdge(ExecutorBinding, IEnumerable<ExecutorBinding>)\` | ⚠ Obsolete — Use AddFanInBarrierEdge(IEnumerable<ExecutorBinding>, ExecutorBinding) instead. | ... |
| AddFanInBarrierEdge | \`...AddFanInBarrierEdge(IEnumerable<ExecutorBinding>, ExecutorBinding)\`           |                                                                                              | ... |
\`\`\`

## Tests

3 new tests in ``ApiSurfaceExtractorTests`` covering:
- Obsolete method visible by default with ``IsObsolete=true`` and message populated.
- Obsolete method without message has ``IsObsolete=true`` and ``ObsoleteMessage=null``.
- ``EditorBrowsable(Never)`` still hidden by default.

``dotnet-inspect.Tests``: 617 total, 0 failures, 31 pre-existing skips. The 3 failures in ``DotnetInspector.Decompiler.Tests`` (1) and ``DotnetInspector.Services.Tests`` (2) are pre-existing on ``main`` and unrelated to this change.

## Version

Bumps version ``0.7.7 → 0.7.8``.