### PR TITLE
Decompiler: generic ldelem rendering + stack-slot spill unification

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -139,6 +139,33 @@ public class CSharpEmitterTests
         }
     }
 
+    // --- Generic ldelem (type-parameter element access) ---
+
+    [Fact]
+    public void GetAt_RendersGenericElementLoad()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.GetAt));
+
+        // ldelem with a type token previously fell back to an IL comment.
+        Assert.Contains("array[index]", output);
+        Assert.DoesNotContain("ldelem", output);
+    }
+
+    [Fact]
+    public void CoreLib_QueueDequeue_SpillsElementLoadToTypedLocal()
+    {
+        // Release shape: the dequeued element stays on the eval stack across
+        // the IsReferenceOrContainsReferences branch. The spill must render as
+        // a typed declaration consumed by the return — no comment fallbacks,
+        // no S_in_* artifacts.
+        string output = EmitCoreLibMethod("System.Collections.Generic.Queue`1", "Dequeue");
+
+        Assert.Contains("T S_0 = V_1[V_0];", output);
+        Assert.Contains("return S_0;", output);
+        Assert.DoesNotContain("S_in_", output);
+        Assert.DoesNotContain("/*", output);
+    }
+
     // --- Exception filters (catch...when) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -295,6 +295,8 @@ public class CfgSampleClass
 
     public static bool ULongGe(ulong a, ulong b) => a >= b;
 
+    public static T GetAt<T>(T[] array, int index) => array[index];
+
     public static ulong MaxULong(ulong a, ulong b)
     {
         if (a >= b)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -86,6 +86,10 @@ public static class CSharpEmitter
         // Labels already emitted (avoid duplicates for shared blocks)
         readonly HashSet<string> _emittedLabels;
 
+        // Stack-slot locals (S_N) declared so far — they exist nowhere in
+        // metadata, so the first surviving store must declare them.
+        readonly HashSet<string> _declaredSlotLocals = [];
+
         // Gotos actually written to the output, and where a suppressed label
         // WOULD have gone — so dangling references can be repaired at the end.
         readonly HashSet<string> _emittedGotos = [];
@@ -1627,13 +1631,7 @@ public static class CSharpEmitter
                 switch (node)
                 {
                     case ILAstAssignment assign:
-                        if (TryEmitCompoundAssignment(assign.Variable.Name, assign.Value, indent))
-                            break;
-                        WriteIndent(indent);
-                        string assignType = SimplifyTypeName(assign.Variable.TypeName ?? "var");
-                        _sb.Append($"{assign.Variable.Name} = ");
-                        EmitExpression(assign.Value);
-                        _sb.AppendLine(";");
+                        EmitAssignmentNode(assign, indent);
                         break;
 
                     case ILAstStatement stmt:
@@ -1643,6 +1641,35 @@ public static class CSharpEmitter
             }
 
             _currentBlockNodes = null;
+        }
+
+        void EmitAssignmentNode(ILAstAssignment assign, int indent)
+        {
+            // A stack-slot merge re-storing the slot it entered the block with
+            // (S_0 = S_in_0) is the identity — both names denote eval-stack
+            // slot 0 — unless a pattern substituted the incoming value.
+            if (assign.Variable.Kind == ILVariableKind.StackSlot
+                && assign.Value is { OpCode: ILOpCode.Nop, Operand: string inName }
+                && inName == $"S_in_{assign.Variable.Index}"
+                && _nullConditionalReceiver is null
+                && !_syntheticSubstitutions.ContainsKey(inName)
+                && !_syntheticSubstitutions.ContainsKey($"{assign.Value.Offset}:{inName}"))
+            {
+                return;
+            }
+
+            if (TryEmitCompoundAssignment(assign.Variable.Name, assign.Value, indent))
+                return;
+
+            WriteIndent(indent);
+            if (assign.Variable.Kind == ILVariableKind.StackSlot
+                && _declaredSlotLocals.Add(assign.Variable.Name))
+            {
+                _sb.Append($"{SimplifyTypeName(assign.Variable.TypeName ?? "var")} ");
+            }
+            _sb.Append($"{assign.Variable.Name} = ");
+            EmitExpression(assign.Value);
+            _sb.AppendLine(";");
         }
 
         void EmitIfThenElse(StructuredBlock block, int indent)
@@ -1731,13 +1758,7 @@ public static class CSharpEmitter
                         EmitStatement(stmt.Expression, indent);
                     else if (condBlock.Nodes[i] is ILAstAssignment assign)
                     {
-                        if (!TryEmitCompoundAssignment(assign.Variable.Name, assign.Value, indent))
-                        {
-                            WriteIndent(indent);
-                            _sb.Append($"{assign.Variable.Name} = ");
-                            EmitExpression(assign.Value);
-                            _sb.AppendLine(";");
-                        }
+                        EmitAssignmentNode(assign, indent);
                     }
                 }
 
@@ -5836,6 +5857,10 @@ public static class CSharpEmitter
                         _sb.Append(blockSubst);
                     else if (_syntheticSubstitutions.TryGetValue(expr.Operand, out var subst))
                         _sb.Append(subst);
