### PR TITLE
Add agent doc structure and refresh docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,18 @@
 # Agent Instructions
 
+## Repository map
+
+Read this file first, then use the docs it points to:
+
+- `README.md`: human and agent entrypoint for capabilities, commands, and common examples.
+- `docs/overview.md`: minimum system/architecture context for this repo.
+- `docs/architecture.md`: deeper architecture and command model details.
+- `docs/design/`: focused design notes for rendering, sections, schemas, version resolution, and related systems.
+- `taste/skill-guidance.md`: examples and rules for maintaining `skills/dotnet-inspect/SKILL.md`.
+- `skills/dotnet-inspect/SKILL.md`: embedded agent skill printed by `dotnet-inspect skill`; keep it workflow-focused and current.
+
+Keep this file as a resolver plus essential repo workflow rules. Put detailed architecture and taste guidance in docs instead of expanding `AGENT.md`.
+
 ## File-Based Apps
 
 Do NOT use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files. Always use file-based apps (new in .NET 10). Always prefer file-based apps over Python, unless a specific Python library is needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Read this file first, then use the docs it points to:
 - `taste/skill-guidance.md`: examples and rules for maintaining `skills/dotnet-inspect/SKILL.md`.
 - `skills/dotnet-inspect/SKILL.md`: embedded agent skill printed by `dotnet-inspect skill`; keep it workflow-focused and current.
 
