### PR TITLE
Expose additional nuspec package metadata

### DIFF
--- a/src/DotnetInspector.Services/NuspecData.cs
+++ b/src/DotnetInspector.Services/NuspecData.cs
@@ -13,7 +13,10 @@ public class NuspecData
     public string? Description { get; set; }
     public string? Authors { get; set; }
     public string? Repository { get; set; }
+    public string? RepositoryType { get; set; }
+    public string? RepositoryCommit { get; set; }
     public string? License { get; set; }
+    public string? LicenseUrl { get; set; }
     public List<string>? PackageTypes { get; set; }
     public bool IsToolPackage { get; set; }
     public string? ReadmeFile { get; set; }

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -26,7 +26,10 @@ public static class NuspecParser
         result.Version = metadata.Element(ns + "version")?.Value;
         result.Description = metadata.Element(ns + "description")?.Value;
         result.Authors = metadata.Element(ns + "authors")?.Value;
-        result.Repository = metadata.Element(ns + "repository")?.Attribute("url")?.Value;
+        var repositoryElement = metadata.Element(ns + "repository");
+        result.Repository = repositoryElement?.Attribute("url")?.Value;
+        result.RepositoryType = repositoryElement?.Attribute("type")?.Value;
+        result.RepositoryCommit = repositoryElement?.Attribute("commit")?.Value;
 
         // Parse license (prefer expression over file or URL)
         var licenseElement = metadata.Element(ns + "license");
@@ -46,6 +49,7 @@ public static class NuspecParser
         if (string.IsNullOrEmpty(result.License))
         {
             var licenseUrl = metadata.Element(ns + "licenseUrl")?.Value;
+            result.LicenseUrl = licenseUrl;
             if (!string.IsNullOrEmpty(licenseUrl) && !licenseUrl.Contains("LICENSE"))
             {
                 if (licenseUrl.StartsWith("https://licenses.nuget.org/"))
@@ -53,6 +57,10 @@ public static class NuspecParser
                     result.License = licenseUrl.Replace("https://licenses.nuget.org/", "");
                 }
             }
+        }
+        else
+        {
+            result.LicenseUrl = metadata.Element(ns + "licenseUrl")?.Value;
         }
 
         // Parse package types

--- a/src/dotnet-inspect.Tests/InspectionResultTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionResultTests.cs
@@ -94,6 +94,32 @@ public class InspectionResultTests
     }
 
     [Fact]
+    public void PackageInfo_RendersNuspecMetadataDetails()
+    {
+        var result = new InspectionResult
+        {
+            PackageName = "Test",
+            Version = "1.0.0",
+            License = "MIT",
+            LicenseUrl = "https://licenses.nuget.org/MIT",
+            Repository = "https://github.com/example/test",
+            RepositoryType = "git",
+            RepositoryCommit = "abcdef",
+            HasReadme = true,
+            ReadmeFile = "docs/README.md"
+        };
+
+        var output = MarkoutSerializer.Serialize(new InspectionResultView(result), InspectionContext.Default);
+
+        Assert.Contains("| License | MIT |", output);
+        Assert.Contains("| License URL | https://licenses.nuget.org/MIT |", output);
+        Assert.Contains("| Repository | https://github.com/example/test |", output);
+        Assert.Contains("| Repository Type | git |", output);
+        Assert.Contains("| Repository Commit | abcdef |", output);
+        Assert.Contains("| Readme | docs/README.md |", output);
+    }
+
+    [Fact]
     public void Manifest_RendersManifestVersionWhenPresent()
     {
         var result = new InspectionResult

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -430,7 +430,10 @@ public class PackageCommand
         result.Description = nuspec.Description;
         result.Authors = nuspec.Authors;
         result.Repository = nuspec.Repository;
+        result.RepositoryType = nuspec.RepositoryType;
+        result.RepositoryCommit = nuspec.RepositoryCommit;
         result.License = nuspec.License;
+        result.LicenseUrl = nuspec.LicenseUrl;
         result.PackageTypes = nuspec.PackageTypes;
         result.IsToolPackage = nuspec.IsToolPackage;
         result.ReadmeFile = nuspec.ReadmeFile;

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -38,7 +38,10 @@ internal static class PackageIndexCache
                 Description = doc.GetString("description"),
                 Authors = doc.GetString("authors"),
                 License = doc.GetString("license"),
+                LicenseUrl = doc.GetString("licenseUrl"),
                 Repository = doc.GetString("repository"),
+                RepositoryType = doc.GetString("repositoryType"),
+                RepositoryCommit = doc.GetString("repositoryCommit"),
                 ReadmeFile = doc.GetString("readmeFile"),
                 HasReadme = doc.GetBool("hasReadme"),
                 IsToolPackage = doc.GetBool("isToolPackage"),
@@ -123,6 +126,10 @@ internal static class PackageIndexCache
         WriteField(buf, "description"u8, result.Description);
         WriteField(buf, "authors"u8, result.Authors);
         WriteField(buf, "license"u8, result.License);
+        WriteField(buf, "licenseUrl"u8, result.LicenseUrl);
+        WriteField(buf, "repository"u8, result.Repository);
+        WriteField(buf, "repositoryType"u8, result.RepositoryType);
+        WriteField(buf, "repositoryCommit"u8, result.RepositoryCommit);
         WriteField(buf, "assemblyCount"u8, result.AssemblyCount);
         WriteField(buf, "hasReadme"u8, result.HasReadme);
         WriteField(buf, "isToolPackage"u8, result.IsToolPackage);
@@ -146,7 +153,6 @@ internal static class PackageIndexCache
             WriteField(buf, "msdlSourceLinkPdbs"u8, binarySignals.MsdlSourceLinkPdbs);
             WriteField(buf, "otherSourceLinkPdbs"u8, binarySignals.OtherSourceLinkPdbs);
         }
