### PR TITLE
Render full member signatures

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.10.1
+version: 0.10.2
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 
@@ -52,7 +52,7 @@ Use the query system when default views do not expose the detail you need. `-D` 
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D "Method Groups" --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -D Methods --tsv
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature;Obsolete"
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature"
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
@@ -66,6 +66,7 @@ Bare `-S` renders a curated high-density view; `-S All` renders an exhaustive do
 - Always quote generic type names in shell commands: `type 'List<T>'`, `member 'Dictionary<TKey,TValue>'`, or `type 'INumber<TSelf>'`. Use `<T>` rather than `<>` for generic type queries.
 - Wildcards are supported for type names and section/schema selection; quote shell patterns, such as `type 'Json*' --package System.Text.Json`, `-S "Async*"`, or `-D "SourceLink*"`.
 - `type` uses `-t` for type filters; `member` uses `-m` for member filters. Dotted member syntax works: `-m JsonSerializer.Deserialize`.
+- Member `Signature` values are single-line C# declarations and may include high-signal attributes such as `[Obsolete]`.
 - Diff ranges use `..`: `--package Foo@1.0.0..2.0.0`. Obsolete members are shown by default; use `--all` for non-public, hidden, and extra members.
 - Unpinned packages use the latest stable by default; add `--preview` when prerelease APIs matter.
 

--- a/src/DotnetInspector.Metadata/ApiSurface.cs
+++ b/src/DotnetInspector.Metadata/ApiSurface.cs
@@ -243,6 +243,10 @@ public class ApiMember
     public bool IsStatic { get; set; }
     public bool IsVirtual { get; set; }
     public bool IsAbstract { get; set; }
+    public bool IsOverride { get; set; }
+    public bool IsSealed { get; set; }
+    public bool IsReadOnly { get; set; }
+    public bool IsConst { get; set; }
     public bool IsUnsafe { get; set; }
 
     /// <summary>

--- a/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/DotnetInspector.Metadata/ApiSurfaceExtractor.cs
@@ -175,6 +175,10 @@ public static class ApiSurfaceExtractor
 
                 var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
                 var isOperator = IsOperatorMethodName(methodName);
+                var methodAttributes = method.Attributes;
+                var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
+                var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
+                var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
                 var member = new ApiMember
                 {
                     Name = methodName,
@@ -185,9 +189,11 @@ public static class ApiSurfaceExtractor
                         _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
                         _ => "method"
                     },
-                    IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
-                    IsVirtual = (method.Attributes & MethodAttributes.Virtual) != 0,
-                    IsAbstract = (method.Attributes & MethodAttributes.Abstract) != 0,
+                    IsStatic = (methodAttributes & MethodAttributes.Static) != 0,
+                    IsVirtual = isVirtual,
+                    IsAbstract = (methodAttributes & MethodAttributes.Abstract) != 0,
+                    IsOverride = isOverride,
+                    IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     Signature = signature,
                     IsUnsafe = HasUnsafeSignature(signature),
                     Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
@@ -215,17 +221,36 @@ public static class ApiSurfaceExtractor
 
                 // Determine best accessor visibility
                 MethodAttributes bestAccess = 0;
+                bool isStaticProperty = false;
+                bool isVirtualProperty = false;
+                bool isAbstractProperty = false;
+                bool isOverrideProperty = false;
+                bool isSealedProperty = false;
                 if (!accessors.Getter.IsNil)
                 {
                     var getter = reader.GetMethodDefinition(accessors.Getter);
+                    var getterAttributes = getter.Attributes;
                     bestAccess = getter.Attributes & MethodAttributes.MemberAccessMask;
+                    isStaticProperty = (getterAttributes & MethodAttributes.Static) != 0;
+                    isVirtualProperty = (getterAttributes & MethodAttributes.Virtual) != 0;
+                    isAbstractProperty = (getterAttributes & MethodAttributes.Abstract) != 0;
+                    isOverrideProperty = isVirtualProperty && (getterAttributes & MethodAttributes.NewSlot) == 0;
+                    isSealedProperty = isOverrideProperty && (getterAttributes & MethodAttributes.Final) != 0;
                 }
                 if (!accessors.Setter.IsNil)
                 {
                     var setter = reader.GetMethodDefinition(accessors.Setter);
-                    var setterAccess = setter.Attributes & MethodAttributes.MemberAccessMask;
+                    var setterAttributes = setter.Attributes;
+                    var setterAccess = setterAttributes & MethodAttributes.MemberAccessMask;
                     if (setterAccess > bestAccess)
                         bestAccess = setterAccess;
+                    var setterVirtual = (setterAttributes & MethodAttributes.Virtual) != 0;
+                    var setterOverride = setterVirtual && (setterAttributes & MethodAttributes.NewSlot) == 0;
+                    isStaticProperty |= (setterAttributes & MethodAttributes.Static) != 0;
+                    isVirtualProperty |= setterVirtual;
+                    isAbstractProperty |= (setterAttributes & MethodAttributes.Abstract) != 0;
+                    isOverrideProperty |= setterOverride;
+                    isSealedProperty |= setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
                 }
 
                 bool isPublicProp = bestAccess == MethodAttributes.Public;
@@ -243,6 +268,11 @@ public static class ApiSurfaceExtractor
                     Name = reader.GetString(prop.Name),
                     Kind = "property",
                     Signature = GetPropertySignature(reader, typeDef, prop, accessors, typeNullableContext, includeAll),
