### PR TITLE
Add special member kind sections to type views

### DIFF
--- a/docs/design/member-order.md
+++ b/docs/design/member-order.md
@@ -49,17 +49,19 @@ The effective order is therefore:
 8. Extension Methods
 9. Events
 
-## Known gaps
+## Implementation notes
 
-Operators are currently represented through method metadata and should become a
-first-class section when the type/member views can classify them separately.
+Operators are represented in metadata as special methods with `op_` names.
+Type/member views classify them into a first-class `Operators` section so they
+do not inflate ordinary method groups.
 
-Explicit interface implementations are not currently modeled as their own
-section. They should be separated from ordinary methods/properties/events when
-the extractor has enough information to identify and render them clearly.
+Explicit interface implementations are often private method definitions, but
+they are part of the public interface contract. Type/member views include them
+without requiring `--all` and render them in `Explicit Interface
+Implementations`.
 
 Extension methods already have a relationship command and library-level
-sections. Type/member views should also expose extension methods defined in the
-inspected binary when they extend the inspected type. Broader reachable
-extension-method discovery should stay in the `extensions` command to avoid
-surprising scope expansion and extra work in default type/member views.
+sections. Type/member views expose extension methods defined in the inspected
+binary when they extend the inspected type. Broader reachable extension-method
+discovery stays in the `extensions` command to avoid surprising scope expansion
+and extra work in default type/member views.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,6 +31,6 @@ Agents working in this repo should preserve these principles:
 - [Rendering model](design/rendering-model.md): output mode and verbosity design.
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S All`, and limiter behavior.
 - [Section model](design/section-model.md): section selection and query behavior.
-- [Member ordering](design/member-order.md): canonical type/member section order and known member-kind gaps.
+- [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -235,7 +235,7 @@ public class ApiType
 public class ApiMember
 {
     public string Name { get; set; } = "";
-    public string Kind { get; set; } = "";  // method, property, field, event, constructor
+    public string Kind { get; set; } = "";  // method, property, field, event, constructor, operator, explicit-interface-implementation, extension-method
 
     public string? ReturnType { get; set; }
     public string? Signature { get; set; }
@@ -272,6 +272,17 @@ public class ApiMember
     /// Only populated when IsExtension is true.
     /// </summary>
     public string? ExtendedType { get; set; }
+
+    /// <summary>
+    /// The type that declares this member when it is shown on another type, such as a local
+    /// extension method projected onto its extended type.
+    /// </summary>
+    public string? DeclaringType { get; set; }
+
+    /// <summary>
+    /// 1-based overload index in <see cref="DeclaringType"/> for projected members.
+    /// </summary>
+    public int? DeclaringOverloadIndex { get; set; }
 
     // Enum value (for enum fields only)
     public long? EnumValue { get; set; }

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -143,12 +143,15 @@ public static class ApiSurfaceExtractor
             {
             apiType.Members = [];
 
+            var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
+
             // Methods
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-                if (methodAccess != MethodAttributes.Public && !includeAll)
+                var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
+                if (methodAccess != MethodAttributes.Public && !includeAll && !isExplicitInterfaceImplementation)
                     continue;
 
                 string methodName = reader.GetString(method.Name);
@@ -163,22 +166,31 @@ public static class ApiSurfaceExtractor
                     continue;
 
                 // Skip EditorBrowsable(Never) methods unless --all; obsolete are surfaced with marker.
-                if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
+                if (!includeAll
+                    && !isExplicitInterfaceImplementation
+                    && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
                     continue;
 
                 var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, method.GetCustomAttributes(), out var obsoleteMessage);
 
                 var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
+                var isOperator = IsOperatorMethodName(methodName);
                 var member = new ApiMember
                 {
                     Name = methodName,
-                    Kind = methodName == ".ctor" ? "constructor" : "method",
+                    Kind = methodName switch
+                    {
+                        ".ctor" => "constructor",
+                        _ when isOperator => "operator",
+                        _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
+                        _ => "method"
+                    },
                     IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
                     IsVirtual = (method.Attributes & MethodAttributes.Virtual) != 0,
                     IsAbstract = (method.Attributes & MethodAttributes.Abstract) != 0,
                     Signature = signature,
                     IsUnsafe = HasUnsafeSignature(signature),
-                    Accessibility = GetAccessibility(methodAccess),
+                    Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage
                 };
@@ -188,6 +200,7 @@ public static class ApiSurfaceExtractor
                 {
                     member.IsExtension = true;
                     member.ExtendedType = GetFirstParameterType(reader, typeDef, method);
+                    member.DeclaringType = apiType.FullName;
                 }
 
                 apiType.Members.Add(member);
@@ -348,6 +361,8 @@ public static class ApiSurfaceExtractor
             surface.PublicTypeCount++;
         }
 
+        AttachLocalExtensionMethods(surface);
+
         // Extract type forwarders (ExportedTypes that are forwarded to other assemblies)
         foreach (var exportedTypeHandle in reader.ExportedTypes)
         {
@@ -375,6 +390,129 @@ public static class ApiSurfaceExtractor
         }
 
         return surface;
+    }
+
+    private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
+        MetadataReader reader, TypeDefinition typeDef)
+    {
+        HashSet<MethodDefinitionHandle> handles = [];
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition)
+                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+        }
+
+        return handles;
+    }
+
+    private static bool IsOperatorMethodName(string methodName) =>
+        methodName.StartsWith("op_", StringComparison.Ordinal);
+
+    private static void AttachLocalExtensionMethods(ApiSurface surface)
+    {
+        var targets = surface.Types
+            .SelectMany(type => GetTypeMatchKeys(type).Select(key => (key, type)))
+            .GroupBy(item => item.key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First().type, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var declaringType in surface.Types)
+        {
+            foreach (var extension in declaringType.Members.Where(member => member.IsExtension))
+            {
+                var key = NormalizeTypeMatchKey(extension.ExtendedType);
+                if (key == null || !targets.TryGetValue(key, out var targetType))
+                    continue;
+                if (ReferenceEquals(targetType, declaringType))
+                    continue;
+                if (targetType.Members.Any(member =>
+                    member.Kind == "extension-method"
+                    && string.Equals(member.DeclaringType, declaringType.FullName, StringComparison.Ordinal)
+                    && string.Equals(member.Name, extension.Name, StringComparison.Ordinal)
+                    && string.Equals(member.Signature, extension.Signature, StringComparison.Ordinal)))
+                    continue;
+
+                var declaringOverloadIndex = declaringType.Members
+                    .Where(member => string.Equals(member.Name, extension.Name, StringComparison.Ordinal))
+                    .ToList()
+                    .IndexOf(extension) + 1;
+
+                targetType.Members.Add(new ApiMember
+                {
+                    Name = extension.Name,
+                    Kind = "extension-method",
+                    ReturnType = extension.ReturnType,
+                    Signature = extension.Signature,
+                    IsStatic = extension.IsStatic,
+                    IsVirtual = extension.IsVirtual,
+                    IsAbstract = extension.IsAbstract,
+                    IsUnsafe = extension.IsUnsafe,
+                    IsExtension = true,
+                    ExtendedType = extension.ExtendedType,
+                    DeclaringType = declaringType.FullName,
+                    DeclaringOverloadIndex = declaringOverloadIndex,
+                    IsObsolete = extension.IsObsolete,
+                    ObsoleteMessage = extension.ObsoleteMessage,
+                    Documentation = extension.Documentation
+                });
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetTypeMatchKeys(ApiType type)
+    {
+        var fullNameKey = NormalizeTypeMatchKey(type.FullName);
+        if (fullNameKey != null)
+            yield return fullNameKey;
+    }
+
+    private static string? NormalizeTypeMatchKey(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return null;
+
+        var value = typeName.Trim();
+        foreach (var prefix in (ReadOnlySpan<string>)["ref ", "in ", "out "])
+        {
+            if (value.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                value = value[prefix.Length..].TrimStart();
+                break;
+            }
+        }
+
+        if (value.EndsWith("?", StringComparison.Ordinal))
+            value = value[..^1];
+
+        value = value switch
+        {
+            "bool" => "System.Boolean",
+            "byte" => "System.Byte",
+            "char" => "System.Char",
+            "decimal" => "System.Decimal",
+            "double" => "System.Double",
+            "float" => "System.Single",
+            "int" => "System.Int32",
+            "long" => "System.Int64",
+            "object" => "System.Object",
+            "sbyte" => "System.SByte",
+            "short" => "System.Int16",
+            "string" => "System.String",
+            "uint" => "System.UInt32",
+            "ulong" => "System.UInt64",
+            "ushort" => "System.UInt16",
+            _ => value
+        };
+
+        var genericIndex = value.IndexOf('<');
+        if (genericIndex > 0)
+            value = value[..genericIndex];
+
+        var arityIndex = value.IndexOf('`');
+        if (arityIndex > 0)
+            value = value[..arityIndex];
+
+        return value;
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2009,6 +2009,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task MemberList_QualifiedPlatformTypeTypo_SuggestsType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializizer", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Type 'JsonSerializizer' not found.", error);
+        Assert.Contains("System.Text.Json.JsonSerializer", error);
+        Assert.DoesNotContain("member requires a type name", error);
+    }
+
+    [Fact]
     public async Task Member_FilteredGenericMethod_RendersMethodTypeParameters()
     {
         var (exit, output, _) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1057,6 +1057,156 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_StringBareSelect_RendersLearnMemberOrder()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib", "-S", "--tips", "q", "--rows", "-n", "3");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        string[] headings =
+        [
+            "## Constructors",
+            "## Fields",
+            "## Properties",
+            "## Method Groups",
+            "## Operators",
+            "## Explicit Interface Implementations",
+            "## Extension Methods"
+        ];
+
+        var previous = -1;
+        foreach (var heading in headings)
+        {
+            var current = output.IndexOf(heading, StringComparison.Ordinal);
+            Assert.True(current > previous, $"{heading} was not after the previous heading.");
+            previous = current;
+        }
+    }
+
+    [Fact]
+    public async Task Member_StringSelectSpecialMemberKinds_RendersRows()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "-S", "Operators,Explicit Interface Implementations,Extension Methods",
+            "--tips", "q", "--rows", "-n", "3");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Operators", output);
+        Assert.Contains("operator ==", output);
+        Assert.Contains("## Explicit Interface Implementations", output);
+        Assert.Contains("System.Collections.IEnumerable.GetEnumerator", output);
+        Assert.Contains("## Extension Methods", output);
+        Assert.Contains("AsMemory", output);
+    }
+
+    [Fact]
+    public async Task Member_StringSupplementalSelectors_RoundTrip()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "-S", "Explicit Interface Implementations", "--show-index", "--tips", "q", "--rows", "-n", "4");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("`explicit:System.IConvertible.ToBoolean`", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "explicit:System.IConvertible.ToBoolean:1", "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("bool System.IConvertible.ToBoolean", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "explicit:System.IConvertible.ToBoolean:1", "-S", "IL", "--tips", "q", "-n", "12");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## IL", output);
+        Assert.Contains("System.Convert::ToBoolean", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "explicit:System.IConvertible.ToBoolean:1", "-S", "Decompiled Source", "--tips", "q", "-n", "12");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("bool System.IConvertible.ToBoolean", output);
+        Assert.DoesNotContain("public bool System.IConvertible.ToBoolean", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "-S", "Extension Methods", "--show-index", "--tips", "q", "--rows", "-n", "4");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("`extension:AsMemory:1`", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "extension:AsMemory:1", "-S", "IL", "--tips", "q", "-n", "12");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## IL", output);
+        Assert.Contains("IL_0000:", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "extension:Normalize:1", "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("string Normalize(string strInput)", output);
+        Assert.DoesNotContain("string Normalize()", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "extension:Normalize", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var doc = JsonDocument.Parse(output);
+        foreach (var member in doc.RootElement.GetProperty("members").EnumerateArray())
+            Assert.Equal("extension-method", member.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public async Task Type_StringShape_RendersLearnMemberOrder()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "String", "--platform", "System.Private.CoreLib", "--shape");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        string[] headings =
+        [
+            "Constructors",
+            "Fields",
+            "Properties",
+            "Methods",
+            "Operators",
+            "Explicit Interface Implementations",
+            "Extension Methods"
+        ];
+
+        var previous = -1;
+        foreach (var heading in headings)
+        {
+            var current = output.IndexOf($"─ {heading}", StringComparison.Ordinal);
+            Assert.True(current > previous, $"{heading} was not after the previous heading.");
+            previous = current;
+        }
+    }
+
+    [Fact]
     public async Task Member_EnumValueFilter_TsvAppliesMemberFilter()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -79,6 +79,9 @@ public class OutputFormatterTests
 
         Assert.Null(schema.GetSection("Method Groups"));
         Assert.Null(schema.GetSection("Methods"));
+        Assert.Null(schema.GetSection("Operators"));
+        Assert.Null(schema.GetSection("Explicit Interface Implementations"));
+        Assert.Null(schema.GetSection("Extension Methods"));
         Assert.Null(schema.GetSection("Events"));
     }
 
