### PR TITLE
Rename integration roll-up count to APIs

### DIFF
--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -31,7 +31,7 @@ The roll-up reports one row per detected integration:
 | Column | Meaning |
 | ------ | ------- |
 | Integration | Ecosystem area, such as Logging or OpenTelemetry. |
-| Examples | Count of actionable API examples in the focused section. |
+| APIs | Count of actionable APIs, support types, and telemetry controls in the focused section. |
 
 `Library Info` also includes an `Integrations` field. That field counts detected
 integration categories, not example rows. It is computed from cheap metadata

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1976,7 +1976,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integrations", output);
-        Assert.Contains("| Integration | Examples |", output);
+        Assert.Contains("| Integration | APIs |", output);
         Assert.Contains("| OpenTelemetry |", output);
         Assert.DoesNotContain("## OpenTelemetry", output);
         Assert.DoesNotContain("Tip:", error);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -626,10 +626,10 @@ internal static class LibraryMetadataService
         List<IntegrationSignal>? signals)
     {
         if (signals is { Count: > 0 })
-            integrations.Add(new IntegrationSummary(name, CountRenderedIntegrationExamples(name, signals)));
+            integrations.Add(new IntegrationSummary(name, CountRenderedIntegrationApis(name, signals)));
     }
 
-    private static int CountRenderedIntegrationExamples(string name, List<IntegrationSignal> signals)
+    private static int CountRenderedIntegrationApis(string name, List<IntegrationSignal> signals)
     {
         var apiCount = signals.Count(signal => signal.Shape == IntegrationSignalShape.Api);
         return apiCount > 0 && name is not ("AI" or "Aspire" or "HTTP Client" or "OpenTelemetry")

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -578,7 +578,7 @@ public record AuditSignalRow(
 [MarkoutSerializable]
 public record IntegrationRow(
     string Integration,
-    int Examples);
+    [property: MarkoutPropertyName("APIs")] int Apis);
 
 [MarkoutSerializable]
 public record IntegrationSignalRow(


### PR DESCRIPTION
## Summary
- rename the Integrations roll-up count column from Examples to APIs
- update the integration design doc and regression assertion
- rename the internal count helper to match the new terminology

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationsSection_RollsUpOpenTelemetry -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationsSection_ForAspireOpenAI_ShowsStarterIntegrations -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationsCategory_ForAspireHostingRedis_RendersAspireSection -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_OpenTelemetrySection_ForAspireKafka_ShowsTelemetryControls -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_HttpClientDiagnostics_ShowsUserFacingHttpClientCurrency
- npx markdownlint-cli docs/design/integrations.md