+                    else if (expr.Operand.StartsWith("S_in_", StringComparison.Ordinal))
+                        // The incoming slot IS the S_N every predecessor stored:
+                        // render the unified name so the reference resolves.
+                        _sb.Append("S_").Append(expr.Operand.AsSpan("S_in_".Length));
                     else
                         _sb.Append(expr.Operand);
                     break;

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -102,13 +102,24 @@ public static class ILAstBuilder
         {
             var remaining = stack.ToArray();
             Array.Reverse(remaining);
+
+            // The values were computed before the block's terminator ran, so
+            // the spill must precede it — a trailing branch statement must stay
+            // last for condition extraction and structuring.
+            int insertAt = block.Nodes.Count;
+            if (insertAt > 0 && block.Nodes[insertAt - 1] is ILAstStatement { Expression.OpCode: var termOp }
+                && (termOp.IsBranch() || termOp is ILOpCode.Switch or ILOpCode.Leave or ILOpCode.Leave_s))
+            {
+                insertAt--;
+            }
+
             for (int i = 0; i < remaining.Length; i++)
             {
                 var variable = new ILVariable(
                     ILVariableKind.StackSlot,
                     remaining[i].ResultType,
                     index: i);
-                block.Nodes.Add(new ILAstAssignment
+                block.Nodes.Insert(insertAt++, new ILAstAssignment
                 {
                     Variable = variable,
                     Value = remaining[i],
@@ -701,14 +712,23 @@ public static class ILAstBuilder
                  ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8 or ILOpCode.Ldelem_ref or
                  ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4:
             {
+                // The token form (ldelem !T in generic code) carries the element
+                // type; resolving it gives the result a real stack kind — Unknown
+                // would read as void and the load would never join the stack.
+                string? elementType = null;
                 if (opcode == ILOpCode.Ldelem)
-                    reader.ReadILToken(); // type token, unused for now
+                {
+                    int token = reader.ReadILToken();
+                    elementType = ResolveTypeName(context.Reader, token, context.GenericContext);
+                }
                 var index = TryPop(stack);
                 var array = TryPop(stack);
                 return new ILAstExpression
                 {
-                    OpCode = opcode, Arguments = { array, index },
-                    ResultType = StackValue.CreatePrimitive(opcode == ILOpCode.Ldelem_ref ? StackValueKind.ObjRef : opcode.ResultKind()),
+                    OpCode = opcode, Operand = elementType, Arguments = { array, index },
+                    ResultType = opcode == ILOpCode.Ldelem
+                        ? StackValue.FromTypeName(elementType ?? "object")
+                        : StackValue.CreatePrimitive(opcode == ILOpCode.Ldelem_ref ? StackValueKind.ObjRef : opcode.ResultKind()),
                     Offset = offset
                 };
             }


### PR DESCRIPTION
Gap #1 from the refreshed h2h doc (#406) — the one keeping \`Stack<T>.Pop\` and \`Queue<T>.Dequeue\` at D+.

## Before / after (\`Stack<T>.Pop\`)

```csharp
// before                                          // after
this._version++;                                   this._version++;
this._size = V_0;                                  this._size = V_0;
/* ldelem(ldloc.1 V_1, ldloc.0 V_0) */             T S_0 = V_1[V_0];
if (RuntimeHelpers.IsReference...())               if (RuntimeHelpers.IsReference...())
{                                                  {
    V_2 = default;                                     V_2 = default;
    V_1[V_0] = V_2;                                    V_1[V_0] = V_2;
    S_0 = S_in_0;                                  }
}                                                  return S_0;
return S_in_0;
```

The after-shape matches the source statement for statement (\`T item = array[size]; if (...) array[size] = default!; return item;\`) — only local naming differs.

## Three connected fixes

1. **Generic \`ldelem\` discarded its type token** and defaulted to an Unknown result kind, which \`PushesValue\` treats as void — so the element load never joined the eval stack and fell back to a statement-position IL comment. The token now resolves through the same path \`StackSimulator\` uses, and the element type (\`T\`) types the spill declaration.

2. **Block-exit stack spills appended after the trailing branch**, so a spill landing in a condition block displaced the branch from its expected last-node position and broke condition extraction (\`if (/* condition */)\`). Spills now insert before the terminator — where the value was actually computed.

3. **Spilled slots render as real locals**: first store declares (\`T S_0 = ...\`), \`S_N = S_in_N\` identity merges are suppressed (unless a pattern substituted the incoming value — null-coalescing/ternary substitutions still apply), and a leftover \`S_in_N\` reference renders as \`S_N\`, the name every predecessor spilled to.

The full 17-method h2h corpus diff shows exactly the two intended method improvements and nothing else. Tests: \`GetAt<T>\` fixture (generic element load renders as indexing, no comment) and a CoreLib \`Queue.Dequeue\` test pinning the Release spill shape. All four suites green (decompiler 240, CLI 953, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)