### PR TITLE
Retire ilspycmd test/CI dependency; keep ILSpy as an h2h analysis reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,6 @@ jobs:
       - name: Build
         run: dotnet build src/dotnet-inspect -c Release
 
-      - name: Install ilspycmd
-        run: dotnet tool install -g ilspycmd --allow-roll-forward
-
       - name: Install ilasm/ildasm
         continue-on-error: true
         shell: bash

--- a/docs/decompiler-h2h-comparison.md
+++ b/docs/decompiler-h2h-comparison.md
@@ -4,6 +4,8 @@ Comparison of `dotnet-inspect` decompiler output against the actual C# source fr
 
 Snapshot: June 2026. Previous snapshot graded a **B** average; the gap items it listed (field compound assignment, `&&`/`||` reconstruction, `goto`-to-`continue`, `ref` arguments, bool return context) have all since been closed.
 
+Methodology note: grades compare against the original dotnet/runtime source. When refreshing this document, [ilspycmd](https://www.nuget.org/packages/ilspycmd) (`dotnet tool install -g ilspycmd`) is a useful second reference — decompiling the same methods with a mature decompiler distinguishes "information lost in compilation" (ILSpy can't recover it either) from "gap in our pipeline" (ILSpy renders it, we don't). It is an analysis aid only; no test or CI infrastructure depends on it.
+
 ---
 
 ## Exact and Near-Exact Matches

--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -1,86 +1,22 @@
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Text.RegularExpressions;
 using DotnetInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
 /// <summary>
-/// Head-to-head comparison tests that validate our IL disassembler output
-/// against ILSpy (ilspycmd) and ILAsm (ilasm) reference tools.
-/// Test cases are generated conditionally — ILAsm cases only appear on Windows
-/// where the tools are available. No traits or skip logic needed.
+/// Round-trip tests that validate our IL disassembler output against the
+/// native ILAsm/ILDasm reference tools: disassemble, reassemble, and compare.
+/// Tests skip when the tools are not installed.
 /// </summary>
-public partial class ILDisassemblerComparisonTests
+public class ILDisassemblerComparisonTests
 {
     static readonly string CoreDll = FindAssembly("DotnetInspector.Core.dll");
     static readonly string MetadataDll = FindAssembly("DotnetInspector.Metadata.dll");
     static readonly string TestDll = typeof(ILDisassemblerComparisonTests).Assembly.Location;
 
-    static readonly bool HasILSpyCmd = CanRunILSpyCmd();
     static readonly bool HasILAsm = CanRunILAsm();
-
-    // --- ILSpy: instruction-level comparison ---
-
-    [Theory]
-    [MemberData(nameof(ILSpyMethodCases))]
-    public void ILSpy_InstructionsMatch(string assembly, string typeName, string methodName)
-    {
-        Assert.SkipUnless(HasILSpyCmd, "ilspycmd not found — install with: dotnet tool install -g ilspycmd --allow-roll-forward");
-
-        var assemblyPath = ResolveAssembly(assembly);
-        var ilspyMethods = ParseILSpyTypeOutput(assemblyPath, typeName);
-        Assert.True(
-            ilspyMethods.TryGetValue(methodName, out var ilspyInstructions),
-            $"ILSpy did not produce output for {typeName}.{methodName}. " +
-            $"Available: {string.Join(", ", ilspyMethods.Keys)}");
-
-        using var stream = File.OpenRead(assemblyPath);
-        using var peReader = new PEReader(stream);
-        var ours = ILDisassembler.DisassembleMethod(peReader, typeName, methodName);
-        Assert.NotNull(ours);
-
-        Assert.Equal(ilspyInstructions.Count, ours.Count);
-
-        for (int i = 0; i < ours.Count; i++)
-        {
-            Assert.Equal(ilspyInstructions[i].Offset, ours[i].Offset);
-            Assert.Equal(ilspyInstructions[i].OpCode, ours[i].OpCodeName);
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(ILSpyTypeCases))]
-    public void ILSpy_AllMethodInstructionCountsMatch(string assembly, string typeName)
-    {
-        Assert.SkipUnless(HasILSpyCmd, "ilspycmd not found — install with: dotnet tool install -g ilspycmd --allow-roll-forward");
-
-        var assemblyPath = ResolveAssembly(assembly);
-
-        using var stream = File.OpenRead(assemblyPath);
-        using var peReader = new PEReader(stream);
-
-        var ilspyMethods = ParseILSpyTypeOutput(assemblyPath, typeName);
-        Assert.NotEmpty(ilspyMethods);
-
-        // ILSpy disagrees on trivial expression-bodied methods
-        HashSet<string> knownMismatches = ["Add"];
-        List<string> mismatches = [];
-
-        foreach (var (methodName, ilspyInstructions) in ilspyMethods)
-        {
-            var ours = ILDisassembler.DisassembleMethod(peReader, typeName, methodName);
-            if (ours is null || knownMismatches.Contains(methodName))
-                continue;
-
-            if (ours.Count != ilspyInstructions.Count)
-                mismatches.Add($"{methodName}: ours={ours.Count}, ILSpy={ilspyInstructions.Count}");
-        }
-
-        Assert.True(mismatches.Count == 0,
-            $"Instruction count mismatches:\n{string.Join("\n", mismatches)}");
-    }
 
     // --- ILAsm: roundtrip validation ---
 
@@ -141,41 +77,6 @@ public partial class ILDisassemblerComparisonTests
 
     // --- Test case data (conditional on tool availability) ---
 
-    /// <summary>Methods to compare instruction-by-instruction against ILSpy.</summary>
-    public static IEnumerable<object[]> ILSpyMethodCases()
-    {
-        yield return ["Core", "DotnetInspector.Core.CoreCache", "Initialize"];
-        yield return ["Core", "DotnetInspector.Core.CoreCache", "GetBasePath"];
-        yield return ["Core", "DotnetInspector.Core.CoreCache", "GetDirectorySize"];
-        // Add omitted: ILSpy disagrees on instruction count for trivial expression-bodied methods
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "Classify"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "CreateList"];
-        // Edge cases: switch, try/catch, generics, constants, 2-byte opcodes
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "SwitchCase"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "TryCatch"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "TryFinally"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "LongConstant"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "CompareEquals"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "ManyLocals"];
-        // More edge cases: arrays, checked math, exceptions, tokens, delegates
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "ArrayOps"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "CheckedArithmetic"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "NestedExceptionHandlers"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "MultipleCatch"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "ThrowAndRethrow"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "GetTypeToken"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "GetDelegate"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "InterfaceCall"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "ConvertTypes"];
-    }
-
-    /// <summary>Types to compare all method instruction counts against ILSpy.</summary>
-    public static IEnumerable<object[]> ILSpyTypeCases()
-    {
-        yield return ["Core", "DotnetInspector.Core.CoreCache"];
-        yield return ["Test", "DotnetInspector.Tests.ILSampleClass"];
-    }
-
     /// <summary>Assemblies for ILAsm roundtrip validation.</summary>
     public static IEnumerable<object[]> ILAsmAssemblyCases()
     {
@@ -193,106 +94,7 @@ public partial class ILDisassemblerComparisonTests
         yield return ["Test", "DotnetInspector.Tests.ILSampleClass", "CompareEquals"];
     }
 
