### PR TITLE
Refine integration scanner ownership

### DIFF
--- a/src/DotnetInspector.Metadata/EcosystemIntegrationNames.cs
+++ b/src/DotnetInspector.Metadata/EcosystemIntegrationNames.cs
@@ -1,0 +1,15 @@
+namespace DotnetInspector.Metadata;
+
+public static class EcosystemIntegrationNames
+{
+    public const string Integrations = "Integrations";
+    public const string AI = "AI";
+    public const string Aspire = "Aspire";
+    public const string DependencyInjection = "Dependency Injection";
+    public const string Logging = "Logging";
+    public const string OpenTelemetry = "OpenTelemetry";
+    public const string Options = "Options";
+    public const string Hosting = "Hosting";
+    public const string HealthChecks = "Health Checks";
+    public const string HttpClient = "HTTP Client";
+}

--- a/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -355,14 +355,23 @@ public static class EcosystemIntegrationScanner
         foreach (var methodHandle in typeDefinition.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            if ((method.Attributes & MethodAttributes.Public) == 0
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
                 || (method.Attributes & MethodAttributes.Static) == 0
                 || !AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes()))
                 continue;
 
             var methodName = reader.GetString(method.Name);
             var context = GenericContext.ForMethod(reader, typeDefinition, method);
-            var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+            }
+            catch (BadImageFormatException)
+            {
+                continue;
+            }
+
             var api = $"{TypeResolver.FormatDisplayName(typeName)}.{methodName}(...)";
             if (TryClassifyAspireStarterMethod(typeName, methodName, signature, out var aspireKind))
                 buckets.Aspire.Apis.TryAdd(api, aspireKind);
@@ -638,24 +647,24 @@ public static class EcosystemIntegrationScanner
 
         public static IntegrationBuckets Create() => new()
         {
-            Aspire = new IntegrationBucket("Aspire", "Aspire"),
-            AIChat = new IntegrationBucket("AI", "Chat"),
-            AIEmbeddings = new IntegrationBucket("AI", "Embeddings"),
-            AIImages = new IntegrationBucket("AI", "Images"),
-            AIRealtime = new IntegrationBucket("AI", "Realtime"),
-            AIHosting = new IntegrationBucket("AI", "Hosting"),
-            AISpeechToText = new IntegrationBucket("AI", "Speech to Text"),
-            AITextToSpeech = new IntegrationBucket("AI", "Text to Speech"),
-            AITools = new IntegrationBucket("AI", "Tools"),
-            AIHostedFiles = new IntegrationBucket("AI", "Hosted Files"),
-            AIBuilder = new IntegrationBucket("AI", "Builder"),
-            AIConfiguration = new IntegrationBucket("AI", "Configuration"),
-            DependencyInjection = new IntegrationBucket("Dependency Injection", "Dependency Injection"),
-            Logging = new IntegrationBucket("Logging", "Logging"),
-            Options = new IntegrationBucket("Options", "Options"),
-            Hosting = new IntegrationBucket("Hosting", "Hosting"),
-            HealthChecks = new IntegrationBucket("Health Checks", "Health Check"),
-            HttpClient = new IntegrationBucket("HTTP Client", "HTTP Client")
+            Aspire = new IntegrationBucket(EcosystemIntegrationNames.Aspire, "Aspire"),
+            AIChat = new IntegrationBucket(EcosystemIntegrationNames.AI, "Chat"),
+            AIEmbeddings = new IntegrationBucket(EcosystemIntegrationNames.AI, "Embeddings"),
+            AIImages = new IntegrationBucket(EcosystemIntegrationNames.AI, "Images"),
+            AIRealtime = new IntegrationBucket(EcosystemIntegrationNames.AI, "Realtime"),
+            AIHosting = new IntegrationBucket(EcosystemIntegrationNames.AI, "Hosting"),
+            AISpeechToText = new IntegrationBucket(EcosystemIntegrationNames.AI, "Speech to Text"),
+            AITextToSpeech = new IntegrationBucket(EcosystemIntegrationNames.AI, "Text to Speech"),
+            AITools = new IntegrationBucket(EcosystemIntegrationNames.AI, "Tools"),
+            AIHostedFiles = new IntegrationBucket(EcosystemIntegrationNames.AI, "Hosted Files"),
+            AIBuilder = new IntegrationBucket(EcosystemIntegrationNames.AI, "Builder"),
+            AIConfiguration = new IntegrationBucket(EcosystemIntegrationNames.AI, "Configuration"),
+            DependencyInjection = new IntegrationBucket(EcosystemIntegrationNames.DependencyInjection, "Dependency Injection"),
+            Logging = new IntegrationBucket(EcosystemIntegrationNames.Logging, "Logging"),
+            Options = new IntegrationBucket(EcosystemIntegrationNames.Options, "Options"),
+            Hosting = new IntegrationBucket(EcosystemIntegrationNames.Hosting, "Hosting"),
+            HealthChecks = new IntegrationBucket(EcosystemIntegrationNames.HealthChecks, "Health Check"),
+            HttpClient = new IntegrationBucket(EcosystemIntegrationNames.HttpClient, "HTTP Client")
         };
     }
 

