### PR TITLE
Support SourceLink Integrity for tool packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,17 +193,14 @@ jobs:
 
       - name: Smoke test - package quiet
         run: |
-          # Pipe through cat to work around a .NET 11 preview SDK regression
-          # where redirecting an AOT binary's stdout directly to a file
-          # ('> file') truncates the output to ~256 bytes. Piping is fine.
-          dotnet-inspect package System.Text.Json 10.0.0 -v:q | cat > smoke-package.md
+          dotnet-inspect package System.Text.Json 10.0.0 -v:q > smoke-package.md
           cat smoke-package.md
           grep -q "System.Text.Json" smoke-package.md
           grep -q "Library" smoke-package.md
 
       - name: Smoke test - package normal
         run: |
-          dotnet-inspect package System.Text.Json 10.0.0 -v:n | cat > smoke-package-normal.md
+          dotnet-inspect package System.Text.Json 10.0.0 -v:n > smoke-package-normal.md
           cat smoke-package-normal.md
           grep -q "## Package Info" smoke-package-normal.md
           grep -q "## Dependencies" smoke-package-normal.md
@@ -211,25 +208,25 @@ jobs:
 
       - name: Smoke test - type command (oneline default)
         run: |
-          dotnet-inspect type --package System.Text.Json@10.0.0 -t JsonSerializer --oneline | cat > smoke-type.txt
+          dotnet-inspect type --package System.Text.Json@10.0.0 -t JsonSerializer --oneline > smoke-type.txt
           cat smoke-type.txt
           grep -q "JsonSerializer" smoke-type.txt
 
       - name: Smoke test - member command (oneline default)
         run: |
-          dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize --oneline | cat > smoke-member.txt
+          dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize --oneline > smoke-member.txt
           cat smoke-member.txt
           grep -q "Serialize" smoke-member.txt
 
       - name: Smoke test - type command (markdown)
         run: |
-          dotnet-inspect type --package System.Text.Json@10.0.0 -v:m -t JsonSerializer | cat > smoke-type.md
+          dotnet-inspect type --package System.Text.Json@10.0.0 -v:m -t JsonSerializer > smoke-type.md
           cat smoke-type.md
           grep -q "JsonSerializer" smoke-type.md
 
       - name: Smoke test - member command (markdown)
         run: |
