### PR TITLE
Bump dotnet-inspect to 0.9.6

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.9.5</VersionPrefix>
+    <VersionPrefix>0.9.6</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump dotnet-inspect package version from 0.9.5 to 0.9.6

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet pack src/dotnet-inspect -c Release --no-build -o /tmp/dotnet-inspect-0.9.6-pack
- verified dotnet-inspect.0.9.6.nupkg nuspec version is 0.9.6