### PR TITLE
Decompiler: three rendering fixes from the whole-type Stack review

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -300,6 +300,46 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("[1]", output);
     }
 
+    // --- Type-scale review findings (whole-type Stack<T> listing) ---
+
+    [Fact]
+    public void LowerBoundCheck_IntCallResultGetsExplicitComparison()
+    {
+        // An int-returning call in condition position must compare against 0
+        // — 'if (array.GetLowerBound(0))' is not C#. The preserved return
+        // type settles bool context where opcode heuristics cannot.
+        string output = EmitMethod(nameof(CfgSampleClass.LowerBoundCheck));
+
+        Assert.Contains("array.GetLowerBound(0) != 0", output);
+        Assert.DoesNotContain("(uint)array", output);
+    }
+
+    [Fact]
+    public void ReverseCopy_SpilledSlotsAreDeclared()
+    {
+        // dst[--j] = src[i++] spills the pre-decrement/post-increment values;
+        // inside a loop body the spill stores must still declare their slots.
+        string output = EmitMethod(nameof(CfgSampleClass.ReverseCopy));
+
+        Assert.DoesNotContain("\n    S_", output.Replace("var S_", "").Replace("int S_", ""));
+        Assert.Contains("S_1", output);
+    }
+
+    [Fact]
+    public void ChecksThenTry_TryRendersAfterGuardsInOrder()
+    {
+        // The shared return block is the leave target — dominated THROUGH the
+        // try region. It must not be absorbed into a guard's arm (which
+        // rendered 'return;' before the try, reading as unreachable code).
+        string output = EmitMethod(nameof(CfgSampleClass.ChecksThenTry));
+
+        int tryIdx = output.IndexOf("try", StringComparison.Ordinal);
+        int firstReturn = output.IndexOf("return", StringComparison.Ordinal);
+        Assert.True(tryIdx >= 0, $"expected try block in:\n{output}");
+        Assert.True(firstReturn < 0 || firstReturn > tryIdx,
+            $"return must not precede the try block:\n{output}");
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -295,6 +295,37 @@ public class CfgSampleClass
 
     public static bool ULongGe(ulong a, ulong b) => a >= b;
 
+    public static string LowerBoundCheck(System.Array array)
+    {
+        if (array.GetLowerBound(0) != 0)
+            return "nonzero";
+        return "zero";
+    }
+
+    public static void ReverseCopy(int[] src, int[] dst, int dstIndex, int count)
+    {
+        int i = 0;
+        int j = dstIndex + count;
+        while (i < count)
+            dst[--j] = src[i++];
+    }
+
+    public static void ChecksThenTry(int x)
+    {
+        if (x < 0)
+            throw new ArgumentOutOfRangeException(nameof(x));
+        if (x > 100)
+            throw new ArgumentException("too big");
+        try
+        {
+            Console.WriteLine(x);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new ArgumentException("bad");
+        }
+    }
+
     public static int DayNumber(string day)
     {
         switch (day)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -4231,13 +4231,7 @@ public static class CSharpEmitter
                 switch (node)
                 {
                     case ILAstAssignment assign:
-                        if (!TryEmitCompoundAssignment(assign.Variable.Name, assign.Value, indent))
-                        {
-                            WriteIndent(indent);
-                            _sb.Append($"{assign.Variable.Name} = ");
-                            EmitExpression(assign.Value);
-                            _sb.AppendLine(";");
-                        }
+                        EmitAssignmentNode(assign, indent);
                         break;
 
                     case ILAstStatement stmt:
@@ -7612,6 +7606,20 @@ public static class CSharpEmitter
             if (expr.ResultType.Kind is not (StackValueKind.Int32 or StackValueKind.NativeInt))
                 return false;
 
+            // The preserved static type settles it both ways: a bool is never
+            // numeric, and an int-typed call result always is (the opcode
+            // heuristics below can't know a method's return type).
+            switch (expr.ResultType.TypeName)
+            {
+                case "bool" or "System.Boolean" or "Boolean":
+                    return false;
+                case "int" or "System.Int32" or "uint" or "System.UInt32"
+                    or "short" or "System.Int16" or "ushort" or "System.UInt16"
+                    or "sbyte" or "System.SByte" or "byte" or "System.Byte"
+                    or "char" or "System.Char":
+                    return true;
+            }
+
             // Comparison instructions produce boolean results
             if (expr.OpCode is ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Clt
                 or ILOpCode.Cgt_un or ILOpCode.Clt_un)
@@ -7716,6 +7724,16 @@ public static class CSharpEmitter
                 return;
             }
 
+            // cgt.un against 0 is csc's != 0 idiom (identical for unsigned
+            // operands too: unsigned > 0 ⇔ != 0).
+            if (op == ">" && IsZeroLiteral(right)
+                && ComparisonKind(left, right) is StackValueKind.Int32 or StackValueKind.Int64 or StackValueKind.NativeInt)
+            {
+                EmitExpression(left);
+                _sb.Append(" != 0");
+                return;
+            }
+
             switch (ComparisonKind(left, right))
             {
                 case StackValueKind.Float:
@@ -7760,6 +7778,15 @@ public static class CSharpEmitter
                     return;
                 EmitExpression(left);
                 _sb.Append(" == null");
+                return;
+            }
+
+            // !(x != 0) → x == 0
+            if (orderedOp == "<=" && IsZeroLiteral(right)
+                && ComparisonKind(left, right) is StackValueKind.Int32 or StackValueKind.Int64 or StackValueKind.NativeInt)
+            {
+                EmitExpression(left);
+                _sb.Append(" == 0");
                 return;
             }
 

--- a/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
+++ b/src/DotnetInspector.Decompiler/StructuredControlFlow.cs
@@ -422,9 +422,6 @@ public sealed class StructuredControlFlow
             {
                 if (processed.Contains(idx))
                     continue;
-                // Exception-region blocks stay with the top-level walk.
-                if (inExceptionRegion.ContainsKey(idx) || exRegionsByBlock.ContainsKey(idx))
-                    continue;
                 DispatchStructured(idx, armChildren);
             }
 
@@ -442,6 +439,11 @@ public sealed class StructuredControlFlow
 
         void CollectDominated(int node, List<int> region)
         {
+            // Exception regions belong to the top-level walk — prune the WHOLE
+            // subtree, not just the region's blocks: code dominated through a
+            // try (its leave target) must render after it, not inside the arm.
+            if (inExceptionRegion.ContainsKey(node) || exRegionsByBlock.ContainsKey(node))
+                return;
             region.Add(node);
             foreach (int child in domTree.GetDominatorTreeChildren(node))
                 CollectDominated(child, region);


### PR DESCRIPTION
The three bugs surfaced by diffing the new whole-type listing (#430) against dotnet/runtime's \`Stack.cs\`.

**1. \`return;\` before \`try\` (order corruption).** The shared return block is the \`leave\` target — dominated *through* the try region — and #420's dominated-region arms skipped exception-region blocks while still absorbing blocks beyond them, pulling the return into a guard's arm ahead of the try. \`CollectDominated\` now prunes the **whole subtree** at exception regions; everything a try dominates stays with the top-level walk and renders in order.

```csharp
// before (Debug)            // after — both configs
if (x > 100) { throw ...; }  if (x > 100) { throw ...; }
return;                      try { Console.WriteLine(x); return; }
try { ... }                  catch (InvalidOperationException) { throw ...; }
```

**2. Int call results as bool conditions.** \`if (array.GetLowerBound(0))\` isn't C#. \`IsNonBooleanNumeric\` now trusts the preserved static type in both directions — bool-typed locals are never numeric (\`if (V_0)\`, not \`if (V_0 != 0)\`), int-typed call results always are (\`!= 0\` appears). Bonus from the same fixture: \`cgt.un\` against zero is csc's \`!= 0\` idiom and now renders as such instead of \`(uint)x > 0\`.

**3. Undeclared spill slots in loop bodies.** \`dst[--j] = src[i++]\` spills correctly (#416) but the loop-body emission path bypassed \`EmitAssignmentNode\`, so \`S_1 = V_1 - 1;\` appeared with no declaration. The path now shares it — declarations, identity suppression and all.

Evidence per the taste doc: three dual-config fixtures (\`LowerBoundCheck\`, \`ReverseCopy\`, \`ChecksThenTry\`); full h2h corpus byte-identical; all suites green in both configs (decompiler 255, CLI 943).

Next per the agreed order: PDB wiring for the type command (real local names), after #430 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)