### PR TITLE
Count integrations and switches in library info

### DIFF
--- a/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/DotnetInspector.Metadata/AssemblyDetailScanner.cs
@@ -364,8 +364,11 @@ public static class AssemblyDetailScanner
 
         // Resources: cheapest check — just a count
         flags.HasManifestResources = reader.GetTableRowCount(TableIndex.ManifestResource) > 0;
-        flags.HasSwitches = SwitchScanner.HasSupport(peReader);
+        var switches = SwitchScanner.Scan(peReader);
+        flags.SwitchCount = switches.Count;
+        flags.HasSwitches = switches.Count > 0;
         var integrationPresence = EcosystemIntegrationScanner.ScanPresence(reader);
+        flags.IntegrationCount = integrationPresence.IntegrationCount;
         flags.HasOpenTelemetrySupport = integrationPresence.HasOpenTelemetrySupport;
         flags.HasAspNetCoreSupport = integrationPresence.HasAspNetCoreSupport;
         flags.HasAspireSupport = integrationPresence.HasAspireSupport;
@@ -509,7 +512,9 @@ public class PresenceFlags
     public bool HasManifestResources { get; set; }
     public bool HasAssemblyAttributes { get; set; }
     public bool HasTypeForwarders { get; set; }
+    public int IntegrationCount { get; set; }
     public bool HasSwitches { get; set; }
+    public int SwitchCount { get; set; }
     public bool HasOpenTelemetrySupport { get; set; }
     public bool HasAspNetCoreSupport { get; set; }
     public bool HasAspireSupport { get; set; }

