### PR TITLE
Improve runtime-async decompilation, reuse downloaded PDBs, fix CI failures

### DIFF
--- a/docs/design/decompiler.md
+++ b/docs/design/decompiler.md
@@ -278,7 +278,8 @@ use cases (LLM troubleshooting, codegen analysis, runtime diagnostics) better
 than sugar-recovered "idiomatic" C# would.
 
 What "lowered" means:
-- `stloc.0` → `V_0 = expr;`, not recovering original variable names
+- `stloc.0` → `V_0 = expr;`, using PDB local names when available (embedded, or an
+  external/downloaded portable PDB) and falling back to synthesized `V_n` slots otherwise
 - Branches → `goto` / `if (...) goto`, not recovering `foreach`/`using`
 - `call get_Property()` stays as a method call, not `obj.Property`
 - `box` / `unbox.any` visible as casts with annotations
@@ -293,6 +294,7 @@ What "lowered" means:
 | Array access     | `ldelem`/`stelem` → `arr[i]`                      |
 | Object creation  | `newobj` → `new Type(args)`                       |
 | Control flow     | `br`/`brtrue` → `goto` / `if (...) goto`          |
+| Runtime async    | `AsyncHelpers.Await(x)` → `await x` (v2)          |
 
 | Component       | Purpose                                             |
 | --------------- | --------------------------------------------------- |

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -529,6 +529,14 @@ public class CSharpEmitterTests
         Assert.Contains("(ushort)", code);
     }
 
+    [Fact]
+    public void BoolParameter_ZeroLiteral_RendersFalse()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.PassesBoolFalse));
+        Assert.Contains("AcceptsBool(false)", code);
+        Assert.DoesNotContain("AcceptsBool(0)", code);
+    }
+
     // --- Helpers ---
 
     static string EmitMethod(string methodName)
@@ -542,5 +550,56 @@ public class CSharpEmitterTests
             methodName);
         Assert.NotNull(context);
         return CSharpEmitter.Emit(context);
+    }
+
+    static string EmitMethod(string methodName, string? externalPdbPath)
+    {
+        var assemblyPath = typeof(CfgSampleClass).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var context = MethodBodyContext.Create(
+            peReader,
+            typeof(CfgSampleClass).FullName!,
+            methodName,
+            externalPdbPath: externalPdbPath);
+        Assert.NotNull(context);
+        return CSharpEmitter.Emit(context);
+    }
+
+    // The test assembly ships a standalone (non-embedded) portable PDB, so without it the
+    // decompiler falls back to synthesized V_n locals, and with it real source names appear.
+    static string TestAssemblyPdbPath() =>
+        Path.ChangeExtension(typeof(CfgSampleClass).Assembly.Location, ".pdb");
+
+    [Fact]
+    public void ExternalPdb_SuppliesLocalVariableNames()
+    {
+        var pdbPath = TestAssemblyPdbPath();
+        Assert.SkipUnless(File.Exists(pdbPath), $"standalone PDB not found at {pdbPath}");
+
+        string withPdb = EmitMethod(nameof(CfgSampleClass.LoopSum), pdbPath);
+
+        // LoopSum declares `int sum` and `int i`; the acquired PDB should restore those names.
+        Assert.Contains("sum", withPdb);
+        Assert.DoesNotContain("V_0", withPdb);
+    }
+
+    [Fact]
+    public void WithoutPdb_FallsBackToSyntheticLocalNames()
+    {
+        // No embedded PDB and no external path: locals render as V_n, never crashing.
+        string noPdb = EmitMethod(nameof(CfgSampleClass.LoopSum));
+
+        Assert.Contains("V_0", noPdb);
+        Assert.DoesNotContain("int sum", noPdb);
+    }
+
+    [Fact]
+    public void ExternalPdb_NonexistentPath_FallsBackGracefully()
+    {
+        // A bogus external path must not throw; it falls back to synthesized names.
+        string output = EmitMethod(nameof(CfgSampleClass.LoopSum), "/no/such/file.pdb");
+
+        Assert.Contains("V_0", output);
     }
 }

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -503,6 +503,10 @@ public class CfgSampleClass
     }
 
     public static ulong ULongNegOne() => unchecked((ulong)-1);
