### PR TITLE
Refactor member method section views

### DIFF
--- a/docs/design/member-order.md
+++ b/docs/design/member-order.md
@@ -1,0 +1,65 @@
+# Member ordering
+
+`dotnet-inspect` should order type/member sections like Microsoft Learn API
+reference pages. This makes the output familiar to .NET developers and keeps
+agent workflows aligned with the canonical documentation shape.
+
+Representative Learn pages checked while recording this design:
+
+- [System.String](https://learn.microsoft.com/dotnet/api/system.string)
+- [System.DateTime](https://learn.microsoft.com/dotnet/api/system.datetime)
+- [System.Linq.Enumerable](https://learn.microsoft.com/dotnet/api/system.linq.enumerable)
+
+Not every type has every member kind, so the complete order has to be inferred
+across several APIs. `System.String` is the best single regression target for
+this ordering because it exercises many uncommon sections on one page, including
+operators, explicit interface implementations, and extension methods.
+
+## Canonical member-kind order
+
+1. Constructors
+2. Fields
+3. Properties
+4. Methods
+5. Operators
+6. Explicit Interface Implementations
+7. Extension Methods
+8. Events
+
+Only render sections that have data for the selected type and query. Do not add
+empty headings just to preserve positions.
+
+## dotnet-inspect mapping
+
+`Method Groups` is dotnet-inspect's compact summary variant of Learn's
+`Methods` section. It occupies the Methods slot in default/broad views. When a
+diagnostic or exhaustive view includes both `Method Groups` and `Methods`,
+render `Method Groups` immediately before `Methods` because it is a progressive
+disclosure summary of the same member family.
+
+The effective order is therefore:
+
+1. Constructors
+2. Fields
+3. Properties
+4. Method Groups
+5. Methods
+6. Operators
+7. Explicit Interface Implementations
+8. Extension Methods
+9. Events
+
+## Known gaps
+
+Operators are currently represented through method metadata and should become a
+first-class section when the type/member views can classify them separately.
+
+Explicit interface implementations are not currently modeled as their own
+section. They should be separated from ordinary methods/properties/events when
+the extractor has enough information to identify and render them clearly.
+
+Extension methods already have a relationship command and library-level
+sections. Type/member views should also expose extension methods defined in the
+inspected binary when they extend the inspected type. Broader reachable
+extension-method discovery should stay in the `extensions` command to avoid
+surprising scope expansion and extra work in default type/member views.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,5 +31,6 @@ Agents working in this repo should preserve these principles:
 - [Rendering model](design/rendering-model.md): output mode and verbosity design.
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S All`, and limiter behavior.
 - [Section model](design/section-model.md): section selection and query behavior.
+- [Member ordering](design/member-order.md): canonical type/member section order and known member-kind gaps.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1043,6 +1043,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectMethodsAndEvents_PreservesPipelineOrder()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "AppDomain", "--platform", "System.Private.CoreLib",
+            "-S", "Methods,Events", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.True(
+            output.IndexOf("## Methods", StringComparison.Ordinal)
+            < output.IndexOf("## Events", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Member_EnumValueFilter_TsvAppliesMemberFilter()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Models;
 using DotnetInspector.Views;
 using DotnetInspector;
+using DotnetInspector.Commands;
 using DotnetInspector.Metadata;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
@@ -69,6 +70,26 @@ public class OutputFormatterTests
         Assert.Equal(
             "System.Threading.Tasks.Task<T> Task(T value)",
             ApiOutputFormatter.GetMemberSignatureSortKey(member));
+    }
+
+    [Fact]
+    public void TypeViewSchema_DoesNotOwnFirstClassMemberRows()
+    {
+        var schema = ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema();
+
+        Assert.Null(schema.GetSection("Method Groups"));
+        Assert.Null(schema.GetSection("Methods"));
+        Assert.Null(schema.GetSection("Events"));
+    }
+
+    [Fact]
+    public void TypeDocumentSchema_MergesFirstClassMemberViews()
+    {
+        var schema = ApiCommand.GetTypeDocumentSchema(new MemberOptions());
+
+        Assert.NotNull(schema.GetSection("Method Groups"));
+        Assert.NotNull(schema.GetSection("Methods"));
+        Assert.NotNull(schema.GetSection("Events"));
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -217,7 +217,7 @@ public static class ApiCommandDefinitions
             switch (result)
             {
                 case MemberOptionsParser.Discovery d:
-                    var memberSchemaMap = ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema();
+                    var memberSchemaMap = ApiCommand.GetTypeDocumentSchema(new MemberOptions());
                     var memberFormat = opts.ResolveFormat(parseResult, OutputFormat.Table);
                     return DiscoverOutput.Execute(d.Discover, memberSchemaMap, tree: d.Tree,
                         json: memberFormat == OutputFormat.Json,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -468,7 +468,11 @@ public class ApiCommand
 
     internal static DocumentSchema GetTypeDocumentSchema(ApiOptions options)
     {
-        var schema = ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema();
+        var schema = MergeSchemas(
+            ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<EventsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<MethodGroupsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<MethodsView>()!.ToDocumentSchema());
         if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
             return schema;
 
@@ -702,12 +706,14 @@ public class ApiCommand
         }
 
         var view = ApiOutputFormatter.BuildTypeView(type, foundIn, packageName, packageVersion, apiSource, selectedTfm, options);
+        EventsView? eventsView = null;
+        MethodGroupsView? methodGroupsView = null;
+        MethodsView? methodsView = null;
 
         // Populate enum values declaratively (pipeline controls visibility via IncludeSections)
         if (type.Kind == "enum")
             ApiOutputFormatter.PopulateEnumValues(view, type, options);
 
-        bool isMember = options is MemberOptions;
         bool fullSerializer = options.Verbosity != Verbosity.Quiet;
 
         if (fullSerializer && view.EnumValues == null && view.EnumValuesWithDocs == null)
@@ -726,10 +732,18 @@ public class ApiCommand
                 var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(options);
                 var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(options);
                 if (renderMemberGroups)
+                {
+                    methodGroupsView ??= new MethodGroupsView();
+                    eventsView ??= new EventsView();
                     ApiOutputFormatter.PopulateMemberSummarySections(
-                        view, type, options, methodGroupsOnly: renderMemberRows);
+                        view, methodGroupsView, eventsView, type, options, methodGroupsOnly: renderMemberRows);
+                }
                 if (renderMemberRows)
-                    ApiOutputFormatter.PopulateMemberSections(view, type, options);
+                {
+                    methodsView ??= new MethodsView();
+                    eventsView ??= new EventsView();
+                    ApiOutputFormatter.PopulateMemberSections(view, methodsView, eventsView, type, options);
+                }
             }
 
             // --index: populate code sections and custom attributes
@@ -758,11 +772,7 @@ public class ApiCommand
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
             var sw = new StringWriter();
             var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
-            ApiViewContext.Default.Serialize(view, writer);
-
-            if (view.MemberCode != null)
-                ApiViewContext.Default.Serialize(view.MemberCode, writer);
-
+            ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
             writer.Flush();
             CountOutput.WriteCountFromMarkdown(MarkdownTableRowLimiter.Apply(sw.ToString(), options.Rows));
         }
@@ -773,7 +783,12 @@ public class ApiCommand
                 var writerOpts = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
                 OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv);
                 OutputFormatter.WriteTable(options.Tsv, sink, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, ApiViewContext.Default, writerOpts));
+                    (writer, formatter) =>
+                    {
+                        var markoutWriter = new MarkoutWriter(writer, formatter, writerOpts);
+                        ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, markoutWriter);
+                        markoutWriter.Flush();
+                    });
             }
             else
             {
@@ -793,22 +808,14 @@ public class ApiCommand
             if (options.PlainText)
             {
                 var writer = new Markout.MarkoutWriter(sink, options.CreateFormatter(), writerOptions);
-                ApiViewContext.Default.Serialize(view, writer);
-
-                if (view.MemberCode != null)
-                    ApiViewContext.Default.Serialize(view.MemberCode, writer);
-
+                ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
                 writer.Flush();
             }
             else
             {
                 var sw = new StringWriter();
                 var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
-                ApiViewContext.Default.Serialize(view, writer);
-
-                if (view.MemberCode != null)
-                    ApiViewContext.Default.Serialize(view.MemberCode, writer);
-
+                ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
                 writer.Flush();
                 var markdown = sw.ToString().TrimEnd();
                 if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
@@ -896,11 +903,13 @@ public class ApiCommand
         };
 
         var view = ApiOutputFormatter.BuildTypeView(type, null, null, null, null, null, renderOptions);
+        EventsView? eventsView = null;
+        MethodGroupsView? methodGroupsView = null;
+        MethodsView? methodsView = null;
 
         if (type.Kind == "enum")
             ApiOutputFormatter.PopulateEnumValues(view, type, renderOptions);
 
-        bool isMember = renderOptions is MemberOptions;
         if (view.EnumValues == null && view.EnumValuesWithDocs == null)
         {
             if (renderOptions is MemberOptions { OverloadIndex: not null })
@@ -910,10 +919,18 @@ public class ApiCommand
                 var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(renderOptions);
                 var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(renderOptions);
                 if (renderMemberGroups)
+                {
+                    methodGroupsView ??= new MethodGroupsView();
+                    eventsView ??= new EventsView();
                     ApiOutputFormatter.PopulateMemberSummarySections(
-                        view, type, renderOptions, methodGroupsOnly: renderMemberRows);
+                        view, methodGroupsView, eventsView, type, renderOptions, methodGroupsOnly: renderMemberRows);
+                }
                 if (renderMemberRows)
-                    ApiOutputFormatter.PopulateMemberSections(view, type, renderOptions);
+                {
+                    methodsView ??= new MethodsView();
+                    eventsView ??= new EventsView();
+                    ApiOutputFormatter.PopulateMemberSections(view, methodsView, eventsView, type, renderOptions);
+                }
             }
 
             if (renderOptions is MemberOptions { OverloadIndex: not null, DllPath: not null } memberOptions)
@@ -938,9 +955,7 @@ public class ApiCommand
         var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, renderOptions);
         var sw = new StringWriter();
         var writer = new MarkoutWriter(sw, new Markout.MarkdownFormatter(), writerOptions);
-        ApiViewContext.Default.Serialize(view, writer);
-        if (view.MemberCode != null)
-            ApiViewContext.Default.Serialize(view.MemberCode, writer);
+        ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
         writer.Flush();
         return sw.ToString();
     }

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -218,7 +218,7 @@ public static class TypeCommand
                     // (catches typos) when a specific section is selected, mirroring the package path.
                     if (tabularProjection && effectiveOptions.IncludeSections is { Count: > 0 })
                     {
-                        var projSchema = ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema();
+                        var projSchema = ApiCommand.GetTypeDocumentSchema(effectiveOptions);
                         if (!ProjectionDiagnostics.ValidateProjection(projSchema, effectiveOptions.IncludeSections, effectiveOptions.Fields, effectiveOptions.Columns))
                             return 1;
                     }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -188,6 +188,25 @@ public static class ApiOutputFormatter
         return grouped.Count == 1;
     }
 
+    internal static void SerializeTypeDocument(
+        TypeView view,
+        EventsView? eventsView,
+        MethodGroupsView? methodGroupsView,
+        MethodsView? methodsView,
+        MemberCodeView? memberCodeView,
+        MarkoutWriter writer)
+    {
+        ApiViewContext.Default.Serialize(view, writer);
+        if (methodGroupsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(methodGroupsView, writer);
+        if (methodsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(methodsView, writer);
+        if (eventsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(eventsView, writer);
+        if (memberCodeView != null)
+            ApiViewContext.Default.Serialize(memberCodeView, writer);
+    }
+
     private static bool SectionRequested(HashSet<string>? sections, string name)
         => sections?.Contains(name) == true;
 
@@ -519,7 +538,8 @@ public static class ApiOutputFormatter
             view.EnumValues = rows;
     }
 
-    internal static (int truncated, string noun) PopulateMemberSections(TypeView view, ApiType type, ApiOptions options)
+    internal static (int truncated, string noun) PopulateMemberSections(
+        TypeView view, MethodsView methodsView, EventsView eventsView, ApiType type, ApiOptions options)
     {
         var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
         if (grouped.Count == 0) return (0, "");
@@ -613,15 +633,15 @@ public static class ApiOutputFormatter
                     break;
                 case "method":
                     if (showSelect)
-                    { if (hasDocs) view.MethodSelectRowsWithDocs = rows; else view.MethodSelectRows = rows; }
+                    { if (hasDocs) methodsView.SelectRowsWithDocs = rows; else methodsView.SelectRows = rows; }
                     else
-                    { if (hasDocs) view.MethodRowsWithDocs = rows; else view.MethodRows = rows; }
+                    { if (hasDocs) methodsView.RowsWithDocs = rows; else methodsView.Rows = rows; }
                     break;
                 case "event":
                     if (showSelect)
-                    { if (hasDocs) view.EventSelectRowsWithDocs = rows; else view.EventSelectRows = rows; }
+                    { if (hasDocs) eventsView.SelectRowsWithDocs = rows; else eventsView.SelectRows = rows; }
                     else
-                    { if (hasDocs) view.EventRowsWithDocs = rows; else view.EventRows = rows; }
+                    { if (hasDocs) eventsView.RowsWithDocs = rows; else eventsView.Rows = rows; }
                     break;
             }
         }
@@ -661,7 +681,8 @@ public static class ApiOutputFormatter
     /// matching the old QuietMemberFormatter design.
     /// </summary>
     internal static (int truncated, string noun) PopulateMemberSummarySections(
-        TypeView view, ApiType type, ApiOptions options, bool methodGroupsOnly = false)
+        TypeView view, MethodGroupsView methodGroupsView, EventsView eventsView,
+        ApiType type, ApiOptions options, bool methodGroupsOnly = false)
     {
         var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
         if (methodGroupsOnly)
@@ -717,9 +738,9 @@ public static class ApiOutputFormatter
                             SignatureParser.ExtractReturnType(e.members[0].Signature),
                             e.members.Count.ToString())).ToList();
                     if (hasOverloads)
-                        view.MethodSummaryRowsWithOverloads = rows;
+                        methodGroupsView.RowsWithOverloads = rows;
                     else
-                        view.MethodSummaryRows = rows;
+                        methodGroupsView.Rows = rows;
                     break;
                 }
                 case "property":
@@ -749,7 +770,7 @@ public static class ApiOutputFormatter
                         var m = e.members[0];
                         return new EventSummaryRow(m.Name, m.ReturnType ?? m.Signature ?? "");
                     }).ToList();
-                    view.EventSummaryRows = rows;
+                    eventsView.SummaryRows = rows;
                     break;
                 }
             }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -118,24 +118,6 @@ public class TypeView
     [JsonIgnore]
     public List<MemberRow>? PropertyRowsWithDocs { get; set; }
 
-    [MarkoutSection(Name = "Methods", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? MethodRows { get; set; }
-    [MarkoutSection(Name = "Methods", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? MethodRowsWithDocs { get; set; }
-
-    [MarkoutSection(Name = "Events", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? EventRows { get; set; }
-    [MarkoutSection(Name = "Events", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? EventRowsWithDocs { get; set; }
-
     // With --show-index: show Select column
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Description")]
     [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
@@ -163,24 +145,6 @@ public class TypeView
     [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertySelectRowsWithDocs { get; set; }
-
-    [MarkoutSection(Name = "Methods", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? MethodSelectRows { get; set; }
-    [MarkoutSection(Name = "Methods")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? MethodSelectRowsWithDocs { get; set; }
-
-    [MarkoutSection(Name = "Events", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? EventSelectRows { get; set; }
-    [MarkoutSection(Name = "Events")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
-    [JsonIgnore]
-    public List<MemberRow>? EventSelectRowsWithDocs { get; set; }
 
     public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
         => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
@@ -210,18 +174,6 @@ public class TypeView
     [JsonIgnore]
     public List<PropertySummaryRow>? PropertySummaryRows { get; set; }
 
-    [MarkoutSection(Name = "Method Groups", IgnoreProperty = nameof(MethodSummaryRow.Overloads))]
-    [JsonIgnore]
-    public List<MethodSummaryRow>? MethodSummaryRows { get; set; }
-
-    [MarkoutSection(Name = "Method Groups")]
-    [JsonIgnore]
-    public List<MethodSummaryRow>? MethodSummaryRowsWithOverloads { get; set; }
-
-    [MarkoutSection(Name = "Events")]
-    [JsonIgnore]
-    public List<EventSummaryRow>? EventSummaryRows { get; set; }
-
     // Index mode sections (--index path)
     [MarkoutSection(Name = "Signature")]
     [MarkoutIgnoreColumnWhen(nameof(SignatureObsoleteIsAllNull), "Obsolete")]
@@ -237,6 +189,83 @@ public class TypeView
     [JsonIgnore]
     public MemberCodeView? MemberCode { get; set; }
 
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class EventsView
+{
+    [MarkoutSection(Name = "Events", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Events", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? RowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Events", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRows { get; set; }
+
+    [MarkoutSection(Name = "Events")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Events")]
+    public List<EventSummaryRow>? SummaryRows { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
+
+    [MarkoutIgnore]
+    public bool HasRows =>
+        Rows is { Count: > 0 }
+        || RowsWithDocs is { Count: > 0 }
+        || SelectRows is { Count: > 0 }
+        || SelectRowsWithDocs is { Count: > 0 }
+        || SummaryRows is { Count: > 0 };
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class MethodGroupsView
+{
+    [MarkoutSection(Name = "Method Groups", IgnoreProperty = nameof(MethodSummaryRow.Overloads))]
+    public List<MethodSummaryRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Method Groups")]
+    public List<MethodSummaryRow>? RowsWithOverloads { get; set; }
+
+    [MarkoutIgnore]
+    public bool HasRows => Rows is { Count: > 0 } || RowsWithOverloads is { Count: > 0 };
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class MethodsView
+{
+    [MarkoutSection(Name = "Methods", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Methods", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? RowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Methods", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRows { get; set; }
+
+    [MarkoutSection(Name = "Methods")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRowsWithDocs { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
+
+    [MarkoutIgnore]
+    public bool HasRows =>
+        Rows is { Count: > 0 }
+        || RowsWithDocs is { Count: > 0 }
+        || SelectRows is { Count: > 0 }
+        || SelectRowsWithDocs is { Count: > 0 };
 }
 
 [MarkoutSerializable]
@@ -481,6 +510,9 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(CliApiSurface))]
 [MarkoutContext(typeof(TypeView))]
+[MarkoutContext(typeof(EventsView))]
+[MarkoutContext(typeof(MethodGroupsView))]
+[MarkoutContext(typeof(MethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]


### PR DESCRIPTION
## Summary

- moves `Method Groups`, `Methods`, and `Events` rows out of `TypeView` into first-class section views
- composes type output from the type identity view plus member section views, preserving pipeline order (`Method Groups`/`Methods` before `Events`)
- merges the first-class member view schemas for discovery/projection so `-D` and selected-section output keep the same shape
- adds architecture and ordering regression tests

Closes #365.

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release`
- `git --no-pager diff --check`
