### PR TITLE
Bump Markout to 0.13.4 (pipe-in-code-span fix)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
-    <PackageVersion Include="Markout" Version="0.13.3" />
+    <PackageVersion Include="Markout" Version="0.13.4" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.1" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />


### PR DESCRIPTION
Consumes [richlander/markout#106](https://github.com/richlander/markout/pull/106), now published as Markout 0.13.4.

Member signatures containing `operator |` (bitwise-OR — `System.Numerics.BigInteger`, `IBitwiseOperators<T>` implementers, flags-like value types, etc.) are rendered inside a `<code>` span in a Markdown table cell. markout previously escaped the pipe as `&#124;`, which GitHub renders literally inside code spans; 0.13.4 escapes it as `\|`, which GFM unescapes while splitting table rows.

One-line version bump — no consumer code change. Verified against the published package:

```
| operator &#124; | `public static System.Numerics.BigInteger operator \|(...)` |
```

The plain-text name column keeps `&#124;` (correct outside code spans); the signature code span now uses `\|` (correct inside). All 919 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)