### PR TITLE
Multi-block IR import: branches, comparisons, conversions, sweep entry

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -240,6 +240,15 @@ public class ControlFlowGraphTests
 /// </summary>
 public class CfgSampleClass
 {
+    public static byte ToByte(int x) => (byte)x;
+
+    public static void Noop() { }
+
+    [System.Runtime.InteropServices.DllImport("nonexistent")]
+    private static extern void Overloaded(int x);
+
+    public static void Overloaded(double x) { _ = x; }
+
     public static int Add(int a, int b) => a + b;
 
     public static bool IsPositive(int x) => x > 0;

--- a/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -60,6 +60,28 @@ public class DecompilerResultTests : IDisposable
     }
 
     [Fact]
+    public void EmptyBody_IsValidCSharpProjection_NotAFailure()
+    {
+        // 'void M() { }' legitimately renders an empty body; only projections
+        // that always have output (the IL views) treat emptiness as DEC0003.
+        var stream = File.OpenRead(typeof(CfgSampleClass).Assembly.Location);
+        var peReader = new PEReader(stream);
+        _disposables.Push(peReader);
+        _disposables.Push(stream);
+        var context = MethodBodyContext.Create(
+            peReader, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.Noop));
+        Assert.NotNull(context);
+
+        var csharp = CSharpEmitter.Decompile(context);
+        var annotated = AnnotatedILEmitter.Decompile(context);
+
+        Assert.True(csharp.Succeeded);
+        Assert.Empty(csharp.Diagnostics);
+        Assert.True(annotated.Succeeded);
+        Assert.NotEqual("", annotated.Output!.Trim());
+    }
+
+    [Fact]
     public void RawProjection_SurvivesAnalysisFailures()
     {
         // 'add' on an empty stack: stack simulation cannot make sense of

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -101,6 +101,40 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Convert_UnsignedNarrowing_MapsToCorrectTargetUnchecked()
+    {
+        // conv.u1 and conv.u2 live far from the main conv.* opcode range;
+        // a range-based importer mapped them to UIntPtr and marked them
+        // checked (mid-point review catch).
+        var function = ImportFixture(nameof(CfgSampleClass.ToByte));
+
+        var convert = Assert.Single(function.Descendants.OfType<Pipeline.Convert>());
+        Assert.Equal("byte", convert.Target.ToDisplayString());
+        Assert.False(convert.IsChecked);
+        Assert.False(convert.IsUnsigned);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void Fidelity_ScansSignatureAndNonExpressionTypes()
+    {
+        // An unsupported type anywhere — signature, locals, store targets —
+        // must cap fidelity, not only expression result types.
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(null));
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "Void"),
+            [new Parameter("p", TypeRef.Unsupported("function pointer"))],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
     public void CoreLib_IsNullOrEmpty_ImportsAtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -12,12 +12,15 @@ public class IrImporterTests
         return function;
     }
 
+    static Block SingleBlock(IrFunction function)
+        => (Block)Assert.Single(function.Body.Children);
+
     [Fact]
     public void Add_BuildsTypedExpressionTree()
     {
         var function = ImportFixture(nameof(CfgSampleClass.Add));
 
-        var ret = Assert.IsType<Return>(Assert.Single(function.Body.Children));
+        var ret = Assert.IsType<Return>(Assert.Single(SingleBlock(function).Children));
         var binary = Assert.IsType<Binary>(ret.Value);
         Assert.Equal(BinaryKind.Add, binary.Kind);
         Assert.Equal("int", binary.ResultType?.ToDisplayString());
@@ -47,7 +50,7 @@ public class IrImporterTests
     public void ReplaceWith_RewiresParentAndSlot()
     {
         var function = ImportFixture(nameof(CfgSampleClass.Add));
-        var binary = (Binary)((Return)function.Body.Children[0]).Value!;
+        var binary = (Binary)((Return)SingleBlock(function).Children[0]).Value!;
         var left = binary.Left;
 
         var constant = new Constant(42, TypeRef.CoreLib("System", "Int32"));
@@ -65,7 +68,7 @@ public class IrImporterTests
     public void Adoption_RejectsNodesThatAlreadyHaveParents()
     {
         var function = ImportFixture(nameof(CfgSampleClass.Add));
-        var binary = (Binary)((Return)function.Body.Children[0]).Value!;
+        var binary = (Binary)((Return)SingleBlock(function).Children[0]).Value!;
 
         // Re-using an attached node without detaching it would silently
         // corrupt the tree; the IR refuses at the rewrite site.
@@ -74,16 +77,63 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void BranchingMethod_StopsHonestly_WithUnsupportedNode()
+    public void ExceptionRegions_StopHonestly_WithUnsupportedNode()
     {
-        var function = ImportFixture(nameof(CfgSampleClass.AbsShort));
+        var function = ImportFixture(nameof(CfgSampleClass.ChecksThenTry));
 
         var unsupported = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
-        Assert.NotEqual("", unsupported.Opcode);
+        Assert.Contains("exception regions", unsupported.Reason);
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
         var diagnostic = Assert.Single(function.Diagnostics);
         Assert.Equal(DiagnosticIds.UnsupportedConstruct, diagnostic.Id);
         function.CheckInvariant();
+    }
+
+    [Fact]
+    public void BranchingMethod_BuildsBlocks()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.AbsShort));
+
+        Assert.True(function.Body.Blocks.Count > 1);
+        Assert.NotEmpty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CoreLib_IsNullOrEmpty_ImportsAtFullFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.String", "IsNullOrEmpty");
+
+        Assert.NotNull(function);
+        Assert.Equal(3, function.Body.Blocks.Count);
+        var conditional = Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        Assert.IsType<LogicalNot>(conditional.Condition);
+        Assert.Single(function.Descendants.OfType<Comparison>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(function.Body.Blocks[2].StartOffset, conditional.TargetOffset);
+    }
+
+    [Fact]
+    public void CoreLib_SimpleCorpusMethods_ImportAtFullFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        (string Type, string Method)[] corpus =
+        [
+            ("System.String", "IsNullOrEmpty"),
+            ("System.Math", "Max"),
+            ("System.Text.StringBuilder", "Clear"),
+            ("System.Collections.Generic.HashSet`1", "Contains"),
+        ];
+
+        foreach (var (type, method) in corpus)
+        {
+            var function = IrImporter.Import(source, type, method);
+            Assert.NotNull(function);
+            Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+            function.CheckInvariant();
+        }
     }
 
     [Fact]
@@ -94,7 +144,8 @@ public class IrImporterTests
         var function = IrImporter.Import(source, "System.Collections.Generic.List`1", "get_Count");
 
         Assert.NotNull(function);
-        var ret = Assert.IsType<Return>(Assert.Single(function.Body.Children));
+        var block = (Block)Assert.Single(function.Body.Children);
+        var ret = Assert.IsType<Return>(Assert.Single(block.Children));
         var field = Assert.IsType<LoadField>(ret.Value);
         Assert.Equal("_size", field.Field.Name);
         Assert.Equal("int", field.ResultType?.ToDisplayString());

--- a/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -57,6 +57,21 @@ public class PipelineImporterTests
     }
 
     [Fact]
+    public void OverloadSelection_CountsBodylessOverloads()
+    {
+        // Legacy parity: overload indices count every name match. Selecting
+        // the extern overload returns null; the bodied one sits at index 1.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+
+        Assert.Null(MethodImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, "Overloaded", overloadIndex: 0));
+        var bodied = MethodImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, "Overloaded", overloadIndex: 1);
+        Assert.NotNull(bodied);
+        Assert.Equal("double", bodied.Signature.Parameters[0].Type.ToDisplayString());
+    }
+
+    [Fact]
     public void Import_TryCatch_MaterializesHandlerRegions()
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);