-          dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -v:m -m Serialize | cat > smoke-member.md
+          dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -v:m -m Serialize > smoke-member.md
           cat smoke-member.md
           grep -q "JsonSerializer" smoke-member.md
           grep -q "Serialize" smoke-member.md

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.9.0
+version: 0.9.1
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Use for factual answers about package contents, API signatures, compatibility changes, relationships, SourceLink, and assembly metadata.
 ---
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -58,6 +58,51 @@ public class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
+    private static (string PointerPackagePath, string RidPackagePath, string TempDir) CreateLocalToolPackageSet()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tool-package-test-{Guid.NewGuid():N}");
+
+        var pointerRoot = Path.Combine(tempDir, "pointer");
+        var pointerToolsDir = Path.Combine(pointerRoot, "tools", "net10.0", "any");
+        Directory.CreateDirectory(pointerToolsDir);
+        File.WriteAllText(Path.Combine(pointerToolsDir, "DotnetToolSettings.xml"), """
+            <DotNetCliTool Version="2">
+              <Commands>
+                <Command Name="test-tool" EntryPoint="Test.Tool.dll" Runner="dotnet" />
+              </Commands>
+              <RuntimeIdentifierPackages>
+                <RuntimeIdentifierPackage RuntimeIdentifier="linux-x64" Id="Test.Tool.linux-x64" />
+                <RuntimeIdentifierPackage RuntimeIdentifier="any" Id="Test.Tool.any" />
+              </RuntimeIdentifierPackages>
+            </DotNetCliTool>
+            """);
+
+        var payloadRoot = Path.Combine(tempDir, "payload");
+        var payloadToolsDir = Path.Combine(payloadRoot, "tools", "net10.0", "any");
+        Directory.CreateDirectory(payloadToolsDir);
+        File.Copy(TestAssemblyPath, Path.Combine(payloadToolsDir, "Test.Tool.dll"));
+
+        var ridRoot = Path.Combine(tempDir, "rid");
+        var ridToolsDir = Path.Combine(ridRoot, "tools", "any", "linux-x64");
+        Directory.CreateDirectory(ridToolsDir);
+        File.WriteAllText(Path.Combine(ridToolsDir, "DotnetToolSettings.xml"), """
+            <DotNetCliTool Version="2">
+              <Commands>
+                <Command Name="test-tool" EntryPoint="test-tool" Runner="executable" />
+              </Commands>
+            </DotNetCliTool>
+            """);
+
+        var pointerPackagePath = Path.Combine(tempDir, "Test.Tool.1.0.0.nupkg");
+        var payloadPackagePath = Path.Combine(tempDir, "Test.Tool.any.1.0.0.nupkg");
+        var ridPackagePath = Path.Combine(tempDir, "Test.Tool.linux-x64.1.0.0.nupkg");
+        ZipFile.CreateFromDirectory(pointerRoot, pointerPackagePath);
+        ZipFile.CreateFromDirectory(payloadRoot, payloadPackagePath);
+        ZipFile.CreateFromDirectory(ridRoot, ridPackagePath);
+
+        return (pointerPackagePath, ridPackagePath, tempDir);
+    }
+
     public CommandExecutionTests()
     {
         NuGetCache.Initialize("dotnet-inspect");
@@ -773,6 +818,46 @@ public class CommandExecutionTests
             Assert.Equal(0, exit);
             Assert.Contains("RegexOptions", output);
             Assert.Contains("Compiled", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Library_ToolPointerPackage_ResolvesAnyPayloadAssembly()
+    {
+        var (packagePath, _, tempDir) = CreateLocalToolPackageSet();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", "Test.Tool.dll", "--package", packagePath, "-S", "Library Info");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("# Test.Tool.dll", output);
+            Assert.Contains("| Name | dotnet-inspect.Tests |", output);
+            Assert.DoesNotContain("No DLLs found", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Library_ToolRidPackage_ResolvesSiblingAnyPayloadAssembly()
+    {
+        var (_, packagePath, tempDir) = CreateLocalToolPackageSet();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", "Test.Tool.dll", "--package", packagePath, "-S", "Library Info");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("# Test.Tool.dll", output);
+            Assert.Contains("| Name | dotnet-inspect.Tests |", output);
+            Assert.DoesNotContain("No DLLs found", error);
         }
         finally
         {

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -174,6 +174,10 @@ public static class InspectionCommandDefinitions
                 else
                     packagePath = source;
             }
+            else if (!string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(explicitPackage))
+            {
+                assemblyPath = source;
+            }
 
             bool showReferences = parseResult.GetValue(referencesOption);
             bool showDependencies = parseResult.GetValue(dependenciesOption);

--- a/src/dotnet-inspect/Commands/AssemblyCommand.cs
+++ b/src/dotnet-inspect/Commands/AssemblyCommand.cs
@@ -167,14 +167,18 @@ public class AssemblyCommand
             else if (!string.IsNullOrEmpty(options.PackagePath))
             {
                 // Extract from package
-                var extractResult = await ExtractFromPackageAsync(assemblyPath, options.PackagePath, options.Tfm, logger, context.HttpClient);
+                var extractResult = await ExtractFromPackageAsync(
+                    assemblyPath, options.PackagePath, options.Tfm,
+                    options.SourceOptions, logger, context.HttpClient);
                 if (extractResult == null)
                 {
                     return 1;
                 }
 
-                var (assemblyPaths, extractPath, extractTempDir, nupkgPath) = extractResult.Value;
+                var (assemblyPaths, extractPath, extractTempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion) = extractResult.Value;
                 tempDir = extractTempDir;
+                packageName = resolvedPackageName;
+                packageVersion = resolvedPackageVersion;
 
                 // Check effective sections cache before running full inspection
                 if (effectiveDiscovery && options.Discover is { Length: 0 } && assemblyPaths.Count > 0)
@@ -491,9 +495,16 @@ public class AssemblyCommand
         return inspections;
     }
 
-    private static async Task<(List<string> assemblyPaths, string extractPath, string? tempDir, string? nupkgPath)?> ExtractFromPackageAsync(string? assemblyName, string packageSource, string? tfm, VerboseLogger logger, HttpClient httpClient)
+    private static async Task<(List<string> assemblyPaths, string extractPath, string? tempDir, string? nupkgPath, string? packageName, string? packageVersion)?> ExtractFromPackageAsync(
+        string? assemblyName,
+        string packageSource,
+        string? tfm,
+        NuGetSourceOptions? sourceOptions,
+        VerboseLogger logger,
+        HttpClient httpClient)
     {
-        var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, packageSource, logger.Log);
+        var outcome = await PackageExtractor.ExtractPackageAsync(
+            httpClient, packageSource, logger.Log, sourceOptions: sourceOptions);
         if (!outcome.IsSuccess)
         {
             Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");
@@ -504,9 +515,35 @@ public class AssemblyCommand
         string extractPath = resolution.ExtractPath;
         string? tempDir = resolution.TempDir;
         string? nupkgPath = resolution.NupkgPath;
+        string? resolvedPackageName = resolution.PackageName;
+        string? resolvedPackageVersion = resolution.Version;
 
         // Find DLLs in the extracted package
         string[] allDlls = Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories);
+        if (allDlls.Length == 0)
+        {
+            var payload = await TryResolveToolPayloadPackageAsync(
+                resolution, packageSource, sourceOptions, logger, httpClient).ConfigureAwait(false);
+
+            if (payload.Error != null)
+            {
+                Console.Error.WriteLine(payload.Error);
+                DeleteTempDir(tempDir);
+                return null;
+            }
+
+            if (payload.Result != null)
+            {
+                DeleteTempDir(tempDir);
+                resolution = payload.Result;
+                extractPath = resolution.ExtractPath;
+                tempDir = resolution.TempDir;
+                nupkgPath = resolution.NupkgPath;
+                resolvedPackageName = resolution.PackageName;
+                resolvedPackageVersion = resolution.Version;
+                allDlls = Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories);
+            }
+        }
 
         // --tfm all: return all assemblies from every TFM
         if (string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase))
@@ -515,10 +552,10 @@ public class AssemblyCommand
             if (candidates.Count == 0)
             {
                 Console.Error.WriteLine("Error: No DLLs found in package.");
-                if (tempDir != null) try { Directory.Delete(tempDir, recursive: true); } catch { }
+                DeleteTempDir(tempDir);
                 return null;
             }
-            return (candidates, extractPath, tempDir, nupkgPath);
+            return (candidates, extractPath, tempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion);
         }
 
         // --tfm <specific>: find assembly by TFM
@@ -538,11 +575,11 @@ public class AssemblyCommand
                 {
                     Console.Error.WriteLine($"  {t}");
                 }
-                if (tempDir != null) try { Directory.Delete(tempDir, recursive: true); } catch { }
+                DeleteTempDir(tempDir);
                 return null;
             }
             logger.Log($"Using TFM: {tfm}");