+
+    public static void AcceptsBool(bool flag) { }
+
+    public static void PassesBoolFalse() => AcceptsBool(false);
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/DotnetInspector.Decompiler.Tests/RuntimeAsyncEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/RuntimeAsyncEmitterTests.cs
@@ -1,0 +1,148 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Decompiler;
+
+namespace DotnetInspector.Decompiler.Tests;
+
+/// <summary>
+/// Verifies that the C# emitter renders .NET 11 "runtime async" (async v2) methods back
+/// into <c>await</c> expressions. Runtime async lowers <c>await x</c> to a call to
+/// <c>System.Runtime.CompilerServices.AsyncHelpers.Await(x)</c> rather than a state machine.
+///
+/// The decompiler-test assembly targets net10.0, so a real runtime-async method cannot be
+/// produced by compiling C#. Instead these tests synthesize an assembly with
+/// <see cref="System.Reflection.Emit.PersistedAssemblyBuilder"/> that contains an
+/// <c>AsyncHelpers.Await</c> helper and methods that call it (carrying the
+/// <c>MethodImplAttributes.Async</c> (0x2000) flag, matching real runtime-async metadata).
+/// </summary>
+public class RuntimeAsyncEmitterTests
+{
+    [Fact]
+    public void VoidAwait_RendersAwaitStatement()
+    {
+        string code = EmitRuntimeAsync("AwaitVoid");
+
+        Assert.Contains("await t", code);
+        Assert.DoesNotContain("AsyncHelpers.Await", code);
+        Assert.DoesNotContain("Await(", code);
+    }
+
+    [Fact]
+    public void ValueAwait_RendersReturnAwait()
+    {
+        string code = EmitRuntimeAsync("AwaitValue");
+
+        Assert.Contains("return await t", code);
+        Assert.DoesNotContain("AsyncHelpers.Await", code);
+    }
+
+    [Fact]
+    public void AwaitResultUsedAsReceiver_IsParenthesized()
+    {
+        string code = EmitRuntimeAsync("AwaitReceiver");
+
+        // The await result is the receiver of a member access, so it must be parenthesized:
+        // (await t).Length — never "await t.Length".
+        Assert.Contains("(await t).Length", code);
+        Assert.DoesNotContain("AsyncHelpers.Await", code);
+    }
+
+    [Fact]
+    public void TaskReturningRuntimeAsync_DoesNotThrowOnStackSimulation()
+    {
+        // A runtime-async method declares Task/Task<T> in metadata, but its IL `ret` carries the
+        // unwrapped value (or nothing for Task). The stack simulator must not treat the declared
+        // Task as an on-stack return value, or it underflows. Regression guard for that crash.
+        Assert.Null(Record.Exception(() => EmitRuntimeAsync("AwaitVoid")));
+        Assert.Null(Record.Exception(() => EmitRuntimeAsync("AwaitValue")));
+    }
+
+    static string EmitRuntimeAsync(string methodName)
+    {
+        using var stream = BuildRuntimeAsyncAssembly();
+        using var peReader = new PEReader(stream);
+        var context = MethodBodyContext.Create(peReader, "RuntimeAsyncSample", methodName);
+        Assert.NotNull(context);
+        return CSharpEmitter.Emit(context);
+    }
+
+    private static MemoryStream BuildRuntimeAsyncAssembly()
+    {
+        const MethodImplAttributes AsyncImplFlag = (MethodImplAttributes)0x2000;
+
+        var ab = new PersistedAssemblyBuilder(
+            new AssemblyName("RuntimeAsyncEmitterFixture"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("RuntimeAsyncEmitterFixture");
+
+        // System.Runtime.CompilerServices.AsyncHelpers with the Await helpers the compiler targets.
+        var helpers = module.DefineType(
+            "System.Runtime.CompilerServices.AsyncHelpers",
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
+
+        var awaitVoid = helpers.DefineMethod(
+            "Await", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void), [typeof(Task)]);
+        var awaitVoidIl = awaitVoid.GetILGenerator();
+        awaitVoidIl.Emit(OpCodes.Ret);
+
+        var awaitGeneric = helpers.DefineMethod(
+            "Await", MethodAttributes.Public | MethodAttributes.Static);
+        var tp = awaitGeneric.DefineGenericParameters("T")[0];
+        awaitGeneric.SetReturnType(tp);
+        awaitGeneric.SetParameters(typeof(Task<>).MakeGenericType(tp));
+        var awaitGenericIl = awaitGeneric.GetILGenerator();
+        var defaultLocal = awaitGenericIl.DeclareLocal(tp);
+        awaitGenericIl.Emit(OpCodes.Ldloca_S, defaultLocal);
+        awaitGenericIl.Emit(OpCodes.Initobj, tp);
+        awaitGenericIl.Emit(OpCodes.Ldloc, defaultLocal);
+        awaitGenericIl.Emit(OpCodes.Ret);
+
+        helpers.CreateType();
+
+        var sample = module.DefineType("RuntimeAsyncSample", TypeAttributes.Public | TypeAttributes.Class);
+
+        // static Task AwaitVoid(Task t) => await t; (IL `ret` carries nothing; metadata says Task)
+        var awaitVoidCaller = sample.DefineMethod(
+            "AwaitVoid", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task), [typeof(Task)]);
+        awaitVoidCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var voidIl = awaitVoidCaller.GetILGenerator();
+        voidIl.Emit(OpCodes.Ldarg_0);
+        voidIl.Emit(OpCodes.Call, awaitVoid);
+        voidIl.Emit(OpCodes.Ret);
+        awaitVoidCaller.SetImplementationFlags(AsyncImplFlag);
+
+        // static Task<int> AwaitValue(Task<int> t) => return await t; (IL `ret` carries the int)
+        var awaitInt = awaitGeneric.MakeGenericMethod(typeof(int));
+        var awaitValueCaller = sample.DefineMethod(
+            "AwaitValue", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [typeof(Task<int>)]);
+        awaitValueCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var valueIl = awaitValueCaller.GetILGenerator();
+        valueIl.Emit(OpCodes.Ldarg_0);
+        valueIl.Emit(OpCodes.Call, awaitInt);
+        valueIl.Emit(OpCodes.Ret);
+        awaitValueCaller.SetImplementationFlags(AsyncImplFlag);
+
+        // static Task<int> AwaitReceiver(Task<string> t) => return (await t).Length;
+        var awaitString = awaitGeneric.MakeGenericMethod(typeof(string));
+        var awaitReceiverCaller = sample.DefineMethod(
+            "AwaitReceiver", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [typeof(Task<string>)]);
+        awaitReceiverCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var receiverIl = awaitReceiverCaller.GetILGenerator();
+        receiverIl.Emit(OpCodes.Ldarg_0);
+        receiverIl.Emit(OpCodes.Call, awaitString);
+        receiverIl.Emit(OpCodes.Callvirt, typeof(string).GetMethod("get_Length")!);
+        receiverIl.Emit(OpCodes.Ret);
+        awaitReceiverCaller.SetImplementationFlags(AsyncImplFlag);
+
+        sample.CreateType();
+
+        var stream = new MemoryStream();
+        ab.Save(stream);
+        stream.Position = 0;
+        return stream;
+    }
+}

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -3024,6 +3024,9 @@ public static class CSharpEmitter
             // Merge emission-context expectedType with AST-level ExpectedType (from BuildCall annotations)
             string? resolvedType = expectedType ?? expr.ExpectedType;
 
+            // A bool-typed parameter/target means 0/1 integer literals are really false/true.
+            boolCtx = boolCtx || resolvedType is "bool" or "System.Boolean" or "Boolean";
+
             // Enum constant resolution for integer literals with known parameter types
             if (IsLdcI4(expr.OpCode) && resolvedType is not null
                 && TryResolveEnumName(resolvedType, GetI4Value(expr), out string? enumName))
@@ -3445,9 +3448,28 @@ public static class CSharpEmitter
         {
             if (isBaseCall)
                 _sb.Append("base");
+            else if (IsRuntimeAwaitCall(receiver))
+            {
+                // `(await GetThingAsync()).Member` — the await result is the receiver, so it
+                // must be parenthesized; `await GetThingAsync().Member` would bind differently.
+                _sb.Append('(');
+                EmitExpression(receiver);
+                _sb.Append(')');
+            }
             else
                 EmitExpression(receiver);
         }
+
+        /// <summary>
+        /// True for a runtime-async await helper call: a static call to
+        /// <c>System.Runtime.CompilerServices.AsyncHelpers.Await</c> with a single awaitable
+        /// argument. Covers every overload (Task/ValueTask, configured, and the generic
+        /// value-returning forms) because the operand carries no parameter or generic-arg text.
+        /// </summary>
+        static bool IsRuntimeAwaitCall(ILAstExpression expr) =>
+            expr.IsStaticCall
+            && expr.Arguments.Count == 1
+            && expr.Operand is "System.Runtime.CompilerServices.AsyncHelpers::Await";
 
         void EmitCallExpression(ILAstExpression expr)
         {
@@ -3455,6 +3477,22 @@ public static class CSharpEmitter
             if (methodName is null)
             {
                 _sb.Append("/* call */");
+                return;
+            }
+
+            // Runtime async (.NET 11+ "async v2"): the compiler lowers `await x` to a call
+            // to System.Runtime.CompilerServices.AsyncHelpers.Await(x) instead of emitting a
+            // state machine. Render it back as `await x` for a faithful, readable view.
+            if (IsRuntimeAwaitCall(expr))
+            {
+                _sb.Append("await ");
+                var awaited = expr.Arguments[0];
+                // The await operand binds as a unary prefix; parenthesize lower-precedence
+                // operands (binary expressions) so `await a + b` doesn't read as `(await a) + b`.
+                bool wrap = IsBinaryOp(awaited.OpCode);
+                if (wrap) _sb.Append('(');
+                EmitExpression(awaited);
+                if (wrap) _sb.Append(')');
                 return;
             }
 

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -213,13 +213,13 @@ public static class ILAstBuilder
             case ILOpCode.Ldc_r4:
             {
                 float val = BitConverter.Int32BitsToSingle((int)reader.ReadILUInt32());
-                return MakeLiteral(opcode, val.ToString("R"), StackValueKind.Float, offset);
+                return MakeLiteral(opcode, val.ToString("R", System.Globalization.CultureInfo.InvariantCulture), StackValueKind.Float, offset);
             }
 
             case ILOpCode.Ldc_r8:
             {
                 double val = BitConverter.Int64BitsToDouble((long)reader.ReadILUInt64());
-                return MakeLiteral(opcode, val.ToString("R"), StackValueKind.Float, offset);
+                return MakeLiteral(opcode, val.ToString("R", System.Globalization.CultureInfo.InvariantCulture), StackValueKind.Float, offset);
             }
 
             case ILOpCode.Ldnull:

--- a/src/DotnetInspector.Decompiler/MethodBodyContext.cs
+++ b/src/DotnetInspector.Decompiler/MethodBodyContext.cs
@@ -141,6 +141,16 @@ public sealed class MethodBodyContext
         var sig = method.DecodeSignature(SignatureDecoder.Instance, genericContext);
         var paramNames = ReadParameterNames(reader, method);
 
+        // Runtime async (.NET 11+ "async v2"): a method carrying MethodImplAttributes.Async
+        // (0x2000) has no compiler state machine; its IL `ret` yields the *unwrapped* awaited
+        // value, not the Task/ValueTask declared in metadata. Map the effective IL return type
+        // accordingly (Task/ValueTask -> void; Task<T>/ValueTask<T> -> T) so stack simulation
+        // and emitted `return` statements stay balanced.
+        const System.Reflection.MethodImplAttributes AsyncImplFlag = (System.Reflection.MethodImplAttributes)0x2000;
+        string effectiveReturnType = (method.ImplAttributes & AsyncImplFlag) != 0
+            ? UnwrapRuntimeAsyncReturnType(sig.ReturnType)
+            : sig.ReturnType;
+
         // Read PDB local variable names if available
         IReadOnlyList<string?>? localNames = null;
         if (pdbReader != null && !methodHandle.IsNil)
@@ -154,45 +164,98 @@ public sealed class MethodBodyContext
             reader,
             sig.ParameterTypes.Length,
             !method.Attributes.HasFlag(System.Reflection.MethodAttributes.Static),
-            sig.ReturnType != "System.Void" && sig.ReturnType != "void",
+            effectiveReturnType != "System.Void" && effectiveReturnType != "void",
             [.. sig.ParameterTypes],
             paramNames,
-            sig.ReturnType,
+            effectiveReturnType,
             declaringType,
             genericContext,
             localNames);
     }
 
     /// <summary>
