### PR TITLE
Decompiler: inline lambda bodies

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -617,23 +617,43 @@ public class CSharpEmitterTests
     }
 
     [Fact]
-    public void ClosureCapture_SimplifiesClosureType()
+    public void ClosureCapture_InlinesLambdaBody()
     {
         string output = EmitMethod(nameof(CfgSampleClass.ClosureCapture));
 
-        Assert.Contains("/* closure */", output);
-        Assert.Contains("/* lambda: ClosureCapture */", output);
+        // The captured variable appears by name inside the inlined body.
+        Assert.Contains("x => x + offset", output);
         Assert.DoesNotContain("<>c__DisplayClass", output);
-        Assert.DoesNotContain("System.Func", output);
+        Assert.DoesNotContain("/* lambda", output);
     }
 
     [Fact]
-    public void ClosureWithLinq_SimplifiesLambda()
+    public void ClosureWithLinq_InlinesLambdaBody()
     {
         string output = EmitMethod(nameof(CfgSampleClass.ClosureWithLinq));
 
-        Assert.Contains("/* lambda: ClosureWithLinq */", output);
+        Assert.Contains("x => x > threshold", output);
         Assert.DoesNotContain("<>c__DisplayClass", output);
+    }
+
+    [Fact]
+    public void CountAbove_InlinesCapturedLambdaExactly()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.CountAbove));
+
+        Assert.Contains("values.Count(v => v > min)", output);
+        // Closure construction is subsumed by the lambda syntax.
+        Assert.DoesNotContain("/* closure */", output);
+    }
+
+    [Fact]
+    public void CountPositive_InlinesStaticLambdaBody()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.CountPositive));
+
+        // The cached-delegate frame is still visible (known follow-up), but the
+        // lambda body itself must be.
+        Assert.Contains("v => v > 0", output);
     }
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Linq;
 using DotnetInspector.Decompiler;
 
 namespace DotnetInspector.Decompiler.Tests;
@@ -357,6 +358,10 @@ public class CfgSampleClass
 
         static int Twice(int v) => v * 2;
     }
+
+    public static int CountPositive(int[] values) => values.Count(v => v > 0);
+
+    public static int CountAbove(int[] values, int min) => values.Count(v => v > min);
 
     public static int LoopWithContinue(int[] values)
     {

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -15,13 +15,23 @@ public static class CSharpEmitter
     /// Emit C# source for a method.
     /// </summary>
     public static string Emit(MethodBodyContext context)
+        => Emit(context, lambdaDepth: 0);
+
+    internal static string Emit(MethodBodyContext context, int lambdaDepth)
     {
         var cfg = ControlFlowGraph.Create(context);
         var simResult = StackSimulator.Simulate(context, cfg);
         var ast = ILAstBuilder.Build(context, cfg, simResult);
         var transforms = Transforms.TransformPipeline.Run(ast);
         var structure = StructuredControlFlow.Analyze(context, cfg);
-        return Emit(ast, structure, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals);
+        var sb = new StringBuilder();
+        var emitter = new EmitterContext(ast, structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals)
+        {
+            BodyContext = context,
+            LambdaDepth = lambdaDepth,
+        };
+        emitter.EmitMethod();
+        return sb.ToString();
     }
 
     /// <summary>
@@ -126,6 +136,13 @@ public static class CSharpEmitter
         // Try/finally regions that are compiler-lowered lock statements.
         readonly Dictionary<StructuredBlock, LockPattern> _lockPatterns = [];
 
+        // Source context for recursive decompilation (lambda bodies); null when
+        // emitting from a pre-built AST without PE access.
+        public MethodBodyContext? BodyContext { get; init; }
+
+        // Lambda nesting depth — recursion guard for lambda body inlining.
+        public int LambdaDepth { get; init; }
+
         // Runtime-async custom awaits lower through an awaiter temp:
         // awaitable.GetAwaiter(); if (!awaiter.IsCompleted) AsyncHelpers.AwaitAwaiter(awaiter); awaiter.GetResult().
         readonly Dictionary<string, ILAstExpression> _runtimeCustomAwaitSources = [];
@@ -215,6 +232,50 @@ public static class CSharpEmitter
             // Pre-detect exception-filter bool temps (declarations print before
             // the filter is rendered as a when clause).
             ScanForFilterLocals(structure.Root);
+
+            // Closure containers: when lambda bodies inline, the display-class
+            // construction and capture stores are subsumed by the lambda syntax.
+            ScanForClosureConstruction(ast);
+        }
+
+        void ScanForClosureConstruction(ILAstMethod ast)
+        {
+            var closureLocals = new HashSet<string>();
+            foreach (var local in ast.Locals)
+            {
+                if (local.TypeName is { } t
+                    && (t.Contains("DisplayClass", StringComparison.Ordinal)
+                        || t.Contains("<>c__", StringComparison.Ordinal)))
+                {
+                    closureLocals.Add(local.Name);
+                }
+            }
+            if (closureLocals.Count == 0)
+                return;
+
+            foreach (var block in ast.Blocks)
+            {
+                foreach (var node in block.Nodes)
+                {
+                    if (node is ILAstAssignment assign && closureLocals.Contains(assign.Variable.Name))
+                    {
+                        _skipNodes.Add(node);
+                    }
+                    else if (node is ILAstStatement { Expression: var expr })
+                    {
+                        bool isClosureStore =
+                            (expr.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                                or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                                && closureLocals.Contains(expr.Operand ?? GetLocalName(expr.OpCode)))
+                            || (expr.OpCode == ILOpCode.Stfld
+                                && expr.Arguments.Count >= 1
+                                && GetLocalReferenceName(expr.Arguments[0]) is { } recv
+                                && closureLocals.Contains(recv));
+                        if (isClosureStore)
+                            _skipNodes.Add(node);
+                    }
+                }
+            }
         }
 
         sealed class LockPattern