--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -33,7 +33,7 @@ public static class AnnotatedILEmitter
     /// for this projection (the IL views are ground truth at every depth).
     /// </summary>
     public static DecompilerResult Decompile(MethodBodyContext context, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
-        => DecompilerResult.Run(() => Emit(context, depth));
+        => DecompilerResult.Run(() => Emit(context, depth), emptyOutputIsFailure: true);
 
     /// <summary>
     /// Emit annotated IL for a method at the specified depth.
@@ -61,7 +61,7 @@ public static class AnnotatedILEmitter
 
     /// <summary>Decompiles annotated IL from a shared <see cref="MethodAnalysis"/>, with failures expressed as diagnostics.</summary>
     public static DecompilerResult Decompile(MethodAnalysis analysis, ILAnnotationDepth depth = ILAnnotationDepth.Typed)
-        => DecompilerResult.Run(() => Emit(analysis, depth));
+        => DecompilerResult.Run(() => Emit(analysis, depth), emptyOutputIsFailure: true);
 
     /// <summary>
     /// Emit annotated IL from pre-computed analysis results.

--- a/src/DotnetInspector.Decompiler/DecompilerResult.cs
+++ b/src/DotnetInspector.Decompiler/DecompilerResult.cs
@@ -44,7 +44,7 @@ public static class DiagnosticIds
     /// <summary>A method body context could not be created.</summary>
     public const string ContextUnavailable = "DEC0002";
 
-    /// <summary>Decompilation produced no output for a method with a body.</summary>
+    /// <summary>A projection that always has output for a method with a body produced none (e.g. IL views). Body-only C# projections legitimately render empty bodies and do not use this.</summary>
     public const string EmptyOutput = "DEC0003";
 
     /// <summary>IL the pipeline does not represent; rendered explicitly, lowers fidelity.</summary>
@@ -70,8 +70,13 @@ public sealed record DecompilerResult(
     public static DecompilerResult Failure(string diagnosticId, string message)
         => new(null, DecompilationFidelity.Failed, [new DecompilerDiagnostic(diagnosticId, message)]);
 
-    /// <summary>Runs a pipeline entry point, converting exceptions and empty output into diagnostics.</summary>
-    internal static DecompilerResult Run(Func<string> pipeline)
+    /// <summary>
+    /// Runs a pipeline entry point, converting exceptions into diagnostics.
+    /// Empty-output policy is projection-specific: IL projections always have
+    /// output for a real body, so emptiness is a failure there; a body-only
+    /// C# projection legitimately renders an empty body (e.g. <c>void M() { }</c>).
+    /// </summary>
+    internal static DecompilerResult Run(Func<string> pipeline, bool emptyOutputIsFailure = false)
     {
         string output;
         try
@@ -82,8 +87,8 @@ public sealed record DecompilerResult(
         {
             return Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
-        return string.IsNullOrWhiteSpace(output)
-            ? Failure(DiagnosticIds.EmptyOutput, "decompilation produced no output")
+        return emptyOutputIsFailure && string.IsNullOrWhiteSpace(output)
+            ? Failure(DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
             : Success(output);
     }
 }

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -26,17 +26,21 @@ public static class IrImporter
             if ((ns.Length == 0 ? name : $"{ns}.{name}") != typeFullName)
                 continue;
 
+            // Overload indices count every name match, body or not (parity
+            // with legacy selection).
             int seen = 0;
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != methodName || method.RelativeVirtualAddress == 0)
+                if (reader.GetString(method.Name) != methodName)
                     continue;
                 if (seen++ != overloadIndex)
                     continue;
+                if (method.RelativeVirtualAddress == 0)
+                    return null;
 
                 var imported = MethodImporter.Import(source, typeDefHandle, methodHandle);
-                return Build(source, imported);
+                return Build(source, imported, CallerScope(reader, typeDef, method));
             }
             return null;
         }
@@ -61,31 +65,46 @@ public static class IrImporter
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (method.RelativeVirtualAddress == 0)
                     continue;
-                var imported = MethodImporter.Import(source, typeDefHandle, methodHandle);
+                string memberName = reader.GetString(method.Name);
                 IrFunction function;
                 try
                 {
-                    function = Build(source, imported);
+                    // Metadata import and IR build are both inside the guard:
+                    // an importer crash is a pipeline bug, but one method's bug
+                    // must not end an assembly sweep — it surfaces as a
+                    // diagnosed partial function, like an out-of-slice stop.
+                    function = Build(
+                        source,
+                        MethodImporter.Import(source, typeDefHandle, methodHandle),
+                        CallerScope(reader, typeDef, method));
                 }
                 catch (Exception ex)
                 {
-                    // An importer crash is a pipeline bug, but one method's bug
-                    // must not end an assembly sweep: surface it as a diagnosed
-                    // partial function, exactly like an out-of-slice stop.
-                    var block = new Block(0);
-                    var container = new BlockContainer();
-                    container.Add(block);
-                    function = new IrFunction(imported.Name, imported.DeclaringType, imported.Signature, imported.Body.Locals, container);
-                    block.Add(new ExpressionStatement(new UnsupportedNode(0, "(importer crash)", $"{ex.GetType().Name}: {ex.Message}")));
-                    function.Diagnostics.Add(new DecompilerDiagnostic(
-                        DiagnosticIds.InternalError, $"importer crash: {ex.GetType().Name}: {ex.Message}"));
+                    function = CrashFunction(memberName, typeName, ex);
                 }
-                yield return (typeName, reader.GetString(method.Name), function);
+                yield return (typeName, memberName, function);
             }
         }
     }
 
-    static IrFunction Build(MetadataSource source, ImportedMethod method)
+    static IrFunction CrashFunction(string methodName, string typeName, Exception ex)
+    {
+        var block = new Block(0);
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(TypeRef.Unsupported("import failed"), [], false, 0);
+        var function = new IrFunction(methodName, TypeRef.Definition("", "", typeName), signature, [], container);
+        block.Add(new ExpressionStatement(new UnsupportedNode(0, "(importer crash)", $"{ex.GetType().Name}: {ex.Message}")));
+        function.Diagnostics.Add(new DecompilerDiagnostic(
+            DiagnosticIds.InternalError, $"importer crash: {ex.GetType().Name}: {ex.Message}"));
+        return function;
+    }
+
+    static GenericScope CallerScope(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+        => new(GenericParameterNames(reader, typeDef.GetGenericParameters()),
+               GenericParameterNames(reader, method.GetGenericParameters()));
+
+    static IrFunction Build(MetadataSource source, ImportedMethod method, GenericScope callerScope)
     {
         var container = new BlockContainer();
         var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container);
@@ -105,7 +124,7 @@ public static class IrImporter
         {
             var block = new Block(leader);
             container.Add(block);
-            if (!BuildBlock(source, method, function, block, span, leader, NextLeader(leaders, leader, span.Length)))
+            if (!BuildBlock(source, method, function, block, span, leader, NextLeader(leaders, leader, span.Length), callerScope))
                 return function;  // honest stop already recorded
         }
 
@@ -130,7 +149,7 @@ public static class IrImporter
             else
             {
                 reader.Skip(opcode);
-                if (opcode == ILOpCode.Ret && reader.Offset < il.Length)
+                if (opcode is ILOpCode.Ret or ILOpCode.Throw && reader.Offset < il.Length)
                     leaders.Add(reader.Offset);
             }
         }
