### PR TITLE
Clean obsolete versioned cache categories

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -311,7 +311,7 @@ public static class CoreCache
     }
 
     /// <summary>
-    /// Cancels cache maintenance, waits briefly for in-flight cleanup to finish, and returns
+    /// Waits briefly for in-flight cleanup to finish, cancels if it exceeds the timeout, and returns
     /// the amount of obsolete cache data removed so far.
     /// </summary>
     public static CacheMaintenanceResult CancelAndWaitForMaintenance(TimeSpan timeout)
@@ -324,10 +324,16 @@ public static class CoreCache
             cts = s_maintenanceCts;
         }
 
-        cts?.Cancel();
         if (task != null)
         {
-            try { task.Wait(timeout); }
+            try
+            {
+                if (!task.Wait(timeout))
+                {
+                    cts?.Cancel();
+                    try { task.Wait(TimeSpan.FromMilliseconds(25)); } catch { }
+                }
+            }
             catch
             {
                 // Best-effort shutdown hook; cleanup must never affect command success.

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -366,6 +366,7 @@ public static class CoreCache
             return;
 
         VersionedCacheCategory[] categories;
+        string root;
         lock (s_maintenanceLock)
         {
             if (s_maintenanceScheduled != 0)
@@ -373,28 +374,27 @@ public static class CoreCache
             if (s_versionedCategories.Count == 0)
                 return;
 
+            try
+            {
+                root = GetBasePath();
+            }
+            catch
+            {
+                return;
+            }
             s_maintenanceScheduled = 1;
             categories = [.. s_versionedCategories];
             s_maintenanceCts = new CancellationTokenSource();
             var token = s_maintenanceCts.Token;
-            s_maintenanceTask = Task.Run(() => CleanupVersionedCategories(categories, token), CancellationToken.None);
+            s_maintenanceTask = Task.Run(() => CleanupVersionedCategories(root, categories, token), CancellationToken.None);
         }
     }
 
     private static void CleanupVersionedCategories(
+        string root,
         IReadOnlyList<VersionedCacheCategory> categories,
         CancellationToken cancellationToken)
     {
-        string root;
-        try
-        {
-            root = GetBasePath();
-        }
-        catch
-        {
-            return;
-        }
-
         if (!Directory.Exists(root))
             return;
 

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -12,6 +12,13 @@ public static class CoreCache
 {
     private static string? _appName;
     private static string? _basePathOverride;
+    private static readonly object s_maintenanceLock = new();
+    private static readonly List<VersionedCacheCategory> s_versionedCategories = [];
+    private static CancellationTokenSource? s_maintenanceCts;
+    private static Task? s_maintenanceTask;
+    private static int s_maintenanceScheduled;
+    private static long s_maintenanceBytesFreed;
+    private static int s_maintenanceDirectoriesDeleted;
 
     /// <summary>
     /// Initializes the cache with the application name used for the cache directory.
@@ -22,6 +29,15 @@ public static class CoreCache
         ArgumentException.ThrowIfNullOrWhiteSpace(appName);
         _appName = appName;
         _basePathOverride = basePath;
+        lock (s_maintenanceLock)
+        {
+            s_maintenanceCts?.Cancel();
+            s_maintenanceCts = null;
+            s_maintenanceTask = null;
+            s_maintenanceScheduled = 0;
+            s_maintenanceBytesFreed = 0;
+            s_maintenanceDirectoriesDeleted = 0;
+        }
     }
 
     private static string AppName => _appName
@@ -94,6 +110,29 @@ public static class CoreCache
     }
 
     /// <summary>
+    /// Registers a versioned cache category family for best-effort cleanup.
+    /// For example, prefix <c>pkg-index-v</c> with current <c>pkg-index-v8</c>
+    /// causes maintenance to delete sibling directories such as <c>pkg-index-v7</c>.
+    /// </summary>
+    public static void RegisterVersionedCategory(string prefix, string current)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(current);
+
+        lock (s_maintenanceLock)
+        {
+            if (s_versionedCategories.Any(c =>
+                c.Prefix.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+                && c.Current.Equals(current, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            s_versionedCategories.Add(new(prefix, current));
+        }
+    }
+
+    /// <summary>
     /// Tries to read cached content by category and key.
     /// </summary>
     /// <returns>The cached content, or null if not found.</returns>
@@ -113,7 +152,7 @@ public static class CoreCache
                 return null;
             }
         }
-        InfoTracker.RecordCacheMiss();
+        RecordCacheMiss();
         return null;
     }
 
