### PR TITLE
Perf: resolve method handles once in api sections; parallelize platform find

### DIFF
--- a/src/DotnetInspector.Decompiler/MethodBodyContext.cs
+++ b/src/DotnetInspector.Decompiler/MethodBodyContext.cs
@@ -202,6 +202,27 @@ public sealed class MethodBodyContext
     public static MethodBodyContext? Create(PEReader peReader, string typeName, string methodName, int overloadIndex = 0, bool publicOnly = false, string? externalPdbPath = null)
     {
         var reader = peReader.GetMetadataReader();
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            if (reader.GetFullTypeName(typeDef) != typeName)
+                continue;
+
+            return Create(peReader, reader, typeDefHandle, methodName, overloadIndex, publicOnly, externalPdbPath);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Overload for callers that have already resolved the declaring type handle, avoiding a repeated
+    /// TypeDefinitions scan per method.
+    /// </summary>
+    public static MethodBodyContext? Create(
+        PEReader peReader, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        string methodName, int overloadIndex = 0, bool publicOnly = false, string? externalPdbPath = null)
+    {
         MetadataReader? pdbReader = TryGetEmbeddedPdbReader(peReader);
 
         // Fall back to an external portable PDB (e.g. acquired from a symbol server) when the
@@ -229,24 +250,18 @@ public sealed class MethodBodyContext
                 }
             }
 
-            foreach (var typeDefHandle in reader.TypeDefinitions)
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            int matchCount = 0;
+            foreach (var methodHandle in typeDef.GetMethods())
             {
-                var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                if (reader.GetFullTypeName(typeDef) != typeName)
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
                     continue;
-
-                int matchCount = 0;
-                foreach (var methodHandle in typeDef.GetMethods())
-                {
-                    var method = reader.GetMethodDefinition(methodHandle);
-                    if (reader.GetString(method.Name) != methodName)
-                        continue;
-                    if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
-                        continue;
-                    if (matchCount == overloadIndex)
-                        return Create(peReader, reader, method, pdbReader, methodHandle);
-                    matchCount++;
-                }
+                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
+                    continue;
+                if (matchCount == overloadIndex)
+                    return Create(peReader, reader, method, pdbReader, methodHandle);
+                matchCount++;
             }
 
             return null;

--- a/src/DotnetInspector.Metadata/AttributeReader.cs
+++ b/src/DotnetInspector.Metadata/AttributeReader.cs
@@ -184,11 +184,23 @@ public static class AttributeReader
     public static List<(string Name, string? Value)> GetMethodAttributes(
         PEReader peReader, string fullTypeName, string methodName, int overloadIndex, bool publicOnly = true)
     {
-        List<(string Name, string? Value)> results = [];
-        if (!peReader.HasMetadata) return results;
+        if (!peReader.HasMetadata) return [];
 
         var reader = peReader.GetMetadataReader();
-        var methodHandle = FindMethodHandle(reader, fullTypeName, methodName, overloadIndex, publicOnly);
+        return ReadMethodAttributes(reader, FindMethodHandle(reader, fullTypeName, methodName, overloadIndex, publicOnly));
+    }
+
+    /// <summary>
+    /// Overload for callers that have already resolved the declaring type handle (e.g. the API output
+    /// formatter, which resolves each method's type once instead of re-scanning per section).
+    /// </summary>
+    public static List<(string Name, string? Value)> GetMethodAttributes(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly = true)
+        => ReadMethodAttributes(reader, FindMethodHandleInType(reader, typeHandle, methodName, overloadIndex, publicOnly));
+
+    private static List<(string Name, string? Value)> ReadMethodAttributes(MetadataReader reader, MethodDefinitionHandle methodHandle)
+    {
+        List<(string Name, string? Value)> results = [];
         if (methodHandle.IsNil) return results;
 
         var method = reader.GetMethodDefinition(methodHandle);
@@ -213,22 +225,30 @@ public static class AttributeReader
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
-            var name = TypeResolver.GetFullName(reader, typeDef);
-            if (name != fullTypeName) continue;
+            if (TypeResolver.GetFullName(reader, typeDef) != fullTypeName) continue;
 
-            int matchIndex = 0;
-            foreach (var mHandle in typeDef.GetMethods())
-            {
-                var method = reader.GetMethodDefinition(mHandle);
-                if (publicOnly && (method.Attributes & MethodAttributes.Public) == 0)
-                    continue;
-                if (reader.GetString(method.Name) != methodName)
-                    continue;
+            return FindMethodHandleInType(reader, typeHandle, methodName, overloadIndex, publicOnly);
+        }
 
-                if (matchIndex == overloadIndex)
-                    return mHandle;
-                matchIndex++;
-            }
+        return default;
+    }
+
+    private static MethodDefinitionHandle FindMethodHandleInType(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        int matchIndex = 0;
+        foreach (var mHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(mHandle);
+            if (publicOnly && (method.Attributes & MethodAttributes.Public) == 0)
+                continue;
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+
+            if (matchIndex == overloadIndex)
+                return mHandle;
+            matchIndex++;
         }
 
         return default;

--- a/src/DotnetInspector.Metadata/ILDisassembler.cs
+++ b/src/DotnetInspector.Metadata/ILDisassembler.cs
@@ -77,26 +77,38 @@ public static class ILDisassembler
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
-            var fullName = reader.GetFullTypeName(typeDef);
-
-            if (fullName != typeName)
+            if (reader.GetFullTypeName(typeDef) != typeName)
                 continue;
 
-            int matchCount = 0;
-            foreach (var methodHandle in typeDef.GetMethods())
-            {
-                var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != methodName)
-                    continue;
+            return DisassembleMethod(peReader, reader, typeDefHandle, methodName, overloadIndex, publicOnly);
+        }
 
