### PR TITLE
Show logging provider starter APIs

### DIFF
--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -50,7 +50,7 @@ Examples:
 | AI | `IChatClient`, `IEmbeddingGenerator<TInput,TEmbedding>`, `AITool`, modality client interfaces, package-owned builder/registration/adapter APIs. |
 | Aspire | `AddRedis(...)`, `RedisResource`, resource-specific `Add*` APIs returning `IResourceBuilder<T>`. |
 | Dependency Injection | Package-owned `Add*` service registration APIs and DI builder types. |
-| Logging | `ILogger`, `ILogger<T>`, `LoggerMessageAttribute`, logging extension types. |
+| Logging | `ILogger`, `ILogger<T>`, `LoggerMessageAttribute`, provider registration APIs such as `AddAWSProvider(...)`. |
 | OpenTelemetry | `ActivitySource`, `Meter`, `DiagnosticSource`, OpenTelemetry provider/exporter types, `DisableTracing`/`DisableMetrics` telemetry controls. |
 | Options | `IOptions<T>`, `IOptionsMonitor<T>`, configure/validate options types. |
 | Hosting | `IHostedService`, `BackgroundService`, host builder types. |

--- a/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -379,6 +379,8 @@ public static class EcosystemIntegrationScanner
                 GetAIBucket(buckets, aiKind).Apis.TryAdd(api, aiKind);
             if (TryClassifyDependencyInjectionStarterMethod(typeName, methodName, signature, out var dependencyInjectionKind))
                 buckets.DependencyInjection.Apis.TryAdd(api, dependencyInjectionKind);
+            if (TryClassifyLoggingStarterMethod(typeName, methodName, signature, out var loggingKind))
+                buckets.Logging.Apis.TryAdd(api, loggingKind);
             if (TryClassifyHostingStarterMethod(typeName, methodName, signature, out var hostingKind))
                 buckets.Hosting.Apis.TryAdd(api, hostingKind);
             if (TryClassifyHttpClientStarterMethod(typeName, methodName, signature, out var httpClientKind))
@@ -400,6 +402,23 @@ public static class EcosystemIntegrationScanner
             return false;
 
         kind = "Service Registration";
+        return true;
+    }
+
+    private static bool TryClassifyLoggingStarterMethod(
+        string declaringType,
+        string methodName,
+        MethodSignature<string> signature,
+        out string kind)
+    {
+        kind = "";
+        if (!declaringType.StartsWith("Microsoft.Extensions.Logging.", StringComparison.Ordinal)
+            || !methodName.StartsWith("Add", StringComparison.Ordinal)
+            || signature.ParameterTypes.Length == 0
+            || signature.ParameterTypes[0] is not ("Microsoft.Extensions.Logging.ILoggingBuilder" or "Microsoft.Extensions.Logging.ILoggerFactory"))
+            return false;
+
+        kind = "Provider";
         return true;
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2222,6 +2222,24 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_LoggingSection_ForAwsLogger_ShowsProviderApis()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "AWS.Logger.AspNetCore", "--library", "-S", "@Integrations", "--rows", "-n", "20");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Integrations", output);
+        Assert.Contains("| Logging | 2 |", output);
+        Assert.Contains("## Logging", output);
+        Assert.Contains("| API |", output);
+        Assert.Contains("AWSLoggerBuilderExtensions.AddAWSProvider(...)", output);
+        Assert.Contains("AWSLoggerFactoryExtensions.AddAWSProvider(...)", output);
+        Assert.DoesNotContain("| Type |", output);
+        Assert.DoesNotContain("AWSLoggerBuilderExtensions` |", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DependencyInjectionSection_ShowsActionableTypesOnly()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -258,9 +258,19 @@ public class LibraryInspectionView
     [MarkoutIgnore]
     public bool HasLogging => _data.Logging is { Count: > 0 };
 
-    [MarkoutSection(Name = EcosystemIntegrationNames.Logging, ShowWhenProperty = nameof(HasLogging))]
+    [MarkoutIgnore]
+    public bool HasLoggingApis => _data.Logging?.Any(signal => signal.Shape == IntegrationSignalShape.Api) == true;
+
+    [MarkoutIgnore]
+    public bool HasLoggingTypesOnly => HasLogging && !HasLoggingApis;
+
+    [MarkoutSection(Name = EcosystemIntegrationNames.Logging, ShowWhenProperty = nameof(HasLoggingApis))]
+    [MarkoutIgnoreColumnWhen(nameof(IntegrationApiKindIsUniform), "Kind")]
+    public List<IntegrationApiSignalRow>? LoggingApiSection => HasLoggingApis ? ToIntegrationApiSignalRows(_data.Logging, includeTypes: false) : null;
+
+    [MarkoutSection(Name = EcosystemIntegrationNames.Logging, ShowWhenProperty = nameof(HasLoggingTypesOnly))]
     [MarkoutIgnoreColumnWhen(nameof(IntegrationKindIsUniform), "Kind")]
-    public List<IntegrationSignalRow>? LoggingSection => ToIntegrationSignalRows(_data.Logging);
+    public List<IntegrationSignalRow>? LoggingTypeSection => ToIntegrationSignalRows(_data.Logging);
 
     [MarkoutIgnore]
     public bool HasOpenTelemetry => _data.OpenTelemetry is { Count: > 0 };


### PR DESCRIPTION
## Summary
- recognize logging provider registration extension methods such as AddAWSProvider as Logging integration currency
- render focused Logging sections with API rows when starter APIs are present
- add an AWS.Logger.AspNetCore regression and update integration design guidance

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_LoggingSection_ForAwsLogger_ShowsProviderApis -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_LoggingSection_DetectsLoggingPrimitives
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- npx markdownlint-cli docs/design/integrations.md