### PR TITLE
Share source-selection parsing across API commands

### DIFF
--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.CommandLine;
+using System.CommandLine;
 
 namespace DotnetInspector.Tests.Parsers;
 
@@ -158,6 +159,35 @@ public class SharedParsersTests
         Assert.Equal("Deserialize", member);
     }
 
+    // ── SplitTrailingMember ───────────────────────────────────────────────
+
+    [Fact]
+    public void SplitTrailingMember_SplitsSimpleMember()
+    {
+        var (typeName, memberName) = SharedParsers.SplitTrailingMember("System.Text.Json.JsonSerializer.Deserialize");
+
+        Assert.Equal("System.Text.Json.JsonSerializer", typeName);
+        Assert.Equal("Deserialize", memberName);
+    }
+
+    [Fact]
+    public void SplitTrailingMember_DoesNotSplitGenericTypeSuffix()
+    {
+        var (typeName, memberName) = SharedParsers.SplitTrailingMember("System.Collections.Generic.List<T>");
+
+        Assert.Equal("System.Collections.Generic.List<T>", typeName);
+        Assert.Null(memberName);
+    }
+
+    [Fact]
+    public void SplitTrailingMember_NoDot_ReturnsOriginal()
+    {
+        var (typeName, memberName) = SharedParsers.SplitTrailingMember("JsonSerializer");
+
+        Assert.Equal("JsonSerializer", typeName);
+        Assert.Null(memberName);
+    }
+
     // ── ParseTypeFilter ──────────────────────────────────────────────────
 
     [Fact]
@@ -313,5 +343,52 @@ public class SharedParsersTests
         Assert.Equal(2, result.Length);
         Assert.Equal("string", result[0]);
         Assert.Equal("int", result[1]);