--- a/src/dotnet-inspect.Tests/EcosystemIntegrationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/EcosystemIntegrationScannerTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public class EcosystemIntegrationScannerTests
+{
+    [Fact]
+    public void Scan_IgnoresNonPublicStarterExtensionMethods()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly();
+        using var peReader = new PEReader(stream);
+
+        var signals = EcosystemIntegrationScanner.Scan(peReader);
+        var apis = signals
+            .Where(signal => signal.Shape == IntegrationSignalShape.Api)
+            .Select(signal => signal.Name)
+            .ToArray();
+
+        Assert.Contains("Microsoft.Extensions.DependencyInjection.TestServiceCollectionExtensions.AddPublicThing(...)", apis);
+        Assert.DoesNotContain("Microsoft.Extensions.DependencyInjection.TestServiceCollectionExtensions.AddInternalThing(...)", apis);
+    }
+
+    private static MemoryStream BuildDependencyInjectionExtensionAssembly()
+    {
+        var assemblyBuilder = new PersistedAssemblyBuilder(
+            new AssemblyName("IntegrationVisibilityFixture"),
+            typeof(object).Assembly);
+        var module = assemblyBuilder.DefineDynamicModule("IntegrationVisibilityFixture");
+
+        var serviceCollection = module.DefineType(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+        var serviceCollectionType = serviceCollection.CreateType();
+
+        var extensions = module.DefineType(
+            "Microsoft.Extensions.DependencyInjection.TestServiceCollectionExtensions",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var extensionAttribute = new CustomAttributeBuilder(
+            typeof(ExtensionAttribute).GetConstructor(Type.EmptyTypes)!,
+            []);
+        extensions.SetCustomAttribute(extensionAttribute);
+
+        DefineExtensionMethod(extensions, "AddPublicThing", MethodAttributes.Public);
+        DefineExtensionMethod(extensions, "AddInternalThing", MethodAttributes.Assembly);
+
+        extensions.CreateType();
+
+        var stream = new MemoryStream();
+        assemblyBuilder.Save(stream);
+        stream.Position = 0;
+        return stream;
+
+        void DefineExtensionMethod(TypeBuilder type, string name, MethodAttributes accessibility)
+        {
+            var method = type.DefineMethod(
+                name,
+                accessibility | MethodAttributes.Static,
+                typeof(void),
+                [serviceCollectionType]);
+            method.SetCustomAttribute(extensionAttribute);
+            method.GetILGenerator().Emit(OpCodes.Ret);
+        }
+    }
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -563,16 +563,10 @@ internal static class LibraryMetadataService
 
     internal static void ScanIntegrations(PEReader peReader, string path, LibraryInspection inspection, VerboseLogger logger)
     {
-        inspection.OpenTelemetry = ScanOpenTelemetry(peReader, path, logger);
+        LibraryIntegrationCatalog.OpenTelemetry.SetSignals(inspection, ScanOpenTelemetry(peReader, path, logger));
         var signals = EcosystemIntegrationScanner.Scan(peReader);
-        inspection.Aspire = SelectIntegrationSignals(signals, "Aspire");
-        inspection.AI = SelectIntegrationSignals(signals, "AI");
-        inspection.DependencyInjection = SelectIntegrationSignals(signals, "Dependency Injection");
-        inspection.Logging = SelectIntegrationSignals(signals, "Logging");
-        inspection.Options = SelectIntegrationSignals(signals, "Options");
-        inspection.Hosting = SelectIntegrationSignals(signals, "Hosting");
-        inspection.HealthChecks = SelectIntegrationSignals(signals, "Health Checks");
-        inspection.HttpClient = SelectIntegrationSignals(signals, "HTTP Client");
+        foreach (var descriptor in LibraryIntegrationCatalog.EcosystemScanned)
+            descriptor.SetSignals(inspection, SelectIntegrationSignals(signals, descriptor.Name));
         inspection.Integrations = BuildIntegrations(inspection);
     }
 
@@ -608,33 +602,18 @@ internal static class LibraryMetadataService
     private static List<IntegrationSummary>? BuildIntegrations(LibraryInspection inspection)
     {
         List<IntegrationSummary> integrations = [];
-        AddIntegration(integrations, "AI", inspection.AI);
-        AddIntegration(integrations, "Aspire", inspection.Aspire);
-        AddIntegration(integrations, "Dependency Injection", inspection.DependencyInjection);
-        AddIntegration(integrations, "Logging", inspection.Logging);
-        AddIntegration(integrations, "OpenTelemetry", inspection.OpenTelemetry);
-        AddIntegration(integrations, "Options", inspection.Options);
-        AddIntegration(integrations, "Hosting", inspection.Hosting);
-        AddIntegration(integrations, "Health Checks", inspection.HealthChecks);
-        AddIntegration(integrations, "HTTP Client", inspection.HttpClient);
+        foreach (var descriptor in LibraryIntegrationCatalog.All)
+            AddIntegration(integrations, descriptor, descriptor.GetSignals(inspection));
         return integrations.Count > 0 ? integrations : null;
     }
 
     private static void AddIntegration(
         List<IntegrationSummary> integrations,
-        string name,
+        LibraryIntegrationDescriptor descriptor,
         List<IntegrationSignal>? signals)
     {
         if (signals is { Count: > 0 })
-            integrations.Add(new IntegrationSummary(name, CountRenderedIntegrationApis(name, signals)));
-    }
-
-    private static int CountRenderedIntegrationApis(string name, List<IntegrationSignal> signals)
-    {
-        var apiCount = signals.Count(signal => signal.Shape == IntegrationSignalShape.Api);
-        return apiCount > 0 && name is not ("AI" or "Aspire" or "HTTP Client" or "OpenTelemetry")
-            ? apiCount
-            : signals.Count;
+            integrations.Add(new IntegrationSummary(descriptor.Name, descriptor.CountRenderedRows(signals)));
     }
 
     internal static void ScanInfoCounts(string path, LibraryInspection inspection, VerboseLogger logger)

--- a/src/dotnet-inspect/Models/LibraryIntegrationCatalog.cs
+++ b/src/dotnet-inspect/Models/LibraryIntegrationCatalog.cs
@@ -1,0 +1,121 @@
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Models;
+
+internal sealed record LibraryIntegrationDescriptor(
+    string Name,
+    Func<LibraryInspection, List<IntegrationSignal>?> GetSignals,
+    Action<LibraryInspection, List<IntegrationSignal>?> SetSignals,
+    Func<LibraryInspection, bool> HasPresence,
+    bool IncludeTypesWhenApisPresent)
+{
+    public bool CanRender(LibraryInspection inspection)
+        => GetSignals(inspection) is { Count: > 0 } || HasPresence(inspection);
+
+    public int CountRenderedRows(List<IntegrationSignal> signals)
+    {
+        var apiCount = signals.Count(signal => signal.Shape == IntegrationSignalShape.Api);
+        return apiCount > 0 && !IncludeTypesWhenApisPresent ? apiCount : signals.Count;
+    }
+}
+
+internal static class LibraryIntegrationCatalog
+{
+    public const string RollupName = EcosystemIntegrationNames.Integrations;
+
+    public static readonly LibraryIntegrationDescriptor AI = new(
+        EcosystemIntegrationNames.AI,
+        inspection => inspection.AI,
+        (inspection, signals) => inspection.AI = signals,
+        inspection => inspection.HasAISupport,
+        IncludeTypesWhenApisPresent: true);
+
+    public static readonly LibraryIntegrationDescriptor Aspire = new(
+        EcosystemIntegrationNames.Aspire,
+        inspection => inspection.Aspire,
+        (inspection, signals) => inspection.Aspire = signals,
+        inspection => inspection.HasAspireSupport,
+        IncludeTypesWhenApisPresent: true);
+
+    public static readonly LibraryIntegrationDescriptor DependencyInjection = new(
+        EcosystemIntegrationNames.DependencyInjection,
+        inspection => inspection.DependencyInjection,
+        (inspection, signals) => inspection.DependencyInjection = signals,
+        inspection => inspection.HasDependencyInjectionSupport,
+        IncludeTypesWhenApisPresent: false);
+
+    public static readonly LibraryIntegrationDescriptor Logging = new(
+        EcosystemIntegrationNames.Logging,
+        inspection => inspection.Logging,
+        (inspection, signals) => inspection.Logging = signals,
+        inspection => inspection.HasLoggingSupport,
+        IncludeTypesWhenApisPresent: false);
+
+    public static readonly LibraryIntegrationDescriptor OpenTelemetry = new(
+        EcosystemIntegrationNames.OpenTelemetry,
+        inspection => inspection.OpenTelemetry,
+        (inspection, signals) => inspection.OpenTelemetry = signals,
+        inspection => inspection.HasOpenTelemetrySupport,
+        IncludeTypesWhenApisPresent: true);
+
+    public static readonly LibraryIntegrationDescriptor Options = new(
+        EcosystemIntegrationNames.Options,
+        inspection => inspection.Options,
+        (inspection, signals) => inspection.Options = signals,
+        inspection => inspection.HasOptionsSupport,
+        IncludeTypesWhenApisPresent: false);
+
+    public static readonly LibraryIntegrationDescriptor Hosting = new(
+        EcosystemIntegrationNames.Hosting,
+        inspection => inspection.Hosting,
+        (inspection, signals) => inspection.Hosting = signals,
+        inspection => inspection.HasHostingSupport,
+        IncludeTypesWhenApisPresent: false);
+
+    public static readonly LibraryIntegrationDescriptor HealthChecks = new(
+        EcosystemIntegrationNames.HealthChecks,
+        inspection => inspection.HealthChecks,
+        (inspection, signals) => inspection.HealthChecks = signals,
+        inspection => inspection.HasHealthChecksSupport,
+        IncludeTypesWhenApisPresent: false);
+
+    public static readonly LibraryIntegrationDescriptor HttpClient = new(
+        EcosystemIntegrationNames.HttpClient,
+        inspection => inspection.HttpClient,
+        (inspection, signals) => inspection.HttpClient = signals,
+        inspection => inspection.HasHttpClientSupport,
+        IncludeTypesWhenApisPresent: true);
+
+    public static readonly LibraryIntegrationDescriptor[] All =
+    [
+        AI,
+        Aspire,
+        DependencyInjection,
+        Logging,
+        OpenTelemetry,
+        Options,
+        Hosting,
+        HealthChecks,
+        HttpClient
+    ];
+
+    public static readonly LibraryIntegrationDescriptor[] EcosystemScanned =
+    [
+        AI,
+        Aspire,
+        DependencyInjection,
+        Logging,
+        Options,
+        Hosting,
+        HealthChecks,
+        HttpClient
+    ];
+
+    public static string[] CategorySections => [RollupName, .. All.Select(descriptor => descriptor.Name)];
+
+    public static bool CanRenderAny(LibraryInspection inspection)
+        => inspection.Integrations is { Count: > 0 } || All.Any(descriptor => descriptor.CanRender(inspection));
+
+    public static int CountPresence(LibraryInspection inspection)
+        => All.Count(descriptor => descriptor.HasPresence(inspection));
+}

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -20,7 +20,7 @@ public static class LibrarySections
     public const string ScannerInfoCounts = "InfoCounts";
     public const string ScannerSymbols = "Symbols";
     public const string ScannerAuditSignals = "AuditSignals";
-    public const string ScannerIntegrations = "Integrations";
+    public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
@@ -52,17 +52,7 @@ public static class LibrarySections
             .Add<CustomAttributes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
-            .AddCategory("@Integrations",
-                "Integrations",
-                "AI",
-                "Aspire",
-                "Dependency Injection",
-                "Logging",
-                "Options",
-                "Hosting",
-                "Health Checks",
-                "HTTP Client",
-                "OpenTelemetry");
+            .AddCategory("@Integrations", LibraryIntegrationCatalog.CategorySections);
     }
 
     /// <summary>Builds the scanner registry with all library scanners registered.</summary>
@@ -122,111 +112,94 @@ public static class LibrarySections
 
     public sealed class OpenTelemetry : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "OpenTelemetry";
+        public static string Name => LibraryIntegrationCatalog.OpenTelemetry.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
         public static bool CanRender(LibraryInspection model)
-            => model.OpenTelemetry is { Count: > 0 } || model.HasOpenTelemetrySupport;
+            => LibraryIntegrationCatalog.OpenTelemetry.CanRender(model);
     }
 
     public sealed class Integrations : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Integrations";