-    /// Convenience: find a method by type/name and create context.
-    /// Tries to read local variable names from embedded PDB if available.
+    /// Unwraps a runtime-async method's declared return type to the type its IL actually
+    /// returns: <c>Task</c>/<c>ValueTask</c> become <c>void</c>, and <c>Task&lt;T&gt;</c>/
+    /// <c>ValueTask&lt;T&gt;</c> become <c>T</c>. Other return types are returned unchanged.
     /// </summary>
-    public static MethodBodyContext? Create(PEReader peReader, string typeName, string methodName, int overloadIndex = 0, bool publicOnly = false)
+    internal static string UnwrapRuntimeAsyncReturnType(string returnType)
+    {
+        if (returnType is "System.Threading.Tasks.Task" or "System.Threading.Tasks.ValueTask")
+            return "System.Void";
+
+        foreach (var wrapper in new[] { "System.Threading.Tasks.Task<", "System.Threading.Tasks.ValueTask<" })
+        {
+            if (returnType.StartsWith(wrapper, StringComparison.Ordinal)
+                && returnType.EndsWith(">", StringComparison.Ordinal))
+                return returnType[wrapper.Length..^1];
+        }
+
+        return returnType;
+    }
+
+    /// <summary>
+    /// Convenience: find a method by type/name and create context.
+    /// Reads local variable names from the embedded PDB when present; otherwise, when an
+    /// <paramref name="externalPdbPath"/> to a portable PDB is supplied (e.g. one the CLI
+    /// downloaded from a symbol server for platform assemblies), reads local names from there.
+    /// </summary>
+    public static MethodBodyContext? Create(PEReader peReader, string typeName, string methodName, int overloadIndex = 0, bool publicOnly = false, string? externalPdbPath = null)
     {
         var reader = peReader.GetMetadataReader();
         MetadataReader? pdbReader = TryGetEmbeddedPdbReader(peReader);
 
-        foreach (var typeDefHandle in reader.TypeDefinitions)
+        // Fall back to an external portable PDB (e.g. acquired from a symbol server) when the
+        // assembly has no embedded PDB. Local names are materialized eagerly inside Create, so the
+        // provider/stream can be disposed as soon as the matching context has been built.
+        FileStream? pdbStream = null;
+        MetadataReaderProvider? externalProvider = null;
+        try
         {
-            var typeDef = reader.GetTypeDefinition(typeDefHandle);
-            if (reader.GetFullTypeName(typeDef) != typeName)
-                continue;
-
-            int matchCount = 0;
-            foreach (var methodHandle in typeDef.GetMethods())
+            if (pdbReader is null && !string.IsNullOrEmpty(externalPdbPath) && File.Exists(externalPdbPath))
             {
-                var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != methodName)
-                    continue;
-                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
-                    continue;
-                if (matchCount == overloadIndex)
-                    return Create(peReader, reader, method, pdbReader, methodHandle);
-                matchCount++;
+                try
+                {
+                    pdbStream = File.OpenRead(externalPdbPath);
+                    externalProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+                    pdbReader = externalProvider.GetMetadataReader();
+                }
+                catch
+                {
+                    externalProvider?.Dispose();
+                    externalProvider = null;
+                    pdbStream?.Dispose();
+                    pdbStream = null;
+                    pdbReader = null;
+                }
             }
-        }
 