-                if (publicOnly && (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
-                    continue;
+        return null;
+    }
 
-                if (matchCount == overloadIndex)
-                    return Disassemble(peReader, reader, method);
+    /// <summary>
+    /// Overload for callers that have already resolved the declaring type handle, avoiding a repeated
+    /// TypeDefinitions scan per method.
+    /// </summary>
+    public static List<ILInstruction>? DisassembleMethod(
+        PEReader peReader, MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly = false)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
 
-                matchCount++;
-            }
+        int matchCount = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+
+            if (publicOnly && (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                continue;
+
+            if (matchCount == overloadIndex)
+                return Disassemble(peReader, reader, method);
+
+            matchCount++;
         }
 
         return null;

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -326,17 +326,41 @@ internal static class TypeSearchService
             var frameworkAssemblies = PlatformResolver.GetAssemblies(refPath!);
             logger.Log($"Searching {frameworkAssemblies.Count} libraries in {framework}@{resolvedVersion}");
 
-            foreach (var asmInfo in frameworkAssemblies)
+            void Tag(List<TypeSearchResult> types)
             {
-                if (ReachedLimit()) break;
-
-                var types = CollectFromAssembly(asmInfo.Path, pattern, options.IncludeAll, logger);
                 foreach (var t in types)
                 {
                     t.Source = framework;
                     t.SourceVersion = resolvedVersion;
                 }
-                results.AddRange(types);
+            }
+
+            // With an active result limit, scan sequentially to honor the early-exit (which results
+            // appear when capped must stay deterministic). Otherwise the per-assembly scans are
+            // independent and CPU-bound, so run them in parallel and reassemble in discovery order.
+            if (pattern != null && options.Limit.HasValue)
+            {
+                foreach (var asmInfo in frameworkAssemblies)
+                {
+                    if (ReachedLimit()) break;
+
+                    var types = CollectFromAssembly(asmInfo.Path, pattern, options.IncludeAll, logger);
+                    Tag(types);
+                    results.AddRange(types);
+                }
+            }
+            else
+            {
+                var perAssembly = new List<TypeSearchResult>[frameworkAssemblies.Count];
+                Parallel.For(0, frameworkAssemblies.Count, i =>
+                {
+                    var types = CollectFromAssembly(frameworkAssemblies[i].Path, pattern, options.IncludeAll, logger);
+                    Tag(types);
+                    perAssembly[i] = types;
+                });
+
+                foreach (var types in perAssembly)
+                    results.AddRange(types);
             }
         }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
