### PR TITLE
Recover runtime async custom awaits

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/RuntimeAsyncEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/RuntimeAsyncEmitterTests.cs
@@ -58,6 +58,63 @@ public class RuntimeAsyncEmitterTests
         Assert.Null(Record.Exception(() => EmitRuntimeAsync("AwaitValue")));
     }
 
+    [Fact]
+    public void CustomAwait_RendersAwaitedAwaitable()
+    {
+        string code = EmitRuntimeAsync("AwaitCustomValue");
+
+        Assert.Contains("return await t", code);
+        Assert.DoesNotContain("GetAwaiter", code);
+        Assert.DoesNotContain("IsCompleted", code);
+        Assert.DoesNotContain("AwaitAwaiter", code);
+        Assert.DoesNotContain("GetResult", code);
+    }
+
+    [Fact]
+    public void CustomAwait_BrfalseHelperPath_RendersAwaitedAwaitable()
+    {
+        string code = EmitRuntimeAsync("AwaitCustomValueBrfalse");
+
+        Assert.Contains("return await t", code);
+        Assert.DoesNotContain("GetAwaiter", code);
+        Assert.DoesNotContain("AwaitAwaiter", code);
+        Assert.DoesNotContain("GetResult", code);
+    }
+
+    [Fact]
+    public void CustomAwait_InvertedGuard_DoesNotFoldToAwait()
+    {
+        string code = EmitRuntimeAsync("InvertedCustomAwaitGuard");
+
+        Assert.DoesNotContain("return await t", code);
+        Assert.Contains("AwaitAwaiter", code);
+        Assert.Contains("GetResult", code);
+    }
+
+    [Fact]
+    public void StructCustomAwait_DoesNotRenderRefAwaitOperand()
+    {
+        string code = EmitRuntimeAsync("AwaitCustomStructValue");
+
+        Assert.Contains("return await t", code);
+        Assert.DoesNotContain("await ref t", code);
+        Assert.DoesNotContain("GetAwaiter", code);
+        Assert.DoesNotContain("AwaitAwaiter", code);
+        Assert.DoesNotContain("GetResult", code);
+    }
+
+    [Fact]
+    public void StructArrayElementCustomAwait_DoesNotRenderRefAwaitOperand()
+    {
+        string code = EmitRuntimeAsync("AwaitCustomStructArrayElement");
+
+        Assert.Contains("return await values[0]", code);
+        Assert.DoesNotContain("await ref values[0]", code);
+        Assert.DoesNotContain("GetAwaiter", code);
+        Assert.DoesNotContain("AwaitAwaiter", code);
+        Assert.DoesNotContain("GetResult", code);
+    }
+
     static string EmitRuntimeAsync(string methodName)
     {
         using var stream = BuildRuntimeAsyncAssembly();
@@ -98,7 +155,62 @@ public class RuntimeAsyncEmitterTests
         awaitGenericIl.Emit(OpCodes.Ldloc, defaultLocal);
         awaitGenericIl.Emit(OpCodes.Ret);
 
+        var awaitAwaiterGeneric = helpers.DefineMethod(
+            "AwaitAwaiter", MethodAttributes.Public | MethodAttributes.Static);
+        var awaiterTp = awaitAwaiterGeneric.DefineGenericParameters("TAwaiter")[0];
+        awaitAwaiterGeneric.SetReturnType(typeof(void));
+        awaitAwaiterGeneric.SetParameters(awaiterTp);
+        var awaitAwaiterIl = awaitAwaiterGeneric.GetILGenerator();
+        awaitAwaiterIl.Emit(OpCodes.Ret);
+
         helpers.CreateType();
+
+        var awaiterType = module.DefineType("CustomAwaiter", TypeAttributes.Public | TypeAttributes.Class);
+        var awaiterCtor = awaiterType.DefineDefaultConstructor(MethodAttributes.Public);
+        var isCompleted = awaiterType.DefineMethod(
+            "get_IsCompleted",
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            typeof(bool),
+            Type.EmptyTypes);
+        var isCompletedIl = isCompleted.GetILGenerator();
+        isCompletedIl.Emit(OpCodes.Ldc_I4_0);
+        isCompletedIl.Emit(OpCodes.Ret);
+
+        var getResult = awaiterType.DefineMethod(
+            "GetResult",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            typeof(int),
+            Type.EmptyTypes);
+        var getResultIl = getResult.GetILGenerator();
+        getResultIl.Emit(OpCodes.Ldc_I4, 42);
+        getResultIl.Emit(OpCodes.Ret);
+        var customAwaiter = awaiterType.CreateType();
+
+        var awaitableType = module.DefineType("CustomAwaitable", TypeAttributes.Public | TypeAttributes.Class);
+        awaitableType.DefineDefaultConstructor(MethodAttributes.Public);
+        var getAwaiter = awaitableType.DefineMethod(
+            "GetAwaiter",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            customAwaiter,
+            Type.EmptyTypes);
+        var getAwaiterIl = getAwaiter.GetILGenerator();
+        getAwaiterIl.Emit(OpCodes.Newobj, awaiterCtor);
+        getAwaiterIl.Emit(OpCodes.Ret);
+        var customAwaitable = awaitableType.CreateType();
+
+        var structAwaitableType = module.DefineType(
+            "CustomStructAwaitable",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.SequentialLayout,
+            typeof(ValueType));
+        var structGetAwaiter = structAwaitableType.DefineMethod(
+            "GetAwaiter",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            customAwaiter,
+            Type.EmptyTypes);
+        var structGetAwaiterIl = structGetAwaiter.GetILGenerator();
+        structGetAwaiterIl.Emit(OpCodes.Newobj, awaiterCtor);
+        structGetAwaiterIl.Emit(OpCodes.Ret);
+        var customStructAwaitable = structAwaitableType.CreateType();
 
         var sample = module.DefineType("RuntimeAsyncSample", TypeAttributes.Public | TypeAttributes.Class);
 
@@ -137,6 +249,120 @@ public class RuntimeAsyncEmitterTests
         receiverIl.Emit(OpCodes.Callvirt, typeof(string).GetMethod("get_Length")!);
         receiverIl.Emit(OpCodes.Ret);
         awaitReceiverCaller.SetImplementationFlags(AsyncImplFlag);
+
+        var awaitCustomAwaiter = awaitAwaiterGeneric.MakeGenericMethod(customAwaiter);
+        var awaitCustomCaller = sample.DefineMethod(
+            "AwaitCustomValue", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [customAwaitable]);
+        awaitCustomCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var customIl = awaitCustomCaller.GetILGenerator();
+        var awaiterLocal = customIl.DeclareLocal(customAwaiter);
+        var afterAwait = customIl.DefineLabel();
+        customIl.Emit(OpCodes.Ldarg_0);
+        customIl.Emit(OpCodes.Callvirt, getAwaiter);
+        customIl.Emit(OpCodes.Stloc, awaiterLocal);
+        customIl.Emit(OpCodes.Ldloc, awaiterLocal);
+        customIl.Emit(OpCodes.Callvirt, isCompleted);
+        customIl.Emit(OpCodes.Brtrue_S, afterAwait);
+        customIl.Emit(OpCodes.Ldloc, awaiterLocal);
+        customIl.Emit(OpCodes.Call, awaitCustomAwaiter);
+        customIl.MarkLabel(afterAwait);
+        customIl.Emit(OpCodes.Ldloc, awaiterLocal);
+        customIl.Emit(OpCodes.Callvirt, getResult);
+        customIl.Emit(OpCodes.Ret);
+        awaitCustomCaller.SetImplementationFlags(AsyncImplFlag);
+
+        var awaitCustomBrfalseCaller = sample.DefineMethod(
+            "AwaitCustomValueBrfalse", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [customAwaitable]);
+        awaitCustomBrfalseCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var customBrfalseIl = awaitCustomBrfalseCaller.GetILGenerator();
+        var brfalseAwaiterLocal = customBrfalseIl.DeclareLocal(customAwaiter);
+        var brfalseHelper = customBrfalseIl.DefineLabel();
+        var afterBrfalseAwait = customBrfalseIl.DefineLabel();
+        customBrfalseIl.Emit(OpCodes.Ldarg_0);
+        customBrfalseIl.Emit(OpCodes.Callvirt, getAwaiter);
+        customBrfalseIl.Emit(OpCodes.Stloc, brfalseAwaiterLocal);
+        customBrfalseIl.Emit(OpCodes.Ldloc, brfalseAwaiterLocal);
+        customBrfalseIl.Emit(OpCodes.Callvirt, isCompleted);
+        customBrfalseIl.Emit(OpCodes.Brfalse_S, brfalseHelper);
+        customBrfalseIl.Emit(OpCodes.Br_S, afterBrfalseAwait);
+        customBrfalseIl.MarkLabel(brfalseHelper);
+        customBrfalseIl.Emit(OpCodes.Ldloc, brfalseAwaiterLocal);
+        customBrfalseIl.Emit(OpCodes.Call, awaitCustomAwaiter);
+        customBrfalseIl.MarkLabel(afterBrfalseAwait);
+        customBrfalseIl.Emit(OpCodes.Ldloc, brfalseAwaiterLocal);
+        customBrfalseIl.Emit(OpCodes.Callvirt, getResult);
+        customBrfalseIl.Emit(OpCodes.Ret);
+        awaitCustomBrfalseCaller.SetImplementationFlags(AsyncImplFlag);
+
+        var invertedGuardCaller = sample.DefineMethod(
+            "InvertedCustomAwaitGuard", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [customAwaitable]);
+        invertedGuardCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var invertedIl = invertedGuardCaller.GetILGenerator();
+        var invertedAwaiterLocal = invertedIl.DeclareLocal(customAwaiter);
+        var invertedHelper = invertedIl.DefineLabel();
+        var afterInverted = invertedIl.DefineLabel();
+        invertedIl.Emit(OpCodes.Ldarg_0);
+        invertedIl.Emit(OpCodes.Callvirt, getAwaiter);
+        invertedIl.Emit(OpCodes.Stloc, invertedAwaiterLocal);
+        invertedIl.Emit(OpCodes.Ldloc, invertedAwaiterLocal);
+        invertedIl.Emit(OpCodes.Callvirt, isCompleted);
+        invertedIl.Emit(OpCodes.Brtrue_S, invertedHelper);
+        invertedIl.Emit(OpCodes.Br_S, afterInverted);
+        invertedIl.MarkLabel(invertedHelper);
+        invertedIl.Emit(OpCodes.Ldloc, invertedAwaiterLocal);
+        invertedIl.Emit(OpCodes.Call, awaitCustomAwaiter);
+        invertedIl.MarkLabel(afterInverted);
+        invertedIl.Emit(OpCodes.Ldloc, invertedAwaiterLocal);
+        invertedIl.Emit(OpCodes.Callvirt, getResult);
+        invertedIl.Emit(OpCodes.Ret);
+        invertedGuardCaller.SetImplementationFlags(AsyncImplFlag);
+
+        var awaitCustomStructCaller = sample.DefineMethod(
+            "AwaitCustomStructValue", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [customStructAwaitable]);
+        awaitCustomStructCaller.DefineParameter(1, ParameterAttributes.None, "t");
+        var customStructIl = awaitCustomStructCaller.GetILGenerator();
+        var structAwaiterLocal = customStructIl.DeclareLocal(customAwaiter);
+        var afterStructAwait = customStructIl.DefineLabel();
+        customStructIl.Emit(OpCodes.Ldarga_S, (byte)0);
+        customStructIl.Emit(OpCodes.Call, structGetAwaiter);
+        customStructIl.Emit(OpCodes.Stloc, structAwaiterLocal);
+        customStructIl.Emit(OpCodes.Ldloc, structAwaiterLocal);
+        customStructIl.Emit(OpCodes.Callvirt, isCompleted);
+        customStructIl.Emit(OpCodes.Brtrue_S, afterStructAwait);
+        customStructIl.Emit(OpCodes.Ldloc, structAwaiterLocal);
+        customStructIl.Emit(OpCodes.Call, awaitCustomAwaiter);
+        customStructIl.MarkLabel(afterStructAwait);
+        customStructIl.Emit(OpCodes.Ldloc, structAwaiterLocal);
+        customStructIl.Emit(OpCodes.Callvirt, getResult);
+        customStructIl.Emit(OpCodes.Ret);
+        awaitCustomStructCaller.SetImplementationFlags(AsyncImplFlag);
+
+        var awaitCustomStructArrayCaller = sample.DefineMethod(
+            "AwaitCustomStructArrayElement", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(Task<int>), [customStructAwaitable.MakeArrayType()]);
+        awaitCustomStructArrayCaller.DefineParameter(1, ParameterAttributes.None, "values");
+        var customStructArrayIl = awaitCustomStructArrayCaller.GetILGenerator();
+        var structArrayAwaiterLocal = customStructArrayIl.DeclareLocal(customAwaiter);
+        var afterStructArrayAwait = customStructArrayIl.DefineLabel();
+        customStructArrayIl.Emit(OpCodes.Ldarg_0);
+        customStructArrayIl.Emit(OpCodes.Ldc_I4_0);
+        customStructArrayIl.Emit(OpCodes.Ldelema, customStructAwaitable);
+        customStructArrayIl.Emit(OpCodes.Call, structGetAwaiter);
+        customStructArrayIl.Emit(OpCodes.Stloc, structArrayAwaiterLocal);
+        customStructArrayIl.Emit(OpCodes.Ldloc, structArrayAwaiterLocal);
+        customStructArrayIl.Emit(OpCodes.Callvirt, isCompleted);
+        customStructArrayIl.Emit(OpCodes.Brtrue_S, afterStructArrayAwait);
+        customStructArrayIl.Emit(OpCodes.Ldloc, structArrayAwaiterLocal);
+        customStructArrayIl.Emit(OpCodes.Call, awaitCustomAwaiter);
+        customStructArrayIl.MarkLabel(afterStructArrayAwait);
+        customStructArrayIl.Emit(OpCodes.Ldloc, structArrayAwaiterLocal);
+        customStructArrayIl.Emit(OpCodes.Callvirt, getResult);
+        customStructArrayIl.Emit(OpCodes.Ret);
+        awaitCustomStructArrayCaller.SetImplementationFlags(AsyncImplFlag);
 
         sample.CreateType();
 

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -127,6 +127,10 @@ public static class CSharpEmitter
         // Try/finally regions that are compiler-lowered lock statements.
         readonly Dictionary<StructuredBlock, LockPattern> _lockPatterns = [];
 
+        // Runtime-async custom awaits lower through an awaiter temp:
+        // awaitable.GetAwaiter(); if (!awaiter.IsCompleted) AsyncHelpers.AwaitAwaiter(awaiter); awaiter.GetResult().
+        readonly Dictionary<string, ILAstExpression> _runtimeCustomAwaitSources = [];
+
         public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
         {
             _ast = ast;
@@ -201,6 +205,10 @@ public static class CSharpEmitter
             // Pre-detect lock patterns so compiler-generated temporaries are suppressed before
             // their initialization blocks are emitted.
             ScanForLockPatterns(structure.Root);
+
+            // Pre-detect runtime-async custom awaiter patterns so awaiter temps and await
+            // scheduling guards can be rendered as source-level await expressions.
+            ScanForRuntimeCustomAwaitPatterns(structure.Root);
 
             // Pre-detect using patterns to suppress local declarations
             ScanForUsingPatterns(structure.Root);
@@ -338,6 +346,244 @@ public static class CSharpEmitter
             }
             return null;
         }
