### PR TITLE
Support bare CoreLib type lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dnx dotnet-inspect -y -- <command>
 | Platform libraries | `library System.Private.CoreLib`, `library System.Text.Json --version 10.0.0`, `diff --platform System.Runtime@9.0.0..10.0.0` | Resolves installed SDK/runtime assemblies, including runtime-only implementation assemblies with no NuGet package. |
 | Local assets | `library ./bin/MyLib.dll`, `package ./pkg/MyLib.nupkg` | Useful for auditing builds before publishing. |
 
-Bare names are routed automatically: platform-looking names (`System.*`, `Microsoft.AspNetCore.*`) resolve to installed platform libraries; other names resolve as NuGet packages. Use explicit commands and `--package`, `--platform`, or `--library` when you need a specific source.
+Bare names are routed automatically: platform-looking names (`System.*`, `Microsoft.AspNetCore.*`) resolve to installed platform libraries; other names resolve as NuGet packages. In API commands, common CoreLib aliases and simple type names such as `string`, `int`, `DateTime`, and `Guid` resolve to `System.Private.CoreLib`. Use explicit commands and `--package`, `--platform`, or `--library` when you need a specific source.
 
 ## Capability inventory
 
@@ -91,6 +91,7 @@ dotnet-inspect library System.Text.Json -S "Signals,SourceLink Availability,Sour
 dotnet-inspect library System.Text.Json -S "SourceLink Integrity"
 dotnet-inspect package System.Text.Json -S Signals
 dotnet-inspect package System.Text.Json --versions
+dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -66,6 +66,8 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json
 
 Carry resolved context forward. Bare names use the router: platform-looking names are tried as installed platform libraries first, then fall back to NuGet packages if platform resolution fails. Use explicit `--platform`, `--package`, or `--library` when the source matters; for multi-library packages, include the `--library` value shown by `find`.
 
+For common CoreLib APIs, aliases and simple type names work without a source flag: use `type string --shape`, `member string`, or `member string -m Normalize`.
+
 Use `type Type --package Foo --shape` for a compact type overview and overload counts. For a specific overload inventory, use `member Type --package Foo -m Name --show-index`; this renders the `Methods` overload rows with full signatures and stable `Name:N` selectors. A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need that specific implementation evidence.
 
 ## Upgrade and compatibility workflow

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1207,6 +1207,45 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_BareStringAlias_RendersCoreLibString()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "string", "--shape", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.String", output);
+        Assert.Contains("─ Methods", output);
+    }
+
+    [Theory]
+    [InlineData("Dictionary<TKey,TValue>")]
+    [InlineData("Dictionary`2")]
+    public async Task Type_BareDictionaryGeneric_RendersCoreLibDictionary(string typeName)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", typeName, "--shape", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Collections.Generic.Dictionary<TKey, TValue>", output);
+        Assert.Contains("void Add(TKey key, TValue value)", output);
+    }
+
+    [Fact]
+    public async Task Member_BareStringAliasWithMemberFilter_RendersStringMembers()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "string", "-m", "Normalize", "-S", "Methods", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("# System.String", output);
+        Assert.Contains("## Methods", output);
+        Assert.Contains("Normalize(", output);
+    }
+
+    [Fact]
     public async Task Member_EnumValueFilter_TsvAppliesMemberFilter()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -336,6 +336,39 @@ public class MemberOptionsParserTests
         Assert.Empty(options.MemberFilter);
     }
 
