### PR TITLE
Add --rows table row limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type filters. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. |
 | Source mapping | `source`, `member -v:d` | SourceLink URLs, member line numbers, source fetching, URL verification, token+IL-offset to source-line resolution. |
-| Agent-friendly output | global flags | Markdown by default, compact `--oneline`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, built-in head/tail limiting. |
+| Agent-friendly output | global flags | Markdown by default, compact `--oneline`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory
 
@@ -67,7 +67,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 
 ## Output and querying
 
-Default output is Markdown. Use `--oneline` for compact rows, `--plaintext` for plain text, `--json` for structured data, `--count` to count table rows in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`.
+Default output is Markdown. Use `--oneline` for compact rows, `--plaintext` for plain text, `--json` for structured data, `--rows -n N` to cap rendered table rows, `--count` to count table rows in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`.
 
 Sections and fields are queryable without a template language:
 

--- a/docs/workflows/core/line-and-result-limiting.md
+++ b/docs/workflows/core/line-and-result-limiting.md
@@ -1,13 +1,13 @@
 ---
 id: line-and-result-limiting
-description: Control output size with line limits, result limits, and row counts
-commands: [-n, -t, -m, --versions, --count]
+description: Control output size with line limits, table row limits, result limits, and row counts
+commands: [-n, --rows, -t, -m, --versions, --count]
 areas: [output, limiting, count, agents]
 ---
 
 # Line, Result, and Row Counting
 
-> Control how much output is returned. `-n` limits output lines (like `head`). `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` returns one integer for the rendered row count of a single selected section. These are essential for agents that need compact, predictable output.
+> Control how much output is returned. `-n` limits output lines (like `head`). `--rows -n N` interprets the same count as table data rows per rendered table. `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` returns one integer for the rendered row count of a single selected section. These are essential for agents that need compact, predictable output.
 
 ## Preconditions
 
@@ -81,11 +81,35 @@ wc -l | tr -d ' '
 Tips:
 ```
 
-## 2. Limit type results
+## 2. Limit table rows
+
+> Goal: Keep Markdown structure and table headers, but show only the first N data rows per rendered table.
+> `--rows` is a mode for `-n`/`-N`; it requires a head count and cannot be combined with `--tail`.
+
+```bash
+dotnet-inspect System.Private.CoreLib -S "Async*" --rows -n 6
+```
+
+```expect
+## Async Methods
+| Name | Declaring Type | Kind | Signature |
+DisposeAsync
+WriteAsync
+```
+
+```query
+grep -c '^| .* | .* | .* | .* |$'
+```
+
+```expect
+6
+```
+
+## 3. Limit type results
 
 > Goal: Return only the first N types from a type listing.
 
-### 2a. Using `type -t N`
+### 3a. Using `type -t N`
 
 ```prompt
 Show me just 3 types from System.Text.Json.
@@ -105,11 +129,11 @@ JsonCommentHandling
 Tips:
 ```
 
-## 3. Filter types by glob
+## 4. Filter types by glob
 
 > Goal: Filter types to those matching a name pattern.
 
-### 3a. Using `type -t pattern`
+### 4a. Using `type -t pattern`
 
 ```bash
 dotnet-inspect type System.Text.Json -t "Json*" --tips q
@@ -125,11 +149,11 @@ SortedSet
 Tips:
 ```
 
-## 4. Limit find results
+## 5. Limit find results
 
 > Goal: Return only the first N matches from a find search.
 
-### 4a. Using `find -t N`
+### 5a. Using `find -t N`
 
 ```bash
 dotnet-inspect find "Json*" -t 3 -v:q
@@ -152,11 +176,11 @@ grep -c '^| Json'
 Tips:
 ```
 
-## 5. Limit member results
+## 6. Limit member results
 
 > Goal: Return only the first N members from a member listing.
 
-### 5a. Using `member -m N`
+### 6a. Using `member -m N`
 
 ```bash
 dotnet-inspect member System.Text.Json JsonSerializer -m 3