@@ -870,6 +872,10 @@ public static class ApiOutputFormatter
     {
         using var stream = File.OpenRead(dllPath);
         using var peReader = new PEReader(stream);
+        if (!peReader.HasMetadata)
+            return;
+
+        var reader = peReader.GetMetadataReader();
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
@@ -877,6 +883,12 @@ public static class ApiOutputFormatter
         bool wantsDecompiledSource = requestedSections.Contains(SectionNames.DecompiledSource);
         bool wantsIL = requestedSections.Contains(SectionNames.IL);
         bool wantsAnnotatedIL = requestedSections.Contains(SectionNames.ILAnnotated);
+
+        // Resolve each method's declaring type once via an index, instead of having every helper
+        // (attributes, IL, decompiled source, annotated IL) re-scan all TypeDefinitions per method.
+        var typeIndex = new Dictionary<string, System.Reflection.Metadata.TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+            typeIndex.TryAdd(reader.GetFullTypeName(reader.GetTypeDefinition(typeDefHandle)), typeDefHandle);
 
         foreach (var method in methods)
         {
@@ -886,11 +898,14 @@ public static class ApiOutputFormatter
                 : overloadIndex;
             var publicOnly = method.Kind != "explicit-interface-implementation";
 
+            if (!typeIndex.TryGetValue(lookupType, out var typeHandle))
+                continue;
+
             // Custom attributes
             if (wantsAttributes)
             {
                 var attributes = AttributeReader.GetMethodAttributes(
-                    peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly);
+                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
                 if (attributes.Count > 0)
                 {
                     view.MethodAttributeRows = attributes
@@ -899,22 +914,30 @@ public static class ApiOutputFormatter
                 }
             }
 
-            // Lowered C#
-            if (wantsDecompiledSource)
+            // Decompiled source and annotated IL share one method-body context (it is immutable),
+            // so the PDB is opened and the method body decoded once rather than per section.
+            Decompiler.MethodBodyContext? context = null;
+            if (wantsDecompiledSource || wantsAnnotatedIL)
             {
                 try
                 {
-                    var context = Decompiler.MethodBodyContext.Create(
-                        peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
-                    if (context != null)
+                    context = Decompiler.MethodBodyContext.Create(
+                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
+                }
+                catch { }
+            }
+
+            // Lowered C#
+            if (wantsDecompiledSource && context != null)
+            {
+                try
+                {
+                    var lowered = Decompiler.CSharpEmitter.Emit(context);
+                    if (!string.IsNullOrWhiteSpace(lowered))
                     {
-                        var lowered = Decompiler.CSharpEmitter.Emit(context);
-                        if (!string.IsNullOrWhiteSpace(lowered))
-                        {
-                            var source = FormatLoweredSourceWithDeclaration(type, method, context, lowered);
-                            memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
-                            hasCode = true;
-                        }
+                        var source = FormatLoweredSourceWithDeclaration(type, method, context, lowered);
+                        memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
+                        hasCode = true;
                     }
                 }
                 catch { }
@@ -924,7 +947,7 @@ public static class ApiOutputFormatter
             if (wantsIL)
             {
                 var instructions = ILDisassembler.DisassembleMethod(
-                    peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly);
+                    peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
                 if (instructions is { Count: > 0 })
                 {
                     var ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
@@ -934,21 +957,16 @@ public static class ApiOutputFormatter
             }
 
             // Annotated IL
-            if (wantsAnnotatedIL)
+            if (wantsAnnotatedIL && context != null)
             {
                 try
                 {
-                    var context = Decompiler.MethodBodyContext.Create(
-                        peReader, lookupType, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
-                    if (context != null)
+                    var annotated = Decompiler.AnnotatedILEmitter.Emit(
+                        context, Decompiler.ILAnnotationDepth.Structured);
+                    if (!string.IsNullOrWhiteSpace(annotated))
                     {
-                        var annotated = Decompiler.AnnotatedILEmitter.Emit(
-                            context, Decompiler.ILAnnotationDepth.Structured);
-                        if (!string.IsNullOrWhiteSpace(annotated))
-                        {
-                            memberCode.AnnotatedIL = new CodeSection("il", annotated.TrimEnd());
-                            hasCode = true;
-                        }
+                        memberCode.AnnotatedIL = new CodeSection("il", annotated.TrimEnd());
+                        hasCode = true;
                     }
                 }
                 catch { }


### PR DESCRIPTION
The perf cluster from the #380 review. Two wins (P5, P8); P9 consciously declined with reasoning below. Full suite green — Metadata 131, Decompiler 208, Services 158, CLI 919 (9 skipped: `ilasm`).

## P5 — resolve method handles once in `api`/`member` index sections

`PopulateIndexSections` drives the IL, decompiled-source, annotated-IL, and custom-attribute sections. For **each** method it called four helpers that each re-scanned all `TypeDefinitions` to resolve the declaring type (`GetFullTypeName` string compares per row), and `MethodBodyContext.Create` re-opened the external PDB — **twice** per method when both source and annotated IL were requested. On a large assembly (CoreLib ~16k typedefs) that was O(methods × typedefs) plus redundant PDB opens.

- Build a `type-name → TypeDefinitionHandle` index once. Per method, resolve the declaring type in O(1) and pass the handle to new handle-based overloads of `AttributeReader.GetMethodAttributes`, `ILDisassembler.DisassembleMethod`, and `MethodBodyContext.Create`. Each keeps its own method-overload loop, so the three helpers' (intentionally) differing `publicOnly` checks are preserved exactly.
- Create the `MethodBodyContext` **once** per method and share it between the decompiled-source and annotated-IL emitters (the context is immutable), so the PDB opens once per method instead of twice.

`TypeResolver.GetFullName` is literally `reader.GetFullTypeName`, so the shared index key matches all three helpers' original type resolution — no behavior change. Verified output unchanged on `System.Version.ToString()` across all three code sections.

## P8 — parallelize the platform-framework assembly scan in `find`

`find --platform` scans every ref assembly in each framework (~150) sequentially, and the per-assembly work (`CollectFromAssembly`: open PE, extract type surface, filter) is independent and CPU-bound. Scan them with `Parallel.For` **when there is no active result limit**, reassembling per-assembly results in original index order so output stays byte-for-byte deterministic. When a single pattern has a result limit, the sequential early-exit path is kept unchanged (which results appear when capped must stay deterministic).

`CollectFromAssembly` is a pure function (independent reader per call; the only shared state is `TypeMatcher`'s thread-safe glob cache). Verified `find 'IList*' --platform` returns identical, identically-ordered output across runs. This also speeds up the no-match suggestion pass, which re-collects with `pattern=null` (→ parallel path).

## P9 — declined (mitigated by P8)

The find no-match fallback re-collects all types for fuzzy suggestions. Eliminating that second pass would mean collecting unfiltered and filtering in-memory on the common path, which loses the `Limit` early-exit (parsing every assembly even when capped) — real behavior risk for marginal benefit on the typo path. And it's now largely mitigated: the fallback collects with `pattern=null`, which flows through P8's parallel path. Left as-is deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)