### PR TITLE
Move type-forwarder resolution into DotnetInspector.Metadata

### DIFF
--- a/src/DotnetInspector.Metadata/TypeForwardResolver.cs
+++ b/src/DotnetInspector.Metadata/TypeForwardResolver.cs
@@ -1,0 +1,146 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+/// <summary>
+/// Locates the file for an assembly by simple name. Policy lives with the
+/// caller (sibling directory, ref pack, shared framework, package graph);
+/// the resolver below supplies only the metadata mechanism. Returns null
+/// when the assembly cannot be located.
+/// </summary>
+public delegate string? AssemblyLocator(string assemblyName);
+
+/// <summary>Where a type is actually defined after following forwarders.</summary>
+public sealed record TypeLocation(string AssemblyPath, string FullTypeName);
+
+/// <summary>
+/// Type-forwarder resolution: the mechanism (ExportedTypes traversal, hop
+/// limit, cycle detection) lives here; locating assembly files is the
+/// caller's policy via <see cref="AssemblyLocator"/> — the same split as
+/// MetadataLoadContext's MetadataAssemblyResolver and ILSpy's
+/// IAssemblyResolver.
+/// </summary>
+public static class TypeForwardResolver
+{
+    /// <summary>
+    /// Resolves the assembly that defines <paramref name="fullTypeName"/>,
+    /// starting at <paramref name="assemblyPath"/> and following type
+    /// forwarders through assemblies supplied by <paramref name="locateAssembly"/>.
+    /// Returns null if the chain dead-ends, exceeds <paramref name="maxHops"/>,
+    /// or revisits an assembly.
+    /// </summary>
+    public static TypeLocation? LocateType(
+        string assemblyPath, string fullTypeName, AssemblyLocator locateAssembly, int maxHops = 8)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string current = assemblyPath;
+
+        for (int hop = 0; hop <= maxHops; hop++)
+        {
+            if (!visited.Add(Path.GetFullPath(current)))
+                return null;
+
+            using var stream = File.OpenRead(current);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return null;
+            var reader = peReader.GetMetadataReader();
+
+            if (FindTypeDefinition(reader, fullTypeName) is { IsNil: false })
+                return new TypeLocation(current, fullTypeName);
+
+            if (ForwardTargetAssembly(reader, fullTypeName) is not { } targetAssembly)
+                return null;
+            if (locateAssembly(targetAssembly) is not { } next || !File.Exists(next))
+                return null;
+            current = next;
+        }
+        return null;
+    }
+
+    /// <summary>True if the assembly contains a type definition matching <paramref name="typeName"/> (pattern-aware via <see cref="TypeMatcher"/>).</summary>
+    public static bool DefinesType(string assemblyPath, string typeName)
+    {
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return false;
+            var reader = peReader.GetMetadataReader();
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(handle);
+                if (TypeMatcher.Matches(FullName(reader, typeDef.Namespace, typeDef.Name), typeName))
+                    return true;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+        }
+        return false;
+    }
+
+    /// <summary>True if the assembly forwards a type matching <paramref name="typeName"/> (pattern-aware via <see cref="TypeMatcher"/>).</summary>
+    public static bool ForwardsType(string assemblyPath, string typeName)
+    {
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return false;
+            var reader = peReader.GetMetadataReader();
+            foreach (var handle in reader.ExportedTypes)
+            {
+                var exported = reader.GetExportedType(handle);
+                if (!exported.IsForwarder)
+                    continue;
+                if (TypeMatcher.Matches(FullName(reader, exported.Namespace, exported.Name), typeName))
+                    return true;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+        }
+        return false;
+    }
+
+    /// <summary>The assembly-reference simple name a forwarder for <paramref name="fullTypeName"/> points at, or null (exact-name match, one hop).</summary>
+    public static string? ForwardTargetAssembly(MetadataReader reader, string fullTypeName)
+    {
+        foreach (var handle in reader.ExportedTypes)
+        {
+            var exported = reader.GetExportedType(handle);
+            if (!exported.IsForwarder)
+                continue;
+            if (FullName(reader, exported.Namespace, exported.Name) != fullTypeName)
+                continue;
+            if (exported.Implementation.Kind == HandleKind.AssemblyReference)
+            {
+                var assembly = reader.GetAssemblyReference((AssemblyReferenceHandle)exported.Implementation);
+                return reader.GetString(assembly.Name);
+            }
+        }
+        return null;
+    }
+
+    static TypeDefinitionHandle FindTypeDefinition(MetadataReader reader, string fullTypeName)
+    {
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (FullName(reader, typeDef.Namespace, typeDef.Name) == fullTypeName)
+                return handle;
+        }
+        return default;
+    }
+
+    static string FullName(MetadataReader reader, StringHandle ns, StringHandle name)
+    {
+        string nsText = reader.GetString(ns);
+        string nameText = reader.GetString(name);
+        return nsText.Length == 0 ? nameText : $"{nsText}.{nameText}";
+    }
+}

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -924,60 +924,13 @@ public static class PlatformResolver
         // e.g., Dictionary`2 is defined in System.Collections, not mscorlib (which only forwards).
         foreach (var dll in Directory.GetFiles(refPath, "*.dll"))
         {
-            if (HasTypeDefinition(dll, normalized))
+            if (Metadata.TypeForwardResolver.DefinesType(dll, normalized))
                 return System.IO.Path.GetFileNameWithoutExtension(dll);
-            if (forwarderMatch == null && HasTypeForwarder(dll, normalized))
+            if (forwarderMatch == null && Metadata.TypeForwardResolver.ForwardsType(dll, normalized))
                 forwarderMatch = System.IO.Path.GetFileNameWithoutExtension(dll);
         }
 
         return forwarderMatch;
