### PR TITLE
Bump dotnet-inspect to 0.10.3

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.10.2
+version: 0.10.3
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.2</VersionPrefix>
+    <VersionPrefix>0.10.3</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v0.10.3
+
+### Library integrations
+
+- Adds library integration discovery for AI, Aspire, Dependency Injection, Logging, Options, Hosting, Health Checks, HTTP Client, and OpenTelemetry.
+- Adds `package <id> --library` to inspect the primary DLL in a package when it is unambiguous.
+- Adds section categories such as `@Integrations` so agents can discover or render related library sections together.
+- Refines focused integration sections to show package-owned starter APIs and user-facing support types instead of raw referenced assemblies.
+- Adds OpenTelemetry telemetry-control rows for public `DisableTracing` and `DisableMetrics` APIs.
+- Adds HTTP Client sub-kinds such as HTTP Logging, HTTP Latency, and HTTP Diagnostics.
+
+### Decompiled source
+
+- Improves lowered C# rendering for loops, conditional returns, generic element loads, operator sugar, lambdas, local functions, enum cases, and compound assignments.
+- Reduces unnecessary goto labels and unsigned casts while preserving clearer control flow.
+
+### Cleanup
+
+- Removes the stale `demo` command.
+
 ## v0.10.2
 
 ### Full member signatures


### PR DESCRIPTION
## Summary
- bump dotnet-inspect VersionPrefix to 0.10.3
- update embedded dotnet-inspect skill metadata to 0.10.3
- add v0.10.3 release notes covering integrations, decompiler improvements, and demo command cleanup

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect -c Release -- --version => 0.10.3+e38cb74
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- npx markdownlint-cli skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md

Local notes:
- dotnet-inspect.Tests currently has an order-dependent local failure in MemberOptionsParserTests.ExplicitPackage_WithImplicitOutput_KeepsTipsEnabled; the same test passes in isolation and CI is green on main.
- DotnetInspector.Decompiler.Tests has local CSharpEmitter assertion failures; this project is not run by the current CI workflow and is unrelated to this version-only change.