+                    IsStatic = isStaticProperty,
+                    IsVirtual = isVirtualProperty,
+                    IsAbstract = isAbstractProperty,
+                    IsOverride = isOverrideProperty,
+                    IsSealed = isSealedProperty,
                     Accessibility = GetAccessibility(bestAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage
@@ -289,6 +319,8 @@ public static class ApiSurfaceExtractor
                     Kind = "field",
                     ReturnType = fieldType,
                     IsStatic = (field.Attributes & FieldAttributes.Static) != 0,
+                    IsReadOnly = (field.Attributes & FieldAttributes.InitOnly) != 0,
+                    IsConst = (field.Attributes & FieldAttributes.Literal) != 0,
                     Accessibility = GetFieldAccessibility(fieldAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage
@@ -341,12 +373,26 @@ public static class ApiSurfaceExtractor
                     continue;
 
                 var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, evt.GetCustomAttributes(), out var obsoleteMessage);
+                var eventType = TypeResolver.GetTypeName(reader, evt.Type, GenericContext.ForType(reader, typeDef)) ?? "";
+                var eventNullableBytes = NullabilityReader.GetNullableBytes(reader, evt.GetCustomAttributes());
+                eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(reader, adder.GetParameters(), 1);
+                if (eventNullableBytes is { Length: > 0 } && eventNullableBytes[0] == 2 && !eventType.EndsWith("?", StringComparison.Ordinal))
+                    eventType += "?";
+                var adderAttributes = adder.Attributes;
+                var isVirtualEvent = (adderAttributes & MethodAttributes.Virtual) != 0;
+                var isOverrideEvent = isVirtualEvent && (adderAttributes & MethodAttributes.NewSlot) == 0;
 
                 var member = new ApiMember
                 {
                     Name = reader.GetString(evt.Name),
                     Kind = "event",
-                    IsStatic = (adder.Attributes & MethodAttributes.Static) != 0,
+                    ReturnType = eventType,
+                    Signature = $"{eventType} {reader.GetString(evt.Name)}",
+                    IsStatic = (adderAttributes & MethodAttributes.Static) != 0,
+                    IsVirtual = isVirtualEvent,
+                    IsAbstract = (adderAttributes & MethodAttributes.Abstract) != 0,
+                    IsOverride = isOverrideEvent,
+                    IsSealed = isOverrideEvent && (adderAttributes & MethodAttributes.Final) != 0,
                     Accessibility = GetAccessibility(adderAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage
@@ -446,6 +492,8 @@ public static class ApiSurfaceExtractor
                     IsStatic = extension.IsStatic,
                     IsVirtual = extension.IsVirtual,
                     IsAbstract = extension.IsAbstract,
+                    IsOverride = extension.IsOverride,
+                    IsSealed = extension.IsSealed,
                     IsUnsafe = extension.IsUnsafe,
                     IsExtension = true,
                     ExtendedType = extension.ExtendedType,
@@ -591,10 +639,22 @@ public static class ApiSurfaceExtractor
 
             // Parameter handles may include return parameter at SequenceNumber 0
             // Actual parameters have SequenceNumber 1, 2, 3...
-            var (paramName, isParams, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
+            var (paramName, isParams, refKind, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
             paramName ??= $"arg{i}";
 
-            var paramStr = isParams ? $"params {type} {paramName}" : $"{type} {paramName}";
+            var isByRef = type.StartsWith("ref ", StringComparison.Ordinal);
+            if (isByRef)
+            {
+                type = type["ref ".Length..];
+                refKind ??= "ref";
+            }
+            else
+            {
+                refKind = null;
+            }
+
+            var modifier = isParams ? "params" : refKind;
+            var paramStr = modifier is null ? $"{type} {paramName}" : $"{modifier} {type} {paramName}";
 
             if (hasDefault)
             {
@@ -611,7 +671,7 @@ public static class ApiSurfaceExtractor
         return $"{treeSignature.ReturnType.Render()} {methodName}({paramStr2})";
     }
 
-    private static (string? name, bool isParams, bool hasDefault, object? defaultValue) GetParameterInfo(
+    private static (string? name, bool isParams, string? refKind, bool hasDefault, object? defaultValue) GetParameterInfo(
         MetadataReader reader, ParameterHandleCollection handles, int sequenceNumber)
     {
         foreach (var handle in handles)
@@ -622,6 +682,11 @@ public static class ApiSurfaceExtractor
                 string name = reader.GetString(param.Name);
                 bool isParams = AttributeReader.HasAttribute(reader, param.GetCustomAttributes(),
                     "System.ParamArrayAttribute");
+                string? refKind = (param.Attributes & System.Reflection.ParameterAttributes.Out) != 0
+                    ? "out"
+                    : (param.Attributes & System.Reflection.ParameterAttributes.In) != 0
+                        ? "in"
+                        : null;
 
                 bool hasDefault = (param.Attributes & System.Reflection.ParameterAttributes.HasDefault) != 0;
                 object? defaultValue = null;
@@ -636,10 +701,11 @@ public static class ApiSurfaceExtractor
                     }
                 }
 
-                return (name, isParams, hasDefault, defaultValue);
+                return (name, isParams, refKind, hasDefault, defaultValue);
             }
         }
-        return (null, false, false, null);
+
+        return (null, false, null, false, null);
     }
 
     private static object? ReadConstantValue(MetadataReader reader, Constant constant)
@@ -745,6 +811,43 @@ public static class ApiSurfaceExtractor
         var requiredPrefix = AttributeReader.HasRequiredMemberAttribute(reader, prop.GetCustomAttributes())
             ? "required "
             : "";
+
+        var paramHandles = hasGetter
+            ? reader.GetMethodDefinition(accessors.Getter).GetParameters()
+            : hasSetter
+                ? reader.GetMethodDefinition(accessors.Setter).GetParameters()
+                : default;
+        var paramTypes = treeSignature.ParameterTypes;
+        List<string> indexerParameters = [];
+        for (var i = 0; i < paramTypes.Length; i++)
+        {
+            var paramBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, i + 1);
+            pos = 0;
+            paramTypes[i].ApplyNullability(paramBytes, ref pos, typeNullableContext);
+            var paramType = paramTypes[i].Render();
+            var (paramName, isParams, refKind, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
+            paramName ??= $"arg{i}";
+
+            var isByRef = paramType.StartsWith("ref ", StringComparison.Ordinal);
+            if (isByRef)
+            {
+                paramType = paramType["ref ".Length..];
+                refKind ??= "ref";
+            }
+            else
+            {
+                refKind = null;
+            }
+
+            var modifier = isParams ? "params" : refKind;
+            var parameter = modifier is null ? $"{paramType} {paramName}" : $"{modifier} {paramType} {paramName}";
+            if (hasDefault)
+                parameter += $" = {FormatDefaultValue(defaultValue, paramType)}";
+            indexerParameters.Add(parameter);
+        }
+
+        if (indexerParameters.Count > 0)
+            return $"{requiredPrefix}{treeSignature.ReturnType.Render()} this[{string.Join(", ", indexerParameters)}] {accessorStr}";
 
         return $"{requiredPrefix}{treeSignature.ReturnType.Render()} {name} {accessorStr}";
     }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -623,6 +623,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Signature", output);
+        Assert.Contains("public static System.Text.Json.JsonElement SerializeToElement<TValue>(TValue value, System.Text.Json.JsonSerializerOptions? options = null)", output);
         Assert.Contains("Type: System.Text.Json.JsonSerializer", output);
         Assert.DoesNotContain("## Methods", output);
         Assert.DoesNotContain("## Decompiled Source", output);
@@ -668,7 +669,7 @@ public class CommandExecutionTests
         Assert.Contains("## Methods", output);
         Assert.Contains("| Select | Name | Signature |", output);
         Assert.Contains("`SerializeToNode:1`", output);
-        Assert.Contains("JsonNode? SerializeToNode(", output);
+        Assert.Contains("public static System.Text.Json.Nodes.JsonNode? SerializeToNode(", output);
         Assert.DoesNotContain("## Method Groups", output);
         Assert.DoesNotContain("| Name | Return Type | Overloads |", output);
     }