@@ -89,6 +92,9 @@ public class OutputFormatterTests
 
         Assert.NotNull(schema.GetSection("Method Groups"));
         Assert.NotNull(schema.GetSection("Methods"));
+        Assert.NotNull(schema.GetSection("Operators"));
+        Assert.NotNull(schema.GetSection("Explicit Interface Implementations"));
+        Assert.NotNull(schema.GetSection("Extension Methods"));
         Assert.NotNull(schema.GetSection("Events"));
     }
 

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -293,6 +293,17 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task Positional_PackageType_WithPlatformPrefix_DoesNotUseTypoFallback()
+    {
+        var options = await ParseSuccessAsync("member", "System.CommandLine", "Command");
+
+        Assert.Equal("Command", options.TypeName);
+        Assert.Equal("System.CommandLine", options.PackagePath);
+        Assert.Null(options.PlatformAssembly);
+        Assert.Empty(options.MemberFilter);
+    }
+
+    [Fact]
     public async Task Positional_QualifiedTypeMember_ResolvesPlatformTypeAndMember()
     {
         var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializer.SerializeToNode");
@@ -312,6 +323,17 @@ public class MemberOptionsParserTests
         Assert.Equal("System.Text.Json", options.PlatformAssembly);
         Assert.Contains("SerializeToNode", options.MemberFilter);
         Assert.Equal(1, options.OverloadIndex);
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedPlatformTypeTypo_PreservesTypeForSuggestions()
+    {
+        var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializizer");
+
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Equal("JsonSerializizer", options.TypeName);
+        Assert.Null(options.PackagePath);
+        Assert.Empty(options.MemberFilter);
     }
 
     // ── Dotted member syntax (-m Type.Member) ────────────────────────────

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -347,6 +347,18 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task KindQualifiedOverloadShorthand_SetsKindFilterAndIndex()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "String", "--platform", "System.Private.CoreLib",
+            "explicit:System.IConvertible.ToBoolean:1");
+
+        Assert.Contains("System.IConvertible.ToBoolean", options.MemberFilter);
+        Assert.Contains("explicit-interface-implementation", options.KindFilter);
+        Assert.Equal(1, options.OverloadIndex);
+    }
+
+    [Fact]
     public async Task IndexOption_SetsOverloadIndex()
     {
         var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Deserialize", "--index", "1");

--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -266,34 +266,49 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsDottedSyntax()
     {
         var members = new[] { "JsonSerializer.Deserialize", "GetValue" };
-        var (typeFilter, overloadIndex) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Equal("GetValue", members[1]);
         Assert.Null(overloadIndex);
+        Assert.Empty(kindFilter);
     }
 
     [Fact]
     public void ProcessMemberArguments_ExtractsOverloadShorthand()
     {
         var members = new[] { "GetValue:2" };
-        var (typeFilter, overloadIndex) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("GetValue", members[0]);
         Assert.Equal(2, overloadIndex);
+        Assert.Empty(kindFilter);
     }
 
     [Fact]
     public void ProcessMemberArguments_ExtractsBoth()
     {
         var members = new[] { "JsonSerializer.Deserialize:1" };
-        var (typeFilter, overloadIndex) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Equal(1, overloadIndex);
+        Assert.Empty(kindFilter);
+    }
+
+    [Fact]
+    public void ProcessMemberArguments_ExtractsKindQualifiedSelector()
+    {
+        var members = new[] { "explicit:System.IConvertible.ToBoolean:1" };
+        var (typeFilter, overloadIndex, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+
+        Assert.Null(typeFilter);
+        Assert.Equal("System.IConvertible.ToBoolean", members[0]);
+        Assert.Equal(1, overloadIndex);
+        Assert.Contains("explicit-interface-implementation", kindFilter);
     }
 
     // ── ParseParamTypes ──────────────────────────────────────────────────

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -989,7 +989,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(15, pipeline.AllSectionNames.Length);
+        Assert.Equal(18, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -1015,6 +1015,9 @@ public class SectionPipelineTests
         Assert.Contains("Properties", names);
         Assert.Contains("Method Groups", names);
         Assert.Contains("Methods", names);
+        Assert.Contains("Operators", names);
+        Assert.Contains("Explicit Interface Implementations", names);
+        Assert.Contains("Extension Methods", names);
         Assert.Contains("Events", names);
         Assert.Contains("IL", names);
         Assert.Contains("Decompiled Source", names);
@@ -1100,6 +1103,7 @@ public class SectionPipelineTests
                 new ApiMember { Name = ".ctor", Kind = "constructor" },
                 new ApiMember { Name = "Count", Kind = "property" },
                 new ApiMember { Name = "GetValue", Kind = "method" },
+                new ApiMember { Name = "op_Equality", Kind = "operator" },
             ]
         };
 
@@ -1109,6 +1113,7 @@ public class SectionPipelineTests
         Assert.Contains("Properties", effective);
         Assert.Contains("Method Groups", effective);
         Assert.Contains("Methods", effective);
+        Assert.Contains("Operators", effective);
         Assert.DoesNotContain("Fields", effective);
         Assert.DoesNotContain("Events", effective);
     }
