### PR TITLE
tests: fix Member_NonMethodRows CI flake (parallel console bleed)

### DIFF
--- a/src/dotnet-inspect.Tests/SelectResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SelectResolverTests.cs
@@ -2,6 +2,11 @@ using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
+// SelectOutput writes to Console.Error directly; without the Console
+// collection these tests run in parallel with ConsoleCapture-based tests
+// and their stderr lands in whichever capture is active (CI flake:
+// Member_NonMethodRows saw "No sections match 'Source*'").
+[Collection("Console")]
 public class SelectResolverTests
 {
     private static readonly string[] TestSections =
@@ -131,28 +136,34 @@ public class SelectResolverTests
     }
 
     [Fact]
-    public void WriteUnresolved_PartialMatch_ReturnsFalse()
+    public async Task WriteUnresolved_PartialMatch_ReturnsFalse()
     {
         var result = new SelectResult(
             new HashSet<string> { "Package Info" },
             [new SelectMiss("Source*", TestSections.ToList(), IsGlob: true)]);
 
-        // Partial match: some resolved, some not — should not be a total failure
-        bool totalFailure = SelectOutput.WriteUnresolved(result);
+        // Partial match: some resolved, some not — should not be a total failure.
+        // Captured so the warning doesn't leak to the real console.
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SelectOutput.WriteUnresolved(result) ? 1 : 0));
 
-        Assert.False(totalFailure);
+        Assert.Equal(0, exit);
+        Assert.Contains("Warning: No sections match 'Source*'.", error);
     }
 
     [Fact]
-    public void WriteUnresolved_TotalFailure_ReturnsTrue()
+    public async Task WriteUnresolved_TotalFailure_ReturnsTrue()
     {
         var result = new SelectResult(
             null,
             [new SelectMiss("Source*", TestSections.ToList(), IsGlob: true)]);
 
-        // Total failure: nothing matched — should be a hard error
-        bool totalFailure = SelectOutput.WriteUnresolved(result);
+        // Total failure: nothing matched — should be a hard error.
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SelectOutput.WriteUnresolved(result) ? 1 : 0));
 
-        Assert.True(totalFailure);
+        Assert.Equal(1, exit);
+        Assert.Contains("Error: No sections match 'Source*'.", error);
+        Assert.Contains("Available sections:", error);
     }
 }


### PR DESCRIPTION
Diagnoses and fixes the CI flake that hit PR #396 and #408 (\`Member_NonMethodRows_RenderFullDeclarations\` failing with \`Assert.Empty(error)\` on stderr \`Error: No sections match 'Source*'.\`).

## Root cause — not PDB acquisition

The string \`Source*\` appears nowhere in product code and in none of the member-command test arguments. It comes from a different test entirely: \`SelectResolverTests.WriteUnresolved_TotalFailure_ReturnsTrue\` constructs a \`SelectMiss("Source*", ...)\` and calls \`SelectOutput.WriteUnresolved\`, which writes directly to \`Console.Error\`.

\`SelectResolverTests\` was not in the \`"Console"\` xunit collection, so it runs in parallel with the console-capturing tests. \`Console.SetError\` is process-global — when the parallel write fires while another test's \`ConsoleCapture\` is active, the message lands in that test's captured stderr. Which victim test fails is pure timing, which is why it only showed on slow/cold CI runners and always passed on re-run.

## Fix

- \`SelectResolverTests\` joins the \`"Console"\` collection
- The two \`WriteUnresolved\` tests run under \`ConsoleCapture\`, which both prevents the leak structurally and upgrades them to assert the rendered message (\`Warning:\`/\`Error: No sections match 'Source*'.\`, \`Available sections:\`) instead of only the return value

CLI suite green (953).

🤖 Generated with [Claude Code](https://claude.com/claude-code)