### PR TITLE
Decompiler: operator sugar, local-function names, enum case labels

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -184,6 +184,47 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("32", output);
     }
 
+    // --- P1 sugar: operators, local functions, enum case labels ---
+
+    [Fact]
+    public void NegateSum_RendersOperatorSugar()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.NegateSum));
+
+        Assert.Contains("a + b", output);
+        Assert.Contains("-(", output);
+        Assert.DoesNotContain("op_Addition", output);
+        Assert.DoesNotContain("op_UnaryNegation", output);
+    }
+
+    [Fact]
+    public void MoneyToInt_RendersImplicitConversionAsCast()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.MoneyToInt));
+
+        Assert.Contains("(int)", output);
+        Assert.DoesNotContain("op_Implicit", output);
+    }
+
+    [Fact]
+    public void DoubleViaLocalFunction_UsesSourceLevelName()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.DoubleViaLocalFunction));
+
+        Assert.Contains("Twice(", output);
+        Assert.DoesNotContain("g__", output);
+    }
+
+    [Fact]
+    public void ColorName_UsesEnumCaseLabels()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.ColorName));
+
+        Assert.Contains("case", output);
+        Assert.Contains("Green", output);
+        Assert.Contains("Yellow", output);
+    }
+
     // --- Inliner soundness ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -331,6 +331,45 @@ public class CfgSampleClass
         public int Value;
     }
 
+    public struct Money
+    {
+        public int Cents;
+        public static Money operator +(Money a, Money b) => new() { Cents = a.Cents + b.Cents };
+        public static Money operator -(Money m) => new() { Cents = -m.Cents };
+        public static implicit operator int(Money m) => m.Cents;
+    }
+
+    public enum Color
+    {
+        Red,
+        Green,
+        Blue,
+        Yellow,
+    }
+
+    public static Money NegateSum(Money a, Money b) => -(a + b);
+
+    public static int MoneyToInt(Money m) => m;
+
+    public static int DoubleViaLocalFunction(int x)
+    {
+        return Twice(x);
+
+        static int Twice(int v) => v * 2;
+    }
+
+    public static string ColorName(Color c)
+    {
+        switch (c)
+        {
+            case Color.Red: return "red";
+            case Color.Green: return "green";
+            case Color.Blue: return "blue";
+            case Color.Yellow: return "yellow";
+            default: return "?";
+        }
+    }
+
     static int s_bumpCount;
 
     public static void Bump(MutableHolder h, int n)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -4698,6 +4698,7 @@ public static class CSharpEmitter
         {
             // Extract the switch value expression from the switch block's last node
             string switchValue = "/* value */";
+            string? switchEnumType = null;
             if (block.SwitchBlockIndex >= 0 && _blockMap.TryGetValue(block.SwitchBlockIndex, out var switchBlock))
             {
                 _consumedBlocks.Add(block.SwitchBlockIndex);
@@ -4727,6 +4728,7 @@ public static class CSharpEmitter
                     && switchExpr.Arguments.Count > 0)
                 {
                     switchValue = ExpressionToString(switchExpr.Arguments[0]);
+                    switchEnumType = switchExpr.Arguments[0].ResultType.TypeName;
                 }
 
                 _currentBlockNodes = null;
@@ -4759,7 +4761,7 @@ public static class CSharpEmitter
                 foreach (int caseVal in cases)
                 {
                     WriteIndent(indent + 1);
-                    _sb.AppendLine($"case {caseVal}:");
+                    _sb.AppendLine($"case {FormatCaseValue(caseVal, switchEnumType)}:");
                 }
                 EmitBasicBlock(targetIdx, indent + 2);
                 // Add break if block doesn't end with return/throw
@@ -4817,6 +4819,14 @@ public static class CSharpEmitter
 
             WriteIndent(indent);
             _sb.AppendLine("}");
+        }
+
+        /// <summary>Case labels on enum-typed switches use the member names.</summary>
+        string FormatCaseValue(int value, string? switchType)
+        {
+            if (switchType is not null && TryResolveEnumName(switchType, value, out string? name) && name is not null)
+                return name;
+            return value.ToString();
         }
 
         bool BlockEndsWithReturn(int blockIndex)
@@ -5801,6 +5811,8 @@ public static class CSharpEmitter
                 memberPart = methodName[(colonIdx + 2)..].TrimEnd('(', ')');
             }
 
+            memberPart = SimplifyLocalFunctionName(memberPart);
+
             if (TryEmitInlineArrayAsSpanExpression(expr, memberPart))
                 return;
 
@@ -5867,8 +5879,26 @@ public static class CSharpEmitter
                         "op_ExclusiveOr" => "^",
                         "op_LeftShift" => "<<",
                         "op_RightShift" => ">>",
+                        "op_UnsignedRightShift" => ">>>",
                         _ => null
                     };
+                    string? checkedSymbol = memberPart switch
+                    {
+                        "op_CheckedAddition" => "+",
+                        "op_CheckedSubtraction" => "-",
+                        "op_CheckedMultiplication" => "*",
+                        "op_CheckedDivision" => "/",
+                        _ => null
+                    };
+                    if (checkedSymbol is not null)
+                    {
+                        _sb.Append("checked(");
+                        EmitExpression(expr.Arguments[0]);
+                        _sb.Append($" {checkedSymbol} ");
+                        EmitExpression(expr.Arguments[1]);
+                        _sb.Append(')');
+                        return;
+                    }
                     if (opSymbol is not null)
                     {
                         EmitExpression(expr.Arguments[0]);
@@ -5883,6 +5913,14 @@ public static class CSharpEmitter
                         EmitExpression(expr.Arguments[1]);
                         _sb.Append(')');
                     }
