### PR TITLE
Decompiler: field compound assignment and char literals

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/AnnotatedILEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/AnnotatedILEmitterTests.cs
@@ -56,8 +56,10 @@ public class AnnotatedILEmitterTests
     {
         string output = EmitMethod(nameof(CfgSampleClass.Add), ILAnnotationDepth.Typed);
 
-        // After loading int args, stack should show Int32
-        Assert.Contains("Int32", output);
+        // After loading int args, the stack annotation shows the precise C#
+        // type when known ("int"), falling back to the kind ("Int32").
+        Assert.True(output.Contains("int") || output.Contains("Int32"),
+            $"Expected an int stack annotation in:\n{output}");
     }
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -162,6 +162,28 @@ public class CSharpEmitterTests
         return CSharpEmitter.Emit(context);
     }
 
+    // --- P1 sugar: field compound assignment and char literals ---
+
+    [Fact]
+    public void Bump_RendersFieldCompoundAssignment()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.Bump));
+
+        Assert.Contains("+=", output);
+        Assert.Contains("++;", output);
+        Assert.DoesNotContain("h.Value = h.Value", output);
+    }
+
+    [Fact]
+    public void IsSpaceOrTab_RendersCharLiterals()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.IsSpaceOrTab));
+
+        Assert.Contains("' '", output);
+        Assert.Contains("'\\t'", output);
+        Assert.DoesNotContain("32", output);
+    }
+
     // --- Inliner soundness ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -331,6 +331,17 @@ public class CfgSampleClass
         public int Value;
     }
 
+    static int s_bumpCount;
+
+    public static void Bump(MutableHolder h, int n)
+    {
+        h.Value += n;
+        h.Value++;
+        s_bumpCount++;
+    }
+
+    public static bool IsSpaceOrTab(char c) => c == ' ' || c == '\t';
+
     public static int StaleFieldRead(MutableHolder h)
     {
         int v = h.Value;

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -2377,6 +2377,67 @@ public static class CSharpEmitter
             return false;
         }
 
