### PR TITLE
Unify qualified type/member routing

### DIFF
--- a/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
+++ b/src/dotnet-inspect.Tests/OfflineVerbosityTests.cs
@@ -91,6 +91,19 @@ public class OfflineVerbosityTests : IDisposable
         Assert.Contains("Method Groups", output);
     }
 
+    [Fact]
+    public async Task SingleType_QualifiedTypeTypo_Offline_SuggestsPlatformType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text.Json.JsonSerializizer", "-v:q", "--offline", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Type 'JsonSerializizer' not found", error);
+        Assert.Contains("JsonSerializer", error);
+        Assert.DoesNotContain("Package 'System.Text.Json.JsonSerializizer'", error);
+    }
+
     // ── member command ───────────────────────────────────────────────
 
     [Fact]
@@ -116,6 +129,19 @@ public class OfflineVerbosityTests : IDisposable
         Assert.Contains("Serialize", output);
     }
 
+    [Fact]
+    public async Task Member_QualifiedTypeTypo_Offline_SuggestsPlatformType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializizer", "-v:q", "--offline", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Type 'JsonSerializizer' not found", error);
+        Assert.Contains("JsonSerializer", error);
+        Assert.DoesNotContain("Package 'System.Text.Json.JsonSerializizer'", error);
+    }
+
     // ── router -> qualified type name ─────────────────────────────────
 
     [Fact]
@@ -137,6 +163,30 @@ public class OfflineVerbosityTests : IDisposable
         Assert.Equal(0, exit);
         Assert.Contains("Deserialize", output);
         Assert.Contains("Overloads", output);
