### PR TITLE
Prototype integration opportunities section

### DIFF
--- a/src/DotnetInspector.Metadata/IntegrationOpportunityScanner.cs
+++ b/src/DotnetInspector.Metadata/IntegrationOpportunityScanner.cs
@@ -1,0 +1,192 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace DotnetInspector.Metadata;
+
+public record IntegrationOpportunityInfo(
+    string Integration,
+    string Api,
+    string IntegrationType,
+    string LookFor);
+
+public static class IntegrationOpportunityScanner
+{
+    public static List<IntegrationOpportunityInfo> Scan(PEReader peReader, IReadOnlySet<string> existingIntegrations)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+
+        var reader = peReader.GetMetadataReader();
+        Dictionary<string, IntegrationOpportunityInfo> gaps = new(StringComparer.Ordinal);
+
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDefinition = reader.GetTypeDefinition(handle);
+            if (!typeDefinition.IsPublic)
+                continue;
+
+            var typeName = reader.GetFullTypeName(typeDefinition);
+            var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+
+            AddAuthDomainGaps(gaps, existingIntegrations, typeName, simpleName);
+            AddCloudClientGaps(gaps, existingIntegrations, typeName, simpleName);
+            AddDatabaseGaps(gaps, existingIntegrations, typeName, simpleName);
+            AddAiClientGaps(gaps, existingIntegrations, typeName, simpleName);
+        }
+
+        return gaps.Values
+            .OrderBy(g => g.Integration, StringComparer.Ordinal)
+            .ThenBy(g => g.Api, StringComparer.Ordinal)
+            .ThenBy(g => g.IntegrationType, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static void AddAuthDomainGaps(
+        Dictionary<string, IntegrationOpportunityInfo> gaps,
+        IReadOnlySet<string> existingIntegrations,
+        string typeName,
+        string simpleName)
+    {
+        if (Has(existingIntegrations, EcosystemIntegrationNames.Authentication))
+            return;
+
+        if (!simpleName.Contains("Cognito", StringComparison.Ordinal)
+            && !simpleName.Contains("UserPool", StringComparison.Ordinal)
+            && !simpleName.Contains("UserSession", StringComparison.Ordinal))
+            return;
+
+        AddGap(gaps,
+            integration: EcosystemIntegrationNames.Authentication,
+            api: typeName,
+            integrationType: "Authentication/Identity registration",
+            lookFor: "AuthenticationBuilder, Add*Identity*, Add*Cognito*");
+    }
+
+    private static void AddCloudClientGaps(
+        Dictionary<string, IntegrationOpportunityInfo> gaps,
+        IReadOnlySet<string> existingIntegrations,
+        string typeName,
+        string simpleName)
+    {
+        var cloudClient = (typeName.StartsWith("Amazon.", StringComparison.Ordinal)
+                           || typeName.StartsWith("Azure.", StringComparison.Ordinal))
+                          && simpleName.EndsWith("Client", StringComparison.Ordinal);
+        if (!cloudClient)
+            return;
+
+        if (!Has(existingIntegrations, EcosystemIntegrationNames.DependencyInjection))
+        {
+            AddGap(gaps,
+                integration: EcosystemIntegrationNames.DependencyInjection,
+                api: typeName,
+                integrationType: "IServiceCollection registration",
+                lookFor: "IServiceCollection, Add*");
+        }
+
+        if (!Has(existingIntegrations, EcosystemIntegrationNames.Aspire))
+        {
+            AddGap(gaps,
+                integration: EcosystemIntegrationNames.Aspire,
+                api: typeName,
+                integrationType: "AppHost resource builder",
+                lookFor: "IResourceBuilder<T>, Add*, *Resource");
+        }
+    }
+
+    private static void AddDatabaseGaps(
+        Dictionary<string, IntegrationOpportunityInfo> gaps,
+        IReadOnlySet<string> existingIntegrations,
+        string typeName,
+        string simpleName)
+    {
+        var databaseShape = typeName is "Npgsql.NpgsqlConnection"
+            or "Microsoft.Data.SqlClient.SqlConnection"
+            or "System.Data.SqlClient.SqlConnection"
+            || typeName == "StackExchange.Redis.ConnectionMultiplexer"
+            || simpleName.EndsWith("DataSource", StringComparison.Ordinal);
+
+        if (!databaseShape)
+            return;
+
+        if (!Has(existingIntegrations, EcosystemIntegrationNames.HealthChecks))
+        {
+            AddGap(gaps,
+                integration: EcosystemIntegrationNames.HealthChecks,
+                api: typeName,
+                integrationType: "IHealthChecksBuilder registration",
+                lookFor: "IHealthChecksBuilder, Add*");
+        }
+
+        if (!Has(existingIntegrations, EcosystemIntegrationNames.Aspire))
+        {
+            AddGap(gaps,
+                integration: EcosystemIntegrationNames.Aspire,
+                api: typeName,
+                integrationType: "AppHost resource builder",
+                lookFor: "IResourceBuilder<T>, Add*, *Resource");
+        }
+    }
+
+    private static void AddAiClientGaps(
+        Dictionary<string, IntegrationOpportunityInfo> gaps,
+        IReadOnlySet<string> existingIntegrations,
+        string typeName,
+        string simpleName)
+    {
+        if (Has(existingIntegrations, EcosystemIntegrationNames.AI))
+            return;
+
+        var aiClient = (typeName.StartsWith("OpenAI.", StringComparison.Ordinal)
+                        || typeName.StartsWith("Azure.AI.", StringComparison.Ordinal))
+                       && (simpleName.EndsWith("Client", StringComparison.Ordinal)
+                           || simpleName.Contains("Chat", StringComparison.Ordinal)
+                           || simpleName.Contains("Embedding", StringComparison.Ordinal));
+
+        if (!aiClient)
+            return;
+
+        AddGap(gaps,
+            integration: EcosystemIntegrationNames.AI,
+            api: typeName,
+            integrationType: "Microsoft.Extensions.AI adapter",
+            lookFor: "IChatClient, AsIChatClient, IEmbeddingGenerator");
+    }
+
+    private static bool Has(IReadOnlySet<string> integrations, string integration)
+        => integrations.Contains(integration);
+
+    private static void AddGap(
+        Dictionary<string, IntegrationOpportunityInfo> gaps,
+        string integration,
+        string api,
+        string integrationType,
+        string lookFor)
+    {
+        var key = $"{integration}\0{integrationType}";
+        var formattedApi = TypeResolver.FormatDisplayName(api);
+        if (gaps.TryGetValue(key, out var existing)
+            && GetEvidenceRank(existing.Api) <= GetEvidenceRank(formattedApi))
+            return;
+
+        gaps[key] = new IntegrationOpportunityInfo(
+            integration,
+            formattedApi,
+            integrationType,
+            lookFor);
+    }
+
+    private static int GetEvidenceRank(string evidence)
+    {
+        var simpleName = evidence[(evidence.LastIndexOf('.') + 1)..];
+        return simpleName switch
+        {
+            "CognitoUser" => 0,
+            "CognitoUserPool" => 1,
+            "CognitoUserSession" => 2,
+            _ when simpleName.EndsWith("Client", StringComparison.Ordinal) => 3,
+            _ when simpleName.EndsWith("Connection", StringComparison.Ordinal) => 3,
+            _ when simpleName.EndsWith("DataSource", StringComparison.Ordinal) => 3,
+            _ => 10
+        };
+    }
+}

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2014,6 +2014,7 @@ public class CommandExecutionTests
                 "Health Checks",
                 "Hosting",
                 "HTTP Client",