@@ -1140,6 +1145,9 @@ public class SectionPipelineTests
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
 
         Assert.Contains("Method Groups", pipeline.InfoSectionNames);
+        Assert.Contains("Operators", pipeline.InfoSectionNames);
+        Assert.Contains("Explicit Interface Implementations", pipeline.InfoSectionNames);
+        Assert.Contains("Extension Methods", pipeline.InfoSectionNames);
         Assert.DoesNotContain("Methods", pipeline.InfoSectionNames);
     }
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -184,7 +184,7 @@ public static class MemberOptionsParser
         var ctorOnly = parseResult.GetValue(args.CtorOption);
 
         // Process dotted syntax and overload shorthand
-        var (dottedTypeFilter, shorthandIndex) = SharedParsers.ProcessMemberArguments(allMembers);
+        var (dottedTypeFilter, shorthandIndex, memberKindFilter) = SharedParsers.ProcessMemberArguments(allMembers);
 
         // Use extracted type name if no explicit type was provided
         if (dottedTypeFilter != null && string.IsNullOrEmpty(typeName))
@@ -197,6 +197,7 @@ public static class MemberOptionsParser
 
         var kindValues = parseResult.GetValue(args.KindOption) ?? [];
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
+        kindFilter.UnionWith(memberKindFilter);
 
         var options = new MemberOptions
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -141,6 +141,8 @@ public static class MemberOptionsParser
             && source.AssemblyPath == null)
         {
             var probe = SourceResolver.TryProbeLocalQualifiedName(source.PackagePath);
+            if (source.TypeName == null)
+                probe ??= SourceResolver.TryProbePlatformQualifiedPrefix(source.PackagePath);
             if (probe != null)
             {
                 if (source.TypeName != null)

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -172,19 +172,30 @@ public static class SharedParsers
     /// </summary>
     /// <param name="members">The member arguments to process.</param>
     /// <returns>Extracted type filter and overload index if found.</returns>
-    public static (string? DottedTypeFilter, int? OverloadIndex) ProcessMemberArguments(string[] members)
+    public static (string? DottedTypeFilter, int? OverloadIndex, HashSet<string> KindFilter) ProcessMemberArguments(string[] members)
     {
         string? dottedTypeFilter = null;
         int? overloadIndex = null;
+        HashSet<string> kindFilter = [];
 
         for (int i = 0; i < members.Length; i++)
         {
-            // Check for dotted syntax (Type.Member)
-            var (typeFilter, memberName) = ParseDottedMember(members[i]);
-            if (typeFilter != null)
+            var kindQualified = TryParseKindQualifiedMember(members[i], out var kind, out var memberName);
+            if (kindQualified)
             {
-                dottedTypeFilter = typeFilter;
+                kindFilter.Add(kind);
                 members[i] = memberName;
+            }
+
+            // Check for dotted syntax (Type.Member)
+            if (!kindQualified)
+            {
+                var (typeFilter, dottedMemberName) = ParseDottedMember(members[i]);
+                if (typeFilter != null)
+                {
+                    dottedTypeFilter = typeFilter;
+                    members[i] = dottedMemberName;
+                }
             }
 
             // Check for overload shorthand (Name:N)
@@ -196,7 +207,24 @@ public static class SharedParsers
             }
         }
 
-        return (dottedTypeFilter, overloadIndex);
+        return (dottedTypeFilter, overloadIndex, kindFilter);
+    }
+
+    private static bool TryParseKindQualifiedMember(string value, out string kind, out string memberName)
+    {
+        foreach (var prefix in (ReadOnlySpan<string>)["operator:", "explicit:", "extension:"])
+        {
+            if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                kind = NormalizeKind(prefix[..^1]);
+                memberName = value[prefix.Length..];
+                return true;
+            }
+        }
+
+        kind = "";
+        memberName = value;
+        return false;
     }
 
     /// <summary>
@@ -207,6 +235,9 @@ public static class SharedParsers
         "prop" or "props" or "property" or "properties" => "property",
         "ctor" or "ctors" or "constructor" or "constructors" => "constructor",
         "method" or "methods" => "method",
