### PR TITLE
Decompiler: reconstruct && / || short-circuit chains

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -129,6 +129,39 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("endfilter", output);
     }
 
+    // --- Short-circuit condition chains (Release-shaped IL) ---
+    // Debug builds materialize && / || as stack values, so chain coverage uses
+    // the always-Release platform assembly.
+
+    [Fact]
+    public void CoreLib_IsNullOrEmpty_ReconstructsShortCircuit()
+    {
+        string output = EmitCoreLibMethod("System.String", "IsNullOrEmpty");
+
+        Assert.True(output.Contains("&&") || output.Contains("||"),
+            $"Expected a short-circuit operator in:\n{output}");
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
+    public void CoreLib_IsNullOrEmpty_KeepsNullCheckSemantics()
+    {
+        string output = EmitCoreLibMethod("System.String", "IsNullOrEmpty");
+
+        Assert.Contains("null", output);
+        Assert.Contains("Length", output);
+    }
+
+    static string EmitCoreLibMethod(string typeName, string methodName)
+    {
+        var assemblyPath = typeof(object).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var context = MethodBodyContext.Create(peReader, typeName, methodName);
+        Assert.NotNull(context);
+        return CSharpEmitter.Emit(context);
+    }
+
     // --- Inliner soundness ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -247,6 +247,36 @@ public class CfgSampleClass
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;
 
+    // --- Short-circuit condition chains ---
+
+    public static string IfAnd(int a, int b)
+    {
+        if (a > 0 && b > 0)
+            return "both";
+        return "no";
+    }
+
+    public static string IfOr(int a, int b)
+    {
+        if (a > 0 || b > 0)
+            return "either";
+        return "neither";
+    }
+
+    public static string TripleAnd(int a, int b, int c)
+    {
+        if (a > 0 && b > 0 && c > 0)
+            return "all";
+        return "no";
+    }
+
+    public static string MixedAndOr(string? s, int n)
+    {
+        if (s != null && (s.Length > n || n < 0))
+            return s;
+        return "";
+    }
+
     public static string UnsignedBoundsBranch(int index, int[] array)
     {
         if ((uint)index >= (uint)array.Length)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1616,7 +1616,8 @@ public static class CSharpEmitter
             }
 
             // Apply negation if the conditional detector swapped then/else
-            if (block.NegateCondition)
+            // (chains consume the flag as last-leaf negation in composition).
+            if (!isChain && block.NegateCondition)
                 condition = NegateConditionString(condition);
 
             if (TryEmitRuntimeCustomAwaitGuard(block))
@@ -1680,7 +1681,13 @@ public static class CSharpEmitter
             {
                 string leaf = RenderTrueCondition(blocks[i]);
                 if (i == blocks.Count - 1)
+                {
+                    // For chains, NegateCondition flags an inverted final test
+                    // (a || b lowers to jump-if-a / jump-if-NOT-b).
+                    if (block.NegateCondition)
+                        leaf = NegateConditionString(leaf);
                     return (leaf, false);
+                }
 
                 // ConditionChain[i] holds the operator joining blocks[i] to the rest.
                 var (rest, restTopOr) = Compose(i + 1);
@@ -1727,10 +1734,12 @@ public static class CSharpEmitter
                 break;
             }
 
-            string rendered = BranchConditionToString(branchExpr);
-            return branchExpr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
-                ? NegateConditionString(rendered)
-                : rendered;
+            // BranchConditionToString already yields the fallthrough/true-path
+            // form for one-argument branches (ExtractCondition normalizes
+            // brfalse(x) to x / x != null / x != 0), and comparison branches
+            // render their jump condition, whose target IS the true edge — so
+            // no polarity adjustment is needed here.
+            return BranchConditionToString(branchExpr);
         }
 
         static bool ContainsLocalLoad(ILAstExpression expr)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1534,6 +1534,20 @@ public static class CSharpEmitter
                 }
             }
 
