### PR TITLE
Fix two statement-dropping decompiler bugs (chain absorption, cross-block inlining)

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -152,12 +152,38 @@ public class CSharpEmitterTests
         Assert.Contains("Length", output);
     }
 
-    static string EmitCoreLibMethod(string typeName, string methodName)
+    [Fact]
+    public void CoreLib_AbsShort_KeepsNegateAssignment()
+    {
+        // Math.Abs(short): the inner overflow check is a fallthrough condition
+        // block, but its block also contains `value = (short)-value`. The chain
+        // detector must NOT absorb it — that drops the assignment, rendering
+        // `if (value >= 0 || value >= 0)`.
+        string output = EmitCoreLibMethod("System.Math", "Abs", overloadIndex: 0);
+
+        Assert.Contains("-value", output);
+        Assert.DoesNotContain("||", output);
+        Assert.DoesNotContain("&&", output);
+    }
+
+    [Fact]
+    public void AbsShort_KeepsNegateAssignment()
+    {
+        // Same shape from the fixture assembly. In Release builds this hits the
+        // chain detector; in Debug the stack-height guard already disables
+        // chains, so the assignment trivially survives.
+        string output = EmitMethod(nameof(CfgSampleClass.AbsShort));
+
+        Assert.Contains("-value", output);
+        Assert.DoesNotContain("||", output);
+    }
+
+    static string EmitCoreLibMethod(string typeName, string methodName, int overloadIndex = 0)
     {
         var assemblyPath = typeof(object).Assembly.Location;
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
-        var context = MethodBodyContext.Create(peReader, typeName, methodName);
+        var context = MethodBodyContext.Create(peReader, typeName, methodName, overloadIndex);
         Assert.NotNull(context);
         return CSharpEmitter.Emit(context);
     }

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -359,6 +359,17 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    public static short AbsShort(short value)
+    {
+        if (value < 0)
+        {
+            value = (short)-value;
+            if (value < 0)
+                throw new OverflowException();
+        }
+        return value;
+    }
+
     public static int CountPositive(int[] values) => values.Count(v => v > 0);
 
     public static int CountAbove(int[] values, int min) => values.Count(v => v > min);

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -23,7 +23,7 @@ public static class CSharpEmitter
         var simResult = StackSimulator.Simulate(context, cfg);
         var ast = ILAstBuilder.Build(context, cfg, simResult);
         var transforms = Transforms.TransformPipeline.Run(ast);