@@ -172,11 +196,11 @@ Deserialize
 Tips:
 ```
 
-## 6. Filter members by name
+## 7. Filter members by name
 
 > Goal: Show only members matching an exact name, including all overloads.
 
-### 6a. Using positional member name
+### 7a. Using positional member name
 
 ```bash
 dotnet-inspect member System.Text.Json JsonSerializer Deserialize --tips q
@@ -192,11 +216,11 @@ Deserialize
 Tips:
 ```
 
-## 7. Limit version list
+## 8. Limit version list
 
 > Goal: Return only the first N versions.
 
-### 7a. Using `--versions N`
+### 8a. Using `--versions N`
 
 ```bash
 dotnet-inspect System.CommandLine --versions 3
@@ -220,11 +244,11 @@ wc -l | tr -d ' '
 Tips:
 ```
 
-## 8. Count rows in a section
+## 9. Count rows in a section
 
 > Goal: Return a single integer row count for a selected table section.
 
-### 8a. Count async methods
+### 9a. Count async methods
 
 ```prompt
 How many async methods are in System.Text.Json?
@@ -248,7 +272,7 @@ positive
 Tips:
 ```
 
-### 8b. Count requires one selected section
+### 9b. Count requires one selected section
 
 ```bash
 dotnet-inspect System.Text.Json --count

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -14,7 +14,7 @@ Invoke through `dnx` unless the tool is already installed:
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, `--rows -n N` to cap rendered table rows, and `-v:d` when you need source/decompiled C#/IL detail.
 
 ## Workflow map
 
@@ -27,7 +27,7 @@ Default output is Markdown. Use `--oneline` to scan, `--json` for structured dat
 | Inspect package/library signals | `library Foo -S Signals` or `package Foo -S Signals` | `Signals` resolves SourceLink for libraries; add `-S "SourceLink Availability"` for source reachability or `-S "SourceLink Integrity"` for slow content verification. |
 | Inventory package library files | `package Foo -S "Library Files"` | Lists all files under `lib/` across TFMs; use paths from this section with `library <file> --package Foo` for specific assemblies. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package/platform scope as needed. |
-| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N` | Prefer built-in limits over shell pipes. |
+| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N`, `--rows -n N` | Prefer built-in limits over shell pipes. |
 
 ## Modern .NET and preview workflow
 

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -69,6 +69,60 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void LimitMarkdownTableRows_LimitsEachTable()
+    {
+        const string markdown = """
+        # Title
+
+        ## First
+
+        | Name |
+        | ---- |
+        | A |
+        | B |
+        | C |
+
+        ## Second
+
+        | Value |
+        | ----- |
+        | 1 |
+        | 2 |
+        """;
+
+        var output = MarkdownTableRowLimiter.Apply(markdown, 2);
+
+        Assert.Contains("| A |", output);
+        Assert.Contains("| B |", output);
+        Assert.DoesNotContain("| C |", output);
+        Assert.Contains("| 1 |", output);
+        Assert.Contains("| 2 |", output);
+    }
+
+    [Fact]
+    public void LimitMarkdownTableRows_IgnoresCodeFences()
+    {
+        const string markdown = """
+        ```md
+        | Name |
+        | ---- |
+        | A |
+        | B |
+        ```
+
+        | Name |
+        | ---- |
+        | A |
+        | B |
+        """;
+
+        var output = MarkdownTableRowLimiter.Apply(markdown, 1);
+
+        Assert.Contains("| B |\n```", output.ReplaceLineEndings("\n"));
+        Assert.DoesNotContain("| B |\n", output.ReplaceLineEndings("\n").Split("```")[2]);
+    }
+
+    [Fact]
     public void MultiAssemblyReport_HasSingleH1()
     {
         var report = CreateTestReport("Test.dll", false, "net9.0", "net8.0");

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -205,6 +205,7 @@ public static class InspectionCommandDefinitions
                 Columns = opts.ParseColumns(parseResult),
                 Fields = opts.ParseFields(parseResult),
                 Count = parseResult.GetValue(opts.Count),
+                Rows = opts.ParseRows(parseResult),
                 Schema = opts.ParseSchema(parseResult),
                 NoHeader = parseResult.GetValue(asmNoHeaderOption),
                 SourceOptions = opts.ParseNuGetSourceOptions(parseResult),

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -207,6 +207,7 @@ public static class SearchCommandDefinitions
                 Tfm = parseResult.GetValue(tfmOption),
                 IncludeAll = parseResult.GetValue(allOption),
                 Limit = CommandLineHelpers.ParseTypeLimit(parseResult.GetValue(typeFilterOption)),
+                Rows = opts.ParseRows(parseResult),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 CompactJson = parseResult.GetValue(compactOption),
                 OneLine = opts.ResolveOneLine(parseResult, oneLineOption),
@@ -323,6 +324,7 @@ public static class SearchCommandDefinitions
                 Tfm = parseResult.GetValue(tfmOption),
                 IncludeAll = parseResult.GetValue(allOption),
                 Limit = CommandLineHelpers.ParseTypeLimit(parseResult.GetValue(typeFilterOption)),
+                Rows = opts.ParseRows(parseResult),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 CompactJson = parseResult.GetValue(compactOption),
                 Verbose = parseResult.GetValue(opts.Verbose),
@@ -395,6 +397,7 @@ public static class SearchCommandDefinitions
                     CompactJson = parseResult.GetValue(compactOption),
                     MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
                     EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
+                    Rows = opts.ParseRows(parseResult),
                     Verbose = parseResult.GetValue(opts.Verbose),
                     SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
                 };
