### PR TITLE
Add declarations to decompiled member source

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -97,6 +97,33 @@ public class CSharpEmitterTests
         Assert.Contains("catch", output);
     }
 
+    [Fact]
+    public void CallByRefTarget_DoesNotDuplicateRefModifier()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.CallByRefTarget));
+
+        Assert.Contains("ByRefTarget(ref value)", output);
+        Assert.DoesNotContain("ref ref value", output);
+    }
+
+    [Fact]
+    public void CallInTarget_UsesInModifier()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.CallInTarget));
+
+        Assert.Contains("InTarget(in value)", output);
+        Assert.DoesNotContain("InTarget(ref value)", output);
+    }
+
+    [Fact]
+    public void CallOutTarget_UsesOutModifier()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.CallOutTarget));
+
+        Assert.Contains("OutTarget(out ", output);
+        Assert.DoesNotContain("OutTarget(ref ", output);
+    }
+
     // --- Return statements ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -414,6 +414,37 @@ public class CfgSampleClass
         flag = true;
     }
 
+    public static void CallByRefTarget(int value)
+    {
+        ByRefTarget(ref value);
+    }
+
+    public static void ByRefTarget(ref int value)
+    {
+        value++;
+    }
+
+    public static void CallInTarget(int value)
+    {
+        InTarget(in value);
+    }
+
+    public static void InTarget(in int value)
+    {
+        Console.WriteLine(value);
+    }
+
+    public static void CallOutTarget()
+    {
+        OutTarget(out int value);
+        Console.WriteLine(value);
+    }
+
+    public static void OutTarget(out int value)
+    {
+        value = 42;
+    }
+
     public static bool BoolAnd(int x, int y)
     {
         return x > 0 && y > 0;

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -5273,10 +5273,67 @@ public static class CSharpEmitter
 
         void EmitCallArgument(ILAstExpression arg)
         {
-            if (arg.OpCode is ILOpCode.Ldloca_s or ILOpCode.Ldloca
-                or ILOpCode.Ldarga_s or ILOpCode.Ldarga)
-                _sb.Append("ref ");
-            EmitExpression(arg);
+            var modifier = arg.ExpectedArgumentModifier;
+            if (modifier == CallArgumentModifier.None && IsAddressExpression(arg))
+                modifier = CallArgumentModifier.Ref;
+
+            if (modifier == CallArgumentModifier.None)
+            {
+                EmitExpression(arg);
+                return;
+            }
+
+            _sb.Append(modifier switch
+            {
+                CallArgumentModifier.In => "in ",
+                CallArgumentModifier.Out => "out ",
+                _ => "ref "
+            });
+
+            if (IsAddressExpression(arg))
+                EmitByRefArgumentTarget(arg);
+            else
+                EmitExpression(arg);
+        }
+
+        void EmitByRefArgumentTarget(ILAstExpression expr)
+        {
+            switch (expr.OpCode)
+            {
+                case ILOpCode.Ldloca_s or ILOpCode.Ldloca:
+                    _sb.Append(expr.Operand ?? "loc");
+                    break;
+                case ILOpCode.Ldarga_s or ILOpCode.Ldarga:
+                    _sb.Append(RemapArg(expr.Operand, expr.OpCode));
+                    break;
+                case ILOpCode.Ldflda:
+                    if (expr.Arguments.Count > 0)
+                    {
+                        EmitExpression(expr.Arguments[0]);
+                        _sb.Append('.');
+                    }
+                    _sb.Append(ExtractMemberName(expr.Operand));
+                    break;
+                case ILOpCode.Ldsflda:
+                    _sb.Append(expr.Operand ?? "/* field */");
+                    break;
+                case ILOpCode.Ldelema:
+                    if (expr.Arguments.Count >= 2)
+                    {
+                        EmitExpression(expr.Arguments[0]);
+                        _sb.Append('[');
+                        EmitExpression(expr.Arguments[1]);
+                        _sb.Append(']');
+                    }
+                    else
+                    {
+                        _sb.Append("/* array element */");
+                    }
+                    break;
+                default:
+                    EmitExpression(expr);
+                    break;
+            }
         }
 
         void EmitReceiver(ILAstExpression receiver, bool isBaseCall)

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -782,6 +782,7 @@ public static class ILAstBuilder
             string returnType;
             string? methodName;
             ImmutableArray<string> parameterTypes = default;
+            ImmutableArray<CallArgumentModifier> parameterModifiers = default;
 
             switch (handle.Kind)
             {
@@ -791,6 +792,7 @@ public static class ILAstBuilder
                     var sig = methodDef.DecodeSignature(SignatureDecoder.Instance, callerGenericContext);
                     paramCount = sig.ParameterTypes.Length;
                     parameterTypes = sig.ParameterTypes;
+                    parameterModifiers = GetParameterModifiers(reader, methodDef, parameterTypes);
                     isStatic = methodDef.Attributes.HasFlag(MethodAttributes.Static);
                     returnType = sig.ReturnType;
                     var declType = reader.GetTypeDefinition(methodDef.GetDeclaringType());
@@ -815,6 +817,7 @@ public static class ILAstBuilder
                     var sig = memberRef.DecodeMethodSignature(SignatureDecoder.Instance, genericCtx);
                     paramCount = sig.ParameterTypes.Length;
                     parameterTypes = sig.ParameterTypes;
+                    parameterModifiers = GetDefaultParameterModifiers(parameterTypes);
                     isStatic = !sig.Header.IsInstance;
                     returnType = sig.ReturnType;
                     methodName = ResolveMethodRefName(reader, memberRef, genericCtx);
@@ -849,7 +852,11 @@ public static class ILAstBuilder
             {
                 int paramStart = (!isStatic && opcode != ILOpCode.Newobj) ? 1 : 0;
                 for (int i = 0; i < parameterTypes.Length && (i + paramStart) < args.Length; i++)
+                {
                     args[i + paramStart].ExpectedType = parameterTypes[i];
+                    if (!parameterModifiers.IsDefault && i < parameterModifiers.Length)
+                        args[i + paramStart].ExpectedArgumentModifier = parameterModifiers[i];
+                }
             }
 
             // Compute result type
@@ -879,6 +886,55 @@ public static class ILAstBuilder
                 ResultType = StackValue.CreateUnknown(), Offset = offset
             };
         }