+        public static string Name => LibraryIntegrationCatalog.RollupName;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.Integrations is { Count: > 0 }
-               || model.HasAISupport
-               || model.HasAspireSupport
-               || model.HasOpenTelemetrySupport
-               || model.HasDependencyInjectionSupport
-               || model.HasLoggingSupport
-               || model.HasOptionsSupport
-               || model.HasHostingSupport
-               || model.HasHealthChecksSupport
-               || model.HasHttpClientSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.CanRenderAny(model);
     }
 
     public sealed class AI : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "AI";
+        public static string Name => LibraryIntegrationCatalog.AI.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.AI is { Count: > 0 } || model.HasAISupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.AI.CanRender(model);
     }
 
     public sealed class Aspire : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Aspire";
+        public static string Name => LibraryIntegrationCatalog.Aspire.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.Aspire is { Count: > 0 } || model.HasAspireSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Aspire.CanRender(model);
     }
 
     public sealed class DependencyInjection : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Dependency Injection";
+        public static string Name => LibraryIntegrationCatalog.DependencyInjection.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
         public static bool CanRender(LibraryInspection model)
-            => model.DependencyInjection is { Count: > 0 } || model.HasDependencyInjectionSupport;
+            => LibraryIntegrationCatalog.DependencyInjection.CanRender(model);
     }
 
     public sealed class Logging : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Logging";
