### PR TITLE
type command: using-directive hoisting in whole-type listings

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1147,6 +1147,12 @@ public class CommandExecutionTests
         Assert.Contains("private T[] _array;", output);
         Assert.Contains("public void Push(T item)", output);
         Assert.Contains("public bool TryPop(out T result)", output);
+        // Using hoisting: qualified names shorten against the metadata
+        // namespace tables; the directives appear at the top.
+        Assert.Contains("using System.Runtime.CompilerServices;", output);
+        Assert.Contains(": IEnumerable<T>, IEnumerable, ICollection, IReadOnlyCollection<T>", output);
+        Assert.Contains("RuntimeHelpers.IsReferenceOrContainsReferences", output);
+        Assert.DoesNotContain("System.Collections.Generic.IEnumerable<T>", output);
     }
 
     [Fact]
@@ -1159,7 +1165,8 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         // Bare C#: no markdown heading, no section title, no code fence, no tips.
-        Assert.StartsWith("namespace System.Collections.Generic;", output);
+        Assert.StartsWith("using System.Collections;", output);
+        Assert.Contains("namespace System.Collections.Generic;", output);
         Assert.DoesNotContain("# ", output);
         Assert.DoesNotContain("```", output);
         Assert.DoesNotContain("Tips:", output);

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -63,7 +63,9 @@ internal static class TypeSourceComposer
             }
 
             sb.AppendLine("}");
-            return any ? sb.ToString().TrimEnd() : null;
+            if (!any)
+                return null;
+            return HoistUsings(sb.ToString().TrimEnd(), reader, type.Namespace);
         }
         catch
         {
@@ -369,6 +371,141 @@ internal static class TypeSourceComposer
             else
                 sb.AppendLine($"{indent}{trimmed}");
         }
