### PR TITLE
Decompiler: fix four classes of semantically wrong C# output

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -129,6 +129,40 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("endfilter", output);
     }
 
+    // --- using detection (must not eat finally code) ---
+
+    [Fact]
+    public void NormalUsing_RendersAsUsing()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.NormalUsing));
+
+        Assert.Contains("using", output);
+        Assert.DoesNotContain("finally", output);
+    }
+
+    [Fact]
+    public void FinallyWithExtraWork_IsNotCollapsedToUsing()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.FinallyWithExtraWork));
+
+        // The finally does more than dispose; rendering it as using would
+        // silently delete the extra statement.
+        Assert.Contains("finally", output);
+        Assert.Contains("Dispose", output);
+        Assert.Contains("-1", output);
+    }
+
+    [Fact]
+    public void ManualDisposeAsyncInFinally_IsNotRenderedAsUsing()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.ManualDisposeAsyncInFinally));
+
+        // DisposeAsync is await using's lowering — a plain using would change
+        // semantics. Keep the faithful try/finally.
+        Assert.Contains("finally", output);
+        Assert.Contains("DisposeAsync", output);
+    }
+
     // --- Control flow ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -129,6 +129,24 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("endfilter", output);
     }
 
+    // --- Inliner soundness ---
+
+    [Fact]
+    public void StaleFieldRead_DoesNotInlinePastMutation()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.StaleFieldRead));
+
+        // v captures h.Value BEFORE h.Value = 99; inlining the read past the
+        // store would compute the post-mutation value. The capture must stay
+        // ordered before the store.
+        int captureIdx = output.IndexOf("= h.Value", StringComparison.Ordinal);
+        int storeIdx = output.IndexOf("= 99", StringComparison.Ordinal);
+        Assert.True(captureIdx >= 0, $"Expected captured read in:\n{output}");
+        Assert.True(storeIdx >= 0, $"Expected field store in:\n{output}");
+        Assert.True(captureIdx < storeIdx,
+            $"Captured read must precede the mutation in:\n{output}");
+    }
+
     // --- using detection (must not eat finally code) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -100,6 +100,35 @@ public class CSharpEmitterTests
         Assert.Contains("/", output);
     }
 
+    // --- Exception filters (catch...when) ---
+
+    [Fact]
+    public void FilterCatch_EmitsWhenClause()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.FilterCatch));
+
+        Assert.Contains("catch", output);
+        Assert.Contains("when", output);
+        Assert.Contains("FormatException", output);
+    }
+
+    [Fact]
+    public void FilterCatch_HandlerBodyIsNotDropped()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.FilterCatch));
+
+        // The handler returns e.Message.Length — its body must appear.
+        Assert.Contains("Message", output);
+    }
+
+    [Fact]
+    public void FilterCatch_FilterCodeDoesNotLeakInline()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.FilterCatch));
+
+        Assert.DoesNotContain("endfilter", output);
+    }
+
     // --- Control flow ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -37,6 +37,69 @@ public class CSharpEmitterTests
             $"Expected parameter names in:\n{output}");
     }
 
+    // --- Unsigned/unordered comparisons (cgt.un, clt.un, b*.un) ---
+
+    [Fact]
+    public void UnsignedBoundsCheck_KeepsUnsignedCasts()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.UnsignedBoundsCheck));
+
+        // (uint)index < (uint)array.Length must not decay to index < array.Length —
+        // that inverts the result for negative indexes.
+        Assert.Contains("(uint)", output);
+    }
+
+    [Fact]
+    public void UnsignedBoundsBranch_KeepsUnsignedCasts()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.UnsignedBoundsBranch));
+
+        Assert.Contains("(uint)", output);
+        Assert.Contains("if", output);
+    }
+
+    [Fact]
+    public void FloatUnordered_DoesNotDecayToOrderedCompare()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.FloatUnordered));
+
+        // !(a <= b) compiles to cgt.un; rendering it as a > b changes the
+        // result when either operand is NaN. Accept the negated-complement
+        // form or the exact source form.
+        Assert.True(output.Contains("!(") || output.Contains("<="),
+            $"Expected unordered-aware rendering in:\n{output}");
+        Assert.DoesNotContain("(uint)", output);
+    }
+
+    [Fact]
+    public void NotNullIdiom_RendersAsNullComparison()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.NotNullIdiom));
+
+        // cgt.un(o, null) is the reference-inequality idiom — never "(uint)o > null".
+        Assert.Contains("null", output);
+        Assert.DoesNotContain("(uint)", output);
+        Assert.DoesNotContain("> null", output);
+    }
+
+    [Fact]
+    public void UnsignedShift_RendersUnsignedShiftOperator()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.UnsignedShift));
+
+        Assert.Contains(">>>", output);
+    }
+
+    [Fact]
+    public void UnsignedDivide_DoesNotRenderSignedDivision()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.UnsignedDivide));
+
+        // div.un on uint operands: plain '/' is fine only with unsigned operands;
+        // the emitter renders casts since IL erases operand signedness.
+        Assert.Contains("/", output);
+    }
+
     // --- Control flow ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -296,6 +296,18 @@ public class CfgSampleClass
         return count;
     }
 
+    public class MutableHolder
+    {
+        public int Value;
+    }
+
+    public static int StaleFieldRead(MutableHolder h)
+    {
+        int v = h.Value;
+        h.Value = 99;
+        return v + h.Value;
+    }
+
     public static long ManualDisposeAsyncInFinally(System.IO.MemoryStream stream)
     {
         try

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -262,6 +262,18 @@ public class CfgSampleClass
 
     public static uint UnsignedDivide(uint a, uint b) => a / b;
 
+    public static int FilterCatch(string s)
+    {
+        try
+        {
+            return int.Parse(s);
+        }
+        catch (FormatException e) when (s.Length > 3)
+        {
+            return e.Message.Length;
+        }
+    }
+
     public static string Classify(int x)
     {
         if (x > 0) return "positive";

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -274,6 +274,40 @@ public class CfgSampleClass
         }
     }
 