@@ -149,7 +168,7 @@ public static class IrImporter
 
     /// <summary>Builds one block. Returns false when the import stopped honestly inside it.</summary>
     static bool BuildBlock(MetadataSource source, ImportedMethod method, IrFunction function, Block body,
-        ReadOnlySpan<byte> il, int start, int end)
+        ReadOnlySpan<byte> il, int start, int end, GenericScope callerScope)
     {
         var stack = new Stack<IrExpression>();
         var reader = new ILReaderLite(il[..end], currentOffset: start);
@@ -250,15 +269,22 @@ public static class IrImporter
                     break;
                 }
 
-                case >= ILOpCode.Conv_i1 and <= ILOpCode.Conv_u8 or ILOpCode.Conv_i or ILOpCode.Conv_u
-                    or ILOpCode.Conv_r_un or (>= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un)
-                    or (>= ILOpCode.Conv_ovf_i1 and <= ILOpCode.Conv_ovf_u):
+                case ILOpCode.Conv_i1 or ILOpCode.Conv_i2 or ILOpCode.Conv_i4 or ILOpCode.Conv_i8
+                    or ILOpCode.Conv_u1 or ILOpCode.Conv_u2 or ILOpCode.Conv_u4 or ILOpCode.Conv_u8
+                    or ILOpCode.Conv_r4 or ILOpCode.Conv_r8 or ILOpCode.Conv_i or ILOpCode.Conv_u
+                    or ILOpCode.Conv_r_un
+                    or ILOpCode.Conv_ovf_i1 or ILOpCode.Conv_ovf_i2 or ILOpCode.Conv_ovf_i4 or ILOpCode.Conv_ovf_i8
+                    or ILOpCode.Conv_ovf_u1 or ILOpCode.Conv_ovf_u2 or ILOpCode.Conv_ovf_u4 or ILOpCode.Conv_ovf_u8
+                    or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_u
+                    or ILOpCode.Conv_ovf_i1_un or ILOpCode.Conv_ovf_i2_un or ILOpCode.Conv_ovf_i4_un or ILOpCode.Conv_ovf_i8_un
+                    or ILOpCode.Conv_ovf_u1_un or ILOpCode.Conv_ovf_u2_un or ILOpCode.Conv_ovf_u4_un or ILOpCode.Conv_ovf_u8_un
+                    or ILOpCode.Conv_ovf_i_un or ILOpCode.Conv_ovf_u_un:
                     stack.Push(MakeConvert(opcode, Pop(stack)));
                     break;
 
                 case ILOpCode.Call or ILOpCode.Callvirt:
                 {
-                    var callee = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var callee = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
@@ -273,27 +299,27 @@ public static class IrImporter
 
                 case ILOpCode.Ldfld or ILOpCode.Ldsfld:
                 {
-                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? Pop(stack) : null));
                     break;
                 }
                 case ILOpCode.Stfld:
                 {
-                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var value = Pop(stack);
                     body.Add(new StoreField(field, Pop(stack), value));
                     break;
                 }
                 case ILOpCode.Stsfld:
                 {
-                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     body.Add(new StoreField(field, null, Pop(stack)));
                     break;
                 }
 
                 case ILOpCode.Newobj:
                 {
-                    var constructor = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var constructor = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var arguments = new IrExpression[constructor.ParameterTypes.Length];
                     for (int i = arguments.Length - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
@@ -302,11 +328,9 @@ public static class IrImporter
                 }
 
                 case ILOpCode.Throw:
+                    // A leader follows every throw (FindLeaders), so the block
+                    // ends here and unreachable IL lands in its own block.
                     body.Add(new Throw(Pop(stack)));
-                    // IL after a throw in the same block is unreachable padding; the
-                    // next leader starts the next block.
-                    while (reader.HasNext && reader.PeekILOpcode() == ILOpCode.Nop)
-                        reader.ReadILOpcode();
                     break;
 
                 case ILOpCode.Neg:
@@ -419,9 +443,16 @@ public static class IrImporter
             ILOpCode.Conv_i or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_i_un => "IntPtr",
             _ => "UIntPtr",
         };
-        bool isChecked = opcode is >= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un
-            or >= ILOpCode.Conv_ovf_i1 and <= ILOpCode.Conv_ovf_u;
-        bool isUnsigned = opcode is ILOpCode.Conv_r_un or >= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un;
+        bool isChecked = opcode is ILOpCode.Conv_ovf_i1 or ILOpCode.Conv_ovf_i2 or ILOpCode.Conv_ovf_i4 or ILOpCode.Conv_ovf_i8
+            or ILOpCode.Conv_ovf_u1 or ILOpCode.Conv_ovf_u2 or ILOpCode.Conv_ovf_u4 or ILOpCode.Conv_ovf_u8
+            or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_u
+            or ILOpCode.Conv_ovf_i1_un or ILOpCode.Conv_ovf_i2_un or ILOpCode.Conv_ovf_i4_un or ILOpCode.Conv_ovf_i8_un
+            or ILOpCode.Conv_ovf_u1_un or ILOpCode.Conv_ovf_u2_un or ILOpCode.Conv_ovf_u4_un or ILOpCode.Conv_ovf_u8_un
+            or ILOpCode.Conv_ovf_i_un or ILOpCode.Conv_ovf_u_un;
+        bool isUnsigned = opcode is ILOpCode.Conv_r_un
+            or ILOpCode.Conv_ovf_i1_un or ILOpCode.Conv_ovf_i2_un or ILOpCode.Conv_ovf_i4_un or ILOpCode.Conv_ovf_i8_un
+            or ILOpCode.Conv_ovf_u1_un or ILOpCode.Conv_ovf_u2_un or ILOpCode.Conv_ovf_u4_un or ILOpCode.Conv_ovf_u8_un
+            or ILOpCode.Conv_ovf_i_un or ILOpCode.Conv_ovf_u_un;
         return new Convert(TypeRef.CoreLib("System", name), isChecked, isUnsigned, operand);
     }
 
@@ -457,7 +488,7 @@ public static class IrImporter
     static StoreLocal MakeStoreLocal(ImportedMethod method, int index, IrExpression value)
         => new(index, method.Body.Locals[index], value);
 
-    internal static MethodRef ResolveMethod(MetadataReader reader, EntityHandle handle)
+    internal static MethodRef ResolveMethod(MetadataReader reader, EntityHandle handle, GenericScope callerScope)
     {
         switch (handle.Kind)
         {
@@ -472,7 +503,7 @@ public static class IrImporter
             case HandleKind.MemberReference:
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
-                var declaring = ResolveParentType(reader, member.Parent);
+                var declaring = ResolveParentType(reader, member.Parent, callerScope);
                 var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
                 return new MethodRef(declaring, reader.GetString(member.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
             }
@@ -481,7 +512,7 @@ public static class IrImporter
         }
     }
 
-    internal static FieldRef ResolveField(MetadataReader reader, EntityHandle handle)
+    internal static FieldRef ResolveField(MetadataReader reader, EntityHandle handle, GenericScope callerScope)
     {
         switch (handle.Kind)
         {
@@ -495,7 +526,7 @@ public static class IrImporter
             case HandleKind.MemberReference:
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
-                var declaring = ResolveParentType(reader, member.Parent);
+                var declaring = ResolveParentType(reader, member.Parent, callerScope);
                 return new FieldRef(declaring, reader.GetString(member.Name), member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty));
             }
             default:
@@ -503,11 +534,12 @@ public static class IrImporter
         }
     }
 
