### PR TITLE
Decompiler: drop implicit base(); explicit type args for parameterless generic calls

### DIFF
--- a/docs/decompiler-h2h-comparison.md
+++ b/docs/decompiler-h2h-comparison.md
@@ -312,7 +312,7 @@ if ((uint)V_0 >= (uint)V_1.Length)
 _version++;
 _size = V_0;
 T S_0 = V_1[V_0];
-if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences())
+if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 {
     V_2 = default;
     V_1[V_0] = V_2;
@@ -381,7 +381,7 @@ else
 int V_0;
 
 _version++;
-if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences())
+if (Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 {
     V_0 = _size;
     _size = 0;

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -359,6 +359,18 @@ public class CSharpEmitterTests
         Assert.DoesNotContain("this.", output);
     }
 
+    [Fact]
+    public void CoreLib_QueueCtor_NoImplicitBaseCall_ExplicitGenericArgs()
+    {
+        // The implicit base constructor call is never written in C# source,
+        // and a parameterless generic method requires explicit type args
+        // (no inference basis): Array.Empty<T>().
+        string output = EmitCoreLibMethod("System.Collections.Generic.Queue`1", ".ctor", overloadIndex: 0);
+
+        Assert.DoesNotContain("base(", output);
+        Assert.Contains("Array.Empty<T>()", output);
+    }
+
     // --- Generic ldelem (type-parameter element access) ---
 
     [Fact]

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -25,7 +25,7 @@ public static class CSharpEmitter
         var transforms = Transforms.TransformPipeline.Run(ast);
         var structure = StructuredControlFlow.Analyze(context, cfg, ast);
         var sb = new StringBuilder();
-        var emitter = new EmitterContext(ast, structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals)
+        var emitter = new EmitterContext(ast, structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals, context.DeclaringType)
         {
             BodyContext = context,
             LambdaDepth = lambdaDepth,
@@ -37,10 +37,10 @@ public static class CSharpEmitter
     /// <summary>
     /// Emit C# source from pre-computed ILAst and control flow structure.
     /// </summary>
-    public static string Emit(ILAstMethod ast, StructuredControlFlow structure, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
+    public static string Emit(ILAstMethod ast, StructuredControlFlow structure, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null, string? declaringType = null)
     {
         var sb = new StringBuilder();
-        var emitter = new EmitterContext(ast, structure, sb, reader, hasThis, returnType, parameterNames, inlinedLocals);
+        var emitter = new EmitterContext(ast, structure, sb, reader, hasThis, returnType, parameterNames, inlinedLocals, declaringType);
         emitter.EmitMethod();
         return sb.ToString();
     }
@@ -60,6 +60,7 @@ public static class CSharpEmitter
         readonly bool _returnsBool;
         readonly string? _returnTypeName;
         readonly IReadOnlyList<string>? _paramNames;
+        readonly string? _declaringType;
 
         // Map block index → ILAstBlock for quick lookup
         readonly Dictionary<int, ILAstBlock> _blockMap;
@@ -170,7 +171,7 @@ public static class CSharpEmitter
         // awaitable.GetAwaiter(); if (!awaiter.IsCompleted) AsyncHelpers.AwaitAwaiter(awaiter); awaiter.GetResult().
         readonly Dictionary<string, ILAstExpression> _runtimeCustomAwaitSources = [];
 
-        public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null)
+        public EmitterContext(ILAstMethod ast, StructuredControlFlow structure, StringBuilder sb, MetadataReader? reader = null, bool hasThis = false, string? returnType = null, IReadOnlyList<string>? parameterNames = null, HashSet<string>? inlinedLocals = null, string? declaringType = null)
         {
             _ast = ast;
             _structure = structure;
@@ -181,6 +182,7 @@ public static class CSharpEmitter
             _returnTypeName = returnType;
             _paramNames = parameterNames;
             _inlinedLocals = inlinedLocals ?? [];
+            _declaringType = declaringType;
 
             _blockMap = [];
             for (int i = 0; i < ast.Blocks.Count; i++)
@@ -6194,6 +6196,20 @@ public static class CSharpEmitter
         void EmitStatement(ILAstExpression expr, int indent)
         {
             TryEnsureCollectionTempForMutation(expr, indent);
+
+            // The implicit base constructor call is never written in C#
+            // source. An argless ctor call on `this` to a DIFFERENT type is
+            // exactly that; argless `: this()` chaining (same type) stays
+            // visible since another ctor body runs.
+            if (expr.OpCode is ILOpCode.Call
+                && expr.Operand is { } ctorOp && ctorOp.EndsWith("::.ctor", StringComparison.Ordinal)
+                && !expr.IsStaticCall
+                && expr.Arguments.Count == 1
+                && expr.Arguments[0].OpCode == ILOpCode.Ldarg_0
+                && ctorOp[..^7] != _declaringType)
+            {
+                return;
+            }
 
             switch (expr.OpCode)
             {

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -958,7 +958,8 @@ public static class ILAstBuilder
 
     static ILAstExpression BuildCall(
         MetadataReader reader, int token, ILOpCode opcode,
-        int offset, Stack<ILAstExpression> stack, GenericContext? callerGenericContext = null)
+        int offset, Stack<ILAstExpression> stack, GenericContext? callerGenericContext = null,
+        string? genericArgsSuffix = null)
     {
         try
         {
@@ -983,6 +984,8 @@ public static class ILAstBuilder
                     returnType = sig.ReturnType;
                     var declType = reader.GetTypeDefinition(methodDef.GetDeclaringType());
                     methodName = $"{reader.GetFullTypeName(declType)}::{reader.GetString(methodDef.Name)}";
+                    if (genericArgsSuffix is not null && paramCount == 0)
+                        methodName += genericArgsSuffix;
                     break;
                 }
 
@@ -1010,13 +1013,28 @@ public static class ILAstBuilder
                     // (its !N are the caller's type params); the SIGNATURE above
                     // decodes in the instantiation context built from it.
                     methodName = ResolveMethodRefName(reader, memberRef, callerGenericContext);
+                    if (genericArgsSuffix is not null && paramCount == 0 && methodName is not null)
+                        methodName += genericArgsSuffix;
                     break;
                 }
 
                 case HandleKind.MethodSpecification:
                 {
                     var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
-                    return BuildCall(reader, MetadataTokens.GetToken(spec.Method), opcode, offset, stack, callerGenericContext);
+                    // Explicit type arguments render only where C# REQUIRES
+                    // them: a parameterless generic method has no inference
+                    // basis (Array.Empty<T>()). Parametered calls infer in
+                    // source, so appending args there would diverge from it.
+                    string? suffix = null;
+                    try
+                    {
+                        var typeArgs = spec.DecodeSignature(SignatureDecoder.Instance, callerGenericContext);
+                        if (typeArgs.Length > 0)
+                            suffix = $"<{string.Join(", ", typeArgs)}>";
+                    }
+                    catch { }
+                    return BuildCall(reader, MetadataTokens.GetToken(spec.Method), opcode, offset, stack,
+                        callerGenericContext, suffix);
                 }
 
                 default:


### PR DESCRIPTION
The next two whole-type polish items.

**1. \`base();\` suppressed.** The implicit base constructor call is never written in C# source. An argless ctor call on \`this\` targeting a *different* type is exactly that lowering and now renders nothing. The guard that matters: argless \`: this()\` chaining to the **same** type stays visible — another ctor body runs, so eliding it would hide real behavior. The declaring type threads from \`MethodBodyContext\` into the emitter to make the distinction.

**2. Explicit type arguments where C# requires them.** \`Array.Empty()\` was missing its \`<T>\` — a parameterless generic method has no inference basis, so the call doesn't compile without explicit args. The MethodSpec instantiation now renders them, gated to **parameterless methods only**: parametered generic calls are written with inference in source (\`EnumerableHelpers.ToArray(collection, out _size)\`), so appending args there would diverge from it. Same oracle discipline as the methods-stay-block-bodied call.

```csharp
// Queue<T>() — before          // after: character-identical to source
base();                          _array = Array.Empty<T>();
this._array = Array.Empty();
return;
```

Bonus corpus exactness: \`RuntimeHelpers.IsReferenceOrContainsReferences<T>()\` in \`List.Clear\`/\`Stack.Pop\`/\`Queue.Dequeue\` now matches the source's spelling precisely (h2h doc updated).

All suites green both configs (decompiler 258, CLI 946).

🤖 Generated with [Claude Code](https://claude.com/claude-code)