### PR TITLE
Bump Markout to 0.13.5 (angle-bracket escaping)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
-    <PackageVersion Include="Markout" Version="0.13.4" />
+    <PackageVersion Include="Markout" Version="0.13.5" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.1" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />


### PR DESCRIPTION
Consumes [richlander/markout#107](https://github.com/richlander/markout/pull/107), published as Markout 0.13.5.

Plain table-cell and heading text now escapes `&`, `<`, `>`, and backtick to entities, so generic type names and free-text descriptions render verbatim on GitHub instead of `<T>` being eaten as an HTML tag (`List<T>` → "List"). Code-span signatures are unchanged (angle brackets literal, pipes `\|`).

One-line version bump — no consumer code change. Verified against the published package:

```
# System.Collections.Generic.List&lt;T&gt;
| System.Collections.Generic.IList&lt;T&gt; |
```

→ renders as `List<T>` / `IList<T>`. All 919 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)