### PR TITLE
CI: run all test suites on all OSes; fix Release-config decompiler bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,30 @@ jobs:
           echo "$ILASM_DIR" >> "$GITHUB_PATH"
           echo "$ILDASM_DIR" >> "$GITHUB_PATH"
 
-      - name: Run tests
+      - name: Run CLI tests
         run: dotnet run --project src/dotnet-inspect.Tests -c Release
+
+      # Decompiler tests run on every OS deliberately: many decompile the
+      # PLATFORM's CoreLib (chain/loop/spill regression tests, emit-all
+      # stress), so each OS contributes a genuinely different IL corpus.
+      - name: Run decompiler tests
+        run: dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
+
+      - name: Run metadata tests
+        run: dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
+
+      - name: Run services tests
+        run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
+
+      # The IL round-trip oracle (vendored managed ILAssembler) is
+      # platform-neutral at the IL level, so one leg suffices.
+      - name: Restore vendored ILAssembler
+        if: matrix.rid == 'linux-x64'
+        run: bash eng/restore-ilassembler.sh
+
+      - name: Run IL round-trip tests
+        if: matrix.rid == 'linux-x64'
+        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
 
   # Pack and smoke test on Ubuntu
   pack:

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -52,10 +52,13 @@ public class CSharpEmitterTests
     [Fact]
     public void UnsignedBoundsBranch_KeepsUnsignedCasts()
     {
+        // Debug compiles the fixture to branches (if/return); Release to a
+        // ternary. Either shape is correct — what must hold is that the
+        // unsigned reinterpretation casts survive on the signed operands.
         string output = EmitMethod(nameof(CfgSampleClass.UnsignedBoundsBranch));
 
-        Assert.Contains("(uint)", output);
-        Assert.Contains("if", output);
+        Assert.Contains("(uint)index", output);
+        Assert.Contains("(uint)array.Length", output);
     }
 
     [Fact]
@@ -114,9 +117,13 @@ public class CSharpEmitterTests
     [Fact]
     public void MaxULong_OmitsRedundantUnsignedCasts()
     {
+        // Debug keeps the if/return branch shape (>=); Release inverts to a
+        // ternary (<). Either way no reinterpretation casts may appear —
+        // the operands are already unsigned.
         string output = EmitMethod(nameof(CfgSampleClass.MaxULong));
 
-        Assert.Contains(">=", output);
+        Assert.True(output.Contains(">=") || output.Contains('<'),
+            $"Expected an unsigned comparison in:\n{output}");
         Assert.DoesNotContain("(ulong)", output);
     }
 

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1650,7 +1650,7 @@ public static class CSharpEmitter
             // slot 0 — unless a pattern substituted the incoming value.
             if (assign.Variable.Kind == ILVariableKind.StackSlot
                 && assign.Value is { OpCode: ILOpCode.Nop, Operand: string inName }
-                && inName == $"S_in_{assign.Variable.Index}"
+                && (inName == $"S_in_{assign.Variable.Index}" || inName == assign.Variable.Name)
                 && _nullConditionalReceiver is null
                 && !_syntheticSubstitutions.ContainsKey(inName)
                 && !_syntheticSubstitutions.ContainsKey($"{assign.Value.Offset}:{inName}"))
@@ -5214,23 +5214,39 @@ public static class CSharpEmitter
         /// </summary>
         bool TryEmitLoopJump(string target, int indent)
         {
-            if (_loopJumpLabels.Count == 0)
+            if (LoopJumpKeyword(target) is not { } keyword)
                 return false;
+            WriteIndent(indent);
+            _sb.AppendLine($"{keyword};");
+            return true;
+        }
 
+        /// <summary>
+        /// Conditional form: Release csc fuses 'if (cond) continue;' into a
+        /// single conditional branch to the loop's re-entry point (Debug
+        /// routes it through an unconditional br).
+        /// </summary>
+        bool TryEmitConditionalLoopJump(ILAstExpression branchExpr, string target, int indent)
+        {
+            if (LoopJumpKeyword(target) is not { } keyword)
+                return false;
+            WriteIndent(indent);
+            _sb.Append("if (");
+            EmitBranchCondition(branchExpr);
+            _sb.AppendLine($") {keyword};");
+            return true;
+        }
+
+        string? LoopJumpKeyword(string target)
+        {
+            if (_loopJumpLabels.Count == 0)
+                return null;
             var (continueLabels, breakLabel) = _loopJumpLabels.Peek();
             if (continueLabels.Contains(target))
-            {
-                WriteIndent(indent);
-                _sb.AppendLine("continue;");
-                return true;
-            }
+                return "continue";
             if (target == breakLabel)
-            {
-                WriteIndent(indent);
-                _sb.AppendLine("break;");
-                return true;
-            }
-            return false;
+                return "break";
+            return null;
         }
 
         void EmitStatement(ILAstExpression expr, int indent)
@@ -5448,6 +5464,10 @@ public static class CSharpEmitter
                     // Conditional branches — when not consumed by structuring
                     // Try guard clause pattern: if (cond) goto TARGET; body → if (negated) { body; }
                     if (expr.Operand is string condTarget && TryEmitGuardClause(expr, condTarget, indent))
