### PR TITLE
type command: real local names in whole-type listings via PDB acquisition

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -532,6 +532,35 @@ public class ApiCommand
         return filtered;
     }
 
+    /// <summary>
+    /// Acquires the portable PDB for an assembly (symbol server / symbol
+    /// package) and returns its on-disk path, so the decompiler can render
+    /// real local-variable names instead of V_n slots. Best-effort: returns
+    /// null when no PDB can be obtained (offline, Windows PDB, no symbols).
+    /// </summary>
+    internal static async Task<string?> TryAcquirePdbPathAsync(
+        string dllPath, ApiOptions options, VerboseLogger logger, HttpClient httpClient)
+    {
+        try
+        {
+            using var service = SourceLinkService.Open(dllPath, logger.Log);
+            var context = service.Context;
+            if (context.NeedsPdb)
+            {
+                var (pkgName, pkgVersion) = !string.IsNullOrEmpty(options.PackagePath)
+                    ? PackageExtractor.ParsePackageReference(options.PackagePath)
+                    : (null, null);
+                await SourceEnricher.AcquirePdbAsync(context, httpClient, pkgName, pkgVersion,
+                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+            }
+            return context.PortablePdbPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     internal static HashSet<string> GetRequestedMemberSections(ApiType type, ApiOptions options)
     {
         var pipeline = ApiMemberSectionPipelines.Create(options);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -190,6 +190,19 @@ public static class TypeCommand
                     // sections (whole-type Decompiled Source).
                     effectiveOptions = effectiveOptions with { DllPath = runtimeAssemblyPath ?? apiDllPath };
 
+                    // Real local names for the listing: acquire the portable
+                    // PDB the same way the member command does — only when the
+                    // section is actually requested (network).
+                    if (effectiveOptions.DllPath is { } dllForPdb
+                        && effectiveOptions.IncludeSections is { Count: > 0 }
+                        && ApiCommand.GetRequestedMemberSections(apiType, effectiveOptions)
+                            .Contains(SectionNames.DecompiledSource))
+                    {
+                        var pdbPath = await ApiCommand.TryAcquirePdbPathAsync(
+                            dllForPdb, effectiveOptions, logger, context.HttpClient);
+                        effectiveOptions = effectiveOptions with { PdbPath = pdbPath };
+                    }
+
                     if (ShouldRejectQuietShape(effectiveOptions))
                     {
                         Console.Error.WriteLine("Error: -v:q is not supported by the type shape renderer.");


### PR DESCRIPTION
Closes the "variable names could not be recovered" observation from the Stack review: they were never lost — the type command just wasn't acquiring the PDB the way the member command does.

```csharp
// before                                // after — matches runtime source
V_0 = 0;                                 srcIndex = 0;
V_1 = arrayIndex + this._size;           dstIndex = arrayIndex + this._size;
while (V_0 < this._size)                 while (srcIndex < this._size)
```

\`TryAcquirePdbPathAsync\` (shared helper in ApiCommand, extracted from the member-command flow) opens the SourceLink context, downloads the portable PDB from the symbol server / symbol package when needed, and returns its on-disk path. \`TypeCommand\` calls it **only when \`-S "Decompiled Source"\` is actually requested**, so plain \`type\` invocations pay no network cost. Best-effort throughout: offline, missing symbols, or Windows-PDB cases return null and the listing falls back to \`V_n\` slot names.

Residual naming gaps, for honesty: eval-stack spills (\`S_N\`) keep slot names — they're stack values, not locals, so no PDB name exists for them — and unnamed compiler temps stay \`V_n\`. Both are a small minority after this change.

CLI suite green (946; the whole-type test passes with or without symbol access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)