+        "op" or "ops" or "operator" or "operators" => "operator",
+        "explicit" or "explicit-interface" or "explicit-interface-implementation" or "explicit-interface-implementations" => "explicit-interface-implementation",
+        "extension" or "extensions" or "extension-method" or "extension-methods" => "extension-method",
         "field" or "fields" => "field",
         "event" or "events" => "event",
         "class" or "classes" => "class",

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -388,7 +388,7 @@ public class ApiCommand
             }
             api.Types = api.Types.Where(t => t.Members.Count > 0).ToList();
             api.PublicTypeCount = api.Types.Count;
-            api.PublicMethodCount = api.Types.Sum(t => t.Members.Count(m => m.Kind is "method" or "constructor"));
+            api.PublicMethodCount = api.Types.Sum(t => t.Members.Count(ApiMemberSectionDescriptors.IsMethodLike));
             api.PublicPropertyCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "property"));
             api.PublicFieldCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "field"));
             api.PublicEventCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "event"));
@@ -470,9 +470,12 @@ public class ApiCommand
     {
         var schema = MergeSchemas(
             ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema(),
-            ApiViewContext.Default.GetSchemaInfo<EventsView>()!.ToDocumentSchema(),
             ApiViewContext.Default.GetSchemaInfo<MethodGroupsView>()!.ToDocumentSchema(),
-            ApiViewContext.Default.GetSchemaInfo<MethodsView>()!.ToDocumentSchema());
+            ApiViewContext.Default.GetSchemaInfo<MethodsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<OperatorsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<ExplicitInterfaceImplementationsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<ExtensionMethodsView>()!.ToDocumentSchema(),
+            ApiViewContext.Default.GetSchemaInfo<EventsView>()!.ToDocumentSchema());
         if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
             return schema;
 
@@ -583,7 +586,8 @@ public class ApiCommand
 
     internal static async Task<ResolvedMethodSource> ResolveMethodSourceAsync(
         string dllPath, string typeName, string methodName, int overloadIndex,
-        ApiOptions options, HttpClient httpClient, VerboseLogger logger, bool fetchSource = true)
+        ApiOptions options, HttpClient httpClient, VerboseLogger logger, bool fetchSource = true,
+        bool publicOnly = true)
     {
         try
         {
@@ -609,7 +613,7 @@ public class ApiCommand
             if (!fetchSource || !service.HasPdb || !service.HasSourceLink)
                 return new ResolvedMethodSource(null, pdbPath);
 
-            var methodInfo = service.ResolveMethodSource(typeName, methodName, overloadIndex, publicOnly: true);
+            var methodInfo = service.ResolveMethodSource(typeName, methodName, overloadIndex, publicOnly);
             if (methodInfo?.SourceUrl == null)
                 return new ResolvedMethodSource(null, pdbPath);
 
@@ -709,6 +713,9 @@ public class ApiCommand
         EventsView? eventsView = null;
         MethodGroupsView? methodGroupsView = null;
         MethodsView? methodsView = null;
+        OperatorsView? operatorsView = null;
+        ExplicitInterfaceImplementationsView? explicitInterfaceImplementationsView = null;
+        ExtensionMethodsView? extensionMethodsView = null;
 
         // Populate enum values declaratively (pipeline controls visibility via IncludeSections)
         if (type.Kind == "enum")
@@ -731,6 +738,7 @@ public class ApiCommand
             {
                 var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(options);
                 var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(options);
+                var renderSupplementalRows = ApiOutputFormatter.ShouldRenderSupplementalMemberRows(options);
                 if (renderMemberGroups)
                 {
                     methodGroupsView ??= new MethodGroupsView();
@@ -738,11 +746,23 @@ public class ApiCommand
                     ApiOutputFormatter.PopulateMemberSummarySections(
                         view, methodGroupsView, eventsView, type, options, methodGroupsOnly: renderMemberRows);
                 }
-                if (renderMemberRows)
+                if (renderMemberRows || renderSupplementalRows)
                 {
                     methodsView ??= new MethodsView();
+                    operatorsView ??= new OperatorsView();
+                    explicitInterfaceImplementationsView ??= new ExplicitInterfaceImplementationsView();
+                    extensionMethodsView ??= new ExtensionMethodsView();
                     eventsView ??= new EventsView();
-                    ApiOutputFormatter.PopulateMemberSections(view, methodsView, eventsView, type, options);
+                    ApiOutputFormatter.PopulateMemberSections(
+                        view,
+                        methodsView,
+                        operatorsView,
+                        explicitInterfaceImplementationsView,
+                        extensionMethodsView,
+                        eventsView,
+                        type,
+                        options,
+                        renderSupplementalRows ? ApiOutputFormatter.SupplementalMemberKinds : null);
                 }
             }
 
@@ -751,7 +771,7 @@ public class ApiCommand
             {
                 var requestedSections = GetRequestedMemberSections(type, mo4);
                 var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" && !m.IsAbstract)
+                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method" && !m.IsAbstract)
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath,
@@ -772,7 +792,9 @@ public class ApiCommand
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
             var sw = new StringWriter();
             var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
-            ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
+            ApiOutputFormatter.SerializeTypeDocument(
+                view, eventsView, methodGroupsView, methodsView, operatorsView,
+                explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
             writer.Flush();
             CountOutput.WriteCountFromMarkdown(MarkdownTableRowLimiter.Apply(sw.ToString(), options.Rows));
         }
@@ -786,7 +808,9 @@ public class ApiCommand
                     (writer, formatter) =>
                     {
                         var markoutWriter = new MarkoutWriter(writer, formatter, writerOpts);
-                        ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, markoutWriter);
+                        ApiOutputFormatter.SerializeTypeDocument(
+                            view, eventsView, methodGroupsView, methodsView, operatorsView,
+                            explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, markoutWriter);
                         markoutWriter.Flush();
                     });
             }
