### PR TITLE
type command: enum whole-type listings; forwarder-following composition

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1160,6 +1160,23 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_DecompiledSource_Enum_RendersValuesListing()
+    {
+        // Enums have no method bodies; the listing renders the declaration
+        // and values — following the ref assembly's type forwarder to the
+        // defining assembly.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.DayOfWeek", "--platform", "System.Runtime",
+            "-S", "Decompiled Source", "--raw");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public enum DayOfWeek", output);
+        Assert.Contains("Sunday = 0,", output);
+        Assert.Contains("Saturday = 6,", output);
+    }
+
+    [Fact]
     public async Task Type_DecompiledSource_Raw_EmitsBareListing()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -820,19 +820,23 @@ public class ApiCommand
                 view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", mo5.MethodSource.SourceCode);
             }
 
-            // Whole-type decompilation (type command; member flows populate per
-            // member above). Explicit-only: requires -S "Decompiled Source".
-            if (options is not MemberOptions
-                && options.DllPath is { } typeDllPath
-                && options.IncludeSections is { Count: > 0 }
-                && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
+        }
+
+        // Whole-type decompilation (type command; member flows populate per
+        // member above). Explicit-only: requires -S "Decompiled Source".
+        // Sits OUTSIDE the member-sections region so enum types (which
+        // populate EnumValues and skip that region) also compose.
+        if (fullSerializer
+            && options is not MemberOptions
+            && options.DllPath is { } typeDllPath
+            && options.IncludeSections is { Count: > 0 }
+            && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
+        {
+            var listing = TypeSourceComposer.Compose(type, typeDllPath, options.PdbPath);
+            if (listing is not null)
             {
-                var listing = TypeSourceComposer.Compose(type, typeDllPath, options.PdbPath);
-                if (listing is not null)
-                {
-                    view.MemberCode ??= new MemberCodeView();
-                    view.MemberCode.DecompiledSourceCode = new Markout.CodeSection("csharp", listing);
-                }
+                view.MemberCode ??= new MemberCodeView();
+                view.MemberCode.DecompiledSourceCode = new Markout.CodeSection("csharp", listing);
             }
         }
 

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -23,23 +23,46 @@ internal static class TypeSourceComposer
 
         try
         {
-            using var stream = File.OpenRead(dllPath);
-            using var peReader = new PEReader(stream);
-            if (!peReader.HasMetadata)
-                return null;
-            var reader = peReader.GetMetadataReader();
-
+            // Follow type forwarders (ref/facade assemblies) to the assembly
+            // that actually defines the type — implementations sit alongside.
+            string currentDll = dllPath;
+            FileStream? stream = null;
+            PEReader? peReader = null;
+            MetadataReader reader = null!;
             TypeDefinitionHandle typeHandle = default;
-            foreach (var h in reader.TypeDefinitions)
+            try
             {
-                if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
+                for (int hop = 0; hop < 4 && typeHandle.IsNil; hop++)
                 {
-                    typeHandle = h;
-                    break;
+                    peReader?.Dispose();
+                    stream?.Dispose();
+                    stream = File.OpenRead(currentDll);
+                    peReader = new PEReader(stream);
+                    if (!peReader.HasMetadata)
+                        return null;
+                    reader = peReader.GetMetadataReader();
+
+                    foreach (var h in reader.TypeDefinitions)
+                    {
+                        if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
+                        {
+                            typeHandle = h;
+                            break;
+                        }
+                    }
+                    if (!typeHandle.IsNil)
+                        break;
+
+                    string? forwardTarget = FindForwardTarget(reader, type);
+                    if (forwardTarget is null)
+                        return null;
+                    string sibling = Path.Combine(Path.GetDirectoryName(currentDll)!, forwardTarget + ".dll");
+                    if (!File.Exists(sibling))
+                        return null;
+                    currentDll = sibling;
                 }
-            }
-            if (typeHandle.IsNil)
-                return null;
+                if (typeHandle.IsNil)
+                    return null;
 
             var sb = new StringBuilder();
             if (!string.IsNullOrEmpty(type.Namespace))
@@ -59,19 +82,46 @@ internal static class TypeSourceComposer
             else
             {
                 ComposeFields(sb, reader, typeHandle, ref any);
-                ComposeMembers(sb, type, peReader, reader, typeHandle, pdbPath, ref any);
+                ComposeMembers(sb, type, peReader!, reader, typeHandle, pdbPath, ref any);
             }
 
             sb.AppendLine("}");
             if (!any)
                 return null;
             return HoistUsings(sb.ToString().TrimEnd(), reader, type.Namespace);
+            }
+            finally
+            {
+                peReader?.Dispose();
+                stream?.Dispose();
+            }
         }
         catch
         {
             // Composition is best-effort; the section is simply absent.
             return null;
         }
+    }
+
+    static string? FindForwardTarget(MetadataReader reader, ApiType type)
+    {
+        foreach (var h in reader.ExportedTypes)
+        {
+            var exported = reader.GetExportedType(h);
+            if (!exported.IsForwarder)
+                continue;
+            string ns = reader.GetString(exported.Namespace);
+            string name = reader.GetString(exported.Name);
+            string full = ns.Length == 0 ? name : $"{ns}.{name}";
+            if (full != type.FullName)
+                continue;
+            if (exported.Implementation.Kind == HandleKind.AssemblyReference)
+            {
+                var asm = reader.GetAssemblyReference((AssemblyReferenceHandle)exported.Implementation);
+                return reader.GetString(asm.Name);
+            }
+        }
+        return null;
     }
 
     static string TypeDeclaration(ApiType type)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -247,7 +247,9 @@ public static class ApiMemberSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(IsMethodLike);
+            // Enums have no method bodies but the whole-type listing renders
+            // their declaration and values.
+            => model.Members.Any(IsMethodLike) || model.Kind == "enum";
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>


### PR DESCRIPTION
Two layers of the same "no data for System.DayOfWeek" report:

**1. Enum gating.** The section's \`CanRender\` required method-like members, and the population call sat inside the member-sections region that enum types skip entirely (they populate \`EnumValues\` instead). Both fixed — enums render the source shape:

```csharp
namespace System;

public enum DayOfWeek
{
    Sunday = 0,
    Monday = 1,
    ...
    Saturday = 6,
}
```

**2. Type forwarders.** Even gated correctly, composition failed: \`--platform System.Runtime\` hands the composer a facade assembly where \`DayOfWeek\` is a type forward, not a definition. \`Compose\` now follows forwarders (up to four hops) to the defining assembly sitting alongside — which benefits *every* forwarded type, not just enums: any class reached through \`System.Runtime\` now finds its real method bodies in \`System.Private.CoreLib\`.

CLI suite green (948) with a new enum test; the Stack listing regression-probed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)