### PR TITLE
Compose && chains in guard-clause emission

### DIFF
--- a/docs/decompiler-h2h-comparison.md
+++ b/docs/decompiler-h2h-comparison.md
@@ -445,12 +445,9 @@ if (value != null)
     {
         for (int V_2 = 0; V_2 < _count; V_2++)
         {
-            if (V_0[V_2].next >= -1)
+            if (V_0[V_2].next >= -1 && EqualityComparer<TValue>.Default.Equals(V_0[V_2].value, value))
             {
-                if (EqualityComparer<TValue>.Default.Equals(V_0[V_2].value, value))
-                {
-                    return true;
-                }
+                return true;
             }
         }
         return false;
@@ -466,7 +463,7 @@ else
 return false;
 ```
 
-**Verdict:** All three loop paths structure correctly in their arms with for-initializer counters, and every expression matches the source. Remaining deltas: the loop-body `&&` conditions render as nested ifs (the chain detector doesn't run inside loop-body emission), the branch order inverts (`value != null` first vs the source's `value == null`), the cached comparer stays hoisted (multi-block local), and the shared `return false` appears per path. What was the corpus's worst method is now a readability quibble, not a correctness or structure problem. **Grade: A-**
+**Verdict:** All three loop paths structure correctly in their arms, the loop-body `&&` conditions compose as the source writes them, and every expression matches. Remaining deltas: the branch order inverts (`value != null` first vs the source's `value == null`), the cached comparer stays hoisted (multi-block local), and the shared `return false` appears per path. **Grade: A-**
 
 ---
 
@@ -490,7 +487,7 @@ return false;
 | `Stack.Pop` | **A-** | spill/temp naming |
 | `Queue.Dequeue` | **A-** | spill/temp naming |
 | `List.Clear` | **A-** | hoisted multi-scope local; extra return |
-| `Dictionary.ContainsValue` | **A-** | nested ifs in loop bodies; path order |
+| `Dictionary.ContainsValue` | **A-** | path order; hoisted comparer |
 
 ### Overall: **A** (12 of 17 exact; all 17 at A-/A; previous snapshots: B, B+, A-)
 
@@ -509,5 +506,4 @@ return false;
 **Remaining gaps, all residual:**
 
 1. **Naming** — eval-stack spills (`S_0`) and compiler temps (`V_2`) have no PDB names by nature; ordinary locals are `V_n` only when no PDB is in play (the type command acquires one). Synthesized names for the residuals are an open design question.
-2. **`&&` chains inside loop bodies** (`ContainsValue`) — the chain detector runs on structured conditionals, not the loop-body emission path.
-3. **Multi-scope local placement** (`List.Clear`'s `int V_0;`) — needs PDB local scopes for true source positions.
+2. **Multi-scope local placement** (`List.Clear`'s `int V_0;`, `ContainsValue`'s comparer) — needs PDB local scopes for true source positions.

--- a/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/CSharpEmitterTests.cs
@@ -209,6 +209,16 @@ public class CSharpEmitterTests
     }
 
     [Fact]
+    public void CoreLib_DictionaryContainsValue_ComposesLoopBodyChains()
+    {
+        // Consecutive same-target guards inside a loop body are the lowering
+        // of 'if (a && b)' — they compose instead of nesting.
+        string output = EmitCoreLibMethod("System.Collections.Generic.Dictionary`2", "ContainsValue");
+
+        Assert.Contains(".next >= -1 && ", output);
+    }
+
+    [Fact]
     public void CoreLib_DictionaryContainsValue_StructuresAllThreePaths()
     {
         // Three parallel scan loops (null / value-type / cached-comparer),

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -4693,6 +4693,7 @@ public static class CSharpEmitter
             string guardCondition = branchExpr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
                 ? condition
                 : NegatedConditionOf(branchExpr, condition);
+            guardCondition = AbsorbChainedGuards(guardCondition, condTarget, fallthroughBlocks);
             WriteIndent(indent);
             _sb.AppendLine($"if ({guardCondition})");
             WriteIndent(indent);
@@ -4702,6 +4703,39 @@ public static class CSharpEmitter
             WriteIndent(indent);
             _sb.AppendLine("}");
             return true;
+        }
+
+        /// <summary>
+        /// Absorbs leading same-target guard blocks into the guard condition:
+        /// consecutive 'jump-if-fail to T' blocks are the lowering of
+        /// 'if (a && b) { body }'. Each absorbed block must be a pure
+        /// condition block (a lone conditional branch to the same target).
+        /// </summary>
+        string AbsorbChainedGuards(string guardCondition, string condTarget, List<int> fallthroughBlocks)
+        {
+            while (fallthroughBlocks.Count > 1
+                && _blockMap.TryGetValue(fallthroughBlocks[0], out var nextBlock)
+                && nextBlock.Nodes
+                    .Where(n => n is not ILAstStatement { Expression.OpCode: ILOpCode.Nop })
+                    .ToList() is [ILAstStatement { Expression: var nextBranch }]
+                && nextBranch.OpCode.IsBranch()
+                && nextBranch.OpCode is not (ILOpCode.Br or ILOpCode.Br_s)
+                && nextBranch.Operand is string nextTarget
+                && nextTarget == condTarget)
+            {
+                string nextCond = BranchConditionToString(nextBranch);
+                string nextGuard = nextBranch.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
+                    ? nextCond
+                    : NegatedConditionOf(nextBranch, nextCond);
+                guardCondition = $"{ParenthesizeIfOr(guardCondition)} && {ParenthesizeIfOr(nextGuard)}";
+                _consumedBlocks.Add(fallthroughBlocks[0]);
+                RemoveGotoTargetsForConsumedBlock(fallthroughBlocks[0]);
+                fallthroughBlocks.RemoveAt(0);
+            }
+            return guardCondition;
+
+            static string ParenthesizeIfOr(string c)
+                => c.Contains("||", StringComparison.Ordinal) ? $"({c})" : c;
         }
 
         bool IsLoopHeaderTarget(string target, NaturalLoop loop)