@@ -808,14 +832,18 @@ public class ApiCommand
             if (options.PlainText)
             {
                 var writer = new Markout.MarkoutWriter(sink, options.CreateFormatter(), writerOptions);
-                ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
+                ApiOutputFormatter.SerializeTypeDocument(
+                    view, eventsView, methodGroupsView, methodsView, operatorsView,
+                    explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
                 writer.Flush();
             }
             else
             {
                 var sw = new StringWriter();
                 var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
-                ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
+                ApiOutputFormatter.SerializeTypeDocument(
+                    view, eventsView, methodGroupsView, methodsView, operatorsView,
+                    explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
                 writer.Flush();
                 var markdown = sw.ToString().TrimEnd();
                 if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
@@ -906,6 +934,9 @@ public class ApiCommand
         EventsView? eventsView = null;
         MethodGroupsView? methodGroupsView = null;
         MethodsView? methodsView = null;
+        OperatorsView? operatorsView = null;
+        ExplicitInterfaceImplementationsView? explicitInterfaceImplementationsView = null;
+        ExtensionMethodsView? extensionMethodsView = null;
 
         if (type.Kind == "enum")
             ApiOutputFormatter.PopulateEnumValues(view, type, renderOptions);
@@ -918,6 +949,7 @@ public class ApiCommand
             {
                 var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(renderOptions);
                 var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(renderOptions);
+                var renderSupplementalRows = ApiOutputFormatter.ShouldRenderSupplementalMemberRows(renderOptions);
                 if (renderMemberGroups)
                 {
                     methodGroupsView ??= new MethodGroupsView();
@@ -925,11 +957,23 @@ public class ApiCommand
                     ApiOutputFormatter.PopulateMemberSummarySections(
                         view, methodGroupsView, eventsView, type, renderOptions, methodGroupsOnly: renderMemberRows);
                 }
-                if (renderMemberRows)
+                if (renderMemberRows || renderSupplementalRows)
                 {
                     methodsView ??= new MethodsView();
+                    operatorsView ??= new OperatorsView();
+                    explicitInterfaceImplementationsView ??= new ExplicitInterfaceImplementationsView();
+                    extensionMethodsView ??= new ExtensionMethodsView();
                     eventsView ??= new EventsView();
-                    ApiOutputFormatter.PopulateMemberSections(view, methodsView, eventsView, type, renderOptions);
+                    ApiOutputFormatter.PopulateMemberSections(
+                        view,
+                        methodsView,
+                        operatorsView,
+                        explicitInterfaceImplementationsView,
+                        extensionMethodsView,
+                        eventsView,
+                        type,
+                        renderOptions,
+                        renderSupplementalRows ? ApiOutputFormatter.SupplementalMemberKinds : null);
                 }
             }
 
@@ -937,7 +981,7 @@ public class ApiCommand
             {
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
                 var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" && !m.IsAbstract)
+                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method" && !m.IsAbstract)
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,
@@ -955,7 +999,9 @@ public class ApiCommand
         var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, renderOptions);
         var sw = new StringWriter();
         var writer = new MarkoutWriter(sw, new Markout.MarkdownFormatter(), writerOptions);
-        ApiOutputFormatter.SerializeTypeDocument(view, eventsView, methodGroupsView, methodsView, view.MemberCode, writer);
+        ApiOutputFormatter.SerializeTypeDocument(
+            view, eventsView, methodGroupsView, methodsView, operatorsView,
+            explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
         writer.Flush();
         return sw.ToString();
     }
@@ -967,6 +1013,9 @@ public class ApiCommand
 
         if (options.MemberFilter.Count > 0)
             members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, options.MemberFilter)).ToList();
+
+        if (options.KindFilter.Count > 0)
+            members = members.Where(m => options.KindFilter.Contains(m.Kind)).ToList();
 
         if (options.UnsafeOnly)
             members = members.Where(m => m.IsUnsafe).ToList();
@@ -1017,6 +1066,9 @@ public class ApiCommand
             [SectionNames.Properties] = m => m.Kind == "property",
             [SectionNames.MethodGroups] = m => m.Kind == "method",
             [SectionNames.Methods] = m => m.Kind == "method",
+            [SectionNames.Operators] = m => m.Kind == "operator",
+            [SectionNames.ExplicitInterfaceImplementations] = m => m.Kind == "explicit-interface-implementation",
+            [SectionNames.ExtensionMethods] = m => m.Kind == "extension-method",
             [SectionNames.Constructors] = m => m.Kind == "constructor",
             [SectionNames.Events] = m => m.Kind == "event",
         };

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -127,9 +127,7 @@ public static class MemberCommand
             if (!effectiveOptions.OverloadIndex.HasValue && ShouldAutoSelectSingleOverload(effectiveOptions))
             {
                 var autoMemberName = effectiveOptions.MemberFilter.First();
-                var autoOverloads = apiType.Members
-                    .Where(m => string.Equals(m.Name, autoMemberName, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                var autoOverloads = GetCandidateMembers(apiType, effectiveOptions, autoMemberName);
                 if (autoOverloads.Count == 1)
                     effectiveOptions = effectiveOptions with { OverloadIndex = 1 };
             }
@@ -144,9 +142,7 @@ public static class MemberCommand
                 }
 
                 var memberName = effectiveOptions.MemberFilter.First();
-                var overloads = apiType.Members
-                    .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
                 var displayOverloads = overloads
                     .OrderBy(m => m.Name, StringComparer.Ordinal)
                     .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
@@ -178,9 +174,7 @@ public static class MemberCommand
                 }
 
                 var memberName = effectiveOptions.MemberFilter.First();
-                var overloads = apiType.Members
-                    .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
 
                 var matches = new List<(ApiMember member, int index)>();
                 for (int i = 0; i < overloads.Count; i++)
@@ -241,11 +235,15 @@ public static class MemberCommand
                 var pdbLookupPath = runtimeAssemblyPath ?? apiDllPath;
                 bool fetchSource = ApiCommand.GetRequestedMemberSections(apiType, effectiveOptions)
                     .Contains(SectionNames.OriginalSource);
+                var selectedMember = apiType.Members.Count == 1 ? apiType.Members[0] : null;
+                var sourceTypeName = selectedMember?.DeclaringType ?? apiType.FullName;
+                var sourceOverloadIndex = (selectedMember?.DeclaringOverloadIndex ?? effectiveOptions.OverloadIndex.Value) - 1;
+                var publicOnly = selectedMember?.Kind != "explicit-interface-implementation";
                 var resolved = await ApiCommand.ResolveMethodSourceAsync(
-                    pdbLookupPath, apiType.FullName,
+                    pdbLookupPath, sourceTypeName,
                     effectiveOptions.MemberFilter.First(),
-                    effectiveOptions.OverloadIndex.Value - 1,
-                    effectiveOptions, context.HttpClient, logger, fetchSource);
+                    sourceOverloadIndex,
+                    effectiveOptions, context.HttpClient, logger, fetchSource, publicOnly);
 
                 effectiveOptions = effectiveOptions with
                 {
@@ -274,7 +272,7 @@ public static class MemberCommand
                     ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
 
                 var overloadGroups = apiType.Members
-                    .Where(m => m.Kind is "method" or "constructor")
+                    .Where(ApiMemberSectionDescriptors.IsMethodLike)
                     .GroupBy(m => m.Name)
                     .OrderByDescending(g => g.Count())
                     .ToList();
@@ -338,6 +336,15 @@ public static class MemberCommand
 
     private static bool IsPureSelector(string[]? select, string name) =>
         select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);
