### PR TITLE
Bump dotnet-inspect to 0.9.2

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -14,9 +14,11 @@ Invoke with `dnx`:
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--plaintext` for text-only output, `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
 
-Use built-in limiters before shell pipes. `-n N` and shorthand like `-6` limit output lines; `--tail N` keeps the last N lines; `--rows -n N` or `--rows -6` caps data rows per rendered Markdown table while preserving headings and table headers; `--count` counts rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
+Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
+
+Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 
 ## Workflow map
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -16,7 +16,7 @@ dnx dotnet-inspect -y -- <command>
 
 Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
 
-Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
+Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections by name or wildcard, such as `-S "Async*"`; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
 
 Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -86,7 +86,7 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serial
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.
 
-Fidelity expectations: SourceLink source is the original source when available. Lowered C# is a best-effort, readable reconstruction from IL that helps explain intent but is not guaranteed to match original syntax, local names, or compiler transformations. Raw IL and annotated IL are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
+Fidelity expectations: SourceLink source is the original source when available. Lowered C# is a best-effort, readable reconstruction from IL that helps explain intent; it uses PDB debug information such as local names when available, but is not guaranteed to match original syntax or compiler transformations. Raw IL and annotated IL are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
 
 ## Package and library Signals workflow
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.9.1
+version: 0.9.2
 description: Query .NET APIs across NuGet packages, platform libraries, and local files. Use for factual answers about package contents, API signatures, compatibility changes, relationships, SourceLink, and assembly metadata.
 ---
 
@@ -14,7 +14,7 @@ Invoke through `dnx` unless the tool is already installed:
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, `--rows -n N` to cap rendered table rows, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, `--rows -n N` or shorthand like `--rows -6` to cap data rows per rendered Markdown table while keeping headers/sections, and `-v:d` when you need source/decompiled C#/IL detail.
 
 ## Workflow map
 
@@ -27,7 +27,7 @@ Default output is Markdown. Use `--oneline` to scan, `--json` for structured dat
 | Inspect package/library signals | `library Foo -S Signals` or `package Foo -S Signals` | `Signals` resolves SourceLink for libraries; add `-S "SourceLink Availability"` for source reachability or `-S "SourceLink Integrity"` for slow content verification. |
 | Inventory package library files | `package Foo -S "Library Files"` | Lists all files under `lib/` across TFMs; use paths from this section with `library <file> --package Foo` for specific assemblies. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package/platform scope as needed. |
-| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N`, `--rows -n N` | Prefer built-in limits over shell pipes. |
+| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N`, `--rows -n N` or `--rows -6` | Prefer built-in limits over shell pipes. `--rows` requires a head count and cannot combine with `--tail`. |
 
 ## Modern .NET and preview workflow
 
@@ -39,7 +39,7 @@ LLM training may miss .NET 10+ runtime/library features. Prefer metadata inspect
 | Runtime-pack assemblies | Many BCL libraries ship only as installed platform/runtime-pack assemblies, not standalone packages. | `library --platform Lib --version <version>` or direct DLL path | Prefer platform/direct DLL inspection when package lookup is misleading. |
 | Memory-safety metadata | Newer compilers may stamp updated memory-safety rules and caller-unsafe members in metadata. | `library Lib --version <version> -S Signals` | Compare `MemorySafetyRules` v2+ with the `RequiresUnsafe` member count; unsafe signatures and P/Invoke remain separate signals. |
 | Extension properties | C# extension blocks can expose properties in addition to extension methods. | `extensions Type --reachable` | Results include extension methods and C# extension properties. |
-| Lowering changes | Compiler/runtime implementation can differ from API signatures. | `member Type Member:1 -v:d` | Inspect Source, Lowered C#, IL, and annotated IL before inferring behavior. |
+| Implementation detail | Compiler/runtime implementation can differ from API signatures. | `member Type Member:1 -v:d` | Prefer SourceLink source when available; use Lowered C# for readable control-flow intent and IL/annotated IL for exact instructions. |
 
 For preview sweeps, resolve the version once, prove one library end-to-end, then fan out to the rest.
 
@@ -84,6 +84,8 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serial
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.
 