@@ -4805,6 +4839,7 @@ public static class CSharpEmitter
             string guardCondition = branchExpr.OpCode is ILOpCode.Brfalse or ILOpCode.Brfalse_s
                 ? condition
                 : NegatedConditionOf(branchExpr, condition);
+            guardCondition = AbsorbChainedGuards(guardCondition, condTarget, fallthroughBlocks);
             WriteIndent(indent);
             _sb.AppendLine($"if ({guardCondition})");
             WriteIndent(indent);


### PR DESCRIPTION
## Summary

Consecutive same-target guard blocks are the lowering of `if (a && b)`: each block tests one operand and jumps to the same fail target. The guard-clause emitters rendered these as nested ifs because `&&` chain detection only ran on structured conditionals, never on the guard-clause path — so loop bodies (which always emit via guard clauses) could never compose conditions.

`AbsorbChainedGuards` folds leading pure-condition fallthrough blocks that branch to the same target into the guard condition with `&&`, matching polarity per branch opcode (`brfalse` uses the condition directly; everything else negates via the type-aware IL duals). Operands containing `||` get parenthesized. Wired into both guard-clause sites: the loop-body variant and the general variant.

## IL shape (taste-doc class 1: IL-exact)

`Dictionary<K,V>.ContainsValue` loop body:

```text
IL_0017: ldloc.0 / ldloc.2 / ... / ldfld next / ldc.i4.m1 / blt.s IL_0044   // guard 1 → fail target
IL_0026: ldsfld Default / ... / callvirt Equals / brfalse.s IL_0044         // guard 2 → same fail target
IL_003e: ldc.i4.1 / ret                                                     // body
```

Two jump-if-fail branches to one target is exactly what `csc` emits for `if (a && b) { ... }` — adopting the composed form recovers the source spelling with no information loss.

## Before / after

```csharp
// before
if (V_0[V_2].next >= -1)
{
    if (EqualityComparer<TValue>.Default.Equals(V_0[V_2].value, value))
    {
        return true;
    }
}

// after — matches dotnet/runtime source
if (V_0[V_2].next >= -1 && EqualityComparer<TValue>.Default.Equals(V_0[V_2].value, value))
{
    return true;
}
```

## Validation

- Full 17-method corpus diff: only `ContainsValue`'s three loop bodies change, all to the source's `&&` form
- Decompiler suite: 260/260 in **both** Debug and Release
- CLI suite: 959 pass
- New CoreLib regression test pins the composed loop guard
- h2h doc updated: `ContainsValue` verdict drops the nested-ifs delta; remaining-gaps list drops the loop-body chain item

🤖 Generated with [Claude Code](https://claude.com/claude-code)