-        return null;
+            foreach (var typeDefHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeDefHandle);
+                if (reader.GetFullTypeName(typeDef) != typeName)
+                    continue;
+
+                int matchCount = 0;
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var method = reader.GetMethodDefinition(methodHandle);
+                    if (reader.GetString(method.Name) != methodName)
+                        continue;
+                    if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
+                        continue;
+                    if (matchCount == overloadIndex)
+                        return Create(peReader, reader, method, pdbReader, methodHandle);
+                    matchCount++;
+                }
+            }
+
+            return null;
+        }
+        finally
+        {
+            externalProvider?.Dispose();
+            pdbStream?.Dispose();
+        }
     }
 
     static IReadOnlyList<string> ReadParameterNames(MetadataReader reader, MethodDefinition method)

--- a/src/DotnetInspector.Metadata/PdbContext.cs
+++ b/src/DotnetInspector.Metadata/PdbContext.cs
@@ -58,6 +58,13 @@ public class PdbContext : IDisposable
     public bool HasReproducibleFlag { get; private set; }
     public bool HasEmbeddedPdb { get; private set; }
     public string? CodeViewPdbPath { get; private set; }
+
+    /// <summary>
+    /// On-disk path to a successfully loaded *portable* PDB file (standalone or downloaded from a
+    /// symbol server), or null for embedded/Windows/no PDB. Lets callers (e.g. the decompiler)
+    /// reuse the acquired symbols for local-variable names after this context is disposed.
+    /// </summary>
+    public string? PortablePdbPath { get; private set; }
     public bool? HasNormalizedPaths { get; private set; }
     public List<string>? NonNormalizedPaths { get; private set; }
 
