### PR TITLE
Run code CI for src markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,7 @@ jobs:
           DOCS=false
           while IFS= read -r file; do
             case "$file" in
-              src/*)
-                case "$file" in
-                  *.md|*.txt) ;;
-                  *) CODE=true ;;
-                esac ;;
+              src/*) CODE=true ;;
               *.props|*.sln) CODE=true ;;
               .github/workflows/*) CODE=true ;;
             esac


### PR DESCRIPTION
## Summary
- treat all changes under `src/` as code changes in CI, including markdown/text files
- keep ordinary docs-only markdown changes outside `src/` on the markdownlint-only path

## Validation
- git diff --check
- local shell smoke checks for `src/*.md` => `code=true docs=true` and `docs/*.md` => `code=false docs=true`