@@ -757,7 +758,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Signature", output);
-        Assert.Contains("GetConverter(System.Type typeToConvert)", output);
+        Assert.Contains("public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert)", output);
     }
 
     [Fact]
@@ -1006,7 +1007,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.StartsWith("select\tsignature", output);
-        Assert.Contains("Serialize:1\tstring Serialize<TValue>", output);
+        Assert.Contains("Serialize:1\tpublic static string Serialize<TValue>", output);
         Assert.DoesNotContain('`', output);
         Assert.DoesNotContain("return_type", output);
         Assert.DoesNotContain("overloads", output);
@@ -1045,11 +1046,135 @@ public class CommandExecutionTests
         using var first = JsonDocument.Parse(lines[0]);
         Assert.True(first.RootElement.TryGetProperty("select", out var select));
         Assert.True(first.RootElement.TryGetProperty("signature", out var signature));
-        Assert.Contains("Serialize", signature.GetString());
+        Assert.Contains("public static string Serialize", signature.GetString());
         Assert.StartsWith("Serialize:", select.GetString());
         Assert.DoesNotContain('`', output);
         Assert.DoesNotContain("return_type", output);
         Assert.DoesNotContain("overloads", output);
+    }
+
+    [Fact]
+    public async Task Member_NarrowedMethods_UnknownProjectedColumnWarnsWithDiscoveryHint()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "--package", "System.Text.Json",
+            "-m", "Serialize", "--show-index",
+            "--columns", "Name;Signature;Obsolete", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith("name\tsignature", output);
+        Assert.Contains("warning: column 'Obsolete' not found in section 'Methods'", error);
+        Assert.Contains("Run -D \"Methods\" to list available columns.", error);
+    }
+
+    [Fact]
+    public async Task Member_NarrowedMethods_OptionGatedProjectedColumnWarnsWithDiscoveryHint()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "--package", "System.Text.Json",
+            "-m", "Serialize",
+            "--columns", "Select;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith("signature", output);
+        Assert.Contains("warning: column 'Select' not found in section 'Methods'", error);
+        Assert.Contains("Run -D \"Methods\" to list available columns.", error);
+    }
+
+    [Fact]
+    public async Task Member_NonMethodRows_RenderFullDeclarations()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.IO.Stream", "--platform", "System.Runtime",
+            "-m", "CanRead", "-S", "Properties",
+            "--columns", "Name;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("CanRead\tpublic abstract bool CanRead { get; }", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "--platform", "System.Runtime",
+            "-m", "Empty", "-S", "Fields",
+            "--columns", "Name;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Empty\tpublic static readonly string Empty", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "System.AppDomain", "--platform", "System.Runtime",
+            "-m", "AssemblyLoad", "-S", "Events",
+            "--columns", "Name;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("AssemblyLoad\tpublic event System.AssemblyLoadEventHandler? AssemblyLoad", output);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "--platform", "System.Runtime",
+            "-m", "Chars", "-S", "Properties",
+            "--columns", "Name;Signature;Description", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Chars\tpublic char this[int index] { get; }", output);
+        Assert.Contains("Gets the Char object at a specified position in the current String object.", output);
+    }
+
+    [Fact]
+    public async Task Member_OutParameter_RendersOutModifier()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text.Json.JsonElement", "--platform", "System.Text.Json",
+            "-m", "TryGetBytesFromBase64", "-S", "Methods",
+            "--columns", "Name;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("TryGetBytesFromBase64\tpublic bool TryGetBytesFromBase64(out byte[]? value)", output);
+    }
+
+    [Fact]
+    public async Task Member_NarrowedMethods_DescriptionsMatchOverloads()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json@10.0.0",
+            "-m", "Serialize", "-S", "Methods",
+            "--columns", "Signature;Description", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public static string Serialize<TValue>(TValue value, System.Text.Json.JsonSerializerOptions? options = null)\tConverts the value of a type specified by a generic type parameter into a JSON string.", output);
+        Assert.Contains("public static void Serialize<TValue>(System.IO.Stream utf8Json, TValue value, System.Text.Json.JsonSerializerOptions? options = null)\tConverts the provided value to UTF-8 encoded JSON text and write it to the Stream.", output);
+    }
+
+    [Fact]
+    public async Task Member_NarrowedMethods_DescriptionsPreserveGenericAndArrayOverloadShape()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "--platform", "System.Runtime",
+            "-m", "Join", "-S", "Methods",
+            "--columns", "Signature;Description", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public static string Join(char separator, System.ReadOnlySpan<object?> values)\tConcatenates the string representations of a span of objects", output);
+        Assert.Contains("public static string Join(char separator, System.ReadOnlySpan<string?> value)\tConcatenates a span of strings", output);
+        Assert.Contains("public static string Join(char separator, string?[] value, int startIndex, int count)\tConcatenates an array of strings", output);
+    }
+
+    [Fact]
+    public async Task Member_ObsoleteMethod_RendersObsoleteAttributeInlineInSignature()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "SampleObsoleteHost", "--library", TestAssemblyPath,
+            "-m", "OldMethod", "-S", "Methods",
+            "--columns", "Name;Signature", "--tsv");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("OldMethod\t[Obsolete(\"Use NewMethod instead.\")] public void OldMethod()", output);
     }
 
     [Fact]
