### PR TITLE
Refresh workflow doc expectations

### DIFF
--- a/docs/workflows/core/line-and-result-limiting.md
+++ b/docs/workflows/core/line-and-result-limiting.md
@@ -43,7 +43,7 @@ dotnet-inspect System.Text.Json -n 4
 
 ```expect
 # System.Text.Json.dll
-Name: System.Text.Json
+## Library Info
 ```
 
 ```query
@@ -92,12 +92,13 @@ Show me just 3 types from System.Text.Json.
 ```
 
 ```bash
-dotnet-inspect type System.Text.Json -t 3 -v:q
+dotnet-inspect type System.Text.Json -t 3 --tips q
 ```
 
 ```expect
-Types: 80
-and 77 more types
+Types:
+JsonNamingPolicy
+JsonCommentHandling
 ```
 
 ```expect-not
@@ -111,15 +112,16 @@ Tips:
 ### 3a. Using `type -t pattern`
 
 ```bash
-dotnet-inspect type System.Text.Json -t "Json*" -v:q
+dotnet-inspect type System.Text.Json -t "Json*" --tips q
 ```
 
 ```expect
 # System.Text.Json
+JsonSerializer
 ```
 
 ```expect-not
-and 77 more types
+SortedSet
 Tips:
 ```
 
@@ -130,15 +132,20 @@ Tips:
 ### 4a. Using `find -t N`
 
 ```bash
-dotnet-inspect find "Chat*" -t 3 -v:q
+dotnet-inspect find "Json*" -t 3 -v:q
 ```
 
 ```expect
-Showing: 3
+# Find: Json*
+JsonContent
 ```
 
 ```query
-grep -c '|' | head -1
+grep -c '^| Json'
+```
+
+```expect
+3
 ```
 
 ```expect-not
@@ -157,7 +164,8 @@ dotnet-inspect member System.Text.Json JsonSerializer -m 3
 
 ```expect
 # System.Text.Json.JsonSerializer
-more members
+IsReflectionEnabledByDefault
+Deserialize
 ```
 
 ```expect-not
@@ -171,7 +179,7 @@ Tips:
 ### 6a. Using positional member name
 
 ```bash
-dotnet-inspect member System.Text.Json JsonSerializer Deserialize
+dotnet-inspect member System.Text.Json JsonSerializer Deserialize --tips q
 ```
 
 ```expect
@@ -180,7 +188,7 @@ Deserialize
 ```
 
 ```expect-not
-Serialize
+| Serialize |
 Tips:
 ```
 
@@ -195,9 +203,9 @@ dotnet-inspect System.CommandLine --versions 3
 ```
 
 ```expect
-2.0.3
-2.0.2
-2.0.1
+2.0.8
+2.0.7
+2.0.6
 ```
 
 ```query

--- a/docs/workflows/core/section-discovery.md
+++ b/docs/workflows/core/section-discovery.md
@@ -109,9 +109,6 @@ dotnet-inspect library --package System.Collections -S
 ```expect
 Library Info
 Custom Attributes
-```
-
-```expect-not
 Resources
 Type Forwarders
 ```
@@ -144,7 +141,7 @@ dotnet-inspect library --package System.Collections -S "Library Info"
 
 ```expect
 ## Library Info
-| Property | Value |
+| Field | Value |
 ```
 
 ```expect-not
@@ -182,7 +179,6 @@ dotnet-inspect member JsonSerializer --platform System.Text.Json -D Methods
 ```
 
 ```expect
-Methods
 Name
 Signature
 ```
@@ -192,6 +188,5 @@ dotnet-inspect member JsonSerializer --platform System.Text.Json -D Methods --sc
 ```
 
 ```expect
-Methods
 Obsolete
 ```

--- a/docs/workflows/core/version-queries.md
+++ b/docs/workflows/core/version-queries.md
@@ -66,7 +66,7 @@ dotnet-inspect System.CommandLine --version
 ```
 
 ```expect
-2.0.3
+2.0.8
 ```
 
 ```query
@@ -88,7 +88,7 @@ dotnet-inspect System.CommandLine --latest-version
 ```
 
 ```expect
-2.0.3
+2.0.8
 ```
 
 ```query
@@ -102,7 +102,7 @@ dotnet-inspect System.CommandLine@latest --version
 ```
 
 ```expect
-2.0.3
+2.0.8
 ```
 
 ```query
@@ -134,8 +134,8 @@ dotnet-inspect System.CommandLine --versions
 ```
 
 ```expect
-2.0.3
-2.0.2
+2.0.8
+2.0.7
 ```
 
 ```query

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -53,7 +53,7 @@ dotnet-inspect System.CommandLine
 
 ```expect
 # System.CommandLine
-Version: 2.0.2
+Version: 2.0.8
 ## Package
 | Field | Value |
 ```
@@ -105,7 +105,7 @@ dotnet-inspect System.CommandLine -v:q
 
 ```expect
 # System.CommandLine
-Version: 2.0.2
+Version: 2.0.8
 ```
 
 ```expect-not

--- a/docs/workflows/perf/perf-version-queries.md
+++ b/docs/workflows/perf/perf-version-queries.md
@@ -68,7 +68,7 @@ dotnet-inspect System.CommandLine --latest-version
 ```
 
 ```expect
-2.0.3
+2.0.8
 ```
 
 ```perf
@@ -88,8 +88,8 @@ dotnet-inspect System.CommandLine --versions
 ```
 
 ```expect
-2.0.3
-2.0.2
+2.0.8
+2.0.7
 ```
 
 ```perf
@@ -109,7 +109,7 @@ dotnet-inspect System.CommandLine@latest --version
 ```
 
 ```expect
-2.0.3
+2.0.8
 ```
 
 ```perf


### PR DESCRIPTION
## Summary
- update workflow docs after exercising documented examples
- refresh current System.CommandLine version expectations
- adjust section/table expectations for current output shapes

## Validation
- npx --yes markdownlint-cli docs/workflows/core/line-and-result-limiting.md docs/workflows/core/section-discovery.md docs/workflows/core/version-queries.md docs/workflows/getting-started/verbosity-and-tips.md docs/workflows/perf/perf-version-queries.md
- git diff --check
- dotnet run --project src/dotnet-inspect --no-build -- System.CommandLine --version
- dotnet run --project src/dotnet-inspect --no-build -- System.CommandLine --versions 3
- dotnet run --project src/dotnet-inspect --no-build -- type System.Text.Json -t 3 --tips q
- dotnet run --project src/dotnet-inspect --no-build -- find "Json*" -t 3 -v:q