### PR TITLE
Decompiler: fix typeof, struct-element field access, and generic naming artifacts

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -167,6 +167,39 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("goto", output);
     }
 
+    [Fact]
+    public void IsValueTypeOf_CollapsesGetTypeFromHandle()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.IsValueTypeOf));
+
+        Assert.Contains("typeof(T).IsValueType", output);
+        Assert.DoesNotContain("GetTypeFromHandle", output);
+    }
+
+    [Fact]
+    public void FirstA_RendersStructElementFieldWithoutRef()
+    {
+        // ldelema exists only because the element is a struct accessed in
+        // place; the C# spelling is pairs[0].A.
+        string output = EmitMethod(nameof(CfgSampleClass.FirstA));
+
+        Assert.Contains("pairs[0].A", output);
+        Assert.DoesNotContain("ref pairs", output);
+    }
+
+    [Fact]
+    public void CoreLib_DictionaryContainsValue_NamesCallerGenericParameters()
+    {
+        // The EqualityComparer<!1> TypeSpec's !1 is Dictionary's TValue;
+        // decoded without the caller's generic context it falls back to T1.
+        string output = EmitCoreLibMethod("System.Collections.Generic.Dictionary`2", "ContainsValue");
+
+        Assert.Contains("EqualityComparer<TValue>.Default", output);
+        Assert.Contains("typeof(TValue).IsValueType", output);
+        Assert.DoesNotContain("T1", output);
+        Assert.DoesNotContain("ref V_0", output);
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -297,6 +297,12 @@ public class CfgSampleClass
 
     public static T GetAt<T>(T[] array, int index) => array[index];
 
+    public static bool IsValueTypeOf<T>() => typeof(T).IsValueType;
+
+    public struct Pair { public int A; public int B; }
+
+    public static int FirstA(Pair[] pairs) => pairs[0].A;
+
     public static ulong MaxULong(ulong a, ulong b)
     {
         if (a >= b)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -5763,7 +5763,7 @@ public static class CSharpEmitter
                 case ILOpCode.Ldfld:
                     if (expr.Arguments.Count > 0)
                     {
-                        EmitExpression(expr.Arguments[0]);
+                        EmitFieldReceiver(expr.Arguments[0]);
                         _sb.Append('.');
                     }
                     _sb.Append(ExtractMemberName(expr.Operand));
@@ -5852,7 +5852,7 @@ public static class CSharpEmitter
                 case ILOpCode.Ldflda:
                     if (expr.Arguments.Count > 0)
                     {
-                        EmitExpression(expr.Arguments[0]);
+                        EmitFieldReceiver(expr.Arguments[0]);
                         _sb.Append('.');
                     }
                     _sb.Append(ExtractMemberName(expr.Operand));
@@ -6148,7 +6148,7 @@ public static class CSharpEmitter
                 case ILOpCode.Ldflda:
                     if (expr.Arguments.Count > 0)
                     {
-                        EmitExpression(expr.Arguments[0]);
+                        EmitFieldReceiver(expr.Arguments[0]);
                         _sb.Append('.');
                     }
                     _sb.Append(ExtractMemberName(expr.Operand));
@@ -6213,7 +6213,7 @@ public static class CSharpEmitter
                 case ILOpCode.Ldflda:
                     if (expr.Arguments.Count > 0)
                     {
-                        EmitExpression(expr.Arguments[0]);
+                        EmitFieldReceiver(expr.Arguments[0]);
                         _sb.Append('.');
                     }
                     _sb.Append(ExtractMemberName(expr.Operand));
@@ -6278,6 +6278,25 @@ public static class CSharpEmitter
         bool IsRuntimeAwaitExpression(ILAstExpression expr)
             => IsRuntimeAwaitCall(expr) || IsRuntimeCustomAwaitGetResultCall(expr);
 
+        /// <summary>
+        /// Renders a field-access receiver. A receiver that is an element
+        /// ADDRESS (ldelema) renders as plain element access — the IL takes
+        /// the address only because the element is a struct accessed in
+        /// place; C# spells that arr[i].field, not ref arr[i].field.
+        /// </summary>
+        void EmitFieldReceiver(ILAstExpression receiver)
+        {
+            if (receiver.OpCode == ILOpCode.Ldelema && receiver.Arguments.Count >= 2)
+            {
+                EmitExpression(receiver.Arguments[0]);
+                _sb.Append('[');
+                EmitExpression(receiver.Arguments[1]);
+                _sb.Append(']');
+                return;
+            }
+            EmitExpression(receiver);
+        }
+
         void EmitCallExpression(ILAstExpression expr)
         {
             string? methodName = expr.Operand;
@@ -6322,6 +6341,18 @@ public static class CSharpEmitter
             }
 
             memberPart = SimplifyLocalFunctionName(memberPart);
+
+            // ldtoken T; call Type.GetTypeFromHandle — the typeof(T) idiom.
+            // The ldtoken argument already renders as typeof(T); the wrapper
+            // call is lowering noise.
+            if (memberPart is "GetTypeFromHandle"
+                && typePart is "System.Type" or "Type"
+                && expr.Arguments.Count == 1
+                && expr.Arguments[0].OpCode == ILOpCode.Ldtoken)
+            {
+                EmitExpression(expr.Arguments[0]);
+                return;
+            }
 
             if (TryEmitInlineArrayAsSpanExpression(expr, memberPart))
                 return;

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -829,7 +829,7 @@ public static class ILAstBuilder
                 case HandleKind.MemberReference:
                 {
                     var memberRef = reader.GetMemberReference((MemberReferenceHandle)handle);
-                    var genericCtx = StackSimulator.BuildGenericContextForMemberRef(reader, memberRef);
+                    var genericCtx = StackSimulator.BuildGenericContextForMemberRef(reader, memberRef, callerGenericContext);
                     // Merge caller's method params for !!N resolution in TypeSpec parents
                     if (callerGenericContext?.MethodParameters.Count > 0 && genericCtx is not null
                         && genericCtx.MethodParameters.Count == 0)
@@ -846,7 +846,10 @@ public static class ILAstBuilder
                     parameterModifiers = GetDefaultParameterModifiers(parameterTypes);
                     isStatic = !sig.Header.IsInstance;
                     returnType = sig.ReturnType;
-                    methodName = ResolveMethodRefName(reader, memberRef, genericCtx);
+                    // The NAME's parent TypeSpec decodes in the caller's context
+                    // (its !N are the caller's type params); the SIGNATURE above
+                    // decodes in the instantiation context built from it.
+                    methodName = ResolveMethodRefName(reader, memberRef, callerGenericContext);
                     break;
                 }
 

--- a/src/DotnetInspector.Decompiler/StackSimulator.cs
+++ b/src/DotnetInspector.Decompiler/StackSimulator.cs
@@ -850,15 +850,19 @@ internal static class StackSimulator
     /// <summary>
     /// Build a GenericContext from a MemberReference's parent type (if it's a generic instantiation).
     /// </summary>
-    internal static Metadata.GenericContext? BuildGenericContextForMemberRef(MetadataReader reader, MemberReference memberRef)
+    internal static Metadata.GenericContext? BuildGenericContextForMemberRef(MetadataReader reader, MemberReference memberRef,
+        Metadata.GenericContext? callerContext = null)
     {
         try
         {
             if (memberRef.Parent.Kind == HandleKind.TypeSpecification)
             {
                 var typeSpec = reader.GetTypeSpecification((TypeSpecificationHandle)memberRef.Parent);
-                // Decode the parent type to get type arguments embedded in the name
-                var parentType = typeSpec.DecodeSignature(Metadata.SignatureDecoder.Instance, genericContext: null);
+                // Decode the parent type to get type arguments embedded in the name.
+                // !N inside the TypeSpec refer to the CALLER's enclosing generic
+                // parameters — without that context they decode to fallback names
+                // (EqualityComparer<T1> instead of EqualityComparer<TValue>).
+                var parentType = typeSpec.DecodeSignature(Metadata.SignatureDecoder.Instance, callerContext);
                 // Extract type arguments from the generic instantiation name like "Dict<string, Logger>"
                 var typeArgs = ExtractGenericArguments(parentType);
                 if (typeArgs.Count > 0)


### PR DESCRIPTION
The expression-level artifacts from the h2h doc's \`Dictionary<K,V>.ContainsValue\` entry — three independent fixes:

| Before | After |
| --- | --- |
| \`Type.GetTypeFromHandle(typeof(TValue)).IsValueType\` | \`typeof(TValue).IsValueType\` |
| \`if (ref V_0[V_2].next >= -1)\` | \`if (V_0[V_2].next >= -1)\` |
| \`EqualityComparer<T1>.Default.Equals(ref V_0[V_2].value, value)\` | \`EqualityComparer<TValue>.Default.Equals(V_0[V_2].value, value)\` |

1. **typeof collapse** — \`ldtoken T; call Type.GetTypeFromHandle\` is the \`typeof\` idiom; the \`ldtoken\` argument already renders as \`typeof(T)\`, so the wrapper call is lowering noise.

2. **Struct element field access** — \`ldfld\`/\`ldflda\` through \`ldelema\` rendered the receiver's \`ref\` prefix, which isn't valid C# in that position. The IL takes the element's address only because the element is a struct accessed in place; \`EmitFieldReceiver\` renders plain \`arr[i].field\`.

3. **Caller generic parameter names** — a MemberRef parent TypeSpec's \`!N\` tokens refer to the *caller's* enclosing generic parameters, but \`BuildGenericContextForMemberRef\` decoded the TypeSpec with a null context, so \`EqualityComparer\`1<!1>\` fell back to \`T1\`. The caller's \`GenericContext\` now threads through: the parent TypeSpec decodes in caller context (yielding the rendered name), and the member signature decodes in the instantiation context built from it.

Full h2h corpus diff confirms every change is confined to \`ContainsValue\`. New fixtures (\`IsValueTypeOf<T>\`, struct \`Pair\` element access) plus a CoreLib \`ContainsValue\` test pin all three. All four suites green (decompiler 245, CLI 953, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)