### PR TITLE
Detect OpenAI AI adapter integrations

### DIFF
--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -47,7 +47,7 @@ Examples:
 
 | Integration | Currency examples |
 | ----------- | ----------------- |
-| AI | `IChatClient`, `IEmbeddingGenerator<TInput,TEmbedding>`, `AITool`, modality client interfaces, package-owned builder/registration APIs. |
+| AI | `IChatClient`, `IEmbeddingGenerator<TInput,TEmbedding>`, `AITool`, modality client interfaces, package-owned builder/registration/adapter APIs. |
 | Aspire | `AddRedis(...)`, `RedisResource`, resource-specific `Add*` APIs returning `IResourceBuilder<T>`. |
 | Dependency Injection | Package-owned `Add*` service registration APIs and DI builder types. |
 | Logging | `ILogger`, `ILogger<T>`, `LoggerMessageAttribute`, logging extension types. |

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.10.3
+version: 0.10.4
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 

--- a/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -155,6 +155,29 @@ public static class EcosystemIntegrationScanner
         return kind.Length > 0;
     }
 
+    private static bool TryClassifyAIAdapterReturnType(string returnType, out string kind)
+    {
+        kind = "";
+        if (returnType.StartsWith("Microsoft.Extensions.AI.IChatClient", StringComparison.Ordinal))
+            kind = "Chat";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.IEmbeddingGenerator", StringComparison.Ordinal))
+            kind = "Embeddings";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.IImageGenerator", StringComparison.Ordinal))
+            kind = "Images";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.IRealtimeClient", StringComparison.Ordinal))
+            kind = "Realtime";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.ISpeechToTextClient", StringComparison.Ordinal))
+            kind = "Speech to Text";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.ITextToSpeechClient", StringComparison.Ordinal))
+            kind = "Text to Speech";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.IHostedFileClient", StringComparison.Ordinal))
+            kind = "Hosted Files";
+        else if (returnType.StartsWith("Microsoft.Extensions.AI.AITool", StringComparison.Ordinal))
+            kind = "Tools";
+
+        return kind.Length > 0;
+    }
+
     private static bool IsAspireType(string typeName) => TryGetAspireKind(typeName, out _);
 
     private static bool TryGetAspireKind(string typeName, out string kind)
@@ -181,6 +204,14 @@ public static class EcosystemIntegrationScanner
     {
         if (AITypes.TryGetValue(typeName, out kind!))
             return true;
+
+        if (typeName.StartsWith("Microsoft.Extensions.AI.", StringComparison.Ordinal)
+            && typeName.Contains("OpenAI", StringComparison.Ordinal)
+            && typeName.Contains("RealtimeClient", StringComparison.Ordinal))
+        {
+            kind = "Realtime";
+            return true;
+        }
 
         if (!typeName.StartsWith("Aspire.", StringComparison.Ordinal)
             || !typeName.Contains("OpenAI", StringComparison.Ordinal))
@@ -330,9 +361,6 @@ public static class EcosystemIntegrationScanner
                 continue;
 
             var methodName = reader.GetString(method.Name);
-            if (!methodName.StartsWith("Add", StringComparison.Ordinal))
-                continue;
-
             var context = GenericContext.ForMethod(reader, typeDefinition, method);
             var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
             var api = $"{TypeResolver.FormatDisplayName(typeName)}.{methodName}(...)";
@@ -447,6 +475,13 @@ public static class EcosystemIntegrationScanner
             return false;
 
         var returnType = signature.ReturnType;
+        if (methodName.StartsWith("AsI", StringComparison.Ordinal)
+            || methodName == "AsAITool")
+        {
+            if (TryClassifyAIAdapterReturnType(returnType, out kind))
+                return true;
+        }
+
         if (returnType.Contains("ChatClientBuilder", StringComparison.Ordinal))
             kind = "Chat";
         else if (returnType.Contains("EmbeddingGeneratorBuilder", StringComparison.Ordinal))

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2063,6 +2063,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_AISection_ForMicrosoftExtensionsAIOpenAI_ShowsAdapterApis()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "Microsoft.Extensions.AI.OpenAI", "--library", "-S", "@Integrations", "--rows", "-n", "40");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Integrations", output);
+        Assert.Contains("| AI | 9 |", output);
+        Assert.Contains("## AI", output);
+        Assert.Contains("| Kind | API |", output);
+        Assert.Contains("| Chat | `Microsoft.Extensions.AI.OpenAIClientExtensions.AsIChatClient(...)` |", output);
+        Assert.Contains("| Embeddings | `Microsoft.Extensions.AI.OpenAIClientExtensions.AsIEmbeddingGenerator(...)` |", output);
+        Assert.Contains("| Images | `Microsoft.Extensions.AI.OpenAIClientExtensions.AsIImageGenerator(...)` |", output);
+        Assert.Contains("| Realtime | `Microsoft.Extensions.AI.OpenAIRealtimeClient` |", output);
+        Assert.Contains("| Speech to Text | `Microsoft.Extensions.AI.OpenAIClientExtensions.AsISpeechToTextClient(...)` |", output);
+        Assert.Contains("| Text to Speech | `Microsoft.Extensions.AI.OpenAIClientExtensions.AsITextToSpeechClient(...)` |", output);
+        Assert.Contains("| Tools | `OpenAI.Responses.MicrosoftExtensionsAIResponsesExtensions.AsAITool(...)` |", output);
+        Assert.DoesNotContain("Dependency Injection", output);
+        Assert.DoesNotContain("Assembly Reference", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
     public async Task LibraryCommand_IntegrationsSection_ForAspireOpenAI_ShowsStarterIntegrations()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.3</VersionPrefix>
+    <VersionPrefix>0.10.4</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v0.10.4
+
+### AI integration fixes
+
+- Detects `Microsoft.Extensions.AI.OpenAI` AI adapter APIs such as `AsIChatClient`, `AsIEmbeddingGenerator`, and related modality adapters.
+- Includes package-owned OpenAI realtime client support types in the AI integration section.
+- Renames the `Integrations` roll-up count column to `APIs`.
+
 ## v0.10.3
 
 ### Library integrations


### PR DESCRIPTION
## Summary
- recognize Microsoft.Extensions.AI.OpenAI adapter APIs such as AsIChatClient and AsIEmbeddingGenerator as AI integration currency
- include package-owned OpenAI realtime client support types in the AI integration section
- document adapter APIs as AI integration currency
- bump dotnet-inspect to 0.10.4 and update release notes / embedded skill metadata

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect -c Release --no-build -- --version => 0.10.4+f006510
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_AISection_ForMicrosoftExtensionsAIOpenAI_ShowsAdapterApis -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_AISection_ForAspireOpenAI_ShowsStarterApis -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_AISection_DetectsAiCurrencyTypes
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- npx markdownlint-cli docs/design/integrations.md skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md