### PR TITLE
Dedup cluster: signature renderer, version-dir scan, dead GitHub URL code

### DIFF
--- a/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/DotnetInspector.Metadata/ExtensionMethodScanner.cs
@@ -416,29 +416,7 @@ public static class ExtensionMethodScanner
         string name = reader.GetString(method.Name);
         var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
 
-        var paramHandles = method.GetParameters();
-        var paramTypes = signature.ParameterTypes;
-
-        List<string> parameters = [];
-        for (int i = 0; i < paramTypes.Length; i++)
-        {
-            string type = paramTypes[i];
-            string? paramName = null;
-            foreach (var handle in paramHandles)
-            {
-                var param = reader.GetParameter(handle);
-                if (param.SequenceNumber == i + 1)
-                {
-                    paramName = reader.GetString(param.Name);
-                    break;
-                }
-            }
-
-            // Mark first parameter as 'this' for extension methods
-            var prefix = i == 0 ? "this " : "";
-            parameters.Add($"{prefix}{type} {paramName ?? $"arg{i}"}");
-        }
-
-        return $"{signature.ReturnType} {name}({string.Join(", ", parameters)})";
+        // First parameter is the extension receiver, rendered with a 'this ' prefix.
+        return SignatureRenderer.RenderDecodedSignature(reader, method, name, signature, extensionThis: true);
     }
 }

--- a/src/DotnetInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/DotnetInspector.Metadata/MethodClassificationScanner.cs
@@ -116,7 +116,7 @@ public static class MethodClassificationScanner
                     var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
                     if (HasPointerType(sig))
                     {
-                        var signature = FormatDecodedSignature(reader, method, methodName, sig);
+                        var signature = SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
                         results.Add(new ClassifiedMethodInfo(
                             methodName, fullTypeName, ns, signature,
                             MethodClassification.Unsafe));
@@ -183,37 +183,11 @@ public static class MethodClassificationScanner
             var context = GenericContext.ForMethod(reader, typeDef, method);
             var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
             string methodName = reader.GetString(method.Name);
-            return FormatDecodedSignature(reader, method, methodName, sig);
+            return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
         }
         catch
         {
             return reader.GetString(method.Name) + "(...)";
         }
-    }
-
-    private static string FormatDecodedSignature(
-        MetadataReader reader, MethodDefinition method, string name, MethodSignature<string> signature)
-    {
-        var paramHandles = method.GetParameters();
-        var paramTypes = signature.ParameterTypes;
-
-        List<string> parameters = [];
-        for (int i = 0; i < paramTypes.Length; i++)
-        {
-            string type = paramTypes[i];
-            string? paramName = null;
-            foreach (var handle in paramHandles)
-            {
-                var param = reader.GetParameter(handle);
-                if (param.SequenceNumber == i + 1)
-                {
-                    paramName = reader.GetString(param.Name);
-                    break;
-                }
-            }
-            parameters.Add($"{type} {paramName ?? $"arg{i}"}");
-        }
-
-        return $"{signature.ReturnType} {name}({string.Join(", ", parameters)})";
     }
 }

--- a/src/DotnetInspector.Metadata/SignatureRenderer.cs
+++ b/src/DotnetInspector.Metadata/SignatureRenderer.cs
@@ -1,0 +1,47 @@
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Renders a decoded method signature as <c>ReturnType Name(type name, ...)</c>, resolving parameter
+/// names from metadata. Shared by the extension-method and method-classification scanners so the
+/// simple-signature format stays identical between them.
+///
+/// This is intentionally the lightweight renderer (string-based <see cref="SignatureDecoder"/>
+/// output). The full API surface uses <c>ApiSurfaceExtractor</c>'s richer renderer, which also
+/// applies nullability annotations, ref/out/params modifiers, and default values.
+/// </summary>
+internal static class SignatureRenderer
+{
+    /// <param name="extensionThis">When true, prefixes the first parameter with <c>this </c>.</param>
+    public static string RenderDecodedSignature(
+        MetadataReader reader,
+        MethodDefinition method,
+        string name,
+        MethodSignature<string> signature,
+        bool extensionThis = false)
+    {
+        var paramHandles = method.GetParameters();
+        var paramTypes = signature.ParameterTypes;
+
+        List<string> parameters = [];
+        for (int i = 0; i < paramTypes.Length; i++)
+        {
+            string? paramName = null;
+            foreach (var handle in paramHandles)
+            {
+                var param = reader.GetParameter(handle);
+                if (param.SequenceNumber == i + 1)
+                {
+                    paramName = reader.GetString(param.Name);
+                    break;
+                }
+            }
+
+            var prefix = extensionThis && i == 0 ? "this " : "";
+            parameters.Add($"{prefix}{paramTypes[i]} {paramName ?? $"arg{i}"}");
+        }
+
+        return $"{signature.ReturnType} {name}({string.Join(", ", parameters)})";
+    }
+}

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -205,48 +205,29 @@ public static class NuGetCache
     {
         var normalizedName = packageName.ToLowerInvariant();
 
-        NuGetVersion? best = null;
-        string? bestOriginal = null;
+        // Newest non-prerelease, structurally-valid version across both caches.
+        bool IsValid(string dir) => IsCachedPackageValid(dir, normalizedName);
+        VersionDir? best = null;
 
         // Check NuGet global cache — skip in isolated mode
         if (!_skipNuGetCache)
         {
-            ScanCacheDir(Path.Combine(GetNuGetCachePath(), normalizedName), normalizedName, ref best, ref bestOriginal);
+            best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
+                Path.Combine(GetNuGetCachePath(), normalizedName), includePrerelease: false, IsValid));
         }
 
         // Check app cache
         try
         {
-            ScanCacheDir(Path.Combine(GetAppCachePath(), normalizedName), normalizedName, ref best, ref bestOriginal);
+            best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
+                Path.Combine(GetAppCachePath(), normalizedName), includePrerelease: false, IsValid));
         }
         catch (InvalidOperationException)
         {
             // App cache not initialized
         }
 
