### PR TITLE
Bump dotnet-inspect to 0.8.1

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -28,6 +28,19 @@ Default output is Markdown. Use `--oneline` to scan, `--json` for structured dat
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package/platform scope as needed. |
 | Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N` | Prefer built-in limits over shell pipes. |
 
+## Modern .NET and preview workflow
+
+LLM training may miss .NET 10+ runtime/library features. Prefer metadata inspection over web search.
+
+| Question | Use | Watch for |
+| -------- | --- | --------- |
+| Which APIs use runtime async vs compiler state machines? | `library --platform Lib --framework runtime@<version> -S "Async*"` | `Kind` distinguishes runtime async from state-machine async; use `--count` only for totals. |
+| Is this a framework assembly or standalone package? | `library --platform Lib --framework runtime@<version>` or direct DLL path | Many BCL assemblies are runtime-pack/platform libraries, not independent NuGet packages. |
+| Did new extension members appear? | `extensions Type --reachable` | Includes extension methods and C# extension properties. |
+| Did compiler/runtime lowering change? | `member Type Member:1 -v:d` | Inspect Source, Lowered C#, IL, and annotated IL before inferring behavior. |
+
+For preview sweeps, resolve the version once, prove one library end-to-end, then fan out to the rest.
+
 ## API lookup workflow
 
 Use `find` when you do not know the package, library, or exact namespace.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.8.0
+version: 0.8.1
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Use for factual answers about package contents, API signatures, compatibility changes, relationships, SourceLink, and assembly metadata.
 ---
 
@@ -32,12 +32,12 @@ Default output is Markdown. Use `--oneline` to scan, `--json` for structured dat
 
 LLM training may miss .NET 10+ runtime/library features. Prefer metadata inspection over web search.
 
-| Question | Use | Watch for |
-| -------- | --- | --------- |
-| Which APIs use runtime async vs compiler state machines? | `library --platform Lib --framework runtime@<version> -S "Async*"` | `Kind` distinguishes runtime async from state-machine async; use `--count` only for totals. |
-| Is this a framework assembly or standalone package? | `library --platform Lib --framework runtime@<version>` or direct DLL path | Many BCL assemblies are runtime-pack/platform libraries, not independent NuGet packages. |
-| Did new extension members appear? | `extensions Type --reachable` | Includes extension methods and C# extension properties. |
-| Did compiler/runtime lowering change? | `member Type Member:1 -v:d` | Inspect Source, Lowered C#, IL, and annotated IL before inferring behavior. |
+| Feature | Description | Use | Watch for |
+| ------- | ----------- | --- | --------- |
+| Runtime async | .NET 11+ libraries may use runtime async instead of compiler-generated state machines. | `library --platform Lib --framework runtime@<version> -S "Async*"` | `Kind` distinguishes runtime async from state-machine async; use `--count` only for totals. |
+| Runtime-pack assemblies | Many BCL libraries ship only as installed platform/runtime-pack assemblies, not standalone packages. | `library --platform Lib --framework runtime@<version>` or direct DLL path | Prefer platform/direct DLL inspection when package lookup is misleading. |
+| Extension properties | C# extension blocks can expose properties in addition to extension methods. | `extensions Type --reachable` | Results include extension methods and C# extension properties. |
+| Lowering changes | Compiler/runtime implementation can differ from API signatures. | `member Type Member:1 -v:d` | Inspect Source, Lowered C#, IL, and annotated IL before inferring behavior. |
 
 For preview sweeps, resolve the version once, prove one library end-to-end, then fan out to the rest.
 
@@ -50,7 +50,7 @@ dnx dotnet-inspect -y -- find JsonSerializer --oneline
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json
 ```
 
-Carry resolved context forward. For multi-library packages, include the `--library` value shown by `find`. For platform APIs, prefer `--platform <LibraryName>` when you want installed framework behavior.
+Carry resolved context forward. Bare names use the router: platform-looking names are tried as installed platform libraries first, then fall back to NuGet packages if platform resolution fails. Use explicit `--platform`, `--package`, or `--library` when the source matters; for multi-library packages, include the `--library` value shown by `find`.
 
 Use `type` for type shape and summaries; use `member` for signatures, overloads, docs, and implementation detail. Add `--show-index` when you need stable `Name:N` overload selectors.
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.8.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,6 +1,14 @@
-# v0.8.0 Release Notes
+# Release Notes
 
-## Highlights
+## v0.8.1
+
+### Skill guidance
+
+- Embedded `dotnet-inspect skill` guidance now includes a compact Modern .NET / preview workflow for runtime async classification, runtime-pack/platform assemblies, extension properties, and implementation-lowering inspection.
+
+## v0.8.0
+
+### Highlights
 
 - `source --il-offset` maps MethodDef token + IL offset pairs to source file locations, with Markdown, oneline, and JSON output.
 - `--count` returns a single integer row count when exactly one table section is selected.
@@ -9,7 +17,7 @@
 - `type` and `member` discovery now default to effective `-D` output; use `--schema` for the static schema.
 - Obsolete members are shown by default with an obsolete marker and message when available.
 
-## Improvements
+### Improvements
 
 - `-S`, `--columns`, and `--fields` accept semicolon-separated lists in addition to comma-separated lists.
 - Effective discovery and field projection are wired through API type/member routing and markdown output.
@@ -17,7 +25,7 @@
 - NuGet configs containing local folder or `file://` sources no longer block later HTTP feeds during package resolution.
 - Assembly public key tokens are computed from the full public key using the ECMA-335 SHA-1 algorithm.
 
-## Documentation
+### Documentation
 
 - README.md is now a concise capability inventory.
 - SKILL.md is now workflow-oriented for agents: upgrade triage, find-to-member drill-in, source/IL lookup, platform release notes, package/library audit, structured queries, and relationship exploration.


### PR DESCRIPTION
## Summary
- bump dotnet-inspect package and embedded skill to 0.8.1
- add Modern .NET / preview guidance to the embedded skill
- describe runtime async, runtime-pack/platform assemblies, extension properties, and implementation-lowering inspection

## Validation
- `npx --yes markdownlint-cli skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md`
- `dotnet run --project src/dotnet-inspect -- --version`
- `dotnet run --project src/dotnet-inspect -- --release-notes`
- `dotnet run --project src/dotnet-inspect -- skill`
- `dotnet pack src/dotnet-inspect/dotnet-inspect.csproj -c Release`