@@ -430,6 +433,7 @@ public static class SearchCommandDefinitions
                 CompactJson = parseResult.GetValue(compactOption),
                 MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
                 EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
+                Rows = opts.ParseRows(parseResult),
                 Verbose = parseResult.GetValue(opts.Verbose),
                 SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
             };
@@ -447,6 +451,7 @@ public static class SearchCommandDefinitions
                     CompactJson = parseResult.GetValue(compactOption),
                     MermaidOutput = opts.ResolveFormat(parseResult) == OutputFormat.Mermaid,
                     EmbeddedMermaid = opts.IsEmbeddedMermaid(parseResult),
+                    Rows = opts.ParseRows(parseResult),
                     Verbose = parseResult.GetValue(opts.Verbose),
                     SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
                 };

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -112,8 +112,9 @@ public static class DiffOptionsParser
             Discover = opts.ParseDiscover(parseResult),
             Tree = parseResult.GetValue(opts.Tree),
             Select = opts.ParseSelect(parseResult),
-                Columns = opts.ParseColumns(parseResult),
-                Fields = opts.ParseFields(parseResult),
+            Columns = opts.ParseColumns(parseResult),
+            Fields = opts.ParseFields(parseResult),
+            Rows = opts.ParseRows(parseResult),
         };
 
         var verbosity = opts.ParseVerbosity(parseResult);

--- a/src/dotnet-inspect/CommandLine/Parsers/FindOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/FindOptionsParser.cs
@@ -89,6 +89,7 @@ public static class FindOptionsParser
             Tfm = parseResult.GetValue(args.TfmOption),
             IncludeAll = parseResult.GetValue(args.AllOption),
             Limit = CommandLineHelpers.ParseTypeLimit(parseResult.GetValue(args.TypeFilterOption)),
+            Rows = opts.ParseRows(parseResult),
             JsonOutput = parseResult.GetValue(opts.Json),
             CompactJson = parseResult.GetValue(args.CompactOption),
             OneLine = opts.ResolveOneLine(parseResult, args.OneLineOption),

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -196,6 +196,7 @@ public static class MemberOptionsParser
             Columns = opts.ParseColumns(parseResult),
             Fields = opts.ParseFields(parseResult),
             Count = parseResult.GetValue(opts.Count),
+            Rows = opts.ParseRows(parseResult),
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -103,6 +103,7 @@ public static class PackageOptionsParser
             Fields = opts.ParseFields(parseResult),
             Schema = opts.ParseSchema(parseResult),
             Count = parseResult.GetValue(opts.Count),