+    }
+
+    // ── Source selection ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ReadSourceSelectionInputs_ExplicitPackage_IsExplicitSource()
+    {
+        var root = new RootCommand();
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        var packageOption = new Option<string?>("--package");
+        var assemblyOption = new Option<string?>("--library");
+        var platformOption = new Option<string?>("--platform");
+        root.Arguments.Add(argsArg);
+        root.Options.Add(packageOption);
+        root.Options.Add(assemblyOption);
+        root.Options.Add(platformOption);
+
+        var result = root.Parse(["JsonSerializer", "--package", "System.Text.Json"]);
+        var inputs = SharedParsers.ReadSourceSelectionInputs(
+            result, argsArg, packageOption, assemblyOption, platformOption);
+
+        Assert.True(inputs.HasExplicitSource);
+        Assert.False(inputs.IsLibrarySelector);
+        Assert.Equal(["JsonSerializer"], inputs.Args);
+        Assert.Equal("System.Text.Json", inputs.ExplicitPackage);
+    }
+
+    [Fact]
+    public void ReadSourceSelectionInputs_LibrarySelector_IsNotExplicitSource()
+    {
+        var root = new RootCommand();
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        var packageOption = new Option<string?>("--package");
+        var assemblyOption = new Option<string?>("--library");
+        var platformOption = new Option<string?>("--platform");
+        root.Arguments.Add(argsArg);
+        root.Options.Add(packageOption);
+        root.Options.Add(assemblyOption);
+        root.Options.Add(platformOption);
+
+        var result = root.Parse(["JsonSerializer", "--library", "System.Text.Json.dll"]);
+        var inputs = SharedParsers.ReadSourceSelectionInputs(
+            result, argsArg, packageOption, assemblyOption, platformOption);
+
+        Assert.True(inputs.IsLibrarySelector);
+        Assert.False(inputs.HasExplicitSource);
+        Assert.Equal("System.Text.Json.dll", inputs.ExplicitAssembly);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -78,15 +78,11 @@ public static class MemberOptionsParser
         SharedOptions opts,
         MemberCommandArgs args)
     {
-        var argsValue = parseResult.GetValue(args.ArgsArg) ?? [];
-        var explicitPackage = parseResult.GetValue(args.PackageOption);
-        var explicitAssembly = parseResult.GetValue(args.AssemblyOption);
-        var explicitPlatform = parseResult.GetValue(args.PlatformOption);
-        bool isLibrarySelector = SourceResolver.IsLibrarySelector(explicitAssembly, explicitPackage);
-        bool hasExplicitSource = SourceResolver.HasExplicitSource(explicitPackage, explicitAssembly, explicitPlatform, isLibrarySelector);
+        var sourceInputs = SharedParsers.ReadSourceSelectionInputs(
+            parseResult, args.ArgsArg, args.PackageOption, args.AssemblyOption, args.PlatformOption);
 
         // Handle projection discovery or help
-        if (argsValue.Length == 0 && !hasExplicitSource)
+        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource)
         {
             if (opts.IsDiscoveryMode(parseResult))
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
@@ -95,15 +91,15 @@ public static class MemberOptionsParser
 
         // Extract positional members
         List<string> positionalMembers = [];
-        if (hasExplicitSource && argsValue.Length >= 2)
-            positionalMembers.AddRange(argsValue[1..]);
-        else if (!hasExplicitSource && argsValue.Length >= 3)
-            positionalMembers.AddRange(argsValue[2..]);
+        if (sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 2)
+            positionalMembers.AddRange(sourceInputs.Args[1..]);
+        else if (!sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 3)
+            positionalMembers.AddRange(sourceInputs.Args[2..]);
 
         // Resolve source
-        var source = await SourceResolver.ResolveAsync(
-            argsValue, explicitPackage, explicitAssembly, explicitPlatform,
-            parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
+        var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
+            sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
+        var source = sourceSelection.Source;
 
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);
@@ -111,7 +107,7 @@ public static class MemberOptionsParser
         // If source resolution left us with an unresolved package that is actually
         // a qualified type name (e.g., "System.Text.Json.JsonDocument"), split it
         // so the user can write: member System.Text.Json.JsonDocument Parse
-        if (explicitPackage == null && source.PackagePath != null && source.PlatformAssembly == null && source.AssemblyPath == null)
+        if (sourceSelection.ExplicitPackage == null && source.PackagePath != null && source.PlatformAssembly == null && source.AssemblyPath == null)
         {
             var probe = SourceResolver.TryProbeLocalQualifiedName(source.PackagePath);
             if (probe != null)
@@ -135,12 +131,11 @@ public static class MemberOptionsParser
         // not a type.member pair.
         if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
         {
-            var lastDot = typeName.LastIndexOf('.');
-            var rightPart = typeName[(lastDot + 1)..];
-            if (!rightPart.Contains('<'))
+            var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
+            if (splitMemberName != null)
             {
-                positionalMembers.Add(rightPart);
-                typeName = typeName[..lastDot];
+                positionalMembers.Add(splitMemberName);
+                typeName = splitTypeName;
             }
         }
 

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -1,3 +1,7 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using DotnetInspector.Services;
+
 namespace DotnetInspector.CommandLine;
 
 /// <summary>
@@ -7,6 +11,78 @@ namespace DotnetInspector.CommandLine;
 /// </summary>
 public static class SharedParsers
 {
+    public sealed record SourceSelection(
+        string[] Args,
+        string? ExplicitPackage,
+        string? ExplicitAssembly,
+        string? ExplicitPlatform,
+        bool IsLibrarySelector,
+        bool HasExplicitSource,
+        SourceResolver.ResolvedSource Source);
+
+    public sealed record SourceSelectionInputs(
+        string[] Args,
+        string? ExplicitPackage,
+        string? ExplicitAssembly,
+        string? ExplicitPlatform,
+        bool IsLibrarySelector,
+        bool HasExplicitSource);
+
+    public static SourceSelectionInputs ReadSourceSelectionInputs(
+        ParseResult parseResult,
+        Argument<string[]> argsArg,
+        Option<string?> packageOption,
+        Option<string?> assemblyOption,
+        Option<string?> platformOption)
+    {
+        var argsValue = parseResult.GetValue(argsArg) ?? [];
+        var explicitPackage = parseResult.GetValue(packageOption);
+        var explicitAssembly = parseResult.GetValue(assemblyOption);
+        var explicitPlatform = parseResult.GetValue(platformOption);
+        bool isLibrarySelector = SourceResolver.IsLibrarySelector(explicitAssembly, explicitPackage);
+        bool hasExplicitSource = SourceResolver.HasExplicitSource(
+            explicitPackage, explicitAssembly, explicitPlatform, isLibrarySelector);
+
+        return new SourceSelectionInputs(
+            argsValue,
+            explicitPackage,
+            explicitAssembly,
+            explicitPlatform,
+            isLibrarySelector,
+            hasExplicitSource);
+    }
+
+    public static async Task<SourceSelection> ResolveSourceSelectionAsync(
+        SourceSelectionInputs inputs,
+        bool verbose,
+        bool tryQualifiedTypeName)
+    {
+        var source = await SourceResolver.ResolveAsync(
+            inputs.Args, inputs.ExplicitPackage, inputs.ExplicitAssembly, inputs.ExplicitPlatform,
+            verbose, tryQualifiedTypeName).ConfigureAwait(false);
+
+        return new SourceSelection(
+            inputs.Args,
+            inputs.ExplicitPackage,
+            inputs.ExplicitAssembly,
+            inputs.ExplicitPlatform,
+            inputs.IsLibrarySelector,
+            inputs.HasExplicitSource,
+            source);
+    }
+
+    public static (string TypeName, string? MemberName) SplitTrailingMember(string typeName)
+    {
+        var lastDot = typeName.LastIndexOf('.');
+        if (lastDot <= 0)
+            return (typeName, null);
+
+        var rightPart = typeName[(lastDot + 1)..];
+        return rightPart.Contains('<')
+            ? (typeName, null)
+            : (typeName[..lastDot], rightPart);
+    }
+
     /// <summary>
     /// Parses member filter values where a single numeric value means limit,
     /// otherwise values are treated as filter names.

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -70,16 +70,12 @@ public static class SourceOptionsParser
         SharedOptions opts,
         SourceCommandArgs args)
     {
-        var argsValue = parseResult.GetValue(args.ArgsArg) ?? [];
-        var explicitPackage = parseResult.GetValue(args.PackageOption);
-        var explicitAssembly = parseResult.GetValue(args.AssemblyOption);
-        var explicitPlatform = parseResult.GetValue(args.PlatformOption);
         var ilOffset = parseResult.GetValue(args.ILOffsetOption);
-        bool isLibrarySelector = SourceResolver.IsLibrarySelector(explicitAssembly, explicitPackage);
-        bool hasExplicitSource = SourceResolver.HasExplicitSource(explicitPackage, explicitAssembly, explicitPlatform, isLibrarySelector);
+        var sourceInputs = SharedParsers.ReadSourceSelectionInputs(
+            parseResult, args.ArgsArg, args.PackageOption, args.AssemblyOption, args.PlatformOption);
 
         // Handle projection discovery or help
-        if (argsValue.Length == 0 && !hasExplicitSource && ilOffset == null)
+        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource && ilOffset == null)
         {
             if (opts.IsDiscoveryMode(parseResult))
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
@@ -87,14 +83,14 @@ public static class SourceOptionsParser
         }
 
         // Check for unrecognized options in positional args
-        var badOption = argsValue.FirstOrDefault(a => a.StartsWith('-'));
+        var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 
         // Resolve source
-        var source = await SourceResolver.ResolveAsync(
-            argsValue, explicitPackage, explicitAssembly, explicitPlatform,
-            parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+        var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
+            sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+        var source = sourceSelection.Source;
 
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);
@@ -107,21 +103,20 @@ public static class SourceOptionsParser
             if (memberName == null)
             {
                 var positionalMembers = new List<string>();
-                if (hasExplicitSource && argsValue.Length >= 2)
-                    positionalMembers.AddRange(argsValue[1..]);
-                else if (!hasExplicitSource && argsValue.Length >= 3)
-                    positionalMembers.AddRange(argsValue[2..]);
+                if (sourceSelection.HasExplicitSource && sourceSelection.Args.Length >= 2)
+                    positionalMembers.AddRange(sourceSelection.Args[1..]);
+                else if (!sourceSelection.HasExplicitSource && sourceSelection.Args.Length >= 3)
+                    positionalMembers.AddRange(sourceSelection.Args[2..]);
 
                 // Handle Type.Member dotted syntax
                 var typeName = source.TypeName;
                 if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
                 {
-                    var lastDot = typeName.LastIndexOf('.');
-                    var rightPart = typeName[(lastDot + 1)..];
-                    if (!rightPart.Contains('<'))
+                    var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
+                    if (splitMemberName != null)
                     {
-                        positionalMembers.Add(rightPart);
-                        source = source with { TypeName = typeName[..lastDot] };
+                        positionalMembers.Add(splitMemberName);
+                        source = source with { TypeName = splitTypeName };
                     }
                 }
 

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -75,15 +75,11 @@ public static class TypeOptionsParser
         SharedOptions opts,
         TypeCommandArgs args)
     {
-        var argsValue = parseResult.GetValue(args.ArgsArg) ?? [];
-        var explicitPackage = parseResult.GetValue(args.PackageOption);
-        var explicitAssembly = parseResult.GetValue(args.AssemblyOption);
-        var explicitPlatform = parseResult.GetValue(args.PlatformOption);
-        bool isLibrarySelector = SourceResolver.IsLibrarySelector(explicitAssembly, explicitPackage);
-        bool hasExplicitSource = SourceResolver.HasExplicitSource(explicitPackage, explicitAssembly, explicitPlatform, isLibrarySelector);
+        var sourceInputs = SharedParsers.ReadSourceSelectionInputs(
+            parseResult, args.ArgsArg, args.PackageOption, args.AssemblyOption, args.PlatformOption);
 
         // Handle projection discovery or help
-        if (argsValue.Length == 0 && !hasExplicitSource)
+        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource)
         {
             if (opts.IsDiscoveryMode(parseResult))
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
@@ -91,14 +87,14 @@ public static class TypeOptionsParser
         }
 
         // Check for unrecognized options in positional args
-        var badOption = argsValue.FirstOrDefault(a => a.StartsWith('-'));
+        var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 
         // Resolve source
-        var source = await SourceResolver.ResolveAsync(
-            argsValue, explicitPackage, explicitAssembly, explicitPlatform,
-            parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+        var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
+            sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+        var source = sourceSelection.Source;
 
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);


### PR DESCRIPTION
## Summary
- extract shared source-selection input handling for `type`, `member`, and `source` parsers
- add a shared `SplitTrailingMember` helper for dotted `Type.Member` parsing
- keep command-specific help/error behavior intact while reducing repeated source-resolution setup
- add direct unit coverage for the new shared helpers

## Validation
- `dotnet build src/dotnet-inspect -v:q`
- `dotnet run --project src/dotnet-inspect.Tests`