+            // Short-circuit chains: the condition spans several blocks joined by
+            // && / ||; compose their true-conditions and consume the chain.
+            bool isChain = block.ConditionChain.Count > 0;
+            if (isChain)
+            {
+                condition = ComposeChainCondition(block);
+                branchExpression = null;
+                foreach (var term in block.ConditionChain)
+                {
+                    _consumedBlocks.Add(term.BlockIndex);
+                    RemoveGotoTargetsForConsumedBlock(term.BlockIndex);
+                }
+            }
+
             // Detect null-conditional pattern: brtrue with dup + trivial else (pop + br.s)
             if (branchExpression is not null && IsNullConditionalPattern(branchExpression, block))
             {
@@ -1542,7 +1556,7 @@ public static class CSharpEmitter
             }
 
             // Detect ternary pattern: both then and else produce a single S_0 value
-            if (block.ThenBlock is not null && block.ElseBlock is not null)
+            if (!isChain && block.ThenBlock is not null && block.ElseBlock is not null)
             {
                 var thenValue = TryExtractTernaryValue(block.ThenBlock);
                 var elseValue = TryExtractTernaryValue(block.ElseBlock);
@@ -1572,7 +1586,7 @@ public static class CSharpEmitter
             }
 
             // Detect ternary/short-circuit with no else but follow block assigns S_0