+Fidelity expectations: SourceLink source is the original source when available. Lowered C# is a best-effort, readable reconstruction from IL that helps explain intent but is not guaranteed to match original syntax, local names, or compiler transformations. Raw IL and annotated IL are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
+
 ## Package and library Signals workflow
 
 Use `Signals` for metadata and provenance observations. It reports observations, not a safety or trust verdict. Cost follows verbosity and explicit selection: `library X -S Signals` reports metadata plus the shared Signals section (acquiring a missing library PDB to resolve SourceLink); add `SourceLink Availability` and `SourceLink Missing Files` for the per-source-file reachability pass. The exhaustive content check is the opt-in `SourceLink Integrity` section.
@@ -94,6 +96,8 @@ dnx dotnet-inspect -y -- library System.Text.Json -S "Signals,SourceLink Availab
 dnx dotnet-inspect -y -- library System.Text.Json -S "SourceLink Integrity"
 dnx dotnet-inspect -y -- package System.Text.Json -S Signals
 ```
+
+For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 
 Library Signals include assembly metadata such as SourceLink presence, SourceLink availability, SourceLink CR/LF diagnostics, determinism, trim/AOT markers, updated memory-safety model, `RequiresUnsafe` member count, unsafe signatures, P/Invoke, and direct references. Package Signals use the same shape for package metadata/assets, dependencies, signature provenance, and NuGet registry observations. `library X -S Signals` resolves SourceLink by acquiring a missing PDB. The per-source-file reachability pass — SourceLink Availability and SourceLink Missing Files, which issue one HTTP HEAD per tracked source URL — is opt-in: select it explicitly with `-S "SourceLink Availability"`. It does not run in a plain `library X -v:d` flow because its cost scales with source-file count. To verify source *content*, select `library X -S "SourceLink Integrity"`: it downloads each tracked source file and compares its hash to the PDB checksum, exits non-zero on true content mismatch, and reports `CR/LF Mismatch` when checksums match after line-ending normalization.
 
@@ -109,9 +113,12 @@ Discover sections, then select or project fields.
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -S Methods --columns "Name;Signature;Obsolete"
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
+dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
 
 For target-based queries, `-D` and bare `-S` report the effective schema by default: only sections and columns that can render for that query. Add `--schema` for the static schema. `-S`, `--columns`, and `--fields` accept comma-separated or semicolon-separated lists. In `--schema` section output, `section (opt-in)` means the section never runs from normal verbosity; select it explicitly with `-S` when needed, or use `-S All` to include all sections including opt-in sections. Use `--count` only when exactly one selected section should produce a row count.
+
+`-n N` and shorthand values like `-6` normally limit output lines. Add `--rows` to reinterpret that head count as data rows per rendered Markdown table; this preserves headings/table headers and applies independently to each table. `--rows` requires `-n/--head` or numeric shorthand and cannot be combined with `--tail`. Prefer `--rows` over shell `head` when you need parseable Markdown tables.
 
 ## Relationship workflow
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -14,7 +14,9 @@ Invoke through `dnx` unless the tool is already installed:
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown. Use `--oneline` to scan, `--json` for structured data, `--count` to count one selected table section, `--rows -n N` or shorthand like `--rows -6` to cap data rows per rendered Markdown table while keeping headers/sections, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown because it preserves headings, section boundaries, table headers, and code fences, making the evidence readable and easy to quote. Use `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
+
+Use built-in limiters before shell pipes. `-n N` and shorthand like `-6` limit output lines; `--tail N` keeps the last N lines; `--rows -n N` or `--rows -6` caps data rows per rendered Markdown table while preserving headings and table headers; `--count` counts rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 
 ## Workflow map
 
@@ -27,7 +29,7 @@ Default output is Markdown. Use `--oneline` to scan, `--json` for structured dat
 | Inspect package/library signals | `library Foo -S Signals` or `package Foo -S Signals` | `Signals` resolves SourceLink for libraries; add `-S "SourceLink Availability"` for source reachability or `-S "SourceLink Integrity"` for slow content verification. |
 | Inventory package library files | `package Foo -S "Library Files"` | Lists all files under `lib/` across TFMs; use paths from this section with `library <file> --package Foo` for specific assemblies. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package/platform scope as needed. |
-| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N`, `--rows -n N` or `--rows -6` | Prefer built-in limits over shell pipes. `--rows` requires a head count and cannot combine with `--tail`. |
+| Keep output small | `--oneline`, `--json`, `-S Section`, `--count`, `-n N`, `--tail N`, `--rows -n N` or `--rows -6` | Prefer built-in limits over shell pipes. `--rows` requires a head count and cannot combine with `--tail`. |
 
 ## Modern .NET and preview workflow
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: dotnet-inspect
 version: 0.9.2
-description: Query .NET APIs across NuGet packages, platform libraries, and local files. Use for factual answers about package contents, API signatures, compatibility changes, relationships, SourceLink, and assembly metadata.
+description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 
 # dotnet-inspect
 
-Use dotnet-inspect when you need evidence about .NET libraries instead of guessing: API signatures, package contents, extension methods, implementors, SourceLink URLs, dependencies, or version-to-version API changes.
+Use dotnet-inspect when you need evidence instead of guesses for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, or version-to-version API changes.
 
-Invoke through `dnx` unless the tool is already installed:
+Invoke with `dnx`:
 
 ```bash
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown because it preserves headings, section boundaries, table headers, and code fences, making the evidence readable and easy to quote. Use `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
+Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--plaintext` for text-only output, `--oneline` for compact one-result-per-line output, `--json` for structured automation, and `-v:d` when you need source/decompiled C#/IL detail.
 
 Use built-in limiters before shell pipes. `-n N` and shorthand like `-6` limit output lines; `--tail N` keeps the last N lines; `--rows -n N` or `--rows -6` caps data rows per rendered Markdown table while preserving headings and table headers; `--count` counts rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 

--- a/src/DotnetInspector.Decompiler.Tests/AnnotatedILEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/AnnotatedILEmitterTests.cs
@@ -128,6 +128,20 @@ public class AnnotatedILEmitterTests
         Assert.True(hasIndentedInstruction, $"Expected indented instructions in:\n{output}");
     }
 
+    [Fact]
+    public void Structured_ExternalPdb_AnnotatesVariableNames()
+    {
+        var pdbPath = TestAssemblyPdbPath();
+        Assert.SkipUnless(File.Exists(pdbPath), $"standalone PDB not found at {pdbPath}");
+
+        string output = EmitMethod(nameof(CfgSampleClass.LoopSum), ILAnnotationDepth.Structured, pdbPath);
+
+        Assert.Matches(@"//\s+Parameters: .* n", output);
+        Assert.Contains("arg: n", output);
+        Assert.Contains("local: sum", output);
+        Assert.Contains("local: i", output);
+    }
+
     // --- Token resolution ---
 
     [Fact]
@@ -236,7 +250,7 @@ public class AnnotatedILEmitterTests
 
     // --- Helpers ---
 
-    static string EmitMethod(string methodName, ILAnnotationDepth depth)
+    static string EmitMethod(string methodName, ILAnnotationDepth depth, string? externalPdbPath = null)
     {
         var assemblyPath = typeof(CfgSampleClass).Assembly.Location;
         var stream = File.OpenRead(assemblyPath);
@@ -244,10 +258,14 @@ public class AnnotatedILEmitterTests
         var context = MethodBodyContext.Create(
             peReader,
             typeof(CfgSampleClass).FullName!,
-            methodName);
+            methodName,
+            externalPdbPath: externalPdbPath);
         Assert.NotNull(context);
         return AnnotatedILEmitter.Emit(context, depth);
     }
