### PR TITLE
Honor --source in find package resolution

### DIFF
--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -233,7 +233,7 @@ internal static class TypeSearchService
         {
             if (ReachedLimit()) break;
 
-            var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, pkg, logger.Log, "inspect-find");
+            var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, pkg, logger.Log, "inspect-find", options.SourceOptions);
             if (!outcome.IsSuccess)
             {
                 Console.Error.WriteLine($"Warning: {outcome.ErrorMessage}");


### PR DESCRIPTION
Found during an audit of how commands share the FQN parser / library loader / package loader.

`find`'s package-extract call dropped the user's NuGet source options:

```csharp
// TypeSearchService.cs:236 — "inspect-find" lands in the tempDirPrefix slot; sourceOptions stays null
await PackageExtractor.ExtractPackageAsync(httpClient, pkg, logger.Log, "inspect-find");
```

So `find <Type> --package X --source <feed>` (also `--add-source`, `--nugetconfig`) was silently ignored — `find` always resolved from the default nuget.org. `FindOptions` already carries `SourceOptions`; every other command threads it through. This routes it through too.

## Verification

```
find JsonSerializer --package Newtonsoft.Json --source <empty-folder>
→ before: silently finds it on nuget.org (--source ignored)
→ after:  "Warning: Package 'Newtonsoft.Json' not found."  (feed honored)
```

Control (no `--source`) still resolves from nuget.org. All 919 CLI tests pass.

Part of a broader audit finding: `find` re-implements `AssemblyCollector`'s extract loop inline rather than routing through it, which is how this drift crept in. Routing `find` through `AssemblyCollector` is a larger follow-up; this PR is the targeted bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)