+
+    private static List<ApiMember> GetCandidateMembers(ApiType apiType, MemberOptions options, string memberName)
+    {
+        var members = apiType.Members
+            .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase));
+        if (options.KindFilter.Count > 0)
+            members = members.Where(m => options.KindFilter.Contains(m.Kind));
+        return members.ToList();
+    }
 
     private static bool NeedsMemberSourceResolution(ApiType apiType, MemberOptions options)
     {

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -258,7 +258,7 @@ public static class TypeCommand
                             ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
 
                         var overloadGroups = apiType.Members
-                            .Where(m => m.Kind is "method" or "constructor")
+                            .Where(ApiMemberSectionDescriptors.IsMethodLike)
                             .GroupBy(m => m.Name)
                             .OrderByDescending(g => g.Count())
                             .ToList();

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -416,7 +416,7 @@ internal static class ApiServices
                     {
                         type.IsForwarded = true;
                         api.Types.Add(type);
-                        api.PublicMethodCount += type.Members.Count(m => m.Kind == "method" || m.Kind == "constructor");
+                        api.PublicMethodCount += type.Members.Count(DotnetInspector.Sections.ApiMemberSectionDescriptors.IsMethodLike);
                         api.PublicPropertyCount += type.Members.Count(m => m.Kind == "property");
                         api.PublicEventCount += type.Members.Count(m => m.Kind == "event");
                         api.PublicFieldCount += type.Members.Count(m => m.Kind == "field");

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -175,7 +175,27 @@ public static class ApiOutputFormatter
         options.Verbosity != Verbosity.Minimal
         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
         || SectionRequested(options.IncludeSections, SectionNames.Methods)
-        || DiscoveryRequests(options, SectionNames.Methods);
+        || (!SelectResolver.IsActiveInfoSelector(options.Select, options.IncludeSections)
+            && (SectionRequested(options.IncludeSections, SectionNames.Operators)
+                || SectionRequested(options.IncludeSections, SectionNames.ExplicitInterfaceImplementations)
+                || SectionRequested(options.IncludeSections, SectionNames.ExtensionMethods)))
+        || DiscoveryRequests(options, SectionNames.Methods)
+        || DiscoveryRequests(options, SectionNames.Operators)
+        || DiscoveryRequests(options, SectionNames.ExplicitInterfaceImplementations)
+        || DiscoveryRequests(options, SectionNames.ExtensionMethods);
+
+    internal static readonly HashSet<string> SupplementalMemberKinds =
+    [
+        "operator",
+        "explicit-interface-implementation",
+        "extension-method"
+    ];
+
+    internal static bool ShouldRenderSupplementalMemberRows(ApiOptions options) =>
+        options.Verbosity == Verbosity.Minimal
+        && !ShouldRenderMemberRows(options)
+        && (options.IncludeSections is null
+            || SelectResolver.IsActiveInfoSelector(options.Select, options.IncludeSections));
 
     internal static bool ShouldRenderSectionedTabularView(ApiType type, ApiOptions options)
     {
@@ -193,6 +213,9 @@ public static class ApiOutputFormatter
         EventsView? eventsView,
         MethodGroupsView? methodGroupsView,
         MethodsView? methodsView,
+        OperatorsView? operatorsView,
+        ExplicitInterfaceImplementationsView? explicitInterfaceImplementationsView,
+        ExtensionMethodsView? extensionMethodsView,
         MemberCodeView? memberCodeView,
         MarkoutWriter writer)
     {
@@ -201,6 +224,12 @@ public static class ApiOutputFormatter
             ApiViewContext.Default.Serialize(methodGroupsView, writer);
         if (methodsView is { HasRows: true })
             ApiViewContext.Default.Serialize(methodsView, writer);
+        if (operatorsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(operatorsView, writer);
+        if (explicitInterfaceImplementationsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(explicitInterfaceImplementationsView, writer);
+        if (extensionMethodsView is { HasRows: true })
+            ApiViewContext.Default.Serialize(extensionMethodsView, writer);
         if (eventsView is { HasRows: true })
             ApiViewContext.Default.Serialize(eventsView, writer);
         if (memberCodeView != null)
@@ -216,6 +245,7 @@ public static class ApiOutputFormatter
 
     private static bool ShouldAbbreviateMemberSignatures(ApiOptions options) =>
         options.Verbosity == Verbosity.Minimal
+        && options.IncludeSections is null
         && !ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
         && !SectionRequested(options.IncludeSections, SectionNames.Methods)
         && !DiscoveryRequests(options, SectionNames.Methods);
@@ -341,6 +371,9 @@ public static class ApiOutputFormatter
             Fields = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
             Properties = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
             Methods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
+            Operators = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "operator")) : null,
+            ExplicitInterfaceImplementations = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "explicit-interface-implementation")) : null,
+            ExtensionMethods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "extension-method")) : null,
             Events = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
