### PR TITLE
Decompiler: conditional returns instead of goto-to-return; demand-driven labels

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -149,6 +149,9 @@ public class CSharpEmitterTests
         string output = EmitCoreLibMethod("System.Math", "Abs", overloadIndex: 0);
 
         Assert.Contains("    Math.ThrowNegateTwosCompOverflow();", output);
+        // The inner guard's branch-to-return renders as a conditional return.
+        Assert.Contains("if (value >= 0) return value;", output);
+        Assert.DoesNotContain("goto", output);
     }
 
     [Fact]
@@ -160,6 +163,8 @@ public class CSharpEmitterTests
         string output = EmitCoreLibMethod("System.Collections.Generic.List`1", "Clear");
 
         Assert.Contains("    Array.Clear", output);
+        Assert.Contains("if (V_0 <= 0) return;", output);
+        Assert.DoesNotContain("goto", output);
     }
 
     // --- Generic ldelem (type-parameter element access) ---

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1492,17 +1492,16 @@ public static class CSharpEmitter
             // but still need to appear at method end for other paths.
             EnsureTrailingReturn();
 
-            FixupDanglingGotoLabels();
+            FixupGotoLabels();
         }
 
         /// <summary>
-        /// Inserts labels for gotos that rendered while their target's label was
-        /// suppressed. Structuring suppresses then/else/follow labels assuming
-        /// every branch to them is absorbed; any branch that still fell back to
-        /// a textual goto would otherwise dangle. Insertions run back-to-front
-        /// so earlier recorded positions stay valid.
+        /// Inserts a label at each recorded block position that an emitted
+        /// textual goto references. Labels are demand-driven: a label appears
+        /// in the output if and only if a goto names it. Insertions run
+        /// back-to-front so earlier recorded positions stay valid.
         /// </summary>
-        void FixupDanglingGotoLabels()
+        void FixupGotoLabels()
         {
             List<(int Pos, string Label)>? pending = null;
             foreach (string target in _emittedGotos)
@@ -1537,13 +1536,14 @@ public static class CSharpEmitter
                 n is ILAstStatement { Expression.OpCode: ILOpCode.Ret });
             if (!hasReturn) return;
 
-            // If this block is a return-only block and all gotos to it were inlined,
-            // its label is no longer needed — skip the trailing return
+            // If this block is a return-only block no rendered goto references
+            // (every branch to it was structured away or inlined), it has
+            // already been represented — skip the trailing return
             if (lastBlock.Nodes.Count == 1
                 && _blockStartOffset.TryGetValue(lastBlockIdx, out int offset))
             {
                 string label = $"IL_{offset:X4}";
-                if (!_emittedLabels.Contains(label))
+                if (!_emittedGotos.Contains(label))
                     return;
             }
 
@@ -4310,6 +4310,50 @@ public static class CSharpEmitter
         }
 
         /// <summary>