@@ -166,6 +173,7 @@ public class PdbContext : IDisposable
             HasPdb = true;
             PdbFormat = "Portable";
             PdbLocation = pdbLocation ?? "Standalone";
+            PortablePdbPath = pdbFilePath;
             SymbolServer = symbolServer;
 
             SourceLinkJson = AssemblyInspector.ExtractSourceLinkFromReader(_pdbReader);

--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -417,20 +417,71 @@ public partial class ILDisassemblerComparisonTests
 
     static bool CanRunILAsm()
     {
+        // The ildasm/ilasm global tools target a specific .NET runtime and may be present on PATH
+        // yet unable to execute (e.g. they exit ~150 when that runtime is absent). A process that
+        // merely *starts* is not enough — probe a real round-trip of the test assembly and only
+        // treat the tools as usable on a clean, output-producing exit. Otherwise the comparison
+        // tests must Assert.Skip rather than fail.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"il-probe-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var probeIl = Path.Combine(tempDir, "probe.il");
+            var probeDll = Path.Combine(tempDir, "probe.dll");
+
+            if (!TryRunTool("ildasm", [TestDll, $"-output={probeIl}", "-utf8"]) || !File.Exists(probeIl))
+                return false;
+
+            if (!TryRunTool("ilasm", [probeIl, "-dll", $"-output={probeDll}", "-quiet"]) || !File.Exists(probeDll))
+                return false;
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
+    /// <summary>
+    /// Runs an external tool to completion, returning true only on a clean (exit code 0) run.
+    /// Never throws and never blocks indefinitely; any failure to start, time out, or non-zero
+    /// exit is reported as false so callers can fall back to skipping.
+    /// </summary>
+    static bool TryRunTool(string fileName, IReadOnlyList<string> arguments)
+    {
         try
         {
             var psi = new ProcessStartInfo
             {
-                FileName = "ildasm",
+                FileName = fileName,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
             };
+            foreach (var arg in arguments)
+                psi.ArgumentList.Add(arg);
 
             using var process = Process.Start(psi);
             if (process is null) return false;
-            process.WaitForExit(TimeSpan.FromSeconds(10));
-            return true;
+
+            // Drain both streams to avoid deadlock on tools that write a lot to stderr.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(TimeSpan.FromSeconds(30)))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* ignore */ }
+                return false;
+            }
+            stdout.GetAwaiter().GetResult();
+            stderr.GetAwaiter().GetResult();
+
+            return process.ExitCode == 0;
         }
         catch
         {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -493,7 +493,9 @@ public class ApiCommand
 
     // ===== Method Source Resolution =====
 
-    internal static async Task<MethodSourceContext?> ResolveMethodSourceAsync(
+    internal sealed record ResolvedMethodSource(MethodSourceContext? Source, string? PdbPath);
+
+    internal static async Task<ResolvedMethodSource> ResolveMethodSourceAsync(
         string dllPath, string typeName, string methodName, int overloadIndex,
         ApiOptions options, HttpClient httpClient, VerboseLogger logger)
     {
@@ -514,17 +516,21 @@ public class ApiCommand
                     isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
             }
 
+            // Capture the acquired portable PDB path now so the decompiler can reuse it for local
+            // names even when SourceLink/source resolution below fails (PDB available, source not).
+            string? pdbPath = context.PortablePdbPath;
+
             if (!service.HasPdb || !service.HasSourceLink)
-                return null;
+                return new ResolvedMethodSource(null, pdbPath);
 
             var methodInfo = service.ResolveMethodSource(typeName, methodName, overloadIndex, publicOnly: true);
             if (methodInfo?.SourceUrl == null)
-                return null;
+                return new ResolvedMethodSource(null, pdbPath);
 
             var fetcher = new SourceFetcher(httpClient);
             var content = await fetcher.FetchSourceAsync(methodInfo.SourceUrl);
             if (content == null)
-                return null;
+                return new ResolvedMethodSource(null, pdbPath);
 
             var lines = content.Split('\n');
             int startLine = methodInfo.StartLine;
@@ -586,12 +592,12 @@ public class ApiCommand
             var dedented = methodLines.Select(l => l.Length >= minIndent ? l[minIndent..] : l);
             var sourceCode = string.Join('\n', dedented).TrimEnd();
 
-            return new MethodSourceContext(sourceCode, methodInfo.SourceUrl);
+            return new ResolvedMethodSource(new MethodSourceContext(sourceCode, methodInfo.SourceUrl), pdbPath);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Failed to resolve method source for {typeName}.{methodName}: {ex.Message}");
-            return null;
+            return new ResolvedMethodSource(null, null);
         }
     }
 
@@ -645,7 +651,7 @@ public class ApiCommand
                     .Where(m => m.Kind is "method" or "constructor" && !m.IsAbstract)
                     .ToList();
                 if (methods.Count > 0)
-                    ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath, mo4.OverloadIndex.Value - 1);
+                    ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath, mo4.OverloadIndex.Value - 1, mo4.PdbPath);
             }
 
             // Source code (already resolved in command layer)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -242,14 +242,17 @@ public static class MemberCommand
             if (effectiveOptions.OverloadIndex.HasValue && apiDllPath != null)
             {
                 var pdbLookupPath = runtimeAssemblyPath ?? apiDllPath;
-                var methodSource = await ApiCommand.ResolveMethodSourceAsync(
+                var resolved = await ApiCommand.ResolveMethodSourceAsync(
                     pdbLookupPath, apiType.FullName,
                     effectiveOptions.MemberFilter.First(),
                     effectiveOptions.OverloadIndex.Value - 1,
                     effectiveOptions, context.HttpClient, logger);
 
-                if (methodSource != null)
-                    effectiveOptions = effectiveOptions with { MethodSource = methodSource };
+                effectiveOptions = effectiveOptions with
+                {
+                    MethodSource = resolved.Source,
+                    PdbPath = resolved.PdbPath
+                };
             }
 
             if (effectiveOptions.EffectiveDiscovery)

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -135,6 +135,10 @@ public record MemberOptions : ApiOptions
     public bool ShowSelect { get; init; }
     public string? DllPath { get; init; }
     public MethodSourceContext? MethodSource { get; init; }
+
+    /// <summary>On-disk path to an acquired portable PDB, used by the decompiler (--index code
+    /// sections) to resolve real local-variable names instead of synthesized <c>V_n</c> slots.</summary>
+    public string? PdbPath { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -626,7 +626,7 @@ public static class ApiOutputFormatter
         }).ToList();
     }
 
