### PR TITLE
Honest failure: DecompilerResult with diagnostics and fidelity levels

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Decompiler;
+
+namespace DotnetInspector.Decompiler.Tests;
+
+public class DecompilerResultTests
+{
+    [Fact]
+    public void Decompile_ValidMethod_ReportsFullFidelity()
+    {
+        using var stream = File.OpenRead(typeof(object).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var context = MethodBodyContext.Create(peReader, "System.String", "IsNullOrEmpty");
+        Assert.NotNull(context);
+
+        var result = CSharpEmitter.Decompile(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(CSharpEmitter.Emit(context), result.Output);
+    }
+
+    [Fact]
+    public void Decompile_CorruptIL_FailsWithInternalErrorDiagnostic()
+    {
+        var result = CSharpEmitter.Decompile(CorruptContext());
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Output);
+        Assert.Equal(DecompilationFidelity.Failed, result.Fidelity);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(DiagnosticIds.InternalError, diagnostic.Id);
+        Assert.Contains(diagnostic.Id, diagnostic.ToString());
+    }
+
+    [Fact]
+    public void AnnotatedDecompile_ValidMethod_MatchesEmit()
+    {
+        using var stream = File.OpenRead(typeof(object).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var context = MethodBodyContext.Create(peReader, "System.String", "IsNullOrEmpty");
+        Assert.NotNull(context);
+
+        var result = AnnotatedILEmitter.Decompile(context, ILAnnotationDepth.Structured);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Equal(AnnotatedILEmitter.Emit(context, ILAnnotationDepth.Structured), result.Output);
+    }
+
+    /// <summary>A context whose IL is a truncated two-byte opcode — the reader throws in both configurations.</summary>
+    static MethodBodyContext CorruptContext()
+    {
+        using var stream = File.OpenRead(typeof(object).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        return new MethodBodyContext(
+            ilBytes: [0xFE],  // extended-opcode prefix with no second byte
+            exceptionRegions: ImmutableArray<ExceptionRegion>.Empty,
+            maxStack: 8,
+            localTypes: [],
+            reader: reader,
+            parameterCount: 0,
+            hasThis: false,
+            hasReturnValue: false,
+            parameterTypes: [],
+            parameterNames: [],
+            returnType: "void");
+    }
+}

--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -28,6 +28,14 @@ public enum ILAnnotationDepth
 public static class AnnotatedILEmitter
 {
     /// <summary>
+    /// Emits annotated IL with failures expressed as diagnostics rather than
+    /// exceptions. On success the fidelity is <see cref="DecompilationFidelity.Full"/>
+    /// for this projection (the IL views are ground truth at every depth).
+    /// </summary>
+    public static DecompilerResult Decompile(MethodBodyContext context, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
+        => DecompilerResult.Run(() => Emit(context, depth));
+
+    /// <summary>
     /// Emit annotated IL for a method at the specified depth.
     /// </summary>
     public static string Emit(MethodBodyContext context, ILAnnotationDepth depth = ILAnnotationDepth.Typed)

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -14,6 +14,14 @@ public static class CSharpEmitter
     /// <summary>
     /// Emit C# source for a method.
     /// </summary>
+    /// <summary>
+    /// Decompiles to C# with failures expressed as diagnostics rather than
+    /// exceptions. Prefer this over <see cref="Emit(MethodBodyContext)"/>
+    /// anywhere a failure should degrade output instead of unwinding.
+    /// </summary>
+    public static DecompilerResult Decompile(MethodBodyContext context)
+        => DecompilerResult.Run(() => Emit(context));
+
     public static string Emit(MethodBodyContext context)
         => Emit(context, lambdaDepth: 0);
 

--- a/src/DotnetInspector.Decompiler/DecompilerResult.cs
+++ b/src/DotnetInspector.Decompiler/DecompilerResult.cs
@@ -1,0 +1,86 @@
+namespace DotnetInspector.Decompiler;
+
+/// <summary>
+/// Fidelity of a decompilation result, ordered from worst to best. The
+/// pipeline-replacement shipping plan routes on these levels
+/// (docs/decompiler-pipeline.md): the current pipeline reports
+/// <see cref="Full"/> or <see cref="Failed"/>; the intermediate levels exist
+/// for the replacement pipeline's honest degradation.
+/// </summary>
+public enum DecompilationFidelity
+{
+    /// <summary>No output could be produced.</summary>
+    Failed,
+
+    /// <summary>No C# rendering; IL projections are still available.</summary>
+    IlOnly,
+
+    /// <summary>Structured control flow over low-level expressions.</summary>
+    StructuredOnly,
+
+    /// <summary>C# containing explicit unrepresentable nodes.</summary>
+    Partial,
+
+    /// <summary>Every construct raised; representable C#.</summary>
+    Full,
+}
+
+/// <summary>
+/// A diagnostic with a stable machine-readable identifier. Identifiers drive
+/// fallback routing and CI triage, so they are stable across releases; the
+/// message is for humans and carries no contract.
+/// </summary>
+public readonly record struct DecompilerDiagnostic(string Id, string Message)
+{
+    public override string ToString() => $"{Id}: {Message}";
+}
+
+/// <summary>Stable diagnostic identifiers. Never renumber or reuse.</summary>
+public static class DiagnosticIds
+{
+    /// <summary>The pipeline threw while decompiling.</summary>
+    public const string InternalError = "DEC0001";
+
+    /// <summary>A method body context could not be created.</summary>
+    public const string ContextUnavailable = "DEC0002";
+
+    /// <summary>Decompilation produced no output for a method with a body.</summary>
+    public const string EmptyOutput = "DEC0003";
+}
+
+/// <summary>
+/// The result of a decompilation: output, diagnostics, and a fidelity level.
+/// The Roslyn-shaped contract (<c>Compilation.Emit</c> returns an
+/// <c>EmitResult</c>): failures are values, never silently swallowed and
+/// never forced on callers as exceptions.
+/// </summary>
+public sealed record DecompilerResult(
+    string? Output,
+    DecompilationFidelity Fidelity,
+    IReadOnlyList<DecompilerDiagnostic> Diagnostics)
+{
+    public bool Succeeded => Output is not null;
+
+    public static DecompilerResult Success(string output)
+        => new(output, DecompilationFidelity.Full, []);
+
+    public static DecompilerResult Failure(string diagnosticId, string message)
+        => new(null, DecompilationFidelity.Failed, [new DecompilerDiagnostic(diagnosticId, message)]);
+
+    /// <summary>Runs a pipeline entry point, converting exceptions and empty output into diagnostics.</summary>
+    internal static DecompilerResult Run(Func<string> pipeline)
+    {
+        string output;
+        try
+        {
+            output = pipeline();
+        }
+        catch (Exception ex)
+        {
+            return Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
+        }
+        return string.IsNullOrWhiteSpace(output)
+            ? Failure(DiagnosticIds.EmptyOutput, "decompilation produced no output")
+            : Success(output);
+    }
+}

--- a/src/DotnetInspector.Decompiler/MethodBodyContext.cs
+++ b/src/DotnetInspector.Decompiler/MethodBodyContext.cs
@@ -73,7 +73,7 @@ public sealed class MethodBodyContext
     /// </summary>
     public System.Reflection.PortableExecutable.PEReader? PE { get; init; }
 
-    MethodBodyContext(
+    internal MethodBodyContext(
         byte[] ilBytes,
         ImmutableArray<ExceptionRegion> exceptionRegions,
         int maxStack,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -947,6 +947,7 @@ public static class ApiOutputFormatter
             // Decompiled source and annotated IL share one method-body context (it is immutable),
             // so the PDB is opened and the method body decoded once rather than per section.
             Decompiler.MethodBodyContext? context = null;
+            Decompiler.DecompilerResult? contextFailure = null;
             if (wantsDecompiledSource || wantsAnnotatedIL)
             {
                 try
@@ -954,23 +955,35 @@ public static class ApiOutputFormatter
                     context = Decompiler.MethodBodyContext.Create(
                         peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    contextFailure = Decompiler.DecompilerResult.Failure(
+                        Decompiler.DiagnosticIds.ContextUnavailable,
+                        $"method body context unavailable: {ex.GetType().Name}: {ex.Message}");
+                }
             }
 
-            // Lowered C#
-            if (wantsDecompiledSource && context != null)
+            // Lowered C#. A null context with no failure means the member has
+            // no IL body (abstract/extern) — nothing to show, not an error.
+            if (wantsDecompiledSource && (context != null || contextFailure != null))
             {
-                try
+                var result = contextFailure ?? Decompiler.CSharpEmitter.Decompile(context!);
+                string? source = null;
+                if (result.Output is { } lowered)
                 {
-                    var lowered = Decompiler.CSharpEmitter.Emit(context);
-                    if (!string.IsNullOrWhiteSpace(lowered))
+                    try
                     {
-                        var source = FormatLoweredSourceWithDeclaration(type, method, context, lowered);
-                        memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
-                        hasCode = true;
+                        source = FormatLoweredSourceWithDeclaration(type, method, context!, lowered);
+                    }
+                    catch (Exception ex)
+                    {
+                        result = Decompiler.DecompilerResult.Failure(
+                            Decompiler.DiagnosticIds.InternalError,
+                            $"declaration formatting failed: {ex.GetType().Name}: {ex.Message}");
                     }
                 }
-                catch { }
+                memberCode.DecompiledSourceCode = new CodeSection("csharp", source ?? DiagnosticComment(result));
+                hasCode = true;
             }
 
             // IL disassembly
@@ -987,25 +1000,23 @@ public static class ApiOutputFormatter
             }
 
             // Annotated IL
-            if (wantsAnnotatedIL && context != null)
+            if (wantsAnnotatedIL && (context != null || contextFailure != null))
             {
-                try
-                {
-                    var annotated = Decompiler.AnnotatedILEmitter.Emit(
-                        context, Decompiler.ILAnnotationDepth.Structured);
-                    if (!string.IsNullOrWhiteSpace(annotated))
-                    {
-                        memberCode.AnnotatedIL = new CodeSection("il", annotated.TrimEnd());
-                        hasCode = true;
-                    }
-                }
-                catch { }
+                var result = contextFailure ?? Decompiler.AnnotatedILEmitter.Decompile(
+                    context!, Decompiler.ILAnnotationDepth.Structured);
+                memberCode.AnnotatedIL = new CodeSection(
+                    "il", result.Output?.TrimEnd() ?? DiagnosticComment(result));
+                hasCode = true;
             }
         }
 
         if (hasCode)
             view.MemberCode = memberCode;
     }
+
+    /// <summary>Renders a failed result as comment lines so the section degrades honestly instead of disappearing.</summary>
+    private static string DiagnosticComment(Decompiler.DecompilerResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
 
     private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context, string lowered)
     {

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -96,10 +96,11 @@ internal static class TypeSourceComposer
                 stream?.Dispose();
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Composition is best-effort; the section is simply absent.
-            return null;
+            // Degrade honestly: the section renders the reason instead of
+            // silently disappearing.
+            return $"// {Decompiler.DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
 
@@ -198,8 +199,10 @@ internal static class TypeSourceComposer
             {
                 fieldType = field.DecodeSignature(SignatureDecoder.Instance, genericContext);
             }
-            catch
+            catch (Exception ex)
             {
+                sb.AppendLine($"    // field {reader.GetString(field.Name)}: {Decompiler.DiagnosticIds.InternalError}: signature undecodable ({ex.GetType().Name})");
+                any = true;
                 continue;
             }
 
@@ -491,12 +494,12 @@ internal static class TypeSourceComposer
                 peReader, reader, typeHandle, member.Name, overloadIndex, publicOnly, pdbPath);
             if (context is null)
                 return null;
-            string body = Decompiler.CSharpEmitter.Emit(context).TrimEnd();
-            return string.IsNullOrWhiteSpace(body) ? null : body;
+            var result = Decompiler.CSharpEmitter.Decompile(context);
+            return result.Output?.TrimEnd() ?? DiagnosticComment(result);
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            return $"// {Decompiler.DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
 
@@ -510,14 +513,17 @@ internal static class TypeSourceComposer
                 peReader, reader, typeHandle, accessorName, 0, publicOnly: false, pdbPath);
             if (context is null)
                 return null;
-            string body = Decompiler.CSharpEmitter.Emit(context).TrimEnd();
-            return string.IsNullOrWhiteSpace(body) ? null : body;
+            var result = Decompiler.CSharpEmitter.Decompile(context);
+            return result.Output?.TrimEnd() ?? DiagnosticComment(result);
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            return $"// {Decompiler.DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
+
+    static string DiagnosticComment(Decompiler.DecompilerResult result)
+        => string.Join("\n", result.Diagnostics.Select(d => $"// {d}"));
 
     static void AppendIndented(StringBuilder sb, string body, string indent)
     {


### PR DESCRIPTION
## Summary

Replacement-plan step 2 from `docs/decompiler-pipeline.md`: failures become values with stable IDs, and the silent `catch { }` blocks die.

**Library** (`DotnetInspector.Decompiler`):

- `DecompilerResult { Output, Fidelity, Diagnostics }` — the Roslyn-shaped contract (`Compilation.Emit` → `EmitResult`).
- `DecompilationFidelity`: `Failed / IlOnly / StructuredOnly / Partial / Full`, the ordered levels the shipping plan's per-method fallback routes on. The current pipeline reports `Full` or `Failed`; the intermediate levels exist for the replacement pipeline's honest degradation.
- Stable diagnostic IDs (`DiagnosticIds`, never renumbered): `DEC0001` internal error, `DEC0002` context unavailable, `DEC0003` empty output.
- New entry points `CSharpEmitter.Decompile(context)` and `AnnotatedILEmitter.Decompile(context, depth)`; the throwing `Emit` primitives remain for callers (like the harness) that want raw exceptions.

**CLI**: all seven bare `catch { }` blocks in `ApiOutputFormatter` and `TypeSourceComposer` replaced. Requested sections that cannot render degrade to `// DEC####: reason` comment lines instead of disappearing. A null context with no exception still means "no IL body" (abstract/extern) and renders nothing — that's correct semantics, not a failure. Undecodable field signatures render a placeholder comment instead of silently dropping the field.

## First catch

The machinery found a real, previously-invisible gap on its first smoke test: `type Stack --package System.Collections` resolves the facade/ref assembly, whose method bodies are metadata-only stubs — bare `ret` bodies rendered as silent `{ }` before, and the stub `Contains` literally renders `return false;`. Now the empty bodies say `DEC0003: decompilation produced no output` instead of looking intentional. The platform-resolution path (`type Stack` with no package) renders full bodies correctly. Follow-up logged: the type listing should follow forwarders to the runtime assembly the way the source command does.

## Validation

- Decompiler suite: 263/263 in **both** Debug and Release (new: success-path fidelity, corrupt-IL → `DEC0001` in both configs, annotated-IL parity)
- CLI suite: 963 pass
- Full h2h corpus diff: byte-identical (no rendering change on the happy path)
- `MethodBodyContext` ctor `private` → `internal` for the corrupt-context test (InternalsVisibleTo already in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)