### PR TITLE
Decompiler: absorb arm-only fallthrough code into if/else arms

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -139,6 +139,29 @@ public class CSharpEmitterTests
         }
     }
 
+    [Fact]
+    public void CoreLib_AbsShort_NestsOutOfLineThrowInsideGuard()
+    {
+        // The throw helper call is only reachable from inside the outer
+        // if-arm (via the inner guard's fallthrough), so it must render
+        // inside the braces — at top level the negative-path code would
+        // appear reachable from the non-negative path.
+        string output = EmitCoreLibMethod("System.Math", "Abs", overloadIndex: 0);
+
+        Assert.Contains("    Math.ThrowNegateTwosCompOverflow();", output);
+    }
+
+    [Fact]
+    public void CoreLib_ListClear_GuardsArrayClearInsideThenArm()
+    {
+        // Array.Clear is only reachable from the IsReferenceOrContains-
+        // References arm; rendered at top level, the else path (which jumps
+        // straight to the return) would appear to flow into it.
+        string output = EmitCoreLibMethod("System.Collections.Generic.List`1", "Clear");
+
+        Assert.Contains("    Array.Clear", output);
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
+++ b/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
@@ -300,6 +300,71 @@ public sealed class StructuredControlFlow
             }
         }
 
+        // Predecessor counts (distinct edges) for arm-chain absorption.
+        var predCounts = new int[cfg.BasicBlocks.Count];
+        foreach (var bb in cfg.BasicBlocks)
+        {
+            var succs = new HashSet<int>();
+            if (bb.BranchTarget is not null) succs.Add(cfg.IndexOf(bb.BranchTarget));
+            if (bb.FallthroughTarget is not null) succs.Add(cfg.IndexOf(bb.FallthroughTarget));
+            if (bb.SwitchCaseTargets is not null)
+                foreach (var t in bb.SwitchCaseTargets) succs.Add(cfg.IndexOf(t));
+            foreach (int sIdx in succs)
+                if (sIdx >= 0) predCounts[sIdx]++;
+        }
+
+        // An if/else arm is the arm head plus its single-predecessor
+        // fallthrough chain: blocks only reachable from inside the arm (e.g.
+        // the continuation after an inverted guard) must render inside the
+        // arm's braces — emitted at top level, the OTHER arm's fallthrough
+        // would appear to flow into them.
+        StructuredBlock BuildArm(int headIndex)
+        {
+            if (headIndex >= 0)
+                processed.Add(headIndex);
+
+            List<int> chain = [headIndex];
+            int cur = headIndex;
+            while (cur >= 0)
+            {
+                var ft = cfg.BasicBlocks[cur].FallthroughTarget;
+                int next = ft is null ? -1 : cfg.IndexOf(ft);
+                if (next < 0 || processed.Contains(next)
+                    || predCounts[next] != 1
+                    || loopHeaders.ContainsKey(next) || blockToLoop.ContainsKey(next)
+                    || inExceptionRegion.ContainsKey(next)
+                    || switchBlocks.ContainsKey(next)
+                    || conditionBlocks.ContainsKey(next))
+                {
+                    break;
+                }
+                chain.Add(next);
+                processed.Add(next);
+                cur = next;
+            }
+
+            if (chain.Count == 1)
+            {
+                return new StructuredBlock
+                {
+                    Kind = StructuredBlockKind.BasicBlock,
+                    BlockIndex = headIndex,
+                    Label = $"Block_{headIndex}"
+                };
+            }
+
+            return new StructuredBlock
+            {
+                Kind = StructuredBlockKind.Sequence,
+                Children = chain.Select(idx => new StructuredBlock
+                {
+                    Kind = StructuredBlockKind.BasicBlock,
+                    BlockIndex = idx,
+                    Label = $"Block_{idx}"
+                }).ToList()
+            };
+        }
+
         for (int i = 0; i < cfg.BasicBlocks.Count; i++)
         {
             if (processed.Contains(i)) continue;
@@ -509,29 +574,13 @@ public sealed class StructuredControlFlow
 
             if (conditionBlocks.TryGetValue(i, out var cond))
             {
-                var thenBlock = new StructuredBlock
-                {
-                    Kind = StructuredBlockKind.BasicBlock,
-                    BlockIndex = cond.ThenIndex,
-                    Label = $"Block_{cond.ThenIndex}"
-                };
-                processed.Add(cond.ThenIndex);
-
-                StructuredBlock? elseBlock = null;
-                if (cond.ElseIndex >= 0)
-                {
-                    elseBlock = new StructuredBlock
-                    {
-                        Kind = StructuredBlockKind.BasicBlock,
-                        BlockIndex = cond.ElseIndex,
-                        Label = $"Block_{cond.ElseIndex}"
-                    };
-                    processed.Add(cond.ElseIndex);
-                }
-
                 processed.Add(i);
                 foreach (var term in cond.ChainTerms)
                     processed.Add(term.BlockIndex);
+
+                var thenBlock = BuildArm(cond.ThenIndex);
+                StructuredBlock? elseBlock = cond.ElseIndex >= 0 ? BuildArm(cond.ElseIndex) : null;
+
                 children.Add(new StructuredBlock
                 {
                     Kind = StructuredBlockKind.IfThenElse,


### PR DESCRIPTION
Gap #3 from the h2h doc (#406) — and it turned out to be a correctness bug, not just cosmetics.

## The bug

Structuring built every if/else arm as a single basic block. A continuation reachable only from inside the arm — the classic inverted-guard shape — was emitted at top level after the conditional, where the other arm appears to fall into it. \`List<T>.Clear\`:

```csharp
// before — else path appears to flow into Array.Clear (it must not)
if (RuntimeHelpers.IsReferenceOrContainsReferences())
{
    V_0 = this._size;
    this._size = 0;
    if (V_0 <= 0) goto IL_003C;
}
else
{
    this._size = 0;
}
Array.Clear(this._items, 0, V_0);
return;
IL_003C:
return;

// after — matches the source structure
if (RuntimeHelpers.IsReferenceOrContainsReferences())
{
    V_0 = this._size;
    this._size = 0;
    if (V_0 <= 0) goto IL_003C;
    Array.Clear(this._items, 0, V_0);
    return;
}
this._size = 0;
IL_003C:
return;
```

\`Math.Abs(short)\` similarly now nests its out-of-line throw inside the guard.

## The fix

\`BuildStructuredTree\` extends each arm head with its fallthrough chain while the next block has exactly one predecessor and isn't owned by another construct (loop, switch, exception region, conditional head, already processed). Multi-block arms become \`Sequence\` nodes — every emitter pattern already guards on \`BlockIndex >= 0\`, so ternary/null-coalescing/lock detection simply skips them. Standard diamonds are untouched (their arms end in \`br\`, no fallthrough to absorb).

Full h2h corpus diff shows exactly the intended changes plus one bonus: \`Dictionary.ContainsValue\`'s null-path loop now renders \`for (V_1 = 0; ...)\` with its init absorbed.

Tests pin the nesting via CoreLib \`Math.Abs(short)\` and \`List<T>.Clear\`. All four suites green (decompiler 242, CLI 953, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)