@@ -1188,7 +1313,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("string Normalize(string strInput)", output);
+        Assert.Contains("public static string Normalize(this string strInput)", output);
         Assert.DoesNotContain("string Normalize()", output);
 
         (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -258,6 +258,24 @@ public static class MemberCommand
                     apiType, ApiMemberSectionPipelines.Create(effectiveOptions), effectiveOptions);
             }
 
+            var projectionSections = effectiveOptions.IncludeSections;
+            if (projectionSections is null && ApiOutputFormatter.ShouldRenderSectionedTabularView(apiType, effectiveOptions))
+            {
+                var grouped = ApiOutputFormatter.GroupMembersByKind(
+                    apiType, effectiveOptions.MemberFilter, effectiveOptions.UnsafeOnly, effectiveOptions.KindFilter);
+                if (grouped.Count == 1)
+                    projectionSections = [GetMemberSectionName(grouped.Keys.Single())];
+            }
+
+            if ((effectiveOptions.Fields is { Length: > 0 } || effectiveOptions.Columns is { Length: > 0 })
+                && projectionSections is { Count: > 0 })
+            {
+                var schema = ApiCommand.ToQueryableSchema(
+                    ApiCommand.GetTypeDocumentSchema(effectiveOptions),
+                    effectiveOptions);
+                if (!ProjectionDiagnostics.ValidateProjection(schema, projectionSections, effectiveOptions.Fields, effectiveOptions.Columns))
+                    return 1;
+            }
 
             ApiCommand.WriteTypeOutput(apiType, foundIn, packageName, packageVersion, apiSource, selectedTfm, effectiveOptions);
 
@@ -345,6 +363,19 @@ public static class MemberCommand
             members = members.Where(m => options.KindFilter.Contains(m.Kind));
         return members.ToList();
     }