-    }
-
-    private static bool HasTypeDefinition(string assemblyPath, string typeName)
-    {
-        try
-        {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new System.Reflection.PortableExecutable.PEReader(stream);
-            if (!peReader.HasMetadata) return false;
-
-            var mdReader = peReader.GetMetadataReader();
-            foreach (var handle in mdReader.TypeDefinitions)
-            {
-                var typeDef = mdReader.GetTypeDefinition(handle);
-                var name = mdReader.GetString(typeDef.Name);
-                var ns = mdReader.GetString(typeDef.Namespace);
-                var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-                if (Metadata.TypeMatcher.Matches(fullName, typeName))
-                    return true;
-            }
-        }
-        catch { }
-        return false;
-    }
-
-    private static bool HasTypeForwarder(string assemblyPath, string typeName)
-    {
-        try
-        {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new System.Reflection.PortableExecutable.PEReader(stream);
-            if (!peReader.HasMetadata) return false;
-
-            var mdReader = peReader.GetMetadataReader();
-            foreach (var handle in mdReader.ExportedTypes)
-            {
-                var exported = mdReader.GetExportedType(handle);
-                if (!exported.IsForwarder) continue;
-                var name = mdReader.GetString(exported.Name);
-                var ns = mdReader.GetString(exported.Namespace);
-                var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-                if (Metadata.TypeMatcher.Matches(fullName, typeName))
-                    return true;
-            }
-        }
-        catch { }
-        return false;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -616,6 +616,30 @@ public class ApiCommand
 
     // ===== Method Source Resolution =====
 
+    /// <summary>
+    /// Forwarder-following policy for whole-type listings: implementations
+    /// beside the starting assembly first, then the installed shared
+    /// framework (so package facades resolve to the platform assemblies
+    /// they forward to at runtime).
+    /// </summary>
+    internal static Metadata.AssemblyLocator PlatformAssemblyLocator(string startingDll)
+    {
+        string? sharedDir = Services.PlatformResolver.GetSharedDirectory();
+        return name =>
+        {
+            string sibling = Path.Combine(Path.GetDirectoryName(startingDll)!, name + ".dll");
+            if (File.Exists(sibling))
+                return sibling;
+            if (sharedDir is null)
+                return null;
+            var (runtimeDir, _, _) = Services.PlatformResolver.ResolveRuntimeFramework("runtime");
+            if (runtimeDir is null)
+                return null;
+            string platform = Path.Combine(runtimeDir, name + ".dll");
+            return File.Exists(platform) ? platform : null;
+        };
+    }
+
     internal sealed record ResolvedMethodSource(MethodSourceContext? Source, string? PdbPath);
 
     internal static async Task<ResolvedMethodSource> ResolveMethodSourceAsync(
@@ -832,7 +856,8 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
-            var listing = TypeSourceComposer.Compose(type, typeDllPath, options.PdbPath);
+            var listing = TypeSourceComposer.Compose(
+                type, typeDllPath, options.PdbPath, PlatformAssemblyLocator(typeDllPath));
             if (listing is not null)
             {
                 view.MemberCode ??= new MemberCodeView();

--- a/src/dotnet-inspect/Output/TypeSourceComposer.cs
+++ b/src/dotnet-inspect/Output/TypeSourceComposer.cs
@@ -16,7 +16,7 @@ namespace DotnetInspector.Output;
 /// </summary>
 internal static class TypeSourceComposer
 {
-    public static string? Compose(ApiType type, string dllPath, string? pdbPath)
+    public static string? Compose(ApiType type, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null)
     {
         if (type.Kind is "delegate")
             return null;
@@ -24,42 +24,32 @@ internal static class TypeSourceComposer
         try
         {
             // Follow type forwarders (ref/facade assemblies) to the assembly
-            // that actually defines the type — implementations sit alongside.
-            string currentDll = dllPath;
+            // that actually defines the type. Default policy: implementations
+            // sit alongside the starting assembly.
+            locateAssembly ??= name =>
+            {
+                string sibling = Path.Combine(Path.GetDirectoryName(dllPath)!, name + ".dll");
+                return File.Exists(sibling) ? sibling : null;
+            };
+            if (TypeForwardResolver.LocateType(dllPath, type.FullName, locateAssembly) is not { } location)
+                return null;
+
             FileStream? stream = null;
             PEReader? peReader = null;
-            MetadataReader reader = null!;
-            TypeDefinitionHandle typeHandle = default;
             try
             {
-                for (int hop = 0; hop < 4 && typeHandle.IsNil; hop++)
+                stream = File.OpenRead(location.AssemblyPath);
+                peReader = new PEReader(stream);
+                MetadataReader reader = peReader.GetMetadataReader();
+
+                TypeDefinitionHandle typeHandle = default;
+                foreach (var h in reader.TypeDefinitions)
                 {
-                    peReader?.Dispose();
-                    stream?.Dispose();
-                    stream = File.OpenRead(currentDll);
-                    peReader = new PEReader(stream);
-                    if (!peReader.HasMetadata)
-                        return null;
-                    reader = peReader.GetMetadataReader();
-
-                    foreach (var h in reader.TypeDefinitions)
+                    if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
                     {
-                        if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
-                        {
-                            typeHandle = h;
-                            break;
-                        }
-                    }
-                    if (!typeHandle.IsNil)
+                        typeHandle = h;
                         break;
-
-                    string? forwardTarget = FindForwardTarget(reader, type);
-                    if (forwardTarget is null)
-                        return null;
-                    string sibling = Path.Combine(Path.GetDirectoryName(currentDll)!, forwardTarget + ".dll");
-                    if (!File.Exists(sibling))
-                        return null;
-                    currentDll = sibling;
+                    }
                 }
                 if (typeHandle.IsNil)
                     return null;
@@ -102,27 +92,6 @@ internal static class TypeSourceComposer
             // silently disappearing.
             return $"// {Decompiler.DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
         }
-    }
-
-    static string? FindForwardTarget(MetadataReader reader, ApiType type)
-    {
-        foreach (var h in reader.ExportedTypes)
-        {
-            var exported = reader.GetExportedType(h);
-            if (!exported.IsForwarder)
-                continue;
-            string ns = reader.GetString(exported.Namespace);
-            string name = reader.GetString(exported.Name);
-            string full = ns.Length == 0 ? name : $"{ns}.{name}";
-            if (full != type.FullName)
-                continue;
-            if (exported.Implementation.Kind == HandleKind.AssemblyReference)
-            {
-                var asm = reader.GetAssemblyReference((AssemblyReferenceHandle)exported.Implementation);
-                return reader.GetString(asm.Name);
-            }
-        }
-        return null;
     }
 
     static string TypeDeclaration(ApiType type)

--- a/tests/DotnetInspector.Metadata.Tests/TypeForwardResolverTests.cs
+++ b/tests/DotnetInspector.Metadata.Tests/TypeForwardResolverTests.cs
@@ -1,0 +1,75 @@
+namespace DotnetInspector.Metadata.Tests;
+
+public class TypeForwardResolverTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+    static string FrameworkDir => Path.GetDirectoryName(CoreLibPath)!;
+    static string NetstandardFacade => Path.Combine(FrameworkDir, "netstandard.dll");
+
+    /// <summary>Sibling-directory policy over the shared framework.</summary>
+    static string? SiblingLocator(string assemblyName)
+    {
+        string candidate = Path.Combine(FrameworkDir, assemblyName + ".dll");
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    [Fact]
+    public void LocateType_DefinedInStartingAssembly_ReturnsIt()
+    {
+        var location = TypeForwardResolver.LocateType(CoreLibPath, "System.String", SiblingLocator);
+
+        Assert.NotNull(location);
+        Assert.Equal(CoreLibPath, location.AssemblyPath);
+    }
+
+    [Fact]
+    public void LocateType_FollowsFacadeToDefiningAssembly()
+    {
+        // netstandard.dll defines nothing; every type is a forwarder.
+        var location = TypeForwardResolver.LocateType(
+            NetstandardFacade, "System.Collections.Generic.List`1", SiblingLocator);
+
+        Assert.NotNull(location);
+        Assert.NotEqual(NetstandardFacade, location.AssemblyPath);
+        Assert.True(TypeForwardResolver.DefinesType(location.AssemblyPath, "System.Collections.Generic.List`1"));
+    }
+
+    [Fact]
+    public void LocateType_LocatorCannotResolve_ReturnsNull()
+    {
+        var location = TypeForwardResolver.LocateType(
+            NetstandardFacade, "System.Collections.Generic.List`1", _ => null);
+
+        Assert.Null(location);
+    }
+
+    [Fact]
+    public void LocateType_UnknownType_ReturnsNull()
+    {
+        var location = TypeForwardResolver.LocateType(
+            CoreLibPath, "Definitely.Not.A.Type", SiblingLocator);
+
+        Assert.Null(location);
+    }
+
+    [Fact]
+    public void LocateType_SelfLoop_Terminates()
+    {
+        // A locator that always points back at the facade would loop forever
+        // without cycle detection.
+        var location = TypeForwardResolver.LocateType(
+            NetstandardFacade, "System.Collections.Generic.List`1", _ => NetstandardFacade);
+
+        Assert.Null(location);
+    }
+
+    [Fact]
+    public void DefinesType_And_ForwardsType_DistinguishFacades()
+    {
+        Assert.True(TypeForwardResolver.DefinesType(CoreLibPath, "System.String"));
+        Assert.False(TypeForwardResolver.ForwardsType(CoreLibPath, "System.String"));
+
+        Assert.False(TypeForwardResolver.DefinesType(NetstandardFacade, "System.String"));
+        Assert.True(TypeForwardResolver.ForwardsType(NetstandardFacade, "System.String"));
+    }
+}


### PR DESCRIPTION
## Summary

Forwarder following was triplicated, each copy with a different hardcoded policy:

- `TypeSourceComposer` (CLI): inline chain-walk assuming forward targets sit **beside the starting dll** — exactly the assumption that broke on package layouts
- `PlatformResolver` (Services): its own `HasTypeDefinition`/`HasTypeForwarder` SRM scans
- `DotnetInspector.Metadata`: reads ExportedTypes in three files but offered no resolution primitive, so consumers each rebuilt one

## Design

Mechanism and policy split, per the neighbors (`MetadataLoadContext.MetadataAssemblyResolver`, ILSpy/Cecil `IAssemblyResolver`):

```csharp
public delegate string? AssemblyLocator(string assemblyName);          // policy: caller's
public sealed record TypeLocation(string AssemblyPath, string FullTypeName);

public static class TypeForwardResolver                                 // mechanism: Metadata's
{
    public static TypeLocation? LocateType(string assemblyPath, string fullTypeName,
        AssemblyLocator locateAssembly, int maxHops = 8);               // hop-limited, cycle-safe
    public static bool DefinesType(string assemblyPath, string typeName);   // TypeMatcher-aware
    public static bool ForwardsType(string assemblyPath, string typeName);
}
```

No SRM types in the public signatures, per the library's conventions.

## Call sites

- `TypeSourceComposer.Compose` takes an optional `AssemblyLocator` (default preserves the sibling-directory behavior); its inline loop and `FindForwardTarget` are deleted. This also unblocks the planned composer→library move — no CLI-grown resolution code travels with it.
- The whole-type listing's locator (ApiCommand) falls back from sibling directory to the **installed shared framework**, so package facades that purely forward now resolve to the platform assemblies they forward to at runtime.
- `PlatformResolver` drops its duplicate traversals and calls `DefinesType`/`ForwardsType`.

## Not fixed here (by design)

Stub-definition ref assemblies (the `type Stack --package System.Collections` case from #454): the type **is defined** in the package lib with metadata-only bodies, so forwarder resolution never applies. The `DEC0003` comments remain the honest rendering until the ref-assembly-detection fallback (logged follow-up).

## Validation

- Metadata suite 141 pass (6 new: definition-site short-circuit, facade-to-definer chase, locator-can't-resolve, unknown type, **self-loop termination**, defines-vs-forwards on a real facade)
- CLI suite 968, Services 158, decompiler 263 — all pass
- Smoke: platform `type Stack` renders full bodies; package stub case unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)