+
+    static string TestAssemblyPdbPath() =>
+        Path.ChangeExtension(typeof(CfgSampleClass).Assembly.Location, ".pdb");
 
     static string EmitMethodDefault(string methodName)
     {

--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -100,21 +100,26 @@ public static class AnnotatedILEmitter
             int offset = reader.Offset;
             var opcode = reader.ReadILOpcode();
             string operand = DecodeOperand(context, ref reader, opcode, offset);
+            string? variableAnnotation = GetVariableAnnotation(context, opcode, operand);
 
             sb.Append($"IL_{offset:X4}: ");
             sb.Append($"{FormatOpCode(opcode),-12}");
             if (operand.Length > 0)
                 sb.Append(' ').Append(operand);
 
+            List<string> annotations = [];
+            if (variableAnnotation != null)
+                annotations.Add(variableAnnotation);
+
             // Append stack type annotation
             if (instructionStacks.TryGetValue(offset, out var stackBefore))
             {
                 string stackStr = FormatStack(stackBefore);
-                if (stackStr.Length > 0)
-                    sb.Append($"  // stack: [{stackStr}]");
-                else
-                    sb.Append("  // stack: []");
+                annotations.Add(stackStr.Length > 0 ? $"stack: [{stackStr}]" : "stack: []");
             }
+
+            if (annotations.Count > 0)
+                sb.Append("  // ").Append(string.Join("; ", annotations));
 
             sb.AppendLine();
         }
@@ -177,6 +182,7 @@ public static class AnnotatedILEmitter
 
             var opcode = reader.ReadILOpcode();
             string operand = DecodeOperand(context, ref reader, opcode, offset);
+            string? variableAnnotation = GetVariableAnnotation(context, opcode, operand);
 
             WriteIndent(sb, currentIndent + 1);
             sb.Append($"IL_{offset:X4}: ");
@@ -184,12 +190,19 @@ public static class AnnotatedILEmitter
             if (operand.Length > 0)
                 sb.Append(' ').Append(operand);
 
+            List<string> annotations = [];
+            if (variableAnnotation != null)
+                annotations.Add(variableAnnotation);
+
             // Stack annotation
             if (instructionStacks.TryGetValue(offset, out var stackBefore))
             {
                 string stackStr = FormatStack(stackBefore);
-                sb.Append($"  // [{stackStr}]");
+                annotations.Add($"[{stackStr}]");
             }
+
+            if (annotations.Count > 0)
+                sb.Append("  // ").Append(string.Join("; ", annotations));
 
             sb.AppendLine();
         }
@@ -201,6 +214,89 @@ public static class AnnotatedILEmitter
             WriteIndent(sb, currentIndent);
             sb.AppendLine("}");
         }