@@ -137,7 +176,7 @@ public static class CoreCache
                 return null;
             }
         }
-        InfoTracker.RecordCacheMiss();
+        RecordCacheMiss();
         return null;
     }
 
@@ -162,7 +201,7 @@ public static class CoreCache
         {
             // Best-effort
         }
-        InfoTracker.RecordCacheMiss();
+        RecordCacheMiss();
         return null;
     }
 
@@ -187,7 +226,7 @@ public static class CoreCache
         {
             // Best-effort
         }
-        InfoTracker.RecordCacheMiss();
+        RecordCacheMiss();
         return null;
     }
 
@@ -272,6 +311,35 @@ public static class CoreCache
     }
 
     /// <summary>
+    /// Cancels cache maintenance, waits briefly for in-flight cleanup to finish, and returns
+    /// the amount of obsolete cache data removed so far.
+    /// </summary>
+    public static CacheMaintenanceResult CancelAndWaitForMaintenance(TimeSpan timeout)
+    {
+        Task? task;
+        CancellationTokenSource? cts;
+        lock (s_maintenanceLock)
+        {
+            task = s_maintenanceTask;
+            cts = s_maintenanceCts;
+        }
+
+        cts?.Cancel();
+        if (task != null)
+        {
+            try { task.Wait(timeout); }
+            catch
+            {
+                // Best-effort shutdown hook; cleanup must never affect command success.
+            }
+        }
+
+        return new CacheMaintenanceResult(
+            Interlocked.Read(ref s_maintenanceBytesFreed),
+            Volatile.Read(ref s_maintenanceDirectoriesDeleted));
+    }
+
+    /// <summary>
     /// Gets the file path for a cached item using SHA256 hash partitioning.
     /// Format: {basePath}/{category}/{hash[0:2]}/{hash[2:]}.{extension}
     /// </summary>
@@ -286,6 +354,103 @@ public static class CoreCache
         return Path.Combine(GetCategoryPath(category), subDir, fileName);
     }
 