+    public static int NormalUsing(string s)
+    {
+        using var reader = new System.IO.StringReader(s);
+        return reader.Read();
+    }
+
+    public static int FinallyWithExtraWork(string s)
+    {
+        var reader = new System.IO.StringReader(s);
+        int count = 0;
+        try
+        {
+            count = reader.Read();
+        }
+        finally
+        {
+            reader.Dispose();
+            count = -1;
+        }
+        return count;
+    }
+
+    public static long ManualDisposeAsyncInFinally(System.IO.MemoryStream stream)
+    {
+        try
+        {
+            return stream.Length;
+        }
+        finally
+        {
+            _ = stream.DisposeAsync();
+        }
+    }
+
     public static string Classify(int x)
     {
         if (x > 0) return "positive";

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -243,6 +243,25 @@ public class CfgSampleClass
 
     public static bool IsPositive(int x) => x > 0;
 
+    // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
+
+    public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;
+
+    public static string UnsignedBoundsBranch(int index, int[] array)
+    {
+        if ((uint)index >= (uint)array.Length)
+            return "out";
+        return "in";
+    }
+
+    public static bool FloatUnordered(double a, double b) => !(a <= b);
+
+    public static bool NotNullIdiom(object o) => o != null;
+
+    public static int UnsignedShift(int x, int n) => x >>> n;
+
+    public static uint UnsignedDivide(uint a, uint b) => a / b;
+
     public static string Classify(int x)
     {
         if (x > 0) return "positive";

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -2263,13 +2263,14 @@ public static class CSharpEmitter
             ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => "+",
             ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un => "-",
             ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un => "*",
-            ILOpCode.Div or ILOpCode.Div_un => "/",
-            ILOpCode.Rem or ILOpCode.Rem_un => "%",
+            ILOpCode.Div => "/",
+            ILOpCode.Rem => "%",
             ILOpCode.And => "&",
             ILOpCode.Or => "|",
             ILOpCode.Xor => "^",
             ILOpCode.Shl => "<<",
-            ILOpCode.Shr or ILOpCode.Shr_un => ">>",
+            ILOpCode.Shr => ">>",
+            ILOpCode.Shr_un => ">>>",
             _ => null
         };
 
@@ -4815,24 +4816,31 @@ public static class CSharpEmitter
                 case ILOpCode.Mul: EmitBinary(expr, "*"); break;
                 case ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un:
                     EmitCheckedBinary(expr, "*"); break;
-                case ILOpCode.Div or ILOpCode.Div_un:
-                    EmitBinary(expr, "/"); break;
-                case ILOpCode.Rem or ILOpCode.Rem_un:
-                    EmitBinary(expr, "%"); break;
+                case ILOpCode.Div: EmitBinary(expr, "/"); break;
+                case ILOpCode.Div_un: EmitUnsignedArithmetic(expr, "/"); break;
+                case ILOpCode.Rem: EmitBinary(expr, "%"); break;
+                case ILOpCode.Rem_un: EmitUnsignedArithmetic(expr, "%"); break;
                 case ILOpCode.And: EmitBinary(expr, "&"); break;
                 case ILOpCode.Or: EmitBinary(expr, "|"); break;
                 case ILOpCode.Xor: EmitBinary(expr, "^"); break;
                 case ILOpCode.Shl: EmitBinary(expr, "<<"); break;
-                case ILOpCode.Shr or ILOpCode.Shr_un:
-                    EmitBinary(expr, ">>"); break;
+                case ILOpCode.Shr: EmitBinary(expr, ">>"); break;
+                // shr.un on any operand is C#'s unsigned right shift.
+                case ILOpCode.Shr_un: EmitBinary(expr, ">>>"); break;
 
                 // Comparison operators
                 case ILOpCode.Ceq:
+                    // ">=u"/"<=u" markers carry bge.un/ble.un semantics from
+                    // ExtractCondition (there are no cge/cle opcodes to map to).
+                    if (expr.Operand == ">=u") { EmitUnsignedComparison(expr, ">=", "<"); break; }
+                    if (expr.Operand == "<=u") { EmitUnsignedComparison(expr, "<=", ">"); break; }
                     if (!TryEmitNegatedComparisonZero(expr))
                         EmitBinary(expr, expr.Operand ?? "==");
                     break;
-                case ILOpCode.Cgt or ILOpCode.Cgt_un: EmitBinary(expr, ">"); break;
-                case ILOpCode.Clt or ILOpCode.Clt_un: EmitBinary(expr, "<"); break;
+                case ILOpCode.Cgt: EmitBinary(expr, ">"); break;
+                case ILOpCode.Cgt_un: EmitUnsignedComparison(expr, ">", "<="); break;
+                case ILOpCode.Clt: EmitBinary(expr, "<"); break;
+                case ILOpCode.Clt_un: EmitUnsignedComparison(expr, "<", ">="); break;
 
                 // Unary operators
                 case ILOpCode.Neg:
@@ -5686,16 +5694,27 @@ public static class CSharpEmitter
                     break;
                 case ILOpCode.Beq or ILOpCode.Beq_s:
                     EmitBinaryCondition(expr, "=="); break;
+                // bne.un is the standard inequality branch: plain != for
+                // integers/references, and C#'s != already has unordered
+                // semantics for floats.
                 case ILOpCode.Bne_un or ILOpCode.Bne_un_s:
                     EmitBinaryCondition(expr, "!="); break;
-                case ILOpCode.Bge or ILOpCode.Bge_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s:
+                case ILOpCode.Bge or ILOpCode.Bge_s:
                     EmitBinaryCondition(expr, ">="); break;
-                case ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s:
+                case ILOpCode.Bge_un or ILOpCode.Bge_un_s:
+                    EmitUnsignedComparison(expr, ">=", "<"); break;
+                case ILOpCode.Bgt or ILOpCode.Bgt_s:
                     EmitBinaryCondition(expr, ">"); break;
-                case ILOpCode.Ble or ILOpCode.Ble_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s:
+                case ILOpCode.Bgt_un or ILOpCode.Bgt_un_s:
+                    EmitUnsignedComparison(expr, ">", "<="); break;
+                case ILOpCode.Ble or ILOpCode.Ble_s:
                     EmitBinaryCondition(expr, "<="); break;
-                case ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Blt_un or ILOpCode.Blt_un_s:
+                case ILOpCode.Ble_un or ILOpCode.Ble_un_s:
+                    EmitUnsignedComparison(expr, "<=", ">"); break;
+                case ILOpCode.Blt or ILOpCode.Blt_s:
                     EmitBinaryCondition(expr, "<"); break;
+                case ILOpCode.Blt_un or ILOpCode.Blt_un_s:
+                    EmitUnsignedComparison(expr, "<", ">="); break;
                 default:
                     EmitExpression(expr);
                     break;
@@ -5756,10 +5775,23 @@ public static class CSharpEmitter
 
             if (comparison is null || comparison.Arguments.Count < 2) return false;
 
+            // Negating an unordered compare yields the ordered complement
+            // (with NaN semantics and unsigned casts handled there).
+            if (comparison.OpCode == ILOpCode.Clt_un)
+            {
+                EmitNegatedUnsignedComparison(comparison, ">=");
+                return true;
+            }
+            if (comparison.OpCode == ILOpCode.Cgt_un)
+            {
+                EmitNegatedUnsignedComparison(comparison, "<=");
+                return true;
+            }
+
             string negatedOp = comparison.OpCode switch
             {
-                ILOpCode.Clt or ILOpCode.Clt_un => ">=",
-                ILOpCode.Cgt or ILOpCode.Cgt_un => "<=",
+                ILOpCode.Clt => ">=",
+                ILOpCode.Cgt => "<=",
                 ILOpCode.Ceq => "!=",
                 _ => ""
             };
@@ -5843,6 +5875,163 @@ public static class CSharpEmitter
                 _sb.Append($" {op} ");
                 EmitExpression(expr.Arguments[1]);
             }
