### PR TITLE
Decompiler: base. only for genuine base dispatch; implicit boxing renders bare

### DIFF
--- a/docs/decompiler-h2h-comparison.md
+++ b/docs/decompiler-h2h-comparison.md
@@ -94,10 +94,10 @@ return _size != 0 && IndexOf(item) >= 0;
 **Decompiled:**
 
 ```csharp
-return _size != 0 && base.IndexOf(item) >= 0;
+return _size != 0 && IndexOf(item) >= 0;
 ```
 
-**Verdict:** Exact. The `&&` chain is reconstructed. The `base.` prefix is kept deliberately: it is the exact C# for the IL's non-virtual dispatch. **Grade: A**
+**Verdict:** Exact, character for character — same-type non-virtual calls render bare names, as the source writes them. **Grade: A**
 
 ---
 
@@ -153,10 +153,10 @@ _version++;
 ```csharp
 if (_size == _array.Length)
 {
-    base.Grow(_size + 1);
+    Grow(_size + 1);
 }
 _array[_tail] = item;
-base.MoveNext(ref _tail);
+MoveNext(ref _tail);
 _size++;
 _version++;
 ```
@@ -171,8 +171,8 @@ Both are one-liners and match exactly:
 
 | Method | Source | Decompiled | Grade |
 | --- | --- | --- | --- |
-| `HashSet.Contains` | `return FindItemIndex(item) >= 0;` | `return base.FindItemIndex(item) >= 0;` | **A** |
-| `StringBuilder.Clear` | `Length = 0; return this;` | `base.Length = 0; return this;` | **A** |
+| `HashSet.Contains` | `return FindItemIndex(item) >= 0;` | `return FindItemIndex(item) >= 0;` | **A** |
+| `StringBuilder.Clear` | `Length = 0; return this;` | `Length = 0; return this;` | **A** |
 
 ---
 
@@ -234,7 +234,7 @@ if (value == null)
 {
     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
 }