+                "Integration Opportunities",
                 "Integrations",
                 "Logging",
                 "OpenAPI",
@@ -2054,6 +2055,45 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("Switches", output);
         Assert.DoesNotContain("Integrations", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IntegrationOpportunities_ForAwsS3_ShowsCloudClientSuggestions()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "AWSSDK.S3", "--library", "-S", "Integration Opportunities", "--rows", "-n", "20");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Integration Opportunities", output);
+        Assert.Contains("| Integration | API | Integration Type | Look For |", output);
+        Assert.Contains("| Aspire | `Amazon.S3.AmazonS3Client` | AppHost resource builder | IResourceBuilder&lt;T&gt;, Add*, *Resource |", output);
+        Assert.Contains("| Dependency Injection | `Amazon.S3.AmazonS3Client` | IServiceCollection registration | IServiceCollection, Add* |", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IntegrationOpportunities_ForCognito_ShowsAuthenticationSuggestion()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "Amazon.Extensions.CognitoAuthentication", "--library", "-S", "Integration Opportunities", "--rows", "-n", "20");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Integration Opportunities", output);
+        Assert.Contains("| Authentication | `Amazon.Extensions.CognitoAuthentication.CognitoUser` | Authentication/Identity registration | AuthenticationBuilder, Add*Identity*, Add*Cognito* |", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IntegrationOpportunities_ForNpgsql_ShowsResourceSuggestions()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "Npgsql", "--library", "-S", "Integration Opportunities", "--rows", "-n", "20");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Integration Opportunities", output);
+        Assert.Contains("| Aspire | `Npgsql.NpgsqlConnection` | AppHost resource builder | IResourceBuilder&lt;T&gt;, Add*, *Resource |", output);
+        Assert.Contains("| Health Checks | `Npgsql.NpgsqlConnection` | IHealthChecksBuilder registration | IHealthChecksBuilder, Add* |", output);
         Assert.DoesNotContain("Tip:", error);
     }
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -207,7 +207,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(30, pipeline.AllSectionNames.Length);
+        Assert.Equal(31, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -216,6 +216,7 @@ public class SectionPipelineTests
         Assert.Contains("Health Checks", pipeline.AllSectionNames);
         Assert.Contains("Hosting", pipeline.AllSectionNames);
         Assert.Contains("HTTP Client", pipeline.AllSectionNames);
+        Assert.Contains("Integration Opportunities", pipeline.AllSectionNames);
         Assert.Contains("Integrations", pipeline.AllSectionNames);
         Assert.Contains("Logging", pipeline.AllSectionNames);
         Assert.Contains("OpenAPI", pipeline.AllSectionNames);
@@ -225,6 +226,27 @@ public class SectionPipelineTests
         Assert.Contains("SourceLink Missing Files", pipeline.AllSectionNames);
         Assert.Contains("SourceLink Integrity", pipeline.AllSectionNames);
         Assert.Contains("Switches", pipeline.AllSectionNames);
+    }
+
+    [Fact]
+    public void CanRender_IntegrationOpportunities_UsesScannedRows()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            IntegrationOpportunities =
+            [
+                new IntegrationOpportunityInfo("Aspire", "Amazon.S3.AmazonS3Client", "AppHost resource builder", "IResourceBuilder<T>, Add*, *Resource")
+            ]
+        };
+
+        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+        var selected = pipeline.GetEffectiveSections(model, Verbosity.Detailed,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Integration Opportunities" });
+
+        Assert.DoesNotContain("Integration Opportunities", effective);
+        Assert.Contains("Integration Opportunities", selected);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -576,6 +576,32 @@ internal static class LibraryMetadataService
         inspection.Integrations = BuildIntegrations(inspection);
     }
 
