### PR TITLE
Decompiler: statement form over poorly-reading return ternaries

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -222,6 +222,30 @@ public class CSharpEmitterTests
         Assert.Contains("else", output);
     }
 
+    [Fact]
+    public void CoreLib_ClampDouble_PrefersInvertedIfOverNegatedTernary()
+    {
+        // !(value > max) ? value : max reads worse than the source's
+        // if (value > max) return max; — negated ternary conditions invert
+        // into the statement form.
+        string output = EmitCoreLibMethod("System.Math", "Clamp", overloadIndex: 8);
+
+        Assert.Contains("if (value > max)", output);
+        Assert.DoesNotContain("!(", output);
+    }
+
+    [Fact]
+    public void CoreLib_StringContains_KeepsTwoReturnShapeForLongExpressions()
+    {
+        // Folding both returns into one ternary produced a 200-character
+        // line; over-long renderings keep the source's guarded-return shape.
+        string output = EmitCoreLibMethod("System.String", "Contains", overloadIndex: 0);
+
+        Assert.Contains("&& value.Length == 1)", output);
+        Assert.Contains("    return base.Contains(value[0]);", output);
+        Assert.DoesNotContain(" ? ", output);
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -2847,10 +2847,64 @@ public static class CSharpEmitter
             }
             if (elseReturn is null) return false;
 
-            WriteIndent(indent);
-            _sb.AppendLine($"return {condition} ? {thenReturn} : {elseReturn};");
+            // Prefer the statement form where the ternary reads poorly:
+            // a negated condition inverts into an if that matches how the
+            // source is written, and an over-long rendering keeps the
+            // source's two-return shape.
+            if (TryStripOuterNegation(condition) is { } inverted)
+            {
+                EmitReturnPair(inverted, elseReturn, thenReturn, indent);
+            }
+            else if (condition.Length + thenReturn.Length + elseReturn.Length > 90)
+            {
+                EmitReturnPair(condition, thenReturn, elseReturn, indent);
+            }
+            else
+            {
+                WriteIndent(indent);
+                _sb.AppendLine($"return {condition} ? {thenReturn} : {elseReturn};");
+            }
             ConsumeReturnBlocks(block);
             return true;
+        }
+
+        void EmitReturnPair(string condition, string guardedReturn, string fallthroughReturn, int indent)
+        {
+            WriteIndent(indent);
+            _sb.AppendLine($"if ({condition})");
+            WriteIndent(indent);
+            _sb.AppendLine("{");
+            WriteIndent(indent + 1);
+            _sb.AppendLine($"return {guardedReturn};");
+            WriteIndent(indent);
+            _sb.AppendLine("}");
+            WriteIndent(indent);
+            _sb.AppendLine($"return {fallthroughReturn};");
+        }
+
+        /// <summary>
+        /// If the condition is a whole-expression negation we wrapped
+        /// ourselves — "!(...)" with the first paren matching the last —
+        /// returns the unwrapped inner condition. The inverted if/return
+        /// renders that case the way the source spells it.
+        /// </summary>
+        static string? TryStripOuterNegation(string condition)
+        {
+            if (!condition.StartsWith("!(", StringComparison.Ordinal)
+                || !condition.EndsWith(")", StringComparison.Ordinal))
+                return null;
+            int depth = 0;
+            for (int i = 1; i < condition.Length; i++)
+            {
+                if (condition[i] == '(') depth++;
+                else if (condition[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                        return i == condition.Length - 1 ? condition[2..^1] : null;
+                }
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes h2h gap #3 (statement-form preference). \`TryEmitTernaryReturn\` folded every \`if (cond) return A; return B;\` into a ternary; two cases read worse than the source:

**Negated conditions** (\`Math.Clamp\`) — the \`!(...)\` only existed because the fold put the fallthrough value first; inverting recovers the source's spelling (NaN semantics identical — same branch, swapped arms):

```csharp
// before                                  // after — source shape
return !(value > max) ? value : max;       if (value > max)
                                           {
                                               return max;
                                           }
                                           return value;
```

**Over-long renderings** (\`String.Contains\`) — a 200-character ternary line becomes the source's guarded-return shape:

```csharp
if (RuntimeHelpers.IsKnownConstant(value) && value.Length == 1)
{
    return base.Contains(value[0]);
}
return SpanHelpers.IndexOf(ref this._firstChar, base.Length, ref value._firstChar, value.Length) >= 0;
```

Short ternaries are untouched — \`Math.Max\`/\`Min\` stay exact (\`return val1 >= val2 ? val1 : val2;\`), as do the fixture chain ternaries. Full h2h corpus diff shows exactly the two intended methods. The negation strip only fires when the \`!(\` wraps the whole expression (paren-balance checked).

Suites green in both configs (decompiler 248 with two new CoreLib tests), CLI 942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)