### PR TITLE
Projection independence and honest-failure gaps from mid-point review

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -59,8 +59,24 @@ public class DecompilerResultTests : IDisposable
         Assert.Equal(AnnotatedILEmitter.Emit(context, ILAnnotationDepth.Structured), result.Output);
     }
 
+    [Fact]
+    public void RawProjection_SurvivesAnalysisFailures()
+    {
+        // 'add' on an empty stack: stack simulation cannot make sense of
+        // this, but the raw IL projection is the fallback layer and must
+        // render without touching CFG or stack analysis.
+        var analysis = MethodAnalysis.Create(ContextWithIL([0x58, 0x2A]));  // add; ret
+
+        var raw = AnnotatedILEmitter.Decompile(analysis, ILAnnotationDepth.Raw);
+
+        Assert.True(raw.Succeeded);
+        Assert.Contains("add", raw.Output);
+    }
+
     /// <summary>A context whose IL is a truncated two-byte opcode — the reader throws in both configurations.</summary>
-    MethodBodyContext CorruptContext()
+    MethodBodyContext CorruptContext() => ContextWithIL([0xFE]);
+
+    MethodBodyContext ContextWithIL(byte[] ilBytes)
     {
         // The PEReader must outlive the context: MetadataReader points into
         // its memory block (disposing it under a live context is a
@@ -71,7 +87,7 @@ public class DecompilerResultTests : IDisposable
         _disposables.Push(stream);
         var reader = peReader.GetMetadataReader();
         return new MethodBodyContext(
-            ilBytes: [0xFE],  // extended-opcode prefix with no second byte
+            ilBytes: ilBytes,
             exceptionRegions: ImmutableArray<ExceptionRegion>.Empty,
             maxStack: 8,
             localTypes: [],

--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -45,9 +45,19 @@ public static class AnnotatedILEmitter
     /// Emits annotated IL from a shared <see cref="MethodAnalysis"/>. Only
     /// the pre-transform stages (CFG, stack simulation) are consumed — the
     /// IL projections stay ground truth regardless of raising transforms.
+    /// Raw depth touches no analysis at all: it is the fallback projection
+    /// that must survive CFG and stack-simulation failures.
     /// </summary>
     public static string Emit(MethodAnalysis analysis, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
-        => Emit(analysis.Context, analysis.Cfg, analysis.Stack, depth);
+    {
+        if (depth == ILAnnotationDepth.Raw)
+        {
+            var sb = new StringBuilder();
+            EmitRaw(analysis.Context, sb);
+            return sb.ToString();
+        }
+        return Emit(analysis.Context, analysis.Cfg, analysis.Stack, depth);
+    }
 
     /// <summary>Decompiles annotated IL from a shared <see cref="MethodAnalysis"/>, with failures expressed as diagnostics.</summary>
     public static DecompilerResult Decompile(MethodAnalysis analysis, ILAnnotationDepth depth = ILAnnotationDepth.Typed)

--- a/src/DotnetInspector.Decompiler/MethodBodyContext.cs
+++ b/src/DotnetInspector.Decompiler/MethodBodyContext.cs
@@ -115,15 +115,10 @@ public sealed class MethodBodyContext
         if (method.RelativeVirtualAddress == 0)
             return null;
 
-        MethodBodyBlock body;
-        try
-        {
-            body = peReader.GetMethodBody(method.RelativeVirtualAddress);
-        }
-        catch
-        {
-            return null;
-        }
+        // A method that claims a body but whose body cannot be read is
+        // corrupt input, not "no body" — let it throw so callers surface a
+        // diagnostic instead of silently dropping sections.
+        var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
 
         var ilBytes = body.GetILContent().ToArray();
 

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -25,6 +25,7 @@ internal static class MemberCodeProvider
         string? LoweredDiagnostic,
         IReadOnlyList<string>? MethodGenericParameters,
         string? ILText,
+        string? ILDiagnostic,
         string? AnnotatedILText,
         string? AnnotatedILDiagnostic,
         IReadOnlyList<(string Name, string? Value)>? Attributes);
@@ -102,13 +103,20 @@ internal static class MemberCodeProvider
                     loweredDiagnostic = DiagnosticComment(result);
             }
 
-            string? ilText = null;
+            string? ilText = null, ilDiagnostic = null;
             if (request.IL)
             {
-                var instructions = ILDisassembler.DisassembleMethod(
-                    peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
-                if (instructions is { Count: > 0 })
-                    ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
+                try
+                {
+                    var instructions = ILDisassembler.DisassembleMethod(
+                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+                    if (instructions is { Count: > 0 })
+                        ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
+                }
+                catch (Exception ex)
+                {
+                    ilDiagnostic = $"// {Decompiler.DiagnosticIds.InternalError}: IL disassembly failed: {ex.GetType().Name}: {ex.Message}";
+                }
             }
 
             string? annotatedText = null, annotatedDiagnostic = null;
@@ -127,6 +135,7 @@ internal static class MemberCodeProvider
                 loweredDiagnostic,
                 context?.GenericContext?.MethodParameters,
                 ilText,
+                ilDiagnostic,
                 annotatedText,
                 annotatedDiagnostic,
                 attributes)));

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -935,7 +935,7 @@ public static class ApiOutputFormatter
                 hasCode = true;
             }
 
-            if (code.ILText is { } ilText)
+            if ((code.ILText ?? code.ILDiagnostic) is { } ilText)
             {
                 memberCode.ILCode = new CodeSection("il", ilText);
                 hasCode = true;


### PR DESCRIPTION
## Summary

Fixes for the three real findings in the external mid-point review.

**1. Raw IL was not independent of later analysis** (review's top item). `AnnotatedILEmitter.Emit(MethodAnalysis, depth)` eagerly evaluated `analysis.Cfg` and `analysis.Stack` even at `Raw` depth, where neither is consumed — so a CFG or stack-simulation failure would take down the one projection that's supposed to be the fallback layer. Raw now touches no analysis at all. Pinned by `RawProjection_SurvivesAnalysisFailures`: raw IL renders for a method whose stack simulation cannot succeed (`add` on an empty stack).

**2. `MethodBodyContext.Create` silently swallowed corrupt bodies.** The `catch { return null; }` around `GetMethodBody` made corrupt input indistinguishable from "no IL body" — sections vanished with no trace, contradicting the honest-failure contract. It now throws; every production caller (`MemberCodeProvider`, `TypeSourceComposer`, the harness) already guards and converts to `DEC0002`.

**3. IL disassembly in `MemberCodeProvider` was unguarded.** The provider's own contract says failures render as diagnostic comments, never missing entries — but a disassembler throw would kill every section for the member. The IL section now degrades to a `DEC0001` comment like its siblings (new `ILDiagnostic` field, rendered by the formatter).

On the review's other points: the `TypeRef` core-first gaps are now labeled in the type's remarks on #462 (definition token and generic-parameter owner identity must close before the parity gate); the `Compose` string-shaped return is acknowledged interim — it becomes structured when type listings route through the statement tree; and the "untracked `Pipeline/`" observation was a snapshot artifact — that code is PR #462 with tests.

## Validation

- Decompiler suite 268/268 in both Debug and Release; CLI 970; Metadata 141
- Full h2h corpus diff: byte-identical
- Harness CoreLib sweep: 39,468/39,468 rendered (the `Create` behavior change introduces no new failures — no corrupt bodies in the shared framework, as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)