-        return bestOriginal;
-    }
-
-    private static void ScanCacheDir(
-        string packageDir,
-        string normalizedName,
-        ref NuGetVersion? best,
-        ref string? bestOriginal)
-    {
-        if (!Directory.Exists(packageDir)) return;
-
-        foreach (var dir in Directory.GetDirectories(packageDir))
-        {
-            var dirName = Path.GetFileName(dir);
-            if (NuGetVersion.TryParse(dirName, out var parsed)
-                && !parsed.IsPrerelease
-                && (best == null || parsed > best)
-                && IsCachedPackageValid(dir, normalizedName))
-            {
-                best = parsed;
-                bestOriginal = dirName;
-            }
-        }
+        return best?.DirName;
     }
 
     /// <summary>

--- a/src/DotnetInspector.Packages/VersionDirectory.cs
+++ b/src/DotnetInspector.Packages/VersionDirectory.cs
@@ -1,0 +1,53 @@
+using NuGet.Versioning;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>A version-named subdirectory: the parsed version plus its path and directory name.</summary>
+public readonly record struct VersionDir(NuGetVersion Version, string DirPath, string DirName);
+
+/// <summary>
+/// Selects the newest valid version-named subdirectory of a cache root. Shared by the package cache
+/// and the platform-pack cache, which previously each had their own copy of the scan loop.
+/// </summary>
+public static class VersionDirectory
+{
+    /// <summary>
+    /// Returns the highest-versioned subdirectory of <paramref name="root"/> whose name parses as a
+    /// semantic version and that <paramref name="isValid"/> accepts, or null if none qualifies.
+    /// Validity is only checked for a candidate that would become the new best (matching the original
+    /// loops, where the structure check is the last and most expensive condition).
+    /// </summary>
+    public static VersionDir? SelectBest(string root, bool includePrerelease, Func<string, bool> isValid)
+    {
+        if (!Directory.Exists(root))
+            return null;
+
+        NuGetVersion? best = null;
+        string? bestDir = null;
+        string? bestName = null;
+
+        foreach (var dir in Directory.GetDirectories(root))
+        {
+            var dirName = Path.GetFileName(dir);
+            if (NuGetVersion.TryParse(dirName, out var parsed)
+                && (includePrerelease || !parsed.IsPrerelease)
+                && (best is null || parsed > best)
+                && isValid(dir))
+            {
+                best = parsed;
+                bestDir = dir;
+                bestName = dirName;
+            }
+        }
+
+        return best is null ? null : new VersionDir(best, bestDir!, bestName!);
+    }
+
+    /// <summary>Returns whichever of two results has the higher version (null-safe).</summary>
+    public static VersionDir? Higher(VersionDir? a, VersionDir? b)
+    {
+        if (a is null) return b;
+        if (b is null) return a;
+        return b.Value.Version > a.Value.Version ? b : a;
+    }
+}

--- a/src/DotnetInspector.Services/GitHubUrlResolver.cs
+++ b/src/DotnetInspector.Services/GitHubUrlResolver.cs
@@ -1,5 +1,3 @@
-using System.Text.RegularExpressions;
-
 namespace DotnetInspector.Services;
 
 /// <summary>
