### PR TITLE
Slice 3: stack-carrying edges, dup, MethodSpec, token-operand nodes

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -179,7 +179,16 @@ public class IrImporterTests
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
         var genericCall = function.Descendants.OfType<Call>().First(c => !c.Callee.TypeArguments.IsEmpty);
         Assert.NotEqual("?", genericCall.Callee.Name);
+        // The call site reports instantiated types, not the callee's formal
+        // !!N parameters (second-review fix).
+        Assert.False(ContainsGenericParameter(genericCall.Callee.ReturnType));
+        Assert.All(genericCall.Callee.ParameterTypes, p => Assert.False(ContainsGenericParameter(p)));
     }
+
+    static bool ContainsGenericParameter(TypeRef type)
+        => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
+            || (type.ElementType is { } element && ContainsGenericParameter(element))
+            || type.TypeArguments.Any(ContainsGenericParameter);
 
     [Fact]
     public void CoreLib_SimpleCorpusMethods_ImportAtFullFidelity()

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -150,6 +150,38 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void CoreLib_Ternary_ImportsViaStackSlots()
+    {
+        // 'TargetFrameworkName ??= ...' carries a value across block
+        // boundaries — the canonical stack-carrying edge, materialized
+        // through position-indexed slots so every predecessor of the join
+        // stores to the same slot.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.AppContext", "get_TargetFrameworkName");
+
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.NotEmpty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.NotEmpty(function.Descendants.OfType<LoadStackSlot>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CoreLib_GenericMethodCall_ResolvesMethodSpecification()
+    {
+        // Array.get_Length calls Unsafe.As<...> — a MethodSpecification.
+        // Unresolved, its arity-0 fallback mis-popped the stack and poisoned
+        // everything downstream (2,484 false stops in the CoreLib sweep).
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.Array", "get_Length");
+
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var genericCall = function.Descendants.OfType<Call>().First(c => !c.Callee.TypeArguments.IsEmpty);
+        Assert.NotEqual("?", genericCall.Callee.Name);
+    }
+
+    [Fact]
     public void CoreLib_SimpleCorpusMethods_ImportAtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);
@@ -157,6 +189,7 @@ public class IrImporterTests
         [
             ("System.String", "IsNullOrEmpty"),
             ("System.Math", "Max"),
+            ("System.Math", "Clamp"),
             ("System.Text.StringBuilder", "Clear"),
             ("System.Collections.Generic.HashSet`1", "Contains"),
         ];

--- a/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -109,6 +109,26 @@ public class TypeRefTests
     }
 
     [Fact]
+    public void Instantiate_SubstitutesGenericParametersThroughShapes()
+    {
+        var intRef = TypeRef.CoreLib("System", "Int32");
+        var listDef = TypeRef.CoreLib("System.Collections.Generic", "List`1");
+        var typeParam = TypeRef.GenericParameter(0, "T");
+        var methodParam = TypeRef.MethodGenericParameter(0, "TResult");
+
+        Assert.Equal(intRef, typeParam.Instantiate([intRef], []));
+        Assert.Equal(intRef, methodParam.Instantiate([], [intRef]));
+        Assert.Equal(
+            TypeRef.GenericInstance(listDef, [intRef]),
+            TypeRef.GenericInstance(listDef, [typeParam]).Instantiate([intRef], []));
+        Assert.Equal(
+            TypeRef.ByRef(intRef),
+            TypeRef.ByRef(methodParam).Instantiate([], [intRef]));
+        // No substitution: same instance back, no churn.
+        Assert.Same(intRef, intRef.Instantiate([TypeRef.CoreLib("System", "String")], []));
+    }
+
+    [Fact]
     public void Equality_GenericParameterName_IsNamingAidNotIdentity()
     {
         Assert.Equal(TypeRef.GenericParameter(0, "T"), TypeRef.GenericParameter(0, "TKey"));

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -119,12 +119,13 @@ public static class IrImporter
 
         var span = method.Body.IL.AsSpan();
         var leaders = FindLeaders(span);
+        var state = new BuildState();
 
         foreach (int leader in leaders)
         {
             var block = new Block(leader);
             container.Add(block);
-            if (!BuildBlock(source, method, function, block, span, leader, NextLeader(leaders, leader, span.Length), callerScope))
+            if (!BuildBlock(source, method, function, block, span, leader, NextLeader(leaders, leader, span.Length), callerScope, state))
                 return function;  // honest stop already recorded
         }
 
@@ -166,13 +167,66 @@ public static class IrImporter
         return ilLength;
     }
 
