### PR TITLE
Bump dotnet-inspect patch version to 0.7.10

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.7.9</VersionPrefix>
+    <VersionPrefix>0.7.10</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump `VersionPrefix` in `src/dotnet-inspect/dotnet-inspect.csproj`
- update dotnet-inspect from `0.7.9` to `0.7.10`

## Notes
- patch-version-only change