### PR TITLE
Split method groups from member overload rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dotnet-inspect library System.Text.Json -S "Async*" --count
 dotnet-inspect library System.Text.Json -S Signals
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders a curated high-density view. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S All` to select all sections; it renders the default section first, then remaining sections alphabetically.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S All` to select all sections; it renders the default section first, then remaining sections alphabetically.
 
 ## Common examples
 

--- a/docs/design/info-view.md
+++ b/docs/design/info-view.md
@@ -26,7 +26,8 @@ Sections are stable content units. Presets decide where those sections appear. T
 | `package X` | What is this package, and what does it ship? | `Package Info`, `Library Files` | Identity/metadata plus asset shape answer most package triage questions without a dependency inventory. |
 | `library X` | What is this assembly, and what dense metadata signals are present? | `Library Info` | Library Info includes identity plus counts for large metadata lists, avoiding noisy inventories while signaling what exists. |
 | selected `member Type.Member:N` | What is this overload, and what does it do? | `Signature`, `Decompiled Source` | Contract plus readable implementation usually answers the first implementation question without IL or SourceLink source. |
-| `type Type` or `member Type` list view | What API members are in this type space? | Member summary sections (`Constructors`, `Properties`, `Methods`, etc.) | Compact per-member-kind summaries show return types and overload counts without full signatures. |
+| `type Type` or broad `member Type` list view | What API member groups are in this type space? | Member summary sections (`Constructors`, `Properties`, `Method Groups`, etc.) | Compact per-member-kind summaries show return types and overload counts without full signatures. |
+| `member Type -m Name` | Which overloads exist for this logical member? | `Methods` or the matching member-kind section | The query is already narrowed to one member name, so overload rows with signatures are the bounded high-value answer. |
 
 ## Non-presets and open questions
 

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -43,7 +43,7 @@ Section selection does two things:
 
 For package, library, and selected-overload member output, focused selected sections keep a compact context row with key fields such as version, source, TFM, and size/type. That prevents section queries from becoming lossy while keeping descriptions out of focused output.
 