--- a/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/DotnetInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -18,6 +18,7 @@ public static class IntegrationSignalShape
 
 public record EcosystemIntegrationPresence
 {
+    public int IntegrationCount { get; init; }
     public bool HasAspNetCoreSupport { get; init; }
     public bool HasAspireSupport { get; init; }
     public bool HasAISupport { get; init; }
@@ -39,7 +40,11 @@ public static class EcosystemIntegrationScanner
         if (!peReader.HasMetadata)
             return [];
 
-        var reader = peReader.GetMetadataReader();
+        return Scan(peReader.GetMetadataReader());
+    }
+
+    private static List<EcosystemIntegrationSignalInfo> Scan(MetadataReader reader)
+    {
         var buckets = IntegrationBuckets.Create();
 
         foreach (var handle in reader.TypeDefinitions)
@@ -61,10 +66,21 @@ public static class EcosystemIntegrationScanner
 
     public static EcosystemIntegrationPresence ScanPresence(MetadataReader reader)
     {
+        var openTelemetrySupport = OpenTelemetryScanner.HasSupport(reader);
         var presence = new MutablePresence
         {
-            HasOpenTelemetrySupport = OpenTelemetryScanner.HasSupport(reader)
+            HasOpenTelemetrySupport = openTelemetrySupport
         };
+
+        var signals = Scan(reader);
+        foreach (var integration in signals.Select(signal => signal.Integration).Distinct(StringComparer.Ordinal))
+            MarkIntegrationPresence(presence, integration);
+
+        presence.IntegrationCount = signals
+            .Select(signal => signal.Integration)
+            .Distinct(StringComparer.Ordinal)
+            .Count()
+            + (openTelemetrySupport ? 1 : 0);
 
         foreach (var handle in reader.TypeDefinitions)
         {
@@ -76,6 +92,46 @@ public static class EcosystemIntegrationScanner
         }
 
         return presence.ToImmutable();
+    }
+
+    private static void MarkIntegrationPresence(MutablePresence presence, string integration)
+    {
+        switch (integration)
+        {
+            case EcosystemIntegrationNames.AI:
+                presence.HasAISupport = true;
+                break;
+            case EcosystemIntegrationNames.AspNetCore:
+                presence.HasAspNetCoreSupport = true;
+                break;
+            case EcosystemIntegrationNames.Aspire:
+                presence.HasAspireSupport = true;
+                break;
+            case EcosystemIntegrationNames.Authentication:
+                presence.HasAuthenticationSupport = true;
+                break;
+            case EcosystemIntegrationNames.DependencyInjection:
+                presence.HasDependencyInjectionSupport = true;
+                break;
+            case EcosystemIntegrationNames.Logging:
+                presence.HasLoggingSupport = true;
+                break;
+            case EcosystemIntegrationNames.OpenAPI:
+                presence.HasOpenApiSupport = true;
+                break;
+            case EcosystemIntegrationNames.Options:
+                presence.HasOptionsSupport = true;
+                break;
+            case EcosystemIntegrationNames.Hosting:
+                presence.HasHostingSupport = true;
+                break;
+            case EcosystemIntegrationNames.HealthChecks:
+                presence.HasHealthChecksSupport = true;
+                break;
+            case EcosystemIntegrationNames.HttpClient:
+                presence.HasHttpClientSupport = true;
+                break;
+        }
     }
 
     private static void AddType(IntegrationBuckets buckets, string typeName, string source)
@@ -937,6 +993,7 @@ public static class EcosystemIntegrationScanner
 
     private sealed class MutablePresence
     {
+        public int IntegrationCount { get; set; }
         public bool HasAspNetCoreSupport { get; set; }
         public bool HasAspireSupport { get; set; }
         public bool HasAISupport { get; set; }
@@ -952,6 +1009,7 @@ public static class EcosystemIntegrationScanner
 
         public EcosystemIntegrationPresence ToImmutable() => new()
         {
+            IntegrationCount = IntegrationCount,
             HasAspNetCoreSupport = HasAspNetCoreSupport,
             HasAspireSupport = HasAspireSupport,
             HasAISupport = HasAISupport,

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2072,6 +2072,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_LibraryInfo_CountsStarterApiOnlyIntegrations()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "AWSSDK.Extensions.Bedrock.MEAI", "--library", "-S", "Library Info");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Library Info", output);
+        Assert.Contains("| Integrations | 1 |", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DiscoverIntegrationsCategory_ListsRenderableIntegrationSections()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -463,6 +463,19 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void SingleAudit_LibraryInfo_UsesExactIntegrationAndSwitchCounts()
+    {
+        var inspection = CreateTestAudit("Test.dll", "net9.0");
+        inspection.IntegrationCount = 1;
+        inspection.SwitchCount = 5;
+
+        var output = Serialize(inspection);
+
+        Assert.Contains("| Integrations | 1 |", output);
+        Assert.Contains("| Switches | 5 |", output);
+    }
+
+    [Fact]
     public void SingleAudit_LibraryInfo_FieldsAreAlphabetical()
     {
         var inspection = CreateTestAudit("Test.dll", "net9.0");
@@ -478,6 +491,10 @@ public class OutputFormatterTests
             < output.IndexOf("| Integrations |", StringComparison.Ordinal));
         Assert.True(output.IndexOf("| Integrations |", StringComparison.Ordinal)
             < output.IndexOf("| Methods |", StringComparison.Ordinal));
+        Assert.True(output.IndexOf("| Source |", StringComparison.Ordinal)
+            < output.IndexOf("| Switches |", StringComparison.Ordinal));
+        Assert.True(output.IndexOf("| Switches |", StringComparison.Ordinal)
+            < output.IndexOf("| Target Framework |", StringComparison.Ordinal));
         Assert.True(output.IndexOf("| Target Framework |", StringComparison.Ordinal)
             < output.IndexOf("| Type Forwarders |", StringComparison.Ordinal));
     }

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -88,9 +88,11 @@ internal static class LibraryMetadataService
             inspection.HasHealthChecksSupport = presenceFlags.HasHealthChecksSupport;
             inspection.HasHttpClientSupport = presenceFlags.HasHttpClientSupport;
             inspection.HasOpenApiSupport = presenceFlags.HasOpenApiSupport;
+            inspection.IntegrationCount = presenceFlags.IntegrationCount;
             inspection.HasAssemblyAttributes = presenceFlags.HasAssemblyAttributes;
             inspection.HasExportedTypeForwarders = presenceFlags.HasTypeForwarders;
             inspection.HasSwitches = presenceFlags.HasSwitches;
+            inspection.SwitchCount = presenceFlags.SwitchCount;
 
             // PE debug directory fields
             inspection.HasReproducibleFlag = pdbContext.HasReproducibleFlag;

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -391,6 +391,10 @@ public class LibraryInspection
     [JsonIgnore]
     public bool HasOpenApiSupport { get; set; }
 
+    /// <summary>Number of integration categories discovered by the presence scan.</summary>
+    [JsonIgnore]
+    public int IntegrationCount { get; set; }
+
     /// <summary>Whether the assembly has non-well-known custom attributes.</summary>
     [JsonIgnore]
     public bool HasAssemblyAttributes { get; set; }
@@ -402,6 +406,10 @@ public class LibraryInspection
     /// <summary>Whether the assembly has feature, compatibility, or runtime switches.</summary>
     [JsonIgnore]
     public bool HasSwitches { get; set; }
+
+    /// <summary>Number of feature, compatibility, or runtime switches discovered by the presence scan.</summary>
+    [JsonIgnore]
+    public int SwitchCount { get; set; }
 
     /// <summary>
     /// View routing flag: when true, show nested dependency tree instead of flat references.

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -143,6 +143,7 @@ public class LibraryInspectionView
         Resources = CountOrZero(_data.Resources),
         Signed = info.IsSigned ? "Yes" : null,
         Source = _data.Source,
+        Switches = CountSwitches(_data),
         TargetFramework = info.TargetFramework,
         TypeForwarders = CountOrZero(_data.TypeForwarders),
         Types = info.TypeDefinitionCount > 0 ? info.TypeDefinitionCount.ToString("N0") : null,
@@ -538,8 +539,14 @@ public class LibraryInspectionView
         if (inspection.Integrations is { Count: > 0 } integrations)
             return integrations.Count;
 
+        if (inspection.IntegrationCount > 0)
+            return inspection.IntegrationCount;
+
         return LibraryIntegrationCatalog.CountPresence(inspection);
     }
+
+    private static int CountSwitches(LibraryInspection inspection)
+        => inspection.Switches?.Count ?? inspection.SwitchCount;
 
     private static List<IntegrationSignalRow>? ToIntegrationSignalRows(List<IntegrationSignal>? signals)
         => signals?
@@ -700,6 +707,7 @@ public class LibraryInfoSection
     public int Resources { get; init; }
     public string? Signed { get; init; }
     public string? Source { get; init; }
+    public int Switches { get; init; }
     public string? TargetFramework { get; init; }
     public int TypeForwarders { get; init; }
     public string? Types { get; init; }


### PR DESCRIPTION
## Summary
- make Library Info integration counts use the same metadata scanner currency as the Integrations section
- add Switches to Library Info as a switch-entry count
- keep Library Info fields in alphabetical order

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_LibraryInfo_CountsStarterApiOnlyIntegrations -method DotnetInspector.Tests.OutputFormatterTests.SingleAudit_LibraryInfo_UsesExactIntegrationAndSwitchCounts -method DotnetInspector.Tests.OutputFormatterTests.SingleAudit_LibraryInfo_FieldsAreAlphabetical
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release