+    }
+
+    static ImmutableArray<CallArgumentModifier> GetParameterModifiers(
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        ImmutableArray<string> parameterTypes)
+    {
+        var modifiers = GetDefaultParameterModifiers(parameterTypes).ToBuilder();
+
+        foreach (var parameterHandle in methodDef.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber == 0)
+                continue;
+
+            var index = parameter.SequenceNumber - 1;
+            if (index < 0 || index >= modifiers.Count)
+                continue;
+
+            if (AttributeReader.HasAttribute(
+                    reader,
+                    parameter.GetCustomAttributes(),
+                    "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
+            {
+                modifiers[index] = CallArgumentModifier.In;
+            }
+            else if ((parameter.Attributes & ParameterAttributes.Out) != 0)
+            {
+                modifiers[index] = CallArgumentModifier.Out;
+            }
+        }
+
+        return modifiers.ToImmutable();
+    }
+
+    static ImmutableArray<CallArgumentModifier> GetDefaultParameterModifiers(ImmutableArray<string> parameterTypes)
+    {
+        if (parameterTypes.IsDefault)
+            return default;
+
+        var modifiers = ImmutableArray.CreateBuilder<CallArgumentModifier>(parameterTypes.Length);
+        foreach (var parameterType in parameterTypes)
+        {
+            modifiers.Add(parameterType.StartsWith("ref ", StringComparison.Ordinal)
+                ? CallArgumentModifier.Ref
+                : CallArgumentModifier.None);
+        }
+
+        return modifiers.ToImmutable();
     }
 
     static bool PushesValue(ILOpCode opcode, MethodBodyContext context, ILAstExpression node)

--- a/src/DotnetInspector.Decompiler/ILAstNode.cs
+++ b/src/DotnetInspector.Decompiler/ILAstNode.cs
@@ -62,6 +62,11 @@ public sealed class ILAstExpression : ILAstNode
     /// </summary>
     public string? ExpectedType { get; set; }
 
+    /// <summary>
+    /// The call-site modifier required by the parameter this expression is being passed to.
+    /// </summary>
+    public CallArgumentModifier ExpectedArgumentModifier { get; set; }
+
     public override void WriteTo(StringBuilder sb, int indent)
     {
         sb.Append(FormatOpCode(OpCode));
@@ -92,6 +97,14 @@ public sealed class ILAstExpression : ILAstNode
         ILOpCode.Ldloc_3 => "ldloc.3",
         _ => opcode.ToString().ToLowerInvariant().Replace('_', '.')
     };
+}
+
+public enum CallArgumentModifier
+{
+    None,
+    Ref,
+    Out,
+    In
 }
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -697,6 +697,8 @@ public class CommandExecutionTests
         Assert.Contains("## IL", output);
         Assert.Contains("## IL (Annotated)", output);
         Assert.DoesNotContain("## Original Source", output);
+        Assert.Contains("WriteNode(in value", output);
+        Assert.DoesNotContain("ref ref", output);
     }
 
     [Fact]