+    }
+
+    /// <summary>
+    /// Shortens qualified type names against the assembly's own metadata
+    /// (TypeDefs + TypeRefs give the real namespace/type tables — no
+    /// guessing about what is a namespace) and hoists the namespaces used
+    /// into a using block. Ambiguous short names stay qualified; string
+    /// literal contents are never rewritten; namespaces covered by implicit
+    /// usings and the type's own namespace are shortened without a using.
+    /// </summary>
+    static string HoistUsings(string listing, MetadataReader reader, string? ownNamespace)
+    {
+        // Namespace → simple type names (arity-stripped), from real metadata.
+        var nsToNames = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        void Register(string ns, string name)
+        {
+            if (ns.Length == 0)
+                return;
+            int tick = name.IndexOf('`');
+            bool generic = tick >= 0;
+            if (generic)
+                name = name[..tick];
+            if (!nsToNames.TryGetValue(ns, out var names))
+                nsToNames[ns] = names = new HashSet<string>(StringComparer.Ordinal);
+            names.Add(generic ? name + "<" : name);
+        }
+        foreach (var h in reader.TypeDefinitions)
+        {
+            var td = reader.GetTypeDefinition(h);
+            Register(reader.GetString(td.Namespace), reader.GetString(td.Name));
+        }
+        foreach (var h in reader.TypeReferences)
+        {
+            var tr = reader.GetTypeReference(h);
+            Register(reader.GetString(tr.Namespace), reader.GetString(tr.Name));
+        }
+
+        // A short name imported from two namespaces would be ambiguous —
+        // but generic and non-generic names are distinct in C#, so owners
+        // are counted per (name, arity-kind). Registration tracked the kind
+        // via the metadata arity suffix.
+        var shortNameOwners = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var (_, names) in nsToNames)
+            foreach (var n in names)
+                shortNameOwners[n] = shortNameOwners.GetValueOrDefault(n) + 1;
+
+        // The emitter strips "System." eagerly, so qualified occurrences may
+        // appear either in full or with the System. prefix already removed —
+        // register both spellings for each namespace.
+        var prefixes = new List<(string Text, string Namespace)>();
+        foreach (var ns in nsToNames.Keys)
+        {
+            prefixes.Add((ns, ns));
+            if (ns.StartsWith("System.", StringComparison.Ordinal))
+                prefixes.Add((ns[7..], ns));
+        }
+        // Longest first so System.Collections.Generic wins over System.Collections.
+        prefixes.Sort((a, b) => b.Text.Length.CompareTo(a.Text.Length));
+
+        var usings = new SortedSet<string>(StringComparer.Ordinal);
+        var output = new StringBuilder(listing.Length);
+        foreach (var rawLine in listing.Split('\n'))
+        {
+            string line = rawLine.TrimEnd('\r');
+            // Never rewrite string literal contents: transform only the
+            // segments outside double quotes.
+            var segments = line.Split('"');
+            for (int i = 0; i < segments.Length; i += 2)
+                segments[i] = ShortenSegment(segments[i], prefixes, nsToNames, shortNameOwners, usings);
+            output.AppendLine(string.Join('"', segments));
+        }
+
+        // Implicit usings (and the type's own namespace) need no directive.
+        usings.Remove(ownNamespace ?? "");
+        foreach (var implicitNs in (string[])
+            ["System", "System.Collections.Generic", "System.IO", "System.Linq",
+             "System.Net.Http", "System.Threading", "System.Threading.Tasks"])
+        {
+            usings.Remove(implicitNs);
+        }
+
+        string result = output.ToString().TrimEnd();
+        if (usings.Count == 0)
+            return result;
+
+        // dotnet/runtime style: using directives precede the namespace.
+        string directives = string.Join('\n', usings.Select(ns => $"using {ns};"));
+        return $"{directives}\n\n{result}";
+    }
+
+    static string ShortenSegment(
+        string segment,
+        List<(string Text, string Namespace)> prefixes,
+        Dictionary<string, HashSet<string>> nsToNames,
+        Dictionary<string, int> shortNameOwners,
+        SortedSet<string> usings)
+    {
+        foreach (var (text, ns) in prefixes)
+        {
+            int searchFrom = 0;
+            while (true)
+            {
+                int at = segment.IndexOf(text + ".", searchFrom, StringComparison.Ordinal);
+                if (at < 0)
+                    break;
+                searchFrom = at + 1;
+
+                // Word boundary before the prefix.
+                if (at > 0 && (char.IsLetterOrDigit(segment[at - 1]) || segment[at - 1] is '_' or '.'))
+                    continue;
+
+                // The identifier after the prefix must be a type from this
+                // namespace, fully present (next char ends the identifier).
+                int nameStart = at + text.Length + 1;
+                int nameEnd = nameStart;
+                while (nameEnd < segment.Length && (char.IsLetterOrDigit(segment[nameEnd]) || segment[nameEnd] == '_'))
+                    nameEnd++;
+                if (nameEnd == nameStart)
+                    continue;
+                string name = segment[nameStart..nameEnd];
+                bool generic = nameEnd < segment.Length && segment[nameEnd] == '<';
+                string key = generic ? name + "<" : name;
+                if (!nsToNames[ns].Contains(key))
+                    continue;
+                // Ambiguity: a (name, arity-kind) owned by more than one
+                // namespace stays qualified.
+                if (shortNameOwners.GetValueOrDefault(key) > 1)
+                    continue;
+
+                segment = segment[..at] + segment[nameStart..];
+                usings.Add(ns);
+                searchFrom = at;
+            }
+        }
+        return segment;
     }
 
     static string Shorten(string typeName) =>


### PR DESCRIPTION
The cleanup from the original per-type idea: qualified type names shorten and their namespaces hoist into a \`using\` block.

```csharp
// before
public class Stack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.ICollection, System.Collections.Generic.IReadOnlyCollection<T>
...
if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences())

// after
using System.Collections;
using System.Runtime.CompilerServices;

namespace System.Collections.Generic;

public class Stack<T> : IEnumerable<T>, IEnumerable, ICollection, IReadOnlyCollection<T>
...
if (RuntimeHelpers.IsReferenceOrContainsReferences())
```

**Principled, not guessed**: the namespace/type tables come from the assembly's own metadata (TypeDefs + TypeRefs), so "is \`System.Collections\` a namespace here?" is answered by facts. Soundness rules:

- string literal contents are never rewritten (transformation applies only to segments outside double quotes)
- a short name owned by more than one namespace stays qualified — with generic/non-generic counted separately, since C# resolves them by arity (\`IEnumerable<T>\` and \`IEnumerable\` shorten independently)
- the body emitter's eagerly-\`System.\`-stripped spellings (\`Runtime.CompilerServices.X\`) register as aliases of their real namespaces
- implicit-usings namespaces and the type's own namespace shorten without emitting a directive
- directives precede the namespace declaration, per runtime style

Scoped to the whole-type listing; per-member sections unchanged. (The PDB import-scope upgrade — reading the *original file's* using list — remains available as a refinement; this version achieves the readability goal without requiring symbols.)

CLI suite green (946) with the whole-type test extended to pin the hoisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)