### PR TITLE
type command: whole-type decompilation (-S "Decompiled Source")

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -112,6 +112,12 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serial
 
 A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need specific implementation evidence.
 
+To read a whole type instead of one member, use `type Name -S "Decompiled Source"`: it renders the entire type as one C# listing — declaration, fields (including non-public, for context), and every member body. Add `--raw` to print only the bare listing (no headings or code fences), suitable for redirecting to a file:
+
+```text
+dnx dotnet-inspect -y -- type Stack --platform System.Collections -S "Decompiled Source" --raw > Stack.cs
+```
+
 Fidelity expectations: `Original Source` is the SourceLink-backed original source when available. `Decompiled Source` is lowered C#, a best-effort readable reconstruction from IL that helps explain intent; it uses PDB debug information such as local names when available, but is not guaranteed to match original syntax or compiler transformations. Raw IL and annotated IL are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1135,6 +1135,21 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_DecompiledSource_RendersWholeTypeListing()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections.Generic.Stack", "--platform", "System.Collections",
+            "-S", "Decompiled Source");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("namespace System.Collections.Generic;", output);
+        Assert.Contains("public class Stack<T>", output);
+        Assert.Contains("private T[] _array;", output);
+        Assert.Contains("public void Push(T item)", output);
+        Assert.Contains("public bool TryPop(out T result)", output);
+    }
+
+    [Fact]
     public async Task Member_NonMethodRows_RenderFullDeclarations()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1150,6 +1150,22 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_DecompiledSource_Raw_EmitsBareListing()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections.Generic.Stack", "--platform", "System.Collections",
+            "-S", "Decompiled Source", "--raw");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        // Bare C#: no markdown heading, no section title, no code fence, no tips.
+        Assert.StartsWith("namespace System.Collections.Generic;", output);
+        Assert.DoesNotContain("# ", output);
+        Assert.DoesNotContain("```", output);
+        Assert.DoesNotContain("Tips:", output);
+    }
+
+    [Fact]
     public async Task Member_NonMethodRows_RenderFullDeclarations()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -93,6 +93,7 @@ public static class ApiCommandDefinitions
         opts.AddCountOptionTo(typeCommand);
         typeCommand.Options.Add(opts.Markdown);
         typeCommand.Options.Add(opts.PlainText);
+        typeCommand.Options.Add(opts.Raw);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 
@@ -204,6 +205,7 @@ public static class ApiCommandDefinitions
         opts.AddCountOptionTo(memberCommand);
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
+        memberCommand.Options.Add(opts.Raw);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -226,6 +226,7 @@ public static class MemberOptionsParser
             OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             PlainText = parseResult.GetValue(opts.PlainText),
+            Raw = parseResult.GetValue(opts.Raw),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             UnsafeOnly = parseResult.GetValue(args.UnsafeOption),
             CtorOnly = ctorOnly,

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -133,6 +133,7 @@ public static class TypeOptionsParser
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
             PlainText = parseResult.GetValue(opts.PlainText),
+            Raw = parseResult.GetValue(opts.Raw),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             ShapeOutput = parseResult.GetValue(args.ShapeOption),
             ShapeExplicitlySet = parseResult.GetResult(args.ShapeOption) is { Implicit: false },

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -779,7 +779,7 @@ public class ApiCommand
                     .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method" && !m.IsAbstract)
                     .ToList();
                 if (methods.Count > 0)
-                    ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath,
+                    ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
                         mo4.OverloadIndex.Value - 1, requestedSections, mo4.PdbPath);
             }
 
@@ -789,6 +789,21 @@ public class ApiCommand
             {
                 view.MemberCode ??= new MemberCodeView();
                 view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", mo5.MethodSource.SourceCode);
+            }
+
+            // Whole-type decompilation (type command; member flows populate per
+            // member above). Explicit-only: requires -S "Decompiled Source".
+            if (options is not MemberOptions
+                && options.DllPath is { } typeDllPath
+                && options.IncludeSections is { Count: > 0 }
+                && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
+            {
+                var listing = TypeSourceComposer.Compose(type, typeDllPath, options.PdbPath);
+                if (listing is not null)
+                {
+                    view.MemberCode ??= new MemberCodeView();
+                    view.MemberCode.DecompiledSourceCode = new Markout.CodeSection("csharp", listing);
+                }
             }
         }
 
@@ -991,7 +1006,7 @@ public class ApiCommand
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,
-                        memberOptions.DllPath, memberOptions.OverloadIndex.Value - 1,
+                        memberOptions.DllPath!, memberOptions.OverloadIndex.Value - 1,
                         requestedSections, memberOptions.PdbPath);
 
                 if (memberOptions.MethodSource != null && requestedSections.Contains(SectionNames.OriginalSource))

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -807,6 +807,30 @@ public class ApiCommand
             }
         }
 
