### PR TITLE
Accept repeated -S / --columns / --fields options

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -402,6 +402,39 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PreprocessArgs_MergesRepeatedSelectIntoOneSemicolonValue()
+    {
+        var result = CommandLineBuilder.PreprocessArgs(["package", "Foo", "-S", "Signals", "-S", "Library Files"]);
+
+        Assert.Equal(["package", "Foo", "-S", "Signals;Library Files"], result);
+    }
+
+    [Fact]
+    public void PreprocessArgs_MergesRepeatedSelectAcrossAliasesAndEqualsForm()
+    {
+        var result = CommandLineBuilder.PreprocessArgs(["package", "Foo", "--select", "A", "--section=B", "-s", "C"]);
+
+        Assert.Equal(["package", "Foo", "-S", "A;B;C"], result);
+    }
+
+    [Fact]
+    public void PreprocessArgs_MergesRepeatedColumns()
+    {
+        var result = CommandLineBuilder.PreprocessArgs(["member", "Foo", "--columns", "Select", "--columns", "Signature"]);
+
+        Assert.Equal(["member", "Foo", "--columns", "Select;Signature"], result);
+    }
+
+    [Fact]
+    public void PreprocessArgs_SingleSelect_Unchanged()
+    {
+        var args = new[] { "package", "Foo", "-S", "Library Files" };
+        var result = CommandLineBuilder.PreprocessArgs(args);
+
+        Assert.Equal(args, result);
+    }
+
+    [Fact]
     public void PreprocessArgs_WithDllFile_PrependsLibrary()
     {
         var args = new[] { "artifacts/bin/Foo/debug/Foo.dll", "--json" };

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -44,6 +44,13 @@ public static class ArgumentPreprocessor
         HeadLines = null;
         TailLines = null;
 
+        // These options are single-valued (comma/semicolon-separated), so a natural `-S A -S B`
+        // otherwise errors with "expects a single argument". Collapse repeated occurrences into one
+        // ';'-joined token so repeated and separated forms behave the same.
+        args = MergeRepeatedListOption(args, SelectAliases, "-S");
+        args = MergeRepeatedListOption(args, ["--columns"], "--columns");
+        args = MergeRepeatedListOption(args, ["--fields"], "--fields");
+
         // Expand -NN shorthand (e.g., -30) into -n 30, like head -30
         for (int i = 0; i < args.Length; i++)
         {
@@ -109,5 +116,61 @@ public static class ArgumentPreprocessor
             return ["router", .. args];
 
         return args;
+    }
+
+    private static readonly string[] SelectAliases = ["-S", "-s", "--select", "--section"];
+
+    /// <summary>
+    /// Collapses repeated occurrences of a single-valued list option into one ';'-joined token at the
+    /// position of the first occurrence. Handles both `alias value` and `alias=value` forms.
+    /// </summary>
+    private static string[] MergeRepeatedListOption(string[] args, string[] aliases, string canonical)
+    {
+        int occurrences = 0;
+        foreach (var arg in args)
+            if (IsListOptionAlias(arg, aliases, out _)) occurrences++;
+        if (occurrences < 2)
+            return args;
+
+        var result = new List<string>(args.Length);
+        var values = new List<string>();
+        int valueSlot = -1;
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (IsListOptionAlias(args[i], aliases, out var inlineValue))
+            {
+                var value = inlineValue ?? (i + 1 < args.Length ? args[++i] : null);
+                if (!string.IsNullOrEmpty(value))
+                    values.Add(value);
+
+                if (valueSlot < 0)
+                {
+                    result.Add(canonical);
+                    valueSlot = result.Count;
+                    result.Add("");
+                }
+                continue;
+            }
+            result.Add(args[i]);
+        }
+
+        result[valueSlot] = string.Join(';', values);
+        return [.. result];
+    }
+
+    private static bool IsListOptionAlias(string arg, string[] aliases, out string? inlineValue)
+    {
+        inlineValue = null;
+        foreach (var alias in aliases)
+        {
+            if (arg == alias)
+                return true;
+            if (arg.StartsWith(alias + "=", StringComparison.Ordinal))
+            {
+                inlineValue = arg[(alias.Length + 1)..];
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes friction point #2 from #379 (an AI eval friction report).

`-S Signals -S "Library Files"` — the natural way to select multiple sections — errored with `Option '-S' expects a single argument but 2 were provided`, even though `-S "Signals;Library Files"` worked. Same wall for `--columns` and `--fields` (all single-valued comma/semicolon list options).

`ArgumentPreprocessor` now collapses repeated occurrences of these options into one `;`-joined token (handles both `alias value` and `alias=value`), so the repeated and separated forms behave identically. Single use is untouched.

```
package System.Text.Json@10.0.0 -S Signals -S "Library Files"   → both sections render
member ... --show-index -S Methods --columns Select --columns Signature   → both columns
```

Tests cover repeated `-S`, alias/`=` mixing, repeated `--columns`, and the single-value no-op. 923 CLI tests pass.

## Status of the other points in #379
- **#1** (`package Name@Version`) — already works (resolves correctly to the pinned version).
- **#3** (`--show-index` selector column) — already works; the column is `Select` (the eval guessed `Selector`/`Index`), discoverable via `-D Methods` and projectable via `--columns Select`.
- **#4** (compact provenance line) — a genuine feature request, not addressed here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)