-        WriteField(buf, "repository"u8, result.Repository);
         WriteField(buf, "readmeFile"u8, result.ReadmeFile);
         WriteField(buf, "toolFormat"u8, result.ToolFormat);
         WriteField(buf, "runtimeTargetRid"u8, result.RuntimeTargetRid);

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -15,7 +15,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class PackageIndexCache
 {
-    private const string Category = "pkg-index-v7";
+    private const string Category = "pkg-index-v8";
 
     /// <summary>
     /// Tries to load a cached InspectionResult for a package version.

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -59,7 +59,10 @@ internal static class PackageInspector
             result.Description = nuspec.Description;
             result.Authors = nuspec.Authors;
             result.Repository = nuspec.Repository;
+            result.RepositoryType = nuspec.RepositoryType;
+            result.RepositoryCommit = nuspec.RepositoryCommit;
             result.License = nuspec.License;
+            result.LicenseUrl = nuspec.LicenseUrl;
             result.PackageTypes = nuspec.PackageTypes;
             result.IsToolPackage = nuspec.IsToolPackage;
             result.ReadmeFile = nuspec.ReadmeFile;

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -24,7 +24,10 @@ public class InspectionResult
 
     public string? Authors { get; set; }
     public string? License { get; set; }
+    public string? LicenseUrl { get; set; }
     public string? Repository { get; set; }
+    public string? RepositoryType { get; set; }
+    public string? RepositoryCommit { get; set; }
 
     /// <summary>
     /// When this package version was published to NuGet (from NuGet API).

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -149,7 +149,10 @@ public class InspectionResultView
 
     public string? Authors => _data.Authors;
     public string? License => _data.License;
+    public string? LicenseUrl => _data.LicenseUrl;
     public string? Repository => _data.Repository;
+    public string? RepositoryType => _data.RepositoryType;
+    public string? RepositoryCommit => _data.RepositoryCommit;
 
     [MarkoutFormat("yyyy-MM-dd")]
     [MarkoutPropertyName("Built")]
@@ -171,6 +174,11 @@ public class InspectionResultView
 
     [MarkoutSkipDefault]
     public bool HasReadme => _data.HasReadme;
+
+    [MarkoutPropertyName("Readme")]
+    public string? ReadmeFile => _data.HasReadme
+        ? _data.ReadmeFile ?? "README.md"
+        : _data.ReadmeFile;
 
     [MarkoutSkipDefault]
     public bool IsToolPackage => _data.IsToolPackage;
@@ -293,8 +301,14 @@ public class InspectionResultView
             fields.Add(new("Owners", string.Join(", ", _data.Owners)));
         if (!string.IsNullOrWhiteSpace(_data.License))
             fields.Add(new("License", _data.License));
+        if (!string.IsNullOrWhiteSpace(_data.LicenseUrl))
+            fields.Add(new("License URL", _data.LicenseUrl));
         if (!string.IsNullOrWhiteSpace(_data.Repository))
             fields.Add(new("Repository", _data.Repository));
+        if (!string.IsNullOrWhiteSpace(_data.RepositoryType))
+            fields.Add(new("Repository Type", _data.RepositoryType));
+        if (!string.IsNullOrWhiteSpace(_data.RepositoryCommit))
+            fields.Add(new("Repository Commit", _data.RepositoryCommit));
 
         if (_data.IsVerified == true)
             fields.Add(new("Verified", "Yes"));
@@ -309,7 +323,7 @@ public class InspectionResultView
         if (_data.AssemblyCount > 1)
             fields.Add(new("Libraries", _data.AssemblyCount.ToString()));
         if (_data.HasReadme)
-            fields.Add(new("Readme", "Yes"));
+            fields.Add(new("Readme", _data.ReadmeFile ?? "README.md"));
         if (_data.Vulnerabilities is { Count: > 0 })
             fields.Add(new("Vulnerabilities", _data.Vulnerabilities.Count.ToString()));
 


### PR DESCRIPTION
## Summary
- parse nuspec repository type and commit metadata
- retain licenseUrl and README path in package inspection results
- render those fields in Package Info and preserve them in the package index cache
- bump the package index cache category so older cached entries do not hide the new fields

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release
- DOTNET_INSPECT_ISOLATED=nuspec-metadata dotnet run --project src/dotnet-inspect -c Release -- package Npgsql --version 9.0.3 -S "Package Info"
- dotnet run --project src/dotnet-inspect -c Release -- package System.Text.Json -S "Package Info"
- dotnet run --project src/dotnet-inspect -c Release -- package OpenAI -S "Package Info"