-    internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int overloadIndex)
+    internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int overloadIndex, string? pdbPath = null)
     {
         using var stream = File.OpenRead(dllPath);
         using var peReader = new PEReader(stream);
@@ -649,7 +649,7 @@ public static class ApiOutputFormatter
             try
             {
                 var context = Decompiler.MethodBodyContext.Create(
-                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true);
+                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true, externalPdbPath: pdbPath);
                 if (context != null)
                 {
                     var lowered = Decompiler.CSharpEmitter.Emit(context);
@@ -672,7 +672,7 @@ public static class ApiOutputFormatter
             try
             {
                 var context = Decompiler.MethodBodyContext.Create(
-                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true);
+                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true, externalPdbPath: pdbPath);
                 if (context != null)
                 {
                     var annotated = Decompiler.AnnotatedILEmitter.Emit(


### PR DESCRIPTION
## Summary

Improves the custom decompiler's handling of .NET 11 runtime async ("async v2"), reuses PDBs the CLI already downloads to recover local variable names, and fixes the pre-existing CI test failures.

## Decompiler — runtime async ("async v2")

The C# compiler now lowers `await x` to a call to `System.Runtime.CompilerServices.AsyncHelpers.Await(x)` instead of emitting a state machine, and marks the method with `MethodImplAttributes.Async` (0x2000).

- Render `AsyncHelpers.Await(x)` back as `await x` across all overloads (Task/ValueTask, configured, generic value-returning), with correct parenthesization for binary operands and for member-access receivers (`(await GetThingAsync()).Member`).
- Unwrap runtime-async return types (`Task`/`ValueTask` → `void`, `Task<T>`/`ValueTask<T>` → `T`) so stack simulation and emitted `return` statements stay balanced — the IL `ret` yields the *unwrapped* awaited value, not the declared Task.
- Render `0`/`1` integer literals as `false`/`true` in bool-typed contexts.

## Decompiler — reuse downloaded PDBs for local names

Previously `## Lowered C#` / `## Annotated IL` only read *embedded* PDBs, so platform-assembly locals rendered as `V_n`, even though the CLI had already downloaded a portable PDB for the `## Source` section.

- `MethodBodyContext.Create` accepts an optional external portable PDB path and reads local names from it when no embedded PDB is present (names are materialized eagerly so the provider/stream are disposed immediately).
- The CLI threads the PDB it acquires from the symbol server through `member`/`type` output, so locals show real names (e.g. `zipArchive`, `stream`) instead of `V_n`. Genuine compiler temporaries correctly stay `V_n`.

## CI fixes

- **9 `ILAsm_Roundtrip_*` failures**: `CanRunILAsm()` returned `true` whenever the `ildasm` process merely *started*, ignoring exit code. Where the global tools are present but can't actually execute (wrong target runtime → exit ~150), tests ran and threw instead of skipping. Rewrote it as a real capability probe that round-trips `TestDll` through `ildasm` → `.il` → `ilasm` → `.dll`, returning `true` only on clean (exit 0) runs producing output, with a 30s timeout, stream draining, and temp cleanup. Tests now **skip** where tools are broken and still **run** where they work.
- **`DoubleLiteral_PositiveInfinity` failure**: float/double IL operands were formatted with `ToString("R")` in the current culture, rendering positive infinity as the culture symbol (e.g. `∞`) so the `double.PositiveInfinity` mapping never matched. Now formatted with `InvariantCulture` (also stabilizes decimal separators).

## Tests

- New `RuntimeAsyncEmitterTests` plus external-PDB and bool-literal coverage.
- Main suite: **679 total, 0 failed, 9 skipped**.
- Decompiler suite: **185 total, 0 failed, 0 skipped**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>