### PR TITLE
Decompiler: if/else arms become dominated regions (multi-path loop structuring)

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -155,9 +155,9 @@ public class CSharpEmitterTests
         // appear reachable from the non-negative path.
         string output = EmitCoreLibMethod("System.Math", "Abs", overloadIndex: 0);
 
-        Assert.Contains("    Math.ThrowNegateTwosCompOverflow();", output);
-        // The inner guard's branch-to-return renders as a conditional return.
-        Assert.Contains("if (value >= 0) return value;", output);
+        // Source-exact nesting: the throw re-nests under the inner guard.
+        Assert.Contains("if (value < 0)", output);
+        Assert.Contains("        Math.ThrowNegateTwosCompOverflow();", output);
         Assert.DoesNotContain("goto", output);
     }
 
@@ -169,8 +169,9 @@ public class CSharpEmitterTests
         // straight to the return) would appear to flow into it.
         string output = EmitCoreLibMethod("System.Collections.Generic.List`1", "Clear");
 
-        Assert.Contains("    Array.Clear", output);
-        Assert.Contains("if (V_0 <= 0) return;", output);
+        // Source-exact nesting: Array.Clear re-nests under if (V_0 > 0).
+        Assert.Contains("if (V_0 > 0)", output);
+        Assert.Contains("        Array.Clear", output);
         Assert.DoesNotContain("goto", output);
     }
 
@@ -205,6 +206,20 @@ public class CSharpEmitterTests
         Assert.Contains("typeof(TValue).IsValueType", output);
         Assert.DoesNotContain("T1", output);
         Assert.DoesNotContain("ref V_0", output);
+    }
+
+    [Fact]
+    public void CoreLib_DictionaryContainsValue_StructuresAllThreePaths()
+    {
+        // Three parallel scan loops (null / value-type / cached-comparer),
+        // each inside its own arm of the if/else chain. Previously the loops
+        // unraveled at top level: one as if+goto, one empty, one unreachable.
+        string output = EmitCoreLibMethod("System.Collections.Generic.Dictionary`2", "ContainsValue");
+
+        Assert.Equal(3, output.Split("for (").Length - 1);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("for (;", output);
+        Assert.Contains("else", output);
     }
 
     // --- Generic ldelem (type-parameter element access) ---

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1599,11 +1599,15 @@ public static class CSharpEmitter
             if (_consumedBlocks.Contains(blockIndex))
                 return;
 
-            // Suppress return-only blocks whose gotos were all inlined
+            // Suppress return-only blocks whose gotos were all inlined — but
+            // only when nothing FALLS into the block: a path that reaches it
+            // by fallthrough (e.g. the last of several scan loops sharing one
+            // return) still needs the return rendered.
             if (astBlock.Nodes.Count == 1
                 && astBlock.Nodes[0] is ILAstStatement { Expression.OpCode: ILOpCode.Ret }
                 && _blockStartOffset.TryGetValue(blockIndex, out int retOffset)
-                && _inlinedReturnLabels.Contains($"IL_{retOffset:X4}"))
+                && _inlinedReturnLabels.Contains($"IL_{retOffset:X4}")
+                && !HasFallthroughPredecessor(blockIndex))
             {
                 _consumedBlocks.Add(blockIndex);
                 return;
@@ -1670,6 +1674,22 @@ public static class CSharpEmitter
             _sb.Append($"{assign.Variable.Name} = ");
             EmitExpression(assign.Value);
             _sb.AppendLine(";");
+        }
+
+        /// <summary>
+        /// True when the preceding block in layout order can fall into this
+        /// one (its last statement is not an unconditional transfer).
+        /// </summary>
+        bool HasFallthroughPredecessor(int blockIndex)
+        {
+            if (blockIndex <= 0 || !_blockMap.TryGetValue(blockIndex - 1, out var prev))
+                return false;
+            if (prev.Nodes.LastOrDefault() is not ILAstStatement { Expression.OpCode: var op })
+                return true;
+            return op is not (ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow
+                or ILOpCode.Br or ILOpCode.Br_s
+                or ILOpCode.Leave or ILOpCode.Leave_s
+                or ILOpCode.Endfinally or ILOpCode.Switch);
         }
 
         void EmitIfThenElse(StructuredBlock block, int indent)

--- a/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
+++ b/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
@@ -300,69 +300,151 @@ public sealed class StructuredControlFlow
             }
         }
 