+
+    private static string GetMemberSectionName(string kind) => kind switch
+    {
+        "constructor" => SectionNames.Constructors,
+        "field" => SectionNames.Fields,
+        "property" => SectionNames.Properties,
+        "method" => SectionNames.Methods,
+        "operator" => SectionNames.Operators,
+        "explicit-interface-implementation" => SectionNames.ExplicitInterfaceImplementations,
+        "extension-method" => SectionNames.ExtensionMethods,
+        "event" => SectionNames.Events,
+        _ => kind
+    };
 
     private static bool NeedsMemberSourceResolution(ApiType apiType, MemberOptions options)
     {

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -530,7 +530,7 @@ internal static class SourceEnricher
         {
             foreach (var member in apiType.Members)
             {
-                var memberDoc = xmlParser.GetMemberDocumentation(apiType.FullName, member.Name, member.Kind);
+                var memberDoc = xmlParser.GetMemberDocumentation(apiType, member);
                 if (memberDoc != null)
                 {
                     member.Documentation = new DocComment

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -115,6 +115,329 @@ public partial class XmlDocFileParser
         return null;
     }
 
+    public DocCommentParser.DocComment? GetMemberDocumentation(ApiType apiType, ApiMember member)
+    {
+        if (!_loaded)
+            return null;
+
+        var typeXmlName = ConvertToXmlDocName(apiType.FullName);
+        var xmlMemberName = member.Name == ".ctor" ? "#ctor" : member.Name;
+        var prefix = member.Kind switch
+        {
+            "property" => "P",
+            "field" => "F",
+            "event" => "E",
+            _ => "M"
+        };
+        var xmlKey = $"{prefix}:{typeXmlName}.{xmlMemberName}";
+
+        if (prefix != "M")
+        {
+            var nonMethodSignatureParameters = GetNormalizedSignatureParameters(member.Signature, EmptyTypeParameterMap, EmptyTypeParameterMap);
+            if (nonMethodSignatureParameters.Count > 0)
+            {
+                var parameterizedCandidates = _members.Keys
+                    .Where(k => k.StartsWith($"{xmlKey}(", StringComparison.Ordinal))
+                    .ToList();
+                var matchingKey = parameterizedCandidates.FirstOrDefault(key =>
+                    TryGetXmlDocParameters(key, out var xmlParameters)
+                    && ParametersMatch(nonMethodSignatureParameters, xmlParameters));
+                return matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode)
+                    ? ParseMemberNode(matchingNode)
+                    : null;
+            }
+
+            return _members.TryGetValue(xmlKey, out var node)
+                ? ParseMemberNode(node)
+                : null;
+        }
+
+        var candidates = _members.Keys
+            .Where(k =>
+                k == xmlKey
+                || k.StartsWith($"{xmlKey}(", StringComparison.Ordinal)
+                || k.StartsWith($"{xmlKey}``", StringComparison.Ordinal))
+            .ToList();
+        if (candidates.Count == 0)
+            return null;
+
+        var typeParameterMap = apiType.TypeParameters
+            .Select((p, i) => (p.Name, Index: i))
+            .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
+        var methodParameterMap = GetMethodGenericParameterMap(member.Signature, member.Name);
+        var signatureParameters = GetNormalizedSignatureParameters(member.Signature, typeParameterMap, methodParameterMap);
+        if (signatureParameters.Count > 0)
+        {
+            var matchingKey = candidates.FirstOrDefault(key =>
+                TryGetXmlDocParameters(key, out var xmlParameters)
+                && ParametersMatch(signatureParameters, xmlParameters));
+            if (matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode))
+                return ParseMemberNode(matchingNode);
+
+            return null;
+        }
+
+        var fallbackKey = candidates.FirstOrDefault(key => key == xmlKey)
+            ?? candidates.FirstOrDefault();
+        return fallbackKey != null && _members.TryGetValue(fallbackKey, out var fallbackNode)
+            ? ParseMemberNode(fallbackNode)
+            : null;
+    }
+
+    private static List<string> GetNormalizedSignatureParameters(
+        string? signature,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap)
+    {
+        var paramList = SignatureParser.ExtractParamList(signature);
+        if (string.IsNullOrEmpty(paramList) && !string.IsNullOrEmpty(signature))
+        {
+            var indexerStart = signature.IndexOf("this[", StringComparison.Ordinal);
+            if (indexerStart >= 0)
+            {
+                var bracketStart = indexerStart + "this".Length;
+                var bracketEnd = signature.IndexOf(']', bracketStart);
+                if (bracketEnd > bracketStart)
+                    paramList = $"({signature[(bracketStart + 1)..bracketEnd]})";
+            }
+        }
+        if (string.IsNullOrEmpty(paramList))
+            return [];
+
+        var inner = paramList.Trim();
+        if (inner.StartsWith('(') && inner.EndsWith(')'))
+            inner = inner[1..^1];
+        if (string.IsNullOrWhiteSpace(inner))
+            return [];
+
+        return SplitParameters(inner)
+            .Select(p => NormalizeParameterType(p, typeParameterMap, methodParameterMap))
+            .ToList();
+    }
+
+    private static bool TryGetXmlDocParameters(string key, out List<string> parameters)
+    {
+        parameters = [];
+        var parenStart = key.IndexOf('(');
+        var parenEnd = key.LastIndexOf(')');
+        if (parenStart < 0 || parenEnd <= parenStart)
+            return false;
+
+        var inner = key[(parenStart + 1)..parenEnd];
+        parameters = string.IsNullOrWhiteSpace(inner)
+            ? []
+            : SplitParameters(inner)
+                .Select(p => NormalizeParameterType(p, EmptyTypeParameterMap, EmptyTypeParameterMap))
+                .ToList();
+        return true;
+    }
+
+    private static bool ParametersMatch(IReadOnlyList<string> signatureParameters, IReadOnlyList<string> xmlParameters)
+    {
+        if (signatureParameters.Count != xmlParameters.Count)
+            return false;
+
+        for (var i = 0; i < signatureParameters.Count; i++)
+        {
+            var left = signatureParameters[i];
+            var right = xmlParameters[i];
+            if (left == "*" || right == "*")
+                continue;
+            if (!string.Equals(left, right, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static List<string> SplitParameters(string parameters)
+    {
+        List<string> result = [];
+        var depth = 0;
+        var lastSplit = 0;
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var c = parameters[i];
+            if (c is '<' or '{' or '(')
+                depth++;
+            else if (c is '>' or '}' or ')')
+                depth--;
+            else if (c == ',' && depth == 0)
+            {
+                result.Add(parameters[lastSplit..i].Trim());
+                lastSplit = i + 1;
+            }
+        }
+
+        result.Add(parameters[lastSplit..].Trim());
+        return result;
+    }
+
+    private static readonly IReadOnlyDictionary<string, int> EmptyTypeParameterMap =
+        new Dictionary<string, int>(StringComparer.Ordinal);
+
+    private static Dictionary<string, int> GetMethodGenericParameterMap(string? signature, string memberName)
+    {
+        if (string.IsNullOrWhiteSpace(signature) || string.IsNullOrWhiteSpace(memberName))
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var genericStart = nameIndex + memberName.Length;
+        if (genericStart >= parenStart || signature[genericStart] != '<')
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        if (!TryGetGenericParts(signature[genericStart..parenStart], 0, out _, out var parameters))
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        return SplitParameters(parameters)
+            .Select((name, index) => (Name: name.Trim(), Index: index))
+            .Where(p => p.Name.Length > 0)
+            .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
+    }
+
+    private static string NormalizeParameterType(
+        string parameter,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap)
+    {
+        var type = SignatureParser.ExtractParamType(parameter.Trim());
+        foreach (var prefix in new[] { "ref ", "out ", "in ", "params ", "this " })
+        {
+            if (type.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                type = type[prefix.Length..].TrimStart();
+                break;
+            }
+        }
+
+        type = type.TrimEnd('@');
+        type = RemoveNullableAnnotations(type);
+
+        if (TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
+            return genericParameter;
+
+        if (type.EndsWith("[]", StringComparison.Ordinal))
+            return $"{NormalizeParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
+
+        var genericStart = IndexOfAny(type, '<', '{');
+        if (genericStart >= 0 && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
+        {
+            var normalizedType = NormalizeSimpleTypeName(genericType);
+            var normalizedArgs = SplitParameters(genericArgs)
+                .Select(p => NormalizeParameterType(p, typeParameterMap, methodParameterMap));
+            return $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
+        }
+
+        return NormalizeSimpleTypeName(type);
+    }
+
+    private static string NormalizeSimpleTypeName(string type)
+        => type switch
+        {
+            "bool" => "System.Boolean",
+            "byte" => "System.Byte",
+            "char" => "System.Char",
+            "decimal" => "System.Decimal",
+            "double" => "System.Double",
+            "float" => "System.Single",
+            "int" => "System.Int32",
+            "long" => "System.Int64",
+            "nint" => "System.IntPtr",
+            "nuint" => "System.UIntPtr",
+            "object" => "System.Object",
+            "sbyte" => "System.SByte",
+            "short" => "System.Int16",
+            "string" => "System.String",
+            "uint" => "System.UInt32",
+            "ulong" => "System.UInt64",
+            "ushort" => "System.UInt16",
+            _ => type
+        };
+
+    private static string RemoveNullableAnnotations(string type)
+        => type.Replace("?", "", StringComparison.Ordinal);
+
+    private static bool TryGetGenericParts(string type, int genericStart, out string genericType, out string genericArgs)
+    {
+        genericType = type[..genericStart];
+        genericArgs = "";
+
+        var open = type[genericStart];
+        var close = open == '<' ? '>' : '}';
+        var depth = 0;
+        for (var i = genericStart; i < type.Length; i++)
+        {
+            var c = type[i];
+            if (c == open)
+                depth++;
+            else if (c == close)
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    genericArgs = type[(genericStart + 1)..i];
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryNormalizeGenericParameterReference(
+        string type,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap,
+        out string normalized)
+    {
+        normalized = "";
+        if (type.StartsWith("``", StringComparison.Ordinal) && int.TryParse(type[2..], out var methodIndex))
+        {
+            normalized = $"M{methodIndex}";
+            return true;
+        }
+
+        if (type.StartsWith('`') && int.TryParse(type[1..], out var typeIndex))
+        {
+            normalized = $"T{typeIndex}";
+            return true;
+        }
+
+        if (methodParameterMap.TryGetValue(type, out methodIndex))
+        {
+            normalized = $"M{methodIndex}";
+            return true;
+        }
+
+        if (typeParameterMap.TryGetValue(type, out typeIndex))
+        {
+            normalized = $"T{typeIndex}";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static int IndexOfAny(string value, char first, char second)
+    {
+        var firstIndex = value.IndexOf(first);
+        var secondIndex = value.IndexOf(second);
+        return (firstIndex, secondIndex) switch
+        {
+            (< 0, < 0) => -1,
+            (< 0, _) => secondIndex,
+            (_, < 0) => firstIndex,
+            _ => Math.Min(firstIndex, secondIndex)
+        };
+    }
+
     /// <summary>
     /// Converts a CLR type name to XML documentation format.
     /// </summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -637,10 +637,6 @@ public static class ApiOutputFormatter
 
             var rows = members.Select(m =>
             {
-                var sig = abbreviate
-                    ? SignatureParser.AbbreviateSignature(m.Signature ?? m.ReturnType ?? "")
-                    : m.Signature ?? m.ReturnType ?? "";
-
                 string? select = null;
                 if (showSelect && overloadCounts != null && overloadIndices != null)
                 {
@@ -652,15 +648,8 @@ public static class ApiOutputFormatter
                     select = MarkoutInline.Code(hasOverloads ? $"{selectorName}:{idx}" : selectorName);
                 }
 
-                var sigDisplay = m.Accessibility != null ? $"{m.Accessibility} {sig}" : sig;
-                string? obsoleteCell = null;
-                if (m.IsObsolete)
-                {
-                    obsoleteCell = string.IsNullOrWhiteSpace(m.ObsoleteMessage)
-                        ? "⚠ Obsolete"
-                        : $"⚠ Obsolete — {m.ObsoleteMessage}";
-                }
-                return new MemberRow(select, OperatorNames.FormatDisplayName(m.Name), MarkoutInline.Code(sigDisplay), obsoleteCell, hasDocs ? (m.Documentation.Summary ?? "") : null);
+                var sigDisplay = FormatMemberDeclaration(type, m, abbreviate: abbreviate);
+                return new MemberRow(select, OperatorNames.FormatDisplayName(m.Name), MarkoutInline.Code(sigDisplay), hasDocs ? (m.Documentation.Summary ?? "") : null);
             }).ToList();
 
             switch (kind)
@@ -725,15 +714,7 @@ public static class ApiOutputFormatter
             return;
 
         var member = type.Members[0];
-        var sig = member.Signature ?? member.ReturnType ?? "";
-        var sigDisplay = member.Accessibility != null ? $"{member.Accessibility} {sig}" : sig;
-        string? obsoleteCell = null;
-        if (member.IsObsolete)
-        {
-            obsoleteCell = string.IsNullOrWhiteSpace(member.ObsoleteMessage)
-                ? "⚠ Obsolete"
-                : $"⚠ Obsolete — {member.ObsoleteMessage}";
-        }
+        var sigDisplay = FormatMemberDeclaration(type, member, abbreviate: false);
 
         var docsRequested = options.ShowDocs
             || options.Columns?.Any(c => c.Equals("Description", StringComparison.OrdinalIgnoreCase)) == true;
@@ -741,7 +722,7 @@ public static class ApiOutputFormatter
 
         view.SignatureRows =
         [
-            new MemberSignatureRow(MarkoutInline.Code(sigDisplay), obsoleteCell, description)
+            new MemberSignatureRow(MarkoutInline.Code(sigDisplay), description)
         ];
     }
 
@@ -993,10 +974,27 @@ public static class ApiOutputFormatter
     }
 
     private static string FormatMemberDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context)
+        => FormatMemberDeclaration(type, member, abbreviate: false, context.GenericContext?.MethodParameters);
+
+    private static string FormatMemberDeclaration(
+        ApiType type,
+        ApiMember member,
+        bool abbreviate,
+        IReadOnlyList<string>? methodParameters = null)
     {
-        var signature = member.Signature ?? member.ReturnType ?? "";
+        var signature = member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType)
+            ? $"{member.ReturnType} {member.Name}"
+            : member.Signature ?? member.ReturnType ?? "";
         if (string.IsNullOrWhiteSpace(signature))
-            return "";
+        {
+            if (member.Kind == "field" && !string.IsNullOrWhiteSpace(member.ReturnType))
+                signature = $"{member.ReturnType} {member.Name}";
+            else
+                return "";
+        }
+
+        if (abbreviate)
+            signature = SignatureParser.AbbreviateSignature(signature);
 
         if (member.Kind == "constructor")
         {
@@ -1009,22 +1007,61 @@ public static class ApiOutputFormatter
         }
         else if (member.Kind is "method" or "extension-method")
         {
-            if (context.GenericContext?.MethodParameters is { Count: > 0 } methodParameters)
+            if (methodParameters is { Count: > 0 })
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
             if (member.IsExtension)
                 signature = AddExtensionThisModifier(signature);
         }
+        else if (member.Kind == "event" && !signature.StartsWith("event ", StringComparison.Ordinal))
+        {
+            signature = $"event {signature}";
+        }
 
-        List<string> modifiers = member.Kind == "explicit-interface-implementation"
-            ? []
-            : [member.Accessibility ?? "public"];
-        if (member.IsStatic)
-            modifiers.Add("static");
+        List<string> parts = [];
+        if (member.IsObsolete)
+            parts.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
 
-        return modifiers.Count == 0
-            ? signature
-            : $"{string.Join(" ", modifiers)} {signature}";
+        List<string> modifiers = [];
+        if (member.Kind != "explicit-interface-implementation")
+        {
+            modifiers.Add(member.Accessibility ?? "public");
+            if (member.IsConst)
+                modifiers.Add("const");
+            else if (member.IsStatic)
+                modifiers.Add("static");
+            if (!member.IsConst && member.IsReadOnly)
+                modifiers.Add("readonly");
+            if (member.IsSealed)
+                modifiers.Add("sealed");
+            if (member.IsAbstract)
+                modifiers.Add("abstract");
+            if (member.IsOverride)
+                modifiers.Add("override");
+            else if (!member.IsAbstract && member.IsVirtual && !member.IsStatic)
+                modifiers.Add("virtual");
+            if (member.IsUnsafe)
+                modifiers.Add("unsafe");
+        }
+
+        if (modifiers.Count > 0)
+            parts.Add(string.Join(" ", modifiers));
+        parts.Add(signature);
+
+        return string.Join(" ", parts);
     }
+
+    private static string FormatObsoleteAttribute(string? message)
+        => string.IsNullOrWhiteSpace(message)
+            ? "[Obsolete]"
+            : $"[Obsolete(\"{EscapeCSharpString(message)}\")]";
+
+    private static string EscapeCSharpString(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
 
     private static string FormatOperatorSignature(string signature, string methodName)
     {

--- a/src/dotnet-inspect/Output/ProjectionDiagnostics.cs
+++ b/src/dotnet-inspect/Output/ProjectionDiagnostics.cs
@@ -77,6 +77,7 @@ public static class ProjectionDiagnostics
             var msg = $"warning: {kind} '{name}' not found in section '{sectionName}'";
             if (validation.Suggestions.TryGetValue(name, out var suggestions))
                 msg += $" (did you mean: {string.Join(", ", suggestions)}?)";
+            msg += $" Run -D \"{sectionName}\" to list available {kind}s.";
             Console.Error.WriteLine(msg);
         }
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -102,66 +102,47 @@ public class TypeView
     // Member sections (populated by ApiOutputFormatter.PopulateMemberSections)
     // Without --show-index: hide Select column
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorRows { get; set; }
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldRows { get; set; }
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertyRows { get; set; }
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertyRowsWithDocs { get; set; }
 
     // With --show-index: show Select column
     [MarkoutSection(Name = "Constructors", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorSelectRows { get; set; }
     [MarkoutSection(Name = "Constructors")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? ConstructorSelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Fields", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldSelectRows { get; set; }
     [MarkoutSection(Name = "Fields")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? FieldSelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Properties", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertySelectRows { get; set; }
     [MarkoutSection(Name = "Properties")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberRow>? PropertySelectRowsWithDocs { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
-    public static bool SignatureObsoleteIsAllNull(List<MemberSignatureRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     // Constructor emphasis (--ctor mode, Normal+ verbosity)
     [MarkoutSection(Name = "Constructors")]
     [JsonIgnore]
@@ -186,7 +167,6 @@ public class TypeView
 
     // Index mode sections (--index path)
     [MarkoutSection(Name = "Signature")]
-    [MarkoutIgnoreColumnWhen(nameof(SignatureObsoleteIsAllNull), "Obsolete")]
     [JsonIgnore]
     public List<MemberSignatureRow>? SignatureRows { get; set; }
 
@@ -205,27 +185,19 @@ public class TypeView
 public class EventsView
 {
     [MarkoutSection(Name = "Events", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Events", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? RowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Events", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Events")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Events")]
     public List<EventSummaryRow>? SummaryRows { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     [MarkoutIgnore]
     public bool HasRows =>
         Rows is { Count: > 0 }
@@ -252,24 +224,16 @@ public class MethodGroupsView
 public class MethodsView
 {
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? RowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Methods", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Methods")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     [MarkoutIgnore]
     public bool HasRows =>
         Rows is { Count: > 0 }
@@ -282,24 +246,16 @@ public class MethodsView
 public class OperatorsView
 {
     [MarkoutSection(Name = "Operators", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Operators", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? RowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Operators", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Operators")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     [MarkoutIgnore]
     public bool HasRows =>
         Rows is { Count: > 0 }
@@ -312,24 +268,16 @@ public class OperatorsView
 public class ExplicitInterfaceImplementationsView
 {
     [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? RowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Explicit Interface Implementations", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Explicit Interface Implementations")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     [MarkoutIgnore]
     public bool HasRows =>
         Rows is { Count: > 0 }
@@ -342,24 +290,16 @@ public class ExplicitInterfaceImplementationsView
 public class ExtensionMethodsView
 {
     [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Description,Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Select")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? RowsWithDocs { get; set; }
 
     [MarkoutSection(Name = "Extension Methods", IgnoreProperty = "Description")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRows { get; set; }
 
     [MarkoutSection(Name = "Extension Methods")]
-    [MarkoutIgnoreColumnWhen(nameof(ObsoleteIsAllNull), "Obsolete")]
     public List<MemberRow>? SelectRowsWithDocs { get; set; }
-
-    public static bool ObsoleteIsAllNull(List<MemberRow>? rows)
-        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Obsolete));
-
     [MarkoutIgnore]
     public bool HasRows =>
         Rows is { Count: > 0 }
@@ -459,20 +399,18 @@ public record MemberRow(
     [property: MarkoutSkipNull] string? Select,
     string Name,
     string Signature,
-    [property: MarkoutSkipNull] string? Obsolete,
     string? Description)
 {
     /// <summary>
-    /// Creates a MemberRow without Select or Obsolete columns.
+    /// Creates a MemberRow without Select column.
     /// </summary>
     public MemberRow(string name, string signature, string? description)
-        : this(null, name, signature, null, description) { }
+        : this(null, name, signature, description) { }
 }
 
 [MarkoutSerializable]
 public record MemberSignatureRow(
     string Signature,
-    [property: MarkoutSkipNull] string? Obsolete,
     [property: MarkoutSkipNull] string? Description);
 
 /// <summary>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.1</VersionPrefix>
+    <VersionPrefix>0.10.2</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v0.10.2
+
+### Full member signatures
+
+- Makes member `Signature` values full single-line C# declarations with accessibility, modifiers, and high-signal attributes such as `[Obsolete]`.
+- Improves overload documentation matching for XML docs.
+- Warns when requested projection columns are not available and points to `-D` discovery.
+
 ## v0.10.1
 
 ### Member output


### PR DESCRIPTION
## Summary
- Make member `Signature` values full single-line C# declarations, including accessibility, modifiers, `out`/`in`/`ref`, indexers, events, and inline high-signal attributes such as `[Obsolete]`.
- Improve XML doc overload matching across generic parameters, arrays, indexers, and native integer aliases.
- Warn when requested projection columns are unavailable and point users to `-D` discovery.
- Bump the tool and embedded skill version to 0.10.2 and add release notes.

Closes #376.
Closes #377.

## Testing
- npx markdownlint-cli skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release