### PR TITLE
Bump dotnet-inspect to 0.9.4

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.9.3</VersionPrefix>
+    <VersionPrefix>0.9.4</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.9.4
+
+### Lowered C# output
+
+- Recovers more recent C# lowering patterns, including `lock` statements, null-conditional assignments, and span collection expressions backed by inline-array helpers.
+- Renders null-conditional property compound assignments such as `target?.Count += value` when the compiler-lowered shape is safe to fold.
+
 ## v0.9.2
 
 ### Package resolution


### PR DESCRIPTION
## Summary
- bump dotnet-inspect package VersionPrefix to 0.9.4
- add v0.9.4 release notes for the recent C# lowering improvements

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- git diff --check
- npx markdownlint-cli src/dotnet-inspect/release-notes.md