### PR TITLE
Pipeline foundations: importer contract and TypeRef

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -1,0 +1,139 @@
+using DotnetInspector.Decompiler.Pipeline;
+
+namespace DotnetInspector.Decompiler.Tests;
+
+public class PipelineImporterTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    [Fact]
+    public void Import_IsNullOrEmpty_SignatureAndBody()
+    {
+        using var source = MetadataSource.Open(CoreLibPath);
+        var method = MethodImporter.Import(source, "System.String", "IsNullOrEmpty");
+
+        Assert.NotNull(method);
+        Assert.Equal("bool", method.Signature.ReturnType.ToDisplayString());
+        var parameter = Assert.Single(method.Signature.Parameters);
+        Assert.Equal("value", parameter.Name);
+        Assert.Equal("string", parameter.Type.ToDisplayString());
+        Assert.False(method.Signature.HasThis);
+        Assert.Equal(15, method.Body.IL.Length);
+        Assert.Empty(method.Body.Locals);
+        Assert.Empty(method.Body.Handlers);
+    }
+
+    [Fact]
+    public void ImportedMethod_IsFullyMaterialized_SourceDisposalIsSafe()
+    {
+        // The contract the old pipeline lacked (docs/decompiler-ir.md):
+        // nothing in the importer's output may depend on the live readers.
+        // Under the old MethodBodyContext this pattern was a use-after-free
+        // that crashed the process.
+        ImportedMethod method;
+        using (var source = MetadataSource.Open(CoreLibPath))
+        {
+            method = MethodImporter.Import(source, "System.Collections.Generic.Dictionary`2", "ContainsValue")!;
+        }
+
+        Assert.Equal("Dictionary`2", method.DeclaringType.Name);
+        Assert.Equal("bool", method.Signature.ReturnType.ToDisplayString());
+        Assert.Equal("TValue", method.Signature.Parameters[0].Type.ToDisplayString());
+        Assert.True(method.Body.IL.Length > 0);
+        Assert.All(method.Body.Locals, local => Assert.NotEqual("", local.ToDisplayString()));
+    }
+
+    [Fact]
+    public void Import_GenericMethod_RecoversParameterNames()
+    {
+        using var source = MetadataSource.Open(CoreLibPath);
+        var method = MethodImporter.Import(source, "System.Collections.Generic.List`1", "Add");
+
+        Assert.NotNull(method);
+        var parameter = Assert.Single(method.Signature.Parameters);
+        Assert.Equal(TypeRefKind.GenericParameter, parameter.Type.Kind);
+        Assert.Equal("T", parameter.Type.GenericParameterName);
+        Assert.Equal(0, parameter.Type.GenericParameterIndex);
+    }
+
+    [Fact]
+    public void Import_TryCatch_MaterializesHandlerRegions()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var method = MethodImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ChecksThenTry));
+
+        Assert.NotNull(method);
+        var handler = Assert.Single(method.Body.Handlers);
+        Assert.Equal(HandlerKind.Catch, handler.Kind);
+        Assert.NotNull(handler.CatchType);
+        Assert.True(handler.TryLength > 0);
+        Assert.True(handler.HandlerLength > 0);
+    }
+}
+
+public class TypeRefTests
+{
+    [Fact]
+    public void Equality_IsSemantic_NotTextual()
+    {
+        var intRef = TypeRef.CoreLib("System", "Int32");
+        var listDef = TypeRef.CoreLib("System.Collections.Generic", "List`1");
+
+        Assert.Equal(intRef, TypeRef.CoreLib("System", "Int32"));
+        Assert.Equal(
+            TypeRef.GenericInstance(listDef, [intRef]),
+            TypeRef.GenericInstance(listDef, [TypeRef.CoreLib("System", "Int32")]));
+        Assert.NotEqual(
+            TypeRef.GenericInstance(listDef, [intRef]),
+            TypeRef.GenericInstance(listDef, [TypeRef.CoreLib("System", "String")]));
+        Assert.NotEqual(TypeRef.Pointer(intRef), TypeRef.SzArray(intRef));
+        Assert.Equal(
+            TypeRef.GenericInstance(listDef, [intRef]).GetHashCode(),
+            TypeRef.GenericInstance(listDef, [TypeRef.CoreLib("System", "Int32")]).GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_GenericParameterName_IsNamingAidNotIdentity()
+    {
+        Assert.Equal(TypeRef.GenericParameter(0, "T"), TypeRef.GenericParameter(0, "TKey"));
+        Assert.NotEqual(TypeRef.GenericParameter(0, "T"), TypeRef.GenericParameter(1, "T"));
+        Assert.NotEqual(TypeRef.GenericParameter(0, "T"), TypeRef.MethodGenericParameter(0, "T"));
+    }
+
+    [Fact]
+    public void FacadeCanonicalization_SameIdentityAcrossSpellings()
+    {
+        // The same metadata signature decoded from a System.Runtime-scoped
+        // reference and from System.Private.CoreLib must compare equal.
+        Assert.Equal(TypeRefDecoder.Canonical("System.Runtime"), TypeRefDecoder.Canonical("System.Private.CoreLib"));
+        Assert.Equal(TypeRefDecoder.Canonical("mscorlib"), TypeRefDecoder.Canonical("netstandard"));
+        Assert.NotEqual(TypeRefDecoder.Canonical("Newtonsoft.Json"), TypeRefDecoder.Canonical("System.Runtime"));
+    }
+
+    [Fact]
+    public void DisplayStrings_RenderCSharpStyle()
+    {
+        var intRef = TypeRef.CoreLib("System", "Int32");
+        var listDef = TypeRef.CoreLib("System.Collections.Generic", "List`1");
+
+        Assert.Equal("int", intRef.ToDisplayString());
+        Assert.Equal("List<int>", TypeRef.GenericInstance(listDef, [intRef]).ToDisplayString());
+        Assert.Equal("int[]", TypeRef.SzArray(intRef).ToDisplayString());
+        Assert.Equal("int[,]", TypeRef.MdArray(intRef, 2).ToDisplayString());
+        Assert.Equal("ref int", TypeRef.ByRef(intRef).ToDisplayString());
+        Assert.Equal("int*", TypeRef.Pointer(intRef).ToDisplayString());
+    }
+
+    [Fact]
+    public void UnsupportedShapes_PropagateToContainingTypes()
+    {
+        var unsupported = TypeRef.Unsupported("function pointer");
+        var listDef = TypeRef.CoreLib("System.Collections.Generic", "List`1");
+
+        Assert.True(unsupported.ContainsUnsupported);
+        Assert.True(TypeRef.SzArray(unsupported).ContainsUnsupported);
+        Assert.True(TypeRef.GenericInstance(listDef, [unsupported]).ContainsUnsupported);
+        Assert.False(TypeRef.GenericInstance(listDef, [TypeRef.CoreLib("System", "Int32")]).ContainsUnsupported);
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,0 +1,65 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Owner of the PE and metadata readers for one assembly — the explicit
+/// lifetime the old pipeline hid (docs/decompiler-ir.md). Everything that
+/// resolves tokens borrows from a live source; results that escape its
+/// scope must be fully materialized (resolved <see cref="TypeRef"/>s,
+/// strings, byte arrays) and never hold metadata handles. The importer's
+/// outputs honor that rule by construction.
+/// </summary>
+public sealed class MetadataSource : IDisposable
+{
+    readonly FileStream _stream;
+
+    MetadataSource(string path, FileStream stream, PEReader peReader, MetadataReader reader, string assemblyName)
+    {
+        Path = path;
+        _stream = stream;
+        Pe = peReader;
+        Reader = reader;
+        AssemblyName = assemblyName;
+    }
+
+    public string Path { get; }
+
+    /// <summary>Simple assembly name (no version/culture).</summary>
+    public string AssemblyName { get; }
+
+    internal PEReader Pe { get; }
+
+    internal MetadataReader Reader { get; }
+
+    /// <summary>Opens an assembly. Throws <see cref="BadImageFormatException"/> for files without managed metadata.</summary>
+    public static MetadataSource Open(string path)
+    {
+        var stream = File.OpenRead(path);
+        PEReader? peReader = null;
+        try
+        {
+            peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                throw new BadImageFormatException($"No managed metadata: {path}");
+            var reader = peReader.GetMetadataReader();
+            string assemblyName = reader.IsAssembly
+                ? reader.GetString(reader.GetAssemblyDefinition().Name)
+                : System.IO.Path.GetFileNameWithoutExtension(path);
+            return new MetadataSource(path, stream, peReader, reader, assemblyName);
+        }
+        catch
+        {
+            peReader?.Dispose();
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        Pe.Dispose();
+        _stream.Dispose();
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/MethodBody.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+public enum HandlerKind { Catch, Filter, Finally, Fault }
+
+/// <summary>An exception region, fully materialized (no metadata handles).</summary>
+public sealed record HandlerRegion(
+    HandlerKind Kind,
+    int TryOffset,
+    int TryLength,
+    int HandlerOffset,
+    int HandlerLength,
+    int FilterOffset,
+    TypeRef? CatchType);
+
+/// <summary>
+/// A method body as plain data: no metadata handles, no lifetime — safe to
+/// hold after its <see cref="MetadataSource"/> is disposed.
+/// </summary>
+public sealed record MethodBody(
+    ImmutableArray<byte> IL,
+    int MaxStack,
+    ImmutableArray<TypeRef> Locals,
+    ImmutableArray<string?> LocalNames,
+    ImmutableArray<HandlerRegion> Handlers);
+
+/// <summary>A parameter: name plus symbolic type.</summary>
+public sealed record Parameter(string Name, TypeRef Type);
+
+/// <summary>A method signature with symbolic types throughout.</summary>
+public sealed record MethodSignature(
+    TypeRef ReturnType,
+    ImmutableArray<Parameter> Parameters,
+    bool HasThis,
+    int GenericParameterCount);
+
+/// <summary>
+/// The importer's output: declaring type, name, signature, and body — all
+/// materialized, valid after the source is disposed.
+/// </summary>
+public sealed record ImportedMethod(
+    TypeRef DeclaringType,
+    string Name,
+    MethodSignature Signature,
+    MethodBody Body);

--- a/src/DotnetInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -1,0 +1,137 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Imports one method from a live <see cref="MetadataSource"/> into fully
+/// materialized data (docs/decompiler-ir.md): symbolic types throughout, no
+/// metadata handles in the output, valid after the source is disposed.
+/// </summary>
+public static class MethodImporter
+{
+    /// <summary>
+    /// Imports a method by metadata type name (<c>System.Collections.Generic.List`1</c>)
+    /// and method name. Returns null when the type, method, or IL body does
+    /// not exist — callers that need the reason use the harness/diagnostic
+    /// paths; this is the mechanical front door.
+    /// </summary>
+    public static ImportedMethod? Import(MetadataSource source, string typeFullName, string methodName, int overloadIndex = 0)
+    {
+        var reader = source.Reader;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            if (FullName(reader, typeDef) != typeFullName)
+                continue;
+
+            int seen = 0;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
+                    continue;
+                if (method.RelativeVirtualAddress == 0)
+                    continue;
+                if (seen++ != overloadIndex)
+                    continue;
+                return Import(source, typeDefHandle, methodHandle);
+            }
+            return null;
+        }
+        return null;
+    }
+
+    internal static ImportedMethod Import(MetadataSource source, TypeDefinitionHandle typeDefHandle, MethodDefinitionHandle methodHandle)
+    {
+        var reader = source.Reader;
+        var typeDef = reader.GetTypeDefinition(typeDefHandle);
+        var method = reader.GetMethodDefinition(methodHandle);
+
+        var scope = new GenericScope(
+            ParameterNames(reader, typeDef.GetGenericParameters()),
+            ParameterNames(reader, method.GetGenericParameters()));
+
+        var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeDefHandle, 0);
+        var decoded = method.DecodeSignature(TypeRefDecoder.Instance, scope);
+
+        var parameters = ImmutableArray.CreateBuilder<Parameter>(decoded.ParameterTypes.Length);
+        var namesByIndex = new Dictionary<int, string>();
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber > 0)
+                namesByIndex[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
+        }
+        for (int i = 0; i < decoded.ParameterTypes.Length; i++)
+            parameters.Add(new Parameter(namesByIndex.GetValueOrDefault(i, $"arg{i}"), decoded.ParameterTypes[i]));
+
+        var signature = new MethodSignature(
+            decoded.ReturnType,
+            parameters.MoveToImmutable(),
+            decoded.Header.IsInstance,
+            decoded.GenericParameterCount);
+
+        var body = source.Pe.GetMethodBody(method.RelativeVirtualAddress);
+
+        var locals = ImmutableArray<TypeRef>.Empty;
+        if (!body.LocalSignature.IsNil)
+        {
+            var localSignature = reader.GetStandaloneSignature(body.LocalSignature);
+            locals = localSignature.DecodeLocalSignature(TypeRefDecoder.Instance, scope);
+        }
+
+        var handlers = ImmutableArray.CreateBuilder<HandlerRegion>(body.ExceptionRegions.Length);
+        foreach (var region in body.ExceptionRegions)
+        {
+            handlers.Add(new HandlerRegion(
+                region.Kind switch
+                {
+                    ExceptionRegionKind.Catch => HandlerKind.Catch,
+                    ExceptionRegionKind.Filter => HandlerKind.Filter,
+                    ExceptionRegionKind.Finally => HandlerKind.Finally,
+                    _ => HandlerKind.Fault,
+                },
+                region.TryOffset,
+                region.TryLength,
+                region.HandlerOffset,
+                region.HandlerLength,
+                region.FilterOffset,
+                CatchType(reader, region.CatchType, scope)));
+        }
+
+        var methodBody = new MethodBody(
+            [.. body.GetILBytes() ?? []],
+            body.MaxStack,
+            locals,
+            LocalNames: [.. Enumerable.Repeat<string?>(null, locals.Length)],
+            handlers.MoveToImmutable());
+
+        return new ImportedMethod(declaringType, reader.GetString(method.Name), signature, methodBody);
+    }
+
+    static TypeRef? CatchType(MetadataReader reader, EntityHandle handle, GenericScope scope) => handle.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)handle, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, scope, (TypeSpecificationHandle)handle, 0),
+        _ => null,
+    };
+
+    static ImmutableArray<string> ParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    static string FullName(MetadataReader reader, TypeDefinition typeDef)
+    {
+        string ns = reader.GetString(typeDef.Namespace);
+        string name = reader.GetString(typeDef.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+public enum TypeRefKind
+{
+    /// <summary>A named type definition or reference (including primitives).</summary>
+    Definition,
+    /// <summary>A generic instantiation: <see cref="TypeRef.ElementType"/> over <see cref="TypeRef.TypeArguments"/>.</summary>
+    GenericInstance,
+    /// <summary>A single-dimensional zero-based array of <see cref="TypeRef.ElementType"/>.</summary>
+    SzArray,
+    /// <summary>A multi-dimensional array of <see cref="TypeRef.ElementType"/> with <see cref="TypeRef.Rank"/>.</summary>
+    Array,
+    ByRef,
+    Pointer,
+    Pinned,
+    /// <summary>A type generic parameter (<c>T</c> in <c>List&lt;T&gt;</c>).</summary>
+    GenericParameter,
+    /// <summary>A method generic parameter (<c>T</c> in <c>M&lt;T&gt;()</c>).</summary>
+    MethodGenericParameter,
+    /// <summary>A shape outside the supported core (function pointers, custom modifiers). Carries a reason; lowers fidelity, never lies.</summary>
+    Unsupported,
+}
+
+/// <summary>
+/// Symbolic type identity for the replacement pipeline (docs/decompiler-ir.md):
+/// assembly identity, name, and shape as a structured, comparable value.
+/// Equality is semantic — structural over the shape, never textual.
+/// Rendering is a printer concern; <see cref="ToDisplayString"/> exists for
+/// diagnostics and tests, not as the product output path.
+/// </summary>
+public sealed class TypeRef : IEquatable<TypeRef>
+{
+    /// <summary>Canonical assembly identity for primitives and other corelib types, regardless of which facade spelled them.</summary>
+    public const string CoreLibrary = "corelib";
+
+    TypeRef(TypeRefKind kind)
+    {
+        Kind = kind;
+        Namespace = "";
+        Name = "";
+        TypeArguments = [];
+    }
+
+    public TypeRefKind Kind { get; private init; }
+
+    /// <summary>Simple assembly name the type resolves through (or <see cref="CoreLibrary"/>). Empty for shapes.</summary>
+    public string Assembly { get; private init; } = "";
+
+    public string Namespace { get; private init; }
+
+    /// <summary>Metadata name, including arity backtick for generic definitions (e.g. <c>List`1</c>). Nested types use <c>Declaring+Nested</c>.</summary>
+    public string Name { get; private init; }
+
+    public TypeRef? ElementType { get; private init; }
+
+    public ImmutableArray<TypeRef> TypeArguments { get; private init; }
+
+    public int Rank { get; private init; }
+
+    /// <summary>Index for generic parameters; -1 otherwise.</summary>
+    public int GenericParameterIndex { get; private init; } = -1;
+
+    /// <summary>Generic parameter name when the importer could recover it (<c>T</c>, <c>TKey</c>); empty otherwise.</summary>
+    public string GenericParameterName { get; private init; } = "";
+
+    /// <summary>Why this shape is unsupported; empty for supported shapes.</summary>
+    public string UnsupportedReason { get; private init; } = "";
+
+    public static TypeRef Definition(string assembly, string ns, string name)
+        => new(TypeRefKind.Definition) { Assembly = assembly, Namespace = ns, Name = name };
+
+    public static TypeRef CoreLib(string ns, string name)
+        => Definition(CoreLibrary, ns, name);
+
+    public static TypeRef GenericInstance(TypeRef definition, ImmutableArray<TypeRef> typeArguments)
+        => new(TypeRefKind.GenericInstance) { ElementType = definition, TypeArguments = typeArguments };
+
+    public static TypeRef SzArray(TypeRef element) => new(TypeRefKind.SzArray) { ElementType = element };
+
+    public static TypeRef MdArray(TypeRef element, int rank) => new(TypeRefKind.Array) { ElementType = element, Rank = rank };
+
+    public static TypeRef ByRef(TypeRef element) => new(TypeRefKind.ByRef) { ElementType = element };
+
+    public static TypeRef Pointer(TypeRef element) => new(TypeRefKind.Pointer) { ElementType = element };
+
+    public static TypeRef Pinned(TypeRef element) => new(TypeRefKind.Pinned) { ElementType = element };
+
+    public static TypeRef GenericParameter(int index, string name = "")
+        => new(TypeRefKind.GenericParameter) { GenericParameterIndex = index, GenericParameterName = name };
+
+    public static TypeRef MethodGenericParameter(int index, string name = "")
+        => new(TypeRefKind.MethodGenericParameter) { GenericParameterIndex = index, GenericParameterName = name };
+
+    public static TypeRef Unsupported(string reason)
+        => new(TypeRefKind.Unsupported) { UnsupportedReason = reason };
+
+    /// <summary>True if this type or any constituent shape is <see cref="TypeRefKind.Unsupported"/> (feeds the fidelity computation).</summary>
+    public bool ContainsUnsupported =>
+        Kind == TypeRefKind.Unsupported
+        || ElementType?.ContainsUnsupported == true
+        || TypeArguments.Any(a => a.ContainsUnsupported);
+
+    public bool Equals(TypeRef? other)
+    {
+        if (other is null)
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
+        if (Kind != other.Kind
+            || Assembly != other.Assembly
+            || Namespace != other.Namespace
+            || Name != other.Name
+            || Rank != other.Rank
+            || GenericParameterIndex != other.GenericParameterIndex
+            || UnsupportedReason != other.UnsupportedReason
+            || !Equals(ElementType, other.ElementType)
+            || TypeArguments.Length != other.TypeArguments.Length)
+        {
+            return false;
+        }
+        for (int i = 0; i < TypeArguments.Length; i++)
+        {
+            if (!TypeArguments[i].Equals(other.TypeArguments[i]))
+                return false;
+        }
+        // GenericParameterName is a naming aid, not identity: 'T' at index 0
+        // and 'TKey' at index 0 of the same owner are the same parameter.
+        return true;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as TypeRef);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Kind);
+        hash.Add(Assembly);
+        hash.Add(Namespace);
+        hash.Add(Name);
+        hash.Add(Rank);
+        hash.Add(GenericParameterIndex);
+        hash.Add(ElementType);
+        foreach (var arg in TypeArguments)
+            hash.Add(arg);
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Diagnostic/test rendering in C# style. Product output paths render at the printer, not here.</summary>
+    public string ToDisplayString() => Kind switch
+    {
+        TypeRefKind.Definition => DisplayName(),
+        TypeRefKind.GenericInstance =>
+            $"{StripArity(ElementType!.DisplayName())}<{string.Join(", ", TypeArguments.Select(a => a.ToDisplayString()))}>",
+        TypeRefKind.SzArray => $"{ElementType!.ToDisplayString()}[]",
+        TypeRefKind.Array => $"{ElementType!.ToDisplayString()}[{new string(',', Rank - 1)}]",
+        TypeRefKind.ByRef => $"ref {ElementType!.ToDisplayString()}",
+        TypeRefKind.Pointer => $"{ElementType!.ToDisplayString()}*",
+        TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString()}",
+        TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter =>
+            GenericParameterName.Length > 0 ? GenericParameterName : $"!{GenericParameterIndex}",
+        _ => $"<unsupported: {UnsupportedReason}>",
+    };
+
+    public override string ToString() => ToDisplayString();
+
+    string DisplayName()
+    {
+        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.TryGetValue(Name, out var keyword))
+            return keyword;
+        return Name;
+    }
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
+    }
+
+    static readonly Dictionary<string, string> s_keywords = new()
+    {
+        ["Boolean"] = "bool", ["Byte"] = "byte", ["SByte"] = "sbyte",
+        ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
+        ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
+        ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
+        ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
+        ["Object"] = "object", ["Void"] = "void",
+    };
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
@@ -30,6 +30,14 @@ public enum TypeRefKind
 /// Rendering is a printer concern; <see cref="ToDisplayString"/> exists for
 /// diagnostics and tests, not as the product output path.
 /// </summary>