+    [Theory]
+    [InlineData("string", "System.String")]
+    [InlineData("int", "System.Int32")]
+    [InlineData("bool", "System.Boolean")]
+    [InlineData("object", "System.Object")]
+    [InlineData("String", "System.String")]
+    [InlineData("DateTime", "System.DateTime")]
+    [InlineData("Guid", "System.Guid")]
+    [InlineData("Math", "System.Math")]
+    [InlineData("System.String", "System.String")]
+    [InlineData("List<T>", "System.Collections.Generic.List`1")]
+    [InlineData("Dictionary<TKey,TValue>", "System.Collections.Generic.Dictionary`2")]
+    [InlineData("Dictionary`2", "System.Collections.Generic.Dictionary`2")]
+    [InlineData("Action", "System.Action")]
+    [InlineData("Action`1", "System.Action`1")]
+    [InlineData("Func`2", "System.Func`2")]
+    public async Task Positional_BareCoreLibType_ResolvesPlatformType(string input, string expectedTypeName)
+    {
+        var (coreLibPath, _, _, coreLibError) = PlatformResolver.ResolveAssembly("System.Private.CoreLib");
+        if (coreLibPath == null || coreLibError != null)
+        {
+            Assert.Skip($"System.Private.CoreLib not available: {coreLibError}");
+            return;
+        }
+
+        var options = await ParseSuccessAsync("member", input);
+
+        Assert.Equal("System.Private.CoreLib", options.PlatformAssembly);
+        Assert.Equal(expectedTypeName, options.TypeName);
+        Assert.Null(options.PackagePath);
+        Assert.Empty(options.MemberFilter);
+    }
+
     // ── Dotted member syntax (-m Type.Member) ────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -1,0 +1,90 @@
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class SourceResolverTests
+{
+    [Theory]
+    [InlineData("string", "System.String")]
+    [InlineData("int", "System.Int32")]
+    [InlineData("bool", "System.Boolean")]
+    [InlineData("object", "System.Object")]
+    [InlineData("nint", "System.IntPtr")]
+    [InlineData("nuint", "System.UIntPtr")]
+    [InlineData("String", "System.String")]
+    [InlineData("DateTime", "System.DateTime")]
+    [InlineData("Guid", "System.Guid")]
+    [InlineData("Math", "System.Math")]
+    [InlineData("System.String", "System.String")]
+    [InlineData("List<T>", "System.Collections.Generic.List`1")]
+    [InlineData("List`1", "System.Collections.Generic.List`1")]
+    [InlineData("Dictionary<TKey,TValue>", "System.Collections.Generic.Dictionary`2")]
+    [InlineData("Dictionary`2", "System.Collections.Generic.Dictionary`2")]
+    [InlineData("Dictionary", "System.Collections.Generic.Dictionary`2")]
+    [InlineData("Action", "System.Action")]
+    [InlineData("Action`1", "System.Action`1")]
+    [InlineData("Tuple", "System.Tuple")]
+    [InlineData("Tuple`2", "System.Tuple`2")]
+    [InlineData("ValueTuple", "System.ValueTuple")]
+    [InlineData("ValueTuple`2", "System.ValueTuple`2")]
+    [InlineData("Func`2", "System.Func`2")]
+    public async Task ResolveAsync_BareCoreLibType_ResolvesAsPlatformType(string input, string expectedTypeName)
+    {
+        SkipIfCoreLibUnavailable();
+
+        var source = await SourceResolver.ResolveAsync(
+            [input], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+
+        Assert.Equal("System.Private.CoreLib", source.PlatformAssembly);
+        Assert.Equal(expectedTypeName, source.TypeName);
+        Assert.Null(source.PackagePath);
+        Assert.Null(source.AssemblyPath);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_BareCoreLibGenericFamilyWithoutArity_KeepsPackageFallback()
+    {
+        SkipIfCoreLibUnavailable();
+
+        var source = await SourceResolver.ResolveAsync(
+            ["Func"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+
+        Assert.Equal("Func", source.PackagePath);
+        Assert.Null(source.PlatformAssembly);
+        Assert.Null(source.TypeName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_UnknownBareName_KeepsPackageFallback()
+    {
+        SkipIfCoreLibUnavailable();
+
+        var source = await SourceResolver.ResolveAsync(
+            ["Definitely.NotACoreLibType"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+
+        Assert.Equal("Definitely.NotACoreLibType", source.PackagePath);
+        Assert.Null(source.PlatformAssembly);
+        Assert.Null(source.TypeName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ExplicitSource_DoesNotUseBareCoreLibLookup()
+    {
+        SkipIfCoreLibUnavailable();
+
+        var source = await SourceResolver.ResolveAsync(
+            ["string"], explicitPackage: "Example.Package", explicitAssembly: null, explicitPlatform: null, verbose: false);
+
+        Assert.Equal("Example.Package", source.PackagePath);
+        Assert.Equal("string", source.TypeName);
+        Assert.Null(source.PlatformAssembly);
+    }
+
+    private static void SkipIfCoreLibUnavailable()
+    {
+        var (coreLibPath, _, _, coreLibError) = PlatformResolver.ResolveAssembly("System.Private.CoreLib");
+        if (coreLibPath == null || coreLibError != null)
+            Assert.Skip($"System.Private.CoreLib not available: {coreLibError}");
+    }
+}

--- a/src/dotnet-inspect.Tests/SymbolPackageDownloaderTests.cs
+++ b/src/dotnet-inspect.Tests/SymbolPackageDownloaderTests.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
 
+[Collection("Console")]
 public class SymbolPackageDownloaderTests : IDisposable
 {
     private readonly string _cacheDir = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-symbol-tests-{Guid.NewGuid():N}");

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -165,6 +165,7 @@ public static class MemberOptionsParser
         if (!sourceInputs.HasExplicitSource
             && typeName != null
             && typeName.Contains('.')
+            && sourceInputs.Args.Length > 1
             && positionalMembers.Count == 0
             && optionMembers.Length == 0)
         {

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -1,5 +1,7 @@
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using DotnetInspector.CommandLine;
+using DotnetInspector.Metadata;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 
@@ -11,6 +13,8 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class SourceResolver
 {
+    private const string CoreLibAssemblyName = "System.Private.CoreLib";
+
     /// <summary>
     /// Result of source resolution containing resolved paths and any extracted type information.
     /// </summary>
@@ -145,6 +149,101 @@ public static class SourceResolver
         => PlatformResolver.HasType(assemblyPath, typeName);
 
     /// <summary>
+    /// Resolves a one-token alias or simple type name from System.Private.CoreLib.
+    /// This intentionally probes one local runtime assembly only; misses keep the
+    /// existing package/source fallback behavior.
+    /// </summary>
+    internal static LocalProbeResult? TryResolveBareCoreLibTypeName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        var typeName = NormalizeCoreLibTypeQuery(name);
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly(CoreLibAssemblyName);
+        if (assemblyPath == null || error != null)
+            return null;
+
+        var match = FindUniquePublicType(assemblyPath, typeName);
+        return match != null
+            ? new LocalProbeResult(CoreLibAssemblyName, match, LocalSourceKind.Platform)
+            : null;
+    }
+
+    private static string NormalizeCoreLibTypeQuery(string name)
+    {
+        var trimmed = name.Trim();
+        return trimmed.ToLowerInvariant() switch
+        {
+            "bool" => "System.Boolean",
+            "byte" => "System.Byte",
+            "sbyte" => "System.SByte",
+            "char" => "System.Char",
+            "decimal" => "System.Decimal",
+            "double" => "System.Double",
+            "float" => "System.Single",
+            "int" => "System.Int32",
+            "uint" => "System.UInt32",
+            "nint" => "System.IntPtr",
+            "nuint" => "System.UIntPtr",
+            "long" => "System.Int64",
+            "ulong" => "System.UInt64",
+            "object" => "System.Object",
+            "short" => "System.Int16",
+            "ushort" => "System.UInt16",
+            "string" => "System.String",
+            "void" => "System.Void",
+            _ => trimmed
+        };
+    }
+
+    private static string? FindUniquePublicType(string assemblyPath, string typeName)
+    {
+        var normalized = DotnetInspector.Metadata.TypeMatcher.Normalize(typeName);
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        if (!peReader.HasMetadata)
+            return null;
+
+        var reader = peReader.GetMetadataReader();
+        List<string> publicTypes = [];
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (!typeDef.IsPublic)
+                continue;
+
+            var name = reader.GetString(typeDef.Name);
+            var ns = reader.GetString(typeDef.Namespace);
+            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+            publicTypes.Add(fullName);
+        }
+
+        var exactMatches = publicTypes.Where(fullName =>
+            fullName.Equals(normalized, StringComparison.OrdinalIgnoreCase)
+            || DotnetInspector.Metadata.TypeMatcher.GetSimpleName(fullName).Equals(normalized, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exactMatches.Count == 1)
+            return exactMatches[0];
+        if (exactMatches.Count > 1)
+            return null;
+
+        string? match = null;
+        foreach (var fullName in publicTypes)
+        {
+            if (!DotnetInspector.Metadata.TypeMatcher.Matches(fullName, normalized))
+                continue;
+
+            if (match != null)
+                return null;
+
+            match = fullName;
+        }
+
+        return match;
+    }
+
+    /// <summary>
     /// Resolves source from positional arguments and explicit options.
     /// Handles file classification, platform resolution, and version detection.
     /// </summary>
@@ -195,6 +294,17 @@ public static class SourceResolver
                     packagePath, assemblyPath, platformAssembly, null, null,
                     VersionError: true,
                     VersionErrorMessage: $"Error: '{typeName}' looks like a version number. Use '{packagePath}@{typeName}' to specify a version.");
+            }
+
+            if (args.Length == 1 && packagePath != null && typeName == null)
+            {
+                var coreLibType = TryResolveBareCoreLibTypeName(packagePath);
+                if (coreLibType != null)
+                {
+                    typeName = coreLibType.Remainder;
+                    platformAssembly = coreLibType.SourceName;
+                    packagePath = null;
+                }
             }
 
             // Detect bare type names (e.g., "Dictionary`2", "List`1") passed without a source.


### PR DESCRIPTION
## Summary
- resolve bare C# aliases and simple CoreLib type names from System.Private.CoreLib before package fallback
- support generic and arity forms such as List<T>, Dictionary<TKey,TValue>, and Dictionary`2
- document the shortcut and add parser, resolver, and end-to-end command coverage

Closes #369

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md