### PR TITLE
Extend null-conditional assignment lowering

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -558,6 +558,78 @@ public class CSharpEmitterTests
     }
 
     [Fact]
+    public void ReadOnlySpanCollectionExpression_EmitsCollectionExpression()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.ReadOnlySpanCollectionExpression));
+
+        Assert.Contains("[a, 42]", code);
+        Assert.DoesNotContain("InlineArray", code);
+        Assert.DoesNotContain("new ReadOnlySpan", code);
+        Assert.DoesNotContain("new int[]", code);
+    }
+
+    [Fact]
+    public void ClassicLock_EmitsLockStatement()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.ClassicLock));
+
+        Assert.Contains("lock (gate)", code);
+        Assert.DoesNotContain("Monitor.Enter", code);
+        Assert.DoesNotContain("Monitor.Exit", code);
+        Assert.DoesNotContain("try", code);
+        Assert.DoesNotContain("finally", code);
+    }
+
+    [Fact]
+    public void SystemThreadingLock_EmitsLockStatement()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.SystemThreadingLock));
+
+        Assert.Contains("lock (gate)", code);
+        Assert.DoesNotContain("EnterScope", code);
+        Assert.DoesNotContain("Dispose", code);
+        Assert.DoesNotContain("using var", code);
+        Assert.DoesNotContain("try", code);
+        Assert.DoesNotContain("finally", code);
+    }
+
+    [Fact]
+    public void NullConditionalFieldAssignment_EmitsConditionalAssignment()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.NullConditionalFieldAssignment));
+
+        Assert.Contains("target?.Value = value;", code);
+        Assert.DoesNotContain("if (target != null)", code);
+    }
+
+    [Fact]
+    public void NullConditionalFieldCompoundAssignment_EmitsConditionalAssignment()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.NullConditionalFieldCompoundAssignment));
+
+        Assert.Contains("target?.Value += value;", code);
+        Assert.DoesNotContain("if (target != null)", code);
+    }
+
+    [Fact]
+    public void NullConditionalPropertyAssignment_EmitsConditionalAssignment()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.NullConditionalPropertyAssignment));
+
+        Assert.Contains("target?.Text = value;", code);
+        Assert.DoesNotContain("if (target != null)", code);
+    }
+
+    [Fact]
+    public void NullConditionalIndexerAssignment_EmitsConditionalAssignment()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.NullConditionalIndexerAssignment));
+
+        Assert.Contains("target?[0] = value;", code);
+        Assert.DoesNotContain("if (target != null)", code);
+    }
+
+    [Fact]
     public void UnsafeReadThroughAddress_EmitsPointerDereference()
     {
         var code = EmitMethod(nameof(CfgSampleClass.UnsafeReadThroughAddress));

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -621,6 +621,15 @@ public class CSharpEmitterTests
     }
 
     [Fact]
+    public void NullConditionalPropertyCompoundAssignment_EmitsConditionalAssignment()
+    {
+        var code = EmitMethod(nameof(CfgSampleClass.NullConditionalPropertyCompoundAssignment));
+
+        Assert.Contains("target?.Count += value;", code);
+        Assert.DoesNotContain("if (target != null)", code);
+    }
+
+    [Fact]
     public void NullConditionalIndexerAssignment_EmitsConditionalAssignment()
     {
         var code = EmitMethod(nameof(CfgSampleClass.NullConditionalIndexerAssignment));

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -555,6 +555,11 @@ public class CfgSampleClass
         target?.Text = value;
     }
 