-    // --- ILSpy output parsing ---
-
-    /// <summary>
-    /// Runs ilspycmd and parses IL instructions per method from its output.
-    /// Returns a dictionary of method name → list of parsed instructions.
-    /// </summary>
-    static Dictionary<string, List<ILSpyInstruction>> ParseILSpyTypeOutput(
-        string assemblyPath, string typeName)
-    {
-        var output = RunILSpyCmd(assemblyPath, typeName);
-        Dictionary<string, List<ILSpyInstruction>> methods = [];
-
-        string? currentMethod = null;
-        List<ILSpyInstruction>? currentInstructions = null;
-
-        foreach (var rawLine in output.Split('\n'))
-        {
-            var line = rawLine.TrimEnd('\r');
-            var trimmed = line.Trim();
-
-            // Detect method start: ".method" directive resets state
-            if (trimmed.StartsWith(".method", StringComparison.Ordinal))
-            {
-                currentMethod = null;
-                currentInstructions = null;
-                continue;
-            }
-
-            // Match method name line like "void Initialize (" or "int32 Add ("
-            if (currentMethod is null && currentInstructions is null)
-            {
-                var nameMatch = MethodNamePattern().Match(trimmed);
-                if (nameMatch.Success)
-                {
-                    currentMethod = nameMatch.Groups[1].Value;
-                    currentInstructions = [];
-                    continue;
-                }
-            }
-
-            // IL instruction lines: "IL_XXXX: opcode ..."
-            if (currentInstructions is not null)
-            {
-                var ilMatch = ILInstructionPattern().Match(trimmed);
-                if (ilMatch.Success)
-                {
-                    int offset = int.Parse(ilMatch.Groups[1].Value, System.Globalization.NumberStyles.HexNumber);
-                    string opcode = ilMatch.Groups[2].Value;
-                    currentInstructions.Add(new ILSpyInstruction(offset, opcode));
-                    continue;
-                }
-
-                if (trimmed.StartsWith("} // end of method", StringComparison.Ordinal))
-                {
-                    if (currentMethod is not null && currentInstructions.Count > 0)
-                        methods.TryAdd(currentMethod, currentInstructions);
-                    currentMethod = null;
-                    currentInstructions = null;
-                }
-            }
-        }
-
-        return methods;
-    }
-
-    record ILSpyInstruction(int Offset, string OpCode);
-
-    [GeneratedRegex(@"^IL_([0-9a-fA-F]{4}):\s+(\S+)")]
-    private static partial Regex ILInstructionPattern();
-
-    [GeneratedRegex(@"(\w[\w.]*)\s*\(")]
-    private static partial Regex MethodNamePattern();
-
     // --- Tool execution ---