-    static TypeRef ResolveParentType(MetadataReader reader, EntityHandle parent) => parent.Kind switch
+    static TypeRef ResolveParentType(MetadataReader reader, EntityHandle parent, GenericScope callerScope) => parent.Kind switch
     {
         HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)parent, 0),
         HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)parent, 0),
-        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)parent, 0),
+        // A MemberRef parent TypeSpec's !N are the CALLER's type parameters.
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, callerScope, (TypeSpecificationHandle)parent, 0),
         _ => TypeRef.Unsupported($"member parent kind {parent.Kind}"),
     };
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -7,10 +7,11 @@ namespace DotnetInspector.Decompiler.Pipeline;
 /// <summary>
 /// Builds the typed IR for one method while its <see cref="MetadataSource"/>
 /// is alive; the resulting <see cref="IrFunction"/> is fully materialized.
-/// Slice scope: straight-line bodies (no branches, no exception regions).
-/// IL outside the slice becomes an explicit <see cref="UnsupportedNode"/>
-/// with a <see cref="DiagnosticIds.UnsupportedConstruct"/> diagnostic and
-/// import stops — fidelity degrades honestly, output never guesses.
+/// Slice scope: branching bodies whose evaluation stack is empty at every
+/// block boundary (no exception regions, no stack-carrying edges). IL
+/// outside the slice becomes an explicit <see cref="UnsupportedNode"/> with
+/// a <see cref="DiagnosticIds.UnsupportedConstruct"/> diagnostic and import
+/// stops — fidelity degrades honestly, output never guesses.
 /// </summary>
 public static class IrImporter
 {
@@ -42,22 +43,123 @@ public static class IrImporter
         return null;
     }
 
+    /// <summary>
+    /// Imports every method body in the assembly — the sweep front door the
+    /// differential harness registers as the replacement pipeline.
+    /// </summary>
+    public static IEnumerable<(string TypeName, string MethodName, IrFunction Function)> ImportAssembly(MetadataSource source)
+    {
+        var reader = source.Reader;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string ns = reader.GetString(typeDef.Namespace);
+            string name = reader.GetString(typeDef.Name);
+            string typeName = ns.Length == 0 ? name : $"{ns}.{name}";
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (method.RelativeVirtualAddress == 0)
+                    continue;
+                var imported = MethodImporter.Import(source, typeDefHandle, methodHandle);
+                IrFunction function;
+                try
+                {
+                    function = Build(source, imported);
+                }
+                catch (Exception ex)
+                {
+                    // An importer crash is a pipeline bug, but one method's bug
+                    // must not end an assembly sweep: surface it as a diagnosed
+                    // partial function, exactly like an out-of-slice stop.
+                    var block = new Block(0);
+                    var container = new BlockContainer();
+                    container.Add(block);
+                    function = new IrFunction(imported.Name, imported.DeclaringType, imported.Signature, imported.Body.Locals, container);
+                    block.Add(new ExpressionStatement(new UnsupportedNode(0, "(importer crash)", $"{ex.GetType().Name}: {ex.Message}")));
+                    function.Diagnostics.Add(new DecompilerDiagnostic(
+                        DiagnosticIds.InternalError, $"importer crash: {ex.GetType().Name}: {ex.Message}"));
+                }
+                yield return (typeName, reader.GetString(method.Name), function);
+            }
+        }
+    }
+
     static IrFunction Build(MetadataSource source, ImportedMethod method)
     {
-        var body = new Block();
-        var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, body);
-        var stack = new Stack<IrExpression>();
-        var reader = new ILReaderLite(method.Body.IL.AsSpan());
+        var container = new BlockContainer();
+        var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container);
 
         if (!method.Body.Handlers.IsEmpty)
         {
-            Stop(function, body, stack, 0, "(exception regions)", "exception regions are outside the straight-line slice");
+            var block = new Block(0);
+            container.Add(block);
+            Stop(function, block, new Stack<IrExpression>(), 0, "(exception regions)", "exception regions are outside the slice");
             return function;
         }
 
+        var span = method.Body.IL.AsSpan();
+        var leaders = FindLeaders(span);
+
+        foreach (int leader in leaders)
+        {
+            var block = new Block(leader);
+            container.Add(block);
+            if (!BuildBlock(source, method, function, block, span, leader, NextLeader(leaders, leader, span.Length)))
+                return function;  // honest stop already recorded
+        }
+
+        function.CheckInvariant();
+        return function;
+    }
+
+    /// <summary>Block leaders: entry, branch targets, and instructions following a branch.</summary>
+    static SortedSet<int> FindLeaders(ReadOnlySpan<byte> il)
+    {
+        var leaders = new SortedSet<int> { 0 };
+        var reader = new ILReaderLite(il);
         while (reader.HasNext)
         {
-            int offset = reader.Offset;
+            var opcode = reader.ReadILOpcode();
+            if (IsBranch(opcode))
+            {
+                leaders.Add(reader.ReadBranchDestination(opcode));
+                if (reader.Offset < il.Length)
+                    leaders.Add(reader.Offset);
+            }
+            else
+            {
+                reader.Skip(opcode);
+                if (opcode == ILOpCode.Ret && reader.Offset < il.Length)
+                    leaders.Add(reader.Offset);
+            }
+        }
+        return leaders;
+    }
+
+    static bool IsBranch(ILOpCode opcode)
+        => opcode is >= ILOpCode.Br_s and <= ILOpCode.Blt_un_s or >= ILOpCode.Br and <= ILOpCode.Blt_un;
+
+    static int NextLeader(SortedSet<int> leaders, int current, int ilLength)
+    {
+        foreach (int leader in leaders.GetViewBetween(current + 1, int.MaxValue))
+            return leader;
+        return ilLength;
+    }
+
+    /// <summary>Builds one block. Returns false when the import stopped honestly inside it.</summary>
+    static bool BuildBlock(MetadataSource source, ImportedMethod method, IrFunction function, Block body,
+        ReadOnlySpan<byte> il, int start, int end)
+    {
+        var stack = new Stack<IrExpression>();
+        var reader = new ILReaderLite(il[..end], currentOffset: start);
+        int offset = start;
+
+        try
+        {
+        while (reader.HasNext)
+        {
+            offset = reader.Offset;
             var opcode = reader.ReadILOpcode();
             switch (opcode)
             {
@@ -70,6 +172,15 @@ public static class IrImporter
                 case ILOpCode.Ldarg_s:
                     stack.Push(MakeLoadArgument(method, reader.ReadILByte()));
                     break;
+                case ILOpCode.Ldarg:
+                    stack.Push(MakeLoadArgument(method, reader.ReadILUInt16()));
+                    break;
+                case ILOpCode.Starg_s:
+                    body.Add(MakeStoreArgument(method, reader.ReadILByte(), Pop(stack)));
+                    break;
+                case ILOpCode.Starg:
+                    body.Add(MakeStoreArgument(method, reader.ReadILUInt16(), Pop(stack)));
+                    break;
 
                 case ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3:
                     stack.Push(MakeLoadLocal(method, opcode - ILOpCode.Ldloc_0));
@@ -77,12 +188,18 @@ public static class IrImporter
                 case ILOpCode.Ldloc_s:
                     stack.Push(MakeLoadLocal(method, reader.ReadILByte()));
                     break;
+                case ILOpCode.Ldloc:
+                    stack.Push(MakeLoadLocal(method, reader.ReadILUInt16()));
+                    break;
 
                 case ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3:
-                    body.Add(MakeStoreLocal(method, opcode - ILOpCode.Stloc_0, stack.Pop()));
+                    body.Add(MakeStoreLocal(method, opcode - ILOpCode.Stloc_0, Pop(stack)));
                     break;
                 case ILOpCode.Stloc_s:
-                    body.Add(MakeStoreLocal(method, reader.ReadILByte(), stack.Pop()));
+                    body.Add(MakeStoreLocal(method, reader.ReadILByte(), Pop(stack)));
+                    break;
+                case ILOpCode.Stloc:
+                    body.Add(MakeStoreLocal(method, reader.ReadILUInt16(), Pop(stack)));
                     break;
 
                 case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8:
@@ -112,11 +229,32 @@ public static class IrImporter
                     or ILOpCode.Div_un or ILOpCode.Rem_un or ILOpCode.Shr_un
                     or ILOpCode.Add_ovf_un or ILOpCode.Sub_ovf_un or ILOpCode.Mul_ovf_un:
                 {
-                    var right = stack.Pop();
-                    var left = stack.Pop();
+                    var right = Pop(stack);
+                    var left = Pop(stack);
                     stack.Push(new Binary(BinaryKindOf(opcode), IsChecked(opcode), IsUnsigned(opcode), left, right));
                     break;
                 }
+
+                case ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Cgt_un or ILOpCode.Clt or ILOpCode.Clt_un:
+                {
+                    var right = Pop(stack);
+                    var left = Pop(stack);
+                    stack.Push(new Comparison(
+                        opcode switch
+                        {
+                            ILOpCode.Ceq => ComparisonKind.Equal,
+                            ILOpCode.Cgt or ILOpCode.Cgt_un => ComparisonKind.GreaterThan,
+                            _ => ComparisonKind.LessThan,
+                        },
+                        opcode is ILOpCode.Cgt_un or ILOpCode.Clt_un, left, right));
+                    break;
+                }
+
+                case >= ILOpCode.Conv_i1 and <= ILOpCode.Conv_u8 or ILOpCode.Conv_i or ILOpCode.Conv_u
+                    or ILOpCode.Conv_r_un or (>= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un)
+                    or (>= ILOpCode.Conv_ovf_i1 and <= ILOpCode.Conv_ovf_u):
+                    stack.Push(MakeConvert(opcode, Pop(stack)));
+                    break;
 
                 case ILOpCode.Call or ILOpCode.Callvirt:
                 {
@@ -124,7 +262,7 @@ public static class IrImporter
                     int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
-                        arguments[i] = stack.Pop();
+                        arguments[i] = Pop(stack);
                     var call = new Call(callee, opcode == ILOpCode.Callvirt, arguments);
                     if (callee.ReturnType is { Name: "Void", Namespace: "System" })
                         body.Add(new ExpressionStatement(call));
@@ -136,41 +274,107 @@ public static class IrImporter
                 case ILOpCode.Ldfld or ILOpCode.Ldsfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
-                    stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? stack.Pop() : null));
+                    stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? Pop(stack) : null));
                     break;
                 }
                 case ILOpCode.Stfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