-            return ([tfmAssembly], extractPath, tempDir, nupkgPath);
+            return ([tfmAssembly], extractPath, tempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion);
         }
 
         // No --tfm and no assembly name: select the highest-priority TFM (default)
@@ -552,7 +589,7 @@ public class AssemblyCommand
             if (candidates.Count == 0)
             {
                 Console.Error.WriteLine("Error: No DLLs found in package.");
-                if (tempDir != null) try { Directory.Delete(tempDir, recursive: true); } catch { }
+                DeleteTempDir(tempDir);
                 return null;
             }
 
@@ -560,11 +597,11 @@ public class AssemblyCommand
             if (selectedPath == null)
             {
                 // No TFM structure found, fall back to first DLL
-                return ([candidates[0]], extractPath, tempDir, nupkgPath);
+                return ([candidates[0]], extractPath, tempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion);
             }
 
             logger.Log($"Using TFM: {selectedTfm}");
-            return ([selectedPath], extractPath, tempDir, nupkgPath);
+            return ([selectedPath], extractPath, tempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion);
         }
 
         var (matchedAssembly, matchedTfm) = TfmSelector.FindAssemblyInPackage(extractPath, assemblyName, tfm);
@@ -572,7 +609,7 @@ public class AssemblyCommand
         {
             Console.Error.WriteLine($"Error: Library '{assemblyName}' not found in package.");
             Console.Error.WriteLine("Use 'dotnet-inspect package <name> --files' to list available libraries.");
-            if (tempDir != null) try { Directory.Delete(tempDir, recursive: true); } catch { }
+            DeleteTempDir(tempDir);
             return null;
         }
 