-        // Predecessor counts (distinct edges) for arm-chain absorption.
-        var predCounts = new int[cfg.BasicBlocks.Count];
-        foreach (var bb in cfg.BasicBlocks)
+        StructuredBlock MakeBasic(int idx) => new()
         {
-            var succs = new HashSet<int>();
-            if (bb.BranchTarget is not null) succs.Add(cfg.IndexOf(bb.BranchTarget));
-            if (bb.FallthroughTarget is not null) succs.Add(cfg.IndexOf(bb.FallthroughTarget));
-            if (bb.SwitchCaseTargets is not null)
-                foreach (var t in bb.SwitchCaseTargets) succs.Add(cfg.IndexOf(t));
-            foreach (int sIdx in succs)
-                if (sIdx >= 0) predCounts[sIdx]++;
+            Kind = StructuredBlockKind.BasicBlock,
+            BlockIndex = idx,
+            Label = $"Block_{idx}"
+        };
+
+        // Shared structuring dispatch for one block — used by the top-level
+        // walk and, recursively, by if/else arm regions. Exception regions are
+        // NOT handled here; the top-level walk claims those first and arm
+        // regions skip them.
+        void DispatchStructured(int i, List<StructuredBlock> output)
+        {
+            if (blockToLoop.TryGetValue(i, out var loop))
+            {
+                var loopChildren = new List<StructuredBlock>();
+                foreach (int bodyIdx in loop.BodyIndices.OrderBy(x => x))
+                {
+                    processed.Add(bodyIdx);
+                    loopChildren.Add(MakeBasic(bodyIdx));
+                }
+
+                output.Add(new StructuredBlock
+                {
+                    Kind = StructuredBlockKind.Loop,
+                    LoopHeaderIndex = loop.HeaderIndex,
+                    Children = loopChildren
+                });
+                return;
+            }
+
+            // Switch detection: block terminates with IL switch opcode
+            if (switchBlocks.ContainsKey(i))
+            {
+                var bb = cfg.BasicBlocks[i];
+                var caseTargets = new List<(int CaseValue, int TargetBlockIndex)>();
+                var caseBlockIndices = new HashSet<int>();
+
+                if (bb.SwitchCaseTargets is not null)
+                {
+                    for (int c = 0; c < bb.SwitchCaseTargets.Count; c++)
+                    {
+                        int targetIdx = cfg.IndexOf(bb.SwitchCaseTargets[c]);
+                        if (targetIdx >= 0)
+                        {
+                            caseTargets.Add((c, targetIdx));
+                            caseBlockIndices.Add(targetIdx);
+                        }
+                    }
+                }
+
+                int defaultIdx = bb.FallthroughTarget is not null
+                    ? cfg.IndexOf(bb.FallthroughTarget)
+                    : -1;
+
+                // Mark case target blocks as processed (they belong to the switch)
+                foreach (int caseIdx in caseBlockIndices)
+                    processed.Add(caseIdx);
+                if (defaultIdx >= 0)
+                    processed.Add(defaultIdx);
+
+                processed.Add(i);
+                output.Add(new StructuredBlock
+                {
+                    Kind = StructuredBlockKind.Switch,
+                    SwitchBlockIndex = i,
+                    SwitchCases = caseTargets,
+                    SwitchDefaultIndex = defaultIdx,
+                    Children = caseBlockIndices.OrderBy(x => x)
+                        .Concat(defaultIdx >= 0 ? [defaultIdx] : [])
+                        .Distinct()
+                        .Select(MakeBasic)
+                        .ToList()
+                });
+                return;
+            }
+
+            if (conditionBlocks.TryGetValue(i, out var cond))
+            {
+                processed.Add(i);
+                foreach (var term in cond.ChainTerms)
+                    processed.Add(term.BlockIndex);
+
+                var thenBlock = BuildArm(cond.ThenIndex);
+                StructuredBlock? elseBlock = cond.ElseIndex >= 0 ? BuildArm(cond.ElseIndex) : null;
+
+                output.Add(new StructuredBlock
+                {
+                    Kind = StructuredBlockKind.IfThenElse,
+                    ConditionBlockIndex = i,
+                    ThenBlock = thenBlock,
+                    ElseBlock = elseBlock,
+                    NegateCondition = cond.NegateCondition,
+                    ConditionChain = cond.ChainTerms
+                });
+                return;
+            }
+
+            processed.Add(i);
+            output.Add(MakeBasic(i));
         }
 
