### PR TITLE
Add MethodAnalysis: one analysis, many projections

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -5,8 +5,16 @@ using DotnetInspector.Decompiler;
 
 namespace DotnetInspector.Decompiler.Tests;
 
-public class DecompilerResultTests
+public class DecompilerResultTests : IDisposable
 {
+    readonly Stack<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        while (_disposables.Count > 0)
+            _disposables.Pop().Dispose();
+    }
+
     [Fact]
     public void Decompile_ValidMethod_ReportsFullFidelity()
     {
@@ -52,10 +60,15 @@ public class DecompilerResultTests
     }
 
     /// <summary>A context whose IL is a truncated two-byte opcode — the reader throws in both configurations.</summary>
-    static MethodBodyContext CorruptContext()
+    MethodBodyContext CorruptContext()
     {
-        using var stream = File.OpenRead(typeof(object).Assembly.Location);
-        using var peReader = new PEReader(stream);
+        // The PEReader must outlive the context: MetadataReader points into
+        // its memory block (disposing it under a live context is a
+        // use-after-free that crashes the process, not a test failure).
+        var stream = File.OpenRead(typeof(object).Assembly.Location);
+        var peReader = new PEReader(stream);
+        _disposables.Push(peReader);
+        _disposables.Push(stream);
         var reader = peReader.GetMetadataReader();
         return new MethodBodyContext(
             ilBytes: [0xFE],  // extended-opcode prefix with no second byte
@@ -93,5 +106,68 @@ public class TypeSourceComposerTests
         Assert.Contains("namespace System.Collections.Generic;", listing);
         Assert.Contains("private T[] _array;", listing);
         Assert.Contains("_array = Array.Empty<T>();", listing);
+    }
+}
+
+public class MethodAnalysisTests : IDisposable
+{
+    readonly Stack<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        while (_disposables.Count > 0)
+            _disposables.Pop().Dispose();
+    }
+
+    MethodBodyContext CoreLibContext(string type, string method)
+    {
+        // PEReader kept alive for the test's lifetime — the context's
+        // MetadataReader points into its memory block.
+        var stream = File.OpenRead(typeof(object).Assembly.Location);
+        var peReader = new PEReader(stream);
+        _disposables.Push(peReader);
+        _disposables.Push(stream);
+        var context = MethodBodyContext.Create(peReader, type, method);
+        Assert.NotNull(context);
+        return context;
+    }
+
+    [Fact]
+    public void SharedAnalysis_ProducesSameOutputsAsDirectPaths()
+    {
+        var context = CoreLibContext("System.String", "IsNullOrWhiteSpace");
+        var analysis = MethodAnalysis.Create(context);
+
+        Assert.Equal(CSharpEmitter.Emit(context), CSharpEmitter.Emit(analysis));
+        Assert.Equal(
+            AnnotatedILEmitter.Emit(context, ILAnnotationDepth.Structured),
+            AnnotatedILEmitter.Emit(analysis, ILAnnotationDepth.Structured));
+    }
+
+    [Fact]
+    public void Stages_ComputeOnce()
+    {
+        var analysis = MethodAnalysis.Create(CoreLibContext("System.String", "IsNullOrEmpty"));
+
+        Assert.Same(analysis.Cfg, analysis.Cfg);
+        Assert.Same(analysis.Stack, analysis.Stack);
+        Assert.Same(analysis.Ast, analysis.Ast);
+        Assert.Same(analysis.Structure, analysis.Structure);
+    }
+
+    [Fact]
+    public void AnnotatedIL_FromSharedAnalysis_UnaffectedByCSharpEmission()
+    {
+        // The IL projection must be identical whether or not the C# emitter
+        // (and its raising transforms) ran first against the same analysis.
+        var context = CoreLibContext("System.String", "IsNullOrWhiteSpace");
+        string ilAlone = AnnotatedILEmitter.Emit(
+            MethodAnalysis.Create(context), ILAnnotationDepth.Structured);
+
+        var shared = MethodAnalysis.Create(context);
+        _ = CSharpEmitter.Emit(shared);
+        string ilAfterCSharp = AnnotatedILEmitter.Emit(shared, ILAnnotationDepth.Structured);
+
+        Assert.Equal(ilAlone, ilAfterCSharp);
     }
 }