+        /// <summary>
+        /// Renders <c>obj.f = obj.f OP x</c> as <c>obj.f OP= x</c> (and
+        /// <c>obj.f++/--</c> for OP 1) when the read and write target the same
+        /// field through the same side-effect-free receiver. The locals-only
+        /// version lives in TryEmitCompoundAssignment.
+        /// </summary>
+        bool TryEmitFieldCompoundAssignment(ILAstExpression expr, int indent)
+        {
+            if (expr.Member is not { } field)
+                return false;
+
+            bool isStatic = expr.OpCode == ILOpCode.Stsfld;
+            ILAstExpression? receiver = isStatic ? null : (expr.Arguments.Count >= 2 ? expr.Arguments[0] : null);
+            ILAstExpression? value = isStatic
+                ? (expr.Arguments.Count >= 1 ? expr.Arguments[0] : null)
+                : (expr.Arguments.Count >= 2 ? expr.Arguments[1] : null);
+            if (value is null || (!isStatic && receiver is null))
+                return false;
+            if (value.Arguments.Count < 2 || CompoundAssignmentOperator(value.OpCode) is not { } op)
+                return false;
+
+            // The left operand must read the SAME field (typed identity) through
+            // an equivalently-rendered, side-effect-free receiver.
+            var read = value.Arguments[0];
+            if (read.OpCode != (isStatic ? ILOpCode.Ldsfld : ILOpCode.Ldfld))
+                return false;
+            if (read.Member is not { } readField
+                || readField.Name != field.Name
+                || readField.DeclaringType != field.DeclaringType)
+            {
+                return false;
+            }
+            if (!isStatic)
+            {
+                if (!IsSideEffectFreeIndexExpression(receiver!)
+                    || read.Arguments.Count == 0
+                    || ExpressionToString(read.Arguments[0]) != ExpressionToString(receiver!))
+                {
+                    return false;
+                }
+            }
+
+            string target = isStatic
+                ? $"{SimplifyTypeName(field.DeclaringType)}.{field.Name}"
+                : $"{ExpressionToString(receiver!)}.{field.Name}";
+            var rhs = value.Arguments[1];
+
+            WriteIndent(indent);
+            if (op is "+" or "-" && IsConstantOne(rhs))
+            {
+                _sb.Append(target);
+                _sb.AppendLine(op == "+" ? "++;" : "--;");
+                return true;
+            }
+
+            _sb.Append($"{target} {op}= ");
+            EmitExpression(rhs, TryResolveFieldType(expr.Operand));
+            _sb.AppendLine(";");
+            return true;
+        }
+
         static string? CompoundAssignmentOperator(ILOpCode op) => op switch
         {
             ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => "+",
@@ -4839,6 +4900,8 @@ public static class CSharpEmitter
 
                 case ILOpCode.Stfld or ILOpCode.Stsfld:
                 {
+                    if (TryEmitFieldCompoundAssignment(expr, indent))
+                        break;
                     WriteIndent(indent);
                     if (expr.OpCode == ILOpCode.Stfld && expr.Arguments.Count >= 2)
                     {
@@ -5034,6 +5097,13 @@ public static class CSharpEmitter
 
             // A bool-typed parameter/target means 0/1 integer literals are really false/true.
             boolCtx = boolCtx || resolvedType is "bool" or "System.Boolean" or "Boolean";
+
+            // Char literals for integer constants in char context (c == ' ').
+            if (IsLdcI4(expr.OpCode) && resolvedType is "char" or "System.Char" or "Char")
+            {
+                _sb.Append(CharLiteral(GetI4Value(expr)));
+                return;
+            }
 
             // Enum constant resolution for integer literals with known parameter types
             if (IsLdcI4(expr.OpCode) && resolvedType is not null
@@ -6176,9 +6246,14 @@ public static class CSharpEmitter
         {
             if (expr.Arguments.Count >= 2)
             {
-                EmitExpression(expr.Arguments[0]);
+                var lhs = expr.Arguments[0];
+                var rhs = expr.Arguments[1];
+                // Same char-literal context rule as EmitBinary.
+                string? rhsType = IsCharTyped(lhs) && IsLdcI4(rhs.OpCode) ? "char" : null;
+                string? lhsType = IsCharTyped(rhs) && IsLdcI4(lhs.OpCode) ? "char" : null;
+                EmitExpression(lhs, lhsType);
                 _sb.Append($" {op} ");
-                EmitExpression(expr.Arguments[1]);
+                EmitExpression(rhs, rhsType);
             }
         }
 
@@ -6353,6 +6428,25 @@ public static class CSharpEmitter
                     return;
                 }
 
+                // When one side is char-typed, an integer constant on the other
+                // side is a char literal (c == ' ', not c == 32).
+                var lhs = expr.Arguments[0];
+                var rhs = expr.Arguments[1];
+                if (IsCharTyped(lhs) && IsLdcI4(rhs.OpCode))
+                {
+                    EmitParenthesized(expr, 0);
+                    _sb.Append($" {op} ");
+                    _sb.Append(CharLiteral(GetI4Value(rhs)));
+                    return;
+                }
+                if (IsCharTyped(rhs) && IsLdcI4(lhs.OpCode))
+                {
+                    _sb.Append(CharLiteral(GetI4Value(lhs)));
+                    _sb.Append($" {op} ");
+                    EmitParenthesized(expr, 1);
+                    return;
+                }
+
                 EmitParenthesized(expr, 0);
                 _sb.Append($" {op} ");
                 EmitParenthesized(expr, 1);
@@ -6361,6 +6455,28 @@ public static class CSharpEmitter
             {
                 _sb.Append($"/* {op} */");
             }
+        }
+
+        static bool IsCharTyped(ILAstExpression expr)
+            => expr.ResultType.TypeName is "char" or "System.Char" or "Char";
+
+        /// <summary>C# char literal for a code unit, escaped as needed.</summary>
+        static string CharLiteral(int value)
+        {
+            if (value < 0 || value > 0xFFFF)
+                return value.ToString();
+            char c = (char)value;
+            return c switch
+            {
+                '\0' => "'\\0'",
+                '\t' => "'\\t'",
+                '\n' => "'\\n'",
+                '\r' => "'\\r'",
+                '\\' => "'\\\\'",
+                '\'' => "'\\''",
+                >= ' ' and <= '~' => $"'{c}'",
+                _ => $"'\\u{value:X4}'"
+            };
         }
 
         bool TryFoldBinary(ILAstExpression expr, string op, out ILAstExpression? foldedExpr)

--- a/src/DotnetInspector.Decompiler/StackValue.cs
+++ b/src/DotnetInspector.Decompiler/StackValue.cs
@@ -23,7 +23,7 @@ public readonly record struct StackValue
         TypeName = typeName;
     }
 
-    public static StackValue CreatePrimitive(StackValueKind kind) => new(kind);
+    public static StackValue CreatePrimitive(StackValueKind kind, string? typeName = null) => new(kind, typeName);
     public static StackValue CreateObjRef(string? typeName = null) => new(StackValueKind.ObjRef, typeName);
     public static StackValue CreateValueType(string typeName) => new(StackValueKind.ValueType, typeName);
     public static StackValue CreateByRef(string? referentType = null) => new(StackValueKind.ByRef, referentType);
@@ -35,6 +35,9 @@ public readonly record struct StackValue
     /// </summary>
     public static StackValue FromTypeName(string typeName) => typeName switch
     {
+        // The type name is preserved so the emitter can keep C#-level
+        // distinctions (char vs int literals, bool contexts) that the stack
+        // category erases.
         "bool" or "System.Boolean" or
         "char" or "System.Char" or
         "sbyte" or "System.SByte" or
@@ -43,15 +46,15 @@ public readonly record struct StackValue
         "ushort" or "System.UInt16" or
         "int" or "System.Int32" or
         "uint" or "System.UInt32"
-            => CreatePrimitive(StackValueKind.Int32),
+            => CreatePrimitive(StackValueKind.Int32, typeName),
 
         "long" or "System.Int64" or
         "ulong" or "System.UInt64"
-            => CreatePrimitive(StackValueKind.Int64),
+            => CreatePrimitive(StackValueKind.Int64, typeName),
 
         "float" or "System.Single" or
         "double" or "System.Double"
-            => CreatePrimitive(StackValueKind.Float),
+            => CreatePrimitive(StackValueKind.Float, typeName),
 
         "nint" or "System.IntPtr" or
         "nuint" or "System.UIntPtr"


### PR DESCRIPTION
## What

Two head-to-head gaps, both flagged "easy" in the comparison doc, both high-frequency in real BCL output:

**Field compound assignment** — `stfld f(obj, OP(ldfld f(obj), x))` renders as `obj.f OP= x` (and `obj.f++`/`--`) when the read and write hit the same field, matched by typed identity (`MemberRefInfo`) through an equivalently-rendered side-effect-free receiver; likewise static fields.

```csharp
// Queue<T>.Enqueue, before          // after
this._size = this._size + 1;         this._size++;
this._version = this._version + 1;   this._version++;
```

**Char literals** — integer constants in char context render as escaped char literals, both via expected-type flow and via operand context in comparisons:

```csharp
return c == ' ' || c == '\t';        // was: c == 32 || c == 9
```

The enabling fix: `StackValue.FromTypeName` was *erasing* type names for primitive kinds — `char`, `bool`, and `int` all collapsed to a bare `Int32` category. It now preserves the name, which also makes the annotated IL emitter's stack annotations more precise (`int` rather than the `Int32` kind).

## Tests

Two new fixture tests; one annotated-IL assertion updated for the more precise display; all suites green (225 / 923 / 131 / 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)