### PR TITLE
Add library switches section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ OpenAPI, and OpenTelemetry. It is a usability index, not a raw evidence report: 
 integration sections list package-owned actionable types and starter APIs rather
 than assembly references.
 
+`Switches` is a peer library section for feature, compatibility, and runtime
+configuration switches such as `FeatureSwitchDefinitionAttribute` and
+`AppContext` switch names.
+
 ## Output and querying
 
 Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--rows -n N` to cap rendered table rows, `--count` to count table rows in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -131,12 +131,15 @@ dnx dotnet-inspect -y -- package System.Text.Json -S Signals
 dnx dotnet-inspect -y -- package System.Text.Json -S "Library Files"
 dnx dotnet-inspect -y -- package Aspire.Azure.AI.OpenAI --library -S @Integrations
 dnx dotnet-inspect -y -- library System.Text.Json -S Signals
+dnx dotnet-inspect -y -- library System.Text.Json -S Switches
 dnx dotnet-inspect -y -- library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 ```
 
 `Signals` reports observations, not a safety or trust verdict. Library Signals include SourceLink presence, SourceLink availability, determinism, trim/AOT markers, async kind (`Runtime`, `State machine`, `Mixed`, or `None`), memory-safety metadata, unsafe/PInvoke observations, and direct references. Package Signals include TFMs, manifest, readme/license, dependencies, package signature, local provenance, vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age.
 
 Use `package Foo --library` to inspect the package's primary DLL when it is unambiguous; add a DLL name when a package contains multiple libraries. Use `-S Integrations` for the ecosystem roll-up, `-S @Integrations` for roll-up plus focused sections, or a focused section such as `OpenTelemetry`. Integration sections cover AI, Aspire resources, Dependency Injection, Logging, Options, Hosting, Health Checks, HTTP Client, OpenAPI, and OpenTelemetry. Focused sections list package-owned starter APIs, support types, and telemetry controls, not raw assembly references.
+
+Use `-S Switches` when runtime feature switches or compatibility switches may affect behavior.
 
 `library X -S Signals` resolves SourceLink by acquiring a missing PDB. Per-source-file reachability is opt-in: add `-S "SourceLink Availability"` and `-S "SourceLink Missing Files"` for HTTP HEAD checks, or `-S "SourceLink Integrity"` to download source files and compare checksums. For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 

--- a/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
@@ -364,6 +364,7 @@ public static class AssemblyDetailScanner
 
         // Resources: cheapest check — just a count
         flags.HasManifestResources = reader.GetTableRowCount(TableIndex.ManifestResource) > 0;
+        flags.HasSwitches = SwitchScanner.HasSupport(peReader);
         var integrationPresence = EcosystemIntegrationScanner.ScanPresence(reader);
         flags.HasOpenTelemetrySupport = integrationPresence.HasOpenTelemetrySupport;
         flags.HasAspireSupport = integrationPresence.HasAspireSupport;
@@ -506,6 +507,7 @@ public class PresenceFlags
     public bool HasManifestResources { get; set; }
     public bool HasAssemblyAttributes { get; set; }
     public bool HasTypeForwarders { get; set; }
+    public bool HasSwitches { get; set; }
     public bool HasOpenTelemetrySupport { get; set; }
     public bool HasAspireSupport { get; set; }
     public bool HasAISupport { get; set; }