--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -39,11 +39,19 @@ public static class AnnotatedILEmitter
     /// Emit annotated IL for a method at the specified depth.
     /// </summary>
     public static string Emit(MethodBodyContext context, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
-    {
-        var cfg = ControlFlowGraph.Create(context);
-        var simResult = StackSimulator.Simulate(context, cfg);
-        return Emit(context, cfg, simResult, depth);
-    }
+        => Emit(MethodAnalysis.Create(context), depth);
+
+    /// <summary>
+    /// Emits annotated IL from a shared <see cref="MethodAnalysis"/>. Only
+    /// the pre-transform stages (CFG, stack simulation) are consumed — the
+    /// IL projections stay ground truth regardless of raising transforms.
+    /// </summary>
+    public static string Emit(MethodAnalysis analysis, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
+        => Emit(analysis.Context, analysis.Cfg, analysis.Stack, depth);
+
+    /// <summary>Decompiles annotated IL from a shared <see cref="MethodAnalysis"/>, with failures expressed as diagnostics.</summary>
+    public static DecompilerResult Decompile(MethodAnalysis analysis, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
+        => DecompilerResult.Run(() => Emit(analysis, depth));
 
     /// <summary>
     /// Emit annotated IL from pre-computed analysis results.

--- a/src/DotnetInspector.Decompiler/CSharpEmitter.cs
+++ b/src/DotnetInspector.Decompiler/CSharpEmitter.cs
@@ -22,18 +22,25 @@ public static class CSharpEmitter
     public static DecompilerResult Decompile(MethodBodyContext context)
         => DecompilerResult.Run(() => Emit(context));
 
+    /// <summary>Decompiles from a shared <see cref="MethodAnalysis"/>, with failures expressed as diagnostics.</summary>
+    public static DecompilerResult Decompile(MethodAnalysis analysis)
+        => DecompilerResult.Run(() => Emit(analysis));
+
     public static string Emit(MethodBodyContext context)
-        => Emit(context, lambdaDepth: 0);
+        => Emit(MethodAnalysis.Create(context), lambdaDepth: 0);
+
+    /// <summary>Emits C# from a shared <see cref="MethodAnalysis"/> so the analysis stages are computed once across projections.</summary>
+    public static string Emit(MethodAnalysis analysis)
+        => Emit(analysis, lambdaDepth: 0);
 
     internal static string Emit(MethodBodyContext context, int lambdaDepth)
+        => Emit(MethodAnalysis.Create(context), lambdaDepth);
+
+    internal static string Emit(MethodAnalysis analysis, int lambdaDepth)
     {
-        var cfg = ControlFlowGraph.Create(context);
-        var simResult = StackSimulator.Simulate(context, cfg);
-        var ast = ILAstBuilder.Build(context, cfg, simResult);
-        var transforms = Transforms.TransformPipeline.Run(ast);
-        var structure = StructuredControlFlow.Analyze(context, cfg, ast);
+        var context = analysis.Context;
         var sb = new StringBuilder();
-        var emitter = new EmitterContext(ast, structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, transforms.InlinedLocals, context.DeclaringType)
+        var emitter = new EmitterContext(analysis.Ast, analysis.Structure, sb, context.Reader, context.HasThis, context.ReturnType, context.ParameterNames, analysis.TransformResults.InlinedLocals, context.DeclaringType)
         {
             BodyContext = context,
             LambdaDepth = lambdaDepth,

--- a/src/DotnetInspector.Decompiler/MethodAnalysis.cs
+++ b/src/DotnetInspector.Decompiler/MethodAnalysis.cs
@@ -1,0 +1,64 @@
+namespace DotnetInspector.Decompiler;
+
+/// <summary>
+/// One analysis, many projections (docs/decompiler-pipeline.md): computes
+/// each pipeline stage for a method exactly once and hands the results to
+/// every consumer — the C# emitter, the annotated IL emitter, stage dumps,
+/// and any future front end. Stages are computed on first use, in pipeline
+/// order; the IL projections consume only the pre-transform stages
+/// (<see cref="Cfg"/>, <see cref="Stack"/>), so the IL views stay ground
+/// truth even after raising transforms rewrite the <see cref="Ast"/>.
+/// Not thread-safe; analyze per method, per thread.
+/// </summary>
+public sealed class MethodAnalysis
+{
+    ControlFlowGraph? _cfg;
+    StackSimulationResult? _stack;
+    ILAstMethod? _ast;
+    Transforms.TransformContext? _transforms;
+    StructuredControlFlow? _structure;
+
+    MethodAnalysis(MethodBodyContext context) => Context = context;
+
+    public static MethodAnalysis Create(MethodBodyContext context) => new(context);
+
+    public MethodBodyContext Context { get; }
+
+    public ControlFlowGraph Cfg => _cfg ??= ControlFlowGraph.Create(Context);
+
+    public StackSimulationResult Stack => _stack ??= StackSimulator.Simulate(Context, Cfg);
+
+    /// <summary>The IL AST after the raising transform pipeline has run.</summary>
+    public ILAstMethod Ast
+    {
+        get
+        {
+            EnsureAstAndTransforms();
+            return _ast!;
+        }
+    }
+
+    /// <summary>Results of the transform pipeline (inlined locals, etc.).</summary>
+    public Transforms.TransformContext TransformResults
+    {
+        get
+        {
+            EnsureAstAndTransforms();
+            return _transforms!;
+        }
+    }
+
+    public StructuredControlFlow Structure
+        => _structure ??= StructuredControlFlow.Analyze(Context, Cfg, Ast);
+
+    void EnsureAstAndTransforms()
+    {
+        if (_ast is not null)
+            return;
+        var ast = ILAstBuilder.Build(Context, Cfg, Stack);
+        // Transforms mutate the AST in place; build and run as one step so
+        // no consumer can observe the untransformed tree through this property.
+        _transforms = Transforms.TransformPipeline.Run(ast);
+        _ast = ast;
+    }
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -965,9 +965,13 @@ public static class ApiOutputFormatter
 
             // Lowered C#. A null context with no failure means the member has
             // no IL body (abstract/extern) — nothing to show, not an error.
-            if (wantsDecompiledSource && (context != null || contextFailure != null))
+            // One analysis feeds both code sections (CFG and stack
+            // simulation are computed once, not per emitter).
+            var analysis = context != null ? Decompiler.MethodAnalysis.Create(context) : null;
+
+            if (wantsDecompiledSource && (analysis != null || contextFailure != null))
             {
-                var result = contextFailure ?? Decompiler.CSharpEmitter.Decompile(context!);
+                var result = contextFailure ?? Decompiler.CSharpEmitter.Decompile(analysis!);
                 string? source = null;
                 if (result.Output is { } lowered)
                 {
@@ -1000,10 +1004,10 @@ public static class ApiOutputFormatter
             }
 
             // Annotated IL
-            if (wantsAnnotatedIL && (context != null || contextFailure != null))
+            if (wantsAnnotatedIL && (analysis != null || contextFailure != null))
             {
                 var result = contextFailure ?? Decompiler.AnnotatedILEmitter.Decompile(
-                    context!, Decompiler.ILAnnotationDepth.Structured);
+                    analysis!, Decompiler.ILAnnotationDepth.Structured);
                 memberCode.AnnotatedIL = new CodeSection(
                     "il", result.Output?.TrimEnd() ?? DiagnosticComment(result));
                 hasCode = true;


### PR DESCRIPTION
## Summary

Seams step from `docs/decompiler-pipeline.md`: the analysis facade. `CSharpEmitter` and `AnnotatedILEmitter` each rebuilt CFG + stack simulation per call; `MethodAnalysis` computes each pipeline stage exactly once (lazily, in pipeline order) and every projection consumes the shared result:

```csharp
var analysis = MethodAnalysis.Create(context);
string csharp    = CSharpEmitter.Emit(analysis);
string annotated = AnnotatedILEmitter.Emit(analysis, ILAnnotationDepth.Structured);
```

Stage-projection guarantee from the design doc, enforced structurally: the IL projections consume only the **pre-transform** stages (`Cfg`, `Stack`), so the IL views stay ground truth even after raising transforms rewrite the `Ast`. A test pins this: annotated IL from an analysis that already fed the C# emitter is byte-identical to a transform-free run.

- Both emitters gain `Emit`/`Decompile` overloads on `MethodAnalysis`; context-based entry points delegate through a fresh analysis (existing callers unchanged)
- `ApiOutputFormatter` feeds both code sections from one analysis (CFG/stack computed once per member, not per section)
- AST building and transform execution are fused in the facade so no consumer can observe the untransformed tree

## A real bug the new tests caught (in test infra)

Test helpers that returned a `MethodBodyContext` after `using`-disposing the `PEReader` were use-after-free — `MetadataReader` points into the reader's memory block — and crashed the suite with an `AccessViolationException`, not a test failure. Readers now live for the test instance's lifetime (`IDisposable` test classes). The pre-existing `CorruptContext` helper had the same latent pattern (it survived only because the IL read throws before touching the reader) and is fixed too. Worth remembering for the eventual `MethodBodyContext` split: the context's dependence on the live `PEReader` is exactly the kind of lifetime coupling the split should make explicit.

## Validation

- Decompiler suite 267/267 in both Debug and Release (3 new facade tests: output parity with direct paths, stages compute once, IL projection unaffected by C# emission)
- CLI suite 970 pass
- Full h2h corpus diff: byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)