+    public static void NullConditionalPropertyCompoundAssignment(CfgNullableTarget? target, int value)
+    {
+        target?.Count += value;
+    }
+
     public static void NullConditionalIndexerAssignment(CfgNullableTarget? target, int value)
     {
         target?[0] = value;
@@ -596,6 +601,8 @@ public sealed class CfgNullableTarget
     public int Value;
 
     public string? Text { get; set; }
+
+    public int Count { get; set; }
 
     public int this[int index]
     {

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -518,6 +518,48 @@ public class CfgSampleClass
         return [with(System.StringComparer.OrdinalIgnoreCase), "Hello", "HELLO", "hello"];
     }
 
+    public static int ReadOnlySpanCollectionExpression(int a)
+    {
+        ReadOnlySpan<int> values = [a, 42];
+        return values[0] + values[1];
+    }
+
+    public static int ClassicLock(object gate)
+    {
+        lock (gate)
+        {
+            return gate.GetHashCode();
+        }
+    }
+
+    public static int SystemThreadingLock(System.Threading.Lock gate)
+    {
+        lock (gate)
+        {
+            return gate.GetHashCode();
+        }
+    }
+
+    public static void NullConditionalFieldAssignment(CfgNullableTarget? target, int value)
+    {
+        target?.Value = value;
+    }
+
+    public static void NullConditionalFieldCompoundAssignment(CfgNullableTarget? target, int value)
+    {
+        target?.Value += value;
+    }
+
+    public static void NullConditionalPropertyAssignment(CfgNullableTarget? target, string value)
+    {
+        target?.Text = value;
+    }
+
+    public static void NullConditionalIndexerAssignment(CfgNullableTarget? target, int value)
+    {
+        target?[0] = value;
+    }
+
     public static unsafe int UnsafeReadThroughAddress()
     {
         int value = 42;
@@ -548,3 +590,16 @@ public class CfgSampleClass
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
+
+public sealed class CfgNullableTarget
+{
+    public int Value;
+
+    public string? Text { get; set; }
+
+    public int this[int index]
+    {
+        get => Value + index;
+        set => Value = value + index;
+    }
+}

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1404,7 +1404,7 @@ public static class CSharpEmitter
 
         bool TryEmitNullConditionalAssignment(StructuredBlock block, string condition, int indent)
         {
-            if (block.ElseBlock is not null)
+            if (block.ElseBlock is not null && !IsTerminalNullPath(block, block.ElseBlock))
                 return false;
             if (!TryParseNotNullCondition(condition, out string? receiver))
                 return false;
@@ -1438,6 +1438,8 @@ public static class CSharpEmitter
                 _consumedBlocks.Add(consumedBlockIndex);
                 RemoveGotoTargetsForConsumedBlock(consumedBlockIndex);
             }
+            if (block.ElseBlock is not null)
+                ConsumeStructuredBlock(block.ElseBlock);
 
             return true;
         }
@@ -1477,6 +1479,8 @@ public static class CSharpEmitter
             if (blockIdx < 0 || !_blockMap.TryGetValue(blockIdx, out var astBlock))
                 return false;
 
+            var receiverAliases = new HashSet<string> { receiver };
+            var consumedReceiverAliases = new HashSet<string>();
             foreach (var node in astBlock.Nodes)
             {
                 if (node is ILAstStatement { Expression: var expr })
@@ -1484,11 +1488,17 @@ public static class CSharpEmitter
                     if (IsIgnorableNullConditionalAssignmentNode(expr))
                         continue;
 
+                    if (TryAddReceiverAlias(expr, receiverAliases, out string? receiverAlias))
+                    {
+                        consumedReceiverAliases.Add(receiverAlias);
+                        continue;
+                    }
+
                     if (value is not null)
                         return false;
                     if (!TryFormatNullConditionalAssignmentTarget(
                             expr,
-                            receiver,
+                            receiverAliases,
                             out targetSuffix,
                             out assignmentOperator,
                             out value,
@@ -1505,9 +1515,290 @@ public static class CSharpEmitter
 
             if (value is null)
                 return false;
+            if (consumedReceiverAliases.Count > 0
+                && (ReferencesAnyLocal(value, consumedReceiverAliases)
+                    || (targetSuffix is not null && ContainsAnyAliasText(targetSuffix, consumedReceiverAliases))
+                    || AliasUsedOutsideBlock(blockIdx, consumedReceiverAliases)))
+            {
+                return false;
+            }
 
             consumedBlockIndex = blockIdx;
             return true;
+        }
+
+        bool IsTerminalNullPath(StructuredBlock ifBlock, StructuredBlock elseBlock)
+        {
+            return TryGetTerminalNullPathTargetIndex(elseBlock, out int terminalBlockIndex)
+                && HasNoMeaningfulFollowingSiblings(ifBlock, terminalBlockIndex);
+        }
+
+        bool TryGetTerminalNullPathTargetIndex(StructuredBlock block, out int terminalBlockIndex)
+        {
+            terminalBlockIndex = -1;
+            if (!TryGetSingleBlockIndex(block, out int blockIdx)
+                || !_blockMap.TryGetValue(blockIdx, out var astBlock))
+            {
+                return false;
+            }
+
+            if (blockIdx == _ast.Blocks.Count - 1 && BlockIsVoidReturnOnly(astBlock))
+            {
+                terminalBlockIndex = blockIdx;
+                return true;
+            }
+
+            if (BlockBranchesOnlyToTerminalReturn(astBlock, out int targetBlockIndex))
+            {
+                terminalBlockIndex = targetBlockIndex;
+                return true;
+            }
+
+            return false;
+        }
+
+        bool TryGetSingleBlockIndex(StructuredBlock block, out int blockIdx)
+        {
+            blockIdx = block.BlockIndex;
+            if (blockIdx >= 0)
+                return true;
+
+            if (block.Kind == StructuredBlockKind.Sequence && block.Children.Count == 1)
+            {
+                blockIdx = block.Children[0].BlockIndex;
+                return blockIdx >= 0;
+            }
+
+            return false;
+        }
+
+        bool HasNoMeaningfulFollowingSiblings(StructuredBlock block, int terminalBlockIndex)
+        {
+            var parent = FindParentSequence(block);
+            if (parent is null)
+                return false;
+
+            int blockIndex = -1;
+            for (int i = 0; i < parent.Children.Count; i++)
+            {
+                if (ReferenceEquals(parent.Children[i], block))
+                {
+                    blockIndex = i;
+                    break;
+                }
+            }
+
+            if (blockIndex < 0)
+                return false;
+
+            for (int i = blockIndex + 1; i < parent.Children.Count; i++)
+            {
+                var sibling = parent.Children[i];
+                if (TryGetSingleBlockIndex(sibling, out int siblingBlockIndex)
+                    && siblingBlockIndex == terminalBlockIndex
+                    && _blockMap.TryGetValue(siblingBlockIndex, out var terminalBlock)
+                    && BlockIsVoidReturnOnly(terminalBlock))
+                {
+                    continue;
+                }
+
+                if (!BlockContainsOnlyNops(sibling))
+                    return false;
+            }
+
+            return true;
+        }
+
+        bool BlockContainsOnlyNops(StructuredBlock block)
+        {
+            foreach (var (_, node) in EnumerateStructuredNodes(block))
+            {
+                if (NodeExpression(node) is { OpCode: not ILOpCode.Nop })
+                    return false;
+            }
+
+            return true;
+        }
+
+        bool BlockIsVoidReturnOnly(ILAstBlock astBlock)
+        {
+            bool sawReturn = false;
+            foreach (var node in astBlock.Nodes)
+            {
+                if (node is not ILAstStatement { Expression: var expr })
+                    return false;
+                if (expr.OpCode == ILOpCode.Nop)
+                    continue;
+                if (expr.OpCode == ILOpCode.Ret && expr.Arguments.Count == 0)
+                {
+                    if (sawReturn)
+                        return false;
+                    sawReturn = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawReturn;
+        }
+
+        bool BlockBranchesOnlyToTerminalReturn(ILAstBlock astBlock, out int targetBlockIndex)
+        {
+            targetBlockIndex = -1;
+            string? target = null;
+            foreach (var node in astBlock.Nodes)
+            {
+                if (node is not ILAstStatement { Expression: var expr })
+                    return false;
+                if (expr.OpCode == ILOpCode.Nop)
+                    continue;
+                if (expr.OpCode is ILOpCode.Br or ILOpCode.Br_s
+                        or ILOpCode.Leave or ILOpCode.Leave_s
+                    && expr.Operand is string branchTarget)
+                {
+                    if (target is not null)
+                        return false;
+                    target = branchTarget;
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (target is null)
+                return false;
+
+            foreach (var (blockIdx, offset) in _blockStartOffset)
+            {
+                if ($"IL_{offset:X4}" != target)
+                    continue;
+                if (blockIdx == _ast.Blocks.Count - 1
+                    && _blockMap.TryGetValue(blockIdx, out var targetBlock)
+                    && BlockIsVoidReturnOnly(targetBlock))
+                {
+                    targetBlockIndex = blockIdx;
+                    return true;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        void ConsumeStructuredBlock(StructuredBlock block)
+        {
+            if (block.BlockIndex >= 0)
+            {
+                _consumedBlocks.Add(block.BlockIndex);
+                RemoveGotoTargetsForConsumedBlock(block.BlockIndex);
+            }
+            foreach (var child in block.Children)
+                ConsumeStructuredBlock(child);
+            foreach (var child in block.TryChildren)
+                ConsumeStructuredBlock(child);
+            foreach (var child in block.HandlerChildren)
+                ConsumeStructuredBlock(child);
+            if (block.ThenBlock is not null)
+                ConsumeStructuredBlock(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ConsumeStructuredBlock(block.ElseBlock);
+        }
+
+        bool TryAddReceiverAlias(ILAstExpression expr, HashSet<string> receiverAliases, out string aliasName)
+        {
+            aliasName = "";
+            if (expr.OpCode is not (ILOpCode.Stloc or ILOpCode.Stloc_s
+                or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3))
+                return false;
+            if (expr.Arguments.Count != 1)
+                return false;
+            if (!TryGetSimpleReceiverString(expr.Arguments[0], out string? assignedReceiver)
+                || assignedReceiver is null
+                || !receiverAliases.Contains(assignedReceiver))
+                return false;
+
+            aliasName = expr.Operand ?? GetLocalName(expr.OpCode);
+            receiverAliases.Add(aliasName);
+            return true;
+        }
+
+        static bool ReferencesAnyLocal(ILAstExpression expr, HashSet<string> localNames)
+        {
+            if (GetLocalReferenceName(expr) is { } localName && localNames.Contains(localName))
+                return true;
+
+            foreach (var arg in expr.Arguments)
+            {
+                if (ReferencesAnyLocal(arg, localNames))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static bool ContainsAnyAliasText(string text, HashSet<string> aliases)
+            => aliases.Any(alias => text.Contains(alias, StringComparison.Ordinal));
+
+        static bool IsSideEffectFreeIndexExpression(ILAstExpression expr)
+        {
+            if (IsLdcI4(expr.OpCode))
+                return true;
+            if (expr.OpCode is ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2
+                or ILOpCode.Ldarg_3 or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+                or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+                or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc)
+            {
+                return true;
+            }
+
+            if (expr.OpCode is ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul
+                or ILOpCode.Div or ILOpCode.Rem
+                or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
+                or ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un
+                or ILOpCode.Conv_i1 or ILOpCode.Conv_i2 or ILOpCode.Conv_i4
+                or ILOpCode.Conv_u1 or ILOpCode.Conv_u2 or ILOpCode.Conv_u4
+                or ILOpCode.Conv_i8 or ILOpCode.Conv_u8)
+            {
+                return expr.Arguments.All(IsSideEffectFreeIndexExpression);
+            }
+
+            return false;
+        }
+
+        bool AliasUsedOutsideBlock(int consumedBlockIndex, HashSet<string> aliases)
+        {
+            for (int i = 0; i < _ast.Blocks.Count; i++)
+            {
+                if (i == consumedBlockIndex)
+                    continue;
+
+                foreach (var node in _ast.Blocks[i].Nodes)
+                {
+                    if (NodeReferencesAnyLocal(node, aliases))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool NodeReferencesAnyLocal(ILAstNode node, HashSet<string> aliases) => node switch
+        {
+            ILAstAssignment assign => aliases.Contains(assign.Variable.Name) || ReferencesAnyLocal(assign.Value, aliases),
+            ILAstStatement { Expression: var expr } => IsStoreToAnyLocal(expr, aliases) || ReferencesAnyLocal(expr, aliases),
+            _ => false
+        };
+
+        static bool IsStoreToAnyLocal(ILAstExpression expr, HashSet<string> aliases)
+        {
+            if (expr.OpCode is not (ILOpCode.Stloc or ILOpCode.Stloc_s
+                or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3))
+                return false;
+
+            string name = expr.Operand ?? GetLocalName(expr.OpCode);
+            return aliases.Contains(name);
         }
 
         static bool IsIgnorableNullConditionalAssignmentNode(ILAstExpression expr)
@@ -1516,7 +1807,7 @@ public static class CSharpEmitter
 
         bool TryFormatNullConditionalAssignmentTarget(
             ILAstExpression expr,
-            string receiver,
+            HashSet<string> receiverAliases,
             out string? targetSuffix,
             out string? assignmentOperator,
             out ILAstExpression? value,
@@ -1530,14 +1821,15 @@ public static class CSharpEmitter
             if (expr.OpCode == ILOpCode.Stfld && expr.Arguments.Count >= 2)
             {
                 if (!TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
-                    || actualReceiver != receiver)
+                    || actualReceiver is null
+                    || !receiverAliases.Contains(actualReceiver))
                     return false;
 
                 targetSuffix = $"?.{ExtractMemberName(expr.Operand)}";
                 expectedType = TryResolveFieldType(expr.Operand);
                 if (TryExtractCompoundAssignmentValue(
                         expr.Arguments[1],
-                        receiver,
+                        receiverAliases,
                         memberName: ExtractMemberName(expr.Operand),
                         indexExpression: null,
                         out assignmentOperator,
@@ -1554,7 +1846,8 @@ public static class CSharpEmitter
             if (IsStelemOpCode(expr.OpCode) && expr.Arguments.Count >= 3)
             {
                 if (!TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
-                    || actualReceiver != receiver)
+                    || actualReceiver is null
+                    || !receiverAliases.Contains(actualReceiver))
                     return false;
 
                 targetSuffix = $"?[{ExpressionToString(expr.Arguments[1])}]";
@@ -1571,24 +1864,40 @@ public static class CSharpEmitter
                 if (memberName.StartsWith("set_", StringComparison.Ordinal)
                     && expr.Arguments.Count >= 2
                     && TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
-                    && actualReceiver == receiver)
+                && actualReceiver is not null
+                && receiverAliases.Contains(actualReceiver))
                 {
-                    if (memberName == "set_Item" && expr.Arguments.Count >= 3)
+                if (memberName == "set_Item" && expr.Arguments.Count >= 3)
+                {
+                    if (!IsSideEffectFreeIndexExpression(expr.Arguments[1]))
+                        return false;
+
+                    string indexExpression = ExpressionToString(expr.Arguments[1]);
+                    targetSuffix = $"?[{indexExpression}]";
+                    if (TryExtractCompoundAssignmentValue(
+                            expr.Arguments[2],
+                            receiverAliases,
+                            memberName: "Item",
+                            indexExpression,
+                            out assignmentOperator,
+                            out value))
                     {
-                        targetSuffix = $"?[{ExpressionToString(expr.Arguments[1])}]";
-                        assignmentOperator = "=";
-                        value = expr.Arguments[2];
+                        return true;
                     }
-                    else
-                    {
-                        string propertyName = memberName[4..];
-                        targetSuffix = $"?.{propertyName}";
-                        if (TryExtractCompoundAssignmentValue(
-                                expr.Arguments[1],
-                                receiver,
-                                propertyName,
-                                indexExpression: null,
-                                out assignmentOperator,
+
+                    assignmentOperator = "=";
+                    value = expr.Arguments[2];
+                }
+                else
+                {
+                    string propertyName = memberName[4..];
+                    targetSuffix = $"?.{propertyName}";
+                    if (TryExtractCompoundAssignmentValue(
+                            expr.Arguments[1],
+                            receiverAliases,
+                            propertyName,
+                            indexExpression: null,
+                            out assignmentOperator,
                                 out value))
                         {
                             return true;
@@ -1607,7 +1916,7 @@ public static class CSharpEmitter
 
         bool TryExtractCompoundAssignmentValue(
             ILAstExpression assignedValue,
-            string receiver,
+            HashSet<string> receiverAliases,
             string memberName,
             string? indexExpression,
             out string? assignmentOperator,
@@ -1620,7 +1929,7 @@ public static class CSharpEmitter
                 return false;
             if (CompoundAssignmentOperator(assignedValue.OpCode) is not { } op)
                 return false;
-            if (!IsSameMemberRead(assignedValue.Arguments[0], receiver, memberName, indexExpression))
+            if (!IsSameMemberRead(assignedValue.Arguments[0], receiverAliases, memberName, indexExpression))
                 return false;
 
             assignmentOperator = $"{op}=";
@@ -1628,10 +1937,16 @@ public static class CSharpEmitter
             return true;
         }
 
-        bool IsSameMemberRead(ILAstExpression expr, string receiver, string memberName, string? indexExpression)
+        bool IsSameMemberRead(ILAstExpression expr, HashSet<string> receiverAliases, string memberName, string? indexExpression)
         {
+            string rendered = ExpressionToString(expr);
             if (indexExpression is null
-                && ExpressionToString(expr) == $"{receiver}.{memberName}")
+                && receiverAliases.Any(receiver => rendered == $"{receiver}.{memberName}"))
+            {
+                return true;
+            }
+            if (indexExpression is not null
+                && receiverAliases.Any(receiver => rendered == $"{receiver}[{indexExpression}]"))
             {
                 return true;
             }
@@ -1641,7 +1956,8 @@ public static class CSharpEmitter
                 && ExtractMemberName(expr.Operand) == memberName
                 && expr.Arguments.Count > 0
                 && TryGetSimpleReceiverString(expr.Arguments[0], out string? fieldReceiver)
-                && fieldReceiver == receiver)
+                && fieldReceiver is not null
+                && receiverAliases.Contains(fieldReceiver))
             {
                 return true;
             }
@@ -1655,7 +1971,18 @@ public static class CSharpEmitter
                 if (indexExpression is null
                     && readMember == $"get_{memberName}"
                     && TryGetSimpleReceiverString(expr.Arguments[0], out string? propertyReceiver)
-                    && propertyReceiver == receiver)
+                    && propertyReceiver is not null
+                    && receiverAliases.Contains(propertyReceiver))
+                {
+                    return true;
+                }
+                if (indexExpression is not null
+                    && readMember is "get_Item" or "get_Chars"
+                    && expr.Arguments.Count >= 2
+                    && TryGetSimpleReceiverString(expr.Arguments[0], out string? indexerReceiver)
+                    && indexerReceiver is not null
+                    && receiverAliases.Contains(indexerReceiver)
+                    && ExpressionToString(expr.Arguments[1]) == indexExpression)
                 {
                     return true;
                 }

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -114,12 +114,18 @@ public static class CSharpEmitter
         readonly Dictionary<int, string> _collectionTemps = [];
         int _nextCollectionTemp;
 
+        // Inline-array collection expression temporaries: local name → element index/value map.
+        readonly Dictionary<string, SortedDictionary<int, ILAstExpression>> _inlineArrayInitValues = [];
+
         // Variables inlined by ExpressionInliner (suppress declarations)
         readonly HashSet<string> _inlinedLocals;
 
         // Item 2: Locals whose declaration is merged with first assignment
         // Maps variable name → init expression string
         readonly Dictionary<string, string> _mergedLocals = [];
+
+        // Try/finally regions that are compiler-lowered lock statements.
+        readonly Dictionary<StructuredBlock, LockPattern> _lockPatterns = [];
 
         public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
         {
@@ -188,8 +194,30 @@ public static class CSharpEmitter
             // Scan all blocks for string interpolation handler patterns
             ScanForInterpolation(ast);
 
+            // C# collection expressions targeting spans can lower through compiler-generated
+            // inline-array helpers. Scan early so their helper locals aren't declared.
+            ScanInlineArrayInitializers(ast);
+
+            // Pre-detect lock patterns so compiler-generated temporaries are suppressed before
+            // their initialization blocks are emitted.
+            ScanForLockPatterns(structure.Root);
+
             // Pre-detect using patterns to suppress local declarations
             ScanForUsingPatterns(structure.Root);
+        }
+
+        sealed class LockPattern
+        {
+            public required ILAstExpression LockExpression { get; init; }
+            public List<ILAstNode> SkipNodes { get; } = [];
+            public List<string> SuppressedLocals { get; } = [];
+        }
+
+        sealed class InlineArrayInitializerCandidate
+        {
+            public SortedDictionary<int, ILAstExpression> Elements { get; } = [];
+            public List<ILAstNode> StoreNodes { get; } = [];
+            public List<ILAstNode> InitNodes { get; } = [];
         }
 
         void ScanForInterpolation(ILAstMethod ast)
@@ -309,6 +337,488 @@ public static class CSharpEmitter
                 return s;
             }
             return null;
+        }
+
+        void ScanForLockPatterns(StructuredBlock block)
+        {
+            if (block.Kind == StructuredBlockKind.TryCatchFinally
+                && block.ExceptionRegion is { Kind: ExceptionRegionKind.Finally }
+                && TryDetectLockPattern(block, out var pattern))
+            {
+                _lockPatterns[block] = pattern;
+                foreach (var node in pattern.SkipNodes)
+                    _skipNodes.Add(node);
+                foreach (string local in pattern.SuppressedLocals)
+                    _suppressedLocals.Add(local);
+            }
+
+            foreach (var c in block.Children)
+                ScanForLockPatterns(c);
+            foreach (var c in block.TryChildren)
+                ScanForLockPatterns(c);
+            foreach (var c in block.HandlerChildren)
+                ScanForLockPatterns(c);
+            if (block.ThenBlock is not null)
+                ScanForLockPatterns(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ScanForLockPatterns(block.ElseBlock);
+        }
+
+        bool TryDetectLockPattern(StructuredBlock block, out LockPattern pattern)
+        {
+            if (TryDetectSystemThreadingLockPattern(block, out pattern))
+                return true;
+
+            return TryDetectMonitorLockPattern(block, out pattern);
+        }
+
+        bool TryDetectSystemThreadingLockPattern(StructuredBlock block, out LockPattern pattern)
+        {
+            pattern = null!;
+
+            if (!TryDetectDirectDisposeOnly(block, out string? scopeVar))
+                return false;
+
+            if (!TryFindPreviousStore(block, scopeVar, out var initNode, out var initExpression))
+                return false;
+            if (HasUnexpectedPreviousNodesAfterFirstExpected(block, allowedStoreLocal: null, initNode))
+            {
+                return false;
+            }
+
+            if (initExpression.Operand is not string initOperand
+                || !initOperand.Contains("System.Threading.Lock::EnterScope", StringComparison.Ordinal)
+                || initExpression.IsStaticCall
+                || initExpression.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            pattern = new LockPattern { LockExpression = initExpression.Arguments[0] };
+            pattern.SkipNodes.Add(initNode);
+            pattern.SuppressedLocals.Add(scopeVar);
+            return true;
+        }
+
+        bool TryDetectMonitorLockPattern(StructuredBlock block, out LockPattern pattern)
+        {
+            pattern = null!;
+
+            ILAstNode? enterNode = null;
+            ILAstExpression? enterExpression = null;
+            foreach (var (_, node) in EnumerateStructuredNodes(block.TryChildren))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (IsIgnorableLockTryNode(expr))
+                    continue;
+                if (expr.Operand is string operand
+                    && operand.Contains("System.Threading.Monitor::Enter", StringComparison.Ordinal)
+                    && expr.IsStaticCall
+                    && expr.Arguments.Count > 0)
+                {
+                    enterNode = node;
+                    enterExpression = expr;
+                    break;
+                }
+
+                return false;
+            }
+
+            if (enterNode is null || enterExpression is null)
+                return false;
+
+            string? lockVar = GetLocalReferenceName(enterExpression.Arguments[0]);
+            if (lockVar is null)
+                return false;
+
+            if (!TryFindPreviousStore(block, lockVar, out var initNode, out var lockExpression))
+                return false;
+
+            string? lockTakenVar = enterExpression.Arguments.Count > 1
+                ? GetLocalReferenceName(enterExpression.Arguments[1]) ?? enterExpression.Arguments[1].Operand
+                : null;
+            if (!HandlerMatchesMonitorExitOnly(block, lockVar, lockTakenVar))
+                return false;
+
+            ILAstNode? lockTakenInitNode = null;
+            if (lockTakenVar is not null)
+                TryFindPreviousStore(block, lockTakenVar, out lockTakenInitNode, out _);
+
+            if (HasUnexpectedPreviousNodesAfterFirstExpected(block, lockTakenVar, initNode, lockTakenInitNode))
+                return false;
+
+            pattern = new LockPattern { LockExpression = lockExpression };
+            pattern.SkipNodes.Add(enterNode);
+            pattern.SkipNodes.Add(initNode);
+            pattern.SuppressedLocals.Add(lockVar);
+
+            if (lockTakenVar is not null)
+            {
+                pattern.SuppressedLocals.Add(lockTakenVar);
+                if (lockTakenInitNode is not null)
+                    pattern.SkipNodes.Add(lockTakenInitNode);
+            }
+
+            return true;
+        }
+
+        static bool IsIgnorableLockTryNode(ILAstExpression expr)
+            => expr.OpCode == ILOpCode.Nop;
+
+        bool HasUnexpectedPreviousNodesAfterFirstExpected(
+            StructuredBlock block,
+            string? allowedStoreLocal,
+            params ILAstNode?[] expectedNodes)
+        {
+            if (!TryGetPreviousSiblingNodes(block, out var nodes))
+                return true;
+
+            var expected = expectedNodes.OfType<ILAstNode>().ToHashSet();
+            if (expected.Count == 0 || !expected.All(nodes.Contains))
+                return true;
+
+            int firstExpectedIndex = nodes.FindIndex(expected.Contains);
+            for (int i = firstExpectedIndex; i < nodes.Count; i++)
+            {
+                var node = nodes[i];
+                if (expected.Contains(node))
+                    continue;
+                if (NodeExpression(node) is not { } expr || IsIgnorableLockTryNode(expr))
+                    continue;
+                if (allowedStoreLocal is not null && IsStoreToLocal(expr, allowedStoreLocal))
+                    continue;
+                return true;
+            }
+
+            return false;
+        }
+
+        bool TryGetPreviousSiblingNodes(StructuredBlock block, out List<ILAstNode> nodes)
+        {
+            nodes = [];
+            var parent = FindParentSequence(block);
+            if (parent is null)
+                return false;
+
+            int blockIndex = -1;
+            for (int i = 0; i < parent.Children.Count; i++)
+            {
+                if (ReferenceEquals(parent.Children[i], block))
+                {
+                    blockIndex = i;
+                    break;
+                }
+            }
+
+            if (blockIndex <= 0)
+                return false;
+
+            for (int i = 0; i < blockIndex; i++)
+                nodes.AddRange(EnumerateStructuredNodes(parent.Children[i]).Select(item => item.Node));
+            return nodes.Count > 0;
+        }
+
+        bool HandlerMatchesMonitorExitOnly(StructuredBlock block, string lockVar, string? lockTakenVar)
+        {
+            if (lockTakenVar is not null)
+                return HandlerMatchesGuardedMonitorExitOnly(block, lockVar, lockTakenVar);
+
+            bool sawExit = false;
+            foreach (var (_, node) in EnumerateStructuredNodes(block.HandlerChildren))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode is ILOpCode.Nop or ILOpCode.Endfinally)
+                    continue;
+                if (expr.Operand is string operand
+                    && operand.Contains("System.Threading.Monitor::Exit", StringComparison.Ordinal)
+                    && expr.IsStaticCall
+                    && expr.Arguments.Count > 0
+                    && IsLoadOf(expr.Arguments[0], lockVar))
+                {
+                    if (sawExit)
+                        return false;
+                    sawExit = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawExit;
+        }
+
+        bool HandlerMatchesGuardedMonitorExitOnly(StructuredBlock block, string lockVar, string lockTakenVar)
+        {
+            if (HandlerMatchesStructuredGuardedMonitorExitOnly(block, lockVar, lockTakenVar))
+                return true;
+
+            bool sawGuard = false;
+            bool sawExit = false;
+
+            foreach (var (_, node) in EnumerateStructuredNodes(block.HandlerChildren))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode == ILOpCode.Nop)
+                    continue;
+                if (expr.OpCode == ILOpCode.Endfinally && sawExit)
+                    continue;
+
+                if (!sawGuard
+                    && (expr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                        or ILOpCode.Brtrue or ILOpCode.Brtrue_s)
+                    && expr.Arguments.Count == 1
+                    && IsLoadOf(expr.Arguments[0], lockTakenVar))
+                {
+                    sawGuard = true;
+                    continue;
+                }
+
+                if (sawGuard
+                    && !sawExit
+                    && expr.Operand is string operand
+                    && operand.Contains("System.Threading.Monitor::Exit", StringComparison.Ordinal)
+                    && expr.IsStaticCall
+                    && expr.Arguments.Count > 0
+                    && IsLoadOf(expr.Arguments[0], lockVar))
+                {
+                    sawExit = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawGuard && sawExit;
+        }
+
+        bool HandlerMatchesStructuredGuardedMonitorExitOnly(StructuredBlock block, string lockVar, string lockTakenVar)
+        {
+            bool sawGuard = false;
+            foreach (var child in block.HandlerChildren)
+            {
+                if (child.Kind == StructuredBlockKind.IfThenElse)
+                {
+                    if (sawGuard
+                        || child.ElseBlock is not null
+                        || !BlockContainsSingleMonitorExit(child.ThenBlock, lockVar))
+                    {
+                        return false;
+                    }
+
+                    sawGuard = true;
+                    continue;
+                }
+
+                if (!BlockContainsOnlyIgnorableFinallyNodes(child))
+                    return false;
+            }
+
+            return sawGuard;
+        }
+
+        bool BlockContainsSingleMonitorExit(StructuredBlock? block, string lockVar)
+        {
+            if (block is null)
+                return false;
+
+            bool sawExit = false;
+            foreach (var (_, node) in EnumerateStructuredNodes(block))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode == ILOpCode.Nop)
+                    continue;
+                if (expr.Operand is string operand
+                    && operand.Contains("System.Threading.Monitor::Exit", StringComparison.Ordinal)
+                    && expr.IsStaticCall
+                    && expr.Arguments.Count > 0
+                    && IsLoadOf(expr.Arguments[0], lockVar))
+                {
+                    if (sawExit)
+                        return false;
+                    sawExit = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawExit;
+        }
+
+        bool BlockContainsOnlyIgnorableFinallyNodes(StructuredBlock block)
+        {
+            foreach (var (_, node) in EnumerateStructuredNodes(block))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode is ILOpCode.Nop or ILOpCode.Endfinally)
+                    continue;
+                return false;
+            }
+
+            return true;
+        }
+
+        bool TryDetectDirectDisposeOnly(StructuredBlock block, out string disposeVar)
+        {
+            disposeVar = "";
+            bool sawDispose = false;
+
+            foreach (var (_, node) in EnumerateStructuredNodes(block.HandlerChildren))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode is ILOpCode.Nop or ILOpCode.Endfinally)
+                    continue;
+
+                if (!sawDispose
+                    && expr.Operand is string operand
+                    && operand.Contains("Dispose", StringComparison.Ordinal)
+                    && !expr.IsStaticCall
+                    && expr.Arguments.Count > 0)
+                {
+                    disposeVar = RenderReceiverName(expr.Arguments[0]);
+                    sawDispose = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawDispose;
+        }
+
+        IEnumerable<(int BlockIndex, ILAstNode Node)> EnumerateStructuredNodes(IEnumerable<StructuredBlock> blocks)
+        {
+            foreach (var block in blocks)
+            {
+                foreach (var item in EnumerateStructuredNodes(block))
+                    yield return item;
+            }
+        }
+
+        IEnumerable<(int BlockIndex, ILAstNode Node)> EnumerateStructuredNodes(StructuredBlock block)
+        {
+            if (block.BlockIndex >= 0 && _blockMap.TryGetValue(block.BlockIndex, out var astBlock))
+            {
+                foreach (var node in astBlock.Nodes)
+                    yield return (block.BlockIndex, node);
+            }
+
+            foreach (var c in block.Children)
+                foreach (var item in EnumerateStructuredNodes(c))
+                    yield return item;
+            foreach (var c in block.TryChildren)
+                foreach (var item in EnumerateStructuredNodes(c))
+                    yield return item;
+            foreach (var c in block.HandlerChildren)
+                foreach (var item in EnumerateStructuredNodes(c))
+                    yield return item;
+            if (block.ThenBlock is not null)
+                foreach (var item in EnumerateStructuredNodes(block.ThenBlock))
+                    yield return item;
+            if (block.ElseBlock is not null)
+                foreach (var item in EnumerateStructuredNodes(block.ElseBlock))
+                    yield return item;
+        }
+
+        static ILAstExpression? NodeExpression(ILAstNode node) => node switch
+        {
+            ILAstStatement { Expression: var expr } => expr,
+            ILAstAssignment { Value: var value } => value,
+            _ => null
+        };
+
+        bool TryFindPreviousStore(
+            StructuredBlock block,
+            string varName,
+            out ILAstNode storeNode,
+            out ILAstExpression value)
+        {
+            storeNode = null!;
+            value = null!;
+
+            var parent = FindParentSequence(block);
+            if (parent is null)
+                return false;
+
+            int blockIndex = -1;
+            for (int i = 0; i < parent.Children.Count; i++)
+            {
+                if (ReferenceEquals(parent.Children[i], block))
+                {
+                    blockIndex = i;
+                    break;
+                }
+            }
+
+            if (blockIndex < 0)
+                return false;
+
+            for (int i = blockIndex - 1; i >= 0; i--)
+            {
+                foreach (var (_, node) in EnumerateStructuredNodes(parent.Children[i]).Reverse())
+                {
+                    if (node is ILAstAssignment assign
+                        && assign.Variable.Name == varName)
+                    {
+                        storeNode = node;
+                        value = assign.Value;
+                        return true;
+                    }
+
+                    if (node is ILAstStatement { Expression: var expr }
+                        && IsStoreToLocal(expr, varName)
+                        && expr.Arguments.Count > 0)
+                    {
+                        storeNode = node;
+                        value = expr.Arguments[0];
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsStoreToLocal(ILAstExpression expr, string varName)
+        {
+            if (expr.OpCode is not (ILOpCode.Stloc or ILOpCode.Stloc_s
+                or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3))
+                return false;
+
+            string name = expr.Operand ?? GetLocalName(expr.OpCode);
+            return name == varName;
+        }
+
+        static string? GetLocalReferenceName(ILAstExpression expr)
+        {
+            if (expr.Operand is { } operand
+                && expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+                    or ILOpCode.Ldloca or ILOpCode.Ldloca_s
+                    or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3)
+            {
+                return operand;
+            }
+
+            return expr.OpCode switch
+            {
+                ILOpCode.Ldloc_0 => "V_0",
+                ILOpCode.Ldloc_1 => "V_1",
+                ILOpCode.Ldloc_2 => "V_2",
+                ILOpCode.Ldloc_3 => "V_3",
+                _ => null
+            };
         }
 
         void ScanForUsingPatterns(StructuredBlock block)
@@ -851,6 +1361,9 @@ public static class CSharpEmitter
             if (block.NegateCondition)
                 condition = NegateConditionString(condition);
 
+            if (TryEmitNullConditionalAssignment(block, condition, indent))
+                return;
+
             // Item 1: Short-circuit return: if(cond) return expr; return false/true;
             if (TryEmitShortCircuitReturn(block, condition, indent))
                 return;
@@ -887,6 +1400,298 @@ public static class CSharpEmitter
                     _sb.AppendLine("}");
                 }
             }
+        }
+
+        bool TryEmitNullConditionalAssignment(StructuredBlock block, string condition, int indent)
+        {
+            if (block.ElseBlock is not null)
+                return false;
+            if (!TryParseNotNullCondition(condition, out string? receiver))
+                return false;
+            if (receiver is null)
+                return false;
+            if (!TryExtractNullConditionalAssignment(
+                    block.ThenBlock,
+                    receiver,
+                    out string? targetSuffix,
+                    out string? assignmentOperator,
+                    out ILAstExpression? value,
+                    out string? expectedType,
+                    out int consumedBlockIndex))
+            {
+                return false;
+            }
+            if (targetSuffix is null || assignmentOperator is null || value is null)
+                return false;
+
+            WriteIndent(indent);
+            _sb.Append(receiver);
+            _sb.Append(targetSuffix);
+            _sb.Append(' ');
+            _sb.Append(assignmentOperator);
+            _sb.Append(' ');
+            EmitExpression(value, expectedType);
+            _sb.AppendLine(";");
+
+            if (consumedBlockIndex >= 0)
+            {
+                _consumedBlocks.Add(consumedBlockIndex);
+                RemoveGotoTargetsForConsumedBlock(consumedBlockIndex);
+            }
+
+            return true;
+        }
+
+        static bool TryParseNotNullCondition(string condition, out string? receiver)
+        {
+            receiver = null;
+            const string suffix = " != null";
+            if (!condition.EndsWith(suffix, StringComparison.Ordinal))
+                return false;
+
+            receiver = condition[..^suffix.Length].Trim();
+            return receiver.Length > 0;
+        }
+
+        bool TryExtractNullConditionalAssignment(
+            StructuredBlock? block,
+            string receiver,
+            out string? targetSuffix,
+            out string? assignmentOperator,
+            out ILAstExpression? value,
+            out string? expectedType,
+            out int consumedBlockIndex)
+        {
+            targetSuffix = null;
+            assignmentOperator = null;
+            value = null;
+            expectedType = null;
+            consumedBlockIndex = -1;
+
+            if (block is null)
+                return false;
+
+            int blockIdx = block.BlockIndex;
+            if (block.Kind == StructuredBlockKind.Sequence && block.Children.Count == 1)
+                blockIdx = block.Children[0].BlockIndex;
+            if (blockIdx < 0 || !_blockMap.TryGetValue(blockIdx, out var astBlock))
+                return false;
+
+            foreach (var node in astBlock.Nodes)
+            {
+                if (node is ILAstStatement { Expression: var expr })
+                {
+                    if (IsIgnorableNullConditionalAssignmentNode(expr))
+                        continue;
+
+                    if (value is not null)
+                        return false;
+                    if (!TryFormatNullConditionalAssignmentTarget(
+                            expr,
+                            receiver,
+                            out targetSuffix,
+                            out assignmentOperator,
+                            out value,
+                            out expectedType))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (value is null)
+                return false;
+
+            consumedBlockIndex = blockIdx;
+            return true;
+        }
+
+        static bool IsIgnorableNullConditionalAssignmentNode(ILAstExpression expr)
+            => expr.OpCode is ILOpCode.Nop or ILOpCode.Br or ILOpCode.Br_s
+                or ILOpCode.Leave or ILOpCode.Leave_s;
+
+        bool TryFormatNullConditionalAssignmentTarget(
+            ILAstExpression expr,
+            string receiver,
+            out string? targetSuffix,
+            out string? assignmentOperator,
+            out ILAstExpression? value,
+            out string? expectedType)
+        {
+            targetSuffix = null;
+            assignmentOperator = null;
+            value = null;
+            expectedType = null;
+
+            if (expr.OpCode == ILOpCode.Stfld && expr.Arguments.Count >= 2)
+            {
+                if (!TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
+                    || actualReceiver != receiver)
+                    return false;
+
+                targetSuffix = $"?.{ExtractMemberName(expr.Operand)}";
+                expectedType = TryResolveFieldType(expr.Operand);
+                if (TryExtractCompoundAssignmentValue(
+                        expr.Arguments[1],
+                        receiver,
+                        memberName: ExtractMemberName(expr.Operand),
+                        indexExpression: null,
+                        out assignmentOperator,
+                        out value))
+                {
+                    return true;
+                }
+
+                assignmentOperator = "=";
+                value = expr.Arguments[1];
+                return true;
+            }
+
+            if (IsStelemOpCode(expr.OpCode) && expr.Arguments.Count >= 3)
+            {
+                if (!TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
+                    || actualReceiver != receiver)
+                    return false;
+
+                targetSuffix = $"?[{ExpressionToString(expr.Arguments[1])}]";
+                assignmentOperator = "=";
+                value = expr.Arguments[2];
+                return true;
+            }
+
+            if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && !expr.IsStaticCall
+                && expr.Operand is string operand)
+            {
+                string memberName = ExtractMemberName(operand);
+                if (memberName.StartsWith("set_", StringComparison.Ordinal)
+                    && expr.Arguments.Count >= 2
+                    && TryGetSimpleReceiverString(expr.Arguments[0], out string? actualReceiver)
+                    && actualReceiver == receiver)
+                {
+                    if (memberName == "set_Item" && expr.Arguments.Count >= 3)
+                    {
+                        targetSuffix = $"?[{ExpressionToString(expr.Arguments[1])}]";
+                        assignmentOperator = "=";
+                        value = expr.Arguments[2];
+                    }
+                    else
+                    {
+                        string propertyName = memberName[4..];
+                        targetSuffix = $"?.{propertyName}";
+                        if (TryExtractCompoundAssignmentValue(
+                                expr.Arguments[1],
+                                receiver,
+                                propertyName,
+                                indexExpression: null,
+                                out assignmentOperator,
+                                out value))
+                        {
+                            return true;
+                        }
+
+                        assignmentOperator = "=";
+                        value = expr.Arguments[1];
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        bool TryExtractCompoundAssignmentValue(
+            ILAstExpression assignedValue,
+            string receiver,
+            string memberName,
+            string? indexExpression,
+            out string? assignmentOperator,
+            out ILAstExpression? rhs)
+        {
+            assignmentOperator = null;
+            rhs = null;
+
+            if (assignedValue.Arguments.Count < 2)
+                return false;
+            if (CompoundAssignmentOperator(assignedValue.OpCode) is not { } op)
+                return false;
+            if (!IsSameMemberRead(assignedValue.Arguments[0], receiver, memberName, indexExpression))
+                return false;
+
+            assignmentOperator = $"{op}=";
+            rhs = assignedValue.Arguments[1];
+            return true;
+        }
+
+        bool IsSameMemberRead(ILAstExpression expr, string receiver, string memberName, string? indexExpression)
+        {
+            if (indexExpression is null
+                && ExpressionToString(expr) == $"{receiver}.{memberName}")
+            {
+                return true;
+            }
+
+            if (expr.OpCode == ILOpCode.Ldfld
+                && indexExpression is null
+                && ExtractMemberName(expr.Operand) == memberName
+                && expr.Arguments.Count > 0
+                && TryGetSimpleReceiverString(expr.Arguments[0], out string? fieldReceiver)
+                && fieldReceiver == receiver)
+            {
+                return true;
+            }
+
+            if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && !expr.IsStaticCall
+                && expr.Operand is string operand
+                && expr.Arguments.Count > 0)
+            {
+                string readMember = ExtractMemberName(operand);
+                if (indexExpression is null
+                    && readMember == $"get_{memberName}"
+                    && TryGetSimpleReceiverString(expr.Arguments[0], out string? propertyReceiver)
+                    && propertyReceiver == receiver)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static string? CompoundAssignmentOperator(ILOpCode op) => op switch
+        {
+            ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => "+",
+            ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un => "-",
+            ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un => "*",
+            ILOpCode.Div or ILOpCode.Div_un => "/",
+            ILOpCode.Rem or ILOpCode.Rem_un => "%",
+            ILOpCode.And => "&",
+            ILOpCode.Or => "|",
+            ILOpCode.Xor => "^",
+            ILOpCode.Shl => "<<",
+            ILOpCode.Shr or ILOpCode.Shr_un => ">>",
+            _ => null
+        };
+
+        bool TryGetSimpleReceiverString(ILAstExpression expr, out string? receiver)
+        {
+            receiver = null;
+            if (expr.OpCode is not (ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2
+                or ILOpCode.Ldarg_3 or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+                or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+                or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc))
+            {
+                return false;
+            }
+
+            receiver = ExpressionToString(expr);
+            return receiver.Length > 0;
         }
 
         /// <summary>
@@ -1277,6 +2082,199 @@ public static class CSharpEmitter
                 else return null;
             }
             return value;
+        }
+
+        /// <summary>
+        /// Scan all blocks for C# collection expressions that lower through compiler-generated
+        /// inline-array helper calls:
+        /// InlineArrayElementRef(ref inlineArray, index) = value;
+        /// InlineArrayAsReadOnlySpan(ref inlineArray, length)
+        /// </summary>
+        void ScanInlineArrayInitializers(ILAstMethod ast)
+        {
+            var candidates = new Dictionary<string, InlineArrayInitializerCandidate>();
+            var spanConsumers = new HashSet<string>();
+
+            foreach (var block in ast.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (TryGetInlineArrayElementStore(node, out string? inlineArrayLocal, out int index, out var value))
+                    {
+                        if (!candidates.TryGetValue(inlineArrayLocal, out var candidate))
+                        {
+                            candidate = new InlineArrayInitializerCandidate();
+                            candidates[inlineArrayLocal] = candidate;
+                        }
+
+                        candidate.Elements[index] = value;
+                        candidate.StoreNodes.Add(node);
+                    }
+                    else if (TryGetInlineArrayDefaultInit(node, out string? initializedLocal))
+                    {
+                        if (!candidates.TryGetValue(initializedLocal, out var candidate))
+                        {
+                            candidate = new InlineArrayInitializerCandidate();
+                            candidates[initializedLocal] = candidate;
+                        }
+
+                        candidate.InitNodes.Add(node);
+                    }
+
+                    if (NodeExpression(node) is { } expr)
+                    {
+                        foreach (string consumedLocal in FindInlineArraySpanConsumers(expr))
+                            spanConsumers.Add(consumedLocal);
+                    }
+                }
+            }
+
+            foreach (var (local, candidate) in candidates)
+            {
+                if (!spanConsumers.Contains(local) || HasUnexpectedInlineArrayUse(ast, local))
+                    continue;
+
+                _inlineArrayInitValues[local] = candidate.Elements;
+                _suppressedLocals.Add(local);
+                foreach (var node in candidate.StoreNodes)
+                    _skipNodes.Add(node);
+                foreach (var node in candidate.InitNodes)
+                    _skipNodes.Add(node);
+            }
+        }
+
+        IEnumerable<string> FindInlineArraySpanConsumers(ILAstExpression expr)
+        {
+            if (IsInlineArrayAsSpanCall(expr)
+                && expr.Arguments.Count > 0
+                && GetLocalReferenceName(expr.Arguments[0]) is { } local)
+            {
+                yield return local;
+            }
+
+            foreach (var arg in expr.Arguments)
+            {
+                foreach (string consumedLocal in FindInlineArraySpanConsumers(arg))
+                    yield return consumedLocal;
+            }
+        }
+
+        static bool IsInlineArrayAsSpanCall(ILAstExpression expr)
+            => expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && expr.Operand is string operand
+                && (operand.Contains("InlineArrayAsReadOnlySpan", StringComparison.Ordinal)
+                    || operand.Contains("InlineArrayAsSpan", StringComparison.Ordinal));
+
+        bool HasUnexpectedInlineArrayUse(ILAstMethod ast, string local)
+        {
+            foreach (var block in ast.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (NodeExpression(node) is { } expr
+                        && HasUnexpectedInlineArrayUse(expr, local))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        bool HasUnexpectedInlineArrayUse(ILAstExpression expr, string local)
+        {
+            if (IsInlineArrayAsSpanCall(expr)
+                || IsInlineArrayElementRefCall(expr))
+            {
+                for (int i = 0; i < expr.Arguments.Count; i++)
+                {
+                    if (i == 0 && GetLocalReferenceName(expr.Arguments[i]) == local)
+                        continue;
+                    if (HasUnexpectedInlineArrayUse(expr.Arguments[i], local))
+                        return true;
+                }
+
+                return false;
+            }
+
+            if (expr.OpCode == ILOpCode.Initobj && expr.Arguments.Count > 0)
+            {
+                for (int i = 0; i < expr.Arguments.Count; i++)
+                {
+                    if (i == 0 && GetLocalReferenceName(expr.Arguments[i]) == local)
+                        continue;
+                    if (HasUnexpectedInlineArrayUse(expr.Arguments[i], local))
+                        return true;
+                }
+
+                return false;
+            }
+
+            if (GetLocalReferenceName(expr) == local)
+                return true;
+
+            foreach (var arg in expr.Arguments)
+            {
+                if (HasUnexpectedInlineArrayUse(arg, local))
+                    return true;
+            }
+
+            return false;
+        }
+
+        bool TryGetInlineArrayElementStore(
+            ILAstNode node,
+            out string inlineArrayLocal,
+            out int index,
+            out ILAstExpression value)
+        {
+            inlineArrayLocal = "";
+            index = -1;
+            value = null!;
+
+            if (node is not ILAstStatement { Expression: var expr })
+                return false;
+            if (expr.OpCode is not (ILOpCode.Stind_i or ILOpCode.Stind_i1 or ILOpCode.Stind_i2
+                or ILOpCode.Stind_i4 or ILOpCode.Stind_i8 or ILOpCode.Stind_r4
+                or ILOpCode.Stind_r8 or ILOpCode.Stind_ref or ILOpCode.Stobj))
+                return false;
+            if (expr.Arguments.Count < 2)
+                return false;
+
+            var valueExpr = expr.Arguments[0];
+            var addressExpr = expr.Arguments[1];
+            if (!IsInlineArrayElementRefCall(addressExpr) || addressExpr.Arguments.Count < 2)
+                return false;
+
+            if (GetLocalReferenceName(addressExpr.Arguments[0]) is not { } local)
+                return false;
+            if (!TryGetConstantIndex(addressExpr.Arguments[1], out int elementIndex))
+                return false;
+
+            inlineArrayLocal = local;
+            index = elementIndex;
+            value = valueExpr;
+            return true;
+        }
+
+        static bool IsInlineArrayElementRefCall(ILAstExpression expr)
+            => expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && expr.Operand is string operand
+                && operand.Contains("InlineArrayElementRef", StringComparison.Ordinal);
+
+        static bool TryGetInlineArrayDefaultInit(ILAstNode node, out string inlineArrayLocal)
+        {
+            inlineArrayLocal = "";
+            if (node is not ILAstStatement { Expression: var expr })
+                return false;
+            if (expr.OpCode != ILOpCode.Initobj || expr.Arguments.Count == 0)
+                return false;
+            if (GetLocalReferenceName(expr.Arguments[0]) is not { } local)
+                return false;
+
+            inlineArrayLocal = local;
+            return true;
         }
 
         /// <summary>
@@ -2312,6 +3310,13 @@ public static class CSharpEmitter
         {
             if (block.ExceptionRegion is not { } region) return;
 
+            if (region.Kind == ExceptionRegionKind.Finally
+                && TryGetLockPattern(block, out var lockPattern))
+            {
+                EmitLockBlock(block, lockPattern, indent);
+                return;
+            }
+
             // Detect using pattern: try { body } finally { if (v != null) v.Dispose(); }
             if (region.Kind == ExceptionRegionKind.Finally
                 && TryDetectDisposeVariable(block) is { } disposeVar)
@@ -2345,6 +3350,47 @@ public static class CSharpEmitter
             // Emit additional handlers (multiple catch)
             foreach (var addl in block.AdditionalHandlers)
                 EmitHandler(addl.Region, addl.HandlerChildren, null, indent);
+        }
+
+        bool TryGetLockPattern(StructuredBlock block, out LockPattern pattern)
+        {
+            if (_lockPatterns.TryGetValue(block, out pattern!))
+                return true;
+
+            if (!TryDetectLockPattern(block, out pattern))
+                return false;
+
+            _lockPatterns[block] = pattern;
+            foreach (var node in pattern.SkipNodes)
+                _skipNodes.Add(node);
+            foreach (string local in pattern.SuppressedLocals)
+                _suppressedLocals.Add(local);
+            return true;
+        }
+
+        void EmitLockBlock(StructuredBlock block, LockPattern pattern, int indent)
+        {
+            WriteIndent(indent);
+            _sb.Append("lock (");
+            EmitExpression(pattern.LockExpression);
+            _sb.AppendLine(")");
+            WriteIndent(indent);
+            _sb.AppendLine("{");
+
+            if (block.TryChildren.Count > 0)
+            {
+                foreach (var child in block.TryChildren)
+                    EmitStructuredBlock(child, indent + 1);
+            }
+            else
+            {
+                EmitBasicBlock(block.BlockIndex, indent + 1);
+            }
+
+            WriteIndent(indent);
+            _sb.AppendLine("}");
+
+            MarkHandlerConsumed(block);
         }
 
         void EmitHandler(ExceptionRegion region, List<StructuredBlock> handlerChildren, StructuredBlock? block, int indent)
@@ -3302,7 +4348,7 @@ public static class CSharpEmitter
                     {
                         if (_collectionTemps.TryGetValue(expr.Offset, out string? collectionTemp))
                             _sb.Append(collectionTemp);
-                        else
+                        else if (!TryEmitSpanCollectionExpression(expr, resolvedType))
                             EmitNewObjectExpression(expr);
                         break;
                     }
@@ -3513,6 +4559,57 @@ public static class CSharpEmitter
             _sb.Append(')');
         }
 
+        bool TryEmitSpanCollectionExpression(ILAstExpression expr, string? expectedType)
+        {
+            string constructedType = ExtractTypeName(expr.Operand);
+            if (!IsSpanOrReadOnlySpanType(constructedType)
+                && !IsSpanOrReadOnlySpanType(expectedType))
+            {
+                return false;
+            }
+
+            if (expr.Arguments.Count != 1 || expr.Arguments[0].OpCode != ILOpCode.Newarr)
+                return false;
+
+            return TryEmitCollectionExpressionFromNewArray(expr.Arguments[0]);
+        }
+
+        bool TryEmitCollectionExpressionFromNewArray(ILAstExpression newArray)
+        {
+            if (newArray.Arguments.Count == 0 || !TryGetConstantIndex(newArray.Arguments[0], out int size))
+                return false;
+            if (!_arrayInitValues.TryGetValue(newArray.Offset, out var initElements))
+                return size == 0 && EmitEmptyCollectionExpression();
+
+            _sb.Append('[');
+            for (int i = 0; i < size; i++)
+            {
+                if (i > 0) _sb.Append(", ");
+                if (initElements.TryGetValue(i, out var element))
+                    EmitExpression(element);
+                else
+                    _sb.Append("default");
+            }
+            _sb.Append(']');
+            return true;
+        }
+
+        bool EmitEmptyCollectionExpression()
+        {
+            _sb.Append("[]");
+            return true;
+        }
+
+        static bool IsSpanOrReadOnlySpanType(string? typeName)
+        {
+            if (typeName is null)
+                return false;
+            return typeName.StartsWith("System.Span<", StringComparison.Ordinal)
+                || typeName.StartsWith("Span<", StringComparison.Ordinal)
+                || typeName.StartsWith("System.ReadOnlySpan<", StringComparison.Ordinal)
+                || typeName.StartsWith("ReadOnlySpan<", StringComparison.Ordinal);
+        }
+
         bool TryEmitPointerDereference(ILAstExpression expr)
         {
             if (expr.Arguments.Count != 1)
@@ -3649,6 +4746,9 @@ public static class CSharpEmitter
                 typePart = methodName[..colonIdx];
                 memberPart = methodName[(colonIdx + 2)..].TrimEnd('(', ')');
             }
+
+            if (TryEmitInlineArrayAsSpanExpression(expr, memberPart))
+                return;
 
             // String interpolation: ToStringAndClear() on a detected handler → $"..."
             if (memberPart is "ToStringAndClear" or "ToString"
@@ -3823,6 +4923,32 @@ public static class CSharpEmitter
                 else
                     _sb.Append($"{SimplifyTypeName(typePart)}.{memberPart}()");
             }
+        }
+
+        bool TryEmitInlineArrayAsSpanExpression(ILAstExpression expr, string memberPart)
+        {
+            if (memberPart is not ("InlineArrayAsReadOnlySpan" or "InlineArrayAsSpan"))
+                return false;
+            if (expr.Arguments.Count < 2)
+                return false;
+            if (GetLocalReferenceName(expr.Arguments[0]) is not { } inlineArrayLocal)
+                return false;
+            if (!TryGetConstantIndex(expr.Arguments[1], out int length))
+                return false;
+            if (!_inlineArrayInitValues.TryGetValue(inlineArrayLocal, out var elements))
+                return false;
+
+            _sb.Append('[');
+            for (int i = 0; i < length; i++)
+            {
+                if (i > 0) _sb.Append(", ");
+                if (elements.TryGetValue(i, out var element))
+                    EmitExpression(element);
+                else
+                    _sb.Append("default");
+            }
+            _sb.Append(']');
+            return true;
         }
 
         void EmitBranchCondition(ILAstExpression expr)


### PR DESCRIPTION
## Summary
- render C# 14 null-conditional property compound assignments such as `target?.Count += value`
- add receiver-alias safety checks so consumed compiler temps cannot remain live in emitted output
- keep indexer compound folding constrained to side-effect-free index expressions for future-safe recognition

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- git diff --check

Runtime custom-await remains deferred because Roslyn lowers it through awaiter temps, IsCompleted guards, AwaitAwaiter/UnsafeAwaitAwaiter, and GetResult; it needs a dedicated data-flow recognizer.