@@ -5632,12 +5693,15 @@ public static class CSharpEmitter
             string typeName = ExtractTypeName(expr.Operand);
             string simplified = SimplifyTypeName(typeName);
 
-            // Delegate construction with closure lambda: new Func<T,R>(closure, <Method>b__N)
-            // Simplify to lambda annotation
+            // Delegate construction with a compiler-generated lambda target:
+            // new Func<T,R>(closureOrNull, ldftn <Method>b__N). Decompile the
+            // target inline as lambda syntax; fall back to an annotation.
             if (expr.Arguments.Count == 2
-                && expr.Arguments[1] is { Operand: string lambdaName }
+                && expr.Arguments[1] is { Operand: string lambdaName } targetExpr
                 && lambdaName.Contains(">b__", StringComparison.Ordinal))
             {
+                if (TryEmitLambdaBody(targetExpr))
+                    return;
                 string cleanLambda = SimplifyLambdaName(lambdaName);
                 _sb.Append($"/* {cleanLambda} */");
                 return;
@@ -5650,6 +5714,114 @@ public static class CSharpEmitter
                 EmitExpression(expr.Arguments[i]);
             }
             _sb.Append(')');
+        }
+
+        /// <summary>
+        /// Decompiles a lambda's compiler-generated target method and renders it
+        /// as lambda syntax: <c>x =&gt; expr</c> for single-return bodies,
+        /// <c>(x, y) =&gt; { ... }</c> otherwise. Captured variables live as
+        /// display-class fields, whose loads render as <c>this.name</c> in the
+        /// inner body; the prefix is stripped since the field names ARE the
+        /// captured variable names.
+        /// </summary>
+        bool TryEmitLambdaBody(ILAstExpression targetExpr)
+        {
+            if (BodyContext?.PE is not { } pe || _reader is null)
+                return false;
+            if (LambdaDepth >= 3)
+                return false;
+            if (targetExpr.Member is not { } target)
+                return false;
+
+            var inner = FindLambdaTargetContext(pe, target);
+            if (inner is null)
+                return false;
+
+            string body;
+            try
+            {
+                body = Emit(inner, LambdaDepth + 1);
+            }
+            catch
+            {
+                return false;
+            }
+
+            bool isClosure = target.DeclaringType.Contains("DisplayClass", StringComparison.Ordinal);
+            if (isClosure)
+                body = body.Replace("this.", "", StringComparison.Ordinal);
+
+            var statements = body
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+            string parameters = inner.ParameterNames is { Count: > 0 } names
+                ? names.Count == 1 ? names[0] ?? "_" : $"({string.Join(", ", names)})"
+                : "()";
+
+            if (statements.Count == 1
+                && statements[0].StartsWith("return ", StringComparison.Ordinal)
+                && statements[0].EndsWith(';'))
+            {
+                _sb.Append($"{parameters} => {statements[0][7..^1]}");
+                return true;
+            }
+
+            // Statement-bodied lambda: rendered single-line inside the expression.
+            _sb.Append($"{parameters} => {{ {string.Join(" ", statements)} }}");
+            return true;
+        }
+
+        /// <summary>
+        /// Locates the lambda target method. Compiler-generated containers
+        /// (&lt;&gt;c, display classes) resolve by bare name, scoped to nested types
+        /// of the CURRENT method's declaring type — every class has its own
+        /// &lt;&gt;c, so a global simple-name search would find the wrong one.
+        /// </summary>
+        MethodBodyContext? FindLambdaTargetContext(System.Reflection.PortableExecutable.PEReader pe, MemberRefInfo target)
+        {
+            foreach (var tdh in _reader!.TypeDefinitions)
+            {
+                var td = _reader.GetTypeDefinition(tdh);
+                string fullName = Metadata.MetadataReaderExtensions.GetFullTypeName(_reader, td);
+
+                if (fullName == target.DeclaringType)
+                {
+                    if (FindMethodIn(pe, td, target.Name) is { } direct)
+                        return direct;
+                }
+
+                if (BodyContext?.DeclaringType is { } declaring && fullName == declaring)
+                {
+                    // The lambda may live on the declaring type itself or on one
+                    // of its compiler-generated nested containers.
+                    if (_reader.GetString(td.Name) == target.DeclaringType
+                        && FindMethodIn(pe, td, target.Name) is { } self)
+                    {
+                        return self;
+                    }
+                    foreach (var nested in td.GetNestedTypes())
+                    {
+                        var ntd = _reader.GetTypeDefinition(nested);
+                        if (_reader.GetString(ntd.Name) != target.DeclaringType)
+                            continue;
+                        if (FindMethodIn(pe, ntd, target.Name) is { } found)
+                            return found;
+                    }
+                }
+            }
+            return null;
+        }
+
+        MethodBodyContext? FindMethodIn(System.Reflection.PortableExecutable.PEReader pe, TypeDefinition td, string methodName)
+        {
+            foreach (var mh in td.GetMethods())
+            {
+                var method = _reader!.GetMethodDefinition(mh);
+                if (_reader.GetString(method.Name) == methodName)
+                    return MethodBodyContext.Create(pe, _reader, method);
+            }
+            return null;
         }
 
         bool TryEmitSpanCollectionExpression(ILAstExpression expr, string? expectedType)

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -633,7 +633,8 @@ public static class ILAstBuilder
                 {
                     OpCode = opcode, Operand = name,
                     ResultType = StackValue.CreatePrimitive(StackValueKind.NativeInt),
-                    Offset = offset
+                    Offset = offset,
+                    Member = name is null ? null : MemberRefInfo.FromQualifiedName(name)
                 };
             }
 