--- a/src/DotnetInspector.Metadata/SwitchScanner.cs
+++ b/src/DotnetInspector.Metadata/SwitchScanner.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+public record SwitchInfo(
+    string Kind,
+    string Switch,
+    string Api);
+
+public static class SwitchScanner
+{
+    private const string FeatureSwitchDefinitionAttributeName =
+        "System.Diagnostics.CodeAnalysis.FeatureSwitchDefinitionAttribute";
+    private const string RuntimeHostConfigurationOptionAttributeName =
+        "System.Runtime.CompilerServices.RuntimeHostConfigurationOptionAttribute";
+
+    public static List<SwitchInfo> Scan(PEReader peReader)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+
+        var reader = peReader.GetMetadataReader();
+        Dictionary<string, SwitchInfo> switches = new(StringComparer.Ordinal);
+        AddRuntimeHostConfigurationOptions(reader, switches);
+        AddFeatureSwitchDefinitions(reader, switches);
+        AddAppContextSwitches(peReader, reader, switches);
+
+        return switches.Values
+            .OrderBy(s => s.Kind, StringComparer.Ordinal)
+            .ThenBy(s => s.Switch, StringComparer.Ordinal)
+            .ThenBy(s => s.Api, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public static bool HasSupport(PEReader peReader)
+        => peReader.HasMetadata && Scan(peReader).Count > 0;
+
+    private static void AddRuntimeHostConfigurationOptions(
+        MetadataReader reader,
+        Dictionary<string, SwitchInfo> switches)
+    {
+        if (reader.IsAssembly)
+            AddAttributes(reader, "Assembly", reader.GetAssemblyDefinition().GetCustomAttributes(), switches);
+        AddAttributes(reader, "Module", reader.GetModuleDefinition().GetCustomAttributes(), switches);
+    }
+
+    private static void AddFeatureSwitchDefinitions(
+        MetadataReader reader,
+        Dictionary<string, SwitchInfo> switches)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            var typeName = reader.GetFullTypeName(type);
+            foreach (var propertyHandle in type.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var propertyName = reader.GetString(property.Name);
+                foreach (var attributeHandle in property.GetCustomAttributes())
+                {
+                    var attribute = reader.GetCustomAttribute(attributeHandle);
+                    if (AttributeReader.GetAttributeTypeName(reader, attribute.Constructor) != FeatureSwitchDefinitionAttributeName)
+                        continue;
+
+                    var switchName = TryGetStringArguments(reader, attribute).FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(switchName))
+                        AddSwitch(switches, "Feature Switch", switchName, $"{TypeResolver.FormatDisplayName(typeName)}.{propertyName}");
+                }
+            }
+        }
+    }
+
+    private static void AddAttributes(
+        MetadataReader reader,
+        string target,
+        CustomAttributeHandleCollection attributes,
+        Dictionary<string, SwitchInfo> switches)
+    {
+        foreach (var attributeHandle in attributes)
+        {
+            var attribute = reader.GetCustomAttribute(attributeHandle);
+            if (AttributeReader.GetAttributeTypeName(reader, attribute.Constructor) != RuntimeHostConfigurationOptionAttributeName)
+                continue;
+
+            var args = TryGetStringArguments(reader, attribute);
+            if (args.Count > 0)
+                AddSwitch(switches, "Runtime Host Configuration", args[0], target);
+        }
+    }
+
+    private static void AddAppContextSwitches(
+        PEReader peReader,
+        MetadataReader reader,
+        Dictionary<string, SwitchInfo> switches)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            var typeName = reader.GetFullTypeName(type);
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                var instructions = ILDisassembler.Disassemble(peReader, reader, method);
+                if (instructions is not { Count: > 0 })
+                    continue;
+
+                string? lastString = null;
+                foreach (var instruction in instructions)
+                {
+                    if (instruction.OpCodeName == "ldstr" && instruction.Operand is { } operand)
+                    {
+                        lastString = Unquote(operand);
+                        continue;
+                    }
+
+                    if (instruction.OpCodeName is not ("call" or "callvirt")
+                        || instruction.Operand is not { } call
+                        || !call.Contains("System.AppContext::", StringComparison.Ordinal)
+                        || lastString is not { Length: > 0 } switchName)
+                        continue;
+
+                    if (call.Contains("::TryGetSwitch(", StringComparison.Ordinal))
+                        AddAppContextSwitch(switches, switchName, $"{TypeResolver.FormatDisplayName(typeName)}.{reader.GetString(method.Name)}(...)");
+                    else if (call.Contains("::SetSwitch(", StringComparison.Ordinal))
+                        AddAppContextSwitch(switches, switchName, $"{TypeResolver.FormatDisplayName(typeName)}.{reader.GetString(method.Name)}(...)");
+                }
+            }
+        }
+    }
+
+    private static void AddAppContextSwitch(
+        Dictionary<string, SwitchInfo> switches,
+        string switchName,
+        string api)
+    {
+        if (IsIgnoredAppContextSwitch(switchName))
+            return;
+
+        AddSwitch(switches, "AppContext", switchName, api);
+    }
+
+    private static bool IsIgnoredAppContextSwitch(string switchName)
+        => switchName.StartsWith("System.Resources.UseSystemResourceKeys", StringComparison.Ordinal)
+           || switchName.StartsWith("TestSwitch.", StringComparison.Ordinal)
+           || switchName.StartsWith("Switch.", StringComparison.Ordinal);
+
+    private static List<string> TryGetStringArguments(MetadataReader reader, CustomAttribute attribute)
+    {
+        try
+        {
+            var blob = reader.GetBlobReader(attribute.Value);
+            if (blob.Length < 2)
+                return [];
+            blob.ReadUInt16();
+
+            List<string> values = [];
+            while (blob.RemainingBytes > 0)
+            {
+                var value = blob.ReadSerializedString();
+                if (value is null)
+                    break;
+                if (!string.IsNullOrWhiteSpace(value))
+                    values.Add(value);
+            }
+
+            return values;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            value = value[1..^1];
+        return value
+            .Replace("\\\"", "\"", StringComparison.Ordinal)
+            .Replace("\\\\", "\\", StringComparison.Ordinal)
+            .Replace("\\n", "\n", StringComparison.Ordinal)
+            .Replace("\\r", "\r", StringComparison.Ordinal)
+            .Replace("\\t", "\t", StringComparison.Ordinal);
+    }
+
+    private static void AddSwitch(
+        Dictionary<string, SwitchInfo> switches,
+        string kind,
+        string switchName,
+        string api)
+    {
+        switches.TryAdd($"{kind}\0{switchName}\0{api}", new SwitchInfo(kind, switchName, api));
+    }
+}

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2021,11 +2021,38 @@ public class CommandExecutionTests
                 "SourceLink Availability",
                 "SourceLink Integrity",
                 "SourceLink Missing Files",