+    /// <summary>Cross-block import state: stack types at block entries, blocks already built, and the dup slot counter.</summary>
+    sealed class BuildState
+    {
+        public Dictionary<int, List<TypeRef?>> EntryStacks { get; } = [];
+        public HashSet<int> Built { get; } = [];
+        public int NextDupSlot { get; set; } = StoreStackSlot.DupSlotBase;
+    }
+
+    /// <summary>
+    /// Spills the leftover evaluation stack into position-indexed slots and
+    /// records the entry stack of every target. Position indexing makes all
+    /// predecessors of a join store to the same slots. Returns false on a
+    /// depth disagreement or a stack-carrying back edge (out of slice).
+    /// </summary>
+    static bool PropagateAndSpill(IrFunction function, Block body, Stack<IrExpression> stack, BuildState state, int[] targets, int offset)
+    {
+        var values = stack.Reverse().ToArray();
+        stack.Clear();
+        var types = values.Select(v => v.ResultType).ToList();
+        for (int i = 0; i < values.Length; i++)
+            body.Add(new StoreStackSlot(i, values[i]));
+        foreach (int target in targets)
+        {
+            if (state.EntryStacks.TryGetValue(target, out var existing))
+            {
+                if (existing.Count != types.Count)
+                {
+                    Stop(function, body, stack, offset, "(join)",
+                        "evaluation-stack depth disagrees between paths into a join, outside the slice");
+                    return false;
+                }
+            }
+            else if (state.Built.Contains(target) && types.Count > 0)
+            {
+                Stop(function, body, stack, offset, "(back edge)",
+                    "stack-carrying back edge, outside the slice");
+                return false;
+            }
+            else
+            {
+                state.EntryStacks[target] = types;
+            }
+        }
+        return true;
+    }
+
     /// <summary>Builds one block. Returns false when the import stopped honestly inside it.</summary>
     static bool BuildBlock(MetadataSource source, ImportedMethod method, IrFunction function, Block body,
-        ReadOnlySpan<byte> il, int start, int end, GenericScope callerScope)
+        ReadOnlySpan<byte> il, int start, int end, GenericScope callerScope, BuildState state)
     {
         var stack = new Stack<IrExpression>();
         var reader = new ILReaderLite(il[..end], currentOffset: start);
         int offset = start;
+
+        // Entry values arrive in position-indexed slots stored by predecessors.
+        state.Built.Add(start);
+        var entry = state.EntryStacks.TryGetValue(start, out var carried) ? carried : [];
+        state.EntryStacks[start] = entry;
+        for (int i = 0; i < entry.Count; i++)
+            stack.Push(new LoadStackSlot(i, entry[i]));
 
         try
         {
@@ -285,6 +339,13 @@ public static class IrImporter
                 case ILOpCode.Call or ILOpCode.Callvirt:
                 {
                     var callee = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    if (callee.DeclaringType.Kind == TypeRefKind.Unsupported)
+                    {
+                        // Unknown arity would mis-pop the stack and corrupt
+                        // everything downstream — stop here instead.
+                        Stop(function, body, stack, offset, "call", $"unresolvable callee: {callee.DeclaringType.UnsupportedReason}");
+                        return false;
+                    }
                     int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
@@ -328,10 +389,18 @@ public static class IrImporter
                 }
 
                 case ILOpCode.Throw:
+                {
                     // A leader follows every throw (FindLeaders), so the block
-                    // ends here and unreachable IL lands in its own block.
-                    body.Add(new Throw(Pop(stack)));
+                    // ends here and unreachable IL lands in its own block. Any
+                    // pending stack values were evaluated before the exception
+                    // argument; they spill as statements in evaluation order.
+                    var thrown = Pop(stack);
+                    foreach (var pending in stack.Reverse())
+                        body.Add(new ExpressionStatement(pending));
+                    stack.Clear();
+                    body.Add(new Throw(thrown));
                     break;
+                }
 
                 case ILOpCode.Neg:
                     stack.Push(new Unary(UnaryKind.Negate, Pop(stack)));
@@ -340,20 +409,73 @@ public static class IrImporter
                     stack.Push(new Unary(UnaryKind.BitwiseNot, Pop(stack)));
                     break;
 
+                case ILOpCode.Dup:
+                {
+                    // Trees cannot share nodes: dup materializes through a slot.
+                    var value = Pop(stack);
+                    int slot = state.NextDupSlot++;
+                    body.Add(new StoreStackSlot(slot, value));
+                    stack.Push(new LoadStackSlot(slot, value.ResultType));
+                    stack.Push(new LoadStackSlot(slot, value.ResultType));
+                    break;
+                }
+
+                case ILOpCode.Ldlen:
+                    stack.Push(new ArrayLength(Pop(stack)));
+                    break;
+
+                case ILOpCode.Box:
+                    stack.Push(new Box(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope), Pop(stack)));
+                    break;
+
+                case ILOpCode.Isinst:
+                    stack.Push(new IsInstance(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope), Pop(stack)));
+                    break;
+
+                case ILOpCode.Castclass:
+                    stack.Push(new CastClass(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope), Pop(stack)));
+                    break;
+
+                case ILOpCode.Newarr:
+                {
+                    var elementType = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    stack.Push(new NewArray(elementType, Pop(stack)));
+                    break;
+                }
+
+                case ILOpCode.Ldtoken:
+                {
+                    var handle = MetadataTokens.EntityHandle(reader.ReadILToken());
+                    stack.Push(handle.Kind is HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification
+                        ? new LoadToken(ResolveTypeToken(source.Reader, handle, callerScope), ResolveTypeToken(source.Reader, handle, callerScope).ToDisplayString())
+                        : new LoadToken(null, $"{handle.Kind} token"));
+                    break;
+                }
+
                 case ILOpCode.Pop:
                     body.Add(new ExpressionStatement(Pop(stack)));
                     break;
 
                 case ILOpCode.Br or ILOpCode.Br_s:
