### PR TITLE
Rename the assembly command to library

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1413,7 +1413,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Library_TsvWithMultipleSelectedSections_ReturnsError()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = "System.Text.Json",
             Select = ["Library Info", "Signals"],
@@ -1423,7 +1423,7 @@ public class CommandExecutionTests
         };
 
         var (exit, _, error) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(1, exit);
         Assert.Contains("Selection matches 2 sections", error);
@@ -1707,15 +1707,15 @@ public class CommandExecutionTests
         Assert.Contains("No pattern", error);
     }
 
-    // ── assembly command ─────────────────────────────────────────────
+    // ── library command ─────────────────────────────────────────────
 
     [Fact]
     public async Task Assembly_PlatformLibrary_ShowsInfo()
     {
-        var options = new AssemblyOptions { PlatformAssembly = "System.Text.Json" };
+        var options = new LibraryOptions { PlatformAssembly = "System.Text.Json" };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("System.Text.Json", output);
@@ -1724,7 +1724,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_SingleSectionCount_WritesInteger()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = "System.Text.Json",
             Select = ["Async*"],
@@ -1732,7 +1732,7 @@ public class CommandExecutionTests
         };
 
         var (exit, output, error) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.True(int.TryParse(output.Trim(), out var count), output);
@@ -1744,14 +1744,14 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_CountWithoutSingleSection_Errors()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = "System.Text.Json",
             Count = true
         };
 
         var (exit, output, error) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
@@ -1782,10 +1782,10 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_LocalAssembly_ShowsInfo()
     {
-        var options = new AssemblyOptions { AssemblyName = TestAssemblyPath };
+        var options = new LibraryOptions { AssemblyName = TestAssemblyPath };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("dotnet-inspect.Tests", output);
@@ -1794,14 +1794,14 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_Signals_ShowsMetadataSignalsOnly()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = "System.Text.Json",
             IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" }
         };
 
         var (exit, output, error) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("## Signals", output);
@@ -1818,14 +1818,14 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_SignalsSectionSelection_PopulatesReferenceSignals()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = "System.Text.Json",
             IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" }
         };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("Direct assembly references", output);
@@ -1937,14 +1937,14 @@ public class CommandExecutionTests
     [Fact]
     public async Task Assembly_Signals_LocalUnsafeAssembly_FocusesOnNewMemorySafetyModel()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             AssemblyName = TestAssemblyPath,
             IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" }
         };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
-            () => AssemblyCommand.ExecuteAsync(options));
+            () => LibraryCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("| Memory safety | Memory safety model | Not marked |", output);

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -326,7 +326,7 @@ public class CommandLineTests
     }
 
     [Fact]
-    public void AssemblyCommand_WithPackage_ParsesCorrectly()
+    public void LibraryCommand_WithPackage_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "System.Text.Json"]);
 
@@ -335,7 +335,7 @@ public class CommandLineTests
     }
 
     [Fact]
-    public void AssemblyCommand_WithTfm_ParsesCorrectly()
+    public void LibraryCommand_WithTfm_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "System.Text.Json", "--tfm", "net8.0"]);
 
@@ -343,7 +343,7 @@ public class CommandLineTests
     }
 
     [Fact]
-    public void AssemblyCommand_WithLocalPath_ParsesCorrectly()
+    public void LibraryCommand_WithLocalPath_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "MyLib.dll"]);
 
@@ -351,7 +351,7 @@ public class CommandLineTests
     }
 
     [Fact]
-    public void AssemblyCommand_WithDependencies_ParsesCorrectly()
+    public void LibraryCommand_WithDependencies_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["library", "MyLib.dll", "--dependencies"]);
 

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -765,7 +765,7 @@ public class OutputFormatterTests
     [Fact]
     public void LibrarySelectedSection_FormatterUsesCompactContext()
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             Verbosity = Verbosity.Minimal,
             IncludeSections = ["Signals"],

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -7,7 +7,7 @@ using DotnetInspector.Services;
 namespace DotnetInspector.CommandLine;
 
 /// <summary>