+                "Switches",
                 "Type Forwarders"
             ],
             optInNames);
         Assert.DoesNotContain(lines, line => line.StartsWith("Missing Source Files", StringComparison.Ordinal));
         Assert.DoesNotContain(lines, line => line.StartsWith("Source Integrity", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LibraryCommand_SwitchesSection_DetectsFeatureSwitchDefinitions()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Switches", "--rows", "-n", "20");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Switches", output);
+        Assert.Contains("| Kind | Switch | API |", output);
+        Assert.Contains("| Feature Switch | `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` | `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` |", output);
+        Assert.Contains("| AppContext | `System.Text.Json.Serialization.RespectNullableAnnotationsDefault` |", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_DiscoverSwitchesCategory_ListsSwitchesSection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-D", "@Switches", "--table");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Switches", output);
+        Assert.DoesNotContain("Integrations", output);
+        Assert.DoesNotContain("Tip:", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -207,7 +207,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(27, pipeline.AllSectionNames.Length);
+        Assert.Equal(28, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
         Assert.Contains("Dependency Injection", pipeline.AllSectionNames);
@@ -222,6 +222,25 @@ public class SectionPipelineTests
         Assert.Contains("SourceLink Availability", pipeline.AllSectionNames);
         Assert.Contains("SourceLink Missing Files", pipeline.AllSectionNames);
         Assert.Contains("SourceLink Integrity", pipeline.AllSectionNames);
+        Assert.Contains("Switches", pipeline.AllSectionNames);
+    }
+
+    [Fact]
+    public void CanRender_Switches_UsesPresenceFlag()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            HasSwitches = true
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+        var selected = pipeline.GetEffectiveSections(model, Verbosity.Detailed,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Switches" });
+
+        Assert.DoesNotContain("Switches", effective);
+        Assert.Contains("Switches", selected);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -88,6 +88,7 @@ internal static class LibraryMetadataService
             inspection.HasOpenApiSupport = presenceFlags.HasOpenApiSupport;
             inspection.HasAssemblyAttributes = presenceFlags.HasAssemblyAttributes;
             inspection.HasExportedTypeForwarders = presenceFlags.HasTypeForwarders;
+            inspection.HasSwitches = presenceFlags.HasSwitches;
 
             // PE debug directory fields
             inspection.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
@@ -675,6 +676,35 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning resources in {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    internal static List<SwitchInfo>? ScanSwitches(string path, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            return ScanSwitches(peReader, path, logger);
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning switches in {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    internal static List<SwitchInfo>? ScanSwitches(PEReader peReader, string path, VerboseLogger logger)
+    {
+        try
+        {
+            var switches = SwitchScanner.Scan(peReader);
+            return switches.Count > 0 ? switches : null;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning switches in {path}: {ex.Message}");
             return null;
         }
     }

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -22,6 +22,8 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(List<IntegrationSummary>))]
 [JsonSerializable(typeof(IntegrationSignal))]
 [JsonSerializable(typeof(List<IntegrationSignal>))]
+[JsonSerializable(typeof(SwitchInfo))]
+[JsonSerializable(typeof(List<SwitchInfo>))]
 [JsonSerializable(typeof(RidPackageReference))]
 public partial class JsonContext : JsonSerializerContext
 {

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -298,6 +298,12 @@ public class LibraryInspection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<TypeForwarderSummary>? TypeForwarders { get; set; }
 
+    /// <summary>
+    /// Feature, compatibility, and runtime switches discovered in metadata or IL.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<SwitchInfo>? Switches { get; set; }
+
     // Presence flags — populated cheaply from MetadataReader before scanners run.
     // Used by CanRender for fast -s discovery without full scanning.
 
@@ -372,6 +378,10 @@ public class LibraryInspection
     /// <summary>Whether the assembly has type forwarders.</summary>
     [JsonIgnore]
     public bool HasExportedTypeForwarders { get; set; }
+
+    /// <summary>Whether the assembly has feature, compatibility, or runtime switches.</summary>
+    [JsonIgnore]
+    public bool HasSwitches { get; set; }
 
     /// <summary>
     /// View routing flag: when true, show nested dependency tree instead of flat references.

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -21,6 +21,7 @@ public static class LibrarySections
     public const string ScannerSymbols = "Symbols";
     public const string ScannerAuditSignals = "AuditSignals";
     public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
+    public const string ScannerSwitches = "Switches";
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
@@ -32,6 +33,7 @@ public static class LibrarySections
             .Add<SourceIntegrity>()
             .Add<Symbols>()
             .Add<Signals>()
+            .Add<Switches>()
             .Add<Integrations>()
             .Add<AI>()
             .Add<Aspire>()
@@ -53,7 +55,8 @@ public static class LibrarySections
             .Add<CustomAttributes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
-            .AddCategory("@Integrations", LibraryIntegrationCatalog.CategorySections);
+            .AddCategory("@Integrations", LibraryIntegrationCatalog.CategorySections)
+            .AddCategory("@Switches", "Switches");
     }
 
     /// <summary>Builds the scanner registry with all library scanners registered.</summary>
@@ -74,6 +77,8 @@ public static class LibrarySections
                 LibraryMetadataService.ScanInfoCounts(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerAuditSignals, ctx =>
                 AuditSignalBuilder.PopulateLibraryAudit(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+            .Add(ScannerSwitches, ctx =>
+                ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger));
     }
@@ -109,6 +114,16 @@ public static class LibrarySections
         public static string? ScannerKey => ScannerAuditSignals;
         public static bool CanRender(LibraryInspection model)
             => model.AuditSignals is { Count: > 0 };
+    }
+
+    public sealed class Switches : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Switches";
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerSwitches;
+        public static bool CanRender(LibraryInspection model)
+            => model.Switches is { Count: > 0 } || model.HasSwitches;
     }
 
     public sealed class OpenTelemetry : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -404,6 +404,7 @@ public record LibraryFileRow(
 [MarkoutContext(typeof(CustomAttributeRow))]
 [MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(AuditSignalRow))]
+[MarkoutContext(typeof(SwitchRow))]
 [MarkoutContext(typeof(IntegrationRow))]
 [MarkoutContext(typeof(IntegrationSignalRow))]
 [MarkoutContext(typeof(IntegrationApiSignalRow))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -194,6 +194,19 @@ public class LibraryInspectionView
         _data.AuditSignals?.Select(s => new AuditSignalRow(s.Area, s.Signal, s.Value, s.Evidence)).ToList();
 
     [MarkoutIgnore]
+    public bool HasSwitches => _data.Switches is { Count: > 0 };
+
+    [MarkoutSection(Name = "Switches", ShowWhenProperty = nameof(HasSwitches))]
+    [MarkoutIgnoreColumnWhen(nameof(SwitchKindIsUniform), "Kind")]
+    public List<SwitchRow>? SwitchesSection =>
+        _data.Switches?
+            .OrderBy(s => s.Kind, StringComparer.Ordinal)
+            .ThenBy(s => s.Switch, StringComparer.Ordinal)
+            .ThenBy(s => s.Api, StringComparer.Ordinal)
+            .Select(s => new SwitchRow(s.Kind, MarkoutInline.Code(s.Switch), MarkoutInline.Code(s.Api)))
+            .ToList();
+
+    [MarkoutIgnore]
     public bool HasIntegrations => _data.Integrations is { Count: > 0 };
 
     [MarkoutSection(Name = EcosystemIntegrationNames.Integrations, ShowWhenProperty = nameof(HasIntegrations))]
@@ -516,6 +529,9 @@ public class LibraryInspectionView
     public static bool IntegrationApiKindIsUniform(List<IntegrationApiSignalRow>? rows)
         => rows?.Select(row => row.Kind).Distinct(StringComparer.Ordinal).Count() <= 1;
 
+    public static bool SwitchKindIsUniform(List<SwitchRow>? rows)
+        => rows?.Select(row => row.Kind).Distinct(StringComparer.Ordinal).Count() <= 1;
+
     private static List<TreeNode> BuildNestedDependencyTree(List<AssemblyReferenceNode> nodes)
     {
         List<TreeNode> result = [];
@@ -601,6 +617,12 @@ public record AuditSignalRow(
     string Signal,
     string Value,
     string Evidence);
+
+[MarkoutSerializable]
+public record SwitchRow(
+    string Kind,
+    string Switch,
+    [property: MarkoutPropertyName("API")] string Api);
 
 [MarkoutSerializable]
 public record IntegrationRow(


### PR DESCRIPTION
## Summary
- add an opt-in Switches library section and @Switches category
- detect FeatureSwitchDefinitionAttribute, RuntimeHostConfigurationOptionAttribute, and AppContext switch string literals
- render switch action points as Kind / Switch / API rows
- document the Switches workflow and add regression coverage

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_SwitchesSection_DetectsFeatureSwitchDefinitions -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_DiscoverSwitchesCategory_ListsSwitchesSection -method DotnetInspector.Tests.SectionPipelineTests.CanRender_Switches_UsesPresenceFlag -method DotnetInspector.Tests.SectionPipelineTests.LibraryPipeline_HasExpectedSectionCount
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_DiscoverSchema_GroupsOptInSections -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_SwitchesSection_DetectsFeatureSwitchDefinitions -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_DiscoverSwitchesCategory_ListsSwitchesSection
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
- npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md