### PR TITLE
Decompiler: loop continue/break rendering; fix loop-body double emission

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -225,6 +225,29 @@ public class CSharpEmitterTests
         Assert.Contains("Yellow", output);
     }
 
+    // --- Loop branches: continue / break ---
+
+    [Fact]
+    public void LoopWithContinue_RendersContinue()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.LoopWithContinue));
+
+        Assert.Contains("continue;", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+        // The summing statement must remain reachable (it follows the guard).
+        Assert.Contains("+=", output);
+    }
+
+    [Fact]
+    public void LoopWithBreak_RendersBreak()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.LoopWithBreak));
+
+        Assert.Contains("break;", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
     // --- Inliner soundness ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -358,6 +358,30 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    public static int LoopWithContinue(int[] values)
+    {
+        int sum = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (values[i] < 0)
+                continue;
+            sum += values[i];
+        }
+        return sum;
+    }
+
+    public static int LoopWithBreak(int[] values, int limit)
+    {
+        int sum = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (sum > limit)
+                break;
+            sum += values[i];
+        }
+        return sum;
+    }
+
     public static string ColorName(Color c)
     {
         switch (c)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -3416,7 +3416,32 @@ public static class CSharpEmitter
                     WriteIndent(indent);
                     _sb.AppendLine("{");
 
-                    EmitLoopBody(bodyIndices, indent + 1, loop);
+                    // Branches inside the body to the loop's re-entry points
+                    // render as continue (header for while; the hoisted increment
+                    // block for for-loops); branches to the exit render as break.
+                    var continueLabels = new HashSet<string>();
+                    if (_blockStartOffset.TryGetValue(headerIdx, out int headerOff))
+                        continueLabels.Add($"IL_{headerOff:X4}");
+                    if (increment is not null && bodyIndices.Count > 0
+                        && _blockStartOffset.TryGetValue(bodyIndices[^1], out int incrOff))
+                    {
+                        continueLabels.Add($"IL_{incrOff:X4}");
+                    }
+                    string? breakLabel = FindLoopExitLabel(headerBlock, loop);
+                    MarkTrailingBackEdgeSkipped(bodyIndices, continueLabels);
+                    // Branches to these render as continue, so their labels
+                    // have no remaining referees inside the loop.
+                    foreach (string cl in continueLabels)
+                        _loopConsumedLabels.Add(cl);
+                    _loopJumpLabels.Push((continueLabels, breakLabel));
+                    try
+                    {
+                        EmitLoopBody(bodyIndices, indent + 1, loop);
+                    }
+                    finally
+                    {
+                        _loopJumpLabels.Pop();
+                    }
 
                     WriteIndent(indent);
                     _sb.AppendLine("}");
@@ -3429,6 +3454,50 @@ public static class CSharpEmitter
                 // Fallback: emit as before
                 foreach (var child in block.Children)
                     EmitStructuredBlock(child, indent);
+            }
+        }
+
+        /// <summary>
+        /// The label of the loop's exit: the header branch's target that is NOT
+        /// a body block, or the fallthrough block after the header.
+        /// </summary>
+        string? FindLoopExitLabel(ILAstBlock headerBlock, NaturalLoop loop)
+        {
+            if (headerBlock.Nodes.LastOrDefault() is not ILAstStatement { Expression: var branchExpr }
+                || branchExpr.Operand is not string branchTarget)
+            {
+                return null;
+            }
+
+            bool targetIsBody = loop.BodyIndices.Any(idx =>
+                _blockStartOffset.TryGetValue(idx, out int off) && branchTarget == $"IL_{off:X4}");
+
+            if (!targetIsBody)
+                return branchTarget;
+
+            // Branch enters the body; the exit is the block following the header.
+            int headerIdx = loop.HeaderIndex;
+            if (_blockStartOffset.TryGetValue(headerIdx + 1, out int nextOff))
+                return $"IL_{nextOff:X4}";
+            return null;
+        }
+
+        /// <summary>
+        /// The loop-around branch at the end of the last body block is implied
+        /// by the loop construct; mark it skipped so it doesn't render as a
+        /// trailing continue.
+        /// </summary>
+        void MarkTrailingBackEdgeSkipped(List<int> bodyIndices, HashSet<string> continueLabels)
+        {
+            if (bodyIndices.Count == 0 || !_blockMap.TryGetValue(bodyIndices[^1], out var lastBody))
+                return;
+            if (lastBody.Nodes.LastOrDefault() is ILAstStatement
+                {
+                    Expression: { OpCode: ILOpCode.Br or ILOpCode.Br_s, Operand: string target }
+                } trailing
+                && continueLabels.Contains(target))
+            {
+                _skipNodes.Add(trailing);
             }
         }
 