+                        break;
+                    // Conditional jump to the innermost loop's re-entry/exit:
+                    // if (cond) continue; / if (cond) break;
+                    if (expr.Operand is string loopJump && TryEmitConditionalLoopJump(expr, loopJump, indent))
                         break;
                     // Branch to a return-only block: render the return under
                     // the condition — no goto, no label needed.

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -90,7 +90,13 @@ public static class ILAstBuilder
             }
             else
             {
-                // If there are unconsumed stack values, flush them as assignments
+                // A statement that runs while values sit on the simulated stack
+                // executes BEFORE those values render (they evaluate at their
+                // consumption site). Any stacked value the statement could
+                // invalidate must be spilled to a slot first, or the rendered
+                // expression reads post-mutation state (Release csc keeps
+                // captured field reads on the stack across the mutation).
+                SpillVulnerableStackValues(node, stack, block, offset);
                 block.Nodes.Add(new ILAstStatement { Expression = node, Offset = offset });
             }
         }
@@ -127,6 +133,160 @@ public static class ILAstBuilder
                 });
             }
         }
+    }
+
+    /// <summary>
+    /// Spills stack entries that <paramref name="stmt"/> could invalidate:
+    /// reads of a field the statement writes, reads of a local/argument the
+    /// statement stores, element/indirect reads when it writes through one,
+    /// and any mutable-state read when it calls (a callee can mutate
+    /// anything). Spilled entries become slot loads; dup-shared occurrences
+    /// are replaced together so the tree is never evaluated twice.
+    /// </summary>
+    static void SpillVulnerableStackValues(
+        ILAstExpression stmt, Stack<ILAstExpression> stack, ILAstBlock block, int offset)
+    {
+        if (stack.Count == 0)
+            return;
+
+        string? writtenField = stmt.OpCode is ILOpCode.Stfld or ILOpCode.Stsfld ? stmt.Operand : null;
+        string? writtenLocal = stmt.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+            or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+            ? stmt.Operand ?? StoredSlotName(stmt.OpCode)
+            : stmt.OpCode is ILOpCode.Starg or ILOpCode.Starg_s ? stmt.Operand : null;
+        bool writesElementOrIndirect = stmt.OpCode is ILOpCode.Stelem or ILOpCode.Stelem_i
+            or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2 or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8
+            or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8 or ILOpCode.Stelem_ref
+            or ILOpCode.Stind_i or ILOpCode.Stind_i1 or ILOpCode.Stind_i2 or ILOpCode.Stind_i4
+            or ILOpCode.Stind_i8 or ILOpCode.Stind_r4 or ILOpCode.Stind_r8 or ILOpCode.Stind_ref
+            or ILOpCode.Stobj or ILOpCode.Initobj or ILOpCode.Cpobj or ILOpCode.Cpblk or ILOpCode.Initblk;
+        bool stmtCalls = TreeContainsCall(stmt);
+
+        if (writtenField is null && writtenLocal is null && !writesElementOrIndirect && !stmtCalls)
+            return;
+
+        var entries = stack.ToArray(); // top of stack first
+        bool spilled = false;
+        for (int i = 0; i < entries.Length; i++)
+        {
+            var value = entries[i];
+            if (value.OpCode == ILOpCode.Nop)
+                continue; // already a slot or block-entry load
+
+            bool vulnerable =
+                (writtenField is not null && TreeReadsField(value, writtenField))
+                || (writtenLocal is not null && TreeReadsLocalOrArg(value, writtenLocal))
+                || (writesElementOrIndirect && TreeReadsElementOrIndirect(value))
+                || (stmtCalls && TreeReadsMutableState(value));
+            if (!vulnerable)
+                continue;
+
+            int position = entries.Length - 1 - i; // stack slot index from the bottom
+            var variable = new ILVariable(ILVariableKind.StackSlot, value.ResultType, index: position);
+            block.Nodes.Add(new ILAstAssignment { Variable = variable, Value = value, Offset = offset });
+            var slotLoad = new ILAstExpression
+            {
+                OpCode = ILOpCode.Nop,
+                Operand = variable.Name,
+                ResultType = value.ResultType,
+                Offset = offset,
+            };
+            for (int j = 0; j < entries.Length; j++)
+            {
+                if (ReferenceEquals(entries[j], value))
+                    entries[j] = slotLoad;
+            }
+            spilled = true;
+        }
+
+        if (!spilled)
+            return;
+        stack.Clear();
+        for (int j = entries.Length - 1; j >= 0; j--)
+            stack.Push(entries[j]);
+    }
+
+    static string? StoredSlotName(ILOpCode op) => op switch
+    {
+        ILOpCode.Stloc_0 => "V_0",
+        ILOpCode.Stloc_1 => "V_1",
+        ILOpCode.Stloc_2 => "V_2",
+        ILOpCode.Stloc_3 => "V_3",
+        _ => null,
+    };
+
+    static bool TreeContainsCall(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Calli or ILOpCode.Newobj)
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (TreeContainsCall(arg))
+                return true;
+        return false;
+    }
+
+    static bool TreeReadsField(ILAstExpression expr, string field)
+    {
+        if (expr.OpCode is ILOpCode.Ldfld or ILOpCode.Ldsfld or ILOpCode.Ldflda or ILOpCode.Ldsflda
+            && expr.Operand == field)
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (TreeReadsField(arg, field))
+                return true;
+        return false;
+    }
+
+    static bool TreeReadsLocalOrArg(ILAstExpression expr, string name)
+    {
+        if (expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldloca or ILOpCode.Ldloca_s
+            or ILOpCode.Ldarg or ILOpCode.Ldarg_s
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+            or ILOpCode.Ldarga or ILOpCode.Ldarga_s)
+        {
+            string? loaded = expr.Operand ?? expr.OpCode switch
+            {
+                ILOpCode.Ldloc_0 => "V_0",
+                ILOpCode.Ldloc_1 => "V_1",
+                ILOpCode.Ldloc_2 => "V_2",
+                ILOpCode.Ldloc_3 => "V_3",
+                ILOpCode.Ldarg_0 => "P_0",
+                ILOpCode.Ldarg_1 => "P_1",
+                ILOpCode.Ldarg_2 => "P_2",
+                ILOpCode.Ldarg_3 => "P_3",
+                _ => null,
+            };
+            if (loaded == name)
+                return true;
+        }
+        foreach (var arg in expr.Arguments)
+            if (TreeReadsLocalOrArg(arg, name))
+                return true;
+        return false;
+    }
+
+    static bool TreeReadsElementOrIndirect(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Ldelem or ILOpCode.Ldelema
+            or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2 or ILOpCode.Ldelem_i4
+            or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8 or ILOpCode.Ldelem_ref
+            or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4
+            or ILOpCode.Ldind_i or ILOpCode.Ldind_i1 or ILOpCode.Ldind_i2 or ILOpCode.Ldind_i4
+            or ILOpCode.Ldind_i8 or ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8 or ILOpCode.Ldind_ref
+            or ILOpCode.Ldind_u1 or ILOpCode.Ldind_u2 or ILOpCode.Ldind_u4 or ILOpCode.Ldobj)
+            return true;
+        foreach (var arg in expr.Arguments)
+            if (TreeReadsElementOrIndirect(arg))
+                return true;
+        return false;
+    }
+
+    static bool TreeReadsMutableState(ILAstExpression expr)
+    {
+        if (expr.OpCode is ILOpCode.Ldfld or ILOpCode.Ldsfld or ILOpCode.Ldflda or ILOpCode.Ldsflda)
+            return true;
+        return TreeReadsElementOrIndirect(expr);
     }
 
     static ILAstExpression? DecodeInstruction(


### PR DESCRIPTION
CI ran only the CLI suite — the decompiler (245), metadata (135), services (158), and IL round-trip (20) suites never ran in CI. Wiring them up required making the decompiler suite green under \`-c Release\`, which surfaced **two real product bugs**, not just test-shape issues.

## Product fixes

**1. Stacked values crossing mutating statements** (the \`StaleFieldRead\` failure). Release csc keeps a captured field read on the eval stack across the mutation — no local involved:

```csharp
// source                          // before (Release)           // after
int v = h.Value;                   h.Value = 99;                 int S_0 = h.Value;
h.Value = 99;                      return h.Value + h.Value;     h.Value = 99;
return v + h.Value;                                              return S_0 + h.Value;
```

Stacked expression trees evaluate where they're *consumed*, so a statement executing in between must not invalidate them. \`BuildBlock\` now spills vulnerable entries to slot locals first, with hazard-matched rules to avoid disturbing dup-based patterns (cached delegates, null-conditional): field reads spill when that field is written; local/arg reads when that local is stored; element/indirect reads under element/indirect writes; any mutable-state read across a call. Dup-shared occurrences are replaced together so trees never evaluate twice.

**2. Conditional loop jumps** (the \`LoopWithContinue\` failure). Release fuses \`if (cond) continue;\` into a single conditional branch to the loop re-entry point; only unconditional \`br\` consulted the loop-jump machinery. Now:

```csharp
// before (Release)                          // after — source-exact
if (values[V_1] < 0) goto IL_0012;           if (values[V_1] < 0) continue;
V_0 += values[V_1];                          V_0 += values[V_1];
IL_0012:
```

## Test fixes (both compiler shapes are legitimate)

- \`UnsignedBoundsBranch\`: assert the \`(uint)\` casts survive, not the if-vs-ternary shape
- \`MaxULong\`: assert a castless comparison, not its direction (Release inverts to \`a < b ? b : a\`)

## CI changes

- Decompiler/metadata/services suites on **all three OSes** — deliberately: the decompiler suite decompiles each platform's CoreLib (regression tests + emit-all stress), so each OS contributes a genuinely different IL corpus
- IL round-trip suite on **linux-x64 only** (~80s; the oracle is platform-neutral at the IL level), with \`eng/restore-ilassembler.sh\` materializing the vendored ILAssembler

Validation: decompiler suite green in BOTH configs, all other suites green in Release, full h2h corpus byte-identical before/after the spill change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)