-                    body.Add(new Branch(reader.ReadBranchDestination(opcode)));
+                {
+                    int target = reader.ReadBranchDestination(opcode);
+                    if (!PropagateAndSpill(function, body, stack, state, [target], offset))
+                        return false;
+                    body.Add(new Branch(target));
                     break;
+                }
 
-                case ILOpCode.Brtrue or ILOpCode.Brtrue_s:
-                    body.Add(new ConditionalBranch(Pop(stack), reader.ReadBranchDestination(opcode)));
+                case ILOpCode.Brtrue or ILOpCode.Brtrue_s or ILOpCode.Brfalse or ILOpCode.Brfalse_s:
+                {
+                    var condition = Pop(stack);
+                    if (opcode is ILOpCode.Brfalse or ILOpCode.Brfalse_s)
+                        condition = new LogicalNot(condition);
+                    int target = reader.ReadBranchDestination(opcode);
+                    if (!PropagateAndSpill(function, body, stack, state, [target, end], offset))
+                        return false;
+                    body.Add(new ConditionalBranch(condition, target));
                     break;
-                case ILOpCode.Brfalse or ILOpCode.Brfalse_s:
-                    body.Add(new ConditionalBranch(new LogicalNot(Pop(stack)), reader.ReadBranchDestination(opcode)));
-                    break;
+                }
 
                 case >= ILOpCode.Beq_s and <= ILOpCode.Blt_un_s or >= ILOpCode.Beq and <= ILOpCode.Blt_un:
                 {
@@ -361,6 +483,8 @@ public static class IrImporter
                     var right = Pop(stack);
                     var left = Pop(stack);
                     var (kind, isUnsigned) = ComparisonOf(opcode);
+                    if (!PropagateAndSpill(function, body, stack, state, [target, end], offset))
+                        return false;
                     body.Add(new ConditionalBranch(new Comparison(kind, isUnsigned, left, right), target));
                     break;
                 }
@@ -385,9 +509,13 @@ public static class IrImporter
 
         if (stack.Count > 0)
         {
-            Stop(function, body, stack, end, "(block boundary)",
-                "evaluation stack carries values across a block boundary, outside the slice");
-            return false;
+            if (end >= il.Length)
+            {
+                Stop(function, body, stack, end, "(method end)",
+                    "evaluation stack is not empty at the end of the method");
+                return false;
+            }
+            return PropagateAndSpill(function, body, stack, state, [end], end);
         }
         return true;
     }