-return Runtime.CompilerServices.RuntimeHelpers.IsKnownConstant(value) && value.Length == 1 ? base.Contains(value[0]) : SpanHelpers.IndexOf(ref _firstChar, base.Length, ref value._firstChar, value.Length) >= 0;
+return Runtime.CompilerServices.RuntimeHelpers.IsKnownConstant(value) && value.Length == 1 ? Contains(value[0]) : SpanHelpers.IndexOf(ref _firstChar, Length, ref value._firstChar, value.Length) >= 0;
 ```
 
 **Verdict:** The `&&` condition is reconstructed exactly, the enum argument renders as `ExceptionArgument.value`, and `ref` arguments are preserved. The if/return pair folds into one long ternary — correct, though the source's statement form reads better. **Grade: A-**
@@ -267,7 +267,7 @@ int V_0 = _size;
 T[] V_1 = _array;
 if ((uint)V_0 >= (uint)V_1.Length)
 {
-    base.PushWithResize(item);
+    PushWithResize(item);
     return;
 }
 V_1[V_0] = item;
@@ -305,7 +305,7 @@ int V_0 = _size - 1;
 T[] V_1 = _array;
 if ((uint)V_0 >= (uint)V_1.Length)
 {
-    base.ThrowForEmptyStack();
+    ThrowForEmptyStack();
 }
 _version++;
 _size = V_0;
@@ -450,7 +450,7 @@ for (V_4 = 0; V_4 < _count; V_4++) { /* cached-comparer loop */ }
 | `String.IsNullOrEmpty` | **A** | exact |
 | `Math.Max` | **A** | exact |
 | `Math.Min` | **A** | exact |
-| `List.Contains` | **A** | exact (`base.` semantic) |
+| `List.Contains` | **A** | exact |
 | `Dictionary.Clear` | **A** | exact (`V_0` naming) |
 | `HashSet.Contains` | **A** | exact |
 | `StringBuilder.Clear` | **A** | exact |

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -242,7 +242,7 @@ public class CSharpEmitterTests
         string output = EmitCoreLibMethod("System.String", "Contains", overloadIndex: 0);
 
         Assert.Contains("&& value.Length == 1)", output);
-        Assert.Contains("    return base.Contains(value[0]);", output);
+        Assert.Contains("    return Contains(value[0]);", output);
         Assert.DoesNotContain(" ? ", output);
     }
 

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -6873,7 +6873,13 @@ public static class CSharpEmitter
 
                 // Boxing - emit as cast to object (boxing is implicit in C#)
                 case ILOpCode.Box:
-                    _sb.Append("(object)");
+                    // C# never writes the box — conversions to object and
+                    // interfaces, null tests of unconstrained T, and ternary
+                    // arm unification all box implicitly. The cast renders
+                    // only where dropping it changes meaning: both operands
+                    // of an equality being boxes (reference identity).
+                    if (expr.ExpectedType is "object" or "System.Object")
+                        _sb.Append("(object)");
                     EmitParenthesized(expr, 0);
                     break;
                 case ILOpCode.Unbox_any:
@@ -7337,6 +7343,30 @@ public static class CSharpEmitter
             && receiver.OpCode == ILOpCode.Ldarg_0
             && !_thisShadowedNames.Contains(memberName);
 
+        /// <summary>
+        /// Whether a call operand's type part names the current declaring
+        /// type. Operands carry instantiated generic names (List&lt;T&gt;)
+        /// while the declaring type is the metadata name (List`1) — compare
+        /// the arity-stripped prefixes.
+        /// </summary>
+        bool TypeMatchesDeclaring(string typePart)
+        {
+            if (_declaringType is null)
+                return false;
+            ReadOnlySpan<char> caller = _declaringType.AsSpan();
+            int tick = caller.IndexOf('`');
+            if (tick >= 0)
+                caller = caller[..tick];
+            ReadOnlySpan<char> callee = typePart.AsSpan();
+            int angle = callee.IndexOf('<');
+            if (angle >= 0)
+                callee = callee[..angle];
+            int calleeTick = callee.IndexOf('`');
+            if (calleeTick >= 0)
+                callee = callee[..calleeTick];
+            return callee.SequenceEqual(caller);
+        }
+
         /// <summary>Receiver + dot, with implicit-this omitted per the style oracle.</summary>
         void EmitReceiverWithDot(ILAstExpression receiver, bool isBaseCall, string dot, string memberName)
         {
@@ -7618,11 +7648,15 @@ public static class CSharpEmitter
                     && expr.Arguments[0] is { OpCode: ILOpCode.Nop, Operand: { } op }
                     && op.StartsWith("S_in_", StringComparison.Ordinal);
 
-                // Base call: non-virtual call on 'this' → base.Method()
+                // Base dispatch: a non-virtual call on 'this' to a member of
+                // a DIFFERENT type is C#'s base.Method(). A non-virtual call
+                // to this type's OWN member is just an ordinary call — the
+                // source writes the bare name.
                 bool isBaseCall = expr.OpCode is ILOpCode.Call
                     && _hasThis
                     && expr.Arguments[0].OpCode is ILOpCode.Ldarg_0
-                    && memberPart != ".ctor";
+                    && memberPart != ".ctor"
+                    && !TypeMatchesDeclaring(typePart);
                 string dot = isNullConditionalCall ? "?." : ".";
 
                 // Indexer getter: get_Item(key)/get_Chars(index) → [key]
@@ -8644,7 +8678,7 @@ public static class CSharpEmitter
         string ExpressionToString(ILAstExpression expr)
         {
             var sb = new StringBuilder();
-            var tempCtx = new EmitterContext(_ast, _structure, sb, _reader, _hasThis, _returnsBool ? "bool" : null, _paramNames)
+            var tempCtx = new EmitterContext(_ast, _structure, sb, _reader, _hasThis, _returnsBool ? "bool" : null, _paramNames, declaringType: _declaringType)
             {
                 // Carry recursive-decompilation context so nested renderings
                 // (inlined lambda bodies) work from string conversions too.
@@ -8667,7 +8701,7 @@ public static class CSharpEmitter
 
             // For comparison-and-branch opcodes (beq, blt, ble, etc.), render via EmitBranchCondition
             var sb = new StringBuilder();
-            var tempCtx = new EmitterContext(_ast, _structure, sb, _reader, _hasThis, _returnsBool ? "bool" : null, _paramNames);
+            var tempCtx = new EmitterContext(_ast, _structure, sb, _reader, _hasThis, _returnsBool ? "bool" : null, _paramNames, declaringType: _declaringType);
             tempCtx.EmitBranchCondition(branchExpr);
             return sb.ToString();
         }


### PR DESCRIPTION
Pulling the thread on \`IEnumerable<T>.GetEnumerator\`'s artifacts unraveled two corpus-wide fidelity issues:

**1. \`base.\` over-application.** Every non-virtual call on \`this\` rendered as \`base.Method()\` — but a non-virtual call to *this type's own member* is just an ordinary call (csc emits \`call\` rather than \`callvirt\` when it can prove the receiver). The source writes bare names:

| Before | After (= source) |
| --- | --- |
| \`base.Grow(_size + 1)\` | \`Grow(_size + 1)\` |
| \`base.PushWithResize(item)\` | \`PushWithResize(item)\` |
| \`base.IndexOf(item) >= 0\` | \`IndexOf(item) >= 0\` |
| \`base.Length = 0\` | \`Length = 0\` |

\`base.\` now requires the callee's declaring type to differ from the current type — the genuinely-semantic case (non-virtual dispatch to an ancestor's virtual). The comparison is arity-normalized (\`List<T>\` operand vs \`List\`1\` declaring name), and the string-rendering temp contexts now carry the declaring type (they silently lacked it, which split the rendering between code paths).

**2. Implicit boxing.** \`box\` rendered \`(object)\` everywhere; C# never writes it — conversions to object/interfaces, null tests of unconstrained \`T\`, and ternary arm unification all box implicitly. The cast now renders only when the box flows into an object-typed context (call argument pinning an overload); null tests read as the source writes them: \`if (value != null)\`, not \`if ((object)value != null)\`.

Corpus sweep: zero \`base.\` remains in the 17-method set; every former occurrence now matches the source name exactly. h2h doc updated (including reversing my own earlier verdict note that called \`List.Contains\`' \`base.\` "semantic" — it was a same-type call all along).

All suites green both configs (decompiler 259, CLI 947).

🤖 Generated with [Claude Code](https://claude.com/claude-code)