+    private static void RecordCacheMiss()
+    {
+        InfoTracker.RecordCacheMiss();
+        ScheduleMaintenanceOnMiss();
+    }
+
+    private static void ScheduleMaintenanceOnMiss()
+    {
+        if (Volatile.Read(ref s_maintenanceScheduled) != 0)
+            return;
+
+        VersionedCacheCategory[] categories;
+        lock (s_maintenanceLock)
+        {
+            if (s_maintenanceScheduled != 0)
+                return;
+            if (s_versionedCategories.Count == 0)
+                return;
+
+            s_maintenanceScheduled = 1;
+            categories = [.. s_versionedCategories];
+            s_maintenanceCts = new CancellationTokenSource();
+            var token = s_maintenanceCts.Token;
+            s_maintenanceTask = Task.Run(() => CleanupVersionedCategories(categories, token), CancellationToken.None);
+        }
+    }
+
+    private static void CleanupVersionedCategories(
+        IReadOnlyList<VersionedCacheCategory> categories,
+        CancellationToken cancellationToken)
+    {
+        string root;
+        try
+        {
+            root = GetBasePath();
+        }
+        catch
+        {
+            return;
+        }
+
+        if (!Directory.Exists(root))
+            return;
+
+        foreach (var category in categories)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            string[] directories;
+            try
+            {
+                directories = Directory.GetDirectories(root, $"{category.Prefix}*");
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var directory in directories)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                var name = Path.GetFileName(directory);
+                if (name.Equals(category.Current, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!name.StartsWith(category.Prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var size = GetDirectorySizeBestEffort(directory);
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    Interlocked.Add(ref s_maintenanceBytesFreed, size);
+                    Interlocked.Increment(ref s_maintenanceDirectoriesDeleted);
+                }
+                catch
+                {
+                    // Cache cleanup is best-effort.
+                }
+            }
+        }
+    }
+
+    private static long GetDirectorySizeBestEffort(string path)
+    {
+        try
+        {
+            return GetDirectorySize(path);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
     private static long GetDirectorySize(string path)
     {
         if (!Directory.Exists(path))
@@ -296,6 +461,10 @@ public static class CoreCache
             .Sum(f => f.Length);
     }
 }
+
+public readonly record struct CacheMaintenanceResult(long BytesFreed, int DirectoriesDeleted);
+
+internal readonly record struct VersionedCacheCategory(string Prefix, string Current);
 
 /// <summary>
 /// Cache statistics for a category or the entire cache.

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Core;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
 
@@ -52,5 +53,28 @@ public class CacheCommandTests : IDisposable
 
         // Should succeed even if cache is empty
         Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void CacheMiss_CleansObsoleteVersionedCategories()
+    {
+        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v7");
+        var currentDir = Path.Combine(_cacheBasePath, "pkg-index-v8");
+        Directory.CreateDirectory(oldDir);
+        Directory.CreateDirectory(currentDir);
+        File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
+        File.WriteAllText(Path.Combine(currentDir, "current.txt"), "keep");
+
+        CoreCache.RegisterVersionedCategory("pkg-index-v", "pkg-index-v8");
+
+        Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
+        Assert.True(SpinWait.SpinUntil(() => !Directory.Exists(oldDir), TimeSpan.FromSeconds(5)));
+
+        var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(1));
+
+        Assert.False(Directory.Exists(oldDir));
+        Assert.True(Directory.Exists(currentDir));
+        Assert.True(result.BytesFreed > 0);
+        Assert.True(result.DirectoriesDeleted >= 1);
     }
 }

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -68,9 +68,7 @@ public class CacheCommandTests : IDisposable
         CoreCache.RegisterVersionedCategory("pkg-index-v", "pkg-index-v8");
 
         Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
-        Assert.True(SpinWait.SpinUntil(() => !Directory.Exists(oldDir), TimeSpan.FromSeconds(5)));
-
-        var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(1));
+        var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(5));
 
         Assert.False(Directory.Exists(oldDir));
         Assert.True(Directory.Exists(currentDir));

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -15,7 +15,12 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class PackageIndexCache
 {
-    private const string Category = "pkg-index-v8";
+    internal const string Category = "pkg-index-v8";
+
+    static PackageIndexCache()
+    {
+        CoreCache.RegisterVersionedCategory("pkg-index-v", Category);
+    }
 
     /// <summary>
     /// Tries to load a cached InspectionResult for a package version.

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -164,4 +164,11 @@ if (showInfo)
     MarkoutSerializer.Serialize(view, Console.Error, InfoViewContext.Default);
 }
 
+var cacheMaintenance = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromMilliseconds(100));
+if (cacheMaintenance.BytesFreed > 0)
+{
+    Console.Error.WriteLine();
+    Console.Error.WriteLine($"Removed {CacheOutputFormatter.FormatSize(cacheMaintenance.BytesFreed)} from obsolete cache entries.");
+}
+
 return exitCode;

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -2,6 +2,10 @@
 
 ## v0.9.4
 
+### Cache
+
+- Cleans obsolete versioned cache categories, such as older package-index schema caches, in the background after cache misses.
+
 ### Lowered C# output
 
 - Recovers more recent C# lowering patterns, including `lock` statements, null-conditional assignments, and span collection expressions backed by inline-array helpers.


### PR DESCRIPTION
## Summary
- add cache-owned maintenance for obsolete versioned cache category families
- register `pkg-index-v*` so older package index schema caches are removed while the current category is kept
- schedule best-effort cleanup on cache misses
- cancel/drain maintenance at process shutdown and report reclaimed cache size when data was removed

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release