-Bare `-S` is command/context-specific: package uses `Package Info` and `Library Files`; library uses `Library Info`; type/member list views use compact member summaries; selected member overloads use `Signature` and `Decompiled Source`. See [Bare `-S` Info view](info-view.md) for the bullseye question each preset is meant to answer.
+Bare `-S` is command/context-specific: package uses `Package Info` and `Library Files`; library uses `Library Info`; type and broad member list views use compact member summaries such as `Method Groups`; member-name views use `Methods` overload rows; selected member overloads use `Signature` and `Decompiled Source`. See [Bare `-S` Info view](info-view.md) for the bullseye question each preset is meant to answer.
 
 For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (lowered C#), `IL`, and `IL (Annotated)`. `Original Source` is SourceLink-backed source text for one method, so it is enabled by detailed verbosity or explicit `-S`.
 
@@ -53,7 +53,8 @@ For selected overloads, the default high-value section is `Signature`. Normal ve
 
 ```bash
 dotnet-inspect member JsonSerializer --package System.Text.Json -D
-dotnet-inspect member JsonSerializer --package System.Text.Json -D Methods
+dotnet-inspect member JsonSerializer --package System.Text.Json -D "Method Groups"
+dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize -D Methods
 ```
 
 For target-based queries, `-D` defaults to effective discovery: it resolves the target and reports only sections/columns that can actually render for that target and option set. Use `--schema` for the static, offline schema.
@@ -63,7 +64,7 @@ For target-based queries, `-D` defaults to effective discovery: it resolves the 
 After selecting a section, `--columns` and `--fields` project the data:
 
 ```bash
-dotnet-inspect member JsonSerializer --package System.Text.Json -S Methods --columns "Name;Signature;Obsolete"
+dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature;Obsolete"
 ```
 
 Projection is validated against the selected section schema. Unknown fields/columns produce diagnostics; valid-but-empty fields are reported as no data.

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -41,13 +41,13 @@ Agents should prefer built-in query and limiter options over shell pipes:
 
 ## Efficient API workflows
 
-For public signatures and overload inventories, prefer type shape:
+For compact type overviews and overload counts, prefer type shape:
 
 ```bash
 dotnet-inspect type JsonSerializer --package System.Text.Json@10.0.0 --shape
 ```
 
-Use `member` when you need docs, stable overload selectors, decompiled/lowered C#, SourceLink-backed original source, or IL:
+Use `member -m Name` when you need a specific overload inventory, docs, stable overload selectors, decompiled/lowered C#, SourceLink-backed original source, or IL:
 
 ```bash
 dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize --show-index

--- a/docs/workflows/core/member-lookup-docs-code.md
+++ b/docs/workflows/core/member-lookup-docs-code.md
@@ -53,7 +53,7 @@ dotnet-inspect member --package System.CommandLine Command
 # System.CommandLine.Command
 ## Constructors
 ## Properties
-## Methods
+## Method Groups
 ```
 
 ```expect-not

--- a/docs/workflows/core/section-discovery.md
+++ b/docs/workflows/core/section-discovery.md
@@ -175,7 +175,7 @@ Tips:
 > Goal: `-D` on type/member queries reports the effective queryable schema by default; `--schema` opts back into the static schema.
 
 ```bash
-dotnet-inspect member JsonSerializer --platform System.Text.Json -D Methods
+dotnet-inspect member JsonSerializer --platform System.Text.Json -m Serialize -D Methods
 ```
 
 ```expect
@@ -184,7 +184,7 @@ Signature
 ```
 
 ```bash
-dotnet-inspect member JsonSerializer --platform System.Text.Json -D Methods --schema
+dotnet-inspect member JsonSerializer --platform System.Text.Json -m Serialize -D Methods --schema
 ```
 
 ```expect

--- a/docs/workflows/core/type-queries.md
+++ b/docs/workflows/core/type-queries.md
@@ -470,6 +470,7 @@ Interfaces
 Baseclass
 Constructors
 Properties
+Method Groups
 Methods
 ```
 
@@ -500,7 +501,7 @@ dotnet-inspect type System.Text.Json JsonSerializer -m 'Deseri*'
 
 ```expect
 # System.Text.Json.JsonSerializer
-## Methods
+## Method Groups
 Deserialize
 DeserializeAsync
 ```

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.10.0
+version: 0.10.1
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 
@@ -14,7 +14,7 @@ Invoke with `dnx`:
 dnx dotnet-inspect -y -- <command>
 ```
 
-Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--table` for compact pretty-printed rows, and `--tsv` for normalized tab-separated rows when agents or shell tools need stable field splitting. Use `--json` for structured automation. Verbosity controls document breadth: default views stay compact, bare `-S` gives a curated high-density view, and `-v:n`/`-v:d` expand fuller section detail such as overload signatures and docs. For selected overload implementation bodies, use `-S "Decompiled Source"`, `-S "Original Source"`, `-S IL`, or `-S "IL (Annotated)"`. Markdown and JSON can represent multi-section documents. Table and TSV are single-table formats; when a query matches multiple sections, select one with `-S` or use Markdown/JSON.
+Default output is Markdown. Use Markdown for readable evidence with headings, section boundaries, table headers, and code fences that are easy to quote. Use `--table` for compact pretty-printed rows, and `--tsv` for normalized tab-separated rows when agents or shell tools need stable field splitting. Use `--json` for structured automation. Verbosity controls document breadth: default type views stay compact with `Method Groups`, narrowed member-name views show overload rows, bare `-S` gives a curated high-density view, and `-v:n`/`-v:d` expand fuller section detail such as docs. For selected overload implementation bodies, use `-S "Decompiled Source"`, `-S "Original Source"`, `-S IL`, or `-S "IL (Annotated)"`. Markdown and JSON can represent multi-section documents. Table and TSV are single-table formats; when a query matches multiple sections, select one with `-S` or use Markdown/JSON.
 
 Format promises:
 
@@ -66,7 +66,7 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json
 
 Carry resolved context forward. Bare names use the router: platform-looking names are tried as installed platform libraries first, then fall back to NuGet packages if platform resolution fails. Use explicit `--platform`, `--package`, or `--library` when the source matters; for multi-library packages, include the `--library` value shown by `find`.
 
-For full public signature or overload inventories, start with `type Type --package Foo --shape`; it gives the clean declaration shape with parameter names, nullable annotations, defaults, and generic parameters. Use `member Type --package Foo -m Name --show-index` when you need docs or stable `Name:N` overload selectors. A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need that specific implementation evidence.
+Use `type Type --package Foo --shape` for a compact type overview and overload counts. For a specific overload inventory, use `member Type --package Foo -m Name --show-index`; this renders the `Methods` overload rows with full signatures and stable `Name:N` selectors. A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need that specific implementation evidence.
 
 ## Upgrade and compatibility workflow
 
@@ -123,13 +123,14 @@ Discover sections, then select or project fields. Use `--tsv` for discovery when
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D --tsv
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D Methods --tsv
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -S Methods --columns "Name;Signature;Obsolete"
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D "Method Groups" --tsv
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -D Methods --tsv
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature;Obsolete"
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can render for that query. Add `--schema` for the static schema. Bare `-S` renders a curated high-density view (`Package Info`/`Library Files`, `Library Info` with counts, compact type/member summaries, or selected-overload `Signature`/`Decompiled Source`). Minimal/default and bare `-S` views favor summaries, counts, and one row per logical item; use named sections or `-S All` for long lists. `-S`, `--columns`, and `--fields` accept comma-separated or semicolon-separated lists. In section output, `section (opt-in)` means the section never runs from normal verbosity or `-v:d`; select it explicitly with `-S` when needed. Focused library/member `-S Section` output keeps a compact context row before the selected section. `-S All` produces an exhaustive document: default section first, remaining sections alphabetically, no compact context row.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can render for that query. Add `--schema` for the static schema. Bare `-S` renders a curated high-density view (`Package Info`/`Library Files`, `Library Info` with counts, compact type/member summaries, narrowed member-name `Methods`, or selected-overload `Signature`/`Decompiled Source`). Minimal/default type views favor summaries, counts, and one row per logical item under `Method Groups`; narrowed member-name views use `Methods` overload rows. `-S`, `--columns`, and `--fields` accept comma-separated or semicolon-separated lists. In section output, `section (opt-in)` means the section never runs from normal verbosity or `-v:d`; select it explicitly with `-S` when needed. Focused library/member `-S Section` output keeps a compact context row before the selected section. `-S All` produces an exhaustive document: default section first, remaining sections alphabetically, no compact context row.
 
 `-n N` and shorthand values like `-6` normally limit output lines. Add `--rows` to reinterpret that head count as data rows per rendered Markdown table; this preserves headings/table headers and applies independently to each table. `--rows` requires `-n/--head` or numeric shorthand and cannot be combined with `--tail`. Prefer `--rows` over shell `head` when you need parseable Markdown tables.
 

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -467,7 +467,10 @@ public static class ApiSurfaceExtractor
         }
 
         string paramStr2 = string.Join(", ", parameters);
-        return $"{treeSignature.ReturnType.Render()} {name}({paramStr2})";
+        var methodName = context.MethodParameters.Count > 0
+            ? $"{name}<{string.Join(", ", context.MethodParameters)}>"
+            : name;
+        return $"{treeSignature.ReturnType.Render()} {methodName}({paramStr2})";
     }
 
     private static (string? name, bool isParams, bool hasDefault, object? defaultValue) GetParameterInfo(

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -64,6 +64,7 @@ public class ApiSurfaceExtractorTests
         Assert.NotNull(method);
 
         // Should have both the generic type and parameter name
+        Assert.Contains("GenericMethod<T>", method.Signature);
         Assert.Contains("T item", method.Signature);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1771,6 +1771,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task MemberList_ExplicitPackageQualifiedType_DoesNotSplitTrailingTypeName()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Type 'System.Text.Json' not found", error);
+        Assert.Contains("# System.Text.Json.JsonSerializer", output);
+        Assert.Contains("## Method Groups", output);
+    }
+
+    [Fact]
+    public async Task Member_FilteredGenericMethod_RendersMethodTypeParameters()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json",
+            "-m", "Serialize", "--rows", "-n", "10", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Serialize<TValue>(TValue value", output);
+    }
+
+    [Fact]
     public async Task Package_SelectAll_IncludesOptInSignals()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -397,7 +397,7 @@ public class CommandExecutionTests
             () => TypeCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        Assert.Contains("| Methods | section |", output);
+        Assert.Contains("| Method Groups | section |", output);
         // JsonSerializer has no custom attributes, so effective-by-default must drop it.
         Assert.DoesNotContain("| Custom Attributes | section |", output);
     }
@@ -437,7 +437,7 @@ public class CommandExecutionTests
             () => TypeCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        Assert.Contains("| Methods | section |", output);
+        Assert.Contains("| Method Groups | section |", output);
         Assert.DoesNotContain("| Fields | section |", output);
     }
 
@@ -456,7 +456,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("| Properties | section |", output);
-        Assert.Contains("| Methods | section |", output);
+        Assert.Contains("| Method Groups | section |", output);
         // Code sections (Decompiled Source, Original Source, IL, IL (Annotated)) are member-detail
         // sections not present in the type schema. They must not appear in effective
         // discovery, since they are not queryable via -D <Section>.
@@ -480,7 +480,7 @@ public class CommandExecutionTests
             () => TypeCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        Assert.Contains("| Methods | section |", output);
+        Assert.Contains("| Method Groups | section |", output);
         // Custom Attributes is in the type schema, but its CanRender probe is a coarse
         // "type has methods" proxy; the section only has data when a specific member's
         // attributes are read. JsonSerializer has none, so effective discovery must not list it.
@@ -644,10 +644,120 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Properties", output);
-        Assert.Contains("## Methods", output);
+        Assert.Contains("## Method Groups", output);
         Assert.Contains("| Name | Return Type | Overloads |", output);
         Assert.Contains("| SerializeToNode | System.Text.Json.Nodes.JsonNode? | 5 |", output);
         Assert.DoesNotContain("| Name | Signature | Description |", output);
+    }
+
+    [Fact]
+    public async Task Member_FilteredDefault_RendersOverloadRows()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToNode" },
+            ShowSelect = true
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Methods", output);
+        Assert.Contains("| Select | Name | Signature |", output);
+        Assert.Contains("`SerializeToNode:1`", output);
+        Assert.Contains("JsonNode? SerializeToNode(", output);
+        Assert.DoesNotContain("## Method Groups", output);
+        Assert.DoesNotContain("| Name | Return Type | Overloads |", output);
+    }
+
+    [Fact]
+    public async Task Member_SingleOverloadFilter_DefaultStaysOverloadInventory()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializerOptions",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GetConverter" },
+            ShowSelect = true
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Methods", output);
+        Assert.Contains("| Select | Name | Signature |", output);
+        Assert.Contains("`GetConverter`", output);
+        Assert.DoesNotContain("## Signature", output);
+
+        options = options with { Select = ["Methods"] };
+        (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Methods", output);
+        Assert.Contains("| Select | Name | Signature |", output);
+        Assert.DoesNotContain("## Signature", output);
+    }
+
+    [Fact]
+    public async Task Member_SingleOverloadFilter_ParamsStillValidatedWithDetailSection()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializerOptions",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GetConverter" },
+            ParamTypes = ["Bogus"],
+            Select = ["IL"]
+        };
+
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(1, exit);
+        Assert.Contains("No overload of GetConverter matches --params", error);
+    }
+
+    [Fact]
+    public async Task Member_SingleOverloadFilter_MixedInfoAndDetailSelect_RendersDetail()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializerOptions",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GetConverter" },
+            Select = ["Info", "IL"]
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## IL", output);
+        Assert.Contains("IL_0000:", output);
+    }
+
+    [Fact]
+    public async Task Member_SingleOverloadFilter_SelectSignature_RendersSignature()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializerOptions",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GetConverter" },
+            Select = ["Signature"]
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Signature", output);
+        Assert.Contains("GetConverter(System.Type typeToConvert)", output);
     }
 
     [Fact]
@@ -1652,7 +1762,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Properties", output);
-        Assert.Contains("## Methods", output);
+        Assert.Contains("## Method Groups", output);
         Assert.Contains("| Name | Return Type | Overloads |", output);
         Assert.Contains("| SerializeToNode | System.Text.Json.Nodes.JsonNode? | 5 |", output);
         Assert.DoesNotContain("| Name | Signature | Description |", output);

--- a/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
+++ b/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
@@ -87,8 +87,8 @@ public class OfflineVerbosityTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.Contains("Deserialize", output);
-        // Oneline tree view lists individual methods (no overload grouping)
-        Assert.Contains("Methods", output);
+        // Minimal type view keeps logical method groups bounded.
+        Assert.Contains("Method Groups", output);
     }
 
     // ── member command ───────────────────────────────────────────────

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -57,6 +57,21 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void GetMemberSignatureSortKey_StripsMethodGenericListOnly()
+    {
+        var member = new ApiMember
+        {
+            Kind = "method",
+            Name = "Task",
+            Signature = "System.Threading.Tasks.Task<T> Task<T>(T value)"
+        };
+
+        Assert.Equal(
+            "System.Threading.Tasks.Task<T> Task(T value)",
+            ApiOutputFormatter.GetMemberSignatureSortKey(member));
+    }
+
+    [Fact]
     public async Task DiscoverOutput_Tsv_RendersHeaderedTsvRows()
     {
         var schema = new DocumentSchema()

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -220,6 +220,16 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task ExplicitPackage_WithQualifiedTypeOnly_PreservesQualifiedType()
+    {
+        var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json");
+
+        Assert.Equal("System.Text.Json.JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PackagePath);
+        Assert.Empty(options.MemberFilter);
+    }
+
+    [Fact]
     public async Task ExplicitPackage_WithMultipleMOptions_SetsAllMembers()
     {
         var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Serialize", "-m", "Deserialize");

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -989,7 +989,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(14, pipeline.AllSectionNames.Length);
+        Assert.Equal(15, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -1013,6 +1013,7 @@ public class SectionPipelineTests
         Assert.Contains("Constructors", names);
         Assert.Contains("Fields", names);
         Assert.Contains("Properties", names);
+        Assert.Contains("Method Groups", names);
         Assert.Contains("Methods", names);
         Assert.Contains("Events", names);
         Assert.Contains("IL", names);
@@ -1106,6 +1107,7 @@ public class SectionPipelineTests
 
         Assert.Contains("Constructors", effective);
         Assert.Contains("Properties", effective);
+        Assert.Contains("Method Groups", effective);
         Assert.Contains("Methods", effective);
         Assert.DoesNotContain("Fields", effective);
         Assert.DoesNotContain("Events", effective);
@@ -1130,6 +1132,24 @@ public class SectionPipelineTests
 
         // Remote Source section was removed — source info lives in the source command now
         Assert.DoesNotContain("Remote Source", names);
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_InfoPreset_UsesMethodGroups()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+
+        Assert.Contains("Method Groups", pipeline.InfoSectionNames);
+        Assert.DoesNotContain("Methods", pipeline.InfoSectionNames);
+    }
+
+    [Fact]
+    public void ApiMemberOverloadPipeline_InfoPreset_UsesMethods()
+    {
+        var pipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+
+        Assert.Contains("Methods", pipeline.InfoSectionNames);
+        Assert.DoesNotContain("Method Groups", pipeline.InfoSectionNames);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -160,7 +160,11 @@ public static class MemberOptionsParser
         //   → source=System.Text.Json, type=JsonDocument, member=Parse
         // Skip if the right part contains '<' — that's a generic type name (e.g., Generic.List<T>),
         // not a type.member pair.
-        if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0 && optionMembers.Length == 0)
+        if (!sourceInputs.HasExplicitSource
+            && typeName != null
+            && typeName.Contains('.')
+            && positionalMembers.Count == 0
+            && optionMembers.Length == 0)
         {
             var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
             if (splitMemberName != null)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -406,6 +406,9 @@ public class ApiCommand
     {
         if (options.IncludeSections is not { Count: > 0 })
             return;
+        if (SelectResolver.IsActiveInfoSelector(options.Select, options.IncludeSections)
+            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+            return;
 
         var filtered = BuildFilteredTypeForSections(type, options);
         var (empty, _) = pipeline.GetEmptySections(filtered, options.Verbosity, options.IncludeSections);
@@ -718,13 +721,15 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateConstructorOverloads(view, type, options);
             }
-            else if (options.Verbosity == Verbosity.Minimal)
-            {
-                ApiOutputFormatter.PopulateMemberSummarySections(view, type, options);
-            }
             else
             {
-                ApiOutputFormatter.PopulateMemberSections(view, type, options);
+                var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(options);
+                var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(options);
+                if (renderMemberGroups)
+                    ApiOutputFormatter.PopulateMemberSummarySections(
+                        view, type, options, methodGroupsOnly: renderMemberRows);
+                if (renderMemberRows)
+                    ApiOutputFormatter.PopulateMemberSections(view, type, options);
             }
 
             // --index: populate code sections and custom attributes
@@ -890,10 +895,16 @@ public class ApiCommand
         {
             if (renderOptions is MemberOptions { OverloadIndex: not null })
                 ApiOutputFormatter.PopulateMemberSignature(view, type, renderOptions);
-            else if (renderOptions.Verbosity == Verbosity.Minimal)
-                ApiOutputFormatter.PopulateMemberSummarySections(view, type, renderOptions);
             else
-                ApiOutputFormatter.PopulateMemberSections(view, type, renderOptions);
+            {
+                var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(renderOptions);
+                var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(renderOptions);
+                if (renderMemberGroups)
+                    ApiOutputFormatter.PopulateMemberSummarySections(
+                        view, type, renderOptions, methodGroupsOnly: renderMemberRows);
+                if (renderMemberRows)
+                    ApiOutputFormatter.PopulateMemberSections(view, type, renderOptions);
+            }
 
             if (renderOptions is MemberOptions { OverloadIndex: not null, DllPath: not null } memberOptions)
             {
@@ -979,6 +990,7 @@ public class ApiCommand
             [SectionNames.Values] = m => m.Kind == "field" && m.EnumValue.HasValue,
             [SectionNames.Fields] = m => m.Kind == "field" && !m.EnumValue.HasValue,
             [SectionNames.Properties] = m => m.Kind == "property",
+            [SectionNames.MethodGroups] = m => m.Kind == "method",
             [SectionNames.Methods] = m => m.Kind == "method",
             [SectionNames.Constructors] = m => m.Kind == "constructor",
             [SectionNames.Events] = m => m.Kind == "event",

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -122,9 +122,9 @@ public static class MemberCommand
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
 
-            // Auto-select the overload index when there's exactly one member with one overload.
-            // This lets "member Foo.Bar" show code sections without requiring ":1".
-            if (!effectiveOptions.OverloadIndex.HasValue && effectiveOptions.MemberFilter.Count == 1)
+            // Keep member-name lookups as overload inventories. Only auto-select the lone
+            // overload when the user explicitly asks for a selected-overload detail section.
+            if (!effectiveOptions.OverloadIndex.HasValue && ShouldAutoSelectSingleOverload(effectiveOptions))
             {
                 var autoMemberName = effectiveOptions.MemberFilter.First();
                 var autoOverloads = apiType.Members
@@ -315,6 +315,29 @@ public static class MemberCommand
             }
         }
     }
+
+    private static bool ShouldAutoSelectSingleOverload(MemberOptions options)
+    {
+        if (options.MemberFilter.Count != 1)
+            return false;
+        if (options.ParamTypes != null || options.FirstParamType != null)
+            return false;
+        if (options.IncludeSections is not { Count: > 0 } sections)
+            return false;
+        if (IsPureSelector(options.Select, SelectResolver.InfoSelector)
+            || IsPureSelector(options.Select, SelectResolver.AllSelector))
+            return false;
+
+        return sections.Contains(SectionNames.Signature)
+               || sections.Contains(SectionNames.CustomAttributes)
+               || sections.Contains(SectionNames.DecompiledSource)
+               || sections.Contains(SectionNames.OriginalSource)
+               || sections.Contains(SectionNames.IL)
+               || sections.Contains(SectionNames.ILAnnotated);
+    }
+
+    private static bool IsPureSelector(string[]? select, string name) =>
+        select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);
 
     private static bool NeedsMemberSourceResolution(ApiType apiType, MemberOptions options)
     {

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -149,7 +149,7 @@ public static class MemberCommand
                     .ToList();
                 var displayOverloads = overloads
                     .OrderBy(m => m.Name, StringComparer.Ordinal)
-                    .ThenBy(m => m.Signature ?? "", StringComparer.Ordinal)
+                    .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
                     .ToList();
 
                 int idx = effectiveOptions.OverloadIndex.Value;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -157,6 +157,39 @@ public static class ApiOutputFormatter
         && !options.JsonOutput
         && !options.OneLine;
 
+    internal static bool ShouldRenderMemberGroups(ApiOptions options)
+    {
+        if (ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options))
+            return false;
+
+        if (SectionRequested(options.IncludeSections, SectionNames.MethodGroups)
+            || DiscoveryRequests(options, SectionNames.MethodGroups))
+            return true;
+
+        return options.Verbosity == Verbosity.Minimal
+            && !SectionRequested(options.IncludeSections, SectionNames.Methods)
+            && !DiscoveryRequests(options, SectionNames.Methods);
+    }
+
+    internal static bool ShouldRenderMemberRows(ApiOptions options) =>
+        options.Verbosity != Verbosity.Minimal
+        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
+        || SectionRequested(options.IncludeSections, SectionNames.Methods)
+        || DiscoveryRequests(options, SectionNames.Methods);
+
+    private static bool SectionRequested(HashSet<string>? sections, string name)
+        => sections?.Contains(name) == true;
+
+    private static bool DiscoveryRequests(ApiOptions options, string name)
+        => options.Discover is { Length: > 0 } discover
+           && discover.Any(d => string.Equals(d, name, StringComparison.OrdinalIgnoreCase));
+
+    private static bool ShouldAbbreviateMemberSignatures(ApiOptions options) =>
+        options.Verbosity == Verbosity.Minimal
+        && !ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
+        && !SectionRequested(options.IncludeSections, SectionNames.Methods)
+        && !DiscoveryRequests(options, SectionNames.Methods);
+
     // ===== Shape Output (--shape) =====
 
     public static void WriteShapeOutput(ApiType type, string? foundIn, string? packageName, string? packageVersion, HashSet<string> memberFilter, HashSet<string>? kindFilter = null)
@@ -495,7 +528,7 @@ public static class ApiOutputFormatter
         bool docsRequested = options.ShowDocs
             || options.Columns?.Any(c => c.Equals("Description", StringComparison.OrdinalIgnoreCase)) == true;
         bool hasDocs = docsRequested && allMembers.Any(m => m.Documentation.Summary != null);
-        bool abbreviate = options.Verbosity == Verbosity.Minimal;
+        bool abbreviate = ShouldAbbreviateMemberSignatures(options);
         bool showSelect = options is MemberOptions mo && mo.ShowSelect;
 
         foreach (var group in kindGroups)
@@ -608,9 +641,14 @@ public static class ApiOutputFormatter
     /// Groups members by name within each kind, with kind-specific columns
     /// matching the old QuietMemberFormatter design.
     /// </summary>
-    internal static (int truncated, string noun) PopulateMemberSummarySections(TypeView view, ApiType type, ApiOptions options)
+    internal static (int truncated, string noun) PopulateMemberSummarySections(
+        TypeView view, ApiType type, ApiOptions options, bool methodGroupsOnly = false)
     {
         var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
+        if (methodGroupsOnly)
+            grouped = grouped
+                .Where(kvp => kvp.Key == "method")
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         if (grouped.Count == 0) return (0, "");
 
         // Flatten all unique-name entries across kinds for --limit
@@ -1178,6 +1216,7 @@ public static class ApiOutputFormatter
                 case "Properties":
                     kinds.Add("property");
                     break;
+                case "Method Groups":
                 case "Methods":
                     kinds.Add("method");
                     break;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -386,7 +386,7 @@ public static class ApiOutputFormatter
                     .Select(g =>
                     {
                         var ordered = g
-                            .OrderBy(m => m.Signature ?? "", StringComparer.Ordinal)
+                            .OrderBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
                             .ToList();
                         if (ordered.Count == 1)
                             return new TreeNode(ordered[0].Signature ?? OperatorNames.FormatDisplayName(ordered[0].Name));
@@ -536,7 +536,7 @@ public static class ApiOutputFormatter
             var kind = group.Key;
             var members = group
                 .OrderBy(m => m.Name, StringComparer.Ordinal)
-                .ThenBy(m => m.Signature ?? "", StringComparer.Ordinal)
+                .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
                 .ToList();
 
             // Pre-compute overload counts and indices for --show-index
@@ -1033,6 +1033,46 @@ public static class ApiOutputFormatter
     {
         var displayName = FormatGenericTypeName(type.Name, type.TypeParameters);
         return string.IsNullOrEmpty(type.Namespace) ? displayName : $"{type.Namespace}.{displayName}";
+    }
+
+    internal static string GetMemberSignatureSortKey(ApiMember member)
+    {
+        var signature = member.Signature ?? "";
+        if (signature.Length == 0 || member.Name.Length == 0)
+            return signature;
+
+        var searchStart = 0;
+        while (searchStart < signature.Length)
+        {
+            var nameIndex = signature.IndexOf(member.Name, searchStart, StringComparison.Ordinal);
+            if (nameIndex < 0)
+                return signature;
+
+            var genericStart = nameIndex + member.Name.Length;
+            if (genericStart < signature.Length && signature[genericStart] == '<')
+            {
+                var depth = 0;
+                for (var i = genericStart; i < signature.Length; i++)
+                {
+                    if (signature[i] == '<')
+                        depth++;
+                    else if (signature[i] == '>')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            if (i + 1 < signature.Length && signature[i + 1] == '(')
+                                return signature.Remove(genericStart, i - genericStart + 1);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            searchStart = nameIndex + member.Name.Length;
+        }
+
+        return signature;
     }
 
     private static string PluralizeKind(string kind) => kind switch

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -83,6 +83,7 @@ public static class ApiMemberSectionDescriptors
             .Add<Constructors>()
             .Add<Fields>()
             .Add<Properties>()
+            .Add<MethodGroups>()
             .Add<Methods>()
             .Add<Events>()
             .Add<MethodAttributes>()
@@ -169,7 +170,16 @@ public static class ApiMemberSectionDescriptors
 
     public sealed class Methods : ISectionDescriptor<ApiType>
     {
-        public static string Name => "Methods";
+        public static string Name => SectionNames.Methods;
+        public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind == "method");
+    }
+
+    public sealed class MethodGroups : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.MethodGroups;
         public static bool IsExpensive => false;
         public static bool Info => true;
         public static string? ScannerKey => null;
@@ -245,12 +255,59 @@ public static class ApiMemberSectionPipelines
     public static SectionPipeline<ApiType> Create(ApiOptions options)
         => UsesDetailPipeline(options)
             ? ApiMemberDetailSectionDescriptors.CreatePipeline()
+            : UsesOverloadInventoryPipeline(options)
+                ? ApiMemberOverloadSectionDescriptors.CreatePipeline()
             : ApiMemberSectionDescriptors.CreatePipeline();
 
     public static bool UsesDetailPipeline(ApiOptions options)
         => options is MemberOptions { OverloadIndex: not null }
            || options is MemberOptions { ParamTypes: not null }
            || options is MemberOptions { FirstParamType: not null };
+
+    public static bool UsesOverloadInventoryPipeline(ApiOptions options)
+        => options is MemberOptions
+           {
+               OverloadIndex: null,
+               ParamTypes: null,
+               FirstParamType: null,
+               MemberFilter.Count: > 0
+           };
+}
+
+/// <summary>
+/// Section descriptors for member-name-scoped overload inventories.
+/// </summary>
+public static class ApiMemberOverloadSectionDescriptors
+{
+    public static SectionPipeline<ApiType> CreatePipeline()
+    {
+        return new SectionPipeline<ApiType>()
+            .Add<ApiMemberSectionDescriptors.Values>()
+            .Add<ApiMemberSectionDescriptors.TypeParameters>()
+            .Add<ApiMemberSectionDescriptors.TypeInterfaces>()
+            .Add<ApiMemberSectionDescriptors.Baseclass>()
+            .Add<ApiMemberSectionDescriptors.Constructors>()
+            .Add<ApiMemberSectionDescriptors.Fields>()
+            .Add<ApiMemberSectionDescriptors.Properties>()
+            .Add<ApiMemberDetailSectionDescriptors.Signature>()
+            .Add<Methods>()
+            .Add<ApiMemberSectionDescriptors.Events>()
+            .Add<ApiMemberSectionDescriptors.MethodAttributes>()
+            .Add<ApiMemberSectionDescriptors.DecompiledSource>()
+            .Add<ApiMemberSectionDescriptors.OriginalSource>()
+            .Add<ApiMemberSectionDescriptors.ILBody>()
+            .Add<ApiMemberSectionDescriptors.AnnotatedIL>();
+    }
+
+    public sealed class Methods : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.Methods;
+        public static bool IsExpensive => false;
+        public static bool Info => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind == "method");
+    }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -54,7 +54,10 @@ public static class SectionNames
     /// <summary>Section for properties.</summary>
     public const string Properties = "Properties";
 
-    /// <summary>Section for methods.</summary>
+    /// <summary>Section for logical method-name groups.</summary>
+    public const string MethodGroups = "Method Groups";
+
+    /// <summary>Section for method overload rows.</summary>
     public const string Methods = "Methods";
 
     /// <summary>Section for events.</summary>

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -210,11 +210,11 @@ public class TypeView
     [JsonIgnore]
     public List<PropertySummaryRow>? PropertySummaryRows { get; set; }
 
-    [MarkoutSection(Name = "Methods", IgnoreProperty = nameof(MethodSummaryRow.Overloads))]
+    [MarkoutSection(Name = "Method Groups", IgnoreProperty = nameof(MethodSummaryRow.Overloads))]
     [JsonIgnore]
     public List<MethodSummaryRow>? MethodSummaryRows { get; set; }
 
-    [MarkoutSection(Name = "Methods")]
+    [MarkoutSection(Name = "Method Groups")]
     [JsonIgnore]
     public List<MethodSummaryRow>? MethodSummaryRowsWithOverloads { get; set; }
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.0</VersionPrefix>
+    <VersionPrefix>0.10.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,6 +6,7 @@
 
 - Splits logical method summaries into `Method Groups`, reserving `Methods` for actual method rows and overload signatures.
 - Makes `member Type -m Name` render overload rows by default, with full signatures and optional `--show-index` selectors.
+- Includes method generic parameter lists, such as `Serialize<TValue>(...)`, in rendered signatures.
 
 ## v0.10.0
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.10.1
+
+### Member output
+
+- Splits logical method summaries into `Method Groups`, reserving `Methods` for actual method rows and overload signatures.
+- Makes `member Type -m Name` render overload rows by default, with full signatures and optional `--show-index` selectors.
+
 ## v0.10.0
 
 ### Table and TSV output


### PR DESCRIPTION
## Summary

- split logical method-name summaries into `Method Groups` and reserve `Methods` for actual method/overload rows
- make `member Type -m Name` render overload inventories by default, including single-overload members
- update 0.10.1 version metadata, release notes, skill guidance, docs, and tests

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release`
- `npx markdownlint-cli README.md docs/design/info-view.md docs/design/progressive-disclosure.md docs/llm-design.md docs/workflows/core/member-lookup-docs-code.md docs/workflows/core/section-discovery.md docs/workflows/core/type-queries.md skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md`