+    }
+
+    static string? GetVariableAnnotation(MethodBodyContext context, ILOpCode opcode, string operand)
+    {
+        var reference = GetVariableReference(opcode, operand);
+        if (reference is null)
+            return null;
+
+        var (kind, index) = reference.Value;
+        return kind switch
+        {
+            VariableReferenceKind.Local => GetLocalDebugName(context, index) is { } name
+                ? $"local: {name}"
+                : null,
+            VariableReferenceKind.Argument => GetArgumentName(context, index) is { } name
+                ? $"arg: {name}"
+                : null,
+            _ => null
+        };
+    }
+
+    static (VariableReferenceKind Kind, int Index)? GetVariableReference(ILOpCode opcode, string operand)
+    {
+        return opcode switch
+        {
+            ILOpCode.Ldloc_0 or ILOpCode.Stloc_0 => (VariableReferenceKind.Local, 0),
+            ILOpCode.Ldloc_1 or ILOpCode.Stloc_1 => (VariableReferenceKind.Local, 1),
+            ILOpCode.Ldloc_2 or ILOpCode.Stloc_2 => (VariableReferenceKind.Local, 2),
+            ILOpCode.Ldloc_3 or ILOpCode.Stloc_3 => (VariableReferenceKind.Local, 3),
+
+            ILOpCode.Ldarg_0 => (VariableReferenceKind.Argument, 0),
+            ILOpCode.Ldarg_1 => (VariableReferenceKind.Argument, 1),
+            ILOpCode.Ldarg_2 => (VariableReferenceKind.Argument, 2),
+            ILOpCode.Ldarg_3 => (VariableReferenceKind.Argument, 3),
+
+            ILOpCode.Ldloc_s or ILOpCode.Stloc_s or ILOpCode.Ldloca_s
+                or ILOpCode.Ldloc or ILOpCode.Stloc or ILOpCode.Ldloca
+                => TryParseVariableIndex(operand, out int localIndex)
+                    ? (VariableReferenceKind.Local, localIndex)
+                    : null,
+
+            ILOpCode.Ldarg_s or ILOpCode.Starg_s or ILOpCode.Ldarga_s
+                or ILOpCode.Ldarg or ILOpCode.Starg or ILOpCode.Ldarga
+                => TryParseVariableIndex(operand, out int argumentIndex)
+                    ? (VariableReferenceKind.Argument, argumentIndex)
+                    : null,
+
+            _ => null
+        };
+    }
+
+    static bool TryParseVariableIndex(string operand, out int index) =>
+        int.TryParse(operand, out index) && index >= 0;
+
+    static string? GetLocalDebugName(MethodBodyContext context, int index)
+    {
+        if (index >= context.LocalNames.Count)
+            return null;
+
+        var name = context.LocalNames[index];
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    static string? GetArgumentName(MethodBodyContext context, int index)
+    {
+        if (context.HasThis)
+        {
+            if (index == 0)
+                return "this";
+            index--;
+        }
+
+        if (index < 0 || index >= context.ParameterNames.Count)
+            return null;
+
+        var name = context.ParameterNames[index];
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    enum VariableReferenceKind
+    {
+        Local,
+        Argument
     }
 
     // --- Header emission ---
@@ -215,12 +311,7 @@ public static class AnnotatedILEmitter
             sb.Append("// Parameters: ");
             sb.AppendLine(string.Join(", ", simResult.Parameters.Select(p =>
             {
-                string name = p.Name;
-                if (context.HasThis)
-                {
-                    if (p.Index == 0) name = "this";
-                    else name = $"P_{p.Index - 1}";
-                }
+                string name = GetArgumentName(context, p.Index) ?? p.Name;
                 return p.TypeName is not null ? $"{p.TypeName} {name}" : name;
             })));
         }
@@ -246,13 +337,7 @@ public static class AnnotatedILEmitter
             sb.Append("//   Parameters: ");
             sb.AppendLine(string.Join(", ", simResult.Parameters.Select(p =>
             {
-                string name = p.Name;
-                // Remap to match lowered C# naming: this + shifted indices
-                if (context.HasThis)
-                {
-                    if (p.Index == 0) name = "this";
-                    else name = $"P_{p.Index - 1}";
-                }
+                string name = GetArgumentName(context, p.Index) ?? p.Name;
                 return p.TypeName is not null ? $"{p.TypeName} {name}" : name;
             })));
         }

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.9.1</VersionPrefix>
+    <VersionPrefix>0.9.2</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump dotnet-inspect VersionPrefix from 0.9.1 to 0.9.2 for the next package publish.
- Update the embedded dotnet-inspect SKILL.md to version 0.9.2.
- Align the reusable intro/description with dotnet-skill and dotnet-skills wording.
- Clarify dnx invocation, why to use Markdown, when to use --oneline/--json, the -D/-S query system including wildcard section selection, and pervasive output limiters, especially --rows.
- Document Source/Lowered C#/IL fidelity expectations, including that lowered C# uses PDB debug info such as local names when available.
- Improve annotated IL output with PDB/metadata names for parameter/local variable access while keeping raw IL exact.

## Validation
- dotnet pack src/dotnet-inspect -c Release -p:OfficialBuild=true
- verified generated package nuspec reports version 0.9.2
- dotnet run --project src/dotnet-inspect -c Release -- skill -n 95
- dotnet run --project src/dotnet-inspect -c Release -- skill -n 35
- dotnet run --project src/dotnet-inspect -c Release -- skill -n 30
- dotnet run --project src/dotnet-inspect -c Release -- skill -n 34
- dotnet run --project src/dotnet-inspect -c Release -- skill -n 24
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- member JsonSerializer --package System.Text.Json Serialize:1 -v:d -S "IL (Annotated)" --rows -n 12
- dotnet run --no-build --project src/dotnet-inspect -c Release -- System.Private.CoreLib -S "Async*" --rows -n 3 -v:q