### PR TITLE
Decompiler: every rendered goto gets its target label

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -120,6 +120,25 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("(ulong)", output);
     }
 
+    [Fact]
+    public void AbsShortHelper_EveryGotoHasALabel()
+    {
+        // CoreLib Math.Abs shape: structuring suppresses the follow-block label
+        // assuming all branches to it were absorbed, but the inner guard still
+        // renders as a goto. Any rendered goto must have its target label.
+        string output = EmitMethod(nameof(CfgSampleClass.AbsShortHelper));
+
+        foreach (string line in output.Split('\n'))
+        {
+            int at = line.IndexOf("goto IL_", StringComparison.Ordinal);
+            if (at < 0)
+                continue;
+            string label = line.Substring(at + 5, 7);
+            Assert.True(output.Contains(label + ":", StringComparison.Ordinal),
+                $"goto {label} has no target label in:\n{output}");
+        }
+    }
+
     // --- Exception filters (catch...when) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -368,6 +368,21 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    static void ThrowOverflow() => throw new OverflowException();
+
+    // CoreLib Math.Abs(short) shape: the throw is an out-of-line call reached
+    // by fallthrough, with both guards jumping PAST it to the return.
+    public static short AbsShortHelper(short value)
+    {
+        if (value < 0)
+        {
+            value = (short)-value;
+            if (value < 0)
+                ThrowOverflow();
+        }
+        return value;
+    }
+
     public static short AbsShort(short value)
     {
         if (value < 0)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -86,6 +86,11 @@ public static class CSharpEmitter
         // Labels already emitted (avoid duplicates for shared blocks)
         readonly HashSet<string> _emittedLabels;
 
+        // Gotos actually written to the output, and where a suppressed label
+        // WOULD have gone — so dangling references can be repaired at the end.
+        readonly HashSet<string> _emittedGotos = [];
+        readonly Dictionary<string, int> _suppressedLabelPositions = [];
+
         // Catch handler statements to suppress (blockIndex, nodeIndex) — already emitted in catch clause
         readonly HashSet<(int blockIndex, int nodeIndex)> _catchVariableStatements;
 
@@ -1482,6 +1487,35 @@ public static class CSharpEmitter
             // Shared return blocks may be consumed by an IfThenElse else branch
             // but still need to appear at method end for other paths.
             EnsureTrailingReturn();
+
+            FixupDanglingGotoLabels();
+        }
+
+        /// <summary>
+        /// Inserts labels for gotos that rendered while their target's label was
+        /// suppressed. Structuring suppresses then/else/follow labels assuming
+        /// every branch to them is absorbed; any branch that still fell back to
+        /// a textual goto would otherwise dangle. Insertions run back-to-front
+        /// so earlier recorded positions stay valid.
+        /// </summary>
+        void FixupDanglingGotoLabels()
+        {
+            List<(int Pos, string Label)>? pending = null;
+            foreach (string target in _emittedGotos)
+            {
+                if (_emittedLabels.Contains(target))
+                    continue;
+                if (_suppressedLabelPositions.TryGetValue(target, out int pos))
+                {
+                    (pending ??= []).Add((pos, target));
+                    _emittedLabels.Add(target);
+                }
+            }
+            if (pending is null)
+                return;
+            pending.Sort((a, b) => b.Pos.CompareTo(a.Pos));
+            foreach (var (pos, label) in pending)
+                _sb.Insert(pos, $"{label}:\n");
         }
 
         void EnsureTrailingReturn()
@@ -5333,6 +5367,7 @@ public static class CSharpEmitter
                     if (expr.Operand is string brRetTarget && TryEmitInlinedReturn(brRetTarget, indent))
                         break;
                     WriteIndent(indent);
+                    if (expr.Operand is string brGoto) _emittedGotos.Add(brGoto);
                     _sb.AppendLine($"goto {expr.Operand};");
                     break;
 
@@ -5352,6 +5387,7 @@ public static class CSharpEmitter
                     WriteIndent(indent);
                     _sb.Append($"if (");
                     EmitBranchCondition(expr);
+                    if (expr.Operand is string condGoto) _emittedGotos.Add(condGoto);
                     _sb.AppendLine($") goto {expr.Operand};");
                     break;
 
@@ -5363,6 +5399,7 @@ public static class CSharpEmitter
                         if (!TryEmitInlinedReturn(leaveTarget, indent))
                         {
                             WriteIndent(indent);
+                            _emittedGotos.Add(leaveTarget);
                             _sb.AppendLine($"goto {leaveTarget};");
                         }
                     }
@@ -7234,6 +7271,12 @@ public static class CSharpEmitter
             if (_blockStartOffset.TryGetValue(blockIndex, out int startOffset))
             {
                 string label = $"IL_{startOffset:X4}";
+                // Wherever a label is withheld, remember the spot: structuring
+                // marks labels consumed on the ASSUMPTION every branch to them
+                // is structured away, but a stray branch can still render as a
+                // goto — FixupDanglingGotoLabels repairs those at the end.
+                if (!_emittedLabels.Contains(label))
+                    _suppressedLabelPositions.TryAdd(label, _sb.Length);
                 // Suppress labels consumed by while-loop conditions or loop headers
                 if (_loopConsumedLabels.Contains(label) || _loopHeaderLabels.Contains(label))
                     return;


### PR DESCRIPTION
Gap #2 from the refreshed head-to-head doc (#406). Three of the five non-A methods rendered \`goto IL_xxxx\` with the target label never emitted, so the output wasn't even syntactically honest.

Root cause: the emitter pre-computes label suppression — every structured conditional marks its then/else/follow block labels as consumed, assuming all branches to them get absorbed. When a branch instead falls back to a textual \`goto\` (guard shapes the structurer doesn't re-nest), the reference dangles.

Since the suppression decision can't know up front which branches will structure cleanly, the fix repairs after the fact:

- \`TryEmitLabel\` records the output position where each withheld label would have gone (the StringBuilder is append-only, so recorded positions stay valid)
- the three goto write sites record their targets
- \`FixupDanglingGotoLabels\` runs at the end of \`EmitMethod\` and inserts missing labels back-to-front

Before/after on \`Math.Abs(short)\`:

```csharp
// before                              // after
if (value < 0)                         if (value < 0)
{                                      {
    value = (short)-value;                 value = (short)-value;
    if (value >= 0) goto IL_0012;          if (value >= 0) goto IL_0012;
}                                      }
Math.ThrowNegateTwosCompOverflow();    Math.ThrowNegateTwosCompOverflow();
return value;                          IL_0012:
                                       return value;
```

Also fixes \`List<T>.Clear\` (\`IL_003C\`) and \`Dictionary<K,V>.ContainsValue\` (\`IL_005E\`, inserted mid-structure at the correct position). New \`AbsShortHelper\` fixture mirrors the CoreLib shape (out-of-line throw call reached by fallthrough) and the test asserts every rendered goto has its label. Decompiler 238 green, CLI 953 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)