-                    var value = stack.Pop();
-                    body.Add(new StoreField(field, stack.Pop(), value));
+                    var value = Pop(stack);
+                    body.Add(new StoreField(field, Pop(stack), value));
                     break;
                 }
                 case ILOpCode.Stsfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
-                    body.Add(new StoreField(field, null, stack.Pop()));
+                    body.Add(new StoreField(field, null, Pop(stack)));
                     break;
                 }
 
-                case ILOpCode.Pop:
-                    body.Add(new ExpressionStatement(stack.Pop()));
+                case ILOpCode.Newobj:
+                {
+                    var constructor = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()));
+                    var arguments = new IrExpression[constructor.ParameterTypes.Length];
+                    for (int i = arguments.Length - 1; i >= 0; i--)
+                        arguments[i] = Pop(stack);
+                    stack.Push(new NewObject(constructor, arguments));
+                    break;
+                }
+
+                case ILOpCode.Throw:
+                    body.Add(new Throw(Pop(stack)));
+                    // IL after a throw in the same block is unreachable padding; the
+                    // next leader starts the next block.
+                    while (reader.HasNext && reader.PeekILOpcode() == ILOpCode.Nop)
+                        reader.ReadILOpcode();
                     break;
 
+                case ILOpCode.Neg:
+                    stack.Push(new Unary(UnaryKind.Negate, Pop(stack)));
+                    break;
+                case ILOpCode.Not:
+                    stack.Push(new Unary(UnaryKind.BitwiseNot, Pop(stack)));
+                    break;
+
+                case ILOpCode.Pop:
+                    body.Add(new ExpressionStatement(Pop(stack)));
+                    break;
+
+                case ILOpCode.Br or ILOpCode.Br_s:
+                    body.Add(new Branch(reader.ReadBranchDestination(opcode)));
+                    break;
+
+                case ILOpCode.Brtrue or ILOpCode.Brtrue_s:
+                    body.Add(new ConditionalBranch(Pop(stack), reader.ReadBranchDestination(opcode)));
+                    break;
+                case ILOpCode.Brfalse or ILOpCode.Brfalse_s:
+                    body.Add(new ConditionalBranch(new LogicalNot(Pop(stack)), reader.ReadBranchDestination(opcode)));
+                    break;
+
+                case >= ILOpCode.Beq_s and <= ILOpCode.Blt_un_s or >= ILOpCode.Beq and <= ILOpCode.Blt_un:
+                {
+                    int target = reader.ReadBranchDestination(opcode);
+                    var right = Pop(stack);
+                    var left = Pop(stack);
+                    var (kind, isUnsigned) = ComparisonOf(opcode);
+                    body.Add(new ConditionalBranch(new Comparison(kind, isUnsigned, left, right), target));
+                    break;
+                }
+
                 case ILOpCode.Ret:
-                    body.Add(new Return(stack.Count > 0 ? stack.Pop() : null));
+                    body.Add(new Return(stack.Count > 0 ? Pop(stack) : null));
                     break;
 
                 default:
                     Stop(function, body, stack, offset, opcode.ToString().ToLowerInvariant(),
-                        "opcode is outside the straight-line slice");
-                    return function;
+                        "opcode is outside the slice");
+                    return false;
             }
         }
 
-        function.CheckInvariant();
-        return function;
+        }
+        catch (OutOfSliceException ex)
+        {
+            Stop(function, body, stack, offset, "(stack underflow)", ex.Message);
+            return false;
+        }
+
+        if (stack.Count > 0)
+        {
+            Stop(function, body, stack, end, "(block boundary)",
+                "evaluation stack carries values across a block boundary, outside the slice");
+            return false;
+        }
+        return true;
     }
+
+    /// <summary>A block whose entry expects stack values is a stack-carrying edge — out of slice, reported honestly via the importer's stop path.</summary>
+    sealed class OutOfSliceException(string reason) : Exception(reason);
+
+    static IrExpression Pop(Stack<IrExpression> stack)
+        => stack.Count > 0
+            ? stack.Pop()
+            : throw new OutOfSliceException("evaluation stack carries values into this block, outside the slice");
 
     /// <summary>Records the honest stopping point: spill the pending stack as statements, append the unsupported marker, attach the diagnostic.</summary>
     static void Stop(IrFunction function, Block body, Stack<IrExpression> stack, int offset, string opcode, string reason)