+    }
+
+    [Fact]
+    public async Task Router_QualifiedMember_Minimal_Offline_Succeeds()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.SerializeToNode", "-v:m", "--offline", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("SerializeToNode", output);
+        Assert.DoesNotContain("Type 'JsonSerializer.SerializeToNode' not found", error);
+    }
+
+    [Fact]
+    public async Task Router_QualifiedTypeTypo_Offline_SuggestsPlatformType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializizer", "-v:q", "--offline", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Type 'JsonSerializizer' not found", error);
+        Assert.Contains("JsonSerializer", error);
+        Assert.DoesNotContain("Package 'System.Text.Json.JsonSerializizer'", error);
     }
 
     // ── type forwarder following ─────────────────────────────────────

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -304,11 +304,33 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task Positional_PackageLikeSingleArg_DoesNotUseRootPlatformFallback()
+    {
+        var options = await ParseSuccessAsync("member", "System.CommandLine");
+
+        Assert.Null(options.TypeName);
+        Assert.Equal("System.CommandLine", options.PackagePath);
+        Assert.Null(options.PlatformAssembly);
+        Assert.Empty(options.MemberFilter);
+    }
+
+    [Fact]
     public async Task Positional_QualifiedTypeMember_ResolvesPlatformTypeAndMember()
     {
         var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializer.SerializeToNode");
 
         Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Null(options.PackagePath);
+        Assert.Contains("SerializeToNode", options.MemberFilter);
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedTypeMemberWithTypo_PreservesTypeForSuggestions()
+    {
+        var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializizer.SerializeToNode");
+
+        Assert.Equal("JsonSerializizer", options.TypeName);
         Assert.Equal("System.Text.Json", options.PlatformAssembly);
         Assert.Null(options.PackagePath);
         Assert.Contains("SerializeToNode", options.MemberFilter);
@@ -334,6 +356,17 @@ public class MemberOptionsParserTests
         Assert.Equal("JsonSerializizer", options.TypeName);
         Assert.Null(options.PackagePath);
         Assert.Empty(options.MemberFilter);
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedPlatformTypeTypoAndMember_PreservesTypeForSuggestions()
+    {
+        var options = await ParseSuccessAsync("member", "System.Text.Json.JsonSerializizer", "SerializeToNode");
+
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Equal("JsonSerializizer", options.TypeName);
+        Assert.Null(options.PackagePath);
+        Assert.Contains("SerializeToNode", options.MemberFilter);
     }
 
     // ── Dotted member syntax (-m Type.Member) ────────────────────────────

--- a/src/dotnet-inspect.Tests/Parsers/SourceOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SourceOptionsParserTests.cs
@@ -1,0 +1,142 @@
+using System.CommandLine;
+using DotnetInspector.CommandLine;
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests.Parsers;
+
+[Collection("Console")]
+public class SourceOptionsParserTests
+{
+    private static (Command Root, SharedOptions Opts, SourceOptionsParser.SourceCommandArgs Args) CreateTestCommand()
+    {
+        var opts = new SharedOptions();
+        var sourceCommand = new Command("source", "test");
+
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        var packageOption = new Option<string?>("--package");
+        var assemblyOption = new Option<string?>("--library");
+        var platformOption = new Option<string?>("--platform");
+        var frameworkOption = new Option<string?>("--framework");
+        var tfmOption = new Option<string?>("--tfm");
+        var allOption = new Option<bool>("--all");
+        var memberOption = new Option<string?>("-m");
+        memberOption.Aliases.Add("--member");
+        var typeFilterOption = new Option<string?>("-t");
+        typeFilterOption.Aliases.Add("--type");
+        var verifyOption = new Option<bool>("--verify");
+        var browsableUrlsOption = new Option<bool>("--browsable-urls");
+        var catOption = new Option<bool>("--cat");
+        var ilOffsetOption = new Option<string?>("--il-offset");
+        var compactOption = new Option<bool>("--compact");
+
+        sourceCommand.Arguments.Add(argsArg);
+        sourceCommand.Options.Add(packageOption);
+        sourceCommand.Options.Add(assemblyOption);
+        sourceCommand.Options.Add(platformOption);
+        sourceCommand.Options.Add(frameworkOption);
+        sourceCommand.Options.Add(tfmOption);
+        sourceCommand.Options.Add(allOption);
+        sourceCommand.Options.Add(memberOption);
+        sourceCommand.Options.Add(typeFilterOption);
+        sourceCommand.Options.Add(verifyOption);
+        sourceCommand.Options.Add(browsableUrlsOption);
+        sourceCommand.Options.Add(catOption);
+        sourceCommand.Options.Add(ilOffsetOption);
+        sourceCommand.Options.Add(opts.Json);
+        sourceCommand.Options.Add(compactOption);
+        opts.AddTableOptionsTo(sourceCommand);
+        opts.AddSectionOptionsTo(sourceCommand);
+        sourceCommand.Options.Add(opts.Markdown);
+        sourceCommand.Options.Add(opts.PlainText);
+        opts.AddOutputOptionsTo(sourceCommand);
+        opts.AddNuGetOptionsTo(sourceCommand);
+
+        sourceCommand.SetAction((_, _) => Task.FromResult(0));
+
+        var root = new RootCommand { sourceCommand };
+        var args = new SourceOptionsParser.SourceCommandArgs(
+            argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
+            allOption, memberOption, typeFilterOption, verifyOption, browsableUrlsOption, catOption,
+            ilOffsetOption, compactOption, opts.OneLine, opts.NoHeaders);
+
+        return (root, opts, args);
+    }
+
+    private static async Task<SourceOptions> ParseSuccessAsync(params string[] args)
+    {
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(args);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await SourceOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+        var success = Assert.IsType<SourceOptionsParser.Success>(result);
+        return success.Options;
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedTypeMember_ResolvesPlatformTypeAndMember()
+    {
+        var options = await ParseSuccessAsync("source", "System.Text.Json.JsonSerializer.SerializeToNode");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Null(options.PackagePath);
+        Assert.Equal("SerializeToNode", options.MemberName);
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedTypeMemberWithOverload_ResolvesIndex()
+    {
+        var options = await ParseSuccessAsync("source", "System.Text.Json.JsonSerializer.SerializeToNode:1");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Equal("SerializeToNode", options.MemberName);
+        Assert.Equal(1, options.OverloadIndex);
+    }
+
+    [Fact]
+    public async Task Positional_QualifiedTypeMemberWithTypo_PreservesTypeForSuggestions()
+    {
+        var options = await ParseSuccessAsync("source", "System.Text.Json.JsonSerializizer.SerializeToNode");
+
+        Assert.Equal("JsonSerializizer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Null(options.PackagePath);
+        Assert.Equal("SerializeToNode", options.MemberName);
+    }
+
+    [Fact]
+    public async Task ExplicitPlatform_WithLocalDottedMember_SplitsTypeAndMember()
+    {
+        var options = await ParseSuccessAsync(
+            "source", "JsonSerializer.SerializeToNode", "--platform", "System.Text.Json");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Equal("SerializeToNode", options.MemberName);
+    }
+
+    [Fact]
+    public async Task ExplicitPlatform_WithQualifiedTypeOnly_PreservesQualifiedType()
+    {
+        var options = await ParseSuccessAsync(
+            "source", "System.Text.Json.JsonSerializer", "--platform", "System.Text.Json");
+
+        Assert.Equal("System.Text.Json.JsonSerializer", options.TypeName);
+        Assert.Equal("System.Text.Json", options.PlatformAssembly);
+        Assert.Null(options.MemberName);
+    }
+
+    [Fact]
+    public async Task Positional_PackageTypeSyntax_DoesNotUseRootPlatformFallback()
+    {
+        var options = await ParseSuccessAsync("source", "System.CommandLine", "Command");
+
+        Assert.Equal("System.CommandLine", options.PackagePath);
+        Assert.Equal("Command", options.TypeName);
+        Assert.Null(options.PlatformAssembly);
+        Assert.Null(options.MemberName);
+    }
+}

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -1,0 +1,61 @@
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class SourceResolverTests
+{
+    public SourceResolverTests()
+    {
+        NuGetCache.Initialize("dotnet-inspect");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_QualifiedPlatformTypeTypo_PreservesPrefixForSuggestions()
+    {
+        var source = await SourceResolver.ResolveAsync(
+            ["System.Text.Json.JsonSerializizer"],
+            explicitPackage: null,
+            explicitAssembly: null,
+            explicitPlatform: null,
+            verbose: false,
+            tryQualifiedTypeName: true);
+
+        Assert.Equal("System.Text.Json", source.PlatformAssembly);
+        Assert.Equal("JsonSerializizer", source.TypeName);
+        Assert.Null(source.PackagePath);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PackageTypeSyntax_DoesNotUseRootPlatformFallback()
+    {
+        var source = await SourceResolver.ResolveAsync(
+            ["System.CommandLine", "Command"],
+            explicitPackage: null,
+            explicitAssembly: null,
+            explicitPlatform: null,
+            verbose: false,
+            tryQualifiedTypeName: true);
+
+        Assert.Equal("System.CommandLine", source.PackagePath);
+        Assert.Equal("Command", source.TypeName);
+        Assert.Null(source.PlatformAssembly);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PackageLikeSingleArg_DoesNotUseRootPlatformFallback()
+    {
+        var source = await SourceResolver.ResolveAsync(
+            ["System.CommandLine"],
+            explicitPackage: null,
+            explicitAssembly: null,
+            explicitPlatform: null,
+            verbose: false,
+            tryQualifiedTypeName: true);
+
+        Assert.Equal("System.CommandLine", source.PackagePath);
+        Assert.Null(source.TypeName);
+        Assert.Null(source.PlatformAssembly);
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -92,6 +92,9 @@ public static class RouterCommandDefinition
                 case RouterOptionsParser.RouteToType route:
                     return await ExecuteTypeCommandAsync(route, opts, parseResult, commandArgs);
 
+                case RouterOptionsParser.RouteToMember route:
+                    return await ExecuteMemberCommandAsync(route, opts, parseResult, commandArgs);
+
                 case RouterOptionsParser.RouteToPackage route:
                     return await ExecutePackageCommandAsync(route);
 
@@ -130,10 +133,22 @@ public static class RouterCommandDefinition
             return assemblyExitCode;
         }
 
+        var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(route.BareName, allowPlatformPrefixFallback: true);
+        if (memberSplit != null)
+        {
+            var memberOptions = BuildMemberOptions(
+                memberSplit.Value.Probe,
+                memberSplit.Value.MemberName,
+                opts,
+                parseResult,
+                commandArgs);
+            return await MemberCommand.ExecuteAsync(memberOptions);
+        }
+
         // Platform resolution failed - check if this is a qualified type name
         // e.g., System.Text.Json.JsonSerializer -> type JsonSerializer --platform System.Text.Json
-        // Probes dotnet hive, dotnet-inspect cache, and NuGet global cache (local only).
-        var probe = SourceResolver.TryProbeLocalQualifiedName(route.BareName);
+        // Probes exact local types first, then keeps a platform prefix for typo-friendly type suggestions.
+        var probe = SourceResolver.TryResolveQualifiedTypeName(route.BareName, allowPlatformPrefixFallback: true);
         if (probe != null)
         {
             var typeOptions = new TypeOptions
@@ -310,6 +325,69 @@ public static class RouterCommandDefinition
         };
 
         return await ApiCommand.ExecuteAsync(typeOptions);
+    }
+
+    private static Task<int> ExecuteMemberCommandAsync(
+        RouterOptionsParser.RouteToMember route,
+        SharedOptions opts,
+        ParseResult parseResult,
+        RouterOptionsParser.RouterCommandArgs commandArgs)
+    {
+        var split = SharedParsers.TrySplitQualifiedTypeMember(route.Args[0], allowPlatformPrefixFallback: false);
+        if (split == null)
+            return Task.FromResult(1);
+
+        var memberOptions = BuildMemberOptions(
+            split.Value.Probe,
+            split.Value.MemberName,
+            opts,
+            parseResult,
+            commandArgs);
+        return MemberCommand.ExecuteAsync(memberOptions);
+    }
+
+    private static MemberOptions BuildMemberOptions(
+        SourceResolver.LocalProbeResult probe,
+        string memberSelector,
+        SharedOptions opts,
+        ParseResult parseResult,
+        RouterOptionsParser.RouterCommandArgs commandArgs)
+    {
+        var (memberName, overloadIndex) = SharedParsers.ParseOverloadShorthand(memberSelector);
+        var verbosity = opts.ParseVerbosity(parseResult);
+
+        return new MemberOptions
+        {
+            TypeName = probe.Remainder,
+            PlatformAssembly = probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
+            PackagePath = probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { memberName },
+            OverloadIndex = overloadIndex,
+            ShowDocs = true,
+            DocsExplicitlySet = false,
+            JsonOutput = parseResult.GetValue(opts.Json),
+            PlainText = opts.ResolveFormat(parseResult) == OutputFormat.PlainText,
+            OneLine = opts.ResolveOneLine(parseResult),
+            Tsv = opts.ResolveTsv(parseResult),
+            OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
+            FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
+            NoHeader = parseResult.GetValue(opts.NoHeaders),
+            CompactJson = parseResult.GetValue(commandArgs.CompactOption),
+            Verbose = parseResult.GetValue(opts.Verbose),
+            Verbosity = verbosity,
+            Discover = opts.ParseDiscover(parseResult),
+            Tree = parseResult.GetValue(opts.Tree),
+            Select = opts.ParseSelect(parseResult),
+            Columns = opts.ParseColumns(parseResult),
+            Fields = opts.ParseFields(parseResult),
+            Count = parseResult.GetValue(opts.Count),
+            Schema = opts.ParseSchema(parseResult),
+            Rows = opts.ParseRows(parseResult),
+            SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
+            TipLevel = ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null
+                ? TipLevel.Quiet
+                : opts.ParseTipLevel(parseResult)
+        };
     }
 
     private static async Task<int> ExecutePackageCommandAsync(RouterOptionsParser.RouteToPackage route)

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -119,7 +119,9 @@ public static class MemberOptionsParser
             && positionalMembers.Count == 0
             && optionMembers.Length == 0)
         {
-            var split = TrySplitQualifiedTypeMember(source.PackagePath);
+            var split = SharedParsers.TrySplitQualifiedTypeMember(
+                source.PackagePath,
+                allowPlatformPrefixFallback: true);
             if (split != null)
             {
                 positionalMembers.Add(split.Value.MemberName);
@@ -140,9 +142,9 @@ public static class MemberOptionsParser
             && source.PlatformAssembly == null
             && source.AssemblyPath == null)
         {
-            var probe = SourceResolver.TryProbeLocalQualifiedName(source.PackagePath);
-            if (source.TypeName == null)
-                probe ??= SourceResolver.TryProbePlatformQualifiedPrefix(source.PackagePath);
+            var probe = SourceResolver.TryResolveQualifiedTypeName(
+                source.PackagePath,
+                allowPlatformPrefixFallback: true);
             if (probe != null)
             {
                 if (source.TypeName != null)
@@ -249,26 +251,6 @@ public static class MemberOptionsParser
         };
 
         return new Success(options);
-    }
-
-    private static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(string value)
-    {
-        for (var i = value.Length - 1; i > 0; i--)
-        {
-            if (value[i] != '.')
-                continue;
-
-            var typeCandidate = value[..i];
-            var memberName = value[(i + 1)..];
-            if (string.IsNullOrWhiteSpace(memberName) || memberName.Contains('<'))
-                continue;
-
-            var probe = SourceResolver.TryProbeLocalQualifiedName(typeCandidate);
-            if (probe != null)
-                return (probe, memberName);
-        }
-
-        return null;
     }
 
     private static (HashSet<string> Filter, int? Limit) BuildMemberFilter(string[] allMembers, bool ctorOnly, out bool clearShorthand)

--- a/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
@@ -79,6 +79,11 @@ public static class RouterOptionsParser
     public record RouteToType(string[] Args) : RouterParseResult;
 
     /// <summary>
+    /// Route to member command for a source-qualified Type.Member shortcut.
+    /// </summary>
+    public record RouteToMember(string[] Args) : RouterParseResult;
+
+    /// <summary>
     /// Route to package command.
     /// </summary>
     public record RouteToPackage(InspectionOptions Options, string BareName, Verbosity Verbosity) : RouterParseResult;
@@ -179,7 +184,11 @@ public static class RouterOptionsParser
         // route as a qualified type name (e.g., "Humanizer.Core.DateHumanize").
         if (!isVersionQuery && packageArgs.Length == 1)
         {
-            var probe = SourceResolver.TryProbeLocalQualifiedName(bareName);
+            var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(bareName, allowPlatformPrefixFallback: false);
+            if (memberSplit != null)
+                return new RouteToMember(packageArgs);
+
+            var probe = SourceResolver.TryResolveQualifiedTypeName(bareName, allowPlatformPrefixFallback: false);
             if (probe != null)
                 return new RouteToType(packageArgs);
         }

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -83,6 +83,28 @@ public static class SharedParsers
             : (typeName[..lastDot], rightPart);
     }
 
+    internal static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(
+        string value,
+        bool allowPlatformPrefixFallback)
+    {
+        for (var i = value.Length - 1; i > 0; i--)
+        {
+            if (value[i] != '.')
+                continue;
+
+            var typeCandidate = value[..i];
+            var memberName = value[(i + 1)..];
+            if (string.IsNullOrWhiteSpace(memberName) || memberName.Contains('<'))
+                continue;
+
+            var probe = SourceResolver.TryResolveQualifiedTypeName(typeCandidate, allowPlatformPrefixFallback);
+            if (probe != null)
+                return (probe, memberName);
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Parses member filter values where a single numeric value means limit,
     /// otherwise values are treated as filter names.

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -103,20 +103,46 @@ public static class SourceOptionsParser
             if (memberName == null)
             {
                 var positionalMembers = new List<string>();
+                if (!sourceSelection.HasExplicitSource && sourceSelection.Args.Length == 1)
+                {
+                    var split = SharedParsers.TrySplitQualifiedTypeMember(
+                        sourceSelection.Args[0],
+                        allowPlatformPrefixFallback: true);
+                    if (split != null)
+                    {
+                        positionalMembers.Add(split.Value.MemberName);
+                        var probe = split.Value.Probe;
+                        source = probe.Kind == SourceResolver.LocalSourceKind.Platform
+                            ? source with { PackagePath = null, PlatformAssembly = probe.SourceName, TypeName = probe.Remainder }
+                            : source with { PackagePath = probe.SourceName, TypeName = probe.Remainder };
+                    }
+                }
+
                 if (sourceSelection.HasExplicitSource && sourceSelection.Args.Length >= 2)
                     positionalMembers.AddRange(sourceSelection.Args[1..]);
                 else if (!sourceSelection.HasExplicitSource && sourceSelection.Args.Length >= 3)
                     positionalMembers.AddRange(sourceSelection.Args[2..]);
 
-                // Handle Type.Member dotted syntax
+                // Handle source-explicit Type.Member shorthand.
                 var typeName = source.TypeName;
                 if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
                 {
-                    var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
-                    if (splitMemberName != null)
+                    var qualifiedSplit = sourceSelection.HasExplicitSource
+                        ? SharedParsers.TrySplitQualifiedTypeMember(typeName, allowPlatformPrefixFallback: true)
+                        : null;
+                    if (qualifiedSplit != null && ProbeMatchesExplicitSource(sourceSelection, qualifiedSplit.Value.Probe))
                     {
-                        positionalMembers.Add(splitMemberName);
-                        source = source with { TypeName = splitTypeName };
+                        positionalMembers.Add(qualifiedSplit.Value.MemberName);
+                        source = source with { TypeName = qualifiedSplit.Value.Probe.Remainder };
+                    }
+                    else if (!IsExplicitSourceQualifiedTypeName(sourceSelection, typeName))
+                    {
+                        var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
+                        if (splitMemberName != null)
+                        {
+                            positionalMembers.Add(splitMemberName);
+                            source = source with { TypeName = splitTypeName };
+                        }
                     }
                 }
 
@@ -127,11 +153,11 @@ public static class SourceOptionsParser
             // Parse overload index shorthand: GetValue:2
             if (memberName != null && memberName.Contains(':'))
             {
-                var colonIdx = memberName.LastIndexOf(':');
-                if (int.TryParse(memberName[(colonIdx + 1)..], out var idx))
+                var (name, idx) = SharedParsers.ParseOverloadShorthand(memberName);
+                if (idx != null)
                 {
                     overloadIndex = idx;
-                    memberName = memberName[..colonIdx];
+                    memberName = name;
                 }
             }
         }
@@ -181,5 +207,44 @@ public static class SourceOptionsParser
         };
 
         return new Success(options);
+    }
+
+    private static bool ProbeMatchesExplicitSource(
+        SharedParsers.SourceSelection sourceSelection,
+        SourceResolver.LocalProbeResult probe)
+    {
+        var explicitName = GetExplicitSourceName(sourceSelection);
+        return explicitName != null
+            && string.Equals(explicitName, NormalizeSourceName(probe.SourceName), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExplicitSourceQualifiedTypeName(
+        SharedParsers.SourceSelection sourceSelection,
+        string typeName)
+    {
+        var explicitName = GetExplicitSourceName(sourceSelection);
+        return explicitName != null
+            && typeName.StartsWith($"{explicitName}.", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? GetExplicitSourceName(SharedParsers.SourceSelection sourceSelection) =>
+        NormalizeSourceName(sourceSelection.ExplicitPlatform)
+        ?? NormalizeSourceName(sourceSelection.ExplicitPackage)
+        ?? NormalizeSourceName(sourceSelection.ExplicitAssembly);
+
+    private static string? NormalizeSourceName(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var name = value;
+        var versionIndex = name.IndexOf('@');
+        if (versionIndex >= 0)
+            name = name[..versionIndex];
+
+        name = Path.GetFileName(name);
+        return name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? name[..^4]
+            : name;
     }
 }

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -105,6 +105,19 @@ public static class SourceResolver
     }
 
     /// <summary>
+    /// Resolves a dotted source-qualified type name using the shared precedence:
+    /// exact local type match first, then a typo-friendly platform prefix match.
+    /// </summary>
+    internal static LocalProbeResult? TryResolveQualifiedTypeName(string name, bool allowPlatformPrefixFallback)
+    {
+        var probe = TryProbeLocalQualifiedName(name);
+        if (probe != null || !allowPlatformPrefixFallback)
+            return probe;
+
+        return TryProbePlatformQualifiedPrefix(name);
+    }
+
+    /// <summary>
     /// Peels a dotted name and returns the longest platform assembly prefix even when the
     /// remaining type name is misspelled. This is intentionally platform-only to avoid
     /// misclassifying one-argument package names as package/type pairs.
@@ -120,6 +133,8 @@ public static class SourceResolver
             var candidate = name[..i];
             var remainder = name[(i + 1)..];
             if (string.IsNullOrEmpty(candidate) || string.IsNullOrEmpty(remainder))
+                continue;
+            if (!candidate.Contains('.'))
                 continue;
 
             if (!PlatformResolver.IsPlatformCandidate(candidate))
@@ -269,7 +284,7 @@ public static class SourceResolver
                 if (tryQualifiedTypeName && typeName == null
                     && packagePath != null && platformAssembly == null && assemblyPath == null)
                 {
-                    var probe = TryProbeLocalQualifiedName(bareName);
+                    var probe = TryResolveQualifiedTypeName(bareName, allowPlatformPrefixFallback: true);
                     if (probe != null)
                     {
                         typeName = probe.Remainder;


### PR DESCRIPTION
## Summary

- share qualified type and Type.Member parsing across type/member/source/router paths
- preserve platform source prefixes for typo-friendly type suggestions
- route bare source-qualified member shortcuts to member output and keep package/type syntax from platform fallback hijacking
- add parser, resolver, and offline router regression coverage

Addresses #370.

## Tests

- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release