-/// Defines the diff and library (assembly) commands.
+/// Defines the diff and library commands.
 /// </summary>
 public static class InspectionCommandDefinitions
 {
@@ -101,7 +101,7 @@ public static class InspectionCommandDefinitions
         return diffCommand;
     }
 
-    public static Command CreateAssemblyCommand(SharedOptions opts)
+    public static Command CreateLibraryCommand(SharedOptions opts)
     {
         var assemblyCommand = new Command("library", "Inspect a .NET library file");
 
@@ -180,7 +180,7 @@ public static class InspectionCommandDefinitions
             bool showReferences = parseResult.GetValue(referencesOption);
             bool showDependencies = parseResult.GetValue(dependenciesOption);
 
-            var options = new AssemblyOptions
+            var options = new LibraryOptions
             {
                 AssemblyName = assemblyPath,
                 IncludeMetadata = true,
@@ -215,7 +215,7 @@ public static class InspectionCommandDefinitions
                 ExtractResources = parseResult.GetValue(extractResourcesOption)
             };
 
-            return await AssemblyCommand.ExecuteAsync(options);
+            return await LibraryCommand.ExecuteAsync(options);
         });
 
         return assemblyCommand;

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -81,11 +81,11 @@ public static class RouterCommandDefinition
                     Console.Error.WriteLine($"Error: Unrecognized option '{error.Option}'.");
                     return 1;
 
-                case RouterOptionsParser.RouteToAssemblyFile route:
-                    return await AssemblyCommand.ExecuteAsync(route.Options);
+                case RouterOptionsParser.RouteToLibraryFile route:
+                    return await LibraryCommand.ExecuteAsync(route.Options);
 
-                case RouterOptionsParser.RouteToPlatformAssembly route:
-                    return await ExecutePlatformAssemblyAsync(route, opts, parseResult, commandArgs);
+                case RouterOptionsParser.RouteToPlatformLibrary route:
+                    return await ExecutePlatformLibraryAsync(route, opts, parseResult, commandArgs);
 
                 case RouterOptionsParser.HandleVersionQuery query:
                     return await ExecuteVersionQueryAsync(query, opts, parseResult, routerVersionsOption);
@@ -107,8 +107,8 @@ public static class RouterCommandDefinition
         return routerCommand;
     }
 