-Keep this file as a resolver plus essential repo workflow rules. Put detailed architecture and taste guidance in docs instead of expanding `AGENT.md`.
+Keep this file as a resolver plus essential repo workflow rules. Put detailed architecture and taste guidance in docs instead of expanding `AGENTS.md`.
 
 ## File-Based Apps
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ dotnet-inspect depends Stream --markdown --mermaid
 
 dotnet-inspect is [designed for LLM-driven development](docs/llm-design.md). The embedded skill (`dotnet-inspect skill`) is also distributed through the [dotnet/skills](https://github.com/dotnet/skills) marketplace.
 
+## Contributor and agent docs
+
+Start with [docs/overview.md](docs/overview.md) for system context. `AGENT.md` is the agent resolver for this repo, and [taste/skill-guidance.md](taste/skill-guidance.md) captures good and bad examples for maintaining the embedded skill.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ dotnet-inspect is [designed for LLM-driven development](docs/llm-design.md). The
 
 ## Contributor and agent docs
 
-Start with [docs/overview.md](docs/overview.md) for system context. `AGENT.md` is the agent resolver for this repo, and [taste/skill-guidance.md](taste/skill-guidance.md) captures good and bad examples for maintaining the embedded skill.
+Start with [docs/overview.md](docs/overview.md) for system context. `AGENTS.md` is the agent resolver for this repo, and [taste/skill-guidance.md](taste/skill-guidance.md) captures good and bad examples for maintaining the embedded skill.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,21 +14,15 @@ Unlike decompilers, dotnet-inspect focuses on the **public API surface**—the c
 ## Quick Example
 
 ```bash
-$ dotnet-inspect api JsonSerializer --package System.Text.Json -m Serialize
+$ dotnet-inspect type JsonSerializer --package System.Text.Json --shape
 
 # System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 
-**Kind:** class
-**Modifiers:** static, abstract, sealed
-
-## Members
-
-| Member | Kind | Signature |
-|--------|------|-----------|
-| Serialize | method | `string Serialize(object value, Type inputType, JsonSerializerOptions options)` |
-| Serialize | method | `string Serialize(TValue value, JsonSerializerOptions options)` |
-| Serialize | method | `void Serialize(Stream utf8Json, TValue value, JsonSerializerOptions options)` |
-...
+System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
+   ├─ string Serialize<TValue>(TValue value, JsonSerializerOptions? options = null)
+   ├─ string Serialize(object? value, Type inputType, JsonSerializerOptions? options = null)
+   ├─ void Serialize<TValue>(Stream utf8Json, TValue value, JsonSerializerOptions? options = null)
+   └─ ...
 ```
 
 ## Documentation
@@ -37,6 +31,7 @@ $ dotnet-inspect api JsonSerializer --package System.Text.Json -m Serialize
 
 | Document | Description |
 | -------- | ----------- |
+| [Overview](overview.md) | Minimum system and architecture context |
 | [Architecture](architecture.md) | Tool overview, commands, and design philosophy |
 | [LLM Design](llm-design.md) | Why output is structured for AI-assisted development |
 | [Platform Components](platform-components.md) | Accessing SDK libraries vs NuGet packages |
@@ -51,6 +46,7 @@ $ dotnet-inspect api JsonSerializer --package System.Text.Json -m Serialize
 | [Style Guide](design/style-guide.md) | Output formatting conventions |
 | [Rendering Model](design/rendering-model.md) | Verbosity vs mode-switch flags: how output is controlled |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool |
+| [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill |
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,26 +27,34 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 
 ## Documentation
 
-### Using the Tool
+### Current system docs
 
-| Document | Description |
+| Document | Need served |
 | -------- | ----------- |
-| [Overview](overview.md) | Minimum system and architecture context |
-| [Architecture](architecture.md) | Tool overview, commands, and design philosophy |
-| [LLM Design](llm-design.md) | Why output is structured for AI-assisted development |
-| [Platform Components](platform-components.md) | Accessing SDK libraries vs NuGet packages |
-| [Signals](assembly-audit.md) | Understanding Signals output and network scope flags |
-| [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved |
-| [Sample References](sample-references.md) | Extracting code samples from XML docs |
+| [Overview](overview.md) | Minimum system and architecture context for humans and agents. |
+| [Architecture](architecture.md) | Current command and metadata architecture. |
+| [LLM Design](llm-design.md) | Current agent-facing output and workflow design. |
+| [Progressive Disclosure](design/progressive-disclosure.md) | Current model for verbosity, `-D`/`-S`, opt-in sections, `-S All`, counts, and row limits. |
+| [Platform Components](platform-components.md) | Accessing SDK libraries vs NuGet packages. |
+| [Signals](assembly-audit.md) | Understanding Signals output and network scope flags. |
+| [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved. |
+| [Sample References](sample-references.md) | Extracting code samples from XML docs. |
 
-### For Contributors
+### Contributor docs
 
-| Document | Description |
+| Document | Need served |
 | -------- | ----------- |
-| [Style Guide](design/style-guide.md) | Output formatting conventions |
-| [Rendering Model](design/rendering-model.md) | Verbosity vs mode-switch flags: how output is controlled |
-| [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool |
-| [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill |
+| [Style Guide](design/style-guide.md) | Output formatting conventions. |
+| [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |
+| [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
+| [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |
+| [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
+| [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
+| [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill. |
+
+### Design history and backlog
+
+Some files under `docs/design/` and `docs/backlog*.md` were written during ideation. They are useful design history, but may not describe current CLI behavior. When current behavior matters, start with Overview, Architecture, Progressive Disclosure, the embedded skill, and tests.
 
 ## Getting Started
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ dotnet-inspect is designed for **LLM-driven .NET development**. The tool priorit
 
 ## Command Structure
 
-The tool is organized around seven commands plus a meta command, each targeting a different level of abstraction:
+The tool is organized around source inspection, API lookup, relationship, and utility commands:
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -23,20 +23,26 @@ The tool is organized around seven commands plus a meta command, each targeting 
 │                        library                              │
 │  PE headers, SourceLink, determinism audit                   │
 ├─────────────────────────────────────────────────────────────┤
-│                          api                                 │
-│  Public API surface: types, methods, signatures              │
-├─────────────────────────────────────────────────────────────┤
 │                         type                                 │
-│  Single type: hierarchy, interfaces, members (shape view)    │
+│  Type shape, public signatures, and summaries                │
+├─────────────────────────────────────────────────────────────┤
+│                        member                               │
+│  Member docs, overload selection, Source/IL drill-in         │
+├─────────────────────────────────────────────────────────────┤
+│                         find                                 │
+│  Search for types across packages, platform, and assets      │
 ├─────────────────────────────────────────────────────────────┤
 │                         diff                                 │
-│  Compare API surfaces between two package versions           │
+│  Compare API surfaces between package/platform versions      │
 ├─────────────────────────────────────────────────────────────┤
-│                        samples                               │
-│  Extract code sample references from XML doc comments        │
+│            depends / extensions / implements                 │
+│  Relationship discovery for APIs, packages, and libraries    │
 ├─────────────────────────────────────────────────────────────┤
-│                       platform                               │
-│  List platform/framework libraries from installed SDK       │
+│                        source                               │
+│  SourceLink URLs, source text, and token+IL offset mapping   │
+├─────────────────────────────────────────────────────────────┤
+│                      cache / skill                           │
+│  Cache inspection and embedded agent guidance                │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -58,22 +64,13 @@ Inspects .NET library files (PE/COFF format):
 - SourceLink and determinism audit
 - Unsafe code detection
 
-### api
+### type and member
 
-Extracts public API surface using reflection metadata:
+Extract public API surface using metadata:
 
-- All public types or filtered by glob pattern
-- Full method signatures with parameter names
-- Filtering by member name, unsafe signatures, hidden/obsolete
-- Source URLs via SourceLink
-
-### type
-
-Displays a single type's shape in shape format:
-
-- Inheritance chain (base classes)
-- Implemented interfaces
-- Members grouped by kind
+- `type` renders type shape, summaries, members, and `--shape` declarations
+- `member` renders member tables, docs, overload selectors, SourceLink source, lowered C#, and IL
+- Both support package/platform/library sources and section/field projection
 
 ### diff
 
@@ -83,21 +80,17 @@ Compares API surfaces between two package versions:
 - Member-level changes within types
 - Version range syntax: `Package@v1..v2`
 
-### samples
+### find
 
-Extracts code sample references from XML doc comments:
+Searches for types across packages, platform libraries, projects, and local assets.
 
-- Sandcastle-style `<code source=...>` references
-- `<seealso href=...>` file references
-- Region extraction from source files
+### relationships
 
-### platform
+`depends`, `extensions`, and `implements` expose dependency graphs, extension methods/properties, implementors, and subclasses.
 
-Lists platform/framework libraries from the installed .NET SDK:
+### source
 
-- Available frameworks and versions
-- Library listing per framework
-- Useful for inspecting BCL types
+Resolves SourceLink URLs, source text, and MethodDef token + IL offset pairs to source locations.
 
 ## LLM Integration
 

--- a/docs/design/command-model.md
+++ b/docs/design/command-model.md
@@ -11,7 +11,7 @@ dotnet-inspect works with .NET libraries. There are three ways to specify where 
 | Command | Source | Example |
 | --------- | -------- | --------- |
 | `package X` | NuGet package | `package System.Text.Json` |
-| `platform X` | Local SDK/runtime | `platform System.Text.Json` |
+| `library --platform X` or bare platform-looking `library X` | Installed platform/runtime packs | `library System.Text.Json` |
 | `library ./path` | Local file | `library ./bin/MyLib.dll` |
 
 These commands expose library/package inspection views. Use `-S Signals` when the goal is provenance, compatibility, or supply-chain signal reporting.
@@ -35,10 +35,10 @@ Use inspection commands for detailed exploration:
 - Keeps high-cost source reachability and integrity work in explicit SourceLink sections
 
 ```bash
-dotnet inspect package Markout@0.1.4 -S Signals       # package metadata signals
-dotnet inspect library System.Text.Json -S Signals    # platform library metadata signals
-dotnet inspect library ./bin/MyLib.dll -S Signals     # local file metadata signals
-dotnet inspect library System.Text.Json -S "Signals,SourceLink Availability,SourceLink Missing Files"
+dotnet-inspect package Markout@0.1.4 -S Signals       # package metadata signals
+dotnet-inspect library System.Text.Json -S Signals    # platform library metadata signals
+dotnet-inspect library ./bin/MyLib.dll -S Signals     # local file metadata signals
+dotnet-inspect library System.Text.Json -S "Signals,SourceLink Availability,SourceLink Missing Files"
 ```
 
 High-cost audit work is exposed as opt-in sections rather than broad flags. For packages, select `Signals` for package and registry-backed signals. For libraries, select `SourceLink Availability`, `SourceLink Missing Files`, or `SourceLink Integrity` for per-source-file network/content checks.
@@ -50,10 +50,10 @@ High-cost audit work is exposed as opt-in sections rather than broad flags. For 
 Start with a package, drill down into details:
 
 ```bash
-dotnet inspect package Newtonsoft.Json           # metadata
-dotnet inspect package Newtonsoft.Json --library # library info
-dotnet inspect package Newtonsoft.Json -S Signals # signals
-dotnet inspect package Newtonsoft.Json --api      # public API
+dotnet-inspect package Newtonsoft.Json             # metadata
+dotnet-inspect package Newtonsoft.Json -S Signals  # signals
+dotnet-inspect type JsonConvert --package Newtonsoft.Json --shape
+dotnet-inspect member JsonConvert --package Newtonsoft.Json -m SerializeObject
 ```
 
 ### Platform-centric workflow
@@ -61,9 +61,9 @@ dotnet inspect package Newtonsoft.Json --api      # public API
 Inspect libraries from the local .NET SDK/runtime:
 
 ```bash
-dotnet inspect platform                          # list frameworks
-dotnet inspect platform System.Text.Json         # inspect library
-dotnet inspect library System.Text.Json -S Signals # platform library signals
+dotnet-inspect library System.Text.Json -S Signals
+dotnet-inspect type JsonSerializer --platform System.Text.Json --shape
+dotnet-inspect diff --platform System.Runtime@9.0.0..10.0.0 --additive
 ```
 
 ### File-centric workflow
@@ -71,8 +71,8 @@ dotnet inspect library System.Text.Json -S Signals # platform library signals
 Inspect local library files:
 
 ```bash
-dotnet inspect library ./bin/MyLib.dll          # basic info
-dotnet inspect library ./bin/MyLib.dll -S Signals # signals
+dotnet-inspect library ./bin/MyLib.dll            # basic info
+dotnet-inspect library ./bin/MyLib.dll -S Signals # signals
 ```
 
 ### Quick audit workflow
@@ -80,7 +80,7 @@ dotnet inspect library ./bin/MyLib.dll -S Signals # signals
 For CI or quick checks:
 
 ```bash
-dotnet inspect package Markout@0.1.4 -S Signals -v:q
+dotnet-inspect package Markout@0.1.4 -S Signals -v:q
 # SourceLink: passed
 # Deterministic: passed
 ```
@@ -91,18 +91,18 @@ Some commands are aliases or have equivalent forms:
 
 ```bash
 # These are equivalent
-dotnet inspect platform System.Text.Json
-dotnet inspect library System.Text.Json --platform
+dotnet-inspect library System.Text.Json
+dotnet-inspect library --platform System.Text.Json
 
 # Use explicit package signals when package routing matters
-dotnet inspect package Markout@0.1.4 -S Signals
+dotnet-inspect package Markout@0.1.4 -S Signals
 ```
 
 ## Stability Guarantees
 
 The following are considered stable and will not change without a major version bump:
 
-1. **Command names**: `package`, `platform`, `library`, `api`, `find`, `type`, `diff`
+1. **Command names**: `package`, `library`, `type`, `member`, `find`, `diff`, `depends`, `extensions`, `implements`, `source`, `cache`, `skill`
 2. **Input syntax**: Package references use `name@version` format
 3. **Exit codes**: Zero for success, non-zero for failure
 4. **JSON output**: Schema for `--json` output is stable per command

--- a/docs/design/platform-assemblies.md
+++ b/docs/design/platform-assemblies.md
@@ -24,10 +24,10 @@ Reference assemblies contain only public API metadata. They are:
 - **Do not contain** implementation code, private members, or debug information
 - Located in: `/usr/local/share/dotnet/packs/` (macOS/Linux) or `C:\Program Files\dotnet\packs\` (Windows)
 
-Commands that use ref assemblies for primary data:
+Commands that use ref assemblies for primary API data:
 
-- `api` - Extracting public API surface
 - `type` - Displaying type structure
+- `member` - Inspecting member docs/signatures
 - `find` - Searching for types
 - `diff` - Comparing API surfaces
 
@@ -46,11 +46,11 @@ Commands that use runtime assemblies:
 
 - `library` - Full library inspection (always uses runtime for `--platform`)
 - `library -S Signals` - library signals for platform-looking targets
-- PDB/SourceLink resolution for `--docs`, `--samples`, or source URL extraction
+- PDB/SourceLink resolution for source URL extraction and implementation drill-in
 
 ## Hybrid Resolution Pattern
 
-For commands that need both API information and source resolution (like `api` with SourceLink), we use a **hybrid pattern**:
+For commands that need both API information and source resolution, dotnet-inspect uses a **hybrid pattern**:
 
 1. **Resolve ref assembly** for API extraction (complete public surface)
 2. **Resolve runtime assembly** for PDB lookup (has CodeView debug info)
@@ -59,7 +59,7 @@ For commands that need both API information and source resolution (like `api` wi
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                        api --platform                           │
+│                  type/member/source --platform                  │
 ├─────────────────────────────────────────────────────────────────┤
 │  1. Resolve ref assembly     →  Extract public types/methods    │
 │  2. Resolve runtime assembly →  Query MSDL for PDB              │
@@ -136,8 +136,8 @@ can use it:
 
 `find` uses ref packs and reports the canonical assembly name (e.g.,
 `System.Collections` for `List<T>`). This preserves the user-facing .NET API
-surface model. Commands that need PDBs or method bodies (`source`, `api` with
-`--docs`) follow forwarders transparently at the type-resolution level.
+surface model. Commands that need PDBs or method bodies (`source`, `member -v:d`)
+follow forwarders transparently at the type-resolution level.
 Mixing ref and runtime data within a single concern is avoided.
 
 ## Framework Mappings
@@ -154,8 +154,8 @@ Note: `netstandard` has no runtime assemblies. It's a reference-only framework t
 
 | Command | Primary Source | PDB Source | Notes |
 | ------- | -------------- | ---------- | ----- |
-| `api --platform` | Ref | Runtime | Hybrid: API from ref, PDB from runtime |
 | `type --platform` | Ref | Runtime | Hybrid: structure from ref, source from runtime |
+| `member --platform` | Ref | Runtime | Hybrid: member metadata from ref, source/IL from runtime |
 | `source --platform` | Ref | Runtime (+forwarders) | Follows type forwarders to implementation assembly PDB |
 | `find --platform` | Ref | *(none)* | Ref only: no PDB needed for search |
 | `diff --platform` | Ref | *(none)* | Ref only: comparing public API |
@@ -187,13 +187,13 @@ Both ref and runtime assemblies support version specifiers:
 
 ```bash
 # Latest version (default)
-dotnet-inspect api --platform System.Text.Json
+dotnet-inspect type JsonSerializer --platform System.Text.Json --shape
 
 # Specific shared runtime version (library/audit)
 dotnet-inspect library --platform System.Text.Json --version 9.0.12
 
 # Optional framework family restriction
-dotnet-inspect api --platform Microsoft.AspNetCore.Mvc --framework aspnetcore
+dotnet-inspect type ControllerBase --platform Microsoft.AspNetCore.Mvc --framework aspnetcore
 ```
 
 The resolver:

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -1,0 +1,112 @@
+# Progressive disclosure model
+
+dotnet-inspect uses progressive disclosure to reduce noise, token cost, and network latency. The core rule is: start with cheap, high-signal output; opt into broader or more expensive work only when needed.
+
+This model combines four mechanisms:
+
+1. **Verbosity levels** for curated default detail.
+2. **Section selection** with `-S` for explicit scope and backpressure.
+3. **Discovery** with `-D` so agents can inspect available sections/columns before choosing.
+4. **Opt-in sections** for expensive work that should never run accidentally.
+
+## Verbosity
+
+Verbosity is the curated path. It controls how much of the default view appears.
+
+| Level | Flag | Intent |
+| ----- | ---- | ------ |
+| Quiet | `-v:q` | Compact identity/context only. |
+| Minimal | `-v:m` | Default high-value section(s). |
+| Normal | `-v:n` | Standard non-network sections. |
+| Detailed | `-v:d` | Broad detail, including sections that are allowed by detailed verbosity. |
+
+Verbosity should reveal more about the same subject. It should not silently run slow source-content checks or unrelated lenses.
+
+## Section selection
+
+`-S` selects sections by name or wildcard:
+
+```bash
+dotnet-inspect library System.Text.Json -S Signals
+dotnet-inspect library System.Text.Json -S "Async*"
+dotnet-inspect package System.Text.Json -S "Package Info,Dependencies"
+```
+
+Section selection does two things:
+
+- It controls rendering.
+- It applies backpressure to data collection, so only scanners needed for requested sections run.
+
+For package and library output, selected sections keep a compact context row with key fields such as version, source, TFM, and size. That prevents section queries from becoming lossy while keeping descriptions out of focused output.
+
+## Discovery
+
+`-D` discovers sections and columns:
+
+```bash
+dotnet-inspect member JsonSerializer --package System.Text.Json -D
+dotnet-inspect member JsonSerializer --package System.Text.Json -D Methods
+```
+
+For target-based queries, `-D` defaults to effective discovery: it resolves the target and reports only sections/columns that can actually render for that target and option set. Use `--schema` for the static, offline schema.
+
+Bare `-S` also lists effective sections. Use `-D` when you need section fields/columns; use bare `-S` when you only need section names.
+
+## Projection
+
+After selecting a section, `--columns` and `--fields` project the data:
+
+```bash
+dotnet-inspect member JsonSerializer --package System.Text.Json -S Methods --columns "Name;Signature;Obsolete"
+```
+
+Projection is validated against the selected section schema. Unknown fields/columns produce diagnostics; valid-but-empty fields are reported as no data.
+
+## Counts and row limits
+
+Use built-in limiters instead of shell pipes:
+
+```bash
+dotnet-inspect library System.Private.CoreLib -S "Async*" --count
+dotnet-inspect library System.Private.CoreLib -S "Async*" --rows -n 10
+dotnet-inspect package System.Text.Json -n 12
+dotnet-inspect package System.Text.Json --tail 8
+```
+
+- `--count` counts table rows for exactly one selected section.
+- `-n N` and numeric shorthand like `-6` limit output lines.
+- `--tail N` keeps the last N lines.
+- `--rows -n N` changes the head count into per-table data rows while preserving headings and table headers.
+
+## Opt-in sections
+
+Some sections are explicit-only because they are slow, network-heavy, or scale with source-file count.
+
+Examples:
+
+```bash
+dotnet-inspect library System.Text.Json -S "SourceLink Availability"
+dotnet-inspect library System.Text.Json -S "SourceLink Integrity"
+```
+
+These sections do not run from normal verbosity or broad default output. Select them explicitly, or use `-S All` when you intentionally want every selectable section, including opt-in sections.
+
+## `-S All`
+
+`-S All` means "select every section the command exposes," including opt-in sections. It is useful for exhaustive inspection and testing, but agents should avoid it as a default first move because it can authorize expensive work.
+
+Prefer:
+
+1. Start with a targeted section such as `Signals`, `Package Info`, `Library Files`, or `Async*`.
+2. Use `-D`/bare `-S` to discover more sections.
+3. Use `-S All` only when the task truly requires exhaustive output.
+
+## Agent guidance
+
+When maintaining commands or docs:
+
+- Preserve cheap defaults.
+- Put slow work behind explicit sections or capability-gated detailed verbosity.
+- Keep section ownership clear; avoid duplicated rows across sections.
+- Add `-D`/schema coverage when adding new sections/columns.
+- Update `skills/dotnet-inspect/SKILL.md` when a progressive-disclosure behavior changes.

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -9,6 +9,8 @@ This model combines four mechanisms:
 3. **Discovery** with `-D` so agents can inspect available sections/columns before choosing.
 4. **Opt-in sections** for expensive work that should never run accidentally.
 
+`-D` and `-S` are intentionally capitalized. They form a small query namespace for discovery and section selection that is less likely to collide with command-specific lowercase options. This matters because the query system is broader than an output formatter: it can affect data collection, network authorization, projection, and rendering. Tools that use lowercase `-f` for templates can mostly get away with it when `-f` means "format output"; a general query system needs a more distinct namespace.
+
 ## Verbosity
 
 Verbosity is the curated path. It controls how much of the default view appears.

--- a/docs/design/schema-query.md
+++ b/docs/design/schema-query.md
@@ -2,6 +2,8 @@
 
 The section-model doc describes the UX: `-D` discovers, `-S` selects, `--fields`/`--columns` project, and renderers format. This doc describes the system beneath that UX — query operations over view model schemas that live in Markout alongside the rendering system.
 
+The uppercase `-D`/`-S` spellings are part of the query design. They create a distinct cross-command query namespace for discovery and selection, avoiding common lowercase option collisions while signaling that these flags do more than format output.
+
 Markout already owns the schema through its attributes (`[MarkoutSection]`, `[MarkoutField]`, etc.) and its source generator. Rather than defining a parallel schema in a separate library, the query system extends Markout. One schema definition, two uses: rendering and querying.
 
 ## The problem

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -18,6 +18,8 @@ There are three query paths, each offering a different level of curation and cus
 
 3. **Discovery + projection** (complete customization) — `-D <section>` drills into a section's schema, then `--fields` or `--columns` projects exactly the fields or columns you want. This is the power-user path. Note that the current UX only allows showing one section at a time when using field or column projection.
 
+The uppercase `-S` and `-D` flags are deliberate. They reserve a small, cross-command query namespace for section selection and discovery, reducing collisions with command-specific lowercase options. This is more important than it would be for a pure output-template flag (for example Docker-style `-f` format templates), because section selection can also drive data collection and network backpressure.
+
 These paths share a common starting point: both bare `-S` and bare `-D` list the available sections, so you can orient yourself before choosing a path.
 
 ```bash=

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -1,249 +1,85 @@
-# Designing for LLMs
+# Designing for agents
 
-dotnet-inspect is designed to accelerate LLM-driven .NET development by integrating API documentation directly into the dotnet CLI. This document describes the design principles and specific optimizations that make the tool effective in AI-assisted workflows.
+dotnet-inspect is designed to give agents factual .NET evidence without forcing them to scrape docs, download packages manually, or infer API shape from memory.
 
-## Design Philosophy
+## Design goals
 
-Traditional CLI tools optimize for human readability—colors, progress bars, interactive prompts. LLMs have different needs:
+1. **Evidence over guesses.** Commands inspect NuGet packages, platform libraries, local assemblies, metadata, PDBs, SourceLink, and NuGet registry data.
+2. **Readable structured output.** Markdown is the default because headings, compact context rows, tables, and code fences are readable to humans and easy for agents to quote.
+3. **Progressive disclosure.** Agents can start with compact output and request sections, fields, source, lowered C#, or IL only when needed.
+4. **Self-documenting workflows.** `dotnet-inspect skill` prints the embedded agent skill with current command patterns and guardrails.
 
-- **Structured output** that can be parsed reliably
-- **Token efficiency** to fit within context windows
-- **Complete information** so the LLM can generate correct code
-- **Self-documentation** so the LLM knows how to use the tool
+## Output shape
 
-dotnet-inspect addresses each of these constraints explicitly.
-
-## Design Goals
-
-Two principles guide every output decision:
-
-1. **Equally readable by humans and LLMs.** The output should be scannable at a glance and parseable by code. No compromise in either direction—if it's hard for a person to read, it's probably hard for an LLM too.
-
-2. **Portable markdown.** Output can be copied to a file, pasted into a GitHub issue, or piped to another tool and render correctly everywhere. Markdown tables are the "web-native CSV"—structured data that displays well in any environment.
-
-## Implementation
-
-dotnet-inspect performs very little markdown formatting itself. Instead, it relies on [Markout](https://github.com/richlander/markout), a source-generated markdown serializer. Data models are annotated with attributes, and the serializer generates the markdown output at compile time—much like `System.Text.Json` serializes objects to JSON.
-
-This approach has several benefits:
-
-- **Consistent formatting.** All output follows the same patterns because it flows through a single serializer.
-- **Declarative models.** The code defines *what* to output, not *how* to format it.
-- **AOT compatible.** Because the serializer is a source generator, there's no reflection at runtime. The tool compiles to native code and starts instantly.
-
-## Structured Output
-
-All output follows a consistent markdown format:
+Most Markdown output follows this pattern:
 
 ```markdown
-# Title (Package Version)
+# Title
 
-Description paragraph.
+Key: Value | Key: Value
 
-Type: Library | TFM: net10.0 | Updated: 2026-01-13
-
-## Metadata
-
-| Property | Value |
-|----------|-------|
-| Authors | Microsoft |
-| License | MIT |
-
-## Section Name
+## Section
 
 | Column | Column |
-|--------|--------|
+| ------ | ------ |
 | data   | data   |
 ```
 
-This structure—H1 title, description, compact summary line, H2 sections with tables—is predictable and machine-parseable. LLMs can reliably extract specific pieces of information without fragile regex patterns.
+Selected package and library sections keep the H1 simple and move identity details into the compact context row. That preserves source/version/TFM context without repeating noisy default descriptions.
 
-### Why Markdown Tables?
+## Query and limiter model
 
-LLMs parse markdown tables more reliably than other formats:
+Agents should prefer built-in query and limiter options over shell pipes:
 
-- Headers provide column semantics
-- Pipe delimiters are unambiguous
-- The format is familiar from training data
-- Tables compress well into tokens compared to verbose prose
+- `-D` discovers sections and columns.
+- `-S Section` selects sections by name or wildcard, such as `-S "Async*"`.
+- `--columns` and `--fields` project table columns/fields.
+- `--count` counts rows in one selected section.
+- `-n N` and numeric shorthand like `-6` work like `head`.
+- `--tail N` works like `tail`.
+- `--rows -n N` limits data rows per rendered Markdown table while preserving headings and table headers.
 
-Pipes in cell content are escaped as `\|` to prevent parsing errors.
+## Efficient API workflows
 
-## Token Efficiency
-
-Context windows are expensive. dotnet-inspect provides multiple mechanisms to control output size.
-
-### Verbosity Levels
-
-The `-v` flag controls output density:
-
-| Flag | Content | Use Case |
-| ---- | ------- | -------- |
-| `-v:q` | Title + compact line only | Quick lookups, tight budgets |
-| `-v:m` | + description | Default, balanced output |
-| `-v:n` | + metadata table | More detail needed |
-| `-v:d` | + all sections | Full inspection |
-
-The compact line packs essential metadata into a single line:
-
-```text
-Type: Library | TFM: net10.0 | Updated: 2026-01-13 | Vulnerabilities: 1
-```
-
-### Section Filtering
-
-For detailed output, you can include or exclude specific sections:
+For public signatures and overload inventories, prefer type shape:
 
 ```bash
-dotnet-inspect package -s                                # List available sections
-dotnet-inspect System.Text.Json -v:d -x:Statistics,Files # Exclude sections by name
-dotnet-inspect System.Text.Json -v:d -s:Metadata         # Include only named sections
+dotnet-inspect type JsonSerializer --package System.Text.Json@10.0.0 --shape
 ```
 
-This enables precision: request exactly the data you need.
-
-### Minimal Output Modes
-
-- `--oneline`: One result per line, columnar output (works on `api`, `find`, `diff`, `implements`)
-- `--json --compact`: Minified JSON with null/false values omitted
+Use `member` when you need docs, stable overload selectors, source, lowered C#, or IL:
 
 ```bash
-# Instead of a full table, get columnar output
-dotnet-inspect api JsonSerializer --package System.Text.Json --oneline
+dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize --show-index
+dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 Serialize:1 -v:d
 ```
 
-## Complete Information
+## Signals workflows
 
-LLMs generating code need complete, accurate information. dotnet-inspect prioritizes:
-
-### Full Signatures with Parameter Names
-
-Type names alone aren't enough. LLMs need parameter names to generate correct calls:
-
-```text
-# Bad: Serialize(Object, Type, JsonSerializerOptions)
-# Good: Serialize(object value, Type inputType, JsonSerializerOptions options)
-```
-
-Parameter names come from the assembly metadata's Parameter table.
-
-### Source URLs for Context
-
-With `--docs`, output includes URLs to source code:
-
-```markdown
-**Source:** https://github.com/dotnet/runtime/raw/abc123/src/JsonSerializer.cs
-```
-
-URLs use the `/raw/` format so LLMs can fetch file content directly without parsing HTML.
-
-### No Hidden Defaults
-
-By default, `[EditorBrowsable(Never)]` and `[Obsolete]` members are excluded to reduce noise. But when you need everything, `--all` includes them.
-
-## Self-Documentation
-
-LLMs need to know how to use tools. dotnet-inspect uses **SKILL.md** as its single source of LLM documentation, distributed via the [dotnet/skills](https://github.com/dotnet/skills) marketplace.
-
-### SKILL.md
-
-SKILL.md is loaded automatically into the LLM's context when the skill activates. It must be self-sufficient — the LLM should be productive without running any additional commands.
-
-The skill contains:
-
-- Decision tree mapping user intent to commands
-- Installation and invocation syntax
-- Key patterns for common workflows
-- Command reference with one-line descriptions
-- Version resolution semantics
-- Filtering and limiting syntax
-- Key gotchas (generic types, inherited members, diff syntax)
-
-### Design Principles
-
-Empirical observation: LLMs start copying patterns immediately from whatever context they have. They rarely run documentation commands even when instructed. This means the skill must contain everything needed for the common case.
-
-The skill is embedded in the binary as a resource (`dotnet-inspect skill` prints it) and distributed via the dotnet/skills marketplace. Both copies must stay in sync.
-
-### Keeping Copies in Sync
-
-SKILL.md lives in `skills/dotnet-inspect/SKILL.md` and is published to the dotnet/skills marketplace:
-
-| Repository | Purpose |
-| ---------- | ------- |
-| `dotnet-inspect` | Source repository, embedded in binary |
-| `dotnet/skills` | Marketplace distribution |
-
-## Practical LLM Workflows
-
-### API Discovery
+`Signals` reports evidence, not a safety verdict.
 
 ```bash
-# What types are available?
-dotnet-inspect api --package System.Text.Json
-
-# What methods does JsonSerializer have?
-dotnet-inspect api JsonSerializer --package System.Text.Json --oneline
+dotnet-inspect package System.Text.Json -S Signals
+dotnet-inspect library System.Text.Json -S Signals
+dotnet-inspect library System.Text.Json -S "SourceLink Integrity"
 ```
 
-### Constructors for Dependency Injection
+Package signals describe NuGet artifacts: metadata, dependencies, vulnerabilities, package shape, symbol availability, and SourceLink coverage.
+
+Library signals describe assemblies: SourceLink presence/reachability, PDB/symbol provenance, trim/AOT metadata, async kind, unsafe signatures, P/Invoke, and direct references.
+
+## Fidelity expectations
+
+- SourceLink source is original source when available.
+- Lowered C# is best-effort, readable reconstruction from IL; it may use PDB debug names when available.
+- Raw IL and annotated IL are the highest-fidelity views for exact instructions, offsets, branches, tokens, and calls.
+
+## Skill guidance
+
+The embedded skill lives at `skills/dotnet-inspect/SKILL.md` and is printed by:
 
 ```bash
-# Show constructor parameters for wiring up DI
-dotnet-inspect api Command --package System.CommandLine --ctor
+dotnet-inspect skill
 ```
 
-### Version Comparison
-
-```bash
-# What changed between versions?
-dotnet-inspect diff JsonSerializer --package System.Text.Json@9.0.0..10.0.2
-```
-
-### Vulnerability Check
-
-```bash
-# Quick vulnerability scan
-dotnet-inspect System.Text.Json 8.0.4 -v:d -s:vulnerabilities
-```
-
-### Source Fetching
-
-```bash
-# Get source URL, then fetch it
-dotnet-inspect api JsonSerializer --package System.Text.Json --docs
-# LLM can curl the /raw/ URL directly
-```
-
-## JSON Output
-
-For programmatic processing, JSON output is available:
-
-```bash
-dotnet-inspect api JsonSerializer --package System.Text.Json --json
-dotnet-inspect api JsonSerializer --package System.Text.Json --json --compact
-```
-
-The `--compact` flag produces minified JSON with null and false values omitted, further reducing tokens.
-
-## Comparison with Traditional Tools
-
-| Aspect | Traditional CLI | dotnet-inspect |
-| ------ | --------------- | -------------- |
-| Output format | Prose, colors | Markdown tables, JSON |
-| Verbosity | One size fits all | Four levels + section filtering |
-| Signatures | Abbreviated | Full with parameter names |
-| Source links | None | Raw URLs for direct fetch |
-| Self-documentation | --help | SKILL.md via marketplace |
-
-## Summary
-
-dotnet-inspect treats LLM consumption as a first-class use case:
-
-1. **Structured markdown** for reliable parsing
-2. **Verbosity controls** for token management
-3. **Complete signatures** for correct code generation
-4. **Raw source URLs** for direct content fetching
-5. **Embedded usage guide** for self-documentation
-
-The tool is designed so that an LLM with access to dotnet-inspect can effectively explore, understand, and generate code against any .NET package.
+Update the skill when command behavior, output shape, or agent workflow guidance changes. Use [../taste/skill-guidance.md](../taste/skill-guidance.md) for examples of good and bad embedded-skill guidance.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,33 @@
+# dotnet-inspect overview
+
+`dotnet-inspect` is a CLI tool for inspecting .NET packages, platform libraries, local assemblies, public APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
+
+It is built for both humans and agents. Markdown is the default output because headings, compact context rows, tables, and code fences are readable and easy for agents to quote. JSON and `--oneline` are available when structured automation or compact row output is more useful.
+
+## Core architecture
+
+- `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
+- `src/DotnetInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details.
+- `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
+- `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
+- `src/DotnetInspector.Decompiler/` emits lowered C#, raw IL, and annotated IL from method bodies.
+
+## Agent contract
+
+Agents working in this repo should preserve these principles:
+
+1. Prefer factual inspection over guesses; keep `dotnet-inspect skill` guidance current with CLI behavior.
+2. Keep output section ownership clear: sectioned output should avoid duplicated rows across sections.
+3. Preserve behavior-safe defaults. Expensive network/source checks should stay explicit or capability-gated.
+4. Use built-in query/limiter concepts (`-D`, `-S`, `--columns`, `--fields`, `--count`, `--rows`) instead of shell-pipe workarounds when possible.
+5. Treat cache schema changes as versioned categories and invalidate/clean stale metadata caches deliberately.
+
+## Important systems
+
+- [Architecture](architecture.md): command and metadata architecture.
+- [Signals](assembly-audit.md): package/library signal semantics and network scope.
+- [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
+- [Rendering model](design/rendering-model.md): output mode and verbosity design.
+- [Section model](design/section-model.md): section selection and query behavior.
+- [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
+- [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,8 +19,9 @@ Agents working in this repo should preserve these principles:
 1. Prefer factual inspection over guesses; keep `dotnet-inspect skill` guidance current with CLI behavior.
 2. Keep output section ownership clear: sectioned output should avoid duplicated rows across sections.
 3. Preserve behavior-safe defaults. Expensive network/source checks should stay explicit or capability-gated.
-4. Use built-in query/limiter concepts (`-D`, `-S`, `--columns`, `--fields`, `--count`, `--rows`) instead of shell-pipe workarounds when possible.
-5. Treat cache schema changes as versioned categories and invalidate/clean stale metadata caches deliberately.
+4. Preserve the progressive-disclosure model: verbosity for curated defaults, `-D`/`-S` for query and backpressure, opt-in sections for expensive work, and `-S All` only for intentional exhaustive output.
+5. Use built-in query/limiter concepts (`-D`, `-S`, `--columns`, `--fields`, `--count`, `--rows`) instead of shell-pipe workarounds when possible.
+6. Treat cache schema changes as versioned categories and invalidate/clean stale metadata caches deliberately.
 
 ## Important systems
 
@@ -28,6 +29,7 @@ Agents working in this repo should preserve these principles:
 - [Signals](assembly-audit.md): package/library signal semantics and network scope.
 - [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
 - [Rendering model](design/rendering-model.md): output mode and verbosity design.
+- [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S All`, and limiter behavior.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -16,7 +16,7 @@ dnx dotnet-inspect -y -- <command>
 
 Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--oneline` for compact tabular output like `docker images` when you need one result per row. Use `--json` for structured automation. Use `-v:d` when you need source/decompiled C#/IL detail.
 
-Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections by name or wildcard, such as `-S "Async*"`; `--columns` and `--fields` project values. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
+Use the query system when you need a specific slice instead of a fixed template. `-D` discovers sections/columns; `-S Section` selects sections by name or wildcard, such as `-S "Async*"`; `--columns` and `--fields` project values. The uppercase `-D`/`-S` flags are the cross-command query namespace. This serves a similar role to Go templates, but you discover the available shape first instead of guessing field names.
 
 Use built-in limiters before shell pipes. `-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines, for example `--rows -n 10` or `--rows -10`. Use `--count` to count rows in one selected table section. Command-specific limiters also matter: `-t N` limits type/find results, `-m N` limits member results, and `--versions N` limits package version lists.
 

--- a/taste/skill-guidance.md
+++ b/taste/skill-guidance.md
@@ -52,6 +52,7 @@ Why it is bad:
 - Lead with the best first command for the task.
 - Prefer workflow guidance over implementation inventory.
 - Use familiar CLI analogies when they clarify behavior (`--oneline` like `docker images`, `-n`/`--tail` like `head`/`tail`).
+- Describe `-D`/`-S` as the uppercase cross-command query namespace when explaining discovery and section selection.
 - Explain `--preview` as the single prerelease opt-in alias in the skill, even when other aliases exist.
 - Keep SourceLink/PDB wording precise: PDBs carry SourceLink data; they are not SourceLink themselves.
 - Keep Signals row ownership clear; avoid describing rows as belonging to multiple sections.

--- a/taste/skill-guidance.md
+++ b/taste/skill-guidance.md
@@ -1,0 +1,58 @@
+# Embedded skill guidance
+
+Use this when editing `skills/dotnet-inspect/SKILL.md`.
+
+## Purpose
+
+The embedded skill is the authoritative agent guide for `dotnet-inspect`. It should teach reliable workflows, syntax guardrails, output-shape expectations, and high-value examples. It should not be a changelog or an exhaustive command manual.
+
+## Good
+
+```md
+For full public signature or overload inventories, start with `type Type --package Foo --shape`; it gives the clean declaration shape with parameter names, nullable annotations, defaults, and generic parameters.
+```
+
+Why it works:
+
+- It maps a common task to one best first command.
+- It explains why that command is efficient.
+- It avoids sending agents through lower-level source/IL workflows unnecessarily.
+
+```md
+`-n N` and numeric shorthand like `-6` work like `head`; `--tail N` works like `tail`; add `--rows` to make head counts cap Markdown table data rows instead of output lines.
+```
+
+Why it works:
+
+- It links tool behavior to familiar CLI concepts.
+- It teaches one important modifier without listing every option.
+
+## Bad
+
+```md
+Recent decompiler work improved collection expression lowering and pointer lowering.
+```
+
+Why it is bad:
+
+- It inventories implementation changes instead of teaching what agents can rely on.
+- Prefer fidelity guidance: SourceLink source is original source when available; Lowered C# is readable best-effort; raw/annotated IL is highest fidelity.
+
+```md
+Use `--plaintext` for text-only output.
+```
+
+Why it is bad:
+
+- All CLI formats are text output.
+- Do not feature `--plaintext` in primary skill guidance unless a concrete agent workflow benefits from it.
+
+## Rules
+
+- Lead with the best first command for the task.
+- Prefer workflow guidance over implementation inventory.
+- Use familiar CLI analogies when they clarify behavior (`--oneline` like `docker images`, `-n`/`--tail` like `head`/`tail`).
+- Explain `--preview` as the single prerelease opt-in alias in the skill, even when other aliases exist.
+- Keep SourceLink/PDB wording precise: PDBs carry SourceLink data; they are not SourceLink themselves.
+- Keep Signals row ownership clear; avoid describing rows as belonging to multiple sections.
+- Update examples when output shape changes, especially compact context rows and selected-section output.


### PR DESCRIPTION
## Summary
- add `docs/overview.md` as the minimum architecture/system context for agents and humans
- add `taste/skill-guidance.md` with good/bad examples for maintaining the embedded skill
- rename `AGENT.md` to `AGENTS.md` and keep it as a resolver that points to source-of-truth docs instead of embedding full design rationale
- link the overview/taste docs from README
- restructure the docs index around the need each doc serves, distinguishing current system docs from design history/backlog
- add `docs/design/progressive-disclosure.md` covering verbosity, `-D`/`-S`, opt-in sections, `-S All`, counts, and row limits
- document why uppercase `-D`/`-S` form a cross-command query namespace with lower conflict risk than lowercase format flags
- refresh stale high-traffic docs that referenced old `api`/`platform` command shapes

## Validation
- npx markdownlint-cli --fix AGENTS.md README.md docs/README.md docs/architecture.md docs/design/command-model.md docs/design/platform-assemblies.md docs/llm-design.md docs/overview.md docs/design/progressive-disclosure.md docs/design/section-model.md docs/design/schema-query.md skills/dotnet-inspect/SKILL.md taste/skill-guidance.md
- npx markdownlint-cli AGENTS.md README.md docs/README.md docs/architecture.md docs/design/command-model.md docs/design/platform-assemblies.md docs/llm-design.md docs/overview.md docs/design/progressive-disclosure.md docs/design/section-model.md docs/design/schema-query.md skills/dotnet-inspect/SKILL.md taste/skill-guidance.md