+    internal static void ScanIntegrationOpportunities(string path, LibraryInspection inspection, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            ScanIntegrationOpportunities(peReader, path, inspection, logger);
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning integration opportunities in {path}: {ex.Message}");
+        }
+    }
+
+    internal static void ScanIntegrationOpportunities(PEReader peReader, string path, LibraryInspection inspection, VerboseLogger logger)
+    {
+        if (inspection.Integrations == null)
+            ScanIntegrations(peReader, path, inspection, logger);
+
+        var existing = new HashSet<string>(
+            inspection.Integrations?.Select(integration => integration.Integration) ?? [],
+            StringComparer.Ordinal);
+        var gaps = IntegrationOpportunityScanner.Scan(peReader, existing);
+        inspection.IntegrationOpportunities = gaps.Count > 0 ? gaps : null;
+    }
+
     internal static List<IntegrationSignal>? ScanOpenTelemetry(PEReader peReader, string path, VerboseLogger logger)
     {
         try

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -22,6 +22,8 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(List<IntegrationSummary>))]
 [JsonSerializable(typeof(IntegrationSignal))]
 [JsonSerializable(typeof(List<IntegrationSignal>))]
+[JsonSerializable(typeof(IntegrationOpportunityInfo))]
+[JsonSerializable(typeof(List<IntegrationOpportunityInfo>))]
 [JsonSerializable(typeof(SwitchInfo))]
 [JsonSerializable(typeof(List<SwitchInfo>))]
 [JsonSerializable(typeof(RidPackageReference))]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -209,6 +209,12 @@ public class LibraryInspection
     public List<IntegrationSummary>? Integrations { get; set; }
 
     /// <summary>
+    /// Potential integration categories suggested by package-owned API shapes.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<IntegrationOpportunityInfo>? IntegrationOpportunities { get; set; }
+
+    /// <summary>
     /// Metadata evidence of ASP.NET Core middleware/endpoint integration.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -21,6 +21,7 @@ public static class LibrarySections
     public const string ScannerSymbols = "Symbols";
     public const string ScannerAuditSignals = "AuditSignals";
     public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