-        var structure = StructuredControlFlow.Analyze(context, cfg);
+        var structure = StructuredControlFlow.Analyze(context, cfg, ast);
         var sb = new StringBuilder();
         var emitter = new EmitterContext(ast, structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals)
         {

--- a/src/DotnetInspector.Decompiler/ConditionalDetector.cs
+++ b/src/DotnetInspector.Decompiler/ConditionalDetector.cs
@@ -60,7 +60,8 @@ internal static class ConditionalDetector
         ControlFlowGraph cfg,
         DominatorTree domTree,
         List<NaturalLoop> loops,
-        int[]? entryStackHeights = null)
+        int[]? entryStackHeights = null,
+        ILAstMethod? ast = null)
     {
         List<ConditionalPattern> patterns = [];
         var loopHeaders = new HashSet<int>(loops.Select(l => l.HeaderIndex));
@@ -69,7 +70,7 @@ internal static class ConditionalDetector
         // single-predecessor condition block forms one combined a && b / a || b
         // condition. Detect chains first; absorbed continuation blocks don't get
         // their own pattern.
-        var chains = DetectShortCircuitChains(cfg, loopHeaders, entryStackHeights, out var absorbed);
+        var chains = DetectShortCircuitChains(cfg, loopHeaders, entryStackHeights, ast, out var absorbed);
 
         for (int i = 0; i < cfg.BasicBlocks.Count; i++)
         {
@@ -213,8 +214,18 @@ internal static class ConditionalDetector
     /// only kept when every link classifies cleanly.
     /// </summary>
     static Dictionary<int, (List<ConditionChainTerm> Terms, bool NegateLast)> DetectShortCircuitChains(
-        ControlFlowGraph cfg, HashSet<int> loopHeaders, int[]? entryStackHeights, out HashSet<int> absorbed)
+        ControlFlowGraph cfg, HashSet<int> loopHeaders, int[]? entryStackHeights, ILAstMethod? ast, out HashSet<int> absorbed)
     {
+        // Absorbing a continuation block hides everything in it except its
+        // condition, so it must contain NOTHING but the condition computation:
+        // nops, foldable local-free temps the branch consumes, and the branch.
+        // Without the AST to verify that, don't chain at all.
+        if (ast is null)
+        {
+            absorbed = [];
+            return [];
+        }
+
         absorbed = [];
         var result = new Dictionary<int, (List<ConditionChainTerm> Terms, bool NegateLast)>();
 
@@ -257,7 +268,8 @@ internal static class ConditionalDetector
             {
                 int ft = cfg.LookupIndex(cfg.BasicBlocks[cur].FallthroughTarget?.Start ?? -1);
                 if (ft < 0 || predCount[ft] != 1 || loopHeaders.Contains(ft) || ConditionEdges(cfg, ft) is null
-                    || EntryHeight(ft) > 0)
+                    || EntryHeight(ft) > 0
+                    || !IsPureConditionBlock(ast, ft))
                     break;
                 chain.Add(ft);
                 cur = ft;
@@ -313,6 +325,105 @@ internal static class ConditionalDetector
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// A block that computes ONLY a condition: optional nops, optional
+    /// single-use local-free temp stores the branch consumes (Debug bool
+    /// routing — mirroring what the emitter's condition folding can absorb),
+    /// and a trailing conditional branch. Anything else (assignments, calls,
+    /// stores) would be silently dropped if the block were absorbed.
+    /// </summary>
+    static bool IsPureConditionBlock(ILAstMethod ast, int blockIdx)
+    {
+        if (blockIdx < 0 || blockIdx >= ast.Blocks.Count)
+            return false;
+        var nodes = ast.Blocks[blockIdx].Nodes;
+        if (nodes.Count == 0)
+            return false;
+        if (nodes[^1] is not ILAstStatement { Expression: var branch }
+            || branch.OpCode is not (ILOpCode.Brtrue or ILOpCode.Brtrue_s
+                or ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                or ILOpCode.Beq or ILOpCode.Beq_s or ILOpCode.Bne_un or ILOpCode.Bne_un_s
+                or ILOpCode.Bge or ILOpCode.Bge_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s
+                or ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s
+                or ILOpCode.Ble or ILOpCode.Ble_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s
+                or ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Blt_un or ILOpCode.Blt_un_s))
+        {
+            return false;
+        }
+
+        for (int i = 0; i < nodes.Count - 1; i++)
+        {
+            if (nodes[i] is not ILAstStatement { Expression: var expr })
+                return false;
+            if (expr.OpCode == ILOpCode.Nop)
+                continue;
+            // Foldable temp: a store the branch reads, whose value loads no
+            // locals. The branch must actually load the stored local — the
+            // emitter folds by substituting that load; an unreferenced store
+            // would be dropped.
+            if (expr.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                    or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                && expr.Arguments.Count == 1
+                && !TreeLoadsAnyLocal(expr.Arguments[0])
+                && StoredLocalName(expr) is string stored
+                && TreeLoadsLocal(branch, stored))
+            {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    static string? StoredLocalName(ILAstExpression store) => store.Operand ?? store.OpCode switch
+    {
+        ILOpCode.Stloc_0 => "V_0",
+        ILOpCode.Stloc_1 => "V_1",
+        ILOpCode.Stloc_2 => "V_2",
+        ILOpCode.Stloc_3 => "V_3",
+        _ => null,
+    };
+
+    static bool TreeLoadsLocal(ILAstExpression expr, string name)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3)
+        {
+            string? loaded = expr.Operand ?? expr.OpCode switch
+            {
+                ILOpCode.Ldloc_0 => "V_0",
+                ILOpCode.Ldloc_1 => "V_1",
+                ILOpCode.Ldloc_2 => "V_2",
+                ILOpCode.Ldloc_3 => "V_3",
+                _ => null,
+            };
+            if (loaded == name)
+                return true;
+        }
+        foreach (var arg in expr.Arguments)
+        {
+            if (TreeLoadsLocal(arg, name))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TreeLoadsAnyLocal(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldloca or ILOpCode.Ldloca_s)
+        {
+            return true;
+        }
+        foreach (var arg in expr.Arguments)
+        {
+            if (TreeLoadsAnyLocal(arg))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
+++ b/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
@@ -210,11 +210,19 @@ public sealed class StructuredControlFlow
     /// Analyze control flow from a pre-computed CFG.
     /// </summary>
     public static StructuredControlFlow Analyze(MethodBodyContext context, ControlFlowGraph cfg)
+        => Analyze(context, cfg, ast: null);
+
+    /// <summary>
+    /// Analyze with the ILAst available: enables transformations that must
+    /// validate block contents (short-circuit chains reject continuation
+    /// blocks containing real statements).
+    /// </summary>
+    public static StructuredControlFlow Analyze(MethodBodyContext context, ControlFlowGraph cfg, ILAstMethod? ast)
     {
         var domTree = DominatorTree.Build(cfg);
         var loops = LoopDetector.DetectLoops(cfg, domTree);
         var entryHeights = StackHeightCalculator.ComputeOffsetEntryHeights(context);
-        var conditionals = ConditionalDetector.DetectConditionals(cfg, domTree, loops, entryHeights);
+        var conditionals = ConditionalDetector.DetectConditionals(cfg, domTree, loops, entryHeights, ast);
         var exRegions = MapExceptionRegions(context, cfg);
 
         var root = BuildStructuredTree(cfg, domTree, loops, conditionals, exRegions);

--- a/src/DotnetInspector.Decompiler/Transforms/ExpressionInliner.cs
+++ b/src/DotnetInspector.Decompiler/Transforms/ExpressionInliner.cs
@@ -20,9 +20,16 @@ sealed class ExpressionInliner : IILAstTransform
     {
         HashSet<string> inlinedLocals = [];
 
+        // Method-wide use counts: a definition that is live at its block's exit
+        // may feed loads in OTHER blocks, which within-block scanning can't see.
+        Dictionary<string, int> methodUses = [];
+        foreach (var b in method.Blocks)
+            foreach (var node in b.Nodes)
+                CountReferencesInNode(node, methodUses);
+
         // Pass 1: within-block inlining (single block, store → load adjacency)
         foreach (var block in method.Blocks)
-            InlineBlock(block, inlinedLocals);
+            InlineBlock(block, inlinedLocals, methodUses);
 
         // Pass 2: cross-block inlining (exactly 1 def + 1 use across entire method)
         InlineCrossBlock(method, inlinedLocals);
@@ -35,7 +42,8 @@ sealed class ExpressionInliner : IILAstTransform
     /// exactly once in a subsequent node, with no intervening redefinition.
     /// Replace the use with the stored expression and nop-out the store.
     /// </summary>
-    static void InlineBlock(ILAstBlock block, HashSet<string> inlinedLocals)
+    static void InlineBlock(ILAstBlock block, HashSet<string> inlinedLocals,
+        Dictionary<string, int> methodUses)
     {
         for (int i = 0; i < block.Nodes.Count; i++)
         {
@@ -97,6 +105,18 @@ sealed class ExpressionInliner : IILAstTransform
                 // within this node (earlier call arguments, receivers) must not
                 // mutate state the value reads.
                 if (readsMutableState && MutatesBeforeFirstRef(candidate, varName))
+                    break;
+
+                // The store is removed when we inline, so the definition must
+                // not be observable anywhere else. If no later node in THIS
+                // block redefines the variable, the definition is live at the
+                // block exit and other blocks may load it (e.g. a condition
+                // temp reused inside the then-arm) — only safe when this is
+                // the variable's only use in the whole method.
+                bool redefinedLater = false;
+                for (int k = j + 1; k < block.Nodes.Count && !redefinedLater; k++)
+                    redefinedLater = IsStoreToVar(block.Nodes[k], varName);
+                if (!redefinedLater && methodUses.GetValueOrDefault(varName) != 1)
                     break;
 
                 // Exactly one reference — inline it
@@ -228,8 +248,11 @@ sealed class ExpressionInliner : IILAstTransform
 
     static void CountExprRefs(ILAstExpression expr, Dictionary<string, int> counts)
     {
+        // ldloca counts as a use: an address read observes the variable's
+        // storage, so a definition feeding one can never be inlined away.
         if (expr.OpCode is ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
-            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc)
+            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldloca or ILOpCode.Ldloca_s)
         {
             string? vn = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
             if (vn is not null)
@@ -252,7 +275,7 @@ sealed class ExpressionInliner : IILAstTransform
     static int CountExprRefs(ILAstExpression expr, string varName)
     {
         int count = 0;
-        if (IsLoadOf(expr, varName))
+        if (IsLoadOf(expr, varName) || IsAddressOf(expr, varName))
             count++;
         foreach (var arg in expr.Arguments)
             count += CountExprRefs(arg, varName);
@@ -296,6 +319,13 @@ sealed class ExpressionInliner : IILAstTransform
             string? name = expr.Operand ?? GetLocalNameFromOp(expr.OpCode);
             return name == varName;
         }
+        return false;
+    }
+
+    static bool IsAddressOf(ILAstExpression expr, string varName)
+    {
+        if (expr.OpCode is ILOpCode.Ldloca or ILOpCode.Ldloca_s)
+            return (expr.Operand ?? GetLocalNameFromOp(expr.OpCode)) == varName;
         return false;
     }
 


### PR DESCRIPTION
Both found by sweeping the CoreLib head-to-head corpus while refreshing the benchmark doc.

## Bug 1: && / || chains absorbed blocks containing real statements

The chain detector (#395) validated continuation blocks purely on CFG shape (single-pred fallthrough, two-way branch, stack-empty entry). A block can satisfy all of that and still *do work* before branching. \`Math.Abs(short)\`:

```csharp
// before — the negation is gone, condition duplicated
if (value >= (nint)0 || value >= (nint)0) { return value; }
Math.ThrowNegateTwosCompOverflow();

// after
if (value < 0)
{
    value = (short)-value;
    if (value >= 0) goto IL_0012;
}
Math.ThrowNegateTwosCompOverflow();
return value;
```

Fix: thread the ILAst into `StructuredControlFlow.Analyze` → `ConditionalDetector`, and require each chain continuation to be a *pure condition block* — nops, local-free temp stores the branch actually consumes (mirroring what `RenderTrueCondition` can fold), and the trailing conditional branch, nothing else. Callers without an AST (annotated IL, structuring tests) get no chains, which is safe.

## Bug 2: inliner dropped definitions still referenced from other blocks

`ExpressionInliner`'s within-block pass counted uses only inside the defining block. A definition live at block exit could be inlined into its single in-block use while another block still read the local. `Dictionary<K,V>.Clear`:

```csharp
// before — V_0 used but never defined
if (this._count > 0)
{
    ...
    Array.Clear(this._entries, 0, V_0);
}

// after
int V_0 = this._count;
if (V_0 > 0)
{
    ...
    Array.Clear(this._entries, 0, V_0);
}
```

Fix: when no later node in the block redefines the variable (definition is live-out), inlining requires a method-wide use count of exactly 1. Also, `ldloca` now counts as a use — an address read observes storage that an elided store would no longer initialize.

## Tests

- `CoreLib_AbsShort_KeepsNegateAssignment` — Release-shaped IL straight from CoreLib, exercises the chain path in CI
- `AbsShort_KeepsNegateAssignment` + `AbsShort` fixture — same shape from the fixture assembly
- All suites green: decompiler 235, metadata 135, CLI 953, services 158

🤖 Generated with [Claude Code](https://claude.com/claude-code)