@@ -408,7 +441,7 @@ public static class ApiOutputFormatter
 
         static List<TreeNode> BuildShapeMemberNodes(string kind, IEnumerable<ApiMember> members)
         {
-            if (kind is "method" or "constructor")
+            if (IsOverloadGroupedKind(kind))
             {
                 return members
                     .GroupBy(m => m.Name)
@@ -433,14 +466,20 @@ public static class ApiOutputFormatter
                 .ToList();
         }
 
+        static bool IsOverloadGroupedKind(string kind)
+            => kind is "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method";
+
         static string GetShapeKindLabel(string kind, int overloadCount, int logicalCount)
         {
-            if (kind is "method" or "constructor" && overloadCount != logicalCount)
+            if (IsOverloadGroupedKind(kind) && overloadCount != logicalCount)
             {
                 var noun = kind switch
                 {
                     "constructor" => "Constructors",
                     "method" => "Methods",
+                    "operator" => "Operators",
+                    "explicit-interface-implementation" => "Explicit Interface Implementations",
+                    "extension-method" => "Extension Methods",
                     _ => GetTreeKindLabel(kind, overloadCount).Split(' ')[0]
                 };
                 return $"{noun} ({logicalCount} logical, {overloadCount} overloads)";
@@ -539,9 +578,21 @@ public static class ApiOutputFormatter
     }
 
     internal static (int truncated, string noun) PopulateMemberSections(
-        TypeView view, MethodsView methodsView, EventsView eventsView, ApiType type, ApiOptions options)
+        TypeView view,
+        MethodsView methodsView,
+        OperatorsView operatorsView,
+        ExplicitInterfaceImplementationsView explicitInterfaceImplementationsView,
+        ExtensionMethodsView extensionMethodsView,
+        EventsView eventsView,
+        ApiType type,
+        ApiOptions options,
+        IReadOnlySet<string>? onlyKinds = null)
     {
         var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
+        if (onlyKinds is { Count: > 0 })
+            grouped = grouped
+                .Where(kvp => onlyKinds.Contains(kvp.Key))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         if (grouped.Count == 0) return (0, "");
 
         // Flatten sorted for --limit application
@@ -597,7 +648,8 @@ public static class ApiOutputFormatter
                     idx++;
                     overloadIndices[m.Name] = idx;
                     bool hasOverloads = overloadCounts[m.Name] > 1;
-                    select = $"`{(hasOverloads ? $"{m.Name}:{idx}" : m.Name)}`";
+                    var selectorName = GetMemberSelectorName(m);
+                    select = $"`{(hasOverloads ? $"{selectorName}:{idx}" : selectorName)}`";
                 }
 
                 var sigDisplay = m.Accessibility != null ? $"{m.Accessibility} {sig}" : sig;
@@ -636,6 +688,24 @@ public static class ApiOutputFormatter
                     { if (hasDocs) methodsView.SelectRowsWithDocs = rows; else methodsView.SelectRows = rows; }
                     else
                     { if (hasDocs) methodsView.RowsWithDocs = rows; else methodsView.Rows = rows; }
+                    break;
+                case "operator":
+                    if (showSelect)
+                    { if (hasDocs) operatorsView.SelectRowsWithDocs = rows; else operatorsView.SelectRows = rows; }
+                    else
+                    { if (hasDocs) operatorsView.RowsWithDocs = rows; else operatorsView.Rows = rows; }
+                    break;
+                case "explicit-interface-implementation":
+                    if (showSelect)
+                    { if (hasDocs) explicitInterfaceImplementationsView.SelectRowsWithDocs = rows; else explicitInterfaceImplementationsView.SelectRows = rows; }
+                    else
+                    { if (hasDocs) explicitInterfaceImplementationsView.RowsWithDocs = rows; else explicitInterfaceImplementationsView.Rows = rows; }
+                    break;
+                case "extension-method":
+                    if (showSelect)
+                    { if (hasDocs) extensionMethodsView.SelectRowsWithDocs = rows; else extensionMethodsView.SelectRows = rows; }
+                    else
+                    { if (hasDocs) extensionMethodsView.RowsWithDocs = rows; else extensionMethodsView.Rows = rows; }
                     break;
                 case "event":
                     if (showSelect)
@@ -829,11 +899,17 @@ public static class ApiOutputFormatter
 
         foreach (var method in methods)
         {
+            var lookupType = method.DeclaringType ?? type.FullName;
+            var lookupOverloadIndex = method.DeclaringOverloadIndex is { } declaringIndex
+                ? declaringIndex - 1
+                : overloadIndex;
+            var publicOnly = method.Kind != "explicit-interface-implementation";
+
             // Custom attributes
             if (wantsAttributes)
             {
                 var attributes = AttributeReader.GetMethodAttributes(
-                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true);
+                    peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly);
                 if (attributes.Count > 0)
                 {
                     view.MethodAttributeRows = attributes
@@ -848,7 +924,7 @@ public static class ApiOutputFormatter
                 try
                 {
                     var context = Decompiler.MethodBodyContext.Create(
-                        peReader, type.FullName, method.Name, overloadIndex, publicOnly: true, externalPdbPath: pdbPath);
+                        peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
                     if (context != null)
                     {
                         var lowered = Decompiler.CSharpEmitter.Emit(context);
@@ -867,7 +943,7 @@ public static class ApiOutputFormatter
             if (wantsIL)
             {
                 var instructions = ILDisassembler.DisassembleMethod(
-                    peReader, type.FullName, method.Name, overloadIndex, publicOnly: true);
+                    peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly);
                 if (instructions is { Count: > 0 })
                 {
                     var ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
@@ -882,7 +958,7 @@ public static class ApiOutputFormatter
                 try
                 {
                     var context = Decompiler.MethodBodyContext.Create(
-                        peReader, type.FullName, method.Name, overloadIndex, publicOnly: true, externalPdbPath: pdbPath);
+                        peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
                     if (context != null)
                     {
                         var annotated = Decompiler.AnnotatedILEmitter.Emit(
@@ -931,7 +1007,7 @@ public static class ApiOutputFormatter
         {
             signature = FormatOperatorSignature(signature, member.Name);
         }
-        else if (member.Kind == "method")
+        else if (member.Kind is "method" or "extension-method")
         {
             if (context.GenericContext?.MethodParameters is { Count: > 0 } methodParameters)
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
@@ -939,11 +1015,15 @@ public static class ApiOutputFormatter
                 signature = AddExtensionThisModifier(signature);
         }
 
-        List<string> modifiers = [member.Accessibility ?? "public"];
+        List<string> modifiers = member.Kind == "explicit-interface-implementation"
+            ? []
+            : [member.Accessibility ?? "public"];
         if (member.IsStatic)
             modifiers.Add("static");
 
-        return $"{string.Join(" ", modifiers)} {signature}";
+        return modifiers.Count == 0
+            ? signature
+            : $"{string.Join(" ", modifiers)} {signature}";
     }
 
     private static string FormatOperatorSignature(string signature, string methodName)
@@ -1115,10 +1195,21 @@ public static class ApiOutputFormatter
         return signature;
     }
 
+    private static string GetMemberSelectorName(ApiMember member) => member.Kind switch
+    {
+        "operator" => $"operator:{member.Name}",
+        "explicit-interface-implementation" => $"explicit:{member.Name}",
+        "extension-method" => $"extension:{member.Name}",
+        _ => member.Name
+    };
+
     private static string PluralizeKind(string kind) => kind switch
     {
         "property" => "Properties",
         "method" => "Methods",
+        "operator" => "Operators",
+        "explicit-interface-implementation" => "Explicit Interface Implementations",
+        "extension-method" => "Extension Methods",
         "field" => "Fields",
         "event" => "Events",
         "constructor" => "Constructors",
@@ -1127,7 +1218,17 @@ public static class ApiOutputFormatter
 
     private static bool IsCompilerGenerated(string name) => MemberFilters.IsCompilerGenerated(name);
 
-    private static readonly string[] MemberKinds = ["constructor", "field", "property", "method", "event"];
+    private static readonly string[] MemberKinds =
+    [
+        "constructor",
+        "field",
+        "property",
+        "method",
+        "operator",
+        "explicit-interface-implementation",
+        "extension-method",
+        "event"
+    ];
 
     internal static int GetMemberSortOrder(string kind)
     {
@@ -1180,8 +1281,8 @@ public static class ApiOutputFormatter
             var detail = e.kind switch
             {
                 "property" => SignatureParser.ExtractAccessors(m.Signature),
-                "constructor" or "method" when e.members.Count > 1 => e.members.Count.ToString(),
-                "constructor" or "method" when e.members.Count == 1 => SignatureParser.ExtractParamList(m.Signature),
+                "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count > 1 => e.members.Count.ToString(),
+                "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count == 1 => SignatureParser.ExtractParamList(m.Signature),
                 _ => ""
             };
             var kindLabel = m.Accessibility != null ? $"{m.Accessibility} {e.kind}" : e.kind;
@@ -1256,11 +1357,14 @@ public static class ApiOutputFormatter
     private static int GetTreeKindOrder(string kind) => kind switch
     {
         "constructor" => 0,
-        "property" => 1,
-        "method" => 2,
-        "event" => 3,
-        "field" => 4,
-        _ => 5
+        "field" => 1,
+        "property" => 2,
+        "method" => 3,
+        "operator" => 4,
+        "explicit-interface-implementation" => 5,
+        "extension-method" => 6,
+        "event" => 7,
+        _ => 8
     };
 
     private static string GetTreeKindLabel(string kind, int count)
@@ -1269,6 +1373,9 @@ public static class ApiOutputFormatter
         {
             "property" => "Properties",
             "method" => "Methods",
+            "operator" => "Operators",
+            "explicit-interface-implementation" => "Explicit Interface Implementations",
+            "extension-method" => "Extension Methods",
             "constructor" => "Constructors",
             "event" => "Events",
             "field" => "Fields",
@@ -1299,6 +1406,15 @@ public static class ApiOutputFormatter
                 case "Method Groups":
                 case "Methods":
                     kinds.Add("method");
+                    break;
+                case "Operators":
+                    kinds.Add("operator");
+                    break;
+                case "Explicit Interface Implementations":
+                    kinds.Add("explicit-interface-implementation");
+                    break;
+                case "Extension Methods":
+                    kinds.Add("extension-method");
                     break;
                 case "Events":
                     kinds.Add("event");

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -85,6 +85,9 @@ public static class ApiMemberSectionDescriptors
             .Add<Properties>()
             .Add<MethodGroups>()
             .Add<Methods>()
+            .Add<Operators>()
+            .Add<ExplicitInterfaceImplementations>()
+            .Add<ExtensionMethods>()
             .Add<Events>()
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
@@ -197,13 +200,43 @@ public static class ApiMemberSectionDescriptors
             => model.Members.Any(m => m.Kind == "event");
     }
 
+    public sealed class Operators : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.Operators;
+        public static bool IsExpensive => false;
+        public static bool Info => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind == "operator");
+    }
+
+    public sealed class ExplicitInterfaceImplementations : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.ExplicitInterfaceImplementations;
+        public static bool IsExpensive => false;
+        public static bool Info => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind == "explicit-interface-implementation");
+    }
+
+    public sealed class ExtensionMethods : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.ExtensionMethods;
+        public static bool IsExpensive => false;
+        public static bool Info => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(m => m.Kind == "extension-method");
+    }
+
     public sealed class MethodAttributes : ISectionDescriptor<ApiType>
     {
         public static string Name => "Custom Attributes";
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(IsMethodLike);
     }
 
     // ===== Expensive sections (decompiler output) =====
@@ -214,7 +247,7 @@ public static class ApiMemberSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(IsMethodLike);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>
@@ -223,7 +256,7 @@ public static class ApiMemberSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(IsMethodLike);
     }
 
     public sealed class AnnotatedIL : ISectionDescriptor<ApiType>
@@ -232,7 +265,7 @@ public static class ApiMemberSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(IsMethodLike);
     }
 
     public sealed class OriginalSource : ISectionDescriptor<ApiType>
@@ -243,8 +276,11 @@ public static class ApiMemberSectionDescriptors
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(IsMethodLike);
     }
+
+    internal static bool IsMethodLike(ApiMember member) =>
+        member.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method";
 }
 
 /// <summary>