+    public const string ScannerIntegrationOpportunities = "IntegrationOpportunities";
     public const string ScannerSwitches = "Switches";
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
@@ -35,6 +36,7 @@ public static class LibrarySections
             .Add<Signals>()
             .Add<Switches>()
             .Add<Integrations>()
+            .Add<IntegrationOpportunities>()
             .Add<AI>()
             .Add<AspNetCore>()
             .Add<Authentication>()
@@ -57,7 +59,7 @@ public static class LibrarySections
             .Add<CustomAttributes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
-            .AddCategory("@Integrations", LibraryIntegrationCatalog.CategorySections)
+            .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities"])
             .AddCategory("@Switches", "Switches");
     }
 
@@ -82,7 +84,9 @@ public static class LibrarySections
             .Add(ScannerSwitches, ctx =>
                 ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerIntegrations, ctx =>
-                LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger));
+                LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+            .Add(ScannerIntegrationOpportunities, ctx =>
+                LibraryMetadataService.ScanIntegrationOpportunities(ctx.AssemblyPath, ctx.Model, ctx.Logger));
     }
 
     // ===== Primary section =====
@@ -145,6 +149,16 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerIntegrations;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.CanRenderAny(model);
+    }
+
+    public sealed class IntegrationOpportunities : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Integration Opportunities";
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerIntegrationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => model.IntegrationOpportunities is { Count: > 0 };
     }
 
     public sealed class AI : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -406,6 +406,7 @@ public record LibraryFileRow(
 [MarkoutContext(typeof(AuditSignalRow))]
 [MarkoutContext(typeof(SwitchRow))]
 [MarkoutContext(typeof(IntegrationRow))]
+[MarkoutContext(typeof(IntegrationOpportunityRow))]
 [MarkoutContext(typeof(IntegrationSignalRow))]
 [MarkoutContext(typeof(IntegrationApiSignalRow))]
 [MarkoutContext(typeof(DependencyGroup))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -219,6 +219,22 @@ public class LibraryInspectionView
             .ToList();
 
     [MarkoutIgnore]
+    public bool HasIntegrationOpportunities => _data.IntegrationOpportunities is { Count: > 0 };
+
+    [MarkoutSection(Name = "Integration Opportunities", ShowWhenProperty = nameof(HasIntegrationOpportunities))]
+    public List<IntegrationOpportunityRow>? IntegrationOpportunitiesSection =>
+        _data.IntegrationOpportunities?
+            .OrderBy(g => g.Integration, StringComparer.Ordinal)
+            .ThenBy(g => g.Api, StringComparer.Ordinal)
+            .ThenBy(g => g.IntegrationType, StringComparer.Ordinal)
+            .Select(g => new IntegrationOpportunityRow(
+                g.Integration,
+                MarkoutInline.Code(g.Api),
+                g.IntegrationType,
+                g.LookFor))
+            .ToList();
+
+    [MarkoutIgnore]
     public bool HasAI => _data.AI is { Count: > 0 };
 
     [MarkoutIgnore]
@@ -669,6 +685,13 @@ public record SwitchRow(
 public record IntegrationRow(
     string Integration,
     [property: MarkoutPropertyName("APIs")] int Apis);
+
+[MarkoutSerializable]
+public record IntegrationOpportunityRow(
+    string Integration,
+    [property: MarkoutPropertyName("API")] string Api,
+    [property: MarkoutPropertyName("Integration Type")] string IntegrationType,
+    [property: MarkoutPropertyName("Look For")] string LookFor);
 
 [MarkoutSerializable]
 public record IntegrationSignalRow(


### PR DESCRIPTION
## Summary
- add an opt-in Integration Opportunities library section
- infer conservative integration opportunities from package-owned API shapes
- include Integration Opportunities in @Integrations so agents can see exposed integrations and suggested follow-ups together
- render Integration / API / Integration Type / Look For columns for follow-up dotnet-inspect searches

## Examples
- AWSSDK.S3 -> Aspire and Dependency Injection opportunities from AmazonS3Client
- Amazon.Extensions.CognitoAuthentication -> Authentication opportunity from CognitoUser
- Npgsql -> Aspire and Health Checks opportunities from NpgsqlConnection
- OpenAI -> AI opportunity from OpenAIClient

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationOpportunities_ForAwsS3_ShowsCloudClientSuggestions -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationOpportunities_ForCognito_ShowsAuthenticationSuggestion -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_IntegrationOpportunities_ForNpgsql_ShowsResourceSuggestions -method DotnetInspector.Tests.SectionPipelineTests.CanRender_IntegrationOpportunities_UsesScannedRows
- dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release