@@ -184,6 +388,43 @@ public static class IrImporter
         function.CheckInvariant();
     }
 
+    static (ComparisonKind Kind, bool IsUnsigned) ComparisonOf(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Beq or ILOpCode.Beq_s => (ComparisonKind.Equal, false),
+        ILOpCode.Bne_un or ILOpCode.Bne_un_s => (ComparisonKind.NotEqual, false),
+        ILOpCode.Bge or ILOpCode.Bge_s => (ComparisonKind.GreaterThanOrEqual, false),
+        ILOpCode.Bge_un or ILOpCode.Bge_un_s => (ComparisonKind.GreaterThanOrEqual, true),
+        ILOpCode.Bgt or ILOpCode.Bgt_s => (ComparisonKind.GreaterThan, false),
+        ILOpCode.Bgt_un or ILOpCode.Bgt_un_s => (ComparisonKind.GreaterThan, true),
+        ILOpCode.Ble or ILOpCode.Ble_s => (ComparisonKind.LessThanOrEqual, false),
+        ILOpCode.Ble_un or ILOpCode.Ble_un_s => (ComparisonKind.LessThanOrEqual, true),
+        ILOpCode.Blt or ILOpCode.Blt_s => (ComparisonKind.LessThan, false),
+        _ => (ComparisonKind.LessThan, true),
+    };
+
+    static Convert MakeConvert(ILOpCode opcode, IrExpression operand)
+    {
+        string name = opcode switch
+        {
+            ILOpCode.Conv_i1 or ILOpCode.Conv_ovf_i1 or ILOpCode.Conv_ovf_i1_un => "SByte",
+            ILOpCode.Conv_u1 or ILOpCode.Conv_ovf_u1 or ILOpCode.Conv_ovf_u1_un => "Byte",
+            ILOpCode.Conv_i2 or ILOpCode.Conv_ovf_i2 or ILOpCode.Conv_ovf_i2_un => "Int16",
+            ILOpCode.Conv_u2 or ILOpCode.Conv_ovf_u2 or ILOpCode.Conv_ovf_u2_un => "UInt16",
+            ILOpCode.Conv_i4 or ILOpCode.Conv_ovf_i4 or ILOpCode.Conv_ovf_i4_un => "Int32",
+            ILOpCode.Conv_u4 or ILOpCode.Conv_ovf_u4 or ILOpCode.Conv_ovf_u4_un => "UInt32",
+            ILOpCode.Conv_i8 or ILOpCode.Conv_ovf_i8 or ILOpCode.Conv_ovf_i8_un => "Int64",
+            ILOpCode.Conv_u8 or ILOpCode.Conv_ovf_u8 or ILOpCode.Conv_ovf_u8_un => "UInt64",
+            ILOpCode.Conv_r4 => "Single",
+            ILOpCode.Conv_r8 or ILOpCode.Conv_r_un => "Double",
+            ILOpCode.Conv_i or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_i_un => "IntPtr",
+            _ => "UIntPtr",
+        };
+        bool isChecked = opcode is >= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un
+            or >= ILOpCode.Conv_ovf_i1 and <= ILOpCode.Conv_ovf_u;
+        bool isUnsigned = opcode is ILOpCode.Conv_r_un or >= ILOpCode.Conv_ovf_i1_un and <= ILOpCode.Conv_ovf_u_un;
+        return new Convert(TypeRef.CoreLib("System", name), isChecked, isUnsigned, operand);
+    }
+
     static LoadArgument MakeLoadArgument(ImportedMethod method, int index)
     {
         if (method.Signature.HasThis)
@@ -195,6 +436,19 @@ public static class IrImporter
         }
         var parameter = method.Signature.Parameters[index];
         return new LoadArgument(index, parameter.Name, parameter.Type);
+    }
+
+    static StoreArgument MakeStoreArgument(ImportedMethod method, int index, IrExpression value)
+    {
+        if (method.Signature.HasThis)
+        {
+            if (index == 0)
+                return new StoreArgument(0, "this", method.DeclaringType, value);
+            var p = method.Signature.Parameters[index - 1];
+            return new StoreArgument(index, p.Name, p.Type, value);
+        }
+        var parameter = method.Signature.Parameters[index];
+        return new StoreArgument(index, parameter.Name, parameter.Type, value);
     }
 
     static LoadLocal MakeLoadLocal(ImportedMethod method, int index)

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -23,6 +23,9 @@ public abstract class IrNode
     /// <summary>One-line description for tree dumps; no recursion into children.</summary>
     public abstract string Describe();
 
+    /// <summary>Types this node references directly (not via children) — the fidelity computation scans these, so a node holding an unsupported type can never report Full.</summary>
+    public virtual IEnumerable<TypeRef> DirectTypes => [];
+
     protected void AddChild(IrNode child)
     {
         Adopt(child, _children.Count);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -32,10 +32,18 @@ public sealed class IrFunction : IrNode
     public BlockContainer Body => (BlockContainer)Children[0];
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 
-    /// <summary>Computed from the tree, never asserted: any unsupported node or type ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
+    public override IEnumerable<TypeRef> DirectTypes
+        => Signature.Parameters.Select(p => p.Type)
+            .Append(Signature.ReturnType)
+            .Append(DeclaringType)
+            .Concat(Locals);
+
+    /// <summary>Computed from the tree, never asserted: any unsupported node or any unsupported type referenced anywhere ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
     public DecompilationFidelity Fidelity
-        => Descendants.OfType<UnsupportedNode>().Any()
-            || Descendants.OfType<IrExpression>().Any(e => e.ResultType?.ContainsUnsupported == true)
+        => Descendants.Prepend(this).Any(n =>
+            n is UnsupportedNode
+            || n.DirectTypes.Any(t => t.ContainsUnsupported)
+            || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
             ? DecompilationFidelity.Partial
             : DecompilationFidelity.Full;
 
@@ -216,6 +224,7 @@ public sealed class StoreArgument : IrNode
     public string Name { get; }
     public TypeRef Type { get; }
     public IrExpression Value => (IrExpression)Children[0];
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
 
     public override string Describe() => $"StoreArgument {Index} ({Type.ToDisplayString()} {Name})";
 }
@@ -247,6 +256,7 @@ public sealed class StoreLocal : IrNode
     public int Index { get; }
     public TypeRef Type { get; }
     public IrExpression Value => (IrExpression)Children[0];
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
 
     public override string Describe() => $"StoreLocal {Index} ({Type.ToDisplayString()})";
 }
@@ -312,6 +322,8 @@ public sealed class Call : IrExpression
     /// <summary>Arguments including the receiver for instance calls.</summary>
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
     public override TypeRef? ResultType => Callee.ReturnType;
+    public override IEnumerable<TypeRef> DirectTypes
+        => Callee.ParameterTypes.Append(Callee.DeclaringType).Append(Callee.ReturnType);
 
     public override string Describe()
         => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
@@ -330,6 +342,8 @@ public sealed class NewObject : IrExpression
     public MethodRef Constructor { get; }
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
     public override TypeRef? ResultType => Constructor.DeclaringType;
+    public override IEnumerable<TypeRef> DirectTypes
+        => Constructor.ParameterTypes.Append(Constructor.DeclaringType);
 
     public override string Describe() => $"NewObject {Constructor.DeclaringType.ToDisplayString()}";
 }
