### PR TITLE
Typed IR core: nodes, invariants, straight-line importer

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1,0 +1,104 @@
+using DotnetInspector.Decompiler.Pipeline;
+
+namespace DotnetInspector.Decompiler.Tests;
+
+public class IrImporterTests
+{
+    static IrFunction ImportFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return function;
+    }
+
+    [Fact]
+    public void Add_BuildsTypedExpressionTree()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.Add));
+
+        var ret = Assert.IsType<Return>(Assert.Single(function.Body.Children));
+        var binary = Assert.IsType<Binary>(ret.Value);
+        Assert.Equal(BinaryKind.Add, binary.Kind);
+        Assert.Equal("int", binary.ResultType?.ToDisplayString());
+        Assert.IsType<LoadArgument>(binary.Left);
+        Assert.IsType<LoadArgument>(binary.Right);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Diagnostics);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ImportedFunction_SurvivesSourceDisposal()
+    {
+        IrFunction function;
+        using (var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location))
+        {
+            function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.Add))!;
+        }
+
+        string dump = IrPrinter.Dump(function);
+        Assert.Contains("Binary.Add", dump);
+        Assert.Contains("LoadArgument", dump);
+        Assert.Contains("fidelity: Full", dump);
+    }
+
+    [Fact]
+    public void ReplaceWith_RewiresParentAndSlot()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.Add));
+        var binary = (Binary)((Return)function.Body.Children[0]).Value!;
+        var left = binary.Left;
+
+        var constant = new Constant(42, TypeRef.CoreLib("System", "Int32"));
+        left.ReplaceWith(constant);
+
+        Assert.Same(constant, binary.Left);
+        Assert.Same(binary, constant.Parent);
+        Assert.Equal(0, constant.ChildIndex);
+        Assert.Null(left.Parent);
+        Assert.Equal(-1, left.ChildIndex);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void Adoption_RejectsNodesThatAlreadyHaveParents()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.Add));
+        var binary = (Binary)((Return)function.Body.Children[0]).Value!;
+
+        // Re-using an attached node without detaching it would silently
+        // corrupt the tree; the IR refuses at the rewrite site.
+        Assert.Throws<InvalidOperationException>(
+            () => new ExpressionStatement(binary.Left));
+    }
+
+    [Fact]
+    public void BranchingMethod_StopsHonestly_WithUnsupportedNode()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.AbsShort));
+
+        var unsupported = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.NotEqual("", unsupported.Opcode);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedConstruct, diagnostic.Id);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CoreLib_StraightLineMethod_ImportsCallsAndFields()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        // get_Count: ldarg.0; ldfld _size; ret
+        var function = IrImporter.Import(source, "System.Collections.Generic.List`1", "get_Count");
+
+        Assert.NotNull(function);
+        var ret = Assert.IsType<Return>(Assert.Single(function.Body.Children));
+        var field = Assert.IsType<LoadField>(ret.Value);
+        Assert.Equal("_size", field.Field.Name);
+        Assert.Equal("int", field.ResultType?.ToDisplayString());
+        Assert.IsType<LoadArgument>(field.Instance);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+}

--- a/src/DotnetInspector.Decompiler/DecompilerResult.cs
+++ b/src/DotnetInspector.Decompiler/DecompilerResult.cs
@@ -46,6 +46,9 @@ public static class DiagnosticIds
 
     /// <summary>Decompilation produced no output for a method with a body.</summary>
     public const string EmptyOutput = "DEC0003";
+
+    /// <summary>IL the pipeline does not represent; rendered explicitly, lowers fidelity.</summary>
+    public const string UnsupportedConstruct = "DEC0004";
 }
 
 /// <summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1,0 +1,310 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Builds the typed IR for one method while its <see cref="MetadataSource"/>
