### PR TITLE
Clarify SourceLink signal evidence

### DIFF
--- a/src/dotnet-inspect.Tests/InspectionResultTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionResultTests.cs
@@ -155,10 +155,10 @@ public class InspectionResultTests
 
         var symbols = Assert.Single(result.AuditSignals!, s => s.Signal == "Symbols");
         Assert.Equal("Yes (5/5)", symbols.Value);
-        Assert.Equal("msdl.microsoft.com PDBs", symbols.Evidence);
+        Assert.Equal("PDBs from msdl.microsoft.com", symbols.Evidence);
 
         var sourceLink = Assert.Single(result.AuditSignals!, s => s.Signal == "SourceLink");
-        Assert.Equal("SourceLink data in msdl.microsoft.com PDBs", sourceLink.Evidence);
+        Assert.Equal("SourceLink data found in PDBs from msdl.microsoft.com", sourceLink.Evidence);
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class InspectionResultTests
             result, new HttpClient(), new VerboseLogger(false));
 
         var symbols = Assert.Single(result.AuditSignals!, s => s.Signal == "Symbols");
-        Assert.Equal("embedded PDBs (1), in-package PDBs (1), .snupkg PDBs (1), msdl.microsoft.com PDBs (1)", symbols.Evidence);
+        Assert.Equal("embedded PDBs (1), PDBs from package (1), PDBs from .snupkg (1), PDBs from msdl.microsoft.com (1)", symbols.Evidence);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -297,7 +297,7 @@ internal static class AuditSignalBuilder
     {
         if (signals.SourceLinkAvailable > 0)
         {
-            return "SourceLink data in " + FormatPdbSources(
+            return "SourceLink data found in " + FormatPdbSources(
                 signals.EmbeddedSourceLinkPdbs,
                 signals.InPackageSourceLinkPdbs,
                 signals.SnupkgSourceLinkPdbs,
@@ -324,10 +324,10 @@ internal static class AuditSignalBuilder
     {
         List<string> parts = [];
         AddPdbSourcePart(parts, "embedded PDBs", embedded, total);
-        AddPdbSourcePart(parts, "in-package PDBs", inPackage, total);
-        AddPdbSourcePart(parts, ".snupkg PDBs", snupkg, total);
-        AddPdbSourcePart(parts, "msdl.microsoft.com PDBs", msdl, total);
-        AddPdbSourcePart(parts, "other symbol-server PDBs", other, total);
+        AddPdbSourcePart(parts, "PDBs from package", inPackage, total);
+        AddPdbSourcePart(parts, "PDBs from .snupkg", snupkg, total);
+        AddPdbSourcePart(parts, "PDBs from msdl.microsoft.com", msdl, total);
+        AddPdbSourcePart(parts, "PDBs from other symbol servers", other, total);
         return parts.Count == 0 ? fallback : string.Join(", ", parts);
     }
 
@@ -397,7 +397,7 @@ internal static class AuditSignalBuilder
                 ? inspection.PdbLocation.ToLowerInvariant()
                 : "unknown";
 
-        return $"PDB (source: {source})";
+        return $"SourceLink data found in PDB from {source}";
     }
 
     private static string FormatBool(bool value) => value ? "Yes" : "No";


### PR DESCRIPTION
## Summary
- distinguish symbol/PDB evidence from the SourceLink signal
- describe package symbols as PDB availability and SourceLink as data found in PDBs
- clarify library SourceLink evidence as SourceLink data found in the PDB

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- package System.Text.Json -S Signals
- dotnet run --project src/dotnet-inspect -c Release -- library System.Text.Json -S Signals --preview