@@ -355,6 +369,7 @@ public sealed class LoadField : IrExpression
     public FieldRef Field { get; }
     public IrExpression? Instance => Children.Count > 0 ? (IrExpression)Children[0] : null;
     public override TypeRef? ResultType => Field.Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
 
     public override string Describe()
         => $"LoadField {Field.DeclaringType.ToDisplayString()}.{Field.Name} ({Field.Type.ToDisplayString()})";
@@ -375,6 +390,7 @@ public sealed class StoreField : IrNode
     public bool HasInstance { get; }
     public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
     public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+    public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
 
     public override string Describe() => $"StoreField {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
 }

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -13,10 +13,10 @@ public sealed record MethodRef(
 /// <summary>A materialized field reference.</summary>
 public sealed record FieldRef(TypeRef DeclaringType, string Name, TypeRef Type);
 
-/// <summary>The root of one method's IR: signature plus a body block, with diagnostics accumulated during construction and passes.</summary>
+/// <summary>The root of one method's IR: signature plus a body container, with diagnostics accumulated during construction and passes.</summary>
 public sealed class IrFunction : IrNode
 {
-    public IrFunction(string name, TypeRef declaringType, MethodSignature signature, ImmutableArray<TypeRef> locals, Block body)
+    public IrFunction(string name, TypeRef declaringType, MethodSignature signature, ImmutableArray<TypeRef> locals, BlockContainer body)
     {
         Name = name;
         DeclaringType = declaringType;
@@ -29,7 +29,7 @@ public sealed class IrFunction : IrNode
     public TypeRef DeclaringType { get; }
     public MethodSignature Signature { get; }
     public ImmutableArray<TypeRef> Locals { get; }
-    public Block Body => (Block)Children[0];
+    public BlockContainer Body => (BlockContainer)Children[0];
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 
     /// <summary>Computed from the tree, never asserted: any unsupported node or type ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
@@ -43,12 +43,136 @@ public sealed class IrFunction : IrNode
         => $"Function {Signature.ReturnType.ToDisplayString()} {Name}({string.Join(", ", Signature.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})";
 }
 
-/// <summary>A sequence of statement nodes.</summary>
+/// <summary>
+/// The basic blocks of a function in IL order. Execution falls through to
+/// the next block unless a block's last statement branches or returns —
+/// fallthrough is implicit, branches are explicit nodes.
+/// </summary>
+public sealed class BlockContainer : IrNode
+{
+    public void Add(Block block) => AddChild(block);
+
+    public IReadOnlyList<Block> Blocks => Children.Cast<Block>().ToList();
+
+    /// <summary>Index of the block starting at the given IL offset; -1 if none.</summary>
+    public int IndexOfOffset(int ilOffset)
+    {
+        for (int i = 0; i < Children.Count; i++)
+        {
+            if (((Block)Children[i]).StartOffset == ilOffset)
+                return i;
+        }
+        return -1;
+    }
+
+    public override string Describe() => "BlockContainer";
+}
+
+/// <summary>A sequence of statement nodes beginning at <see cref="StartOffset"/>.</summary>
 public sealed class Block : IrNode
 {
+    public Block(int startOffset = 0) => StartOffset = startOffset;
+
+    public int StartOffset { get; }
+
     public void Add(IrNode statement) => AddChild(statement);
 
-    public override string Describe() => "Block";
+    public override string Describe() => $"Block IL_{StartOffset:X4}";
+}
+
+/// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
+public sealed class Branch : IrNode
+{
+    public Branch(int targetOffset) => TargetOffset = targetOffset;
+
+    public int TargetOffset { get; }
+
+    public override string Describe() => $"Branch IL_{TargetOffset:X4}";
+}
+
+/// <summary>Branches to <see cref="TargetOffset"/> when the condition is true; falls through otherwise.</summary>
+public sealed class ConditionalBranch : IrNode
+{
+    public ConditionalBranch(IrExpression condition, int targetOffset)
+    {
+        TargetOffset = targetOffset;
+        AddChild(condition);
+    }
+
+    public IrExpression Condition => (IrExpression)Children[0];
+    public int TargetOffset { get; }
+
+    public override string Describe() => $"ConditionalBranch IL_{TargetOffset:X4}";
+}
+
+public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }
+
+public sealed class Comparison : IrExpression
+{
+    public Comparison(ComparisonKind kind, bool isUnsigned, IrExpression left, IrExpression right)
+    {
+        Kind = kind;
+        IsUnsigned = isUnsigned;
+        AddChild(left);
+        AddChild(right);
+    }
+
+    public ComparisonKind Kind { get; }
+    public bool IsUnsigned { get; }
+    public IrExpression Left => (IrExpression)Children[0];
+    public IrExpression Right => (IrExpression)Children[1];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+
+    public override string Describe() => $"Comparison.{Kind}{(IsUnsigned ? " unsigned" : "")}";
+}
+
+/// <summary>Logical negation of a truth-valued operand (the brfalse lowering; raising passes refine to comparisons).</summary>
+public sealed class LogicalNot : IrExpression
+{
+    public LogicalNot(IrExpression operand) => AddChild(operand);
+
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+
+    public override string Describe() => "LogicalNot";
+}
+
+public enum UnaryKind { Negate, BitwiseNot }
+
+public sealed class Unary : IrExpression
+{
+    public Unary(UnaryKind kind, IrExpression operand)
+    {
+        Kind = kind;
+        AddChild(operand);
+    }
+
+    public UnaryKind Kind { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Operand.ResultType;
+
+    public override string Describe() => $"Unary.{Kind}";
+}
+
+/// <summary>A numeric conversion (the conv.* family).</summary>
+public sealed class Convert : IrExpression
+{
+    public Convert(TypeRef target, bool isChecked, bool isUnsigned, IrExpression operand)
+    {
+        Target = target;
+        IsChecked = isChecked;
+        IsUnsigned = isUnsigned;
+        AddChild(operand);
+    }
+
+    public TypeRef Target { get; }
+    public bool IsChecked { get; }
+    public bool IsUnsigned { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Target;
+
+    public override string Describe()
+        => $"Convert {Target.ToDisplayString()}{(IsChecked ? " checked" : "")}{(IsUnsigned ? " unsigned" : "")}";
 }
 
 /// <summary>An expression evaluated for its side effects (void call, popped value).</summary>
@@ -76,6 +200,24 @@ public sealed class LoadArgument : IrExpression
     public override TypeRef? ResultType => Type;
 
     public override string Describe() => $"LoadArgument {Index} ({Type.ToDisplayString()} {Name})";
+}
+
+public sealed class StoreArgument : IrNode
+{
+    public StoreArgument(int index, string name, TypeRef type, IrExpression value)
+    {
+        Index = index;
+        Name = name;
+        Type = type;
+        AddChild(value);
+    }
+
+    public int Index { get; }
+    public string Name { get; }
+    public TypeRef Type { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => $"StoreArgument {Index} ({Type.ToDisplayString()} {Name})";
 }
 
 public sealed class LoadLocal : IrExpression
@@ -173,6 +315,32 @@ public sealed class Call : IrExpression
 
     public override string Describe()
         => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
+}
+
+/// <summary>Object construction: <c>newobj</c> with the constructor's MethodRef (receiver excluded from arguments).</summary>
+public sealed class NewObject : IrExpression
+{
+    public NewObject(MethodRef constructor, IEnumerable<IrExpression> arguments)
+    {
+        Constructor = constructor;
+        foreach (var argument in arguments)
+            AddChild(argument);
+    }
+
+    public MethodRef Constructor { get; }
+    public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => Constructor.DeclaringType;
+
+    public override string Describe() => $"NewObject {Constructor.DeclaringType.ToDisplayString()}";
+}
+
+public sealed class Throw : IrNode
+{
+    public Throw(IrExpression value) => AddChild(value);
+
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => "Throw";
 }
 
 public sealed class LoadField : IrExpression

--- a/src/DotnetInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -25,17 +25,18 @@ public static class MethodImporter
             if (FullName(reader, typeDef) != typeFullName)
                 continue;
 
+            // Overload indices count every name match, body or not (parity
+            // with legacy selection); a selected overload without a body is
+            // null, not silently the next one with a body.
             int seen = 0;
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != methodName)
                     continue;
-                if (method.RelativeVirtualAddress == 0)
-                    continue;
                 if (seen++ != overloadIndex)
                     continue;
-                return Import(source, typeDefHandle, methodHandle);
+                return method.RelativeVirtualAddress == 0 ? null : Import(source, typeDefHandle, methodHandle);
             }
             return null;
         }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 
 using DotnetInspector.Decompiler;
