### PR TITLE
Decompiler: fold ComputeStringHash string switches to switch expressions

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -283,6 +283,27 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("(string)o.Length", output);
     }
 
+    [Fact]
+    public void DayNumber_HashForm_FoldsToStringSwitchExpression()
+    {
+        string output = EmitMethod(nameof(CfgSampleClass.DayNumber));
+
+#if DEBUG
+        // Debug lowers the string switch through ComputeStringHash — the
+        // dispatch tree carries no source semantics and folds away.
+        Assert.Contains("return day switch", output);
+        Assert.Contains("\"mon\" => 1,", output);
+        Assert.Contains("_ => 0", output);
+        Assert.DoesNotContain("ComputeStringHash", output);
+        Assert.DoesNotContain("uint", output);
+#else
+        // Release lowers via length/char bucketing — not yet recognized
+        // (follow-up); the rendering must still carry the semantics.
+        Assert.Contains("day == \"mon\"", output);
+        Assert.Contains("return 1;", output);
+#endif
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -295,6 +295,31 @@ public class CfgSampleClass
 
     public static bool ULongGe(ulong a, ulong b) => a >= b;
 
+    public static int DayNumber(string day)
+    {
+        switch (day)
+        {
+            case "mon": return 1;
+            case "tue": return 2;
+            case "wed": return 3;
+            case "thu": return 4;
+            case "fri": return 5;
+            case "sat": return 6;
+            case "sun": return 7;
+            default: return 0;
+        }
+    }
+
+    public static int SmallStringSwitch(string s)
+    {
+        switch (s)
+        {
+            case "a": return 1;
+            case "b": return 2;
+            default: return 0;
+        }
+    }
+
     public static int LenOrZero(object o)
     {
         var s = o as string;

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -86,6 +86,16 @@ public static class CSharpEmitter
         // Labels already emitted (avoid duplicates for shared blocks)
         readonly HashSet<string> _emittedLabels;
 
+        // Recognized hash-form string switches, keyed by root block index.
+        readonly Dictionary<int, StringSwitchInfo> _stringSwitches = [];
+
+        sealed record StringSwitchInfo(
+            string Subject,
+            List<(List<string> Literals, ILAstExpression Value)> Arms,
+            ILAstExpression DefaultValue,
+            HashSet<int> ConsumedBlocks,
+            List<ILAstNode> SkipNodes);
+
         // Stack-slot locals (S_N) declared so far — they exist nowhere in
         // metadata, so the first surviving store must declare them.
         readonly HashSet<string> _declaredSlotLocals = [];
@@ -1460,6 +1470,10 @@ public static class CSharpEmitter
             // Switch-expression arm temps fold away; suppress their declarations.
             ScanForSwitchExpressionLocals();
 
+            // Hash-form string switches (ComputeStringHash dispatch) fold to
+            // switch expressions; suppresses hash/copy/temp declarations.
+            ScanForStringSwitches();
+
             // Emit local variable declarations
             if (_ast.Locals.Count > 0)
             {
@@ -1826,6 +1840,12 @@ public static class CSharpEmitter
             // The condition block's last expression is the branch condition
             string condition = "/* condition */";
             ILAstExpression? branchExpression = null;
+            if (block.ConditionBlockIndex >= 0 && _stringSwitches.TryGetValue(block.ConditionBlockIndex, out var stringSwitch))
+            {
+                EmitStringSwitchExpression(block, stringSwitch, indent);
+                return;
+            }
+
             if (block.ConditionBlockIndex >= 0 && _blockMap.TryGetValue(block.ConditionBlockIndex, out var condBlock))
             {
                 _currentBlockNodes = condBlock.Nodes;
@@ -5339,6 +5359,291 @@ public static class CSharpEmitter
 
             WriteIndent(indent);
             _sb.AppendLine("}");
+        }
+
+        /// <summary>
+        /// Recognizes the hash-form string switch: csc lowers
+        /// 'switch (s)' over many string cases to
+        /// 'H = ComputeStringHash(s)' + a branch tree over H + per-case
+        /// 'if (s == "lit")' verification leaves sharing one default. The
+        /// dispatch tree carries no source semantics — the (literal, arm)
+        /// pairs and the default are the whole switch.
+        /// </summary>
+        void ScanForStringSwitches()
+        {
+            foreach (var (rootIdx, rootBlock) in _blockMap)
+            {
+                // Find: stloc H = call ComputeStringHash(ldloc subject)
+                string? hashLocal = null;
+                string? subjectLocal = null;
+                ILAstNode? hashNode = null;
+                foreach (var node in rootBlock.Nodes)
+                {
+                    if (node is ILAstStatement { Expression: var e }
+                        && e.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                            or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                        && e.Arguments.Count == 1
+                        && e.Arguments[0] is { OpCode: ILOpCode.Call } call
+                        && call.Operand?.Contains("ComputeStringHash", StringComparison.Ordinal) == true
+                        && call.Arguments.Count == 1
+                        && GetLocalReferenceName(call.Arguments[0]) is { } subj)
+                    {
+                        hashLocal = e.Operand ?? GetLocalName(e.OpCode);
+                        subjectLocal = subj;
+                        hashNode = node;
+                        break;
+                    }
+                }
+                if (hashLocal is null || subjectLocal is null)
+                    continue;
+
+                if (TryBuildStringSwitch(rootIdx, rootBlock, hashNode!, hashLocal, subjectLocal) is { } info)
+                    _stringSwitches[rootIdx] = info;
+            }
+        }
+
+        StringSwitchInfo? TryBuildStringSwitch(
+            int rootIdx, ILAstBlock rootBlock, ILAstNode hashNode, string hashLocal, string subjectLocal)
+        {
+            var consumed = new HashSet<int>();
+            var verifications = new List<(string Literal, int ArmStart)>();
+            var defaultCandidates = new HashSet<int>();
+
+            // Walk the dispatch tree from the root's trailing branch.
+            var queue = new Queue<int>();
+            var seen = new HashSet<int> { rootIdx };
+            EnqueueSuccessors(rootIdx, queue, seen);
+
+            while (queue.Count > 0)
+            {
+                int idx = queue.Dequeue();
+                if (!_blockMap.TryGetValue(idx, out var b))
+                    return null;
+                var nodes = b.Nodes
+                    .Where(n => n is not ILAstStatement { Expression.OpCode: ILOpCode.Nop })
+                    .ToList();
+
+                // Verification leaf: brtrue/brfalse(op_Equality(subject, ldstr)).
+                if (nodes.Count == 1
+                    && nodes[0] is ILAstStatement { Expression: var leaf }
+                    && leaf.OpCode is ILOpCode.Brtrue or ILOpCode.Brtrue_s or ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                    && leaf.Arguments.Count == 1
+                    && leaf.Arguments[0] is { OpCode: ILOpCode.Call, Arguments.Count: 2 } eq
+                    && eq.Operand?.Contains("op_Equality", StringComparison.Ordinal) == true
+                    && GetLocalReferenceName(eq.Arguments[0]) == subjectLocal
+                    && eq.Arguments[1].OpCode == ILOpCode.Ldstr
+                    && eq.Arguments[1].Operand is { } literal
+                    && leaf.Operand is string leafTarget
+                    && BlockAtLabel(leafTarget) is { } leafTargetIdx)
+                {
+                    bool isTrue = leaf.OpCode is ILOpCode.Brtrue or ILOpCode.Brtrue_s;
+                    int armStart = isTrue ? leafTargetIdx : idx + 1;
+                    int failStart = isTrue ? idx + 1 : leafTargetIdx;
+                    // The fail path must be (a hop to) the shared default.
+                    int failResolved = ResolveBareBr(failStart);
+                    consumed.Add(idx);
+                    if (failResolved != failStart)
+                        consumed.Add(failStart);
+                    verifications.Add((literal, armStart));
+                    defaultCandidates.Add(failResolved);
+                    continue;
+                }
+
+                // Dispatch block: every statement only touches the hash local.
+                bool isDispatch = nodes.Count > 0 && nodes.All(n =>
+                    n is ILAstStatement { Expression: var d }
+                    && (d.OpCode is ILOpCode.Br or ILOpCode.Br_s
+                        || (d.OpCode.IsBranch() && TreeOnlyLoadsLocalOrConsts(d, hashLocal))));
+                if (isDispatch)
+                {
+                    consumed.Add(idx);
+                    EnqueueSuccessors(idx, queue, seen);
+                    continue;
+                }
+
+                // Anything else reached from the dispatch tree is the default's
+                // start (reached by a bare br already consumed) — record it.
+                defaultCandidates.Add(idx);
+            }
+
+            if (verifications.Count < 2 || defaultCandidates.Count != 1)
+                return null;
+            int defaultIdx = defaultCandidates.Single();
+
+            // Arms (and default) must be single-value/throw shapes.
+            var temps = new HashSet<string>();
+            var armByTarget = new Dictionary<int, (List<string> Literals, ILAstExpression Value)>();
+            foreach (var (literal, armStart) in verifications)
+            {
+                if (!armByTarget.TryGetValue(armStart, out var arm))
+                {
+                    var value = ResolveSwitchArm(armStart, consumed, temps);
+                    if (value is null)
+                        return null;
+                    armByTarget[armStart] = arm = ([], value);
+                }
+                arm.Literals.Add(literal);
+            }
+            var defaultValue = ResolveSwitchArm(defaultIdx, consumed, temps);
+            if (defaultValue is null)
+                return null;
+
+            // Subject: follow trivial copies inside the root block; the copies
+            // and hash store render inside the expression, so they are skipped
+            // when nothing else reads them.
+            var skipNodes = new List<ILAstNode> { hashNode };
+            string subject = subjectLocal;
+            var suppressNames = new HashSet<string> { hashLocal };
+            string cur = subjectLocal;
+            for (int hops = 0; hops < 3; hops++)
+            {
+                ILAstNode? copyNode = null;
+                ILAstExpression? source = null;
+                foreach (var node in rootBlock.Nodes)
+                {
+                    if (node is ILAstStatement { Expression: var st }
+                        && st.OpCode is ILOpCode.Stloc or ILOpCode.Stloc_s
+                            or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+                        && (st.Operand ?? GetLocalName(st.OpCode)) == cur
+                        && st.Arguments.Count == 1)
+                    {
+                        copyNode = node;
+                        source = st.Arguments[0];
+                    }
+                }
+                if (copyNode is null || source is null)
+                    break;
+                bool simpleSource = source.OpCode is ILOpCode.Ldarg or ILOpCode.Ldarg_s
+                    or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+                    or ILOpCode.Ldloc or ILOpCode.Ldloc_s
+                    or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3;
+                if (!simpleSource)
+                    break;
+                skipNodes.Add(copyNode);
+                suppressNames.Add(cur);
+                subject = ExpressionToString(source);
+                if (GetLocalReferenceName(source) is not { } next)
+                    break;
+                cur = next;
+            }
+
+            // Locals folded into the expression must have no reads elsewhere.
+            foreach (var (idx, b) in _blockMap)
+            {
+                if (consumed.Contains(idx) || idx == rootIdx)
+                    continue;
+                foreach (string name in suppressNames.Append(subjectLocal).Concat(temps))
+                {
+                    if (BlockReferencesLocal(b, name))
+                        return null;
+                }
+            }
+            _suppressedLocals.UnionWith(suppressNames);
+            _suppressedLocals.UnionWith(temps);
+
+            var arms = armByTarget
+                .OrderBy(kv => kv.Key)
+                .Select(kv => kv.Value)
+                .ToList();
+            return new StringSwitchInfo(subject, arms, defaultValue, consumed, skipNodes);
+        }
+
+        void EnqueueSuccessors(int idx, Queue<int> queue, HashSet<int> seen)
+        {
+            if (!_blockMap.TryGetValue(idx, out var b)
+                || b.Nodes.LastOrDefault() is not ILAstStatement { Expression: var last })
+                return;
+            if (last.Operand is string target && (last.OpCode.IsBranch() || last.OpCode is ILOpCode.Br or ILOpCode.Br_s)
+                && BlockAtLabel(target) is { } targetIdx && seen.Add(targetIdx))
+            {
+                queue.Enqueue(targetIdx);
+            }
+            // Conditional branches fall through to the next block.
+            if (last.OpCode is not (ILOpCode.Br or ILOpCode.Br_s) && seen.Add(idx + 1))
+                queue.Enqueue(idx + 1);
+        }
+
+        int ResolveBareBr(int idx)
+        {
+            if (_blockMap.TryGetValue(idx, out var b)
+                && b.Nodes.Where(n => n is not ILAstStatement { Expression.OpCode: ILOpCode.Nop }).ToList()
+                    is [ILAstStatement { Expression: { OpCode: ILOpCode.Br or ILOpCode.Br_s, Operand: string t } }]
+                && BlockAtLabel(t) is { } targetIdx)
+            {
+                return targetIdx;
+            }
+            return idx;
+        }
+
+        static bool TreeOnlyLoadsLocalOrConsts(ILAstExpression expr, string local)
+        {
+            if (expr.OpCode is ILOpCode.Ldloc or ILOpCode.Ldloc_s
+                or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3)
+            {
+                return (expr.Operand ?? GetLocalName(expr.OpCode)) == local;
+            }
+            if (expr.OpCode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Calli or ILOpCode.Newobj
+                or ILOpCode.Ldfld or ILOpCode.Ldsfld or ILOpCode.Ldarg or ILOpCode.Ldarg_s
+                or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3)
+            {
+                return false;
+            }
+            foreach (var arg in expr.Arguments)
+            {
+                if (!TreeOnlyLoadsLocalOrConsts(arg, local))
+                    return false;
+            }
+            return true;
+        }
+
+        void EmitStringSwitchExpression(StructuredBlock block, StringSwitchInfo info, int indent)
+        {
+            if (_blockMap.TryGetValue(block.ConditionBlockIndex, out var rootBlock))
+            {
+                _currentBlockNodes = rootBlock.Nodes;
+                TryEmitLabel(block.ConditionBlockIndex);
+                for (int i = 0; i < rootBlock.Nodes.Count - 1; i++)
+                {
+                    var node = rootBlock.Nodes[i];
+                    if (_skipNodes.Contains(node) || info.SkipNodes.Contains(node))
+                        continue;
+                    if (node is ILAstStatement stmt)
+                        EmitStatement(stmt.Expression, indent);
+                    else if (node is ILAstAssignment assign)
+                        EmitAssignmentNode(assign, indent);
+                }
+                _currentBlockNodes = null;
+            }
+
+            WriteIndent(indent);
+            _sb.AppendLine($"return {info.Subject} switch");
+            WriteIndent(indent);
+            _sb.AppendLine("{");
+            foreach (var (literals, value) in info.Arms)
+            {
+                WriteIndent(indent + 1);
+                _sb.Append(string.Join(" or ", literals));
+                _sb.Append(" => ");
+                EmitSwitchArmValue(value);
+                _sb.AppendLine(",");
+            }
+            WriteIndent(indent + 1);
+            _sb.Append("_ => ");
+            EmitSwitchArmValue(info.DefaultValue);
+            _sb.AppendLine();
+            WriteIndent(indent);
+            _sb.AppendLine("};");
+
+            _consumedBlocks.Add(block.ConditionBlockIndex);
+            foreach (int idx in info.ConsumedBlocks)
+            {
+                _consumedBlocks.Add(idx);
+                RemoveGotoTargetsForConsumedBlock(idx);
+            }
+            if (block.ThenBlock is not null)
+                ConsumeStructuredBlock(block.ThenBlock);
+            if (block.ElseBlock is not null)
+                ConsumeStructuredBlock(block.ElseBlock);
         }
 
         /// <summary>


### PR DESCRIPTION
The string-switch ledger item, scoped per \`docs/decompiler-taste.md\`.

**IL shape targeted**: \`H = <PrivateImplementationDetails>.ComputeStringHash(s)\` + a branch tree over \`H\` + per-case \`if (s == "lit")\` verification leaves sharing one default — csc's lowering for string switches with enough cases.

**Class**: 1 — the hash dispatch is pure lowering artifact (no source semantics); the verification literals and arm values are the entire switch, and \`csharp_style_prefer_switch_expression\` picks the expression form.

```csharp
// before (35 lines)                          // after — source-exact
string V_0 = day;                             return day switch
uint V_2 = <PrivateImplementationDetails>     {
    .ComputeStringHash(V_0);                      "mon" => 1,
if (V_2 > (uint)-1542547220)                      "tue" => 2,
{                                                 "wed" => 3,
    if (V_2 > (uint)-702770473)                   "thu" => 4,
    {                                             "fri" => 5,
        if (V_2 == -531742879)                    "sat" => 6,
        {                                         "sun" => 7,
            if (V_0 == "sun") ...                 _ => 0
...                                           };
```

**Mechanics**: a pre-scan finds the hash store, BFS-walks the dispatch tree (blocks whose every statement touches only the hash local), collects verification leaves (\`brtrue\`/\`brfalse\` over \`string.op_Equality(subject, ldstr)\`), and validates all failure paths converge on a single default. Arm values reuse #426's resolver (single return/throw, or-grouping for shared arms). Soundness guards: any arm-shape miss, multiple default candidates, or a read of the hash local / subject copies / arm temps outside the consumed blocks vetoes the fold entirely — fallback is today's rendering.

**Not covered (follow-up)**: Release's length/char-bucketing lowering for smaller string switches — keeps its current correct if-chain rendering; the config-aware fixture pins both behaviors.

**Evidence**: dual-config \`DayNumber\` fixture (Debug folds, Release pins the bucketing fallback); h2h corpus byte-identical; all suites green both configs (decompiler 252, CLI 942).

🤖 Generated with [Claude Code](https://claude.com/claude-code)