+            Rows = opts.ParseRows(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
         };
 

--- a/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
@@ -139,6 +139,7 @@ public static class RouterOptionsParser
                     Fields = opts.ParseFields(parseResult),
                     Schema = opts.ParseSchema(parseResult),
                     Count = parseResult.GetValue(opts.Count),
+                    Rows = opts.ParseRows(parseResult),
                 };
                 return new RouteToAssemblyFile(assemblyOptions);
             }
@@ -207,6 +208,7 @@ public static class RouterOptionsParser
             Fields = opts.ParseFields(parseResult),
             Schema = opts.ParseSchema(parseResult),
             Count = parseResult.GetValue(opts.Count),
+            Rows = opts.ParseRows(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             ForceLatest = forceLatest || showLatestVersion
         };
@@ -255,6 +257,7 @@ public static class RouterOptionsParser
             NoHeader = parseResult.GetValue(args.NoHeaderOption),
             Schema = opts.ParseSchema(parseResult),
             Count = parseResult.GetValue(opts.Count),
+            Rows = opts.ParseRows(parseResult),
         };
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -167,6 +167,7 @@ public static class SourceOptionsParser
             Select = opts.ParseSelect(parseResult),
             Columns = opts.ParseColumns(parseResult),
             Fields = opts.ParseFields(parseResult),
+            Rows = opts.ParseRows(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),
             NuGetOptions = opts.ParseNuGetSourceOptions(parseResult)

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -140,6 +140,7 @@ public static class TypeOptionsParser
             Columns = opts.ParseColumns(parseResult),
             Fields = opts.ParseFields(parseResult),
             Count = parseResult.GetValue(opts.Count),
+            Rows = opts.ParseRows(parseResult),
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -473,6 +473,7 @@ public class ApiCommand
         {
             var writerOptions = ApiOutputFormatter.BuildWriterOptions(api, options);
             var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions);
+            markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
             CountOutput.WriteCountFromMarkdown(markdown);
         }
         else if (options.OneLine)
@@ -487,7 +488,15 @@ public class ApiCommand
         else
         {
             var writerOptions = ApiOutputFormatter.BuildWriterOptions(api, options);
-            MarkoutSerializer.Serialize(view, Console.Out, options.CreateFormatter(), ApiViewContext.Default, writerOptions);
+            if (options.PlainText)
+            {
+                MarkoutSerializer.Serialize(view, Console.Out, options.CreateFormatter(), ApiViewContext.Default, writerOptions);
+            }
+            else
+            {
+                var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions).TrimEnd();
+                Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+            }
         }
     }
 
@@ -673,7 +682,7 @@ public class ApiCommand
                 ApiViewContext.Default.Serialize(view.MemberCode, writer);
 
             writer.Flush();
-            CountOutput.WriteCountFromMarkdown(sw.ToString());
+            CountOutput.WriteCountFromMarkdown(MarkdownTableRowLimiter.Apply(sw.ToString(), options.Rows));
         }
         else if (options.OneLine)
         {
@@ -687,13 +696,28 @@ public class ApiCommand
         else
         {
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
-            var writer = new Markout.MarkoutWriter(sink, options.CreateFormatter(), writerOptions);
-            ApiViewContext.Default.Serialize(view, writer);
+            if (options.PlainText)
+            {
+                var writer = new Markout.MarkoutWriter(sink, options.CreateFormatter(), writerOptions);
+                ApiViewContext.Default.Serialize(view, writer);
 
-            if (view.MemberCode != null)
-                ApiViewContext.Default.Serialize(view.MemberCode, writer);
+                if (view.MemberCode != null)
+                    ApiViewContext.Default.Serialize(view.MemberCode, writer);
 
-            writer.Flush();
+                writer.Flush();
+            }
+            else
+            {
+                var sw = new StringWriter();
+                var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
+                ApiViewContext.Default.Serialize(view, writer);
+
+                if (view.MemberCode != null)
+                    ApiViewContext.Default.Serialize(view.MemberCode, writer);
+
+                writer.Flush();
+                sink.WriteLine(MarkdownTableRowLimiter.Apply(sw.ToString().TrimEnd(), options.Rows));
+            }
         }
     }
 

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using NuGetFetch;
 using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