+        // --raw: only the selected code section's content — no heading, no
+        // fence — suitable for redirecting to a .cs/.il file.
+        if (options.Raw)
+        {
+            var raw = options.IncludeSections is { Count: 1 } included
+                ? included.First() switch
+                {
+                    SectionNames.DecompiledSource => view.MemberCode?.DecompiledSourceCode.Content,
+                    SectionNames.OriginalSource => view.MemberCode?.OriginalSourceCode.Content,
+                    "IL" => view.MemberCode?.ILCode.Content,
+                    "IL (Annotated)" => view.MemberCode?.AnnotatedIL.Content,
+                    _ => null,
+                }
+                : null;
+            if (raw is null)
+            {
+                Console.Error.WriteLine(
+                    "Error: --raw requires a single -S code section with content (Decompiled Source, IL, IL (Annotated), Original Source).");
+                return;
+            }
+            sink.WriteLine(raw.TrimEnd());
+            return;
+        }
+
         if (options.Count)
         {
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -186,6 +186,10 @@ public static class TypeCommand
                     if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                         effectiveOptions = options with { ShowDocs = true };
 
+                    // The resolved assembly path enables decompiler-backed
+                    // sections (whole-type Decompiled Source).
+                    effectiveOptions = effectiveOptions with { DllPath = runtimeAssemblyPath ?? apiDllPath };
+
                     if (ShouldRejectQuietShape(effectiveOptions))
                     {
                         Console.Error.WriteLine("Error: -v:q is not supported by the type shape renderer.");

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -46,6 +46,10 @@ public partial record ApiOptions
     public bool OneLineExplicitlySet { get; init; }
     public bool PlainText { get; init; }
 
+    /// <summary>Print only the selected section's content with no heading,
+    /// fence, or tips — suitable for redirecting code sections to files.</summary>
+    public bool Raw { get; init; }
+
     /// <summary>
     /// True when the user explicitly chose an output format via CLI flags.
     /// When false, commands are free to apply their own default format (e.g., shape/tree).
@@ -97,7 +101,7 @@ public partial record ApiOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public virtual bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || Count;
+    public virtual bool IsRawOutput => Raw || JsonOutput || OneLine || Jsonl || NoHeader || Count;
 }
 
 /// <summary>
@@ -135,7 +139,7 @@ public record TypeOptions : ApiOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public override bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ShapeOutput || Count;
+    public override bool IsRawOutput => Raw || JsonOutput || OneLine || Jsonl || NoHeader || ShapeOutput || Count;
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -7,7 +7,7 @@ namespace DotnetInspector.Options;
 /// <summary>
 /// Base options shared by type and member commands.
 /// </summary>
-public record ApiOptions
+public partial record ApiOptions
 {
     /// <summary>
     /// Type name to inspect (positional argument). Null for full API listing.
@@ -103,6 +103,18 @@ public record ApiOptions
 /// <summary>
 /// Options specific to the type command.
 /// </summary>
+public partial record ApiOptions
+{
+    /// <summary>On-disk path of the resolved assembly, when a command has one
+    /// in hand — enables decompiler-backed sections (member code sections,
+    /// whole-type Decompiled Source).</summary>
+    public string? DllPath { get; init; }
+
+    /// <summary>On-disk path to an acquired portable PDB, used by the decompiler
+    /// to resolve real local-variable names instead of synthesized <c>V_n</c> slots.</summary>
+    public string? PdbPath { get; init; }
+}
+
 public record TypeOptions : ApiOptions
 {
     public string? TypeFilter { get; init; }
@@ -136,12 +148,7 @@ public record MemberOptions : ApiOptions
     public string[]? ParamTypes { get; init; }
     public string? FirstParamType { get; init; }
     public bool ShowSelect { get; init; }
-    public string? DllPath { get; init; }
     public MethodSourceContext? MethodSource { get; init; }
-
-    /// <summary>On-disk path to an acquired portable PDB, used by the decompiler (--index code
-    /// sections) to resolve real local-variable names instead of synthesized <c>V_n</c> slots.</summary>
-    public string? PdbPath { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -1,0 +1,378 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Composes a whole type as one C# listing: the type declaration, field
+/// declarations (including non-public fields, for context the bodies
+/// reference), and every member's decompiled body — the reading unit for
+/// building intuition about what a type does, and the comparison unit that
+/// matches both reference decompilers and dotnet/runtime's per-type source
+/// files.
+/// </summary>
+internal static class TypeSourceComposer
+{
+    public static string? Compose(ApiType type, string dllPath, string? pdbPath)
+    {
+        if (type.Kind is "delegate")
+            return null;
+
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return null;
+            var reader = peReader.GetMetadataReader();
+
+            TypeDefinitionHandle typeHandle = default;
+            foreach (var h in reader.TypeDefinitions)
+            {
+                if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
+                {
+                    typeHandle = h;
+                    break;
+                }
+            }
+            if (typeHandle.IsNil)
+                return null;
+
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(type.Namespace))
+            {
+                sb.AppendLine($"namespace {type.Namespace};");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine(TypeDeclaration(type));
+            sb.AppendLine("{");
+
+            bool any = false;
+            if (type.Kind == "enum")
+            {
+                ComposeEnumValues(sb, type, ref any);
+            }
+            else
+            {
+                ComposeFields(sb, reader, typeHandle, ref any);
+                ComposeMembers(sb, type, peReader, reader, typeHandle, pdbPath, ref any);
+            }
+
+            sb.AppendLine("}");
+            return any ? sb.ToString().TrimEnd() : null;
+        }
+        catch
+        {
+            // Composition is best-effort; the section is simply absent.
+            return null;
+        }
+    }
+
+    static string TypeDeclaration(ApiType type)
+    {
+        var sb = new StringBuilder("public ");
+        if (type.Kind == "class")
+        {
+            if (type.IsStatic) sb.Append("static ");
+            else if (type.IsAbstract) sb.Append("abstract ");
+            else if (type.IsSealed) sb.Append("sealed ");
+        }
+        sb.Append(type.Kind == "enum" ? "enum" : type.Kind);
+        sb.Append(' ');
+        sb.Append(DisplayName(type));
+
+        var bases = new List<string>();
+        if (type.BaseType is { } baseType
+            && baseType is not ("System.Object" or "object" or "System.ValueType" or "System.Enum"))
+        {
+            bases.Add(baseType);
+        }
+        bases.AddRange(type.Interfaces);
+        if (bases.Count > 0)
+            sb.Append($" : {string.Join(", ", bases)}");
+        return sb.ToString();
+    }
+
+    static string DisplayName(ApiType type)
+    {
+        string name = type.Name;
+        int tick = name.IndexOf('`');
+        if (tick >= 0)
+            name = name[..tick];
+        if (type.TypeParameters.Count > 0)
+            name += $"<{string.Join(", ", type.TypeParameters.Select(p => p.Name))}>";
+        return name;
+    }
+
+    static void ComposeEnumValues(StringBuilder sb, ApiType type, ref bool any)
+    {
+        foreach (var member in type.Members)
+        {
+            if (member.Kind != "field" || member.EnumValue is null)
+                continue;
+            sb.AppendLine($"    {member.Name} = {member.EnumValue},");
+            any = true;
+        }
+    }
+
+    static void ComposeFields(StringBuilder sb, MetadataReader reader, TypeDefinitionHandle typeHandle, ref bool any)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var genericContext = GenericContext.ForType(reader, typeDef);
+        bool wrote = false;
+
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            string name = reader.GetString(field.Name);
+            if (name.Contains('<'))
+                continue; // compiler-generated backing fields
+
+            string access = (field.Attributes & FieldAttributes.FieldAccessMask) switch
+            {
+                FieldAttributes.Public => "public",
+                FieldAttributes.Family => "protected",
+                FieldAttributes.Assembly => "internal",
+                FieldAttributes.FamORAssem => "protected internal",
+                FieldAttributes.FamANDAssem => "private protected",
+                _ => "private",
+            };
+            string fieldType;
+            try
+            {
+                fieldType = field.DecodeSignature(SignatureDecoder.Instance, genericContext);
+            }
+            catch
+            {
+                continue;
+            }
+
+            var decl = new StringBuilder($"    {access} ");
+            if (field.Attributes.HasFlag(FieldAttributes.Literal))
+                decl.Append("const ");
+            else
+            {
+                if (field.Attributes.HasFlag(FieldAttributes.Static))
+                    decl.Append("static ");
+                if (field.Attributes.HasFlag(FieldAttributes.InitOnly))
+                    decl.Append("readonly ");
+            }
+            decl.Append($"{Shorten(fieldType)} {name};");
+            sb.AppendLine(decl.ToString());
+            wrote = true;
+            any = true;
+        }
+
+        if (wrote)
+            sb.AppendLine();
+    }
+
+    static void ComposeMembers(
+        StringBuilder sb, ApiType type, PEReader peReader, MetadataReader reader,
+        TypeDefinitionHandle typeHandle, string? pdbPath, ref bool any)
+    {
+        // Per-name running overload index — the same positional pairing the
+        // member command uses for Name:N.
+        var overloadIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        bool first = true;
+
+        foreach (var member in type.Members)
+        {
+            switch (member.Kind)
+            {
+                case "constructor" or "method" or "operator" or "explicit-interface-implementation":
+                {
+                    int index = overloadIndex.GetValueOrDefault(member.Name);
+                    overloadIndex[member.Name] = index + 1;
+
+                    if (!first) sb.AppendLine();
+                    first = false;
+                    any = true;
+
+                    string? body = member.IsAbstract
+                        ? null
+                        : DecompileBody(peReader, reader, typeHandle, member, index, pdbPath);
+                    AppendMember(sb, MethodDeclaration(type, member), body);
+                    break;
+                }
+
+                case "property":
+                {
+                    if (!first) sb.AppendLine();
+                    first = false;
+                    any = true;
+                    ComposeProperty(sb, peReader, reader, typeHandle, member, pdbPath);
+                    break;
+                }
+
+                case "event":
+                {
+                    if (!first) sb.AppendLine();
+                    first = false;
+                    any = true;
+                    string sig = member.Signature ?? member.Name;
+                    if (!sig.StartsWith("public", StringComparison.Ordinal))
+                        sig = $"public event {sig}";
+                    sb.AppendLine($"    {sig};");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The extractor's method signatures carry no modifiers (property
+    /// signatures do); synthesize the declaration from the member flags.
+    /// Constructors rename .ctor/.cctor to the type's display name.
+    /// </summary>
+    static string MethodDeclaration(ApiType type, ApiMember member)
+    {
+        string signature = member.Signature ?? member.Name;
+        string typeName = DisplayName(type);
+        int tick = typeName.IndexOf('<');
+        string ctorName = tick >= 0 ? typeName[..tick] : typeName;
+
+        if (member.Name == ".cctor")
+            return $"static {ctorName}()";
+        if (member.Name == ".ctor")
+        {
+            if (signature.StartsWith("void ", StringComparison.Ordinal))
+                signature = signature[5..];
+            return $"public {signature.Replace(".ctor", ctorName)}";
+        }
+
+        // Explicit interface implementations take no modifiers.
+        if (member.Kind == "explicit-interface-implementation")
+            return signature;
+
+        var parts = new List<string> { member.Accessibility ?? "public" };
+        if (type.Kind != "interface")
+        {
+            if (member.IsStatic) parts.Add("static");
+            if (member.IsAbstract) parts.Add("abstract");
+            else if (member.IsSealed && member.IsOverride) parts.Add("sealed override");
+            else if (member.IsOverride) parts.Add("override");
+            else if (member.IsVirtual) parts.Add("virtual");
+        }
+        parts.Add(signature);
+        return string.Join(" ", parts);
+    }
+
+    static void AppendMember(StringBuilder sb, string signature, string? body)
+    {
+        if (body is null)
+        {
+            sb.AppendLine($"    {signature};");
+            return;
+        }
+        sb.AppendLine($"    {signature}");
+        sb.AppendLine("    {");
+        AppendIndented(sb, body, "        ");
+        sb.AppendLine("    }");
+    }
+
+    static void ComposeProperty(
+        StringBuilder sb, PEReader peReader, MetadataReader reader,
+        TypeDefinitionHandle typeHandle, ApiMember member, string? pdbPath)
+    {
+        string signature = member.Signature ?? member.Name;
+        int accessorList = signature.IndexOf('{');
+        string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
+
+        var accessors = new List<(string Keyword, string? Body)>();
+        if (accessorList >= 0)
+        {
+            string list = signature[accessorList..];
+            if (list.Contains("get;", StringComparison.Ordinal))
+                accessors.Add(("get", DecompileAccessor(peReader, reader, typeHandle, $"get_{member.Name}", pdbPath)));
+            if (list.Contains("set;", StringComparison.Ordinal))
+                accessors.Add(("set", DecompileAccessor(peReader, reader, typeHandle, $"set_{member.Name}", pdbPath)));
+            if (list.Contains("init;", StringComparison.Ordinal))
+                accessors.Add(("init", DecompileAccessor(peReader, reader, typeHandle, $"set_{member.Name}", pdbPath)));
+        }
+
+        if (accessors.Count == 0 || member.IsAbstract || accessors.All(a => a.Body is null))
+        {
+            sb.AppendLine($"    {signature}");
+            return;
+        }
+
+        sb.AppendLine($"    {head}");
+        sb.AppendLine("    {");
+        for (int i = 0; i < accessors.Count; i++)
+        {
+            var (keyword, body) = accessors[i];
+            if (i > 0) sb.AppendLine();
+            if (body is null)
+            {
+                sb.AppendLine($"        {keyword};");
+                continue;
+            }
+            sb.AppendLine($"        {keyword}");
+            sb.AppendLine("        {");
+            AppendIndented(sb, body, "            ");
+            sb.AppendLine("        }");
+        }
+        sb.AppendLine("    }");
+    }
+
+    static string? DecompileBody(
+        PEReader peReader, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        ApiMember member, int overloadIndex, string? pdbPath)
+    {
+        try
+        {
+            bool publicOnly = member.Kind != "explicit-interface-implementation";
+            var context = Decompiler.MethodBodyContext.Create(
+                peReader, reader, typeHandle, member.Name, overloadIndex, publicOnly, pdbPath);
+            if (context is null)
+                return null;
+            string body = Decompiler.CSharpEmitter.Emit(context).TrimEnd();
+            return string.IsNullOrWhiteSpace(body) ? null : body;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string? DecompileAccessor(
+        PEReader peReader, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        string accessorName, string? pdbPath)
+    {
+        try
+        {
+            var context = Decompiler.MethodBodyContext.Create(
+                peReader, reader, typeHandle, accessorName, 0, publicOnly: false, pdbPath);
+            if (context is null)
+                return null;
+            string body = Decompiler.CSharpEmitter.Emit(context).TrimEnd();
+            return string.IsNullOrWhiteSpace(body) ? null : body;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static void AppendIndented(StringBuilder sb, string body, string indent)
+    {
+        foreach (var line in body.Split('\n'))
+        {
+            string trimmed = line.TrimEnd();
+            if (trimmed.Length == 0)
+                sb.AppendLine();
+            else
+                sb.AppendLine($"{indent}{trimmed}");
+        }
+    }
+
+    static string Shorten(string typeName) =>
+        typeName.StartsWith("System.", StringComparison.Ordinal) && typeName.IndexOf('.', 7) < 0
+            ? typeName[7..]
+            : typeName;
+}

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -17,6 +17,7 @@ public class SharedOptions
     public Option<bool> Json { get; } = new("--json") { Description = "Output as JSON" };
     public Option<bool> Markdown { get; } = new("--markdown") { Description = "Output as markdown" };
     public Option<bool> PlainText { get; } = new("--plaintext") { Description = "Output as plain text" };
+    public Option<bool> Raw { get; } = new("--raw") { Description = "Print only the selected section's content, undecorated (single -S code section; e.g. redirect Decompiled Source to a .cs file)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };


### PR DESCRIPTION
The per-type export TODO, v1. \`type Stack --platform System.Collections -S "Decompiled Source"\` now renders the whole type as one C# listing:

```csharp
namespace System.Collections.Generic;

public class Stack<T> : IEnumerable<T>, ICollection, IReadOnlyCollection<T>
{
    private T[] _array;
    private int _size;
    private int _version;

    public Stack(int capacity)
    {
        base();
        ArgumentOutOfRangeException.ThrowIfNegative(capacity, "capacity");
        this._array = new T[capacity];
        return;
    }

    public void Push(T item)
    {
        ...
    }
    ...
}
```

**Why** (from the TODO): a type is the natural unit for building intuition — member bodies read differently when the fields they reference are declared above them (non-public fields are deliberately included for exactly this reason). And it collapses the h2h comparison loop: \`ilspycmd -t\` and dotnet/runtime source files are both per-type units, so all three artifacts become directly diffable.

**Mechanics**: a new \`TypeSourceComposer\` walks the ApiType — synthesized type declaration; metadata-decoded field declarations; every ctor/method/operator body via \`CSharpEmitter\` (declarations synthesized from member flags, \`.ctor\`/\`.cctor\` renamed); properties expand accessors with decompiled bodies; enums list values. \`DllPath\`/\`PdbPath\` move from \`MemberOptions\` up to \`ApiOptions\` so the type command carries the resolved assembly path (member flows unchanged). Population is explicit-only — requires \`-S\` selection; never part of a default view.

**Known v1 rough edges** (all pre-existing per-member rendering traits now more visible at type scale, per the TODO's prediction): \`base();\` in ctors, trailing \`return;\`, explicit-interface property accessors as \`get_*\` methods, and semi-qualified names — the using-hoisting follow-up addresses the last. Enums with no methods report "no data" rather than rendering the values listing (CanRender is shared with member pipelines).

All suites green (CLI 944 incl. new whole-type test, decompiler 252, metadata 135, services 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)