+        }
+
+        /// <summary>
+        /// Renders the unsigned/unordered comparison opcodes (cgt.un, clt.un, and
+        /// the b*.un branches). Their semantics differ from the signed forms:
+        /// for floats they mean "compare or unordered" — the negation of the
+        /// complementary ordered compare (cgt.un(a,b) == !(a &lt;= b), which differs
+        /// from a &gt; b when either operand is NaN); for integers they compare the
+        /// bits as unsigned, which C# expresses by casting both operands (the
+        /// classic bounds-check (uint)i &lt; (uint)length). cgt.un against null is
+        /// the compiler's reference-inequality idiom.
+        /// </summary>
+        void EmitUnsignedComparison(ILAstExpression expr, string op, string orderedComplement)
+        {
+            if (expr.Arguments.Count < 2)
+            {
+                EmitBinary(expr, op);
+                return;
+            }
+
+            var left = expr.Arguments[0];
+            var right = expr.Arguments[1];
+
+            if (op == ">" && right.OpCode == ILOpCode.Ldnull)
+            {
+                EmitExpression(left);
+                _sb.Append(" != null");
+                return;
+            }
+
+            switch (ComparisonKind(left, right))
+            {
+                case StackValueKind.Float:
+                    _sb.Append("!(");
+                    EmitExpression(left);
+                    _sb.Append($" {orderedComplement} ");
+                    EmitExpression(right);
+                    _sb.Append(')');
+                    break;
+                case StackValueKind.Int64:
+                    EmitUnsignedBinary(expr, op, "(ulong)", ILOpCode.Conv_u8);
+                    break;
+                case StackValueKind.NativeInt:
+                    EmitUnsignedBinary(expr, op, "(nuint)", ILOpCode.Conv_u);
+                    break;
+                case StackValueKind.Int32:
+                    EmitUnsignedBinary(expr, op, "(uint)", ILOpCode.Conv_u4);
+                    break;
+                default:
+                    // ObjRef/ByRef/unknown — pointer-style comparison; the raw
+                    // operator is the closest C# rendering.
+                    EmitBinary(expr, op);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Negated form (via ceq(cmp, 0)) of an unsigned/unordered comparison.
+        /// Note the asymmetry with <see cref="EmitUnsignedComparison"/>: negating
+        /// an unordered compare yields the ORDERED complement — !cgt.un(a,b) is
+        /// exactly a &lt;= b, including NaN behavior.
+        /// </summary>
+        void EmitNegatedUnsignedComparison(ILAstExpression comparison, string orderedOp)
+        {
+            var left = comparison.Arguments[0];
+            var right = comparison.Arguments[1];
+
+            // !(x != null) → x == null
+            if (orderedOp == "<=" && right.OpCode == ILOpCode.Ldnull)
+            {
+                EmitExpression(left);
+                _sb.Append(" == null");
+                return;
+            }
+
+            switch (ComparisonKind(left, right))
+            {
+                case StackValueKind.Float:
+                    EmitExpression(left);
+                    _sb.Append($" {orderedOp} ");
+                    EmitExpression(right);
+                    break;
+                case StackValueKind.Int64:
+                    EmitUnsignedBinary(comparison, orderedOp, "(ulong)", ILOpCode.Conv_u8);
+                    break;
+                case StackValueKind.NativeInt:
+                    EmitUnsignedBinary(comparison, orderedOp, "(nuint)", ILOpCode.Conv_u);
+                    break;
+                case StackValueKind.Int32:
+                    EmitUnsignedBinary(comparison, orderedOp, "(uint)", ILOpCode.Conv_u4);
+                    break;
+                default:
+                    EmitBinary(comparison, orderedOp);
+                    break;
+            }
+        }
+
+        /// <summary>div.un/rem.un: unsigned arithmetic, rendered with operand casts.</summary>
+        void EmitUnsignedArithmetic(ILAstExpression expr, string op)
+        {
+            if (expr.Arguments.Count < 2)
+            {
+                EmitBinary(expr, op);
+                return;
+            }
+
+            switch (ComparisonKind(expr.Arguments[0], expr.Arguments[1]))
+            {
+                case StackValueKind.Int64:
+                    EmitUnsignedBinary(expr, op, "(ulong)", ILOpCode.Conv_u8);
+                    break;
+                case StackValueKind.NativeInt:
+                    EmitUnsignedBinary(expr, op, "(nuint)", ILOpCode.Conv_u);
+                    break;
+                default:
+                    EmitUnsignedBinary(expr, op, "(uint)", ILOpCode.Conv_u4);
+                    break;
+            }
+        }
+
+        void EmitUnsignedBinary(ILAstExpression expr, string op, string cast, ILOpCode redundantConv)
+        {
+            EmitUnsignedOperand(expr.Arguments[0], cast, redundantConv);
+            _sb.Append($" {op} ");
+            EmitUnsignedOperand(expr.Arguments[1], cast, redundantConv);
+        }
+
+        void EmitUnsignedOperand(ILAstExpression arg, string cast, ILOpCode redundantConv)
+        {
+            // Non-negative constants are unchanged by unsigned reinterpretation,
+            // and an operand that is itself the matching conversion already
+            // renders the cast.
+            if ((IsLdcI4(arg.OpCode) && GetI4Value(arg) >= 0) || arg.OpCode == redundantConv)
+            {
+                EmitExpression(arg);
+                return;
+            }
+
+            _sb.Append(cast);
+            bool wrap = IsBinaryOp(arg.OpCode);
+            if (wrap) _sb.Append('(');
+            EmitExpression(arg);
+            if (wrap) _sb.Append(')');
+        }
+
+        /// <summary>Joint stack-value kind of a comparison's operands.</summary>
+        static StackValueKind ComparisonKind(ILAstExpression left, ILAstExpression right)
+        {
+            var a = left.ResultType.Kind;
+            var b = right.ResultType.Kind;
+            if (a == StackValueKind.Float || b == StackValueKind.Float) return StackValueKind.Float;
+            if (a == StackValueKind.ObjRef || b == StackValueKind.ObjRef) return StackValueKind.ObjRef;
+            if (a == StackValueKind.ByRef || b == StackValueKind.ByRef) return StackValueKind.ByRef;
+            if (a == StackValueKind.Int64 || b == StackValueKind.Int64) return StackValueKind.Int64;
+            if (a == StackValueKind.NativeInt || b == StackValueKind.NativeInt) return StackValueKind.NativeInt;
+            if (a == StackValueKind.Int32 || b == StackValueKind.Int32) return StackValueKind.Int32;
+            return StackValueKind.Unknown;
         }
 
         // --- Helpers ---
@@ -6283,6 +6472,16 @@ public static class CSharpEmitter
 
         static string NegateConditionString(string condition)
         {
+            // A fully-wrapped negation strips exactly. This must run before the
+            // operator flips: float unordered forms like !(a <= b) negate to the
+            // ordered a <= b, not to !(a > b) (which differs under NaN).
+            if (condition.StartsWith("!(", StringComparison.Ordinal)
+                && condition.EndsWith(')')
+                && ParenWrapsWholeString(condition))
+            {
+                return condition[2..^1];
+            }
+
             // Flip comparison operators if present
             if (condition.Contains(" != "))
                 return condition.Replace(" != ", " == ");
@@ -6298,11 +6497,33 @@ public static class CSharpEmitter
                 return condition.Replace(" <= ", " > ");
 
             // Simple negation
-            if (condition.StartsWith("!(") && condition.EndsWith(')'))
-                return condition[2..^1];
             if (condition.StartsWith('!'))
                 return condition[1..];
             return $"!{condition}";
+        }
+
+        /// <summary>
+        /// True when the parenthesis opened at index 1 closes at the final
+        /// character — i.e. <c>!(...)</c> wraps the whole condition rather than
+        /// just its first term (<c>!(a) &amp;&amp; b</c>).
+        /// </summary>
+        static bool ParenWrapsWholeString(string condition)
+        {
+            int depth = 0;
+            for (int i = 1; i < condition.Length; i++)
+            {
+                if (condition[i] == '(')
+                {
+                    depth++;
+                }
+                else if (condition[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                        return i == condition.Length - 1;
+                }
+            }
+            return false;
         }
 
         static ILAstExpression ExtractCondition(ILAstExpression branchExpr)
@@ -6367,15 +6588,28 @@ public static class CSharpEmitter
             }
             if (branchExpr.Arguments.Count == 2)
             {
-                // Binary comparison branch — reconstruct as comparison expression
+                // Binary comparison branch — reconstruct as comparison expression.
+                // bge/ble/bne have no c* counterpart, so they ride on Ceq with the
+                // operator (or ">=u"/"<=u" unsigned marker) in Operand, which the
+                // Ceq emit case honors.
                 return new ILAstExpression
                 {
                     OpCode = branchExpr.OpCode switch
                     {
-                        ILOpCode.Beq or ILOpCode.Beq_s => ILOpCode.Ceq,
-                        ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s => ILOpCode.Cgt,
-                        ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Blt_un or ILOpCode.Blt_un_s => ILOpCode.Clt,
+                        ILOpCode.Bgt or ILOpCode.Bgt_s => ILOpCode.Cgt,
+                        ILOpCode.Bgt_un or ILOpCode.Bgt_un_s => ILOpCode.Cgt_un,
+                        ILOpCode.Blt or ILOpCode.Blt_s => ILOpCode.Clt,
+                        ILOpCode.Blt_un or ILOpCode.Blt_un_s => ILOpCode.Clt_un,
                         _ => ILOpCode.Ceq
+                    },
+                    Operand = branchExpr.OpCode switch
+                    {
+                        ILOpCode.Bne_un or ILOpCode.Bne_un_s => "!=",
+                        ILOpCode.Bge or ILOpCode.Bge_s => ">=",
+                        ILOpCode.Bge_un or ILOpCode.Bge_un_s => ">=u",
+                        ILOpCode.Ble or ILOpCode.Ble_s => "<=",
+                        ILOpCode.Ble_un or ILOpCode.Ble_un_s => "<=u",
+                        _ => null
                     },
                     ResultType = StackValue.CreatePrimitive(StackValueKind.Int32),
                     Arguments = { branchExpr.Arguments[0], branchExpr.Arguments[1] }
@@ -6457,13 +6691,14 @@ public static class CSharpEmitter
                 ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => "+",
                 ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un => "-",
                 ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un => "*",
-                ILOpCode.Div or ILOpCode.Div_un => "/",
-                ILOpCode.Rem or ILOpCode.Rem_un => "%",
+                ILOpCode.Div => "/",
+                ILOpCode.Rem => "%",
                 ILOpCode.And => "&",
                 ILOpCode.Or => "|",
                 ILOpCode.Xor => "^",
                 ILOpCode.Shl => "<<",
-                ILOpCode.Shr or ILOpCode.Shr_un => ">>",
+                ILOpCode.Shr => ">>",
+                ILOpCode.Shr_un => ">>>",
                 _ => null
             };
             if (opSymbol is null) return false;
@@ -6504,13 +6739,14 @@ public static class CSharpEmitter
                 ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => "+",
                 ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un => "-",
                 ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un => "*",
-                ILOpCode.Div or ILOpCode.Div_un => "/",
-                ILOpCode.Rem or ILOpCode.Rem_un => "%",
+                ILOpCode.Div => "/",
+                ILOpCode.Rem => "%",
                 ILOpCode.And => "&",
                 ILOpCode.Or => "|",
                 ILOpCode.Xor => "^",
                 ILOpCode.Shl => "<<",
-                ILOpCode.Shr or ILOpCode.Shr_un => ">>",
+                ILOpCode.Shr => ">>",
+                ILOpCode.Shr_un => ">>>",
                 _ => null
             };
             if (opSymbol is null) return null;

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -932,9 +932,7 @@ public static class CSharpEmitter
                     continue;
 
                 if (!sawDispose
-                    && expr.Operand is string operand
-                    && operand.Contains("Dispose", StringComparison.Ordinal)
-                    && !expr.IsStaticCall
+                    && IsDisposeCall(expr)
                     && expr.Arguments.Count > 0)
                 {
                     disposeVar = RenderReceiverName(expr.Arguments[0]);
@@ -4216,6 +4214,10 @@ public static class CSharpEmitter
         /// Detect the dispose pattern in a finally handler:
         /// IfThenElse { if (var != null) { var.Dispose(); } } + endfinally
         /// Returns the variable name being disposed, or null.
+        /// The member must be exactly Dispose (DisposeAsync is an await using —
+        /// not representable as a plain using statement), and the finally must
+        /// contain NOTHING ELSE: rendering as using discards the handler, so any
+        /// extra statement would be silently deleted from the output.
         /// </summary>
         string? TryDetectDisposeVariable(StructuredBlock block)
         {
@@ -4229,18 +4231,80 @@ public static class CSharpEmitter
                         foreach (var node in thenAst.Nodes)
                         {
                             if (node is ILAstStatement { Expression: var expr }
-                                && expr.Operand is string operand
-                                && operand.Contains("Dispose", StringComparison.Ordinal)
-                                && !expr.IsStaticCall
+                                && IsDisposeCall(expr)
                                 && expr.Arguments.Count > 0)
                             {
-                                return RenderReceiverName(expr.Arguments[0]);
+                                string disposeVar = RenderReceiverName(expr.Arguments[0]);
+                                return FinallyContainsOnlyDisposeOf(block, disposeVar) ? disposeVar : null;
                             }
                         }
                     }
                 }
             }
             return null;
+        }
+
+        static bool IsDisposeCall(ILAstExpression expr)
+            => expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt
+                && !expr.IsStaticCall
+                && expr.Operand is string operand
+                && ExtractMemberName(operand) == "Dispose";
+
+        /// <summary>
+        /// Verifies a finally handler consists solely of the dispose-of-variable
+        /// pattern: nops, endfinally, null-check guards on the variable, and the
+        /// Dispose call itself.
+        /// </summary>
+        bool FinallyContainsOnlyDisposeOf(StructuredBlock block, string disposeVar)
+        {
+            bool sawDispose = false;
+            foreach (var (_, node) in EnumerateStructuredNodes(block.HandlerChildren))
+            {
+                if (node is ILAstAssignment)
+                    return false;
+                if (NodeExpression(node) is not { } expr)
+                    continue;
+                if (expr.OpCode is ILOpCode.Nop or ILOpCode.Endfinally
+                    or ILOpCode.Br or ILOpCode.Br_s)
+                {
+                    continue;
+                }
+
+                // Null-check guard on the disposed variable.
+                if (expr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                        or ILOpCode.Brtrue or ILOpCode.Brtrue_s
+                    && expr.Arguments.Count == 1
+                    && TreeReferencesLocal(expr.Arguments[0], disposeVar))
+                {
+                    continue;
+                }
+
+                if (IsDisposeCall(expr)
+                    && expr.Arguments.Count > 0
+                    && TreeReferencesLocal(expr.Arguments[0], disposeVar))
+                {
+                    if (sawDispose)
+                        return false;
+                    sawDispose = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            return sawDispose;
+        }
+
+        static bool TreeReferencesLocal(ILAstExpression expr, string localName)
+        {
+            if (GetLocalReferenceName(expr) is { } name && name == localName)
+                return true;
+            foreach (var arg in expr.Arguments)
+            {
+                if (TreeReferencesLocal(arg, localName))
+                    return true;
+            }
+            return false;
         }
 
         void EmitUsingBlock(StructuredBlock block, string disposeVar, int indent)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -212,6 +212,10 @@ public static class CSharpEmitter
 
             // Pre-detect using patterns to suppress local declarations
             ScanForUsingPatterns(structure.Root);
+
+            // Pre-detect exception-filter bool temps (declarations print before
+            // the filter is rendered as a when clause).
+            ScanForFilterLocals(structure.Root);
         }
 
         sealed class LockPattern
@@ -1464,6 +1468,18 @@ public static class CSharpEmitter
 
         void EmitIfThenElse(StructuredBlock block, int indent)
         {
+            // A consumed condition block means the construct was already rendered
+            // by a recognized pattern (e.g. an exception filter's blocks become a
+            // when clause) — emitting it again would leak the lowered form.
+            if (block.ConditionBlockIndex >= 0 && _consumedBlocks.Contains(block.ConditionBlockIndex))
+            {
+                if (block.ThenBlock is not null)
+                    ConsumeStructuredBlock(block.ThenBlock);
+                if (block.ElseBlock is not null)
+                    ConsumeStructuredBlock(block.ElseBlock);
+                return;
+            }
+
             // Skip constant-condition branches (Debug stepping markers like brtrue [ldc.i4.1])
             if (block.ConditionBlockIndex >= 0 && _blockMap.TryGetValue(block.ConditionBlockIndex, out var earlyCondBlock))
             {
@@ -4029,6 +4045,171 @@ public static class CSharpEmitter
                 WriteIndent(indent);
                 _sb.AppendLine("}");
             }
+            else if (region.Kind == ExceptionRegionKind.Filter)
+            {
+                WriteIndent(indent);
+                _sb.AppendLine(BuildFilterCatchHeader(region));
+                WriteIndent(indent);
+                _sb.AppendLine("{");
+                foreach (var child in handlerChildren)
+                    EmitStructuredBlock(child, indent + 1);
+                WriteIndent(indent);
+                _sb.AppendLine("}");
+            }
+            else if (region.Kind == ExceptionRegionKind.Fault)
+            {
+                WriteIndent(indent);
+                _sb.AppendLine("finally /* fault: runs only when an exception escapes the try */");
+                WriteIndent(indent);
+                _sb.AppendLine("{");
+                foreach (var child in handlerChildren)
+                    EmitStructuredBlock(child, indent + 1);
+                WriteIndent(indent);
+                _sb.AppendLine("}");
+            }
+        }
+
+        /// <summary>
+        /// Builds a <c>catch (T name) when (cond)</c> header from a filter region
+        /// and consumes the filter code blocks so they don't leak into the output.
+        /// The C# compiler's filter shape is stable: <c>isinst T</c> on the
+        /// exception, a store to the catch local, the user condition normalized
+        /// with <c>ldc.i4.0 cgt.un</c>, then <c>endfilter</c>. Anything that
+        /// doesn't match falls back to a placeholder condition comment.
+        /// </summary>
+        string BuildFilterCatchHeader(ExceptionRegion region)
+        {
+            // Collect (and consume) the filter blocks: [FilterOffset, HandlerOffset).
+            var filterNodes = new List<ILAstNode>();
+            foreach (var (blockIdx, offset) in _blockStartOffset.OrderBy(kv => kv.Value))
+            {
+                if (offset < region.FilterOffset || offset >= region.HandlerOffset)
+                    continue;
+                _consumedBlocks.Add(blockIdx);
+                RemoveGotoTargetsForConsumedBlock(blockIdx);
+                if (_blockMap.TryGetValue(blockIdx, out var astBlock))
+                    filterNodes.AddRange(astBlock.Nodes);
+            }
+
+            string? exType = null;
+            string? catchVar = null;
+            ILAstExpression? conditionExpr = null;
+
+            foreach (var node in filterNodes)
+            {
+                if (NodeExpression(node) is not { } expr)
+                    continue;
+
+                // Exception type test: first isinst in the filter.
+                if (exType is null && FindOpcodeInTree(expr, ILOpCode.Isinst) is { Operand: string typeOp })
+                    exType = SimplifyTypeName(typeOp);
+
+                // Catch local: a store whose value involves the type-tested exception.
+                if (catchVar is null
+                    && node is ILAstStatement { Expression: var stExpr }
+                    && stExpr.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                        or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                    && stExpr.Arguments.Count == 1
+                    && (FindOpcodeInTree(stExpr.Arguments[0], ILOpCode.Isinst) is not null
+                        || stExpr.Arguments[0].Operand is string ld && ld.StartsWith("S_in_", StringComparison.Ordinal)))
+                {
+                    catchVar = stExpr.Operand ?? GetLocalName(stExpr.OpCode);
+                }
+
+                // User condition: bool-normalized as cgt.un(cond, 0) before endfilter.
+                if (expr.OpCode is ILOpCode.Cgt_un
+                    && expr.Arguments.Count == 2
+                    && IsZeroLiteral(expr.Arguments[1]))
+                {
+                    conditionExpr = expr.Arguments[0];
+                }
+            }
+
+            // The normalized condition is often just a load of a bool temp the
+            // filter assigned earlier — substitute the temp's defining expression.
+            if (conditionExpr is not null && GetLocalReferenceName(conditionExpr) is { } condLocal)
+            {
+                foreach (var node in filterNodes)
+                {
+                    if (node is ILAstStatement { Expression: var stExpr }
+                        && IsStoreToLocal(stExpr, condLocal)
+                        && stExpr.Arguments.Count == 1)
+                    {
+                        conditionExpr = stExpr.Arguments[0];
+                    }
+                }
+                _suppressedLocals.Add(condLocal);
+            }
+
+            // The handler refers to the exception as the synthetic incoming stack
+            // value; give it the catch variable's name (or one we invent).
+            string varName = catchVar ?? "ex";
+            _syntheticSubstitutions["S_in_0"] = varName;
+
+            string condition = conditionExpr is not null
+                ? ExpressionToString(conditionExpr)
+                : $"/* filter at IL_{region.FilterOffset:X4} */";
+            string header = exType is null ? $"catch ({varName})" : $"catch ({exType} {varName})";
+            return $"{header} when ({condition})";
+        }
+
+        /// <summary>
+        /// Suppresses declarations of bool temps that exception filters normalize
+        /// through (cgt.un(temp, 0) before endfilter) — the when-clause rendering
+        /// inlines their defining expression.
+        /// </summary>
+        void ScanForFilterLocals(StructuredBlock block)
+        {
+            var regions = new List<ExceptionRegion>();
+            if (block.ExceptionRegion is { Kind: ExceptionRegionKind.Filter } filterRegion)
+                regions.Add(filterRegion);
+            foreach (var addl in block.AdditionalHandlers)
+                if (addl.Region.Kind == ExceptionRegionKind.Filter)
+                    regions.Add(addl.Region);
+
+            foreach (var region in regions)
+            {
+                foreach (var (blockIdx, offset) in _blockStartOffset)
+                {
+                    if (offset < region.FilterOffset || offset >= region.HandlerOffset)
+                        continue;
+                    if (!_blockMap.TryGetValue(blockIdx, out var astBlock))
+                        continue;
+                    foreach (var node in astBlock.Nodes)
+                    {
+                        if (NodeExpression(node) is { OpCode: ILOpCode.Cgt_un, Arguments.Count: 2 } expr
+                            && IsZeroLiteral(expr.Arguments[1])
+                            && GetLocalReferenceName(expr.Arguments[0]) is { } condLocal)
+                        {
+                            _suppressedLocals.Add(condLocal);
+                        }
+                    }
+                }
+            }
+
+            foreach (var c in block.Children)
+                ScanForFilterLocals(c);
+            foreach (var c in block.TryChildren)
+                ScanForFilterLocals(c);
+            foreach (var c in block.HandlerChildren)
+                ScanForFilterLocals(c);
+            if (block.ThenBlock is not null)
+                ScanForFilterLocals(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ScanForFilterLocals(block.ElseBlock);
+        }
+
+        /// <summary>Depth-first search for an opcode in an expression tree.</summary>
+        static ILAstExpression? FindOpcodeInTree(ILAstExpression expr, ILOpCode opCode)
+        {
+            if (expr.OpCode == opCode)
+                return expr;
+            foreach (var arg in expr.Arguments)
+            {
+                if (FindOpcodeInTree(arg, opCode) is { } found)
+                    return found;
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/DotnetInspector.Decompiler/ExpressionInliner.cs
+++ b/src/DotnetInspector.Decompiler/ExpressionInliner.cs
@@ -59,6 +59,14 @@ sealed class ExpressionInliner
             if (ExprReferencesVar(valueExpr, varName))
                 continue;
 
+            // Moving the evaluation to the use site is only sound if nothing the
+            // value reads can change in between: track the locals it loads, and
+            // whether it reads mutable state (fields, array elements, indirection)
+            // that any call or store could invalidate.
+            var localsRead = new HashSet<string>();
+            CollectLocalReads(valueExpr, localsRead);
+            bool readsMutableState = ReadsMutableState(valueExpr);
+
             // Scan forward for a single use of this variable before any redefinition
             for (int j = i + 1; j < block.Nodes.Count; j++)
             {
@@ -71,9 +79,22 @@ sealed class ExpressionInliner
                 // Count references to this variable in the candidate node
                 int refCount = CountReferences(candidate, varName);
                 if (refCount == 0)
+                {
+                    // No use here — but does this node invalidate the captured value?
+                    if (StoresToAny(candidate, localsRead))
+                        break;
+                    if (readsMutableState && NodeMutatesOrCalls(candidate))
+                        break;
                     continue;
+                }
                 if (refCount > 1)
                     break; // multiple uses — can't inline
+
+                // The use site itself: anything evaluated BEFORE the reference
+                // within this node (earlier call arguments, receivers) must not
+                // mutate state the value reads.
+                if (readsMutableState && MutatesBeforeFirstRef(candidate, varName))
+                    break;
 
                 // Exactly one reference — inline it
                 if (ReplaceReference(candidate, varName, valueExpr))
@@ -140,8 +161,10 @@ sealed class ExpressionInliner
 
             var valueExpr = storeExpr.Arguments[0];
 
-            // Don't inline side-effecting expressions across blocks
-            if (IsSideEffecting(valueExpr))
+            // Across blocks there is no ordering guarantee between definition and
+            // use (the def may sit in a loop, the use after it; nothing here checks
+            // dominance), so only position-independent constants are sound to move.
+            if (!IsPositionIndependent(valueExpr))
                 continue;
 
             // Don't inline self-referential stores
@@ -304,6 +327,133 @@ sealed class ExpressionInliner
                 return true;
         return false;
     }
+
+    /// <summary>Locals loaded anywhere in the expression tree.</summary>
+    static void CollectLocalReads(ILAstExpression expr, HashSet<string> locals)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldloca or ILOpCode.Ldloca_s)
+        {
+            string? name = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
+            if (name is not null)
+                locals.Add(name);
+        }
+        foreach (var arg in expr.Arguments)
+            CollectLocalReads(arg, locals);
+    }
+
+    /// <summary>
+    /// True when the expression reads state a call or store could change:
+    /// fields, array elements, or indirection. (Array length is immutable
+    /// per instance, and local reads are tracked separately.)
+    /// </summary>
+    static bool ReadsMutableState(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Ldfld or ILOpCode.Ldsfld or ILOpCode.Ldflda or ILOpCode.Ldsflda
+            or ILOpCode.Ldelem or ILOpCode.Ldelema
+            or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2 or ILOpCode.Ldelem_i4
+            or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8 or ILOpCode.Ldelem_ref
+            or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4
+            or ILOpCode.Ldind_i or ILOpCode.Ldind_i1 or ILOpCode.Ldind_i2 or ILOpCode.Ldind_i4
+            or ILOpCode.Ldind_i8 or ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8 or ILOpCode.Ldind_ref
+            or ILOpCode.Ldind_u1 or ILOpCode.Ldind_u2 or ILOpCode.Ldind_u4 or ILOpCode.Ldobj)
+        {
+            return true;
+        }
+        foreach (var arg in expr.Arguments)
+            if (ReadsMutableState(arg))
+                return true;
+        return false;
+    }
+
+    static bool IsMutationOrCall(ILOpCode op) => op is
+        ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Calli or ILOpCode.Newobj
+        or ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Stobj or ILOpCode.Initobj
+        or ILOpCode.Cpobj or ILOpCode.Cpblk or ILOpCode.Initblk
+        or ILOpCode.Stind_i or ILOpCode.Stind_i1 or ILOpCode.Stind_i2 or ILOpCode.Stind_i4
+        or ILOpCode.Stind_i8 or ILOpCode.Stind_r4 or ILOpCode.Stind_r8 or ILOpCode.Stind_ref
+        or ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
+        or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
+        or ILOpCode.Stelem_ref;
+
+    static bool NodeMutatesOrCalls(ILAstNode node) => node switch
+    {
+        ILAstStatement { Expression: var expr } => TreeMutatesOrCalls(expr),
+        ILAstAssignment { Value: var value } => TreeMutatesOrCalls(value),
+        _ => false
+    };
+
+    static bool TreeMutatesOrCalls(ILAstExpression expr)
+    {
+        if (IsMutationOrCall(expr.OpCode))
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (TreeMutatesOrCalls(arg))
+                return true;
+        return false;
+    }
+
+    /// <summary>Does the node store to any local in <paramref name="locals"/>?</summary>
+    static bool StoresToAny(ILAstNode node, HashSet<string> locals)
+    {
+        foreach (string local in locals)
+            if (IsStoreToVar(node, local))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Walks the node's evaluation order (depth-first, argument order) and
+    /// reports whether any mutation/call executes before the first load of
+    /// <paramref name="varName"/> — the position the inlined expression
+    /// would evaluate at.
+    /// </summary>
+    static bool MutatesBeforeFirstRef(ILAstNode node, string varName)
+    {
+        var expr = node switch
+        {
+            ILAstStatement s => s.Expression,
+            ILAstAssignment a => a.Value,
+            _ => null
+        };
+        if (expr is null)
+            return true; // unknown shape — don't inline
+
+        bool foundRef = false;
+        return Walk(expr, varName, ref foundRef);
+
+        static bool Walk(ILAstExpression expr, string varName, ref bool foundRef)
+        {
+            // Arguments evaluate before the operation itself.
+            foreach (var arg in expr.Arguments)
+            {
+                if (Walk(arg, varName, ref foundRef))
+                    return true;
+                if (foundRef)
+                    return false;
+            }
+
+            if (IsLoadOf(expr, varName))
+            {
+                foundRef = true;
+                return false;
+            }
+
+            return IsMutationOrCall(expr.OpCode);
+        }
+    }
+
+    /// <summary>
+    /// True for expressions whose value cannot depend on where they are
+    /// evaluated: constants and string/null/token loads.
+    /// </summary>
+    static bool IsPositionIndependent(ILAstExpression expr) => expr.OpCode is
+        ILOpCode.Ldc_i4 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4_m1
+        or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2 or ILOpCode.Ldc_i4_3
+        or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6 or ILOpCode.Ldc_i4_7
+        or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
+        or ILOpCode.Ldstr or ILOpCode.Ldnull;
 
     static string? GetLocalNameFromOp(ILOpCode op) => op switch
     {


### PR DESCRIPTION
## What

Four correctness fixes for the Lowered C# section, from the decompiler audit. Each could previously make the output *lie* about what the code does.

1. **Unsigned/unordered comparisons** — `cgt.un`/`clt.un` and the `b*.un` branches rendered as plain signed operators. The ubiquitous bounds-check `(uint)index < (uint)array.Length` decompiled to `index < array.Length` (inverted for negative indexes); float `.un` compares lost NaN semantics. Now: unsigned operand casts for integers, negated-ordered-complement form for floats (`!(a <= b)`), `x != null` idiom preserved, `shr.un` renders as `>>>`. Bonus: `bge`/`ble`/`bne.un` in ternary/short-circuit contexts rendered as `==` (ExtractCondition collapsed them to Ceq).

2. **Exception filters** — `catch…when` handler bodies were silently dropped and the filter's code blocks leaked inline as stray labels. Now reconstructed as `catch (FormatException ex) when (s.Length > 3)` from the compiler's stable filter shape, with a `when (/* filter at IL_xxxx */)` fallback. Fault handlers render as a commented finally.

3. **`using` over-detection** — any finally whose member name *contained* "Dispose" became a `using`, deleting any other finally statements and rendering `DisposeAsync` (await using) as a plain `using`. The finally must now contain exactly the dispose pattern, and the member must be exactly `Dispose`.

4. **Inliner soundness** — within-block inlining moved evaluations past mutations of state they read (`int v = h.Value; h.Value = 99; return v + h.Value;` inlined into the post-mutation value); cross-block inlining had no ordering check at all. Now: hazard tracking between definition and use (including evaluation order inside the use node), and cross-block restricted to position-independent constants.

## Tests

13 new fixture-based emitter tests; all suites green (221 decompiler / 923 CLI / 131 metadata / 158 services).

## Follow-up

Next step on this track is the transform-pass refactor (typed conditions, pattern detection as ILAst passes) before expanding re-sugaring coverage — these fixes are deliberately in-architecture surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)