+        public static string Name => LibraryIntegrationCatalog.Logging.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.Logging is { Count: > 0 } || model.HasLoggingSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Logging.CanRender(model);
     }
 
     public sealed class Options : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Options";
+        public static string Name => LibraryIntegrationCatalog.Options.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.Options is { Count: > 0 } || model.HasOptionsSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Options.CanRender(model);
     }
 
     public sealed class Hosting : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Hosting";
+        public static string Name => LibraryIntegrationCatalog.Hosting.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.Hosting is { Count: > 0 } || model.HasHostingSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Hosting.CanRender(model);
     }
 
     public sealed class HealthChecks : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Health Checks";
+        public static string Name => LibraryIntegrationCatalog.HealthChecks.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.HealthChecks is { Count: > 0 } || model.HasHealthChecksSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.HealthChecks.CanRender(model);
     }
 
     public sealed class HttpClient : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "HTTP Client";
+        public static string Name => LibraryIntegrationCatalog.HttpClient.Name;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
-        public static bool CanRender(LibraryInspection model)
-            => model.HttpClient is { Count: > 0 } || model.HasHttpClientSupport;
+        public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.HttpClient.CanRender(model);
     }
 
     // ===== Opt-in SourceLink sections =====

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -196,7 +196,7 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasIntegrations => _data.Integrations is { Count: > 0 };
 