@@ -507,6 +635,14 @@ public static class IrImporter
                 var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
                 return new MethodRef(declaring, reader.GetString(member.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
             }
+            case HandleKind.MethodSpecification:
+            {
+                // A generic method instantiation: resolve the underlying
+                // method, then attach the decoded type arguments.
+                var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                var generic = ResolveMethod(reader, spec.Method, callerScope);
+                return generic with { TypeArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope) };
+            }
             default:
                 return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
         }
@@ -533,6 +669,14 @@ public static class IrImporter
                 return new FieldRef(TypeRef.Unsupported($"field handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown field type"));
         }
     }
+
+    static TypeRef ResolveTypeToken(MetadataReader reader, EntityHandle handle, GenericScope callerScope) => handle.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)handle, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, callerScope, (TypeSpecificationHandle)handle, 0),
+        _ => TypeRef.Unsupported($"type token kind {handle.Kind}"),
+    };
 
     static TypeRef ResolveParentType(MetadataReader reader, EntityHandle parent, GenericScope callerScope) => parent.Kind switch
     {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -198,6 +198,26 @@ public static class IrImporter
                         "evaluation-stack depth disagrees between paths into a join, outside the slice");
                     return false;
                 }
+                for (int i = 0; i < types.Count; i++)
+                {
+                    if (Equals(existing[i], types[i]) || types[i] is null)
+                        continue;
+                    if (existing[i] is null)
+                    {
+                        if (!state.Built.Contains(target))
+                            existing[i] = types[i];
+                        continue;
+                    }
+                    if (state.Built.Contains(target))
+                    {
+                        // The join was already built with the first type; a
+                        // conflicting later edge cannot be retyped honestly.
+                        Stop(function, body, stack, offset, "(join)",
+                            "evaluation-stack types disagree between paths into a join, outside the slice");
+                        return false;
+                    }
+                    existing[i] = null;  // unknown — honest, never a guess
+                }
             }
             else if (state.Built.Contains(target) && types.Count > 0)
             {
@@ -446,9 +466,45 @@ public static class IrImporter
                 case ILOpCode.Ldtoken:
                 {
                     var handle = MetadataTokens.EntityHandle(reader.ReadILToken());
-                    stack.Push(handle.Kind is HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification
-                        ? new LoadToken(ResolveTypeToken(source.Reader, handle, callerScope), ResolveTypeToken(source.Reader, handle, callerScope).ToDisplayString())
-                        : new LoadToken(null, $"{handle.Kind} token"));
+                    switch (handle.Kind)
+                    {
+                        case HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification:
+                        {
+                            var type = ResolveTypeToken(source.Reader, handle, callerScope);
+                            stack.Push(new LoadToken(RuntimeTokenKind.Type, type, type.ToDisplayString()));
+                            break;
+                        }
+                        case HandleKind.MethodDefinition or HandleKind.MethodSpecification:
+                        {
+                            var callee = ResolveMethod(source.Reader, handle, callerScope);
+                            stack.Push(new LoadToken(RuntimeTokenKind.Method, null, $"{callee.DeclaringType.ToDisplayString()}.{callee.Name}"));
+                            break;
+                        }
+                        case HandleKind.FieldDefinition:
+                        {
+                            var field = ResolveField(source.Reader, handle, callerScope);
+                            stack.Push(new LoadToken(RuntimeTokenKind.Field, null, $"{field.DeclaringType.ToDisplayString()}.{field.Name}"));
+                            break;
+                        }
+                        case HandleKind.MemberReference:
+                        {
+                            var member = source.Reader.GetMemberReference((MemberReferenceHandle)handle);
+                            if (member.GetKind() == MemberReferenceKind.Field)
+                            {
+                                var field = ResolveField(source.Reader, handle, callerScope);
+                                stack.Push(new LoadToken(RuntimeTokenKind.Field, null, $"{field.DeclaringType.ToDisplayString()}.{field.Name}"));
+                            }
+                            else
+                            {
+                                var callee = ResolveMethod(source.Reader, handle, callerScope);
+                                stack.Push(new LoadToken(RuntimeTokenKind.Method, null, $"{callee.DeclaringType.ToDisplayString()}.{callee.Name}"));
+                            }
+                            break;
+                        }
+                        default:
+                            Stop(function, body, stack, offset, "ldtoken", $"unrepresentable token kind {handle.Kind}");
+                            return false;
+                    }
                     break;
                 }
 
@@ -633,15 +689,31 @@ public static class IrImporter
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
                 var declaring = ResolveParentType(reader, member.Parent, callerScope);
                 var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
-                return new MethodRef(declaring, reader.GetString(member.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
+                // The signature's !N are the declaring type's parameters;
+                // instantiate them against the parent's type arguments so a
+                // call on List<int> reports int, not T.
+                var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
+                return new MethodRef(
+                    declaring,
+                    reader.GetString(member.Name),
+                    signature.ReturnType.Instantiate(typeArguments, []),
+                    [.. signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, []))],
+                    signature.Header.IsInstance);
             }
             case HandleKind.MethodSpecification:
             {
                 // A generic method instantiation: resolve the underlying
-                // method, then attach the decoded type arguments.
+                // method, then instantiate its !!N against the decoded type
+                // arguments so the call site reports concrete types.
                 var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
                 var generic = ResolveMethod(reader, spec.Method, callerScope);
-                return generic with { TypeArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope) };
+                var methodArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope);
+                return generic with
+                {
+                    TypeArguments = methodArguments,
+                    ReturnType = generic.ReturnType.Instantiate([], methodArguments),
+                    ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
+                };
             }
             default:
                 return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