@@ -86,7 +87,7 @@ public class DependsCommand
                         Title = rootName,
                         Dependencies = treeNodes
                     };
-                    MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                    WriteMarkdown(view, options.Rows);
                 }
             }
 
@@ -188,7 +189,7 @@ public class DependsCommand
                     Title = assemblyName,
                     Dependencies = treeNodes
                 };
-                MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                WriteMarkdown(view, options.Rows);
             }
             return 0;
         }
@@ -296,7 +297,7 @@ public class DependsCommand
                     Title = title,
                     Dependencies = treeNodes
                 };
-                MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+                WriteMarkdown(view, options.Rows);
             }
             return 0;
         }
@@ -394,5 +395,11 @@ public class DependsCommand
             Console.Out.WriteLine();
         mdWriter.WriteCodeEnd();
         mdWriter.Flush();
+    }
+
+    private static void WriteMarkdown(PackageDependenciesView view, int? rows)
+    {
+        var markdown = MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default).TrimEnd();
+        Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
     }
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -252,7 +252,8 @@ public class DiffCommand
             return nameWriter.ToString();
         }
 
-        return DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
+        var markdown = DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
+        return MarkdownTableRowLimiter.Apply(markdown, options.Rows);
     }
 
     private static IReadOnlyList<TypeDiff> FilterByClassification(IReadOnlyList<TypeDiff> typeDiffs, DiffOptions options)
@@ -298,6 +299,7 @@ public record DiffOptions
     public string[]? Select { get; init; }
     public string[]? Columns { get; init; }
     public string[]? Fields { get; init; }
+    public int? Rows { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -90,7 +90,7 @@ public class ExtensionsCommand
             }
             else
             {
-                WriteMarkoutOutput(targetType, results, options.Verbosity);
+                WriteMarkoutOutput(targetType, results, options.Verbosity, options.Rows);
             }
 
             return 0;
@@ -145,10 +145,11 @@ public class ExtensionsCommand
         JsonOutputHelper.Write(results, ExtensionsJsonContext.Default.ListExtensionMethodResult, ExtensionsCompactJsonContext.Default.ListExtensionMethodResult, compact);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity)
+    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, int? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
-        Console.WriteLine(MarkoutSerializer.Serialize(view, SearchViewContext.Default));
+        var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
+        Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
     }
 
     /// <summary>
@@ -215,4 +216,3 @@ public record class ExtensionMethodResult
     [JsonPropertyName("reachable_from_type")]
     public string? ReachableFromType { get; set; }
 }
-

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -92,7 +92,8 @@ public class FindCommand
         }
         else
         {
-            Console.WriteLine(MarkoutSerializer.Serialize(view, SearchViewContext.Default));
+            var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
         }
     }
 }
@@ -123,4 +124,3 @@ public record class TypeSearchResult
     [JsonPropertyName("source_version")]
     public string? SourceVersion { get; set; }
 }
-

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -79,7 +79,7 @@ public class ImplementsCommand
             }
             else
             {
-                WriteMarkoutOutput(targetType, results, options.OneLine, options.NoHeader, options.Columns, options.Fields);
+                WriteMarkoutOutput(targetType, results, options.OneLine, options.NoHeader, options.Columns, options.Fields, options.Rows);
             }
 
             return 0;
@@ -132,7 +132,7 @@ public class ImplementsCommand
         JsonOutputHelper.Write(results, ImplementsJsonContext.Default.ListImplementerResult, ImplementsCompactJsonContext.Default.ListImplementerResult, compact);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool oneLine, bool noHeader, string[]? columns, string[]? fields)