@@ -79,35 +77,5 @@ public static class GitHubUrlResolver
     public static string ConvertRawToBlobUrl(string url)
     {
         return url.Replace("/raw/", "/blob/");
-    }
-
-    /// <summary>
-    /// Converts a raw.githubusercontent.com URL to a github.com/raw/ URL for display.
-    /// </summary>
-    public static string? ConvertToGitHubRawUrl(string? rawUrl)
-    {
-        if (rawUrl == null) return null;
-
-        var match = Regex.Match(rawUrl,
-            @"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/(.+)");
-        if (match.Success)
-            return $"https://github.com/{match.Groups[1].Value}/{match.Groups[2].Value}/raw/{match.Groups[3].Value}/{match.Groups[4].Value}";
-
-        return rawUrl;
-    }
-
-    /// <summary>
-    /// Converts a github.com raw/blob URL to a raw.githubusercontent.com URL for fetching content.
-    /// </summary>
-    public static string ConvertToRawGitHubContentUrl(string url)
-    {
-        if (url.Contains("github.com"))
-        {
-            var match = Regex.Match(url,
-                @"https://github\.com/([^/]+)/([^/]+)/(raw|blob)/([^/]+)/(.+)");
-            if (match.Success)
-                return $"https://raw.githubusercontent.com/{match.Groups[1].Value}/{match.Groups[2].Value}/{match.Groups[4].Value}/{match.Groups[5].Value}";
-        }
-        return url;
     }
 }

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -207,25 +207,10 @@ public static class PlatformPackService
         if (cachePath == null) return null;
 
         var packRoot = Path.Combine(cachePath, packName);
-        if (!Directory.Exists(packRoot)) return null;
 
-        // Find the newest valid cached version by semver
-        NuGet.Versioning.NuGetVersion? best = null;
-        string? bestDir = null;
-
-        foreach (var dir in Directory.GetDirectories(packRoot))
-        {
-            var dirName = Path.GetFileName(dir);
-            if (NuGet.Versioning.NuGetVersion.TryParse(dirName, out var parsed)
-                && IsPackValid(dir)
-                && (best == null || parsed > best))
-            {
-                best = parsed;
-                bestDir = dir;
-            }
-        }
-
-        return best != null ? (best.ToNormalizedString(), bestDir!) : null;
+        // Newest valid cached version by semver (prerelease packs are allowed).
+        var best = Packages.VersionDirectory.SelectBest(packRoot, includePrerelease: true, IsPackValid);
+        return best is { } b ? (b.Version.ToNormalizedString(), b.DirPath) : null;
     }
 
     /// <summary>


### PR DESCRIPTION
The next deferred-dedup batch from the #380 review (independent of #381). Three findings, all behavior-preserving; full suite green (Metadata 131, Decompiler 208, Services 158, CLI 919 / 9 skipped for `ilasm`).

## D6 — share the simple method-signature renderer

`MethodClassificationScanner.FormatDecodedSignature` and `ExtensionMethodScanner.FormatMethodSignature` carried the same ~20-line loop that renders `ReturnType Name(type name, ...)` (resolving parameter names via `SequenceNumber`), differing only in the extension receiver's leading `this `. Extracted to `Metadata.SignatureRenderer.RenderDecodedSignature(..., extensionThis)` and routed both callers (three call sites) through it. Output unchanged.

The richer `ApiSurfaceExtractor` renderer (nullability, ref/out/params, default values) is intentionally **not** merged in — that's the separate full-surface path, and folding it in would change extension/pinvoke signature output. Dedup, not behavior change.

## D10 — share the cached-version directory scan

`NuGetCache.ScanCacheDir` and `PlatformPackService` each had their own "newest valid version-named subdirectory" loop, differing only in prerelease handling, the validity predicate, and return shape. Extracted `VersionDirectory.SelectBest(root, includePrerelease, isValid)` (+ a null-safe `Higher`). `NuGetCache`'s two-cache accumulation becomes `Higher(nuget, app)` — equivalent, since the cross-root best is just a max. Validity stays the last-checked (most expensive) condition, preserving the original short-circuit behavior.

## D12 — remove dead GitHub URL conversions

`GitHubUrlResolver.ConvertToGitHubRawUrl` and `ConvertToRawGitHubContentUrl` had **zero callers**. These regex raw↔github.com shape conversions were the "second owner" of GitHub-URL-shape logic that `SourceLinkResolver` already delegates to the SourceLinkFetch package. Deleted them (and the now-unused `Regex` import) rather than forcing a consolidation of code that serves genuinely different output targets. The live surface is now just `ResolveSampleUrl` and `ConvertRawToBlobUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)