+/// <remarks>
+/// Core-first slice, two deliberate gaps versus the full design contract:
+/// no definition token (identity is assembly + name, which cannot
+/// distinguish two same-named types in one assembly scope), and generic
+/// parameters compare by index and kind only — without owner identity,
+/// parameter equality is meaningful only within a single owner's scope.
+/// Both must close before the parity gate makes this the contract.
+/// </remarks>
 public sealed class TypeRef : IEquatable<TypeRef>
 {
     /// <summary>Canonical assembly identity for primitives and other corelib types, regardless of which facade spelled them.</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>Generic parameter names in scope while decoding a signature.</summary>
+internal sealed record GenericScope(ImmutableArray<string> TypeParameters, ImmutableArray<string> MethodParameters)
+{
+    public static readonly GenericScope Empty = new([], []);
+}
+
+/// <summary>
+/// Decodes metadata signatures into <see cref="TypeRef"/>s. Primitives and
+/// corelib-resolved types canonicalize to <see cref="TypeRef.CoreLibrary"/>
+/// so identity does not depend on which facade spelled the reference.
+/// Shapes outside the supported core (function pointers, custom modifiers)
+/// decode to <see cref="TypeRefKind.Unsupported"/> — honest, fidelity-lowering,
+/// never a guess.
+/// </summary>
+internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericScope>
+{
+    public static readonly TypeRefDecoder Instance = new();
+
+    public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
+        => TypeRef.CoreLib("System", typeCode switch
+        {
+            PrimitiveTypeCode.Boolean => "Boolean",
+            PrimitiveTypeCode.Byte => "Byte",
+            PrimitiveTypeCode.SByte => "SByte",
+            PrimitiveTypeCode.Char => "Char",
+            PrimitiveTypeCode.Int16 => "Int16",
+            PrimitiveTypeCode.UInt16 => "UInt16",
+            PrimitiveTypeCode.Int32 => "Int32",
+            PrimitiveTypeCode.UInt32 => "UInt32",
+            PrimitiveTypeCode.Int64 => "Int64",
+            PrimitiveTypeCode.UInt64 => "UInt64",
+            PrimitiveTypeCode.Single => "Single",
+            PrimitiveTypeCode.Double => "Double",
+            PrimitiveTypeCode.IntPtr => "IntPtr",
+            PrimitiveTypeCode.UIntPtr => "UIntPtr",
+            PrimitiveTypeCode.String => "String",
+            PrimitiveTypeCode.Object => "Object",
+            PrimitiveTypeCode.Void => "Void",
+            PrimitiveTypeCode.TypedReference => "TypedReference",
+            _ => typeCode.ToString(),
+        });
+
+    public TypeRef GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(typeDef.Name);
+        string ns = reader.GetString(typeDef.Namespace);
+        if (typeDef.IsNested)
+        {
+            var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
+            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}");
+        }
+        string assembly = reader.IsAssembly
+            ? Canonical(reader.GetString(reader.GetAssemblyDefinition().Name))
+            : "";
+        return TypeRef.Definition(assembly, ns, name);
+    }
+
+    public TypeRef GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        string name = reader.GetString(typeRef.Name);
+        string ns = reader.GetString(typeRef.Namespace);
+        switch (typeRef.ResolutionScope.Kind)
+        {
+            case HandleKind.AssemblyReference:
+                var assembly = reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope);
+                return TypeRef.Definition(Canonical(reader.GetString(assembly.Name)), ns, name);
+            case HandleKind.TypeReference:
+                var declaring = GetTypeFromReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, 0);
+                return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}");
+            default:
+                return TypeRef.Definition("", ns, name);
+        }
+    }
+
+    public TypeRef GetTypeFromSpecification(MetadataReader reader, GenericScope genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public TypeRef GetSZArrayType(TypeRef elementType) => TypeRef.SzArray(elementType);
+
+    public TypeRef GetArrayType(TypeRef elementType, ArrayShape shape) => TypeRef.MdArray(elementType, shape.Rank);
+
+    public TypeRef GetByReferenceType(TypeRef elementType) => TypeRef.ByRef(elementType);
+
+    public TypeRef GetPointerType(TypeRef elementType) => TypeRef.Pointer(elementType);
+
+    public TypeRef GetPinnedType(TypeRef elementType) => TypeRef.Pinned(elementType);
+
+    public TypeRef GetGenericInstantiation(TypeRef genericType, ImmutableArray<TypeRef> typeArguments)
+        => TypeRef.GenericInstance(genericType, typeArguments);
+
+    public TypeRef GetGenericTypeParameter(GenericScope genericContext, int index)
+        => TypeRef.GenericParameter(index, NameAt(genericContext.TypeParameters, index));
+
+    public TypeRef GetGenericMethodParameter(GenericScope genericContext, int index)
+        => TypeRef.MethodGenericParameter(index, NameAt(genericContext.MethodParameters, index));
+
+    public TypeRef GetFunctionPointerType(MethodSignature<TypeRef> signature)
+        => TypeRef.Unsupported("function pointer");
+
+    public TypeRef GetModifiedType(TypeRef modifier, TypeRef unmodifiedType, bool isRequired)
+        => TypeRef.Unsupported($"custom modifier ({(isRequired ? "modreq" : "modopt")} {modifier.ToDisplayString()})");
+
+    static string NameAt(ImmutableArray<string> names, int index)
+        => index >= 0 && index < names.Length ? names[index] : "";
+
+    /// <summary>Canonicalizes corelib spellings so facade choice never affects identity.</summary>
+    internal static string Canonical(string assemblyName) => assemblyName is
+        "System.Private.CoreLib" or "System.Runtime" or "mscorlib" or "netstandard" or "System.Runtime.Extensions"
+        ? TypeRef.CoreLibrary
+        : assemblyName;
+}


