### PR TITLE
Improve overload lookup guidance

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -58,7 +58,7 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json
 
 Carry resolved context forward. Bare names use the router: platform-looking names are tried as installed platform libraries first, then fall back to NuGet packages if platform resolution fails. Use explicit `--platform`, `--package`, or `--library` when the source matters; for multi-library packages, include the `--library` value shown by `find`.
 
-Use `type` for type shape and summaries; use `member` for signatures, overloads, docs, and implementation detail. Add `--show-index` when you need stable `Name:N` overload selectors.
+For full public signature or overload inventories, start with `type Type --package Foo --shape`; it gives the clean declaration shape with parameter names, nullable annotations, defaults, and generic parameters. Use `member Type --package Foo -m Name --show-index` when you need docs or stable `Name:N` overload selectors, and use `member Type Name:N -v:d` only when you need source, lowered C#, or IL for a selected overload.
 
 ## Upgrade and compatibility workflow
 

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -157,6 +157,16 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task ExplicitPackage_WithQualifiedTypeAndMOption_PreservesQualifiedType()
+    {
+        var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json", "-m", "Serialize");
+
+        Assert.Equal("System.Text.Json.JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PackagePath);
+        Assert.Contains("Serialize", options.MemberFilter);
+    }
+
+    [Fact]
     public async Task ExplicitPackage_WithMultipleMOptions_SetsAllMembers()
     {
         var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Serialize", "-m", "Deserialize");

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -129,7 +129,8 @@ public static class MemberOptionsParser
         //   → source=System.Text.Json, type=JsonDocument, member=Parse
         // Skip if the right part contains '<' — that's a generic type name (e.g., Generic.List<T>),
         // not a type.member pair.
-        if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
+        var optionMembers = parseResult.GetValue(args.MemberOption) ?? [];
+        if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0 && optionMembers.Length == 0)
         {
             var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
             if (splitMemberName != null)
@@ -145,8 +146,7 @@ public static class MemberOptionsParser
             return new UnrecognizedOption(badOption);
 
         // Combine -m option with positional members
-        var members = parseResult.GetValue(args.MemberOption) ?? [];
-        var allMembers = members.Concat(positionalMembers).ToArray();
+        var allMembers = optionMembers.Concat(positionalMembers).ToArray();
         var ctorOnly = parseResult.GetValue(args.CtorOption);
 
         // Process dotted syntax and overload shorthand


### PR DESCRIPTION
## Summary
- update dotnet-inspect SKILL.md to recommend `type --shape` first for public signature and overload inventory tasks
- clarify that `member` is for docs, overload selectors, and implementation detail
- preserve fully qualified type names in `member` when `-m/--member` already supplies the member filter

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- member System.Text.Json.JsonSerializer --package System.Text.Json@10.0.0 -m Serialize --rows -n 5
- dotnet run --project src/dotnet-inspect -c Release -- type JsonSerializer --package System.Text.Json@10.0.0 --shape