+/// is alive; the resulting <see cref="IrFunction"/> is fully materialized.
+/// Slice scope: straight-line bodies (no branches, no exception regions).
+/// IL outside the slice becomes an explicit <see cref="UnsupportedNode"/>
+/// with a <see cref="DiagnosticIds.UnsupportedConstruct"/> diagnostic and
+/// import stops — fidelity degrades honestly, output never guesses.
+/// </summary>
+public static class IrImporter
+{
+    public static IrFunction? Import(MetadataSource source, string typeFullName, string methodName, int overloadIndex = 0)
+    {
+        var reader = source.Reader;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string ns = reader.GetString(typeDef.Namespace);
+            string name = reader.GetString(typeDef.Name);
+            if ((ns.Length == 0 ? name : $"{ns}.{name}") != typeFullName)
+                continue;
+
+            int seen = 0;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName || method.RelativeVirtualAddress == 0)
+                    continue;
+                if (seen++ != overloadIndex)
+                    continue;
+
+                var imported = MethodImporter.Import(source, typeDefHandle, methodHandle);
+                return Build(source, imported);
+            }
+            return null;
+        }
+        return null;
+    }
+
+    static IrFunction Build(MetadataSource source, ImportedMethod method)
+    {
+        var body = new Block();
+        var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, body);
+        var stack = new Stack<IrExpression>();
+        var reader = new ILReaderLite(method.Body.IL.AsSpan());
+
+        if (!method.Body.Handlers.IsEmpty)
+        {
+            Stop(function, body, stack, 0, "(exception regions)", "exception regions are outside the straight-line slice");
+            return function;
+        }
+
+        while (reader.HasNext)
+        {
+            int offset = reader.Offset;
+            var opcode = reader.ReadILOpcode();
+            switch (opcode)
+            {
+                case ILOpCode.Nop:
+                    break;
+
+                case ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3:
+                    stack.Push(MakeLoadArgument(method, opcode - ILOpCode.Ldarg_0));
+                    break;
+                case ILOpCode.Ldarg_s:
+                    stack.Push(MakeLoadArgument(method, reader.ReadILByte()));
+                    break;
+
+                case ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3:
+                    stack.Push(MakeLoadLocal(method, opcode - ILOpCode.Ldloc_0));
+                    break;
+                case ILOpCode.Ldloc_s:
+                    stack.Push(MakeLoadLocal(method, reader.ReadILByte()));
+                    break;
+
+                case ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3:
+                    body.Add(MakeStoreLocal(method, opcode - ILOpCode.Stloc_0, stack.Pop()));
+                    break;
+                case ILOpCode.Stloc_s:
+                    body.Add(MakeStoreLocal(method, reader.ReadILByte(), stack.Pop()));
+                    break;
+
+                case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8:
+                    stack.Push(new Constant(opcode - ILOpCode.Ldc_i4_0, TypeRef.CoreLib("System", "Int32")));
+                    break;
+                case ILOpCode.Ldc_i4_s:
+                    stack.Push(new Constant((int)(sbyte)reader.ReadILByte(), TypeRef.CoreLib("System", "Int32")));
+                    break;
+                case ILOpCode.Ldc_i4:
+                    stack.Push(new Constant((int)reader.ReadILUInt32(), TypeRef.CoreLib("System", "Int32")));
+                    break;
+                case ILOpCode.Ldc_i8:
+                    stack.Push(new Constant((long)reader.ReadILUInt64(), TypeRef.CoreLib("System", "Int64")));
+                    break;
+                case ILOpCode.Ldnull:
+                    stack.Push(new Constant(null, TypeRef.CoreLib("System", "Object")));
+                    break;
+                case ILOpCode.Ldstr:
+                    stack.Push(new Constant(
+                        source.Reader.GetUserString(MetadataTokens.UserStringHandle(reader.ReadILToken())),
+                        TypeRef.CoreLib("System", "String")));
+                    break;
+
+                case ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul or ILOpCode.Div or ILOpCode.Rem
+                    or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor or ILOpCode.Shl or ILOpCode.Shr
+                    or ILOpCode.Add_ovf or ILOpCode.Sub_ovf or ILOpCode.Mul_ovf
+                    or ILOpCode.Div_un or ILOpCode.Rem_un or ILOpCode.Shr_un
+                    or ILOpCode.Add_ovf_un or ILOpCode.Sub_ovf_un or ILOpCode.Mul_ovf_un:
+                {
+                    var right = stack.Pop();
+                    var left = stack.Pop();
+                    stack.Push(new Binary(BinaryKindOf(opcode), IsChecked(opcode), IsUnsigned(opcode), left, right));
+                    break;
+                }
+
+                case ILOpCode.Call or ILOpCode.Callvirt:
+                {
+                    var callee = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
+                    var arguments = new IrExpression[argumentCount];
+                    for (int i = argumentCount - 1; i >= 0; i--)
+                        arguments[i] = stack.Pop();
+                    var call = new Call(callee, opcode == ILOpCode.Callvirt, arguments);
+                    if (callee.ReturnType is { Name: "Void", Namespace: "System" })
+                        body.Add(new ExpressionStatement(call));
+                    else
+                        stack.Push(call);
+                    break;
+                }
+
+                case ILOpCode.Ldfld or ILOpCode.Ldsfld:
+                {
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? stack.Pop() : null));
+                    break;
+                }
+                case ILOpCode.Stfld:
+                {
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var value = stack.Pop();
+                    body.Add(new StoreField(field, stack.Pop(), value));
+                    break;
+                }
+                case ILOpCode.Stsfld:
+                {
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    body.Add(new StoreField(field, null, stack.Pop()));
+                    break;
+                }
+
+                case ILOpCode.Pop:
+                    body.Add(new ExpressionStatement(stack.Pop()));
+                    break;
+
+                case ILOpCode.Ret:
+                    body.Add(new Return(stack.Count > 0 ? stack.Pop() : null));
+                    break;
+
+                default:
+                    Stop(function, body, stack, offset, opcode.ToString().ToLowerInvariant(),
+                        "opcode is outside the straight-line slice");
+                    return function;
+            }
+        }
+
+        function.CheckInvariant();
+        return function;
+    }
+
+    /// <summary>Records the honest stopping point: spill the pending stack as statements, append the unsupported marker, attach the diagnostic.</summary>
+    static void Stop(IrFunction function, Block body, Stack<IrExpression> stack, int offset, string opcode, string reason)
+    {
+        foreach (var pending in stack.Reverse())
+            body.Add(new ExpressionStatement(pending));
+        stack.Clear();
+        body.Add(new ExpressionStatement(new UnsupportedNode(offset, opcode, reason)));
+        function.Diagnostics.Add(new DecompilerDiagnostic(
+            DiagnosticIds.UnsupportedConstruct, $"IL_{offset:X4} {opcode}: {reason}"));
+        function.CheckInvariant();
+    }
+
+    static LoadArgument MakeLoadArgument(ImportedMethod method, int index)
+    {
+        if (method.Signature.HasThis)
+        {
+            if (index == 0)
+                return new LoadArgument(0, "this", method.DeclaringType);
+            var p = method.Signature.Parameters[index - 1];
+            return new LoadArgument(index, p.Name, p.Type);
+        }
+        var parameter = method.Signature.Parameters[index];
+        return new LoadArgument(index, parameter.Name, parameter.Type);
+    }
+
+    static LoadLocal MakeLoadLocal(ImportedMethod method, int index)
+        => new(index, method.Body.Locals[index]);
+
+    static StoreLocal MakeStoreLocal(ImportedMethod method, int index, IrExpression value)
+        => new(index, method.Body.Locals[index], value);
+
+    internal static MethodRef ResolveMethod(MetadataReader reader, EntityHandle handle)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+            {
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, method.GetDeclaringType(), 0);
+                var typeScope = new GenericScope(GenericParameterNames(reader, reader.GetTypeDefinition(method.GetDeclaringType()).GetGenericParameters()), []);
+                var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
+                return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
+            }
+            case HandleKind.MemberReference:
+            {
+                var member = reader.GetMemberReference((MemberReferenceHandle)handle);
+                var declaring = ResolveParentType(reader, member.Parent);
+                var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                return new MethodRef(declaring, reader.GetString(member.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
+            }
+            default:
+                return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
+        }
+    }
+
+    internal static FieldRef ResolveField(MetadataReader reader, EntityHandle handle)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.FieldDefinition:
+            {
+                var field = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, field.GetDeclaringType(), 0);
+                var typeScope = new GenericScope(GenericParameterNames(reader, reader.GetTypeDefinition(field.GetDeclaringType()).GetGenericParameters()), []);
+                return new FieldRef(declaring, reader.GetString(field.Name), field.DecodeSignature(TypeRefDecoder.Instance, typeScope));
+            }
+            case HandleKind.MemberReference:
+            {
+                var member = reader.GetMemberReference((MemberReferenceHandle)handle);
+                var declaring = ResolveParentType(reader, member.Parent);
+                return new FieldRef(declaring, reader.GetString(member.Name), member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+            }
+            default:
+                return new FieldRef(TypeRef.Unsupported($"field handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown field type"));
+        }
+    }
+
+    static TypeRef ResolveParentType(MetadataReader reader, EntityHandle parent) => parent.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)parent, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)parent, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)parent, 0),
+        _ => TypeRef.Unsupported($"member parent kind {parent.Kind}"),
+    };
+
+    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    static BinaryKind BinaryKindOf(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un => BinaryKind.Add,
+        ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un => BinaryKind.Subtract,
+        ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un => BinaryKind.Multiply,
+        ILOpCode.Div or ILOpCode.Div_un => BinaryKind.Divide,
+        ILOpCode.Rem or ILOpCode.Rem_un => BinaryKind.Remainder,
+        ILOpCode.And => BinaryKind.And,
+        ILOpCode.Or => BinaryKind.Or,
+        ILOpCode.Xor => BinaryKind.Xor,
+        ILOpCode.Shl => BinaryKind.ShiftLeft,
+        _ => BinaryKind.ShiftRight,
+    };
+
+    static bool IsChecked(ILOpCode opcode) => opcode is ILOpCode.Add_ovf or ILOpCode.Add_ovf_un
+        or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un;
+
+    static bool IsUnsigned(ILOpCode opcode) => opcode is ILOpCode.Div_un or ILOpCode.Rem_un
+        or ILOpCode.Shr_un or ILOpCode.Add_ovf_un or ILOpCode.Sub_ovf_un or ILOpCode.Mul_ovf_un;
+}
+
+/// <summary>Indented tree dump of the IR — the stage projection for this layer (consumed by the harness's --dump as the pipeline grows).</summary>
+public static class IrPrinter
+{
+    public static string Dump(IrFunction function)
+    {
+        var sb = new System.Text.StringBuilder();
+        Append(sb, function, 0);
+        foreach (var diagnostic in function.Diagnostics)
+            sb.AppendLine($"// {diagnostic}");
+        sb.AppendLine($"// fidelity: {function.Fidelity}");
+        return sb.ToString();
+    }
+
+    static void Append(System.Text.StringBuilder sb, IrNode node, int indent)
+    {
+        sb.Append(' ', indent * 2).AppendLine(node.Describe());
+        foreach (var child in node.Children)
+            Append(sb, child, indent + 1);
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Base node of the replacement pipeline's typed IR (docs/decompiler-ir.md):
+/// a mutable tree with parent pointers and child slots, in the ILSpy
+/// <c>ILInstruction</c> tradition. <see cref="ReplaceWith"/> is the primitive
+/// rewrite; <see cref="CheckInvariant"/> validates parent/child consistency
+/// after every pass in debug builds.
+/// </summary>
+public abstract class IrNode
+{
+    readonly List<IrNode> _children = [];
+
+    public IrNode? Parent { get; private set; }
+
+    /// <summary>Slot index in the parent; -1 for detached nodes and the root.</summary>
+    public int ChildIndex { get; private set; } = -1;
+
+    public IReadOnlyList<IrNode> Children => _children;
+
+    /// <summary>One-line description for tree dumps; no recursion into children.</summary>
+    public abstract string Describe();
+
+    protected void AddChild(IrNode child)
+    {
+        Adopt(child, _children.Count);
+        _children.Add(child);
+    }
+
+    public void SetChild(int index, IrNode child)
+    {
+        var old = _children[index];
+        old.Parent = null;
+        old.ChildIndex = -1;
+        Adopt(child, index);
+        _children[index] = child;
+    }
+
+    void Adopt(IrNode child, int index)
+    {
+        if (child.Parent is not null)
+            throw new InvalidOperationException($"Node '{child.Describe()}' already has a parent; detach it first.");
+        if (ReferenceEquals(child, this))
+            throw new InvalidOperationException("A node cannot be its own child.");
+        child.Parent = this;
+        child.ChildIndex = index;
+    }
+
+    /// <summary>Replaces this node at its slot in the parent. The primitive rewrite — what makes "this node was consumed" a tree edit instead of side-channel state.</summary>
+    public void ReplaceWith(IrNode replacement)
+    {
+        if (Parent is null)
+            throw new InvalidOperationException("Cannot replace a detached or root node.");
+        Parent.SetChild(ChildIndex, replacement);
+    }
+
+    public IEnumerable<IrNode> Descendants
+    {
+        get
+        {
+            foreach (var child in _children)
+            {
+                yield return child;
+                foreach (var descendant in child.Descendants)
+                    yield return descendant;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validates parent/child consistency for this subtree. Debug builds run
+    /// this after every pass; a violation is a pipeline bug, never input data.
+    /// </summary>
+    [Conditional("DEBUG")]
+    public void CheckInvariant()
+    {
+        for (int i = 0; i < _children.Count; i++)
+        {
+            var child = _children[i];
+            if (!ReferenceEquals(child.Parent, this))
+                throw new InvalidOperationException($"Invariant violated: child '{child.Describe()}' of '{Describe()}' has wrong parent.");
+            if (child.ChildIndex != i)
+                throw new InvalidOperationException($"Invariant violated: child '{child.Describe()}' of '{Describe()}' has slot {child.ChildIndex}, expected {i}.");
+            child.CheckInvariant();
+        }
+    }
+
+    public override string ToString() => Describe();
+}
+
+/// <summary>An IR node that produces a value, typed by <see cref="TypeRef"/>.</summary>
+public abstract class IrExpression : IrNode
+{
+    /// <summary>The expression's result type; null when the pipeline does not know (itself a fidelity signal).</summary>
+    public abstract TypeRef? ResultType { get; }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1,0 +1,247 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>A materialized method reference — callee identity with symbolic types, no metadata handles.</summary>
+public sealed record MethodRef(
+    TypeRef DeclaringType,
+    string Name,
+    TypeRef ReturnType,
+    ImmutableArray<TypeRef> ParameterTypes,
+    bool HasThis);
+
+/// <summary>A materialized field reference.</summary>
+public sealed record FieldRef(TypeRef DeclaringType, string Name, TypeRef Type);
+
+/// <summary>The root of one method's IR: signature plus a body block, with diagnostics accumulated during construction and passes.</summary>
+public sealed class IrFunction : IrNode
+{
+    public IrFunction(string name, TypeRef declaringType, MethodSignature signature, ImmutableArray<TypeRef> locals, Block body)
+    {
+        Name = name;
+        DeclaringType = declaringType;
+        Signature = signature;
+        Locals = locals;
+        AddChild(body);
+    }
+
+    public string Name { get; }
+    public TypeRef DeclaringType { get; }
+    public MethodSignature Signature { get; }
+    public ImmutableArray<TypeRef> Locals { get; }
+    public Block Body => (Block)Children[0];
+    public List<DecompilerDiagnostic> Diagnostics { get; } = [];
+
+    /// <summary>Computed from the tree, never asserted: any unsupported node or type ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
+    public DecompilationFidelity Fidelity
+        => Descendants.OfType<UnsupportedNode>().Any()
+            || Descendants.OfType<IrExpression>().Any(e => e.ResultType?.ContainsUnsupported == true)
+            ? DecompilationFidelity.Partial
+            : DecompilationFidelity.Full;
+
+    public override string Describe()
+        => $"Function {Signature.ReturnType.ToDisplayString()} {Name}({string.Join(", ", Signature.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})";
+}
+
+/// <summary>A sequence of statement nodes.</summary>
+public sealed class Block : IrNode
+{
+    public void Add(IrNode statement) => AddChild(statement);
+
+    public override string Describe() => "Block";
+}
+
+/// <summary>An expression evaluated for its side effects (void call, popped value).</summary>
+public sealed class ExpressionStatement : IrNode
+{
+    public ExpressionStatement(IrExpression expression) => AddChild(expression);
+
+    public IrExpression Expression => (IrExpression)Children[0];
+
+    public override string Describe() => "ExpressionStatement";
+}
+
+public sealed class LoadArgument : IrExpression
+{
+    public LoadArgument(int index, string name, TypeRef type)
+    {
+        Index = index;
+        Name = name;
+        Type = type;
+    }
+
+    public int Index { get; }
+    public string Name { get; }
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => Type;
+
+    public override string Describe() => $"LoadArgument {Index} ({Type.ToDisplayString()} {Name})";
+}
+
+public sealed class LoadLocal : IrExpression
+{
+    public LoadLocal(int index, TypeRef type)
+    {
+        Index = index;
+        Type = type;
+    }
+
+    public int Index { get; }
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => Type;
+
+    public override string Describe() => $"LoadLocal {Index} ({Type.ToDisplayString()})";
+}
+
+public sealed class StoreLocal : IrNode
+{
+    public StoreLocal(int index, TypeRef type, IrExpression value)
+    {
+        Index = index;
+        Type = type;
+        AddChild(value);
+    }
+
+    public int Index { get; }
+    public TypeRef Type { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => $"StoreLocal {Index} ({Type.ToDisplayString()})";
+}
+
+public sealed class Constant : IrExpression
+{
+    public Constant(object? value, TypeRef type)
+    {
+        Value = value;
+        Type = type;
+    }
+
+    public object? Value { get; }
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => Type;
+
+    public override string Describe() => Value switch
+    {
+        null => "Constant null",
+        string s => $"Constant \"{s}\" (string)",
+        _ => $"Constant {Value} ({Type.ToDisplayString()})",
+    };
+}
+
+public enum BinaryKind { Add, Subtract, Multiply, Divide, Remainder, And, Or, Xor, ShiftLeft, ShiftRight }
+
+public sealed class Binary : IrExpression
+{
+    public Binary(BinaryKind kind, bool isChecked, bool isUnsigned, IrExpression left, IrExpression right)
+    {
+        Kind = kind;
+        IsChecked = isChecked;
+        IsUnsigned = isUnsigned;
+        AddChild(left);
+        AddChild(right);
+    }
+
+    public BinaryKind Kind { get; }
+    public bool IsChecked { get; }
+    public bool IsUnsigned { get; }
+    public IrExpression Left => (IrExpression)Children[0];
+    public IrExpression Right => (IrExpression)Children[1];
+
+    /// <summary>Result typing follows the left operand for the slice; full ECMA-335 binary numeric promotion arrives with the type pass.</summary>
+    public override TypeRef? ResultType => Left.ResultType;
+
+    public override string Describe()
+        => $"Binary.{Kind}{(IsChecked ? " checked" : "")}{(IsUnsigned ? " unsigned" : "")}";
+}
+
+public sealed class Call : IrExpression
+{
+    public Call(MethodRef callee, bool isVirtual, IEnumerable<IrExpression> arguments)
+    {
+        Callee = callee;
+        IsVirtual = isVirtual;
+        foreach (var argument in arguments)
+            AddChild(argument);
+    }
+
+    public MethodRef Callee { get; }
+    public bool IsVirtual { get; }
+    /// <summary>Arguments including the receiver for instance calls.</summary>
+    public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => Callee.ReturnType;
+
+    public override string Describe()
+        => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
+}
+
+public sealed class LoadField : IrExpression
+{
+    public LoadField(FieldRef field, IrExpression? instance)
+    {
+        Field = field;
+        if (instance is not null)
+            AddChild(instance);
+    }
+
+    public FieldRef Field { get; }
+    public IrExpression? Instance => Children.Count > 0 ? (IrExpression)Children[0] : null;
+    public override TypeRef? ResultType => Field.Type;
+
+    public override string Describe()
+        => $"LoadField {Field.DeclaringType.ToDisplayString()}.{Field.Name} ({Field.Type.ToDisplayString()})";
+}
+
+public sealed class StoreField : IrNode
+{
+    public StoreField(FieldRef field, IrExpression? instance, IrExpression value)
+    {
+        Field = field;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        AddChild(value);
+    }
+
+    public FieldRef Field { get; }
+    public bool HasInstance { get; }
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+
+    public override string Describe() => $"StoreField {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
+}
+
+public sealed class Return : IrNode
+{
+    public Return(IrExpression? value)
+    {
+        if (value is not null)
+            AddChild(value);
+    }
+
+    public IrExpression? Value => Children.Count > 0 ? (IrExpression)Children[0] : null;
+
+    public override string Describe() => "Return";
+}
+
+/// <summary>
+/// IL the pipeline does not (yet) represent — kept explicit in the tree and
+/// rendered honestly, never forced into plausible output. Any occurrence
+/// caps the function's fidelity at <see cref="DecompilationFidelity.Partial"/>.
+/// </summary>
+public sealed class UnsupportedNode : IrExpression
+{
+    public UnsupportedNode(int ilOffset, string opcode, string reason)
+    {
+        ILOffset = ilOffset;
+        Opcode = opcode;
+        Reason = reason;
+    }
+
+    public int ILOffset { get; }
+    public string Opcode { get; }
+    public string Reason { get; }
+    public override TypeRef? ResultType => null;
+
+    public override string Describe() => $"Unsupported IL_{ILOffset:X4} {Opcode}: {Reason}";
+}


### PR DESCRIPTION
## Summary

Second PR of the replacement pipeline, in dependency order: the typed IR from `docs/decompiler-ir.md`.

**`IrNode`** — the mutable tree base in the ILSpy `ILInstruction` tradition:
- Parent pointers + child slots; `ReplaceWith` as the primitive rewrite
- Adoption rules refuse nodes that already have parents (the tree-corruption bug class caught at the rewrite site, pinned by a test)
- `CheckInvariant` validates parent/child/slot consistency recursively, debug builds, after every pass — present from the first PR that has passes to run it after
- `IrExpression` adds `TypeRef` result typing (`null` = pipeline doesn't know, itself a fidelity signal)

**The slice node set**: `IrFunction` / `Block` / `ExpressionStatement` / `LoadArgument` / `LoadLocal` / `StoreLocal` / `Constant` / `Binary` (checked/unsigned flags) / `Call` (materialized `MethodRef`) / `LoadField` / `StoreField` (materialized `FieldRef`) / `Return` / `UnsupportedNode`.

Two design points worth review:
- **Fidelity is computed from the tree, never asserted**: any `UnsupportedNode` or unsupported `TypeRef` anywhere in the function caps it at `Partial` — exactly the doc's "fidelity is computed from the finished tree" rule.
- **Honest stopping**: `IrImporter` handles straight-line bodies (linear stack walk over the shared `ILReaderLite`); the first out-of-slice opcode spills the pending stack, appends an `UnsupportedNode`, attaches a `DEC0004` diagnostic (new stable ID), and stops. A branching method imports as `Partial` with the stopping point visible in the dump — never a guess.

**`IrPrinter`** is this layer's stage projection — indented tree dump with diagnostics and fidelity — ready for the harness's `--dump` as the pipeline grows.

```text
Function int Add(int a, int b)
  Block
    Return
      Binary.Add
        LoadArgument 0 (int a)
        LoadArgument 1 (int b)
// fidelity: Full
```

## Validation

- Decompiler suite 283/283 in both Debug and Release (7 new: tree shape + typing, source-disposal survival, ReplaceWith rewiring, adoption rejection, honest stopping on branches, CoreLib field/call import)
- Still present-but-unwired: no product path references the IR yet

Next in dependency order: port CFG + stack simulation onto the IR (multi-block functions), then the first raising passes, then harness registration as `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)