@@ -647,7 +648,8 @@ public static class ILAstBuilder
                     OpCode = opcode, Operand = name,
                     Arguments = { obj },
                     ResultType = StackValue.CreatePrimitive(StackValueKind.NativeInt),
-                    Offset = offset
+                    Offset = offset,
+                    Member = name is null ? null : MemberRefInfo.FromQualifiedName(name)
                 };
             }
 

--- a/src/DotnetInspector.Decompiler/MethodBodyContext.cs
+++ b/src/DotnetInspector.Decompiler/MethodBodyContext.cs
@@ -67,6 +67,12 @@ public sealed class MethodBodyContext
     /// </summary>
     public GenericContext? GenericContext { get; }
 
+    /// <summary>
+    /// The PE reader the context was created from, when available. Enables
+    /// recursive decompilation (lambda targets); the caller owns its lifetime.
+    /// </summary>
+    public System.Reflection.PortableExecutable.PEReader? PE { get; init; }
+
     MethodBodyContext(
         byte[] ilBytes,
         ImmutableArray<ExceptionRegion> exceptionRegions,
@@ -170,7 +176,10 @@ public sealed class MethodBodyContext
             effectiveReturnType,
             declaringType,
             genericContext,
-            localNames);
+            localNames)
+        {
+            PE = peReader,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## What

The audit's biggest remaining visible gap: delegate creation rendered as `/* lambda: Method */` comments with the actual code unreachable. The compiler-generated target method lives in the same assembly — so decompile it recursively and render real lambda syntax:

```csharp
return values.Count(v => v > min);              // was: values.Count(/* lambda: CountAbove */)
Func<int, int> f = x => x + offset;             // captured variable, by name
return items.Where(x => x > threshold).ToList();
```

## How

- `MethodBodyContext` keeps its `PEReader`; the emitter threads the context plus a lambda depth (recursion capped).
- `ldftn` operands carry typed `MemberRefInfo`; target lookup resolves compiler-generated containers (`<>c`, display classes) by bare name **scoped to nested types of the current declaring type** — every class has its own `<>c`, so a global name search would inline the wrong lambda.
- Captured variables are display-class fields rendering as `this.name` in the inner body; the prefix strips since the field names are the captured variable names. Single-return bodies become expression lambdas.
- Display-class construction/capture stores (`closure = new …; closure.min = min;`) are subsumed by the lambda syntax and suppressed.

## Known follow-up

The static cached-delegate frame (the `<>9__` field null-check dance) still renders its S-value scaffolding around the now-visible body — that's the Debug/value-merge shape on the books.

## Tests

Four lambda tests (two updated from the comment era); all suites green (233 / 951 / 131 / 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)