@@ -663,7 +735,10 @@ public static class IrImporter
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
                 var declaring = ResolveParentType(reader, member.Parent, callerScope);
-                return new FieldRef(declaring, reader.GetString(member.Name), member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+                var fieldType = member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                if (declaring.Kind == TypeRefKind.GenericInstance)
+                    fieldType = fieldType.Instantiate(declaring.TypeArguments, []);
+                return new FieldRef(declaring, reader.GetString(member.Name), fieldType);
             }
             default:
                 return new FieldRef(TypeRef.Unsupported($"field handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown field type"));

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -8,7 +8,11 @@ public sealed record MethodRef(
     string Name,
     TypeRef ReturnType,
     ImmutableArray<TypeRef> ParameterTypes,
-    bool HasThis);
+    bool HasThis)
+{
+    /// <summary>Generic method type arguments (MethodSpec instantiations); empty for non-generic callees.</summary>
+    public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
+}
 
 /// <summary>A materialized field reference.</summary>
 public sealed record FieldRef(TypeRef DeclaringType, string Name, TypeRef Type);
@@ -323,7 +327,7 @@ public sealed class Call : IrExpression
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
     public override TypeRef? ResultType => Callee.ReturnType;
     public override IEnumerable<TypeRef> DirectTypes
-        => Callee.ParameterTypes.Append(Callee.DeclaringType).Append(Callee.ReturnType);
+        => Callee.ParameterTypes.Concat(Callee.TypeArguments).Append(Callee.DeclaringType).Append(Callee.ReturnType);
 
     public override string Describe()
         => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
@@ -406,6 +410,135 @@ public sealed class Return : IrNode
     public IrExpression? Value => Children.Count > 0 ? (IrExpression)Children[0] : null;
 
     public override string Describe() => "Return";