+    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool oneLine, bool noHeader, string[]? columns, string[]? fields, int? rows)
     {
         var view = ImplementsOutputFormatter.BuildView(targetType, results);
 
@@ -152,7 +152,8 @@ public class ImplementsCommand
         }
         else
         {
-            Console.WriteLine(MarkoutSerializer.Serialize(view, SearchViewContext.Default));
+            var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
         }
     }
 }
@@ -183,4 +184,3 @@ public record class ImplementerResult
     [JsonPropertyName("source_version")]
     public string? SourceVersion { get; set; }
 }
-

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -725,7 +725,15 @@ public static class SourceCommand
             Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
         };
         var formatter = options.PlainText ? (IMarkoutFormatter)new PlainTextFormatter() : new MarkdownFormatter();
-        MarkoutSerializer.Serialize(view, Console.Out, formatter, SourceViewContext.Default, writerOpts);
+        if (options.PlainText)
+        {
+            MarkoutSerializer.Serialize(view, Console.Out, formatter, SourceViewContext.Default, writerOpts);
+        }
+        else
+        {
+            var markdown = MarkoutSerializer.Serialize(view, SourceViewContext.Default, writerOpts).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+        }
     }
 
     private static void WriteJson<T>(T view, bool compact) where T : class

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -63,6 +63,7 @@ public record ApiOptions
     public string[]? Fields { get; init; }
     public bool Schema { get; init; }
     public bool Count { get; init; }
+    public int? Rows { get; init; }
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 
     /// <summary>

--- a/src/dotnet-inspect/Options/AssemblyOptions.cs
+++ b/src/dotnet-inspect/Options/AssemblyOptions.cs
@@ -149,6 +149,11 @@ public record AssemblyOptions
     public bool Count { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// NuGet source configuration options.
     /// </summary>
     public NuGetSourceOptions? SourceOptions { get; init; }

--- a/src/dotnet-inspect/Options/DependsOptions.cs
+++ b/src/dotnet-inspect/Options/DependsOptions.cs
@@ -68,6 +68,11 @@ public record DependsOptions : IAssemblySourceOptions
     public bool EmbeddedMermaid { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// Show progress messages on stderr.
     /// </summary>
     public bool Verbose { get; init; }

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -58,6 +58,11 @@ public record ExtensionsOptions : IAssemblySourceOptions
     public int? Limit { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// Output as JSON.
     /// </summary>
     public bool JsonOutput { get; init; }

--- a/src/dotnet-inspect/Options/FindOptions.cs
+++ b/src/dotnet-inspect/Options/FindOptions.cs
@@ -58,6 +58,11 @@ public record FindOptions : IAssemblySourceOptions
     public int? Limit { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// Output as JSON.
     /// </summary>
     public bool JsonOutput { get; init; }
@@ -127,4 +132,5 @@ public record FindOptions : IAssemblySourceOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown). Tips should be suppressed.
     /// </summary>
-    public bool IsRawOutput => JsonOutput || OneLine || NoHeader;}
+    public bool IsRawOutput => JsonOutput || OneLine || NoHeader;
+}

--- a/src/dotnet-inspect/Options/ImplementsOptions.cs
+++ b/src/dotnet-inspect/Options/ImplementsOptions.cs
@@ -48,6 +48,11 @@ public record ImplementsOptions : IAssemblySourceOptions
     public int? Limit { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// Output as JSON.
     /// </summary>
     public bool JsonOutput { get; init; }
@@ -115,4 +120,5 @@ public record ImplementsOptions : IAssemblySourceOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown). Tips should be suppressed.
     /// </summary>
-    public bool IsRawOutput => JsonOutput || OneLine || NoHeader;}
+    public bool IsRawOutput => JsonOutput || OneLine || NoHeader;
+}

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -172,6 +172,11 @@ public record InspectionOptions
     public bool Count { get; init; }
 
     /// <summary>
+    /// Limit data rows per rendered table.
+    /// </summary>
+    public int? Rows { get; init; }
+
+    /// <summary>
     /// True when output is raw text (not rendered markdown). Tips should be suppressed.
     /// </summary>
     public bool IsRawOutput => JsonOutput || OneLine || NoHeader || ListLayout || ListFiles || ListTfms || ListVersions || ShowReadme || ShowDependencies || Count;