-    private static async Task<int> ExecutePlatformAssemblyAsync(
-        RouterOptionsParser.RouteToPlatformAssembly route,
+    private static async Task<int> ExecutePlatformLibraryAsync(
+        RouterOptionsParser.RouteToPlatformLibrary route,
         SharedOptions opts,
         ParseResult parseResult,
         RouterOptionsParser.RouterCommandArgs commandArgs)
@@ -122,7 +122,7 @@ public static class RouterCommandDefinition
 
         if (resolvedPath != null && resolvedError == null)
         {
-            var assemblyExitCode = await AssemblyCommand.ExecuteAsync(route.Options);
+            var assemblyExitCode = await LibraryCommand.ExecuteAsync(route.Options);
 
             if (assemblyExitCode == 0 && !route.Options.FormatExplicitlySet && !route.Options.IsRawOutput)
             {

--- a/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/RouterOptionsParser.cs
@@ -51,17 +51,17 @@ public static class RouterOptionsParser
     public record UnrecognizedOption(string Option) : RouterParseResult;
 
     /// <summary>
-    /// Route to assembly command for a .dll file.
+    /// Route to the library command for a .dll file.
     /// </summary>
-    public record RouteToAssemblyFile(AssemblyOptions Options) : RouterParseResult;
+    public record RouteToLibraryFile(LibraryOptions Options) : RouterParseResult;
 
     /// <summary>
-    /// Route to assembly command for a platform library.
+    /// Route to the library command for a platform library.
     /// </summary>
     /// <param name="OriginalArg">Original package argument (e.g., "System.CommandLine@2.0.2") preserved for fallback
     /// to package command. Platform candidates like "System.CommandLine" are tried as platform libraries first,
     /// but if resolution fails they fall through to NuGet package inspection and need the version preserved.</param>
-    public record RouteToPlatformAssembly(AssemblyOptions Options, string BareName, string OriginalArg, Verbosity Verbosity, bool OneLine, bool NoHeader) : RouterParseResult;
+    public record RouteToPlatformLibrary(LibraryOptions Options, string BareName, string OriginalArg, Verbosity Verbosity, bool OneLine, bool NoHeader) : RouterParseResult;
 
     /// <summary>
     /// Handle --version query with cache check first.
@@ -126,7 +126,7 @@ public static class RouterOptionsParser
         {
             if (dllPath != null)
             {
-                var assemblyOptions = new AssemblyOptions
+                var assemblyOptions = new LibraryOptions
                 {
                     AssemblyName = dllPath,
                     IncludeMetadata = true,
@@ -149,7 +149,7 @@ public static class RouterOptionsParser
                     Count = parseResult.GetValue(opts.Count),
                     Rows = opts.ParseRows(parseResult),
                 };
-                return new RouteToAssemblyFile(assemblyOptions);
+                return new RouteToLibraryFile(assemblyOptions);
             }
             // .nupkg falls through to package command below
         }
@@ -171,13 +171,13 @@ public static class RouterOptionsParser
 
         // Platform candidate check (skip for version queries)
         // Note: Qualified type names (e.g., System.Text.Json.JsonSerializer) are also platform candidates
-        // and will be routed here. The ExecutePlatformAssemblyAsync handler will check for qualified
+        // and will be routed here. The ExecutePlatformLibraryAsync handler will check for qualified
         // type names if platform resolution fails.
         if (!isVersionQuery && PlatformResolver.IsPlatformCandidate(bareName))
         {
-            var assemblyOptions = BuildPlatformAssemblyOptions(parseResult, opts, args, bareName, hasExplicitVersion, explicitVersion);
+            var assemblyOptions = BuildPlatformLibraryOptions(parseResult, opts, args, bareName, hasExplicitVersion, explicitVersion);
             var noHeader = parseResult.GetValue(opts.NoHeaders);
-            return new RouteToPlatformAssembly(assemblyOptions, bareName, name, verbosity, assemblyOptions.OneLine, noHeader);
+            return new RouteToPlatformLibrary(assemblyOptions, bareName, name, verbosity, assemblyOptions.OneLine, noHeader);
         }
 
         // For single-arg names that aren't platform candidates, try local peel-and-probe.
@@ -239,7 +239,7 @@ public static class RouterOptionsParser
         return new RouteToPackage(options, bareName, verbosity);
     }
 
-    private static AssemblyOptions BuildPlatformAssemblyOptions(
+    private static LibraryOptions BuildPlatformLibraryOptions(
         ParseResult parseResult,
         SharedOptions opts,
         RouterCommandArgs args,
@@ -256,7 +256,7 @@ public static class RouterOptionsParser
                 platformFrameworkSpec = $"{discoveredFramework}@{explicitVersion}";
         }
 
-        return new AssemblyOptions
+        return new LibraryOptions
         {
             PlatformAssembly = bareName,
             PlatformFramework = platformFrameworkSpec,

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -73,8 +73,8 @@ public static class CommandLineBuilder
         // Member command (member inspection, docs by default)
         rootCommand.Subcommands.Add(ApiCommandDefinitions.CreateMemberCommand(opts));
 
-        // Assembly command
-        rootCommand.Subcommands.Add(InspectionCommandDefinitions.CreateAssemblyCommand(opts));
+        // Library command
+        rootCommand.Subcommands.Add(InspectionCommandDefinitions.CreateLibraryCommand(opts));
 
         // Cache command
         rootCommand.Subcommands.Add(UtilityCommandDefinitions.CreateCacheCommand(opts));

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -18,9 +18,9 @@ namespace DotnetInspector.Commands;
 /// <summary>
 /// Inspects a single .NET assembly.
 /// </summary>
-public class AssemblyCommand
+public class LibraryCommand
 {
-    public static async Task<int> ExecuteAsync(AssemblyOptions options)
+    public static async Task<int> ExecuteAsync(LibraryOptions options)
     {
         var assemblyPath = options.AssemblyName;
         var pipeline = LibrarySections.CreatePipeline();
@@ -284,7 +284,7 @@ public class AssemblyCommand
     }
 
     private static int WriteEffectiveSections(string assemblyPath, LibraryInspection inspection,
-        AssemblyOptions options, SectionPipeline<LibraryInspection> pipeline, Verbosity userVerbosity = Verbosity.Minimal)
+        LibraryOptions options, SectionPipeline<LibraryInspection> pipeline, Verbosity userVerbosity = Verbosity.Minimal)
     {
         // Compute all target-available sections for caching, including opt-in sections.
         var allEffective = pipeline.GetAvailableSections(inspection);
@@ -308,7 +308,7 @@ public class AssemblyCommand
 
     private const string EffectiveCategory = "effective-v3";
 
-    static AssemblyCommand()
+    static LibraryCommand()
     {
         CoreCache.RegisterVersionedCategory("effective-v", EffectiveCategory);
     }
@@ -356,14 +356,14 @@ public class AssemblyCommand
         return $"{assemblyPath}#{size}";
     }
 
-    private static List<string> FilterEffective(List<string> sections, AssemblyOptions options)
+    private static List<string> FilterEffective(List<string> sections, LibraryOptions options)
     {
         if (options.IncludeSections is { Count: > 0 })
             sections = sections.Where(s => options.IncludeSections.Contains(s)).ToList();
         return sections;
     }
 
-    private static int RenderEffective(List<string> effective, DocumentSchema schema, AssemblyOptions options,
+    private static int RenderEffective(List<string> effective, DocumentSchema schema, LibraryOptions options,
         Verbosity userVerbosity = Verbosity.Minimal, string? rootLabel = null)
     {
         return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
@@ -421,7 +421,7 @@ public class AssemblyCommand
         return filtered;
     }
 
-    private static void WarnEmptySections(LibraryInspection inspection, AssemblyOptions options,
+    private static void WarnEmptySections(LibraryInspection inspection, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         var (empty, requested) = pipeline.GetEmptySections(inspection, options.Verbosity, options.IncludeSections);
@@ -432,7 +432,7 @@ public class AssemblyCommand
         }
     }
 
-    private static void ExtractResourcesIfRequested(string assemblyPath, AssemblyOptions options, VerboseLogger logger)
+    private static void ExtractResourcesIfRequested(string assemblyPath, LibraryOptions options, VerboseLogger logger)
     {
         if (string.IsNullOrEmpty(options.ExtractResources))
             return;
@@ -461,7 +461,7 @@ public class AssemblyCommand
     }
 
     private static async Task<List<LibraryInspection>> CollectPackageInspectionsAsync(
-        List<string> assemblyPaths, AssemblyOptions options, VerboseLogger logger,
+        List<string> assemblyPaths, LibraryOptions options, VerboseLogger logger,
         string? packageName, string? packageVersion, string extractPath,
         HttpClient httpClient, SignatureVerificationResult? signatureResult,
         HashSet<string>? scanners = null, ScannerRegistry? scannerRegistry = null)

--- a/src/dotnet-inspect/Commands/PerfCommand.cs
+++ b/src/dotnet-inspect/Commands/PerfCommand.cs
@@ -111,13 +111,13 @@ public static class PerfCommand
 
     private static async Task RunLibraryAsync(string platformLibrary)
     {
-        var options = new AssemblyOptions
+        var options = new LibraryOptions
         {
             PlatformAssembly = platformLibrary,
             IncludeMetadata = true,
             Verbosity = Verbosity.Quiet
         };
-        await AssemblyCommand.ExecuteAsync(options);
+        await LibraryCommand.ExecuteAsync(options);
     }
 
     private static async Task RunTypeAsync(string target)

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -23,7 +23,7 @@ internal static class LibraryMetadataService
     /// </summary>
     public static async Task<LibraryInspection?> InspectAsync(
         string path,
-        AssemblyOptions options,
+        LibraryOptions options,
         VerboseLogger logger,
         string? packageName,
         string? packageVersion,

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -17,7 +17,7 @@ internal static class SourceEnricher
     // ===== PDB Acquisition =====
 
     /// <summary>
-    /// Orchestrates PDB download for a PdbContext. Shared by AssemblyCommand and API enrichment.
+    /// Orchestrates PDB download for a PdbContext. Shared by LibraryCommand and API enrichment.
     /// </summary>
     internal static async Task AcquirePdbAsync(
         PdbContext context, HttpClient httpClient,

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -5,7 +5,7 @@ namespace DotnetInspector.Options;
 /// <summary>
 /// Configuration options for assembly inspection.
 /// </summary>
-public record AssemblyOptions
+public record LibraryOptions
 {
     /// <summary>
     /// Assembly name within a package (positional argument).
@@ -181,12 +181,12 @@ public record AssemblyOptions
     /// <summary>
     /// Default options: basic assembly info only.
     /// </summary>
-    public static AssemblyOptions Default => new();
+    public static LibraryOptions Default => new();
 
     /// <summary>
     /// All inspection features enabled.
     /// </summary>
-    public static AssemblyOptions All => new()
+    public static LibraryOptions All => new()
     {
     };
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -120,7 +120,7 @@ public static class OutputFormatter
         };
     }
 
-    public static void WriteLibraryResult(LibraryInspection inspection, AssemblyOptions options,
+    public static void WriteLibraryResult(LibraryInspection inspection, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         bool selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
@@ -192,7 +192,7 @@ public static class OutputFormatter
         }
     }
 
-    public static void WriteLibraryResults(List<LibraryInspection> inspections, AssemblyOptions options,
+    public static void WriteLibraryResults(List<LibraryInspection> inspections, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         bool selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
@@ -275,7 +275,7 @@ public static class OutputFormatter
         };
     }
 
-    internal static bool ShouldRenderLibraryContext(AssemblyOptions options) =>
+    internal static bool ShouldRenderLibraryContext(LibraryOptions options) =>
         options.Verbosity == Verbosity.Quiet
         || (options.IncludeSections is { Count: > 0 }
             && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)


### PR DESCRIPTION
The CLI command is registered as `library`, but its internals still said "assembly" — a stale name that surfaced when `dotnet-inspect assembly` silently fell through to the hidden router (package-resolving "assembly") instead of inspecting a library. This aligns the code with the user-facing verb.

## Renamed (the library command's own identifiers)
- `AssemblyCommand` → `LibraryCommand` (file too); `AssemblyOptions` → `LibraryOptions` (file too)
- `CreateAssemblyCommand` → `CreateLibraryCommand`
- `ExecutePlatformAssemblyAsync` → `ExecutePlatformLibraryAsync`; `BuildPlatformAssemblyOptions` → `BuildPlatformLibraryOptions`
- router `RouteToAssemblyFile` → `RouteToLibraryFile`; `RouteToPlatformAssembly` → `RouteToPlatformLibrary`
- "Assembly command" comments/doc-comments → "library command"

## Deliberately kept (.NET-domain terms — "assembly" is the precise word for the artifact)
`AssemblyReader`, `AssemblyInspector`, `AssemblyInfo`, `AssemblyReference(Node)`, the BCL attribute type names (`AssemblyCompanyAttribute`, …), the shared `IAssemblySourceOptions` interface, and `PlatformResolver.ResolveAssemblyAsync` (a Services-layer resolver also used by `diff`). Renaming these would be inaccurate or break the build.

## Verification
`library --help` shows the correct `Usage: dotnet-inspect library [<source>]`; `library <dll>` inspects normally. No behavior change — pure rename. All 919 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)