### PR TITLE
Improve collection and pointer lowering

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -537,6 +537,63 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("AcceptsBool(0)", code);
     }
 
+    [Fact]
+    public void CollectionWithCapacity_ReusesConstructedCollection()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.CollectionWithCapacity));
+
+        Assert.Equal(1, CountOccurrences(code, "new List<string>"));
+        Assert.Contains(".AddRange", code);
+    }
+
+    [Fact]
+    public void CollectionWithComparer_ReusesConstructedCollection()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.CollectionWithComparer));
+
+        Assert.Equal(1, CountOccurrences(code, "new HashSet<string>"));
+        Assert.Contains(".Add(\"Hello\")", code);
+        Assert.Contains(".Add(\"HELLO\")", code);
+        Assert.Contains(".Add(\"hello\")", code);
+    }
+
+    [Fact]
+    public void UnsafeReadThroughAddress_EmitsPointerDereference()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.UnsafeReadThroughAddress));
+
+        Assert.Contains("*(&", code);
+        Assert.DoesNotContain("(nuint)", code);
+    }
+
+    [Fact]
+    public void AddressAsNativeUInt_KeepsNativeUIntCast()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.AddressAsNativeUInt));
+
+        Assert.Contains("(nuint)&", code);
+    }
+
+    [Fact]
+    public void UnsafeReadArrayElementAddress_EmitsPointerDereference()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.UnsafeReadArrayElementAddress));
+
+        Assert.Contains("*(&", code);
+        Assert.Contains("[0]", code);
+        Assert.DoesNotContain("(nuint)ref", code);
+    }
+
+    [Fact]
+    public void ArrayElementAddressAsNativeUInt_KeepsNativeUIntCast()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.ArrayElementAddressAsNativeUInt));
+
+        Assert.Contains("(nuint)&", code);
+        Assert.Contains("[0]", code);
+        Assert.DoesNotContain("(nuint)ref", code);
+    }
+
     // --- Helpers ---
 
     static string EmitMethod(string methodName)
@@ -570,6 +627,18 @@ public class CSharpEmitterTests
     // decompiler falls back to synthesized V_n locals, and with it real source names appear.
     static string TestAssemblyPdbPath() =>
         Path.ChangeExtension(typeof(CfgSampleClass).Assembly.Location, ".pdb");
+
+    static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
 
     [Fact]
     public void ExternalPdb_SuppliesLocalVariableNames()

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -507,6 +507,44 @@ public class CfgSampleClass
     public static void AcceptsBool(bool flag) { }
 
     public static void PassesBoolFalse() => AcceptsBool(false);
+
+    public static List<string> CollectionWithCapacity(List<string> values)
+    {
+        return [with(capacity: values.Count * 2), .. values];
+    }
+
+    public static HashSet<string> CollectionWithComparer()
+    {
+        return [with(System.StringComparer.OrdinalIgnoreCase), "Hello", "HELLO", "hello"];
+    }
+
+    public static unsafe int UnsafeReadThroughAddress()
+    {
+        int value = 42;
+        return *(&value);
+    }
+
+    public static unsafe nuint AddressAsNativeUInt()
+    {
+        int value = 42;
+        return (nuint)(&value);
+    }
+
+    public static unsafe int UnsafeReadArrayElementAddress(int[] values)
+    {
+        fixed (int* p = &values[0])
+        {
+            return *p;
+        }
+    }
+
+    public static unsafe nuint ArrayElementAddressAsNativeUInt(int[] values)
+    {
+        fixed (int* p = &values[0])
+        {
+            return (nuint)p;
+        }
+    }
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -110,6 +110,10 @@ public static class CSharpEmitter
         // Array initializer elements: newarr IL offset → collected element values
         readonly Dictionary<int, SortedDictionary<int, ILAstExpression>> _arrayInitValues = [];
 
+        // Collection construction temporaries: newobj IL offset → synthesized local name.
+        readonly Dictionary<int, string> _collectionTemps = [];
+        int _nextCollectionTemp;
+
         // Variables inlined by ExpressionInliner (suppress declarations)
         readonly HashSet<string> _inlinedLocals;
 
@@ -1312,6 +1316,61 @@ public static class CSharpEmitter
             ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or
             ILOpCode.Stelem_i2 or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or
             ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8 or ILOpCode.Stelem_ref;