--- a/src/dotnet-inspect/Options/SourceOptions.cs
+++ b/src/dotnet-inspect/Options/SourceOptions.cs
@@ -70,6 +70,7 @@ public record SourceOptions
     public bool PlainText { get; init; }
     public bool NoHeader { get; init; }
     public int? Limit { get; init; }
+    public int? Rows { get; init; }
     public bool Verbose { get; init; }
 
     // Projection & discovery

--- a/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
+++ b/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
@@ -1,0 +1,77 @@
+namespace DotnetInspector.Output;
+
+internal static class MarkdownTableRowLimiter
+{
+    public static string Apply(string markdown, int? maxRows)
+    {
+        if (maxRows is null or < 0)
+            return markdown;
+
+        var normalized = markdown.ReplaceLineEndings("\n");
+        var lines = normalized.Split('\n');
+        List<string> output = new(lines.Length);
+        var inCodeFence = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (IsCodeFence(line))
+            {
+                inCodeFence = !inCodeFence;
+                output.Add(line);
+                continue;
+            }
+
+            if (inCodeFence || !IsTableLine(line) || i + 1 >= lines.Length || !IsSeparatorLine(lines[i + 1]))
+            {
+                output.Add(line);
+                continue;
+            }
+
+            output.Add(line);
+            output.Add(lines[++i]);
+
+            var rows = 0;
+            while (i + 1 < lines.Length && IsTableLine(lines[i + 1]))
+            {
+                i++;
+                if (IsSeparatorLine(lines[i]))
+                {
+                    output.Add(lines[i]);
+                    continue;
+                }
+
+                if (rows < maxRows.Value)
+                {
+                    output.Add(lines[i]);
+                    rows++;
+                }
+            }
+        }
+
+        return string.Join('\n', output);
+    }
+
+    private static bool IsTableLine(string line)
+    {
+        var trimmed = line.Trim();
+        return trimmed.Length >= 2 && trimmed.StartsWith('|') && trimmed.EndsWith('|');
+    }
+
+    private static bool IsCodeFence(string line)
+        => line.TrimStart().StartsWith("```", StringComparison.Ordinal);
+
+    private static bool IsSeparatorLine(string line)
+    {
+        if (!IsTableLine(line))
+            return false;
+
+        var cells = line.Trim().Trim('|').Split('|', StringSplitOptions.TrimEntries);
+        return cells.Length > 0 && cells.All(IsSeparatorCell);
+    }
+
+    private static bool IsSeparatorCell(string cell)
+        => cell.Length > 0
+           && cell.Any(c => c == '-')
+           && cell.All(c => c is '-' or ':' or ' ');
+}

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -29,6 +29,7 @@ public static class OutputFormatter
         var view = new InspectionResultView(result);
         var writerOptions = BuildWriterOptions(result, options, pipeline);
         var markdown = MarkoutSerializer.Serialize(view, InspectionContext.Default, writerOptions).TrimEnd();
+        markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
         return options.Count ? CountOutput.CountMarkdownTableRows(markdown).ToString() : markdown;
     }
 
@@ -84,6 +85,7 @@ public static class OutputFormatter
         if (options.Count)
         {
             var markdown = MarkoutSerializer.Serialize(auditView, InspectionContext.Default, writerOpts);
+            markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
             CountOutput.WriteCountFromMarkdown(markdown);
             return;
         }
