### PR TITLE
Decompiler: trim trailing return; expression-bodied properties

### DIFF
--- a/docs/decompiler-h2h-comparison.md
+++ b/docs/decompiler-h2h-comparison.md
@@ -129,10 +129,9 @@ if (V_0 > 0)
     _freeCount = 0;
     Array.Clear(_entries, 0, V_0);
 }
-return;
 ```
 
-**Verdict:** Exact, statement for statement. Only `V_0` vs `count` (no PDB in this snapshot's flow) and the trailing `return;` differ. **Grade: A**
+**Verdict:** Exact, statement for statement. Only `V_0` vs `count` (no PDB in this snapshot's flow) differs. **Grade: A**
 
 ---
 
@@ -160,7 +159,6 @@ _array[_tail] = item;
 base.MoveNext(ref _tail);
 _size++;
 _version++;
-return;
 ```
 
 **Verdict:** Exact. Field compound assignment (`_size++`) and the `ref` argument are both reconstructed. **Grade: A**
@@ -277,7 +275,6 @@ if ((uint)V_0 >= (uint)V_1.Length)
 V_1[V_0] = item;
 _version++;
 _size = V_0 + 1;
-return;
 ```
 
 **Verdict:** Semantically exact, and the `(uint)` bounds-check casts are preserved (load-bearing — the operands are signed). The if/else is rendered as a guard clause with early return: the compiler emits the rare branch first, and the decompiler follows the IL order. **Grade: A-**
@@ -393,7 +390,6 @@ if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences())
     return;
 }
 _size = 0;
-return;
 ```
 
 **Verdict:** Goto-free and semantically exact (two snapshots ago this method rendered the else path appearing to flow into `Array.Clear` — wrong output; one snapshot ago, a dangling `goto`). Same early-return-vs-re-nesting difference as `Abs`: the source nests `if (size > 0) Array.Clear(...)`; we render the inverted guard. **Grade: A-**

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -1531,6 +1531,36 @@ public static class CSharpEmitter
             EnsureTrailingReturn();
 
             FixupGotoLabels();
+            TrimRedundantTrailingReturn();
+        }
+
+        /// <summary>
+        /// A bare 'return;' as the method's final top-level statement is
+        /// implicit in C#; the IL's trailing ret renders as noise. Kept when
+        /// a label points at it — a goto target needs a statement.
+        /// </summary>
+        void TrimRedundantTrailingReturn()
+        {
+            string text = _sb.ToString();
+            string trimmed = text.TrimEnd();
+            const string tail = "return;";
+            if (!trimmed.EndsWith(tail, StringComparison.Ordinal))
+                return;
+            int lineStart = trimmed.Length - tail.Length;
+            // Column 0 only — an indented return lives inside a construct.
+            if (lineStart > 0 && trimmed[lineStart - 1] != '\n')
+                return;
+            if (lineStart > 0)
+            {
+                int prevStart = trimmed.LastIndexOf('\n', lineStart - 2) + 1;
+                string prevLine = trimmed[prevStart..(lineStart - 1)].TrimEnd();
+                if (prevLine.EndsWith(':'))
+                    return; // label target
+            }
+            _sb.Clear();
+            string remaining = trimmed[..lineStart].TrimEnd();
+            if (remaining.Length > 0)
+                _sb.AppendLine(remaining);
         }
 
         /// <summary>

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -285,6 +285,16 @@ internal static class TypeSourceComposer
         int accessorList = signature.IndexOf('{');
         string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
 
+        // The extractor's property signatures sometimes omit modifiers.
+        if (!head.StartsWith("public", StringComparison.Ordinal)
+            && !head.StartsWith("protected", StringComparison.Ordinal)
+            && !head.StartsWith("internal", StringComparison.Ordinal)
+            && !head.StartsWith("private", StringComparison.Ordinal))
+        {
+            string access = member.Accessibility ?? "public";
+            head = member.IsStatic ? $"{access} static {head}" : $"{access} {head}";
+        }
+
         var accessors = new List<(string Keyword, string? Body)>();
         if (accessorList >= 0)
         {
@@ -303,6 +313,16 @@ internal static class TypeSourceComposer
             return;
         }
 
+        // Expression bodies per the style oracle
+        // (csharp_style_expression_bodied_properties/accessors = true):
+        // a lone getter returning one expression is 'head => expr;', and any
+        // single-statement accessor is 'get/set => ...;'.
+        if (accessors is [("get", { } loneGet)] && ExpressionOf(loneGet) is { } propExpr)
+        {
+            sb.AppendLine($"    {head} => {propExpr};");
+            return;
+        }
+
         sb.AppendLine($"    {head}");
         sb.AppendLine("    {");
         for (int i = 0; i < accessors.Count; i++)
@@ -314,12 +334,34 @@ internal static class TypeSourceComposer
                 sb.AppendLine($"        {keyword};");
                 continue;
             }
+            if (ExpressionOf(body) is { } accessorExpr)
+            {
+                sb.AppendLine($"        {keyword} => {accessorExpr};");
+                continue;
+            }
             sb.AppendLine($"        {keyword}");
             sb.AppendLine("        {");
             AppendIndented(sb, body, "            ");
             sb.AppendLine("        }");
         }
         sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// The expression of a single-statement body suitable for '=>':
+    /// 'return X;' yields X; a lone statement yields itself without ';'.
+    /// </summary>
+    static string? ExpressionOf(string body)
+    {
+        string line = body.Trim();
+        if (line.Contains('\n') || !line.EndsWith(';'))
+            return null;
+        line = line[..^1];
+        if (line.StartsWith("return ", StringComparison.Ordinal))
+            return line[7..];
+        if (line is "return")
+            return null;
+        return line;
     }
 
     static string? DecompileBody(


### PR DESCRIPTION
The "extra \`return\` statements" observation, addressed in its two classes:

**1. Trailing \`return;\` in void methods** — the IL's final \`ret\` rendered as a statement the source never writes. Now trimmed after label fixup, with the guard that matters: when a goto label points at the final return it stays (a label needs a statement). Column-0 only, so early returns inside constructs are untouched. Corpus diff: exactly the four trailing returns (\`Dictionary.Clear\`, \`List.Clear\`, \`Stack.Push\`, \`Queue.Enqueue\`).

**2. Property expansion** — the user's example head-on:

```csharp
// before                     // after — source shape
int Count                     public int Count => this._size;
{
    get
    {
        return _size;
    }
}
```

Per the oracle (\`csharp_style_expression_bodied_properties/accessors = true\`): a lone getter returning one expression renders as an expression-bodied property; any single-statement accessor renders \`get/set => ...;\`. **Methods deliberately stay block-bodied** — the rule is \`:silent\` (preference, not enforcement) and the grading corpus writes trivial methods with block bodies (\`IsNullOrEmpty\`), so converting methods would regress h2h exactness. Property heads also gain their missing accessibility modifiers.

(The \`this._size\` in the example becomes \`_size\` when #436 lands — independent branches.)

All suites green both configs (decompiler 255, CLI 946); h2h doc pinned outputs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)