### PR DESCRIPTION
## Summary

First code of the replacement pipeline, implementing the two contracts from `docs/decompiler-ir.md` (merged as #461). Namespace `DotnetInspector.Decompiler.Pipeline`, per the design's naming proposal.

**Importer contract** — the three-role split with the lifetime made structural:

- `MetadataSource` (`IDisposable`): explicit owner of the PE/metadata readers
- `MethodImporter.Import(source, type, method)` → `ImportedMethod`: declaring type, signature, and `MethodBody` (IL bytes, max stack, locals, materialized handler regions) — **no metadata handles in the output**
- The #458 lesson as a contract test: `ImportedMethod_IsFullyMaterialized_SourceDisposalIsSafe` disposes the source, then consumes everything. Under the old `MethodBodyContext` this exact pattern was a process-crashing use-after-free.

**`TypeRef`** — symbolic type identity:

- Shape-structured: definitions, generic instantiations, SZ/MD arrays, byref, pointer, pinned, type/method generic parameters
- **Semantic equality**: structural over the shape; `List<int>` equals `List<int>` wherever decoded; generic parameter *names* are a recovered display aid, excluded from identity (`T`@0 == `TKey`@0)
- **Facade canonicalization**: primitives and corelib references collapse to one identity whether the metadata spelled `System.Runtime`, `System.Private.CoreLib`, `mscorlib`, or `netstandard` — the design doc's "two facades, one type" rule
- **Core shapes first, honestly**: function pointers and custom modifiers decode to explicit `Unsupported` shapes; `ContainsUnsupported` propagates through containing shapes to feed the fidelity computation
- `ToDisplayString()` is a diagnostic/test aid (C#-keyword style); product rendering remains a printer concern

`TypeRefDecoder` implements `ISignatureTypeProvider<TypeRef, GenericScope>`, shared by method signatures, local signatures, and catch types; `GenericScope` carries type/method generic parameter names recovered from metadata.

## Not in this PR (by design)

The IR nodes, CFG/stack port, and harness registration come next, in dependency order. Nothing references the new namespace from product paths yet — present-but-unwired per the shipping plan's stage 1.

## Validation

- Decompiler suite 276/276 in both Debug and Release (9 new: importer signature/body/generics/handler tests, TypeRef equality/canonicalization/display/unsupported-propagation)
- Existing suites untouched; no product-path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)