-
-    static string RunILSpyCmd(string assemblyPath, string typeName)
-    {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "ilspycmd",
-            ArgumentList = { "-il", "-t", typeName, assemblyPath },
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        psi.Environment["DOTNET_ROLL_FORWARD"] = "LatestMajor";
-
-        using var process = Process.Start(psi)!;
-        string output = process.StandardOutput.ReadToEnd();
-        process.WaitForExit(TimeSpan.FromSeconds(30));
-
-        if (process.ExitCode != 0)
-        {
-            string stderr = process.StandardError.ReadToEnd();
-            throw new InvalidOperationException(
-                $"ilspycmd exited with code {process.ExitCode}: {stderr}");
-        }
-
-        return output;
-    }
 
     static string RunILDasm(string assemblyPath, string outputPath)
     {
@@ -388,31 +190,6 @@ public partial class ILDisassemblerComparisonTests
     {
         var testDir = Path.GetDirectoryName(typeof(ILDisassemblerComparisonTests).Assembly.Location)!;
         return Path.Combine(testDir, name);
-    }
-
-    static bool CanRunILSpyCmd()
-    {
-        try
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "ilspycmd",
-                ArgumentList = { "--version" },
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            };
-            psi.Environment["DOTNET_ROLL_FORWARD"] = "LatestMajor";
-
-            using var process = Process.Start(psi);
-            if (process is null) return false;
-            process.WaitForExit(TimeSpan.FromSeconds(10));
-            return process.ExitCode == 0;
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     static bool CanRunILAsm()


### PR DESCRIPTION
Retires the ilspycmd differential tests and the CI install step, per the plan from the ILAssembler vendoring track.

## Why

- **Redundant oracle**: the ILSpy comparison tests validated the IL disassembler by matching another disassembler's text. Since the round-trip baseline landed, the disassembler is verified the stronger way — disassemble → reassemble (native ilasm) → compare opcodes/offsets. Those round-trip tests are untouched.
- **CI liability**: the install step was not \`continue-on-error\` (a NuGet hiccup failed the whole test job) and used \`--allow-roll-forward\` unpinned (an upstream ilspycmd release could change output format and break CI with no commit on our side).

## What changed

- \`ci.yml\`: drop the \`Install ilspycmd\` step
- \`ILDisassemblerComparisonTests\`: remove the two ILSpy theories, the ilspycmd output parser, and runner plumbing; the ILAsm round-trip tests and helpers remain (still skip-if-absent)
- \`docs/decompiler-h2h-comparison.md\`: methodology note recording ILSpy's new role — a local second reference when writing h2h analysis docs, useful for distinguishing "information lost in compilation" (ILSpy can't recover it either) from "gap in our pipeline" (ILSpy renders it, we don't). No test or CI infrastructure depends on it.

CLI suite green (939; the delta from 953 is the removed ILSpy theories). markdownlint passes on the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)