+
+        void TryEnsureCollectionTempForMutation(ILAstExpression expr, int indent)
+        {
+            if (!TryGetCollectionMutationReceiver(expr, out var newObj))
+                return;
+            if (_collectionTemps.ContainsKey(newObj.Offset))
+                return;
+
+            string tempName = CreateCollectionTempName();
+
+            WriteIndent(indent);
+            _sb.Append($"{SimplifyTypeName(ExtractTypeName(newObj.Operand))} {tempName} = ");
+            EmitNewObjectExpression(newObj);
+            _sb.AppendLine(";");
+
+            _collectionTemps[newObj.Offset] = tempName;
+        }
+
+        bool TryGetCollectionMutationReceiver(ILAstExpression expr, out ILAstExpression newObj)
+        {
+            if (expr.OpCode == ILOpCode.Pop && expr.Arguments.Count == 1)
+                return TryGetCollectionMutationReceiver(expr.Arguments[0], out newObj);
+
+            newObj = null!;
+            if (expr.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt))
+                return false;
+            if (expr.IsStaticCall || expr.Arguments.Count == 0)
+                return false;
+
+            string memberName = ExtractMemberName(expr.Operand);
+            if (memberName is not ("Add" or "AddRange"))
+                return false;
+
+            var receiver = expr.Arguments[0];
+            if (receiver.OpCode != ILOpCode.Dup || receiver.Arguments.Count != 1)
+                return false;
+            if (receiver.Arguments[0].OpCode != ILOpCode.Newobj)
+                return false;
+
+            newObj = receiver.Arguments[0];
+            return true;
+        }
+
+        string CreateCollectionTempName()
+        {
+            while (true)
+            {
+                string name = $"__collection{_nextCollectionTemp++}";
+                if (_ast.Locals.Any(l => l.Name == name))
+                    continue;
+                if (_paramNames is not null && _paramNames.Contains(name))
+                    continue;
+                return name;
+            }
+        }
 
         static bool TryGetConstantIndex(ILAstExpression expr, out int value)
         {
@@ -2775,6 +2834,8 @@ public static class CSharpEmitter
 
         void EmitStatement(ILAstExpression expr, int indent)
         {
+            TryEnsureCollectionTempForMutation(expr, indent);
+
             switch (expr.OpCode)
             {
                 case ILOpCode.Ret:
@@ -3213,7 +3274,16 @@ public static class CSharpEmitter
                 case ILOpCode.Conv_i: EmitCast(expr, "nint"); break;
                 case ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_i_un:
                     EmitCheckedCast(expr, "nint"); break;
-                case ILOpCode.Conv_u: EmitCast(expr, "nuint"); break;
+                case ILOpCode.Conv_u:
+                    if (expr.Arguments.Count > 0 && IsAddressExpression(expr.Arguments[0]))
+                    {
+                        if (!IsPointerType(resolvedType))
+                            _sb.Append("(nuint)");
+                        EmitAddressExpression(expr.Arguments[0]);
+                    }
+                    else
+                        EmitCast(expr, "nuint");
+                    break;
                 case ILOpCode.Conv_ovf_u or ILOpCode.Conv_ovf_u_un:
                     EmitCheckedCast(expr, "nuint"); break;
 
@@ -3229,31 +3299,13 @@ public static class CSharpEmitter
 
                 // Object creation
                 case ILOpCode.Newobj:
-                {
-                    string typeName = ExtractTypeName(expr.Operand);
-                    string simplified = SimplifyTypeName(typeName);
-
-                    // Delegate construction with closure lambda: new Func<T,R>(closure, <Method>b__N)
-                    // Simplify to lambda annotation
-                    if (expr.Arguments.Count == 2
-                        && expr.Arguments[1] is { Operand: string lambdaName }
-                        && lambdaName.Contains(">b__", StringComparison.Ordinal))
                     {
-                        string cleanLambda = SimplifyLambdaName(lambdaName);
-                        _sb.Append($"/* {cleanLambda} */");
+                        if (_collectionTemps.TryGetValue(expr.Offset, out string? collectionTemp))
+                            _sb.Append(collectionTemp);
+                        else
+                            EmitNewObjectExpression(expr);
                         break;
                     }
-
-                    _sb.Append($"new {simplified}(");
-                    // Skip 'this' argument (first arg for instance constructor)
-                    for (int i = 0; i < expr.Arguments.Count; i++)
-                    {
-                        if (i > 0) _sb.Append(", ");
-                        EmitExpression(expr.Arguments[i]);
-                    }
-                    _sb.Append(')');
-                    break;
-                }
 
                 case ILOpCode.Newarr:
                     if (_arrayInitValues.TryGetValue(expr.Offset, out var initElements))
@@ -3304,7 +3356,7 @@ public static class CSharpEmitter
                      ILOpCode.Ldind_u1 or ILOpCode.Ldind_u2 or ILOpCode.Ldind_u4 or
                      ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8 or ILOpCode.Ldind_ref or
                      ILOpCode.Ldobj:
-                    if (expr.Arguments.Count > 0)
+                    if (!TryEmitPointerDereference(expr) && expr.Arguments.Count > 0)
                         EmitExpression(expr.Arguments[0]);
                     break;
 
@@ -3432,6 +3484,98 @@ public static class CSharpEmitter
                     _sb.Append("/* ");
                     expr.WriteTo(_sb, 0);
                     _sb.Append(" */");
+                    break;
+            }
+        }
+
+        void EmitNewObjectExpression(ILAstExpression expr)
+        {
+            string typeName = ExtractTypeName(expr.Operand);
+            string simplified = SimplifyTypeName(typeName);
+
+            // Delegate construction with closure lambda: new Func<T,R>(closure, <Method>b__N)
+            // Simplify to lambda annotation
+            if (expr.Arguments.Count == 2
+                && expr.Arguments[1] is { Operand: string lambdaName }
+                && lambdaName.Contains(">b__", StringComparison.Ordinal))
+            {
+                string cleanLambda = SimplifyLambdaName(lambdaName);
+                _sb.Append($"/* {cleanLambda} */");
+                return;
+            }
+
+            _sb.Append($"new {simplified}(");
+            for (int i = 0; i < expr.Arguments.Count; i++)
+            {
+                if (i > 0) _sb.Append(", ");
+                EmitExpression(expr.Arguments[i]);
+            }
+            _sb.Append(')');
+        }
+
+        bool TryEmitPointerDereference(ILAstExpression expr)
+        {
+            if (expr.Arguments.Count != 1)
+                return false;
+
+            var address = expr.Arguments[0];
+            if (address.OpCode != ILOpCode.Conv_u || address.Arguments.Count != 1)
+                return false;
+            if (!IsAddressExpression(address.Arguments[0]))
+                return false;
+
+            _sb.Append("*(");
+            EmitAddressExpression(address.Arguments[0]);
+            _sb.Append(')');
+            return true;
+        }
+
+        static bool IsAddressExpression(ILAstExpression expr) =>
+            expr.OpCode is ILOpCode.Ldloca_s or ILOpCode.Ldloca
+                or ILOpCode.Ldarga_s or ILOpCode.Ldarga
+                or ILOpCode.Ldflda or ILOpCode.Ldsflda
+                or ILOpCode.Ldelema;
+
+        static bool IsPointerType(string? typeName) =>
+            typeName is not null && typeName.EndsWith('*');
+
+        void EmitAddressExpression(ILAstExpression expr)
+        {
+            _sb.Append('&');
+            switch (expr.OpCode)
+            {
+                case ILOpCode.Ldloca_s or ILOpCode.Ldloca:
+                    _sb.Append(expr.Operand ?? "loc");
+                    break;
+                case ILOpCode.Ldarga_s or ILOpCode.Ldarga:
+                    _sb.Append(RemapArg(expr.Operand, expr.OpCode));
+                    break;
+                case ILOpCode.Ldflda:
+                    if (expr.Arguments.Count > 0)
+                    {
+                        EmitExpression(expr.Arguments[0]);
+                        _sb.Append('.');
+                    }
+                    _sb.Append(ExtractMemberName(expr.Operand));
+                    break;
+                case ILOpCode.Ldsflda:
+                    _sb.Append(expr.Operand ?? "/* field */");
+                    break;
+                case ILOpCode.Ldelema:
+                    if (expr.Arguments.Count >= 2)
+                    {
+                        EmitExpression(expr.Arguments[0]);
+                        _sb.Append('[');
+                        EmitExpression(expr.Arguments[1]);
+                        _sb.Append(']');
+                    }
+                    else
+                    {
+                        _sb.Append("/* array element */");
+                    }
+                    break;
+                default:
+                    EmitExpression(expr);
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- Preserve a single collection instance when IL uses `newobj` + `dup` + `Add`/`AddRange`, avoiding dropped collection mutations in lowered C#.
- Render unsafe pointer dereferences from `ldind(conv.u(address))`, including locals, args, fields, and array element addresses.
- Keep standalone native-uint address conversions as `(nuint)&...` and add regression fixtures for C# 15 collection expressions and unsafe address patterns.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release`

Note: `src/dotnet-inspect.Tests` has an unrelated direct `FindCommand` cache-initialization failure reproducible on clean `origin/main`; equivalent CLI `find --platform` scenarios pass.