-            if (block.ThenBlock is not null && block.ElseBlock is null)
+            if (!isChain && block.ThenBlock is not null && block.ElseBlock is null)
             {
                 var thenValue = TryExtractTernaryValue(block.ThenBlock);
                 var followValue = TryExtractFollowTernaryValue(block);
@@ -1608,7 +1622,7 @@ public static class CSharpEmitter
             if (TryEmitRuntimeCustomAwaitGuard(block))
                 return;
 
-            if (TryEmitNullConditionalAssignment(block, condition, indent))
+            if (!isChain && TryEmitNullConditionalAssignment(block, condition, indent))
                 return;
 
             // Item 1: Short-circuit return: if(cond) return expr; return false/true;
@@ -1647,6 +1661,107 @@ public static class CSharpEmitter
                     _sb.AppendLine("}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Renders a short-circuit chain's combined condition. The recursion is
+        /// right-nested by construction (a || (b &amp;&amp; c)), which matches C#
+        /// precedence with parentheses only when an || group sits under an &amp;&amp;.
+        /// </summary>
+        string ComposeChainCondition(StructuredBlock block)
+        {
+            var blocks = new List<int> { block.ConditionBlockIndex };
+            foreach (var term in block.ConditionChain)
+                blocks.Add(term.BlockIndex);
+
+            return Compose(0).Text;
+
+            (string Text, bool TopLevelOr) Compose(int i)
+            {
+                string leaf = RenderTrueCondition(blocks[i]);
+                if (i == blocks.Count - 1)
+                    return (leaf, false);
+
+                // ConditionChain[i] holds the operator joining blocks[i] to the rest.
+                var (rest, restTopOr) = Compose(i + 1);
+                if (block.ConditionChain[i].CombineWithOr)
+                    return ($"{leaf} || {rest}", true);
+                return ($"{leaf} && {(restTopOr ? $"({rest})" : rest)}", false);
+            }
+        }
+
+        /// <summary>
+        /// Renders the condition under which a condition block transfers to the
+        /// TRUE path. Comparison branches and brtrue jump when true, so their
+        /// rendering is used directly; brfalse renders its jump (false)
+        /// condition, which is negated. Pre-branch temp stores (Debug builds
+        /// route subexpressions through locals) are folded into the expression.
+        /// </summary>
+        string RenderTrueCondition(int blockIdx)
+        {
+            if (!_blockMap.TryGetValue(blockIdx, out var astBlock)
+                || astBlock.Nodes.LastOrDefault() is not ILAstStatement { Expression: var branchExpr })
+            {
+                return "/* condition */";
+            }
+
+            for (int i = astBlock.Nodes.Count - 2; i >= 0; i--)
+            {
+                if (astBlock.Nodes[i] is not ILAstStatement { Expression: var stExpr })
+                    break;
+                if (stExpr.OpCode is ILOpCode.Nop)
+                    continue;
+                if (stExpr.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                        or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                    && stExpr.Arguments.Count == 1
+                    // ILAst trees share nodes (dup), so splicing a value that
+                    // itself loads locals can make a tree its own descendant.
+                    // Only fold local-free values — the Debug temp shapes that
+                    // motivate folding (comparisons of args/constants) qualify.
+                    && !ContainsLocalLoad(stExpr.Arguments[0]))
+                {
+                    string name = stExpr.Operand ?? GetLocalName(stExpr.OpCode);
+                    if (SubstituteFirstLoad(branchExpr, name, stExpr.Arguments[0]))
+                        continue;
+                }
+                break;
+            }
+
+            string rendered = BranchConditionToString(branchExpr);
+            return branchExpr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                ? NegateConditionString(rendered)
+                : rendered;
+        }
+
+        static bool ContainsLocalLoad(ILAstExpression expr)
+        {
+            if (expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+                or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+                or ILOpCode.Ldloca or ILOpCode.Ldloca_s)
+            {
+                return true;
+            }
+            foreach (var arg in expr.Arguments)
+            {
+                if (ContainsLocalLoad(arg))
+                    return true;
+            }
+            return false;
+        }
+
+        static bool SubstituteFirstLoad(ILAstExpression expr, string localName, ILAstExpression value)
+        {
+            for (int i = 0; i < expr.Arguments.Count; i++)
+            {
+                if (GetLocalReferenceName(expr.Arguments[i]) == localName)
+                {
+                    expr.Arguments[i] = value;
+                    return true;
+                }
+                if (SubstituteFirstLoad(expr.Arguments[i], localName, value))
+                    return true;
+            }
+            return false;
         }
 
         bool TryEmitRuntimeCustomAwaitGuard(StructuredBlock block)

--- a/src/DotnetInspector.Decompiler/ConditionalDetector.cs
+++ b/src/DotnetInspector.Decompiler/ConditionalDetector.cs
@@ -23,15 +23,30 @@ public sealed class ConditionalPattern
     /// <summary>Whether the condition should be negated when emitting (due to then/else swap).</summary>
     public bool NegateCondition { get; }
 
-    public ConditionalPattern(int conditionIndex, int thenIndex, int elseIndex, int followIndex, bool negateCondition = false)
+    /// <summary>
+    /// Short-circuit continuation condition blocks absorbed into this pattern
+    /// (a &amp;&amp; b, a || b chains), in evaluation order after
+    /// <see cref="ConditionIndex"/>. Empty for plain conditionals.
+    /// </summary>
+    public IReadOnlyList<ConditionChainTerm> ChainTerms { get; }
+
+    public ConditionalPattern(int conditionIndex, int thenIndex, int elseIndex, int followIndex, bool negateCondition = false, IReadOnlyList<ConditionChainTerm>? chainTerms = null)
     {
         ConditionIndex = conditionIndex;
         ThenIndex = thenIndex;
         ElseIndex = elseIndex;
         FollowIndex = followIndex;
         NegateCondition = negateCondition;
+        ChainTerms = chainTerms ?? [];
     }
 }
+
+/// <summary>
+/// One absorbed short-circuit condition block. <see cref="CombineWithOr"/>
+/// gives the operator joining the preceding condition to the rest of the
+/// chain starting at this block: prev &amp;&amp; rest or prev || rest.
+/// </summary>
+public sealed record ConditionChainTerm(int BlockIndex, bool CombineWithOr);
 
 /// <summary>
 /// Detects if/else patterns from conditional branches in the CFG.
@@ -44,10 +59,17 @@ internal static class ConditionalDetector
     public static List<ConditionalPattern> DetectConditionals(
         ControlFlowGraph cfg,
         DominatorTree domTree,
-        List<NaturalLoop> loops)
+        List<NaturalLoop> loops,
+        int[]? entryStackHeights = null)
     {
         List<ConditionalPattern> patterns = [];
         var loopHeaders = new HashSet<int>(loops.Select(l => l.HeaderIndex));
+
+        // Short-circuit chains: a condition block whose fallthrough is another
+        // single-predecessor condition block forms one combined a && b / a || b
+        // condition. Detect chains first; absorbed continuation blocks don't get
+        // their own pattern.
+        var chains = DetectShortCircuitChains(cfg, loopHeaders, entryStackHeights, out var absorbed);
 
         for (int i = 0; i < cfg.BasicBlocks.Count; i++)
         {
@@ -55,6 +77,28 @@ internal static class ConditionalDetector
 
             // Need exactly 2 successors (conditional branch)
             if (block.Targets.Count != 2) continue;
+
+            // Continuation blocks of a short-circuit chain are rendered as part
+            // of the chain head's combined condition.
+            if (absorbed.Contains(i)) continue;
+
+            // Chain heads: then/else come from the LAST chain block (the head's
+            // own fallthrough just enters the chain), and the readability swaps
+            // don't apply — the combined condition's polarity is fixed.
+            if (chains.TryGetValue(i, out var chainTerms) && chainTerms.Count > 0)
+            {
+                var lastEdges = ConditionEdges(cfg, chainTerms[^1].BlockIndex)!.Value;
+                int chainThen = lastEdges.TrueIdx;
+                int chainElse = lastEdges.FalseIdx;
+                int chainFollow = FindFollowBlock(cfg, domTree, chainTerms[^1].BlockIndex, chainThen, chainElse);
+                if (chainFollow == -1 && IsDirectPredecessor(cfg, chainThen, chainElse))
+                {
+                    chainFollow = chainElse;
+                    chainElse = -1;
+                }
+                patterns.Add(new ConditionalPattern(i, chainThen, chainElse, chainFollow, negateCondition: false, chainTerms));
+                continue;
+            }
 
             // Use the structured branch/fallthrough info when available
             int branchIdx = block.BranchTarget is not null ? cfg.LookupIndex(block.BranchTarget.Start) : -1;
@@ -157,6 +201,130 @@ internal static class ConditionalDetector
         }
 
         return patterns;
+    }
+
+    /// <summary>
+    /// Walks fallthrough successions of condition blocks. For each chain head,
+    /// resolves then/else from the LAST block's branch sense, then validates
+    /// every leading block against them: a block whose false-edge goes to the
+    /// overall else continues on true (an &amp;&amp; link); a block whose true-edge
+    /// goes to the overall then continues on false (an || link). Chains are
+    /// only kept when every link classifies cleanly.
+    /// </summary>
+    static Dictionary<int, List<ConditionChainTerm>> DetectShortCircuitChains(
+        ControlFlowGraph cfg, HashSet<int> loopHeaders, int[]? entryStackHeights, out HashSet<int> absorbed)
+    {
+        absorbed = [];
+        var result = new Dictionary<int, List<ConditionChainTerm>>();
+
+        // Entry stack height of a block; > 0 means it consumes stack-carried
+        // values (a value merge, not a statement-level condition).
+        int EntryHeight(int idx)
+        {
+            if (entryStackHeights is null) return 0;
+            int start = cfg.BasicBlocks[idx].Start;
+            return start >= 0 && start < entryStackHeights.Length
+                ? Math.Max(entryStackHeights[start], 0)
+                : 0;
+        }
+
+        // Predecessor counts: a continuation must be reachable only from the
+        // preceding condition, or its evaluation isn't conditional on it.
+        var predCount = new int[cfg.BasicBlocks.Count];
+        foreach (var b in cfg.BasicBlocks)
+        {
+            foreach (var t in b.Targets)
+            {
+                int ti = cfg.LookupIndex(t.Start);
+                if (ti >= 0) predCount[ti]++;
+            }
+        }
+
+        var chainMembers = new HashSet<int>();
+
+        for (int i = 0; i < cfg.BasicBlocks.Count; i++)
+        {
+            if (chainMembers.Contains(i) || loopHeaders.Contains(i))
+                continue;
+            if (ConditionEdges(cfg, i) is null)
+                continue;
+
+            // Collect the fallthrough succession of single-pred condition blocks.
+            var chain = new List<int> { i };
+            int cur = i;
+            while (true)
+            {
+                int ft = cfg.LookupIndex(cfg.BasicBlocks[cur].FallthroughTarget?.Start ?? -1);
+                if (ft < 0 || predCount[ft] != 1 || loopHeaders.Contains(ft) || ConditionEdges(cfg, ft) is null
+                    || EntryHeight(ft) > 0)
+                    break;
+                chain.Add(ft);
+                cur = ft;
+            }
+
+            if (chain.Count < 2)
+                continue;
+
+            // Resolve overall then/else from the last block, then validate links.
+            // Trim from the end until validation succeeds or the chain is gone.
+            while (chain.Count >= 2)
+            {
+                var last = ConditionEdges(cfg, chain[^1])!.Value;
+                int thenIdx = last.TrueIdx;
+                int elseIdx = last.FalseIdx;
+
+                var terms = new List<ConditionChainTerm>();
+                bool valid = EntryHeight(thenIdx) == 0 && EntryHeight(elseIdx) == 0;
+                int join = FindFollowBlock(cfg, null!, chain[^1], thenIdx, elseIdx);
+                if (join >= 0 && EntryHeight(join) > 0)
+                    valid = false;
+                for (int c = 0; c < chain.Count - 1; c++)
+                {
+                    var e = ConditionEdges(cfg, chain[c])!.Value;
+                    int next = chain[c + 1];
+                    if (e.TrueIdx == next && e.FalseIdx == elseIdx)
+                        terms.Add(new ConditionChainTerm(next, CombineWithOr: false)); // cond && rest
+                    else if (e.FalseIdx == next && e.TrueIdx == thenIdx)
+                        terms.Add(new ConditionChainTerm(next, CombineWithOr: true));  // cond || rest
+                    else
+                    {
+                        valid = false;
+                        break;
+                    }
+                }
+
+                if (valid)
+                {
+                    result[chain[0]] = terms;
+                    foreach (var t in terms)
+                        absorbed.Add(t.BlockIndex);
+                    chainMembers.UnionWith(chain);
+                    break;
+                }
+
+                chain.RemoveAt(chain.Count - 1);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// True/false targets of a two-way condition block, normalized for branch
+    /// sense: comparison branches and brtrue jump when the condition is TRUE;
+    /// brfalse jumps when it is FALSE.
+    /// </summary>
+    internal static (int TrueIdx, int FalseIdx)? ConditionEdges(ControlFlowGraph cfg, int idx)
+    {
+        var b = cfg.BasicBlocks[idx];
+        if (b.Targets.Count != 2 || b.BranchTarget is null || b.FallthroughTarget is null)
+            return null;
+        int bt = cfg.LookupIndex(b.BranchTarget.Start);
+        int ft = cfg.LookupIndex(b.FallthroughTarget.Start);
+        if (bt < 0 || ft < 0)
+            return null;
+        bool jumpWhenFalse = b.TerminatingBranch is ILOpCode.Brfalse or ILOpCode.Brfalse_s;
+        return jumpWhenFalse ? (ft, bt) : (bt, ft);
     }
 
     /// <summary>

--- a/src/DotnetInspector.Decompiler/ConditionalDetector.cs
+++ b/src/DotnetInspector.Decompiler/ConditionalDetector.cs
@@ -85,18 +85,19 @@ internal static class ConditionalDetector
             // Chain heads: then/else come from the LAST chain block (the head's
             // own fallthrough just enters the chain), and the readability swaps
             // don't apply — the combined condition's polarity is fixed.
-            if (chains.TryGetValue(i, out var chainTerms) && chainTerms.Count > 0)
+            if (chains.TryGetValue(i, out var chainInfo) && chainInfo.Terms.Count > 0)
             {
-                var lastEdges = ConditionEdges(cfg, chainTerms[^1].BlockIndex)!.Value;
-                int chainThen = lastEdges.TrueIdx;
-                int chainElse = lastEdges.FalseIdx;
-                int chainFollow = FindFollowBlock(cfg, domTree, chainTerms[^1].BlockIndex, chainThen, chainElse);
+                var lastEdges = ConditionEdges(cfg, chainInfo.Terms[^1].BlockIndex)!.Value;
+                int chainThen = chainInfo.NegateLast ? lastEdges.FalseIdx : lastEdges.TrueIdx;
+                int chainElse = chainInfo.NegateLast ? lastEdges.TrueIdx : lastEdges.FalseIdx;
+                int chainFollow = FindFollowBlock(cfg, domTree, chainInfo.Terms[^1].BlockIndex, chainThen, chainElse);
                 if (chainFollow == -1 && IsDirectPredecessor(cfg, chainThen, chainElse))
                 {
                     chainFollow = chainElse;
                     chainElse = -1;
                 }
-                patterns.Add(new ConditionalPattern(i, chainThen, chainElse, chainFollow, negateCondition: false, chainTerms));
+                // For chains, NegateCondition means: negate the LAST leaf only.
+                patterns.Add(new ConditionalPattern(i, chainThen, chainElse, chainFollow, chainInfo.NegateLast, chainInfo.Terms));
                 continue;
             }
 
@@ -211,11 +212,11 @@ internal static class ConditionalDetector
     /// goes to the overall then continues on false (an || link). Chains are
     /// only kept when every link classifies cleanly.
     /// </summary>
-    static Dictionary<int, List<ConditionChainTerm>> DetectShortCircuitChains(
+    static Dictionary<int, (List<ConditionChainTerm> Terms, bool NegateLast)> DetectShortCircuitChains(
         ControlFlowGraph cfg, HashSet<int> loopHeaders, int[]? entryStackHeights, out HashSet<int> absorbed)
     {
         absorbed = [];
-        var result = new Dictionary<int, List<ConditionChainTerm>>();
+        var result = new Dictionary<int, (List<ConditionChainTerm> Terms, bool NegateLast)>();
 
         // Entry stack height of a block; > 0 means it consumes stack-carried
         // values (a value merge, not a statement-level condition).
@@ -265,44 +266,49 @@ internal static class ConditionalDetector
             if (chain.Count < 2)
                 continue;
 
-            // Resolve overall then/else from the last block, then validate links.
+            // Resolve overall then/else from the last block — trying both
+            // polarities, since the final test may be inverted (a || b lowers
+            // to jump-if-a-true / jump-if-NOT-b-true) — then validate links.
             // Trim from the end until validation succeeds or the chain is gone.
-            while (chain.Count >= 2)
+            bool found = false;
+            while (!found && chain.Count >= 2)
             {
                 var last = ConditionEdges(cfg, chain[^1])!.Value;
-                int thenIdx = last.TrueIdx;
-                int elseIdx = last.FalseIdx;
-
-                var terms = new List<ConditionChainTerm>();
-                bool valid = EntryHeight(thenIdx) == 0 && EntryHeight(elseIdx) == 0;
-                int join = FindFollowBlock(cfg, null!, chain[^1], thenIdx, elseIdx);
-                if (join >= 0 && EntryHeight(join) > 0)
-                    valid = false;
-                for (int c = 0; c < chain.Count - 1; c++)
+                foreach (bool negateLast in (ReadOnlySpan<bool>)[false, true])
                 {
-                    var e = ConditionEdges(cfg, chain[c])!.Value;
-                    int next = chain[c + 1];
-                    if (e.TrueIdx == next && e.FalseIdx == elseIdx)
-                        terms.Add(new ConditionChainTerm(next, CombineWithOr: false)); // cond && rest
-                    else if (e.FalseIdx == next && e.TrueIdx == thenIdx)
-                        terms.Add(new ConditionChainTerm(next, CombineWithOr: true));  // cond || rest
-                    else
-                    {
+                    int thenIdx = negateLast ? last.FalseIdx : last.TrueIdx;
+                    int elseIdx = negateLast ? last.TrueIdx : last.FalseIdx;
+
+                    var terms = new List<ConditionChainTerm>();
+                    bool valid = EntryHeight(thenIdx) == 0 && EntryHeight(elseIdx) == 0;
+                    int join = FindFollowBlock(cfg, null!, chain[^1], thenIdx, elseIdx);
+                    if (join >= 0 && EntryHeight(join) > 0)
                         valid = false;
+                    for (int c = 0; valid && c < chain.Count - 1; c++)
+                    {
+                        var e = ConditionEdges(cfg, chain[c])!.Value;
+                        int next = chain[c + 1];
+                        if (e.TrueIdx == next && e.FalseIdx == elseIdx)
+                            terms.Add(new ConditionChainTerm(next, CombineWithOr: false)); // cond && rest
+                        else if (e.FalseIdx == next && e.TrueIdx == thenIdx)
+                            terms.Add(new ConditionChainTerm(next, CombineWithOr: true));  // cond || rest
+                        else
+                            valid = false;
+                    }
+
+                    if (valid)
+                    {
+                        result[chain[0]] = (terms, negateLast);
+                        foreach (var t in terms)
+                            absorbed.Add(t.BlockIndex);
+                        chainMembers.UnionWith(chain);
+                        found = true;
                         break;
                     }
                 }
 
-                if (valid)
-                {
-                    result[chain[0]] = terms;
-                    foreach (var t in terms)
-                        absorbed.Add(t.BlockIndex);
-                    chainMembers.UnionWith(chain);
-                    break;
-                }
-
-                chain.RemoveAt(chain.Count - 1);
+                if (!found)
+                    chain.RemoveAt(chain.Count - 1);
             }
         }
 

--- a/src/DotnetInspector.Decompiler/StackHeightCalculator.cs
+++ b/src/DotnetInspector.Decompiler/StackHeightCalculator.cs
@@ -22,14 +22,31 @@ internal static class StackHeightCalculator
     /// Computes the maximum evaluation stack depth for the given method body.
     /// </summary>
     public static int ComputeMaxStack(MethodBodyContext context)
+        => Compute(context, heightsOut: null);
+
+    /// <summary>
+    /// Per-IL-offset entry stack heights (<see cref="StackHeightNotSet"/> for
+    /// offsets the linear walk never assigned). Lets conditional detection tell
+    /// statement-level joins (height 0) from stack value merges (height &gt; 0).
+    /// </summary>
+    public static int[] ComputeOffsetEntryHeights(MethodBodyContext context)
+    {
+        var heights = new int[context.ILBytes.Length];
+        Compute(context, heights);
+        return heights;
+    }
+
+    static int Compute(MethodBodyContext context, int[]? heightsOut)
     {
         var ilReader = new ILReaderLite(context.ILBytes);
         int stackHeight = 0;
         int maxStack = 0;
 
-        Span<int> stackHeights = ilReader.Size <= StackAllocThreshold
-            ? stackalloc int[StackAllocThreshold].Slice(0, ilReader.Size)
-            : new int[ilReader.Size];
+        Span<int> stackHeights = heightsOut is not null
+            ? heightsOut.AsSpan(0, ilReader.Size)
+            : ilReader.Size <= StackAllocThreshold
+                ? stackalloc int[StackAllocThreshold].Slice(0, ilReader.Size)
+                : new int[ilReader.Size];
 
         stackHeights.Fill(StackHeightNotSet);
 

--- a/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
+++ b/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
@@ -58,6 +58,12 @@ public class StructuredBlock
     /// <summary>Whether the condition should be negated when emitting.</summary>
     public bool NegateCondition { get; init; }
 
+    /// <summary>
+    /// Short-circuit continuation condition blocks absorbed into this
+    /// conditional's combined condition (see <see cref="ConditionChainTerm"/>).
+    /// </summary>
+    public IReadOnlyList<ConditionChainTerm> ConditionChain { get; init; } = [];
+
     /// <summary>Loop header block index (for Loop).</summary>
     public int LoopHeaderIndex { get; init; } = -1;
 
@@ -207,7 +213,8 @@ public sealed class StructuredControlFlow
     {
         var domTree = DominatorTree.Build(cfg);
         var loops = LoopDetector.DetectLoops(cfg, domTree);
-        var conditionals = ConditionalDetector.DetectConditionals(cfg, domTree, loops);
+        var entryHeights = StackHeightCalculator.ComputeOffsetEntryHeights(context);
+        var conditionals = ConditionalDetector.DetectConditionals(cfg, domTree, loops, entryHeights);
         var exRegions = MapExceptionRegions(context, cfg);
 
         var root = BuildStructuredTree(cfg, domTree, loops, conditionals, exRegions);
@@ -515,13 +522,16 @@ public sealed class StructuredControlFlow
                 }
 
                 processed.Add(i);
+                foreach (var term in cond.ChainTerms)
+                    processed.Add(term.BlockIndex);
                 children.Add(new StructuredBlock
                 {
                     Kind = StructuredBlockKind.IfThenElse,
                     ConditionBlockIndex = i,
                     ThenBlock = thenBlock,
                     ElseBlock = elseBlock,
-                    NegateCondition = cond.NegateCondition
+                    NegateCondition = cond.NegateCondition,
+                    ConditionChain = cond.ChainTerms
                 });
                 continue;
             }


### PR DESCRIPTION
## What

The head-to-head comparison's biggest readability gap: compound conditions lowered to nested branches emitted as nested ifs with gotos (`String.Contains` graded C+, `IsNullOrWhiteSpace` B-).

`ConditionalDetector` now recognizes short-circuit chains on the CFG — a condition block whose fallthrough is a single-predecessor condition block — classifying each link against the chain's last block (sense-normalized true/false edges): a block whose false edge hits the overall else continues on true (`&&`); one whose true edge hits the overall then continues on false (`||`). The final block's test is often inverted (`a || b` lowers to jump-if-a, jump-if-NOT-b), so validation tries both polarities and flags last-leaf negation. The emitter composes the combined condition right-nested, matching C# precedence with parentheses only where needed.

Two stack-height guards keep this Release-shaped: Debug builds materialize `&&`/`||` as stack *values* (branches merging at a height-1 join), which stays with the existing S-value machinery (`StackHeightCalculator` now exposes per-offset entry heights).

## Results

Release-built fixtures and CoreLib methods reconstruct exactly:

```csharp
return value == null || value.Length == 0;              // String.IsNullOrEmpty
return a > 0 || b > 0 ? "either" : "neither";
return s != null && (s.Length > n || n < 0) ? s : "";   // parenthesization exact
```

`String.IsNullOrWhiteSpace` now decompiles character-for-character identical to the dotnet/runtime source (guard clause, for loop, negated condition — previously a B- with a loop goto). One pre-existing **semantic inversion** is fixed along the way: the cross-polarity `||` shape used to render with inverted nesting (evidenced by the new `IfOr` fixture).

A stress-test catch during development: ILAst trees share nodes (`dup`), so condition-temp folding only splices local-free values — the CoreLib emit-all test caught the cyclic-tree stack overflow.

## Tests

Two CoreLib-based chain tests (the platform assembly is always Release-built); new Release-shaped fixtures; all suites green (223 / 923 / 131 / 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)