@@ -580,7 +617,114 @@ public class AssemblyCommand
             logger.Log($"Using TFM: {matchedTfm}");
 
         logger.Log($"Found: {Path.GetRelativePath(extractPath, matchedAssembly)}");
-        return ([matchedAssembly], extractPath, tempDir, nupkgPath);
+        return ([matchedAssembly], extractPath, tempDir, nupkgPath, resolvedPackageName, resolvedPackageVersion);
+    }
+
+    private sealed record ToolPayloadResolution(PackageExtractionResult? Result, string? Error);
+
+    private static async Task<ToolPayloadResolution> TryResolveToolPayloadPackageAsync(
+        PackageExtractionResult package,
+        string originalPackageSource,
+        NuGetSourceOptions? sourceOptions,
+        VerboseLogger logger,
+        HttpClient httpClient)
+    {
+        var payloadId = GetToolPayloadPackageId(package.ExtractPath, package.PackageName);
+        if (payloadId == null)
+            return new(null, null);
+
+        var version = package.Version ?? GetNuspecVersion(package.ExtractPath);
+        if (version == null)
+            return new(null, $"Error: Tool package '{package.PackageName}' has no DLLs and its version could not be determined.");
+
+        var localPayload = TryFindLocalSiblingPackage(originalPackageSource, payloadId, version);
+        var payloadOutcome = localPayload != null
+            ? await PackageExtractor.ExtractPackageAsync(httpClient, localPayload, logger.Log).ConfigureAwait(false)
+            : await PackageExtractor.ExtractPackageAsync(
+                httpClient, payloadId, logger.Log, sourceOptions: sourceOptions, version: version).ConfigureAwait(false);
+
+        if (!payloadOutcome.IsSuccess)
+            return new(null, $"Error: Tool package '{package.PackageName}' has no inspectable DLLs and payload package '{payloadId}@{version}' could not be resolved: {payloadOutcome.ErrorMessage}");
+
+        var payload = payloadOutcome.Result!;
+        var dlls = Directory.GetFiles(payload.ExtractPath, "*.dll", SearchOption.AllDirectories)
+            .Where(d => !d.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (dlls.Count == 0)
+        {
+            DeleteTempDir(payload.TempDir);
+            return new(null, $"Error: Tool payload package '{payload.PackageName}@{payload.Version}' does not contain inspectable .NET DLLs.");
+        }
+
+        logger.Log($"Tool package has no DLLs; inspecting payload package: {payload.PackageName} {payload.Version}");
+        return new(payload, null);
+    }
+
+    private static string? GetToolPayloadPackageId(string extractPath, string? packageName)
+    {
+        var toolsDir = Path.Combine(extractPath, "tools");
+        if (Directory.Exists(toolsDir))
+        {
+            var settings = ToolsAnalyzer.ReadToolSettings(toolsDir);
+            var anyPayload = settings?.RuntimeIdentifierPackages?
+                .FirstOrDefault(r => r.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(anyPayload?.PackageId))
+                return anyPayload.PackageId;
+        }
+
+        return TryGetSiblingAnyPackageId(packageName);
+    }
+
+    private static string? TryGetSiblingAnyPackageId(string? packageName)
+    {
+        if (string.IsNullOrWhiteSpace(packageName))
+            return null;
+
+        string[] knownRidSuffixes =
+        [
+            ".win-x64",
+            ".win-arm64",
+            ".linux-x64",
+            ".linux-arm64",
+            ".osx-arm64"
+        ];
+
+        var suffix = knownRidSuffixes.FirstOrDefault(s =>
+            packageName.EndsWith(s, StringComparison.OrdinalIgnoreCase));
+        return suffix == null ? null : packageName[..^suffix.Length] + ".any";
+    }
+
+    private static string? TryFindLocalSiblingPackage(string originalPackageSource, string payloadId, string version)
+    {
+        if (!originalPackageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(originalPackageSource));
+        if (directory == null)
+            return null;
+
+        var exact = Path.Combine(directory, $"{payloadId}.{version}.nupkg");
+        if (File.Exists(exact))
+            return exact;
+
+        return Directory.GetFiles(directory, $"{payloadId}.*.nupkg")
+            .OrderByDescending(f => f, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static string? GetNuspecVersion(string extractPath)
+    {
+        var nuspec = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault();
+        return nuspec == null ? null : NuspecParser.Parse(nuspec).Version;
+    }
+
+    private static void DeleteTempDir(string? tempDir)
+    {
+        if (tempDir == null)
+            return;
+
+        try { Directory.Delete(tempDir, recursive: true); } catch { }
     }
 
 }

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -9,14 +9,21 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 public static class ToolsAnalyzer
 {
+    public sealed record ToolSettings(
+        string? Version,
+        string? ToolFormat,
+        bool IsRidSpecificPointerPackage,
+        List<string>? Commands,
+        List<RidPackageReference>? RuntimeIdentifierPackages);
+
     public static void AnalyzeToolsDirectory(string toolsDir, InspectionResult result)
     {
         // Check for DotnetToolSettings.xml: root, one level deep, or two levels deep
         // Standard locations: tools/, tools/{tfm}/, or tools/{tfm}/{rid}/
-        string? settingsFile = FindSettingsFile(toolsDir);
-        if (settingsFile != null)
+        var settings = ReadToolSettings(toolsDir);
+        if (settings != null)
         {
-            ParseToolSettings(settingsFile, result);
+            ApplyToolSettings(settings, result);
         }
 
         // Tools directory structure: tools/{tfm}/{rid}/ or tools/{tfm}/any/
@@ -165,7 +172,13 @@ public static class ToolsAnalyzer
         return null;
     }
 
-    private static void ParseToolSettings(string settingsFile, InspectionResult result)
+    public static ToolSettings? ReadToolSettings(string toolsDir)
+    {
+        var settingsFile = FindSettingsFile(toolsDir);
+        return settingsFile == null ? null : ParseToolSettings(settingsFile);
+    }
+
+    private static ToolSettings? ParseToolSettings(string settingsFile)
     {
         try
         {
@@ -173,18 +186,13 @@ public static class ToolsAnalyzer
             var root = doc.Root;
 
             string? version = root?.Attribute("Version")?.Value;
-            result.ManifestVersion = version;
             if (version == "2")
             {
-                result.ToolFormat = "DotNetCliTool Version=\"2\" (RID-specific)";
-                result.IsRidSpecificPointerPackage = true;
-                result.IsFrameworkDependent = false;
-                result.HasRidSpecificAssets = true;
-
                 var commands = root?.Element("Commands")?.Elements("Command");
+                List<string>? commandNames = null;
                 if (commands != null)
                 {
-                    result.ToolCommands = commands
+                    commandNames = commands
                         .Select(c => c.Attribute("Name")?.Value)
                         .Where(n => n != null)
                         .Cast<string>()
@@ -192,39 +200,69 @@ public static class ToolsAnalyzer
                 }
 
                 var ridPackages = root?.Element("RuntimeIdentifierPackages")?.Elements("RuntimeIdentifierPackage");
+                List<RidPackageReference>? runtimeIdentifierPackages = null;
                 if (ridPackages != null)
                 {
-                    result.RuntimeIdentifierPackages = ridPackages
+                    runtimeIdentifierPackages = ridPackages
                         .Select(r => new RidPackageReference
                         {
                             RuntimeIdentifier = r.Attribute("RuntimeIdentifier")?.Value ?? "",
                             PackageId = r.Attribute("Id")?.Value ?? ""
                         })
                         .ToList();
-
-                    result.SupportedRids = result.RuntimeIdentifierPackages
-                        .Select(r => r.RuntimeIdentifier)
-                        .ToList();
                 }
+
+                return new ToolSettings(
+                    version,
+                    "DotNetCliTool Version=\"2\" (RID-specific)",
+                    IsRidSpecificPointerPackage: true,
+                    commandNames,
+                    runtimeIdentifierPackages);
             }
             else if (version == "1" || version == null)
             {
-                result.ToolFormat = "DotNetCliTool Version=\"1\" (portable)";
-
                 var commands = root?.Element("Commands")?.Elements("Command");
+                List<string>? commandNames = null;
                 if (commands != null)
                 {
-                    result.ToolCommands = commands
+                    commandNames = commands
                         .Select(c => c.Attribute("Name")?.Value)
                         .Where(n => n != null)
                         .Cast<string>()
                         .ToList();
                 }
+
+                return new ToolSettings(
+                    version,
+                    "DotNetCliTool Version=\"1\" (portable)",
+                    IsRidSpecificPointerPackage: false,
+                    commandNames,
+                    RuntimeIdentifierPackages: null);
             }
         }
         catch
         {
             // Ignore parse errors
+        }
+
+        return null;
+    }
+
+    private static void ApplyToolSettings(ToolSettings settings, InspectionResult result)
+    {
+        result.ManifestVersion = settings.Version;
+        result.ToolFormat = settings.ToolFormat;
+        result.ToolCommands = settings.Commands;
+
+        if (settings.IsRidSpecificPointerPackage)
+        {
+            result.IsRidSpecificPointerPackage = true;
+            result.IsFrameworkDependent = false;
+            result.HasRidSpecificAssets = true;
+            result.RuntimeIdentifierPackages = settings.RuntimeIdentifierPackages;
+            result.SupportedRids = settings.RuntimeIdentifierPackages?
+                .Select(r => r.RuntimeIdentifier)
+                .ToList();
         }
     }
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.9.1
+
+### Fixes
+
+- `library <dll> --package <tool-package> -S "SourceLink Integrity"` now resolves Tool v2 pointer/RID packages to their inspectable framework-dependent payload package.
+- CI smoke tests now write directly to files again after the .NET 11 stdout redirection fix.
+
 ## v0.9.0
 
 ### Signals


### PR DESCRIPTION
## Summary
- resolve Tool v2 pointer and RID packages to their inspectable framework-dependent `.any` payload for `library --package`
- allow tool package binaries such as `dotnet-inspect.dll` to run `SourceLink Integrity`
- remove the CI smoke-test `| cat > file` workaround now that the SDK stdout redirection bug is fixed
- bump the tool to patch version 0.9.1

## Validation
- `dotnet run --project src/dotnet-inspect.Tests`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet pack src/dotnet-inspect -c Release -p:OfficialBuild=true`
- `dotnet run --project src/dotnet-inspect -- library dotnet-inspect.dll --package dotnet-inspect@0.9.0 -S "SourceLink Integrity"`
- direct redirection smoke commands from `.github/workflows/ci.yml`

Fixes #333
Fixes #319