+                }
+                // Conversion operators render as casts (the return type is the
+                // target), unary operators as prefixes.
+                else if (memberPart.StartsWith("op_", StringComparison.Ordinal)
+                    && expr.Arguments.Count == 1
+                    && TryEmitUnaryOperator(memberPart, expr))
+                {
+                    // emitted by helper
                 }
                 else
                 {
@@ -7301,6 +7339,84 @@ public static class CSharpEmitter
         /// Simplify compiler-generated lambda method names like "&lt;ClosureCapture&gt;b__0"
         /// to readable form like "lambda: ClosureCapture".
         /// </summary>
+        /// <summary>
+        /// Renders one-argument operator methods: conversions (op_Implicit/
+        /// op_Explicit) as casts to the operator's return type, unary operators
+        /// as prefixes. Returns false for shapes without a C# spelling
+        /// (op_True/op_False, op_Increment as a plain call).
+        /// </summary>
+        bool TryEmitUnaryOperator(string memberPart, ILAstExpression expr)
+        {
+            var arg = expr.Arguments[0];
+
+            if (memberPart is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit")
+            {
+                string? target = expr.Member?.ReturnOrFieldType;
+                if (target is null)
+                    return false;
+                bool isChecked = memberPart == "op_CheckedExplicit";
+                if (isChecked) _sb.Append("checked(");
+                _sb.Append($"({SimplifyTypeName(target)})");
+                EmitPrefixOperand(arg);
+                if (isChecked) _sb.Append(')');
+                return true;
+            }
+
+            (string Prefix, bool Checked)? unary = memberPart switch
+            {
+                "op_UnaryNegation" => ("-", false),
+                "op_CheckedUnaryNegation" => ("-", true),
+                "op_UnaryPlus" => ("+", false),
+                "op_LogicalNot" => ("!", false),
+                "op_OnesComplement" => ("~", false),
+                _ => null
+            };
+            if (unary is not { } u)
+                return false;
+
+            if (u.Checked) _sb.Append("checked(");
+            _sb.Append(u.Prefix);
+            EmitPrefixOperand(arg);
+            if (u.Checked) _sb.Append(')');
+            return true;
+        }
+
+        void EmitPrefixOperand(ILAstExpression arg)
+        {
+            // A call operand may itself render as a binary expression (operator
+            // sugar: op_Addition becomes a + b), so parenthesize anything that
+            // isn't a plain load or constant.
+            bool wrap = !IsSimpleOperand(arg.OpCode);
+            if (wrap) _sb.Append('(');
+            EmitExpression(arg);
+            if (wrap) _sb.Append(')');
+        }
+
+        static bool IsSimpleOperand(ILOpCode op) => op is
+            ILOpCode.Ldarg or ILOpCode.Ldarg_s
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+            or ILOpCode.Ldloc or ILOpCode.Ldloc_s
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldc_i4 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4_m1
+            or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2 or ILOpCode.Ldc_i4_3
+            or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6 or ILOpCode.Ldc_i4_7
+            or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
+            or ILOpCode.Ldstr or ILOpCode.Ldnull
+            or ILOpCode.Ldfld or ILOpCode.Ldsfld;
+
+        /// <summary>
+        /// Local functions compile to mangled names like
+        /// <c>&lt;Outer&gt;g__Helper|0_0</c>; render the source-level name.
+        /// </summary>
+        static string SimplifyLocalFunctionName(string memberPart)
+        {
+            int marker = memberPart.IndexOf(">g__", StringComparison.Ordinal);
+            if (marker < 0)
+                return memberPart;
+            int bar = memberPart.IndexOf('|', marker);
+            return bar > marker + 4 ? memberPart[(marker + 4)..bar] : memberPart;
+        }
+
         static string SimplifyLambdaName(string name)
         {
             // Extract the enclosing method name from "<>c__DisplayClass::<MethodName>b__N" 


### PR DESCRIPTION
## What

Three rendering gaps closed, all built on the typed-operand foundation from #394:

**Operators** — the binary table gains `>>>` and C# 11 checked forms (`checked(a + b)`); one-argument operators render as prefixes; conversion operators render as casts to the operator's return type (from `MemberRefInfo`):

```csharp
return (int)m;        // was: Money.op_Implicit(m)
return -(a + b);      // was: Money.op_UnaryNegation(Money.op_Addition(a, b))
```

(Including a precedence catch: prefix operands parenthesize anything that isn't a plain load, since a call operand may itself render as a binary expression — `-(a + b)`, not `-a + b`.)

**Local functions** — mangled names render at source level: `Twice(x)` instead of `<DoubleViaLocalFunction>g__Twice|0_0(x)`.

**Enum switches** — case labels use member names via the preserved `StackValue` type name:

```csharp
switch (c)
{
    case Color.Red: ...
    case Color.Green: ...
```

## Tests

Four new fixture tests (operator-bearing struct, local function, local enum switch); all suites green (229 / 923 / 131 / 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)