+using DotnetInspector.Decompiler.Pipeline;
 
 namespace DotnetInspector.DecompilerHarness;
 
@@ -36,12 +37,14 @@ static class Program
         int maxExamples = 5;
 
         string? dumpMethod = null;
+        string pipelineName = "current";
 
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
             {
                 case "--dump": dumpMethod = args[++i]; break;
+                case "--pipeline": pipelineName = args[++i]; break;
                 case "--baseline": baselineName = args[++i]; break;
                 case "--candidate": candidateName = args[++i]; break;
                 case "--report": reportPath = args[++i]; break;
@@ -61,6 +64,13 @@ static class Program
         var assemblies = ResolveAssemblies(inputs);
         if (assemblies.Count == 0)
             return Fail("No managed assemblies found in the given inputs.");
+
+        if (pipelineName.Equals("next", StringComparison.OrdinalIgnoreCase))
+        {
+            if (candidateName is not null)
+                return Fail("Diff mode against 'next' arrives with its C# printer; today 'next' supports inventory and --dump.");
+            return dumpMethod is not null ? DumpNext(assemblies, dumpMethod) : SweepNext(assemblies);
+        }
 
         if (dumpMethod is not null)
             return DumpStages(assemblies, dumpMethod);
@@ -112,6 +122,68 @@ static class Program
             Console.WriteLine($"JSON: {jsonPath}");
         }
         return 0;
+    }
+
+    /// <summary>
+    /// Inventory sweep of the replacement pipeline: fidelity histogram plus
+    /// the stop-reason buckets that ARE the prioritized slice roadmap.
+    /// </summary>
+    static int SweepNext(List<string> assemblies)
+    {
+        long total = 0, full = 0, crashes = 0;
+        var stops = new Dictionary<string, long>();
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath);
+            foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
+            {
+                total++;
+                if (function.Fidelity == DecompilationFidelity.Full)
+                {
+                    full++;
+                    continue;
+                }
+                var diagnostic = function.Diagnostics.FirstOrDefault();
+                if (diagnostic.Id == DiagnosticIds.InternalError)
+                {
+                    crashes++;
+                    Console.Error.WriteLine($"IMPORTER BUG: {diagnostic.Message}");
+                    continue;
+                }
+                string bucket = diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
+                stops[bucket] = stops.GetValueOrDefault(bucket) + 1;
+            }
+        }
+
+        Console.WriteLine($"next: {full}/{total} Full ({Percent(full, total)}); importer bugs: {crashes}");
+        Console.WriteLine("Top stop reasons (the slice roadmap):");
+        foreach (var stop in stops.OrderByDescending(s => s.Value).Take(15))
+            Console.WriteLine($"  {stop.Value,8}  {stop.Key}");
+        return crashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>Stage dump through the replacement pipeline: the IR tree with diagnostics and fidelity.</summary>
+    static int DumpNext(List<string> assemblies, string dumpMethod)
+    {
+        int separator = dumpMethod.IndexOf("::", StringComparison.Ordinal);
+        if (separator <= 0)
+            return Fail("--dump expects Namespace.Type::Method (metadata type name)");
+        string typeName = dumpMethod[..separator];
+        string methodName = dumpMethod[(separator + 2)..];
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath);
+            var function = IrImporter.Import(source, typeName, methodName);
+            if (function is null)
+                continue;
+            Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next)");
+            Console.WriteLine();
+            Console.WriteLine("==== IR (typed tree after import) ====");
+            Console.Write(IrPrinter.Dump(function));
+            return 0;
+        }
+        return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
     }
 
     /// <summary>
@@ -360,6 +432,8 @@ static class Program
         options:
           --dump <T::M>         print every stage projection for one method
                                 (e.g. --dump 'System.String::IsNullOrEmpty')
+          --pipeline <name>     'current' (default) or 'next' (replacement
+                                pipeline: fidelity inventory and IR dumps)
           --baseline <name>     pipeline to run (default: current)
           --candidate <name>    second pipeline; enables diff mode
           --report <path>       write a markdown report


### PR DESCRIPTION
## Summary

Slice 2 of the replacement pipeline: multi-block bodies. The CFG discipline ported onto the IR — leaders from an IL scan, `BlockContainer`/`Block` with explicit `Branch`/`ConditionalBranch` nodes (fallthrough implicit, branches explicit), per-block linear stack walk.

New nodes: `Comparison` (both branch-encoded `blt/bge/...` and value-producing `ceq/cgt/clt`, with unsigned flags), `LogicalNot` (the `brfalse` lowering, for raising passes to refine), `Convert` (the `conv.*` family with checked/unsigned), `Unary` (`neg`/`not`), `StoreArgument`, `NewObject`, `Throw`.

## The headline number

**CoreLib full sweep: 41,159 method bodies; 26,122 — 63.5% — import at `Full` fidelity.** `IsNullOrEmpty` (the corpus front door), `Math.Max`, `AbsShort` with its nested guard, `HashSet.Contains` — all `Full`, all `CheckInvariant`-clean, in both configs.

And the stop-reason histogram is the prioritized roadmap for slice 3, free of guesswork:

| Count | Stop reason |
| --- | --- |
| 3,081 | stack-carrying block boundaries (ternaries, `&&`/`||` values) |
| 1,825 | `ldloca` (address-of local) |
| 1,711 | `ldarga` |
| 1,059 | exception regions |
| 977 | `dup` |
| 695 | `ldflda` |
| 509 | `isinst` |

## The sweep as debugging instrument

`ImportAssembly` is the front door the harness registers as `next`. Its contract: one method's importer crash must not end an assembly sweep — crashes convert to diagnosed `Partial` functions carrying `DEC0001`. That contract immediately paid for itself: the first full sweep surfaced a 718-occurrence crash class (`Pop` on empty stack when a block's *entry* carries values), which is out-of-slice **input**, not a bug — it now stops honestly via a typed `OutOfSliceException` at the `Pop` site. The remaining **48 genuine importer bugs** (`Exception::.ctor`, `Random::.ctor`, …) stay visible by name in every sweep until fixed — pounds of IL, applied to the new pipeline from its second PR.

## Validation

- Decompiler suite 286/286 in both Debug and Release (multi-block tests: `IsNullOrEmpty` 3-block shape with branch-target verification, branching fixtures at `Full`, exception regions stop honestly, corpus set at `Full`)
- Sweep numbers above; still present-but-unwired from product paths

Next: harness `next` registration (the layer-by-layer comparison goes live), then slice 3 by histogram order — stack-carrying edges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)