+        /// Renders a conditional branch whose target contains only a return as
+        /// <c>if (cond) return ...;</c>. The target block itself still emits
+        /// normally for paths that reach it by fallthrough.
+        /// </summary>
+        bool TryEmitConditionalReturn(ILAstExpression branchExpr, string targetLabel, int indent)
+        {
+            if (FindReturnOnlyBlock(targetLabel) is not { } retExpr)
+                return false;
+
+            WriteIndent(indent);
+            _sb.Append("if (");
+            EmitBranchCondition(branchExpr);
+            _sb.Append(") ");
+            if (retExpr.Arguments.Count > 0)
+            {
+                _sb.Append("return ");
+                bool wasBool = _emitBoolContext;
+                if (_returnsBool)
+                    _emitBoolContext = true;
+                EmitExpression(retExpr.Arguments[0], _returnTypeName);
+                _emitBoolContext = wasBool;
+                _sb.AppendLine(";");
+            }
+            else
+            {
+                _sb.AppendLine("return;");
+            }
+            return true;
+        }
+
+        ILAstExpression? FindReturnOnlyBlock(string targetLabel)
+        {
+            foreach (var (blockIdx, offset) in _blockStartOffset)
+            {
+                if ($"IL_{offset:X4}" != targetLabel) continue;
+                if (!_blockMap.TryGetValue(blockIdx, out var targetBlock)) return null;
+                if (targetBlock.Nodes.Count != 1) return null;
+                if (targetBlock.Nodes[0] is not ILAstStatement { Expression: var retExpr }) return null;
+                return retExpr.OpCode == ILOpCode.Ret ? retExpr : null;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// If the goto target is a block containing only a return statement,
         /// emit the return directly and return true. Otherwise return false.
         /// </summary>
@@ -5404,6 +5448,10 @@ public static class CSharpEmitter
                     // Conditional branches — when not consumed by structuring
                     // Try guard clause pattern: if (cond) goto TARGET; body → if (negated) { body; }
                     if (expr.Operand is string condTarget && TryEmitGuardClause(expr, condTarget, indent))
+                        break;
+                    // Branch to a return-only block: render the return under
+                    // the condition — no goto, no label needed.
+                    if (expr.Operand is string condRet && TryEmitConditionalReturn(expr, condRet, indent))
                         break;
                     WriteIndent(indent);
                     _sb.Append($"if (");
@@ -7296,17 +7344,12 @@ public static class CSharpEmitter
             if (_blockStartOffset.TryGetValue(blockIndex, out int startOffset))
             {
                 string label = $"IL_{startOffset:X4}";
-                // Wherever a label is withheld, remember the spot: structuring
-                // marks labels consumed on the ASSUMPTION every branch to them
-                // is structured away, but a stray branch can still render as a
-                // goto — FixupDanglingGotoLabels repairs those at the end.
-                if (!_emittedLabels.Contains(label))
-                    _suppressedLabelPositions.TryAdd(label, _sb.Length);
-                // Suppress labels consumed by while-loop conditions or loop headers
-                if (_loopConsumedLabels.Contains(label) || _loopHeaderLabels.Contains(label))
-                    return;
-                if (_gotoTargets.Contains(label) && _emittedLabels.Add(label))
-                    _sb.AppendLine($"{label}:");
+                // Labels are lazy: record where this one WOULD go and let
+                // FixupGotoLabels insert it only if a textual goto actually
+                // references it. Eager printing can't know that — structuring
+                // absorbs most branch references, and patterns (inlined
+                // returns, guard clauses) absorb more during emission.
+                _suppressedLabelPositions.TryAdd(label, _sb.Length);
             }
         }
 


### PR DESCRIPTION
Follow-up to #410, closing the inner-guard item: \`List<T>.Clear\` and \`Math.Abs(short)\` are now goto-free and match the source structure.

```csharp
// Math.Abs(short) — before          // after
if (value < 0)                       if (value < 0)
{                                    {
    value = (short)-value;               value = (short)-value;
    if (value >= 0) goto IL_0012;        if (value >= 0) return value;
    Math.ThrowNegateTwosCompOverflow();  Math.ThrowNegateTwosCompOverflow();
}                                    }
IL_0012:                             return value;
return value;
```

Two mechanisms:

1. **Conditional branch to a return-only block → \`if (cond) return ...;\`** — same return-argument handling as the existing unconditional inline-return (bool context, return type). The target block still renders for fallthrough paths, so shared returns stay intact.

2. **Demand-driven labels.** Eagerly printing labels from the pre-computed goto-target set left strays, because most branch references don't survive emission (structuring absorbs them; guard clauses and inlined returns absorb more). #407 already recorded every would-be label position and tracked every emitted goto for the dangling case — this flips the default: \`FixupGotoLabels\` inserts a label iff a textual goto names it. A label now appears in output exactly when something references it.

Full h2h corpus diff shows only the two intended rewrites (gotos → conditional returns, their labels gone); \`Dictionary.ContainsValue\`'s loop goto and label are untouched. All four suites green (decompiler 242, CLI 953, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)