@@ -3538,6 +3607,9 @@ public static class CSharpEmitter
 
         // Set of (blockIndex, nodeIndex) for for-loop increment statements to suppress
         readonly HashSet<(int blockIndex, int nodeIndex)> _forIncrementStatements = [];
+
+        // Innermost-loop jump targets: branches to these render as continue/break.
+        readonly Stack<(HashSet<string> ContinueLabels, string? BreakLabel)> _loopJumpLabels = new();
 
         /// <summary>
         /// Try to extract a loop initializer from the already-emitted output.
@@ -3720,6 +3792,11 @@ public static class CSharpEmitter
         void EmitBasicBlockForLoop(int blockIndex, int indent, NaturalLoop loop)
         {
             if (blockIndex < 0 || !_blockMap.TryGetValue(blockIndex, out var astBlock))
+                return;
+
+            // A guard clause earlier in the body may have consumed this block
+            // (its fallthrough body); re-emitting would duplicate statements.
+            if (_consumedBlocks.Contains(blockIndex))
                 return;
 
             _consumedBlocks.Add(blockIndex);
@@ -4850,6 +4927,31 @@ public static class CSharpEmitter
 
         // --- Expression emission ---
 
+        /// <summary>
+        /// Renders a branch to the innermost loop's re-entry point as continue
+        /// and to its exit as break.
+        /// </summary>
+        bool TryEmitLoopJump(string target, int indent)
+        {
+            if (_loopJumpLabels.Count == 0)
+                return false;
+
+            var (continueLabels, breakLabel) = _loopJumpLabels.Peek();
+            if (continueLabels.Contains(target))
+            {
+                WriteIndent(indent);
+                _sb.AppendLine("continue;");
+                return true;
+            }
+            if (target == breakLabel)
+            {
+                WriteIndent(indent);
+                _sb.AppendLine("break;");
+                return true;
+            }
+            return false;
+        }
+
         void EmitStatement(ILAstExpression expr, int indent)
         {
             TryEnsureCollectionTempForMutation(expr, indent);
@@ -5039,6 +5141,9 @@ public static class CSharpEmitter
 
                 // Branches become comments in the initial output
                 case ILOpCode.Br or ILOpCode.Br_s:
+                    // Loop jumps: continue/break for the innermost loop.
+                    if (expr.Operand is string loopTarget && TryEmitLoopJump(loopTarget, indent))
+                        break;
                     // Suppress gotos into loop headers (the while condition replaces them)
                     if (expr.Operand is string brTarget && _loopHeaderLabels.Contains(brTarget))
                         break;


### PR DESCRIPTION
## What

The last unfinished item from the head-to-head comparison's top-gaps list ("goto → continue/break in loops") — and the investigation found something worse than ugly output: **a mid-loop-body `continue` produced semantically wrong code.** Two bugs:

1. `EmitBasicBlockForLoop` never checked `_consumedBlocks` (unlike its non-loop twin `EmitBasicBlock`), so a block consumed by a guard clause earlier in the body re-emitted as a sibling — the continue fixture rendered its summing statement behind an unconditional duplicate jump, i.e. unreachable as written.
2. Branches to loop re-entry points rendered as raw gotos, or were blanket-suppressed when targeting the header — which silently *dropped* mid-body continues in while-shaped loops.

Loop emission now maintains an innermost-loop jump-label stack: branches to the header (or the hoisted for-loop increment block) render as `continue`, branches to the loop exit as `break` — nested loops bind to the innermost, matching C# semantics. The natural trailing back-edge is pre-marked as implied by the loop construct, and continue-target labels are suppressed once their referees become structured statements.

## Result

```csharp
for (int i = 0; i < values.Length; i++)
{
    if (values[i] < 0)
    {
        continue;
    }
    sum += values[i];
}
```

— previously rendered with a spurious duplicate jump making the loop body unreachable. With this, every item from the h2h doc's "top remaining gaps" list is closed.

## Tests

Two new fixture tests (continue and break, asserting no gotos/labels and reachable bodies); all suites green (231 / 923 / 131 / 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)