+}
+
+/// <summary>
+/// A synthetic variable carrying an evaluation-stack value across a block
+/// boundary (ternaries, short-circuit values) or materializing a dup.
+/// Edge slots are position-indexed so every predecessor of a join stores to
+/// the same slot; dup slots allocate from <see cref="DupSlotBase"/> up.
+/// </summary>
+public sealed class StoreStackSlot : IrNode
+{
+    public const int DupSlotBase = 256;
+
+    public StoreStackSlot(int slot, IrExpression value)
+    {
+        Slot = slot;
+        AddChild(value);
+    }
+
+    public int Slot { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => $"StoreStackSlot S_{Slot}";
+}
+
+public sealed class LoadStackSlot : IrExpression
+{
+    public LoadStackSlot(int slot, TypeRef? type)
+    {
+        Slot = slot;
+        Type = type;
+    }
+
+    public int Slot { get; }
+    public TypeRef? Type { get; }
+    public override TypeRef? ResultType => Type;
+
+    public override string Describe() => $"LoadStackSlot S_{Slot}";
+}
+
+public sealed class ArrayLength : IrExpression
+{
+    public ArrayLength(IrExpression array) => AddChild(array);
+
+    public IrExpression Array => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Int32");
+
+    public override string Describe() => "ArrayLength";
+}
+
+public sealed class Box : IrExpression
+{
+    public Box(TypeRef type, IrExpression operand)
+    {
+        Type = type;
+        AddChild(operand);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Object");
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"Box {Type.ToDisplayString()}";
+}
+
+/// <summary>The isinst test producing the cast-or-null value (raising refines to is-patterns or as-casts).</summary>
+public sealed class IsInstance : IrExpression
+{
+    public IsInstance(TypeRef type, IrExpression operand)
+    {
+        Type = type;
+        AddChild(operand);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"IsInstance {Type.ToDisplayString()}";
+}
+
+public sealed class CastClass : IrExpression
+{
+    public CastClass(TypeRef type, IrExpression operand)
+    {
+        Type = type;
+        AddChild(operand);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"CastClass {Type.ToDisplayString()}";
+}
+
+public sealed class NewArray : IrExpression
+{
+    public NewArray(TypeRef elementType, IrExpression length)
+    {
+        ElementType = elementType;
+        AddChild(length);
+    }
+
+    public TypeRef ElementType { get; }
+    public IrExpression Length => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.SzArray(ElementType);
+
+    public override string Describe() => $"NewArray {ElementType.ToDisplayString()}[]";
+}
+
+/// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
+public sealed class LoadToken : IrExpression
+{
+    public LoadToken(TypeRef? type, string display)
+    {
+        Type = type;
+        Display = display;
+    }
+
+    /// <summary>The token's type when it is a type token; null for method/field tokens.</summary>
+    public TypeRef? Type { get; }
+    public string Display { get; }
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", Type is null ? "RuntimeHandle" : "RuntimeTypeHandle");
+    public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
+
+    public override string Describe() => $"LoadToken {Display}";
 }
 
 /// <summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -523,22 +523,32 @@ public sealed class NewArray : IrExpression
     public override string Describe() => $"NewArray {ElementType.ToDisplayString()}[]";
 }
 
+public enum RuntimeTokenKind { Type, Method, Field }
+
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
 public sealed class LoadToken : IrExpression
 {
-    public LoadToken(TypeRef? type, string display)
+    public LoadToken(RuntimeTokenKind kind, TypeRef? type, string display)
     {
+        Kind = kind;
         Type = type;
         Display = display;
     }
 
+    public RuntimeTokenKind Kind { get; }
+
     /// <summary>The token's type when it is a type token; null for method/field tokens.</summary>
     public TypeRef? Type { get; }
     public string Display { get; }
-    public override TypeRef? ResultType => TypeRef.CoreLib("System", Type is null ? "RuntimeHandle" : "RuntimeTypeHandle");
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", Kind switch
+    {
+        RuntimeTokenKind.Type => "RuntimeTypeHandle",
+        RuntimeTokenKind.Method => "RuntimeMethodHandle",
+        _ => "RuntimeFieldHandle",
+    });
     public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
 
-    public override string Describe() => $"LoadToken {Display}";
+    public override string Describe() => $"LoadToken {Kind} {Display}";
 }
 
 /// <summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/TypeRef.cs
@@ -104,6 +104,43 @@ public sealed class TypeRef : IEquatable<TypeRef>
     public static TypeRef Unsupported(string reason)
         => new(TypeRefKind.Unsupported) { UnsupportedReason = reason };
 
+    /// <summary>
+    /// Substitutes generic parameters with the given arguments (type
+    /// parameters from a generic instantiation, method parameters from a
+    /// MethodSpec). Returns this instance when nothing substitutes.
+    /// </summary>
+    public TypeRef Instantiate(ImmutableArray<TypeRef> typeArguments, ImmutableArray<TypeRef> methodArguments)
+    {
+        switch (Kind)
+        {
+            case TypeRefKind.GenericParameter when GenericParameterIndex >= 0 && GenericParameterIndex < typeArguments.Length:
+                return typeArguments[GenericParameterIndex];
+            case TypeRefKind.MethodGenericParameter when GenericParameterIndex >= 0 && GenericParameterIndex < methodArguments.Length:
+                return methodArguments[GenericParameterIndex];
+            case TypeRefKind.SzArray or TypeRefKind.Array or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+            {
+                var element = ElementType!.Instantiate(typeArguments, methodArguments);
+                return ReferenceEquals(element, ElementType) ? this : new TypeRef(Kind) { ElementType = element, Rank = Rank };
+            }
+            case TypeRefKind.GenericInstance:
+            {
+                var definition = ElementType!.Instantiate(typeArguments, methodArguments);
+                var arguments = TypeArguments;
+                bool changed = !ReferenceEquals(definition, ElementType);
+                var builder = ImmutableArray.CreateBuilder<TypeRef>(arguments.Length);
+                foreach (var argument in arguments)
+                {
+                    var substituted = argument.Instantiate(typeArguments, methodArguments);
+                    changed |= !ReferenceEquals(substituted, argument);
+                    builder.Add(substituted);
+                }
+                return changed ? GenericInstance(definition, builder.MoveToImmutable()) : this;
+            }
+            default:
+                return this;
+        }
+    }
+
     /// <summary>True if this type or any constituent shape is <see cref="TypeRefKind.Unsupported"/> (feeds the fidelity computation).</summary>
     public bool ContainsUnsupported =>
         Kind == TypeRefKind.Unsupported

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -21,8 +21,15 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/shared/Microsoft.NETCore.App/11.0.0 \
   --report harness.md --json harness.json
 
-# Diff mode, once the replacement pipeline registers under "next"
-dotnet run --project tools/DecompilerHarness -c Release -- --candidate next
+# Replacement-pipeline inventory: fidelity histogram + stop-reason roadmap
+dotnet run --project tools/DecompilerHarness -c Release -- --pipeline next
+
+# Replacement-pipeline IR dump for one method
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --pipeline next --dump 'System.String::IsNullOrEmpty'
+
+# Diff mode (--candidate next) activates when the replacement pipeline
+# grows its C# printer
 
 # Stage-by-stage dump of one method (metadata type name)
 dotnet run --project tools/DecompilerHarness -c Release -- \


### PR DESCRIPTION
## Summary

Slice 3, taken in stop-histogram order from #467.

**Stack-carrying edges** — the histogram's top entry (2,954). Leftover evaluation-stack values at block boundaries (ternaries, `&&`/`||` values, `??`) materialize through position-indexed `StoreStackSlot`/`LoadStackSlot` pairs: every predecessor of a join stores to the same slots, the successor's entry loads them. The importer propagates entry-stack types per edge, with honest `DEC0004` stops for genuine out-of-slice shapes (depth disagreements between paths, stack-carrying back edges). `dup` spills through a slot from a separate counter range — trees cannot share nodes, so materialization is the honest representation.

**The biggest single win was a resolution gap, found by the sweep.** `MethodSpecification` callees (generic method instantiations — `Unsafe.As<T>`, everywhere in CoreLib) fell to the arity-0 unsupported fallback, silently mis-popping the stack; 2,484 false "(method end)" stops traced to it. MethodSpecs now resolve to the underlying method with decoded `TypeArguments` on `MethodRef`, and calls with unresolvable callees stop honestly rather than mis-pop.

**Token-operand nodes**: `ArrayLength`, `Box`, `IsInstance`, `CastClass`, `NewArray`, `LoadToken` — each trivial, each a histogram entry.

## Numbers

| | #467 | this PR |
| --- | --- | --- |
| CoreLib Full fidelity | 63.4% | **75.6%** (31,101/41,159) |
| Importer bugs | 0 | 0 |

Remaining histogram (the slice-4 docket): the address-of family (`ldloca`/`ldarga`/`ldflda`/`ldelema`, ~4,900 — needs a real `AddressOf` design, not just nodes), exception regions (1,059), `unbox.any`/`ldelem`/`ldobj`, and the IL prefixes (`constrained.`, `volatile.`).

## Validation

- Decompiler suite 292/292 in both Debug and Release (new: ternary-via-slots on a real coalescing method, MethodSpec resolution pinned against `Array.get_Length`, `Math.Clamp` added to the Full-fidelity corpus list)
- `--pipeline next` harness inventory confirms the sweep numbers; exit code stays wired to importer bugs for CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)