### PR TITLE
Guard cache deletion paths

### DIFF
--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -116,7 +116,10 @@ public static class CoreCache
     public static void EnsurePathInCacheContext(string path)
     {
         if (!IsPathInCacheContext(path))
+        {
+            Console.Error.WriteLine($"Warning: refusing to delete path outside dotnet-inspect cache: {path}");
             throw new InvalidOperationException($"Refusing to delete path outside dotnet-inspect cache: {path}");
+        }
     }
 
     /// <summary>

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -110,6 +110,39 @@ public static class CoreCache
     }
 
     /// <summary>
+    /// Throws unless <paramref name="path"/> is inside the active cache root or the legacy cache root.
+    /// Use before deleting cache paths to prevent path traversal or accidental user-file deletion.
+    /// </summary>
+    public static void EnsurePathInCacheContext(string path)
+    {
+        if (!IsPathInCacheContext(path))
+            throw new InvalidOperationException($"Refusing to delete path outside dotnet-inspect cache: {path}");
+    }
+
+    /// <summary>
+    /// Returns true when a path is the active cache root, the legacy cache root, or a child of either.
+    /// </summary>
+    public static bool IsPathInCacheContext(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(path);
+            if (IsSameOrChildPath(fullPath, GetBasePath()))
+                return true;
+
+            var legacy = GetLegacyBasePath();
+            return legacy != null && IsSameOrChildPath(fullPath, legacy);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Registers a versioned cache category family for best-effort cleanup.
     /// For example, prefix <c>pkg-index-v</c> with current <c>pkg-index-v8</c>
     /// causes maintenance to delete sibling directories such as <c>pkg-index-v7</c>.
@@ -281,6 +314,7 @@ public static class CoreCache
     public static long Clear(string? category = null)
     {
         var targetPath = category != null ? GetCategoryPath(category) : GetBasePath();
+        EnsurePathInCacheContext(targetPath);
         if (!Directory.Exists(targetPath))
             return 0;
 
@@ -429,6 +463,8 @@ public static class CoreCache
                     continue;
                 if (!name.StartsWith(category.Prefix, StringComparison.OrdinalIgnoreCase))
                     continue;
+                if (!IsSameOrChildPath(directory, root))
+                    continue;
 
                 var size = GetDirectorySizeBestEffort(directory);
                 try
@@ -465,6 +501,16 @@ public static class CoreCache
         return new DirectoryInfo(path)
             .EnumerateFiles("*", SearchOption.AllDirectories)
             .Sum(f => f.Length);
+    }
+
+    private static bool IsSameOrChildPath(string path, string root)
+    {
+        var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        var fullRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+
+        return fullPath.Equals(fullRoot, StringComparison.OrdinalIgnoreCase)
+            || fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+            || fullPath.StartsWith(fullRoot + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -181,6 +181,7 @@ public static class NuGetCache
             // Remove incomplete cache if exists
             if (Directory.Exists(targetPath))
             {
+                CoreCache.EnsurePathInCacheContext(targetPath);
                 Directory.Delete(targetPath, recursive: true);
             }
 

--- a/src/DotnetInspector.Services/PackageCacheService.cs
+++ b/src/DotnetInspector.Services/PackageCacheService.cs
@@ -79,6 +79,7 @@ public static class PackageCacheService
 
     private static long DeleteCacheDirectory(string path)
     {
+        CoreCache.EnsurePathInCacheContext(path);
         if (!Directory.Exists(path))
             return 0;
 

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -290,7 +290,15 @@ public static class PlatformPackService
         }
         catch (Exception)
         {
-            try { if (Directory.Exists(packDir)) Directory.Delete(packDir, recursive: true); } catch { }
+            try
+            {
+                if (Directory.Exists(packDir))
+                {
+                    CoreCache.EnsurePathInCacheContext(packDir);
+                    Directory.Delete(packDir, recursive: true);
+                }
+            }
+            catch { }
             return null;
         }
         finally
@@ -325,7 +333,10 @@ public static class PlatformPackService
 
             var destDir = Path.Combine(destination, dirName);
             if (Directory.Exists(destDir))
+            {
+                CoreCache.EnsurePathInCacheContext(destDir);
                 Directory.Delete(destDir, recursive: true);
+            }
             Directory.Move(dir, destDir);
         }
 

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -77,9 +77,15 @@ public class CacheCommandTests : IDisposable
     }
 
     [Fact]
-    public void CoreCache_Clear_RejectsTraversalOutsideCacheRoot()
+    public async Task CoreCache_Clear_RejectsTraversalOutsideCacheRoot()
     {
-        Assert.Throws<InvalidOperationException>(() => CoreCache.Clear(".."));
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => CoreCache.Clear(".."));
+            return Task.FromResult(0);
+        });
+
+        Assert.Contains("Warning: refusing to delete path outside dotnet-inspect cache", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -75,4 +75,22 @@ public class CacheCommandTests : IDisposable
         Assert.True(result.BytesFreed > 0);
         Assert.True(result.DirectoriesDeleted >= 1);
     }
+
+    [Fact]
+    public void CoreCache_Clear_RejectsTraversalOutsideCacheRoot()
+    {
+        Assert.Throws<InvalidOperationException>(() => CoreCache.Clear(".."));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInvalidSessionName_ReturnsError()
+    {
+        var options = new CacheOptions(Clean: true, Verbose: false, Session: "../user-data");
+
+        var (result, _, error) = await ConsoleCapture.RunAsync(
+            () => CacheCommand.ExecuteAsync(options));
+
+        Assert.Equal(1, result);
+        Assert.Contains("Session name must not contain path separators", error);
+    }
 }

--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -73,7 +73,19 @@ public class CacheCommand
 
     private static int ClearSession(string sessionName)
     {
+        if (!IsSafeSessionName(sessionName))
+        {
+            Console.Error.WriteLine("Error: Session name must not contain path separators or traversal.");
+            return 1;
+        }
+
         var sessionPath = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-{sessionName}");
+        if (!IsUnderTempDirectory(sessionPath))
+        {
+            Console.Error.WriteLine("Error: Refusing to clear session outside the temporary directory.");
+            return 1;
+        }
+
         if (!Directory.Exists(sessionPath))
         {
             Console.WriteLine($"Session '{sessionName}' not found.");
@@ -93,6 +105,26 @@ public class CacheCommand
         {
             Console.Error.WriteLine($"Error clearing session '{sessionName}': {ex.Message}");
             return 1;
+        }
+    }
+
+    private static bool IsSafeSessionName(string sessionName) =>
+        !string.IsNullOrWhiteSpace(sessionName)
+        && !sessionName.Contains("..", StringComparison.Ordinal)
+        && sessionName.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, Path.VolumeSeparatorChar]) < 0;
+
+    private static bool IsUnderTempDirectory(string path)
+    {
+        try
+        {
+            var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            var tempRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.GetTempPath()));
+            return fullPath.StartsWith(tempRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                || fullPath.StartsWith(tempRoot + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -5,6 +5,7 @@
 ### Cache
 
 - Cleans obsolete versioned cache categories, such as older package-index schema caches, in the background after cache misses.
+- Cache deletion paths are guarded so cache clearing and cleanup refuse to delete outside the active or legacy dotnet-inspect cache roots.
 
 ### Lowered C# output
 


### PR DESCRIPTION
## Summary
- add CoreCache path guards so cache deletion refuses paths outside the active or legacy dotnet-inspect cache roots
- apply the guards to cache clear, package cache replacement, platform pack cache cleanup, and versioned cache maintenance
- validate isolated session names before deleting session caches under the temp directory
- add tests for traversal rejection and invalid session names

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release