@@ -108,12 +110,14 @@ public static class OutputFormatter
         }
         else if (options.VerbosityEnabled)
         {
-            Console.WriteLine(MarkoutSerializer.Serialize(auditView, InspectionContext.Default, writerOpts).TrimEnd());
+            var markdown = MarkoutSerializer.Serialize(auditView, InspectionContext.Default, writerOpts).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
         }
         else if (writerOpts.IncludeSections is { Count: > 1 } && !options.OneLineExplicitlySet)
         {
             // Auto-promote to markdown when multiple sections and oneline wasn't explicitly requested
-            Console.WriteLine(MarkoutSerializer.Serialize(auditView, InspectionContext.Default, writerOpts).TrimEnd());
+            var markdown = MarkoutSerializer.Serialize(auditView, InspectionContext.Default, writerOpts).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
         }
         else
         {
@@ -140,6 +144,7 @@ public static class OutputFormatter
         if (options.Count)
         {
             var markdown = MarkoutSerializer.Serialize(report, InspectionContext.Default, writerOptions);
+            markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
             CountOutput.WriteCountFromMarkdown(markdown);
             return;
         }
@@ -152,7 +157,8 @@ public static class OutputFormatter
 
         if (options.VerbosityEnabled)
         {
-            Console.WriteLine(MarkoutSerializer.Serialize(report, InspectionContext.Default, writerOptions).TrimEnd());
+            var markdown = MarkoutSerializer.Serialize(report, InspectionContext.Default, writerOptions).TrimEnd();
+            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
         }
         else
         {

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -97,8 +97,20 @@ if (args.Length == 1 && args[0] == "--release-notes")
 // Pre-process args for implicit package command (also expands -NN → -n NN)
 args = CommandLineBuilder.PreprocessArgs(args);
 
-// Install line-limiting writer when -NN shorthand was used (e.g. -30)
-if (CommandLineBuilder.HeadLines is int headLines)
+// Install line-limiting writer when -NN shorthand was used (e.g. -30).
+// With --rows, -n/-NN is interpreted by commands as per-table row limits.
+var rowLimitMode = args.Any(a => a == "--rows");
+if (rowLimitMode && CommandLineBuilder.TailLines != null)
+{
+    Console.Error.WriteLine("Error: --rows cannot be combined with --tail.");
+    return 1;
+}
+if (rowLimitMode && CommandLineBuilder.HeadLines == null)
+{
+    Console.Error.WriteLine("Error: --rows requires -n/--head or -N.");
+    return 1;
+}
+if (!rowLimitMode && CommandLineBuilder.HeadLines is int headLines)
     Console.SetOut(new LineLimitingTextWriter(Console.Out, headLines));
 
 // Install tail writer when --tail N was used

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -23,6 +23,7 @@ public class SharedOptions
 
     // Output control options
     public Option<int?> Limit { get; }
+    public Option<bool> Rows { get; } = new("--rows") { Description = "Interpret -n/-N as data rows per rendered table instead of output lines" };
     public Option<int?> Tail { get; }
     public Option<bool> Count { get; } = new("--count") { Description = "With a single selected section, output the number of table rows" };
     public Option<bool> Info { get; } = new("--info") { Description = "Show operational metrics (output, time, HTTP, cache) on stderr" };
@@ -107,6 +108,7 @@ public class SharedOptions
         command.Options.Add(Tips);
         command.Options.Add(Info);
         command.Options.Add(Limit);
+        command.Options.Add(Rows);
         command.Options.Add(Tail);
     }
 
@@ -138,6 +140,9 @@ public class SharedOptions
     {
         command.Options.Add(Count);
     }
+
+    public int? ParseRows(ParseResult parseResult)
+        => parseResult.GetValue(Rows) ? parseResult.GetValue(Limit) : null;
 
     /// <summary>
     /// Adds NuGet source options to a command.


### PR DESCRIPTION
## Summary
- add --rows as a mode for -n/-N to limit Markdown table data rows per rendered table
- preserve existing -n/-N line limiting when --rows is not present and reject --rows with --tail or without a head count
- apply row limiting across library/package/API/source/search/diff table outputs and document the workflow

## Validation
- dotnet build src/dotnet-inspect -v:q
- dotnet run --project src/dotnet-inspect.Tests
- dotnet run --project src/dotnet-inspect -- System.Private.CoreLib -S "Async*" --rows -n 6
- dotnet run --project src/dotnet-inspect -- System.Private.CoreLib -S "Async*" --rows -6
- dotnet run --project src/dotnet-inspect -- System.Private.CoreLib -S "Async*" -n 6