### PR TITLE
Decompiler: omit redundant casts on unsigned-typed comparison operands

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -100,6 +100,26 @@ public class CSharpEmitterTests
         Assert.Contains("/", output);
     }
 
+    [Fact]
+    public void ULongGe_OmitsRedundantUnsignedCasts()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.ULongGe));
+
+        // Both operands are statically ulong — C# compiles a >= b straight to
+        // the unsigned compare, so reinterpretation casts are redundant noise.
+        Assert.Contains(">=", output);
+        Assert.DoesNotContain("(ulong)", output);
+    }
+
+    [Fact]
+    public void MaxULong_OmitsRedundantUnsignedCasts()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.MaxULong));
+
+        Assert.Contains(">=", output);
+        Assert.DoesNotContain("(ulong)", output);
+    }
+
     // --- Exception filters (catch...when) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -293,6 +293,15 @@ public class CfgSampleClass
 
     public static uint UnsignedDivide(uint a, uint b) => a / b;
 
+    public static bool ULongGe(ulong a, ulong b) => a >= b;
+
+    public static ulong MaxULong(ulong a, ulong b)
+    {
+        if (a >= b)
+            return a;
+        return b;
+    }
+
     public static int FilterCatch(string s)
     {
         try

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -6823,9 +6823,11 @@ public static class CSharpEmitter
         void EmitUnsignedOperand(ILAstExpression arg, string cast, ILOpCode redundantConv)
         {
             // Non-negative constants are unchanged by unsigned reinterpretation,
-            // and an operand that is itself the matching conversion already
-            // renders the cast.
-            if ((IsLdcI4(arg.OpCode) && GetI4Value(arg) >= 0) || arg.OpCode == redundantConv)
+            // an operand that is itself the matching conversion already renders
+            // the cast, and an operand whose static type is already unsigned
+            // (C# compiles ulong >= ulong straight to bge.un) needs none.
+            if ((IsLdcI4(arg.OpCode) && GetI4Value(arg) >= 0) || arg.OpCode == redundantConv
+                || IsUnsignedTyped(arg))
             {
                 EmitExpression(arg);
                 return;
@@ -6836,6 +6838,23 @@ public static class CSharpEmitter
             if (wrap) _sb.Append('(');
             EmitExpression(arg);
             if (wrap) _sb.Append(')');
+        }
+
+        /// <summary>
+        /// True when the operand's static type is an unsigned (or otherwise
+        /// non-negative: char) integer, so unsigned reinterpretation is the
+        /// identity. Signed-typed operands keep their casts — that is the
+        /// bounds-check idiom (uint)i &lt; (uint)length.
+        /// </summary>
+        static bool IsUnsignedTyped(ILAstExpression arg)
+        {
+            var tn = arg.ResultType.TypeName;
+            if (tn is null)
+                return false;
+            if (tn.StartsWith("System.", StringComparison.Ordinal))
+                tn = tn[7..];
+            return tn is "ulong" or "uint" or "ushort" or "byte" or "nuint" or "char"
+                or "UInt64" or "UInt32" or "UInt16" or "Byte" or "UIntPtr" or "Char";
         }
 
         /// <summary>Joint stack-value kind of a comparison's operands.</summary>


### PR DESCRIPTION
Found while refreshing the head-to-head doc. \`Math.Max(ulong)\` rendered:

```csharp
return (ulong)val1 >= (ulong)val2 ? val1 : val2;
```

The operands are already \`ulong\` — C# compiles \`val1 >= val2\` directly to \`bge.un\`, so the reinterpretation casts are pure noise. Now that \`StackValue.FromTypeName\` preserves primitive type names (#396), \`EmitUnsignedOperand\` can distinguish the two reasons an unsigned compare appears in IL:

- **signed operands** → the bounds-check idiom, casts are load-bearing: \`(uint)index >= (uint)this._stringLength\` (verified unchanged on \`String.this[int]\`)
- **unsigned operands** (\`ulong\`/\`uint\`/\`ushort\`/\`byte\`/\`nuint\`/\`char\`) → casts dropped: \`return val1 >= val2 ? val1 : val2;\` — now source-exact

Applies to both polarity paths (direct \`cgt.un\`-family and the negated \`ceq(cmp,0)\` form) and to \`div.un\`/\`rem.un\` (\`a / b\` on \`uint\` operands no longer renders casts).

Tests: \`ULongGe\` (negated path) and \`MaxULong\` (branch path) fixtures assert no \`(ulong)\` casts; existing signed-operand tests (\`UnsignedBoundsCheck\`, \`UnsignedBoundsBranch\`) still pass. Decompiler 237 green, CLI 953 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)