-        // An if/else arm is the arm head plus its single-predecessor
-        // fallthrough chain: blocks only reachable from inside the arm (e.g.
-        // the continuation after an inverted guard) must render inside the
-        // arm's braces — emitted at top level, the OTHER arm's fallthrough
-        // would appear to flow into them.
+        // An if/else arm is the dominated region of its head: every block
+        // reachable ONLY through the arm. Emitted anywhere else, the other
+        // arm's fallthrough would appear to flow into that code. The region
+        // is structured recursively with the same dispatch as the top level,
+        // so nested loops and conditionals keep their shape inside arms
+        // (Dictionary.ContainsValue's per-path scan loops).
         StructuredBlock BuildArm(int headIndex)
         {
-            if (headIndex >= 0)
-                processed.Add(headIndex);
+            if (headIndex < 0 || processed.Contains(headIndex))
+                return MakeBasic(headIndex);
 
-            List<int> chain = [headIndex];
-            int cur = headIndex;
-            while (cur >= 0)
+            var region = new List<int>();
+            CollectDominated(headIndex, region);
+            region.Sort();
+
+            var armChildren = new List<StructuredBlock>();
+            foreach (int idx in region)
             {
-                var ft = cfg.BasicBlocks[cur].FallthroughTarget;
-                int next = ft is null ? -1 : cfg.IndexOf(ft);
-                if (next < 0 || processed.Contains(next)
-                    || predCounts[next] != 1
-                    || loopHeaders.ContainsKey(next) || blockToLoop.ContainsKey(next)
-                    || inExceptionRegion.ContainsKey(next)
-                    || switchBlocks.ContainsKey(next)
-                    || conditionBlocks.ContainsKey(next))
-                {
-                    break;
-                }
-                chain.Add(next);
-                processed.Add(next);
-                cur = next;
+                if (processed.Contains(idx))
+                    continue;
+                // Exception-region blocks stay with the top-level walk.
+                if (inExceptionRegion.ContainsKey(idx) || exRegionsByBlock.ContainsKey(idx))
+                    continue;
+                DispatchStructured(idx, armChildren);
             }
 
-            if (chain.Count == 1)
+            return armChildren.Count switch
             {
-                return new StructuredBlock
+                0 => MakeBasic(headIndex),
+                1 => armChildren[0],
+                _ => new StructuredBlock
                 {
-                    Kind = StructuredBlockKind.BasicBlock,
-                    BlockIndex = headIndex,
-                    Label = $"Block_{headIndex}"
-                };
-            }
-
-            return new StructuredBlock
-            {
-                Kind = StructuredBlockKind.Sequence,
-                Children = chain.Select(idx => new StructuredBlock
-                {
-                    Kind = StructuredBlockKind.BasicBlock,
-                    BlockIndex = idx,
-                    Label = $"Block_{idx}"
-                }).ToList()
+                    Kind = StructuredBlockKind.Sequence,
+                    Children = armChildren
+                },
             };
+        }
+
+        void CollectDominated(int node, List<int> region)
+        {
+            region.Add(node);
+            foreach (int child in domTree.GetDominatorTreeChildren(node))
+                CollectDominated(child, region);
         }
 
         for (int i = 0; i < cfg.BasicBlocks.Count; i++)
@@ -498,108 +580,7 @@ public sealed class StructuredControlFlow
                 continue;
             }
 