-    [MarkoutSection(Name = "Integrations", ShowWhenProperty = nameof(HasIntegrations))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Integrations, ShowWhenProperty = nameof(HasIntegrations))]
     public List<IntegrationRow>? IntegrationsSection =>
         _data.Integrations?
             .Select(i => new IntegrationRow(
@@ -213,11 +213,11 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasAITypesOnly => HasAI && !HasAIApis;
 
-    [MarkoutSection(Name = "AI", ShowWhenProperty = nameof(HasAI))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.AI, ShowWhenProperty = nameof(HasAI))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? AIApiSection => HasAIApis ? ToIntegrationApiSignalRows(_data.AI, includeTypes: true) : null;
 
-    [MarkoutSection(Name = "AI", ShowWhenProperty = nameof(HasAITypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.AI, ShowWhenProperty = nameof(HasAITypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? AITypeSection => ToIntegrationSignalRows(_data.AI);
 
@@ -230,11 +230,11 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasAspireTypesOnly => HasAspire && !HasAspireApis;
 
-    [MarkoutSection(Name = "Aspire", ShowWhenProperty = nameof(HasAspireApis))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Aspire, ShowWhenProperty = nameof(HasAspireApis))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? AspireApiSection => HasAspireApis ? ToIntegrationApiSignalRows(_data.Aspire, includeTypes: true) : null;
 
-    [MarkoutSection(Name = "Aspire", ShowWhenProperty = nameof(HasAspireTypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Aspire, ShowWhenProperty = nameof(HasAspireTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? AspireTypeSection => ToIntegrationSignalRows(_data.Aspire);
 
@@ -247,18 +247,18 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasDependencyInjectionTypesOnly => HasDependencyInjection && !HasDependencyInjectionApis;
 
-    [MarkoutSection(Name = "Dependency Injection", ShowWhenProperty = nameof(HasDependencyInjectionApis))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.DependencyInjection, ShowWhenProperty = nameof(HasDependencyInjectionApis))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? DependencyInjectionApiSection => HasDependencyInjectionApis ? ToIntegrationApiSignalRows(_data.DependencyInjection, includeTypes: false) : null;
 
-    [MarkoutSection(Name = "Dependency Injection", ShowWhenProperty = nameof(HasDependencyInjectionTypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.DependencyInjection, ShowWhenProperty = nameof(HasDependencyInjectionTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? DependencyInjectionTypeSection => ToIntegrationSignalRows(_data.DependencyInjection);
 
     [MarkoutIgnore]
     public bool HasLogging => _data.Logging is { Count: > 0 };
 
-    [MarkoutSection(Name = "Logging", ShowWhenProperty = nameof(HasLogging))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Logging, ShowWhenProperty = nameof(HasLogging))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? LoggingSection => ToIntegrationSignalRows(_data.Logging);
 
@@ -271,18 +271,18 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasOpenTelemetryTypesOnly => HasOpenTelemetry && !HasOpenTelemetryApis;
 
-    [MarkoutSection(Name = "OpenTelemetry", ShowWhenProperty = nameof(HasOpenTelemetryApis))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.OpenTelemetry, ShowWhenProperty = nameof(HasOpenTelemetryApis))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? OpenTelemetryApiSection => HasOpenTelemetryApis ? ToIntegrationApiSignalRows(_data.OpenTelemetry, includeTypes: true) : null;
 
-    [MarkoutSection(Name = "OpenTelemetry", ShowWhenProperty = nameof(HasOpenTelemetryTypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.OpenTelemetry, ShowWhenProperty = nameof(HasOpenTelemetryTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? OpenTelemetryTypeSection => ToIntegrationSignalRows(_data.OpenTelemetry);
 
     [MarkoutIgnore]
     public bool HasOptions => _data.Options is { Count: > 0 };
 
-    [MarkoutSection(Name = "Options", ShowWhenProperty = nameof(HasOptions))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Options, ShowWhenProperty = nameof(HasOptions))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? OptionsSection => ToIntegrationSignalRows(_data.Options);
 
@@ -295,18 +295,18 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasHostingTypesOnly => HasHosting && !HasHostingApis;
 
-    [MarkoutSection(Name = "Hosting", ShowWhenProperty = nameof(HasHostingApis))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Hosting, ShowWhenProperty = nameof(HasHostingApis))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? HostingApiSection => HasHostingApis ? ToIntegrationApiSignalRows(_data.Hosting, includeTypes: false) : null;
 
-    [MarkoutSection(Name = "Hosting", ShowWhenProperty = nameof(HasHostingTypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.Hosting, ShowWhenProperty = nameof(HasHostingTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? HostingTypeSection => ToIntegrationSignalRows(_data.Hosting);
 
     [MarkoutIgnore]
     public bool HasHealthChecks => _data.HealthChecks is { Count: > 0 };
 
-    [MarkoutSection(Name = "Health Checks", ShowWhenProperty = nameof(HasHealthChecks))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.HealthChecks, ShowWhenProperty = nameof(HasHealthChecks))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? HealthChecksSection => ToIntegrationSignalRows(_data.HealthChecks);
 
@@ -319,11 +319,11 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasHttpClientTypesOnly => HasHttpClient && !HasHttpClientApis;
 
-    [MarkoutSection(Name = "HTTP Client", ShowWhenProperty = nameof(HasHttpClientApis))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.HttpClient, ShowWhenProperty = nameof(HasHttpClientApis))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
     public List<IntegrationApiSignalRow>? HttpClientApiSection => HasHttpClientApis ? ToIntegrationApiSignalRows(_data.HttpClient, includeTypes: true) : null;
 
-    [MarkoutSection(Name = "HTTP Client", ShowWhenProperty = nameof(HasHttpClientTypesOnly))]
+    [MarkoutSection(Name = EcosystemIntegrationNames.HttpClient, ShowWhenProperty = nameof(HasHttpClientTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
     public List<IntegrationSignalRow>? HttpClientTypeSection => ToIntegrationSignalRows(_data.HttpClient);
 
@@ -454,17 +454,7 @@ public class LibraryInspectionView
         if (inspection.Integrations is { Count: > 0 } integrations)
             return integrations.Count;
 
-        var count = 0;
-        if (inspection.HasAISupport) count++;
-        if (inspection.HasAspireSupport) count++;
-        if (inspection.HasDependencyInjectionSupport) count++;
-        if (inspection.HasLoggingSupport) count++;
-        if (inspection.HasOpenTelemetrySupport) count++;
-        if (inspection.HasOptionsSupport) count++;
-        if (inspection.HasHostingSupport) count++;
-        if (inspection.HasHealthChecksSupport) count++;
-        if (inspection.HasHttpClientSupport) count++;
-        return count;
+        return LibraryIntegrationCatalog.CountPresence(inspection);
     }
 
     private static List<IntegrationSignalRow>? ToIntegrationSignalRows(List<IntegrationSignal>? signals)


### PR DESCRIPTION
## Summary
- centralize integration names and section metadata in a shared catalog
- harden starter-method scanning to require truly public extension methods and skip undecodable signatures
- add a scanner regression for non-public integration starter methods

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.EcosystemIntegrationScannerTests.Scan_IgnoresNonPublicStarterExtensionMethods
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method- DotnetInspector.Tests.Parsers.MemberOptionsParserTests.ExplicitPackage_WithImplicitOutput_KeepsTipsEnabled
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release

Note: full src/dotnet-inspect.Tests currently has an unrelated parser test failure in DotnetInspector.Tests.Parsers.MemberOptionsParserTests.ExplicitPackage_WithImplicitOutput_KeepsTipsEnabled.