+
+        void ScanForRuntimeCustomAwaitPatterns(StructuredBlock block)
+        {
+            if (block.Kind == StructuredBlockKind.IfThenElse
+                && TryMatchRuntimeCustomAwaitGuard(block, out string? awaiterVar, out var awaitedExpression, out var storeNode))
+            {
+                _runtimeCustomAwaitSources[awaiterVar] = awaitedExpression;
+                _skipNodes.Add(storeNode);
+                _suppressedLocals.Add(awaiterVar);
+            }
+
+            foreach (var c in block.Children)
+                ScanForRuntimeCustomAwaitPatterns(c);
+            foreach (var c in block.TryChildren)
+                ScanForRuntimeCustomAwaitPatterns(c);
+            foreach (var c in block.HandlerChildren)
+                ScanForRuntimeCustomAwaitPatterns(c);
+            if (block.ThenBlock is not null)
+                ScanForRuntimeCustomAwaitPatterns(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ScanForRuntimeCustomAwaitPatterns(block.ElseBlock);
+        }
+
+        bool TryMatchRuntimeCustomAwaitGuard(
+            StructuredBlock block,
+            out string awaiterVar,
+            out ILAstExpression awaitedExpression,
+            out ILAstNode storeNode)
+        {
+            awaiterVar = "";
+            awaitedExpression = null!;
+            storeNode = null!;
+
+            if (block.ElseBlock is not null || block.ConditionBlockIndex < 0)
+                return false;
+            if (!_blockMap.TryGetValue(block.ConditionBlockIndex, out var conditionBlock))
+                return false;
+            if (conditionBlock.Nodes.LastOrDefault() is not ILAstStatement { Expression: var branchExpr })
+                return false;
+            if (!TryMatchNotCompletedAwaitGuard(branchExpr, block.NegateCondition, out awaiterVar))
+                return false;
+            if (!BlockContainsSingleRuntimeAwaitHelper(block.ThenBlock, awaiterVar))
+                return false;
+            if (!TryFindAwaiterStore(awaiterVar, out storeNode, out awaitedExpression))
+                return false;
+            if (!HasGetResultUse(awaiterVar))
+                return false;
+
+            return true;
+        }
+
+        bool TryMatchNotCompletedAwaitGuard(ILAstExpression branchExpr, bool negateCondition, out string awaiterVar)
+        {
+            awaiterVar = "";
+            if (branchExpr.Arguments.Count != 1)
+                return false;
+            if (!TryGetIsCompletedAwaiter(branchExpr.Arguments[0], out awaiterVar))
+                return false;
+
+            return branchExpr.OpCode switch
+            {
+                ILOpCode.Brtrue or ILOpCode.Brtrue_s => negateCondition,
+                ILOpCode.Brfalse or ILOpCode.Brfalse_s => negateCondition,
+                _ => false
+            };
+        }
+
+        bool TryGetIsCompletedAwaiter(ILAstExpression expr, out string awaiterVar)
+        {
+            awaiterVar = "";
+
+            if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && expr.Operand is string operand
+                && ExtractMemberName(operand) == "get_IsCompleted"
+                && expr.Arguments.Count > 0
+                && GetLocalReferenceName(expr.Arguments[0]) is { } local)
+            {
+                awaiterVar = local;
+                return true;
+            }
+
+            return false;
+        }
+
+        bool BlockContainsSingleRuntimeAwaitHelper(StructuredBlock? block, string awaiterVar)
+        {
+            if (block is null)
+                return false;
+
+            bool sawHelper = false;
+            foreach (var (_, node) in EnumerateStructuredNodes(block))
+            {
+                var expr = NodeExpression(node);
+                if (expr is null)
+                    continue;
+                if (expr.OpCode is ILOpCode.Nop or ILOpCode.Br or ILOpCode.Br_s
+                    or ILOpCode.Leave or ILOpCode.Leave_s)
+                    continue;
+
+                if (IsRuntimeAwaiterHelperCall(expr, awaiterVar))
+                {
+                    if (sawHelper)
+                        return false;
+                    sawHelper = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawHelper;
+        }
+
+        static bool IsRuntimeAwaiterHelperCall(ILAstExpression expr, string awaiterVar)
+        {
+            if (expr.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt)
+                || expr.Operand is not string operand)
+                return false;
+
+            if (!operand.StartsWith("System.Runtime.CompilerServices.AsyncHelpers::", StringComparison.Ordinal))
+                return false;
+
+            string memberName = ExtractMemberName(operand);
+            if (memberName is not ("AwaitAwaiter" or "UnsafeAwaitAwaiter"))
+                return false;
+
+            return expr.Arguments.Count == 1 && IsLoadOf(expr.Arguments[0], awaiterVar);
+        }
+
+        bool TryFindAwaiterStore(string awaiterVar, out ILAstNode storeNode, out ILAstExpression awaitedExpression)
+        {
+            storeNode = null!;
+            awaitedExpression = null!;
+            bool found = false;
+
+            foreach (var block in _ast.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (node is not ILAstStatement { Expression: var expr }
+                        || !IsStoreToLocal(expr, awaiterVar)
+                        || expr.Arguments.Count != 1)
+                    {
+                        continue;
+                    }
+
+                    if (found)
+                        return false;
+                    if (!TryGetAwaitedExpressionFromGetAwaiter(expr.Arguments[0], out awaitedExpression))
+                        return false;
+
+                    storeNode = node;
+                    found = true;
+                }
+            }
+
+            return found;
+        }
+
+        static bool TryGetAwaitedExpressionFromGetAwaiter(ILAstExpression getAwaiterExpr, out ILAstExpression awaitedExpression)
+        {
+            awaitedExpression = null!;
+            if (getAwaiterExpr.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt)
+                || getAwaiterExpr.Operand is not string operand
+                || ExtractMemberName(operand) != "GetAwaiter"
+                || getAwaiterExpr.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            awaitedExpression = NormalizeAwaitedExpression(getAwaiterExpr.Arguments[0]);
+            return true;
+        }
+
+        static ILAstExpression NormalizeAwaitedExpression(ILAstExpression receiver)
+        {
+            if (receiver.OpCode is ILOpCode.Ldarga or ILOpCode.Ldarga_s)
+            {
+                return new ILAstExpression
+                {
+                    OpCode = ILOpCode.Ldarg,
+                    Operand = receiver.Operand,
+                    ResultType = StackValue.CreateUnknown(),
+                    Offset = receiver.Offset
+                };
+            }
+
+            if (receiver.OpCode == ILOpCode.Ldelema && receiver.Arguments.Count >= 2)
+            {
+                var value = new ILAstExpression
+                {
+                    OpCode = ILOpCode.Ldelem,
+                    Operand = receiver.Operand,
+                    ResultType = StackValue.CreateUnknown(),
+                    Offset = receiver.Offset
+                };
+                value.Arguments.AddRange(receiver.Arguments);
+                return value;
+            }
+
+            return receiver;
+        }
+
+        bool HasGetResultUse(string awaiterVar)
+        {
+            foreach (var block in _ast.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (NodeExpression(node) is { } expr && HasGetResultUse(expr, awaiterVar))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool HasGetResultUse(ILAstExpression expr, string awaiterVar)
+        {
+            if (IsGetResultCallOnAwaiter(expr, awaiterVar))
+                return true;
+
+            foreach (var arg in expr.Arguments)
+            {
+                if (HasGetResultUse(arg, awaiterVar))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static bool IsGetResultCallOnAwaiter(ILAstExpression expr, string awaiterVar)
+            => expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && !expr.IsStaticCall
+                && expr.Operand is string operand
+                && ExtractMemberName(operand) == "GetResult"
+                && expr.Arguments.Count > 0
+                && IsLoadOf(expr.Arguments[0], awaiterVar);
 
         void ScanForLockPatterns(StructuredBlock block)
         {
@@ -1267,6 +1513,9 @@ public static class CSharpEmitter
                 // Emit any statements before the branch
                 for (int i = 0; i < condBlock.Nodes.Count - 1; i++)
                 {
+                    if (_skipNodes.Contains(condBlock.Nodes[i]))
+                        continue;
+
                     if (condBlock.Nodes[i] is ILAstStatement stmt)
                         EmitStatement(stmt.Expression, indent);
                     else if (condBlock.Nodes[i] is ILAstAssignment assign)
@@ -1361,6 +1610,9 @@ public static class CSharpEmitter
             if (block.NegateCondition)
                 condition = NegateConditionString(condition);
 
+            if (TryEmitRuntimeCustomAwaitGuard(block))
+                return;
+
             if (TryEmitNullConditionalAssignment(block, condition, indent))
                 return;
 
@@ -1400,6 +1652,21 @@ public static class CSharpEmitter
                     _sb.AppendLine("}");
                 }
             }
+        }
+
+        bool TryEmitRuntimeCustomAwaitGuard(StructuredBlock block)
+        {
+            if (!TryMatchRuntimeCustomAwaitGuard(block, out string awaiterVar, out _, out _))
+                return false;
+            if (!_runtimeCustomAwaitSources.ContainsKey(awaiterVar))
+                return false;
+
+            if (block.ThenBlock is not null)
+                ConsumeStructuredBlock(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ConsumeStructuredBlock(block.ElseBlock);
+
+            return true;
         }
 
         bool TryEmitNullConditionalAssignment(StructuredBlock block, string condition, int indent)
@@ -5016,7 +5283,7 @@ public static class CSharpEmitter
         {
             if (isBaseCall)
                 _sb.Append("base");
-            else if (IsRuntimeAwaitCall(receiver))
+            else if (IsRuntimeAwaitExpression(receiver))
             {
                 // `(await GetThingAsync()).Member` — the await result is the receiver, so it
                 // must be parenthesized; `await GetThingAsync().Member` would bind differently.
@@ -5038,6 +5305,18 @@ public static class CSharpEmitter
             expr.IsStaticCall
             && expr.Arguments.Count == 1
             && expr.Operand is "System.Runtime.CompilerServices.AsyncHelpers::Await";
+
+        bool IsRuntimeCustomAwaitGetResultCall(ILAstExpression expr)
+            => expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && !expr.IsStaticCall
+                && expr.Operand is string operand
+                && ExtractMemberName(operand) == "GetResult"
+                && expr.Arguments.Count > 0
+                && GetLocalReferenceName(expr.Arguments[0]) is { } awaiterVar
+                && _runtimeCustomAwaitSources.ContainsKey(awaiterVar);
+
+        bool IsRuntimeAwaitExpression(ILAstExpression expr)
+            => IsRuntimeAwaitCall(expr) || IsRuntimeCustomAwaitGetResultCall(expr);
 
         void EmitCallExpression(ILAstExpression expr)
         {
@@ -5061,6 +5340,14 @@ public static class CSharpEmitter
                 if (wrap) _sb.Append('(');
                 EmitExpression(awaited);
                 if (wrap) _sb.Append(')');
+                return;
+            }
+
+            if (IsRuntimeCustomAwaitGetResultCall(expr)
+                && GetLocalReferenceName(expr.Arguments[0]) is { } awaiterVar
+                && _runtimeCustomAwaitSources.TryGetValue(awaiterVar, out var awaitedExpression))
+            {
+                EmitAwaitExpression(awaitedExpression);
                 return;
             }
 
@@ -5250,6 +5537,15 @@ public static class CSharpEmitter
                 else
                     _sb.Append($"{SimplifyTypeName(typePart)}.{memberPart}()");
             }
+        }
+
+        void EmitAwaitExpression(ILAstExpression awaited)
+        {
+            _sb.Append("await ");
+            bool wrap = IsBinaryOp(awaited.OpCode);
+            if (wrap) _sb.Append('(');
+            EmitExpression(awaited);
+            if (wrap) _sb.Append(')');
         }
 
         bool TryEmitInlineArrayAsSpanExpression(ILAstExpression expr, string memberPart)


### PR DESCRIPTION
## Summary
- recognize runtime-async custom awaiter lowering through GetAwaiter, IsCompleted, AsyncHelpers.AwaitAwaiter/UnsafeAwaitAwaiter, and GetResult
- render matching GetResult calls as source-level `await` expressions
- normalize by-ref await operands for struct awaitables, including parameter and array element receivers

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- git diff --check origin/main..HEAD

Remaining null-conditional assignment forms are deferred for a separate targeted safety pass.