-            if (blockToLoop.TryGetValue(i, out var loop))
-            {
-                var loopChildren = new List<StructuredBlock>();
-                foreach (int bodyIdx in loop.BodyIndices.OrderBy(x => x))
-                {
-                    processed.Add(bodyIdx);
-                    loopChildren.Add(new StructuredBlock
-                    {
-                        Kind = StructuredBlockKind.BasicBlock,
-                        BlockIndex = bodyIdx,
-                        Label = $"Block_{bodyIdx}"
-                    });
-                }
-
-                children.Add(new StructuredBlock
-                {
-                    Kind = StructuredBlockKind.Loop,
-                    LoopHeaderIndex = loop.HeaderIndex,
-                    Children = loopChildren
-                });
-                continue;
-            }
-
-            // Switch detection: block terminates with IL switch opcode
-            if (switchBlocks.ContainsKey(i))
-            {
-                var bb = cfg.BasicBlocks[i];
-                var caseTargets = new List<(int CaseValue, int TargetBlockIndex)>();
-                var caseBlockIndices = new HashSet<int>();
-
-                if (bb.SwitchCaseTargets is not null)
-                {
-                    for (int c = 0; c < bb.SwitchCaseTargets.Count; c++)
-                    {
-                        int targetIdx = cfg.IndexOf(bb.SwitchCaseTargets[c]);
-                        if (targetIdx >= 0)
-                        {
-                            caseTargets.Add((c, targetIdx));
-                            caseBlockIndices.Add(targetIdx);
-                        }
-                    }
-                }
-
-                int defaultIdx = bb.FallthroughTarget is not null
-                    ? cfg.IndexOf(bb.FallthroughTarget)
-                    : -1;
-
-                // Mark case target blocks as processed (they belong to the switch)
-                foreach (int caseIdx in caseBlockIndices)
-                    processed.Add(caseIdx);
-                if (defaultIdx >= 0)
-                    processed.Add(defaultIdx);
-
-                processed.Add(i);
-                children.Add(new StructuredBlock
-                {
-                    Kind = StructuredBlockKind.Switch,
-                    SwitchBlockIndex = i,
-                    SwitchCases = caseTargets,
-                    SwitchDefaultIndex = defaultIdx,
-                    Children = caseBlockIndices.OrderBy(x => x)
-                        .Concat(defaultIdx >= 0 ? [defaultIdx] : [])
-                        .Distinct()
-                        .Select(idx => new StructuredBlock
-                        {
-                            Kind = StructuredBlockKind.BasicBlock,
-                            BlockIndex = idx,
-                            Label = $"Block_{idx}"
-                        })
-                        .ToList()
-                });
-                continue;
-            }
-
-            if (conditionBlocks.TryGetValue(i, out var cond))
-            {
-                processed.Add(i);
-                foreach (var term in cond.ChainTerms)
-                    processed.Add(term.BlockIndex);
-
-                var thenBlock = BuildArm(cond.ThenIndex);
-                StructuredBlock? elseBlock = cond.ElseIndex >= 0 ? BuildArm(cond.ElseIndex) : null;
-
-                children.Add(new StructuredBlock
-                {
-                    Kind = StructuredBlockKind.IfThenElse,
-                    ConditionBlockIndex = i,
-                    ThenBlock = thenBlock,
-                    ElseBlock = elseBlock,
-                    NegateCondition = cond.NegateCondition,
-                    ConditionChain = cond.ChainTerms
-                });
-                continue;
-            }
-
-            processed.Add(i);
-            children.Add(new StructuredBlock
-            {
-                Kind = StructuredBlockKind.BasicBlock,
-                BlockIndex = i,
-                Label = $"Block_{i}"
-            });
+            DispatchStructured(i, children);
         }
 
         return new StructuredBlock


### PR DESCRIPTION
Closes h2h gap #1 (multi-path loop structuring, the last C-grade method) — and gap #2 (guard re-nesting) fell out of the same change.

## The change

#410 made arms single-pred fallthrough *chains*, which stop at any nested construct. A loop or conditional belonging inside an arm spilled to top level and unraveled. An arm is now the **dominated region** of its head — every block reachable only through the arm — structured recursively with the same dispatch (loop/switch/conditional/basic) as the top-level walk. The ILSpy reference in the h2h doc proved this shape recoverable; this is the region-based structuring borrow we discussed.

## \`Dictionary.ContainsValue\` (C → A-)

All three scan loops now render in their correct arms, goto-free:

```csharp
if ((object)value != null)
{
    if (typeof(TValue).IsValueType)
    {
        for (V_2 = 0; V_2 < this._count; V_2++) { ... }
        return false;
    }
    V_3 = EqualityComparer<TValue>.Default;
    for (V_4 = 0; V_4 < this._count; V_4++) { ... }
}
else
{
    for (V_1 = 0; V_1 < this._count; V_1++) { ... }
    return false;
}
return false;
```

## \`Math.Abs(short)\` / \`List<T>.Clear\` (A- → source-exact)

Inner conditionals inside arms now structure as proper nested ifs instead of inverted early returns:

```csharp
if (value < 0)                          if (RuntimeHelpers.IsReference...())
{                                       {
    value = (short)-value;                  V_0 = this._size;
    if (value < 0)                          this._size = 0;
    {                                       if (V_0 > 0)
        Math.ThrowNegateTwosCompOverflow(); {
    }                                           Array.Clear(this._items, 0, V_0);
}                                               return;
return value;                               }
                                        }
                                        else { this._size = 0; }
```

One emitter fix rode along: inlined-return suppression now checks for a fallthrough predecessor — the last scan loop falls into the shared \`return false\`, which suppression previously dropped (would have been missing-return output).

Full h2h corpus diff shows exactly these three methods changed. All suites green in both configs (decompiler 246 incl. the new three-paths structure test, CLI 942, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)