@@ -291,6 +327,9 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Properties>()
             .Add<ApiMemberDetailSectionDescriptors.Signature>()
             .Add<Methods>()
+            .Add<ApiMemberSectionDescriptors.Operators>()
+            .Add<ApiMemberSectionDescriptors.ExplicitInterfaceImplementations>()
+            .Add<ApiMemberSectionDescriptors.ExtensionMethods>()
             .Add<ApiMemberSectionDescriptors.Events>()
             .Add<ApiMemberSectionDescriptors.MethodAttributes>()
             .Add<ApiMemberSectionDescriptors.DecompiledSource>()
@@ -352,7 +391,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class DecompiledSource : ISectionDescriptor<ApiType>
@@ -363,7 +402,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class OriginalSource : ISectionDescriptor<ApiType>
@@ -374,7 +413,7 @@ public static class ApiMemberDetailSectionDescriptors
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>
@@ -383,7 +422,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class AnnotatedIL : ISectionDescriptor<ApiType>
@@ -393,6 +432,6 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind is "method" or "constructor");
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 }

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -60,6 +60,15 @@ public static class SectionNames
     /// <summary>Section for method overload rows.</summary>
     public const string Methods = "Methods";
 
+    /// <summary>Section for operators.</summary>
+    public const string Operators = "Operators";
+
+    /// <summary>Section for explicit interface implementations.</summary>
+    public const string ExplicitInterfaceImplementations = "Explicit Interface Implementations";
+
+    /// <summary>Section for extension methods defined in the inspected binary.</summary>
+    public const string ExtensionMethods = "Extension Methods";
+
     /// <summary>Section for events.</summary>
     public const string Events = "Events";
 

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -105,6 +105,40 @@ public static class SourceResolver
     }
 
     /// <summary>
+    /// Peels a dotted name and returns the longest platform assembly prefix even when the
+    /// remaining type name is misspelled. This is intentionally platform-only to avoid
+    /// misclassifying one-argument package names as package/type pairs.
+    /// </summary>
+    internal static LocalProbeResult? TryProbePlatformQualifiedPrefix(string name)
+    {
+        var bestDot = -1;
+        for (int i = name.Length - 1; i >= 0; i--)
+        {
+            if (name[i] != '.')
+                continue;
+
+            var candidate = name[..i];
+            var remainder = name[(i + 1)..];
+            if (string.IsNullOrEmpty(candidate) || string.IsNullOrEmpty(remainder))
+                continue;
+
+            if (!PlatformResolver.IsPlatformCandidate(candidate))
+                continue;
+
+            var (path, _, _, _) = PlatformResolver.ResolveAssembly(candidate);
+            if (path != null)
+            {
+                bestDot = i;
+                break;
+            }
+        }
+
+        return bestDot > 0
+            ? new LocalProbeResult(name[..bestDot], name[(bestDot + 1)..], LocalSourceKind.Platform)
+            : null;
+    }
+
+    /// <summary>
     /// Lightweight type existence check using raw metadata.
     /// </summary>
     internal static bool AssemblyHasType(string assemblyPath, string typeName)

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -52,6 +52,16 @@ public class TypeView
     [MarkoutSkipNull] public int? Fields { get; set; }
     [MarkoutSkipNull] public int? Properties { get; set; }
     [MarkoutSkipNull] public int? Methods { get; set; }
+    [MarkoutSkipNull] public int? Operators { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Explicit Interface Implementations")]
+    public int? ExplicitInterfaceImplementations { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Extension Methods")]
+    public int? ExtensionMethods { get; set; }
+
     [MarkoutSkipNull] public int? Events { get; set; }
 
     /// <summary>
@@ -254,6 +264,96 @@ public class MethodsView
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Methods")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRowsWithDocs { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
+
+    [MarkoutIgnore]
+    public bool HasRows =>
+        Rows is { Count: > 0 }
+        || RowsWithDocs is { Count: > 0 }
+        || SelectRows is { Count: > 0 }
+        || SelectRowsWithDocs is { Count: > 0 };
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class OperatorsView
+{
+    [MarkoutSection(Name = "Operators", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Operators", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? RowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Operators", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRows { get; set; }
+
+    [MarkoutSection(Name = "Operators")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRowsWithDocs { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
+
+    [MarkoutIgnore]
+    public bool HasRows =>
+        Rows is { Count: > 0 }
+        || RowsWithDocs is { Count: > 0 }
+        || SelectRows is { Count: > 0 }
+        || SelectRowsWithDocs is { Count: > 0 };
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class ExplicitInterfaceImplementationsView
+{
+    [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? RowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRows { get; set; }
+
+    [MarkoutSection(Name = "Explicit Interface Implementations")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRowsWithDocs { get; set; }
+
+    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
+
+    [MarkoutIgnore]
+    public bool HasRows =>
+        Rows is { Count: > 0 }
+        || RowsWithDocs is { Count: > 0 }
+        || SelectRows is { Count: > 0 }
+        || SelectRowsWithDocs is { Count: > 0 };
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public class ExtensionMethodsView
+{
+    [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Description,Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? Rows { get; set; }
+
+    [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Select")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? RowsWithDocs { get; set; }
+
+    [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Description")]
+    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
+    public List<MemberRow>? SelectRows { get; set; }
+
+    [MarkoutSection(Name = "Extension Methods")]
     [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
 
@@ -513,6 +613,9 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(EventsView))]
 [MarkoutContext(typeof(MethodGroupsView))]
 [MarkoutContext(typeof(MethodsView))]
+[MarkoutContext(typeof(OperatorsView))]
+[MarkoutContext(typeof(ExplicitInterfaceImplementationsView))]
+[MarkoutContext(typeof(ExtensionMethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -8,6 +8,7 @@
 - Makes `member Type -m Name` render overload rows by default, with full signatures and optional `--show-index` selectors.
 - Includes method generic parameter lists, such as `Serialize<TValue>(...)`, in rendered signatures.
 - Aligns `--table` and `--tsv` selected-section output with Markdown so narrowed `-S Methods` renders overload rows.
+- Adds first-class `Operators`, `Explicit Interface Implementations`, and local `Extension Methods` sections to type/member views.
 
 ## v0.10.0
 


### PR DESCRIPTION
## Summary

- implement the Learn-derived member order in type/member output using `System.String` as the regression target
- classify operators into `Operators` instead of ordinary Methods
- include explicit interface implementations without `--all` and render them in `Explicit Interface Implementations`
- project extension methods defined in the inspected binary onto their extended type as `Extension Methods`
- add kind-prefixed selectors (`operator:`, `explicit:`, `extension:`) so supplemental rows round-trip and detail sections resolve correctly
- update the member-order design note and release notes

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release`
- `npx markdownlint-cli docs/design/member-order.md docs/overview.md src/dotnet-inspect/release-notes.md`
- `git --no-pager diff --check`


## Follow-up

- improves one-token platform-qualified `member` shortcut typo handling, so `member System.Text.Json.JsonSerializizer` preserves the `System.Text.Json` source prefix and produces type suggestions instead of `member requires a type name`;
- keeps normal package/type forms such as `member System.CommandLine Command` from being hijacked by the typo fallback.
