### PR TITLE
Extract MemberCodeProvider: the formatter stops opening PE files

### DIFF
--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -1,0 +1,141 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Acquires per-member code sections — decompiled source, IL, annotated IL,
+/// custom attributes — from an assembly on disk. Owns all PE and metadata
+/// access for member code so the output formatter only renders views
+/// (docs/decompiler-pipeline.md, seams). Failures surface as diagnostic
+/// comment text, never as missing entries.
+/// </summary>
+internal static class MemberCodeProvider
+{
+    internal sealed record Request(bool DecompiledSource, bool IL, bool AnnotatedIL, bool Attributes);
+
+    /// <summary>
+    /// Code content for one member. Body and diagnostic are mutually
+    /// exclusive per section: a body renders (with declaration formatting
+    /// applied by the caller), a diagnostic renders verbatim as comments.
+    /// </summary>
+    internal sealed record Item(
+        string? LoweredBody,
+        string? LoweredDiagnostic,
+        IReadOnlyList<string>? MethodGenericParameters,
+        string? ILText,
+        string? AnnotatedILText,
+        string? AnnotatedILDiagnostic,
+        IReadOnlyList<(string Name, string? Value)>? Attributes);
+
+    internal static List<(ApiMember Member, Item Code)> Collect(
+        ApiType type, List<ApiMember> methods, string dllPath, int overloadIndex,
+        Request request, string? pdbPath = null)
+    {
+        var results = new List<(ApiMember, Item)>();
+        using var stream = File.OpenRead(dllPath);
+        using var peReader = new PEReader(stream);
+        if (!peReader.HasMetadata)
+            return results;
+
+        var reader = peReader.GetMetadataReader();
+
+        // Resolve each method's declaring type once via an index, instead of having every helper
+        // (attributes, IL, decompiled source, annotated IL) re-scan all TypeDefinitions per method.
+        var typeIndex = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+            typeIndex.TryAdd(reader.GetFullTypeName(reader.GetTypeDefinition(typeDefHandle)), typeDefHandle);
+
+        foreach (var method in methods)
+        {
+            var lookupType = method.DeclaringType ?? type.FullName;
+            var lookupOverloadIndex = method.DeclaringOverloadIndex is { } declaringIndex
+                ? declaringIndex - 1
+                : overloadIndex;
+            var publicOnly = method.Kind != "explicit-interface-implementation";
+
+            if (!typeIndex.TryGetValue(lookupType, out var typeHandle))
+                continue;
+
+            IReadOnlyList<(string Name, string? Value)>? attributes = null;
+            if (request.Attributes)
+            {
+                var found = AttributeReader.GetMethodAttributes(
+                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+                if (found.Count > 0)
+                    attributes = found.Select(a => (a.Name, a.Value)).ToList();
+            }
+
+            // Decompiled source and annotated IL share one method-body context (it is immutable),
+            // so the PDB is opened and the method body decoded once rather than per section.
+            Decompiler.MethodBodyContext? context = null;
+            Decompiler.DecompilerResult? contextFailure = null;
+            if (request.DecompiledSource || request.AnnotatedIL)
+            {
+                try
+                {
+                    context = Decompiler.MethodBodyContext.Create(
+                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
+                }
+                catch (Exception ex)
+                {
+                    contextFailure = Decompiler.DecompilerResult.Failure(
+                        Decompiler.DiagnosticIds.ContextUnavailable,
+                        $"method body context unavailable: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            // A null context with no failure means the member has no IL body
+            // (abstract/extern) — nothing to show, not an error. One analysis
+            // feeds both code sections (CFG and stack simulation are computed
+            // once, not per emitter).
+            var analysis = context != null ? Decompiler.MethodAnalysis.Create(context) : null;
+
+            string? loweredBody = null, loweredDiagnostic = null;
+            if (request.DecompiledSource && (analysis != null || contextFailure != null))
+            {
+                var result = contextFailure ?? Decompiler.CSharpEmitter.Decompile(analysis!);
+                if (result.Output is { } lowered)
+                    loweredBody = lowered;
+                else
+                    loweredDiagnostic = DiagnosticComment(result);
+            }
+
+            string? ilText = null;
+            if (request.IL)
+            {
+                var instructions = ILDisassembler.DisassembleMethod(
+                    peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+                if (instructions is { Count: > 0 })
+                    ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
+            }
+
+            string? annotatedText = null, annotatedDiagnostic = null;
+            if (request.AnnotatedIL && (analysis != null || contextFailure != null))
+            {
+                var result = contextFailure ?? Decompiler.AnnotatedILEmitter.Decompile(
+                    analysis!, Decompiler.ILAnnotationDepth.Structured);
+                if (result.Output is { } annotated)
+                    annotatedText = annotated.TrimEnd();
+                else
+                    annotatedDiagnostic = DiagnosticComment(result);
+            }
+
+            results.Add((method, new Item(
+                loweredBody,
+                loweredDiagnostic,
+                context?.GenericContext?.MethodParameters,
+                ilText,
+                annotatedText,
+                annotatedDiagnostic,
+                attributes)));
+        }
+
+        return results;
+    }
+
+    /// <summary>Renders a failed result as comment lines so sections degrade honestly instead of disappearing.</summary>
+    static string DiagnosticComment(Decompiler.DecompilerResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1,6 +1,3 @@
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Metadata;
 using DotnetInspector.Options;
@@ -900,116 +897,53 @@ public static class ApiOutputFormatter
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null)
     {
-        using var stream = File.OpenRead(dllPath);
-        using var peReader = new PEReader(stream);
-        if (!peReader.HasMetadata)
-            return;
-
-        var reader = peReader.GetMetadataReader();
+        var request = new MemberCodeProvider.Request(
+            DecompiledSource: requestedSections.Contains(SectionNames.DecompiledSource),
+            IL: requestedSections.Contains(SectionNames.IL),
+            AnnotatedIL: requestedSections.Contains(SectionNames.ILAnnotated),
+            Attributes: requestedSections.Contains(SectionNames.CustomAttributes));
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
-        bool wantsAttributes = requestedSections.Contains(SectionNames.CustomAttributes);
-        bool wantsDecompiledSource = requestedSections.Contains(SectionNames.DecompiledSource);
-        bool wantsIL = requestedSections.Contains(SectionNames.IL);
-        bool wantsAnnotatedIL = requestedSections.Contains(SectionNames.ILAnnotated);
 
-        // Resolve each method's declaring type once via an index, instead of having every helper
-        // (attributes, IL, decompiled source, annotated IL) re-scan all TypeDefinitions per method.
-        var typeIndex = new Dictionary<string, System.Reflection.Metadata.TypeDefinitionHandle>(StringComparer.Ordinal);
-        foreach (var typeDefHandle in reader.TypeDefinitions)
-            typeIndex.TryAdd(reader.GetFullTypeName(reader.GetTypeDefinition(typeDefHandle)), typeDefHandle);
-
-        foreach (var method in methods)
+        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath))
         {
-            var lookupType = method.DeclaringType ?? type.FullName;
-            var lookupOverloadIndex = method.DeclaringOverloadIndex is { } declaringIndex
-                ? declaringIndex - 1
-                : overloadIndex;
-            var publicOnly = method.Kind != "explicit-interface-implementation";
-
-            if (!typeIndex.TryGetValue(lookupType, out var typeHandle))
-                continue;
-
-            // Custom attributes
-            if (wantsAttributes)
+            if (code.Attributes is { Count: > 0 } attributes)
             {
-                var attributes = AttributeReader.GetMethodAttributes(
-                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
-                if (attributes.Count > 0)
-                {
-                    view.MethodAttributeRows = attributes
-                        .Select(a => new MethodAttributeRow(a.Name, a.Value ?? ""))
-                        .ToList();
-                }
+                view.MethodAttributeRows = attributes
+                    .Select(a => new MethodAttributeRow(a.Name, a.Value ?? ""))
+                    .ToList();
             }
 
-            // Decompiled source and annotated IL share one method-body context (it is immutable),
-            // so the PDB is opened and the method body decoded once rather than per section.
-            Decompiler.MethodBodyContext? context = null;
-            Decompiler.DecompilerResult? contextFailure = null;
-            if (wantsDecompiledSource || wantsAnnotatedIL)
+            if (code.LoweredBody is { } lowered)
             {
+                string source;
                 try
                 {
-                    context = Decompiler.MethodBodyContext.Create(
-                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
+                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered);
                 }
                 catch (Exception ex)
                 {
-                    contextFailure = Decompiler.DecompilerResult.Failure(
-                        Decompiler.DiagnosticIds.ContextUnavailable,
-                        $"method body context unavailable: {ex.GetType().Name}: {ex.Message}");
+                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
                 }
+                memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
+                hasCode = true;
             }
-
-            // Lowered C#. A null context with no failure means the member has
-            // no IL body (abstract/extern) — nothing to show, not an error.
-            // One analysis feeds both code sections (CFG and stack
-            // simulation are computed once, not per emitter).
-            var analysis = context != null ? Decompiler.MethodAnalysis.Create(context) : null;
-
-            if (wantsDecompiledSource && (analysis != null || contextFailure != null))
+            else if (code.LoweredDiagnostic is { } loweredDiagnostic)
             {
-                var result = contextFailure ?? Decompiler.CSharpEmitter.Decompile(analysis!);
-                string? source = null;
-                if (result.Output is { } lowered)
-                {
-                    try
-                    {
-                        source = FormatLoweredSourceWithDeclaration(type, method, context!, lowered);
-                    }
-                    catch (Exception ex)
-                    {
-                        result = Decompiler.DecompilerResult.Failure(
-                            Decompiler.DiagnosticIds.InternalError,
-                            $"declaration formatting failed: {ex.GetType().Name}: {ex.Message}");
-                    }
-                }
-                memberCode.DecompiledSourceCode = new CodeSection("csharp", source ?? DiagnosticComment(result));
+                memberCode.DecompiledSourceCode = new CodeSection("csharp", loweredDiagnostic);
                 hasCode = true;
             }
 
-            // IL disassembly
-            if (wantsIL)
+            if (code.ILText is { } ilText)
             {
-                var instructions = ILDisassembler.DisassembleMethod(
-                    peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
-                if (instructions is { Count: > 0 })
-                {
-                    var ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
-                    memberCode.ILCode = new CodeSection("il", ilText);
-                    hasCode = true;
-                }
+                memberCode.ILCode = new CodeSection("il", ilText);
+                hasCode = true;
             }
 
-            // Annotated IL
-            if (wantsAnnotatedIL && (analysis != null || contextFailure != null))
+            if ((code.AnnotatedILText ?? code.AnnotatedILDiagnostic) is { } annotated)
             {
-                var result = contextFailure ?? Decompiler.AnnotatedILEmitter.Decompile(
-                    analysis!, Decompiler.ILAnnotationDepth.Structured);
-                memberCode.AnnotatedIL = new CodeSection(
-                    "il", result.Output?.TrimEnd() ?? DiagnosticComment(result));
+                memberCode.AnnotatedIL = new CodeSection("il", annotated);
                 hasCode = true;
             }
         }
@@ -1018,13 +952,9 @@ public static class ApiOutputFormatter
             view.MemberCode = memberCode;
     }
 
-    /// <summary>Renders a failed result as comment lines so the section degrades honestly instead of disappearing.</summary>
-    private static string DiagnosticComment(Decompiler.DecompilerResult result)
-        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
-
-    private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context, string lowered)
+    private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, IReadOnlyList<string>? methodGenericParameters, string lowered)
     {
-        var declaration = FormatMemberDeclaration(type, member, context);
+        var declaration = FormatMemberDeclaration(type, member, abbreviate: false, methodGenericParameters);
         var body = lowered.TrimEnd();
         if (string.IsNullOrWhiteSpace(declaration))
             return body;
@@ -1035,9 +965,6 @@ public static class ApiOutputFormatter
 
         return $"{declaration}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
     }
-
-    private static string FormatMemberDeclaration(ApiType type, ApiMember member, Decompiler.MethodBodyContext context)
-        => FormatMemberDeclaration(type, member, abbreviate: false, context.GenericContext?.MethodParameters);
 
     private static string FormatMemberDeclaration(
         ApiType type,


### PR DESCRIPTION
## Summary

Seams step from `docs/decompiler-pipeline.md` (and item 6 of the external review): `ApiOutputFormatter.PopulateIndexSections` opened PE files, indexed TypeDefinitions, resolved methods, created `MethodBodyContext`s, and invoked all three emitters — acquisition logic living inside a renderer.

`MemberCodeProvider` (Inspectors) now owns all of that. Its contract returns raw per-member results:

```csharp
record Item(
    string? LoweredBody, string? LoweredDiagnostic,          // mutually exclusive
    IReadOnlyList<string>? MethodGenericParameters,
    string? ILText,
    string? AnnotatedILText, string? AnnotatedILDiagnostic,  // mutually exclusive
    IReadOnlyList<(string Name, string? Value)>? Attributes);
```

The formatter consumes the list and only renders: declaration wrapping (kept in the formatter because `FormatMemberDeclaration` is shared with two other render paths), view assignment, `CodeSection` construction. The honest-failure semantics from #454 carry over exactly — bodies get declaration formatting, diagnostics render verbatim as `// DEC####` comments.

Net effect on the boundary: **`ApiOutputFormatter` no longer references `System.Reflection.Metadata` or `PortableExecutable` at all** — the usings are gone, and the CLI's SRM usage now sits only in acquisition components. The shared-analysis behavior from #458 (one `MethodAnalysis` feeding both code sections) moved into the provider intact.

## Validation

- CLI suite 970 pass (including the SectionPipelineTests that pin selected-member section behavior)
- Decompiler suite 267 pass
- Smoke: `member String.IsNullOrEmpty` with Decompiled Source, IL, and IL (Annotated) — output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)