### PR TITLE
Move TypeSourceComposer into DotnetInspector.Decompiler

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -71,3 +71,27 @@ public class DecompilerResultTests
             returnType: "void");
     }
 }
+
+public class TypeSourceComposerTests
+{
+    [Fact]
+    public void Compose_WholeType_RendersDeclarationFieldsAndBodies()
+    {
+        string dll = Path.Combine(
+            Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Collections.dll");
+        Metadata.ApiType type;
+        using (var stream = File.OpenRead(dll))
+        using (var peReader = new PEReader(stream))
+        {
+            var surface = Metadata.ApiSurfaceExtractor.Extract(peReader);
+            type = surface.Types.Single(t => t.FullName == "System.Collections.Generic.Stack`1");
+        }
+
+        string? listing = TypeSourceComposer.Compose(type, dll, pdbPath: null);
+
+        Assert.NotNull(listing);
+        Assert.Contains("namespace System.Collections.Generic;", listing);
+        Assert.Contains("private T[] _array;", listing);
+        Assert.Contains("_array = Array.Empty<T>();", listing);
+    }
+}

--- a/src/DotnetInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/DotnetInspector.Decompiler/TypeSourceComposer.cs
@@ -4,7 +4,7 @@ using System.Reflection.PortableExecutable;
 using System.Text;
 using DotnetInspector.Metadata;
 
-namespace DotnetInspector.Output;
+namespace DotnetInspector.Decompiler;
 
 /// <summary>
 /// Composes a whole type as one C# listing: the type declaration, field
@@ -14,7 +14,7 @@ namespace DotnetInspector.Output;
 /// matches both reference decompilers and dotnet/runtime's per-type source
 /// files.
 /// </summary>
-internal static class TypeSourceComposer
+public static class TypeSourceComposer
 {
     public static string? Compose(ApiType type, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null)
     {
@@ -90,7 +90,7 @@ internal static class TypeSourceComposer
         {
             // Degrade honestly: the section renders the reason instead of
             // silently disappearing.
-            return $"// {Decompiler.DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
+            return $"// {DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
 
@@ -170,7 +170,7 @@ internal static class TypeSourceComposer
             }
             catch (Exception ex)
             {
-                sb.AppendLine($"    // field {reader.GetString(field.Name)}: {Decompiler.DiagnosticIds.InternalError}: signature undecodable ({ex.GetType().Name})");
+                sb.AppendLine($"    // field {reader.GetString(field.Name)}: {DiagnosticIds.InternalError}: signature undecodable ({ex.GetType().Name})");
                 any = true;
                 continue;
             }
@@ -459,16 +459,16 @@ internal static class TypeSourceComposer
         try
         {
             bool publicOnly = member.Kind != "explicit-interface-implementation";
-            var context = Decompiler.MethodBodyContext.Create(
+            var context = MethodBodyContext.Create(
                 peReader, reader, typeHandle, member.Name, overloadIndex, publicOnly, pdbPath);
             if (context is null)
                 return null;
-            var result = Decompiler.CSharpEmitter.Decompile(context);
+            var result = CSharpEmitter.Decompile(context);
             return result.Output?.TrimEnd() ?? DiagnosticComment(result);
         }
         catch (Exception ex)
         {
-            return $"// {Decompiler.DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
+            return $"// {DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
 
@@ -478,20 +478,20 @@ internal static class TypeSourceComposer
     {
         try
         {
-            var context = Decompiler.MethodBodyContext.Create(
+            var context = MethodBodyContext.Create(
                 peReader, reader, typeHandle, accessorName, 0, publicOnly: false, pdbPath);
             if (context is null)
                 return null;
-            var result = Decompiler.CSharpEmitter.Decompile(context);
+            var result = CSharpEmitter.Decompile(context);
             return result.Output?.TrimEnd() ?? DiagnosticComment(result);
         }
         catch (Exception ex)
         {
-            return $"// {Decompiler.DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
+            return $"// {DiagnosticIds.ContextUnavailable}: method body context unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
 
-    static string DiagnosticComment(Decompiler.DecompilerResult result)
+    static string DiagnosticComment(DecompilerResult result)
         => string.Join("\n", result.Diagnostics.Select(d => $"// {d}"));
 
     static void AppendIndented(StringBuilder sb, string body, string indent)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -856,7 +856,7 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
-            var listing = TypeSourceComposer.Compose(
+            var listing = Decompiler.TypeSourceComposer.Compose(
                 type, typeDllPath, options.PdbPath, PlatformAssemblyLocator(typeDllPath));
             if (listing is not null)
             {


### PR DESCRIPTION
## Summary

Seams step from the pipeline replacement plan (docs/decompiler-pipeline.md): whole-type composition moves from the CLI into the library.

This was flagged in the multi-front-end discussion as gap 1 — "show me this type as source" is the single most front-end-desirable capability, and it lived in `src/dotnet-inspect/Output/`, so any other front end would have had to rebuild listings, using-hoisting, synthesized declarations, and forwarder-following from scratch. After #456 stripped the CLI-grown resolution code out of it, the move is pure code motion:

- `TypeSourceComposer` → `src/DotnetInspector.Decompiler/`, namespace `DotnetInspector.Decompiler`, `internal` → `public`
- Dependencies were already library-clean: Metadata types (`ApiType`/`ApiMember`, `AssemblyLocator`, `TypeMatcher`, `SignatureDecoder`) + SRM + the Decompiler itself
- File-location policy still arrives from the host via `AssemblyLocator` (the CLI passes its sibling-dir + shared-framework locator)
- One CLI call site updated

## Validation

- New library-level test: composes `Stack<T>` end-to-end from the shared-framework assembly via `ApiSurfaceExtractor` → `Compose` — the first whole-type test that runs entirely against library API with no CLI involved (exactly what a second front end would do)
- Decompiler suite 264/264 in both Debug and Release; CLI suite 970 pass
- Smoke: `type Stack -S "Decompiled Source" --raw` unchanged

With this, the library's per-type story matches its per-method story: `MethodBodyContext` → `CSharpEmitter`/`AnnotatedILEmitter` for members, `ApiSurfaceExtractor` → `TypeSourceComposer` for whole types, all consumable without the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)