@@ -719,7 +721,126 @@ public class CommandExecutionTests
         Assert.Contains("GetTypeInfo", output);
         Assert.Contains("WriteElement", output);
         Assert.DoesNotContain("## Original Source", output);
-        Assert.DoesNotContain("public static JsonElement SerializeToElement", output);
+        Assert.Contains("public static System.Text.Json.JsonElement SerializeToElement<TValue>(TValue value, System.Text.Json.JsonSerializerOptions? options = null)", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOperator_SelectDecompiledSource_RendersCSharpOperatorDeclaration()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Private.CoreLib",
+            TypeName = "String",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "op_Equality" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public static bool operator ==(string? a, string? b)", output);
+        Assert.DoesNotContain("public static bool op_Equality", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedCheckedOperator_SelectDecompiledSource_RendersCSharpCheckedOperatorDeclaration()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Private.CoreLib",
+            TypeName = "Int128",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "op_CheckedAddition" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public static System.Int128 operator checked +(System.Int128 left, System.Int128 right)", output);
+        Assert.DoesNotContain("System.Int128 checked operator +", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedCheckedConversion_SelectDecompiledSource_RendersCSharpCheckedConversionDeclaration()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Private.CoreLib",
+            TypeName = "Int128",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "op_CheckedExplicit" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public static explicit operator checked System.Int128(double value)", output);
+        Assert.DoesNotContain("checked explicit operator System.Int128", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedExtensionMethod_SelectDecompiledSource_RendersThisParameter()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Linq",
+            TypeName = "Enumerable",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Where" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public static System.Collections.Generic.IEnumerable<TSource> Where<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate)", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_SelectDecompiledSource_UsesDisplayedOverloadIndex()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Private.CoreLib",
+            TypeName = "Enum",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Parse" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public static TEnum Parse<TEnum>(System.ReadOnlySpan<char> value)", output);
+        Assert.DoesNotContain("public static object Parse(System.Type enumType, string value)", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedGenericTypeConstructor_SelectDecompiledSource_RendersUngenericConstructorName()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Private.CoreLib",
+            TypeName = "List<T>",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".ctor" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public List()", output);
+        Assert.DoesNotContain("public List<T>()", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -147,6 +147,10 @@ public static class MemberCommand
                 var overloads = apiType.Members
                     .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase))
                     .ToList();
+                var displayOverloads = overloads
+                    .OrderBy(m => m.Name, StringComparer.Ordinal)
+                    .ThenBy(m => m.Signature ?? "", StringComparer.Ordinal)
+                    .ToList();
 
                 int idx = effectiveOptions.OverloadIndex.Value;
                 if (idx < 1 || idx > overloads.Count)
@@ -155,9 +159,13 @@ public static class MemberCommand
                     return 1;
                 }
 
-                var selected = overloads[idx - 1];
+                var selected = displayOverloads[idx - 1];
                 apiType.Members = [selected];
-                effectiveOptions = effectiveOptions with { DllPath = apiDllPath };
+                effectiveOptions = effectiveOptions with
+                {
+                    DllPath = apiDllPath,
+                    OverloadIndex = overloads.IndexOf(selected) + 1
+                };
             }
 
             // --params / -of: select overload by parameter type matching

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -338,7 +338,7 @@ public static class ApiOutputFormatter
             {
                 var kindLabel = GetTreeKindLabel(group.Key, group.Count());
                 var memberSignatures = group
-                    .OrderBy(m => m.Name)
+                    .OrderBy(m => m.Name, StringComparer.Ordinal)
                     .Select(m => m.Signature ?? OperatorNames.FormatDisplayName(m.Name))
                     .ToList();
 
@@ -461,7 +461,10 @@ public static class ApiOutputFormatter
         foreach (var group in kindGroups)
         {
             var kind = group.Key;
-            var members = group.OrderBy(m => m.Name).ThenBy(m => m.Signature).ToList();
+            var members = group
+                .OrderBy(m => m.Name, StringComparer.Ordinal)
+                .ThenBy(m => m.Signature ?? "", StringComparer.Ordinal)
+                .ToList();
 
             // Pre-compute overload counts and indices for --show-index
             var overloadCounts = showSelect
@@ -733,7 +736,8 @@ public static class ApiOutputFormatter
                         var lowered = Decompiler.CSharpEmitter.Emit(context);
                         if (!string.IsNullOrWhiteSpace(lowered))
                         {
-                            memberCode.DecompiledSourceCode = new CodeSection("csharp", lowered.TrimEnd());
+                            var source = FormatLoweredSourceWithDeclaration(type, method, context, lowered);
+                            memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
                             hasCode = true;
                         }
                     }
@@ -778,6 +782,131 @@ public static class ApiOutputFormatter
 
         if (hasCode)
             view.MemberCode = memberCode;
+    }
+
+    private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context, string lowered)
+    {
+        var declaration = FormatMemberDeclaration(type, member, context);
+        var body = lowered.TrimEnd();
+        if (string.IsNullOrWhiteSpace(declaration))
+            return body;
+
+        var indentedBody = string.Join(
+            Environment.NewLine,
+            body.ReplaceLineEndings("\n").Split('\n').Select(line => line.Length == 0 ? "" : $"    {line}"));
+
+        return $"{declaration}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
+    }
+
+    private static string FormatMemberDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context)
+    {
+        var signature = member.Signature ?? member.ReturnType ?? "";
+        if (string.IsNullOrWhiteSpace(signature))
+            return "";
+
+        if (member.Kind == "constructor")
+        {
+            var typeName = FormatConstructorTypeName(type.Name);
+            signature = $"{typeName}{SignatureParser.FormatConstructorCall(signature)}";
+        }
+        else if (member.Name.StartsWith("op_", StringComparison.Ordinal))
+        {
+            signature = FormatOperatorSignature(signature, member.Name);
+        }
+        else if (member.Kind == "method")
+        {
+            if (context.GenericContext?.MethodParameters is { Count: > 0 } methodParameters)
+                signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
+            if (member.IsExtension)
+                signature = AddExtensionThisModifier(signature);
+        }
+
+        List<string> modifiers = [member.Accessibility ?? "public"];
+        if (member.IsStatic)
+            modifiers.Add("static");
+
+        return $"{string.Join(" ", modifiers)} {signature}";
+    }
+
+    private static string FormatOperatorSignature(string signature, string methodName)
+    {
+        var parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        var returnType = signature[..nameIndex].TrimEnd();
+        var parameters = signature[parenStart..];
+
+        if (methodName.StartsWith("op_Checked", StringComparison.Ordinal)
+            && TryGetCheckedOperatorSymbol(methodName["op_Checked".Length..]) is { } checkedSymbol)
+            return $"{returnType} operator checked {checkedSymbol}{parameters}";
+
+        return methodName switch
+        {
+            "op_Implicit" => $"implicit operator {returnType}{parameters}",
+            "op_Explicit" => $"explicit operator {returnType}{parameters}",
+            "op_CheckedExplicit" => $"explicit operator checked {returnType}{parameters}",
+            _ => $"{returnType} {OperatorNames.FormatDisplayName(methodName)}{parameters}"
+        };
+    }
+
+    private static string? TryGetCheckedOperatorSymbol(string suffix) => suffix switch
+    {
+        "Addition" => "+",
+        "Subtraction" => "-",
+        "Multiply" => "*",
+        "Division" => "/",
+        "Increment" => "++",
+        "Decrement" => "--",
+        "UnaryNegation" => "-",
+        _ => null
+    };
+
+    private static string FormatConstructorTypeName(string name)
+    {
+        var arityIndex = name.IndexOf('`');
+        return arityIndex < 0 ? name : name[..arityIndex];
+    }
+
+    private static string AddMethodGenericParameters(string signature, string methodName, IReadOnlyList<string> methodParameters)
+    {
+        if (methodParameters.Count == 0 || string.IsNullOrEmpty(methodName))
+            return signature;
+
+        var parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        var insertAt = nameIndex + methodName.Length;
+        if (insertAt < parenStart && signature[insertAt] == '<')
+            return signature;
+
+        return signature.Insert(insertAt, $"<{string.Join(", ", methodParameters)}>");
+    }
+
+    private static string AddExtensionThisModifier(string signature)
+    {
+        var parenStart = signature.IndexOf('(');
+        var parenEnd = signature.LastIndexOf(')');
+        if (parenStart < 0 || parenEnd <= parenStart + 1)
+            return signature;
+
+        var firstParameterStart = parenStart + 1;
+        while (firstParameterStart < signature.Length && char.IsWhiteSpace(signature[firstParameterStart]))
+            firstParameterStart++;
+
+        if (signature.AsSpan(firstParameterStart).StartsWith("this ".AsSpan(), StringComparison.Ordinal))
+            return signature;
+
+        return signature.Insert(firstParameterStart, "this ");
     }
 
     // ===== Helper Methods =====


### PR DESCRIPTION
## Summary
- wrap selected member Decompiled Source output in a C# declaration block
- render method generics, constructors, operators, extension this parameters, and ref/out/in call-site modifiers more accurately
- align Name:N overload selection with displayed --show-index ordering while preserving metadata index lookup for implementation sections

## Tests
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-build
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release --no-build