### PR TITLE
Slice 4: address-of family, indirection, elements, prefixes, switch

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -244,6 +244,14 @@ public class CfgSampleClass
 
     public static void Noop() { }
 
+    public static int ParseOrZero(string s) => int.TryParse(s, out var v) ? v : 0;
+
+    public static int FirstElement(int[] a) => a[0];
+
+    public static void SetFirstElement(int[] a, int v) => a[0] = v;
+
+    public static int PowerOfTwo(int x) => x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 };
+
     [System.Runtime.InteropServices.DllImport("nonexistent")]
     private static extern void Overloaded(int x);
 

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -267,3 +267,55 @@ public class IrImporterTests
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
 }
+
+public class JoinTypeConflictTests : IDisposable
+{
+    readonly Stack<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        while (_disposables.Count > 0)
+            _disposables.Pop().Dispose();
+    }
+
+    IrFunction BuildSynthetic(byte[] il)
+    {
+        var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        _disposables.Push(source);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var method = new ImportedMethod(
+            TypeRef.CoreLib("Synthetic", "T"), "M", signature,
+            new MethodBody([.. il], MaxStack: 8, Locals: [], LocalNames: [], Handlers: []));
+        return IrImporter.Build(source, method, GenericScope.Empty);
+    }
+
+    [Fact]
+    public void JoinTypeConflict_BeforeJoinIsBuilt_MergesToHonestUnknown()
+    {
+        // ldc.i4.1; brtrue.s L1; ldc.i4.0; br.s J; L1: ldnull; J: pop; ret
+        // Two forward edges carry int and object into J: pre-build conflict
+        // merges to null (honest unknown), never a guessed type.
+        var function = BuildSynthetic([0x17, 0x2D, 0x03, 0x16, 0x2B, 0x01, 0x14, 0x26, 0x2A]);
+
+        Assert.Empty(function.Diagnostics);
+        var load = Assert.Single(function.Descendants.OfType<LoadStackSlot>(),
+            l => l.Parent is ExpressionStatement);
+        Assert.Null(load.Type);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void JoinTypeConflict_AfterJoinIsBuilt_StopsHonestly()
+    {
+        // ldc.i4.0; br.s J; J: pop; ret; (unreachable) ldnull; br.s J
+        // The join is built with int before the object-carrying edge arrives;
+        // already-emitted loads cannot be retyped, so the import stops.
+        var function = BuildSynthetic([0x16, 0x2B, 0x00, 0x26, 0x2A, 0x14, 0x2B, 0xFB]);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedConstruct, diagnostic.Id);
+        Assert.Contains("types disagree", diagnostic.Message);
+        function.CheckInvariant();
+    }
+}

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -191,6 +191,44 @@ public class IrImporterTests
             || type.TypeArguments.Any(ContainsGenericParameter);
 
     [Fact]
+    public void AddressOf_OutArgument_ImportsAsLocalAddress()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.ParseOrZero));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var address = function.Descendants.OfType<LoadLocalAddress>().First();
+        Assert.Equal("ref int", address.ResultType?.ToDisplayString());
+        var call = function.Descendants.OfType<Call>().First(c => c.Callee.Name == "TryParse");
+        Assert.Contains(call.Arguments, a => a is LoadLocalAddress);
+    }
+
+    [Fact]
+    public void ElementAccess_ImportsTypedLoadAndStore()
+    {
+        var load = ImportFixture(nameof(CfgSampleClass.FirstElement));
+        var store = ImportFixture(nameof(CfgSampleClass.SetFirstElement));
+
+        Assert.Equal(DecompilationFidelity.Full, load.Fidelity);
+        Assert.Equal("int", Assert.Single(load.Descendants.OfType<LoadElement>()).ResultType?.ToDisplayString());
+        Assert.Equal(DecompilationFidelity.Full, store.Fidelity);
+        Assert.Single(store.Descendants.OfType<StoreElement>());
+    }
+
+    [Fact]
+    public void Switch_ImportsWithTargetsAsLeaders()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.PowerOfTwo));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var switchBranch = Assert.Single(function.Descendants.OfType<SwitchBranch>());
+        Assert.True(switchBranch.TargetOffsets.Length >= 4);
+        // Every switch target starts a block.
+        Assert.All(switchBranch.TargetOffsets,
+            target => Assert.True(function.Body.IndexOfOffset(target) >= 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void CoreLib_SimpleCorpusMethods_ImportAtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -147,6 +147,18 @@ public static class IrImporter
                 if (reader.Offset < il.Length)
                     leaders.Add(reader.Offset);
             }
+            else if (opcode == ILOpCode.Switch)
+            {
+                uint count = reader.ReadILUInt32();
+                var raw = new int[count];
+                for (int i = 0; i < count; i++)
+                    raw[i] = (int)reader.ReadILUInt32();
+                int next = reader.Offset;
+                foreach (int target in raw)
+                    leaders.Add(next + target);
+                if (next < il.Length)
+                    leaders.Add(next);
+            }
             else
             {
                 reader.Skip(opcode);
@@ -240,6 +252,8 @@ public static class IrImporter
         var stack = new Stack<IrExpression>();
         var reader = new ILReaderLite(il[..end], currentOffset: start);
         int offset = start;
+        TypeRef? constrainedTo = null;
+        bool volatilePrefix = false, readonlyPrefix = false;
 
         // Entry values arrive in position-indexed slots stored by predecessors.
         state.Built.Add(start);
@@ -256,6 +270,21 @@ public static class IrImporter
             var opcode = reader.ReadILOpcode();
             switch (opcode)
             {
+                case ILOpCode.Constrained:
+                    constrainedTo = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    continue;
+                case ILOpCode.Volatile:
+                    volatilePrefix = true;
+                    continue;
+                case ILOpCode.Readonly:
+                    readonlyPrefix = true;
+                    continue;
+                case ILOpCode.Unaligned:
+                    // Alignment is a JIT hint with no source-level meaning;
+                    // the operand byte is consumed and the access proceeds.
+                    reader.ReadILByte();
+                    continue;
+
                 case ILOpCode.Nop:
                     break;
 
@@ -307,6 +336,35 @@ public static class IrImporter
                 case ILOpCode.Ldc_i8:
                     stack.Push(new Constant((long)reader.ReadILUInt64(), TypeRef.CoreLib("System", "Int64")));
                     break;
+                case ILOpCode.Ldc_r4:
+                    stack.Push(new Constant(BitConverter.UInt32BitsToSingle(reader.ReadILUInt32()), TypeRef.CoreLib("System", "Single")));
+                    break;
+                case ILOpCode.Ldc_r8:
+                    stack.Push(new Constant(BitConverter.UInt64BitsToDouble(reader.ReadILUInt64()), TypeRef.CoreLib("System", "Double")));
+                    break;
+
+                case ILOpCode.Sizeof:
+                    stack.Push(new SizeOf(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope)));
+                    break;
+
+                case ILOpCode.Switch:
+                {
+                    uint count = reader.ReadILUInt32();
+                    var rawTargets = new int[count];
+                    for (int i = 0; i < count; i++)
+                        rawTargets[i] = (int)reader.ReadILUInt32();
+                    int next = reader.Offset;
+                    var targets = ImmutableArray.CreateBuilder<int>((int)count);
+                    foreach (int raw in rawTargets)
+                        targets.Add(next + raw);
+                    var value = Pop(stack);
+                    var allSuccessors = targets.Append(end).Distinct().ToArray();
+                    if (!PropagateAndSpill(function, body, stack, state, allSuccessors, offset))
+                        return false;
+                    body.Add(new SwitchBranch(value, targets.MoveToImmutable()));
+                    break;
+                }
+
                 case ILOpCode.Ldnull:
                     stack.Push(new Constant(null, TypeRef.CoreLib("System", "Object")));
                     break;
@@ -370,7 +428,8 @@ public static class IrImporter
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
-                    var call = new Call(callee, opcode == ILOpCode.Callvirt, arguments);
+                    var call = new Call(callee, opcode == ILOpCode.Callvirt, arguments) { ConstrainedTo = constrainedTo };
+                    constrainedTo = null;
                     if (callee.ReturnType is { Name: "Void", Namespace: "System" })
                         body.Add(new ExpressionStatement(call));
                     else
@@ -381,22 +440,132 @@ public static class IrImporter
                 case ILOpCode.Ldfld or ILOpCode.Ldsfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
-                    stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? Pop(stack) : null));
+                    stack.Push(new LoadField(field, opcode == ILOpCode.Ldfld ? Pop(stack) : null) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
                     break;
                 }
                 case ILOpCode.Stfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var value = Pop(stack);
-                    body.Add(new StoreField(field, Pop(stack), value));
+                    body.Add(new StoreField(field, Pop(stack), value) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
                     break;
                 }
                 case ILOpCode.Stsfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
-                    body.Add(new StoreField(field, null, Pop(stack)));
+                    body.Add(new StoreField(field, null, Pop(stack)) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
                     break;
                 }
+
+                case ILOpCode.Ldflda or ILOpCode.Ldsflda:
+                {
+                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    stack.Push(new LoadFieldAddress(field, opcode == ILOpCode.Ldflda ? Pop(stack) : null));
+                    break;
+                }
+
+                case ILOpCode.Ldloca_s:
+                {
+                    int index = reader.ReadILByte();
+                    stack.Push(new LoadLocalAddress(index, method.Body.Locals[index]));
+                    break;
+                }
+                case ILOpCode.Ldloca:
+                {
+                    int index = reader.ReadILUInt16();
+                    stack.Push(new LoadLocalAddress(index, method.Body.Locals[index]));
+                    break;
+                }
+                case ILOpCode.Ldarga_s:
+                    stack.Push(MakeLoadArgumentAddress(method, reader.ReadILByte()));
+                    break;
+                case ILOpCode.Ldarga:
+                    stack.Push(MakeLoadArgumentAddress(method, reader.ReadILUInt16()));
+                    break;
+
+                case ILOpCode.Ldelema:
+                {
+                    var elementType = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var index = Pop(stack);
+                    stack.Push(new LoadElementAddress(elementType, Pop(stack), index, readonlyPrefix));
+                    readonlyPrefix = false;
+                    break;
+                }
+
+                case ILOpCode.Ldobj:
+                {
+                    var type = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    stack.Push(new LoadIndirect(type, Pop(stack)) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
+                    break;
+                }
+                case ILOpCode.Stobj:
+                {
+                    var type = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var value = Pop(stack);
+                    body.Add(new StoreIndirect(type, Pop(stack), value) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
+                    break;
+                }
+                case ILOpCode.Initobj:
+                {
+                    var type = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    body.Add(new InitObject(type, Pop(stack)));
+                    break;
+                }
+
+                case >= ILOpCode.Ldind_i1 and <= ILOpCode.Ldind_ref:
+                {
+                    stack.Push(new LoadIndirect(IndirectTypeOf(opcode), Pop(stack)) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
+                    break;
+                }
+                case ILOpCode.Stind_ref or (>= ILOpCode.Stind_i1 and <= ILOpCode.Stind_r8) or ILOpCode.Stind_i:
+                {
+                    var value = Pop(stack);
+                    body.Add(new StoreIndirect(IndirectTypeOf(opcode), Pop(stack), value) { IsVolatile = volatilePrefix });
+                    volatilePrefix = false;
+                    break;
+                }
+
+                case ILOpCode.Ldelem:
+                {
+                    var elementType = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var index = Pop(stack);
+                    stack.Push(new LoadElement(elementType, Pop(stack), index));
+                    break;
+                }
+                case >= ILOpCode.Ldelem_i1 and <= ILOpCode.Ldelem_ref or ILOpCode.Ldelem_i:
+                {
+                    var index = Pop(stack);
+                    stack.Push(new LoadElement(ElementTypeOf(opcode), Pop(stack), index));
+                    break;
+                }
+                case ILOpCode.Stelem:
+                {
+                    var elementType = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var value = Pop(stack);
+                    var index = Pop(stack);
+                    body.Add(new StoreElement(elementType, Pop(stack), index, value));
+                    break;
+                }
+                case >= ILOpCode.Stelem_i and <= ILOpCode.Stelem_ref:
+                {
+                    var value = Pop(stack);
+                    var index = Pop(stack);
+                    body.Add(new StoreElement(ElementTypeOf(opcode), Pop(stack), index, value));
+                    break;
+                }
+
+                case ILOpCode.Unbox:
+                    stack.Push(new Unbox(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope), Pop(stack)));
+                    break;
+                case ILOpCode.Unbox_any:
+                    stack.Push(new UnboxAny(ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope), Pop(stack)));
+                    break;
 
                 case ILOpCode.Newobj:
                 {
@@ -554,6 +723,13 @@ public static class IrImporter
                         "opcode is outside the slice");
                     return false;
             }
+
+            if (constrainedTo is not null || volatilePrefix || readonlyPrefix)
+            {
+                Stop(function, body, stack, offset, opcode.ToString().ToLowerInvariant(),
+                    "an IL prefix applied to an instruction that does not accept it");
+                return false;
+            }
         }
 
         }
@@ -652,6 +828,50 @@ public static class IrImporter
         var parameter = method.Signature.Parameters[index];
         return new LoadArgument(index, parameter.Name, parameter.Type);
     }
+
+    static LoadArgumentAddress MakeLoadArgumentAddress(ImportedMethod method, int index)
+    {
+        if (method.Signature.HasThis)
+        {
+            if (index == 0)
+                return new LoadArgumentAddress(0, "this", method.DeclaringType);
+            var p = method.Signature.Parameters[index - 1];
+            return new LoadArgumentAddress(index, p.Name, p.Type);
+        }
+        var parameter = method.Signature.Parameters[index];
+        return new LoadArgumentAddress(index, parameter.Name, parameter.Type);
+    }
+
+    /// <summary>Element/indirection type encoded by a typed ldind/stind/ldelem/stelem opcode; null for the .ref forms (the operand's type stands in).</summary>
+    static TypeRef? IndirectTypeOf(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Ldind_i1 or ILOpCode.Stind_i1 => TypeRef.CoreLib("System", "SByte"),
+        ILOpCode.Ldind_u1 => TypeRef.CoreLib("System", "Byte"),
+        ILOpCode.Ldind_i2 or ILOpCode.Stind_i2 => TypeRef.CoreLib("System", "Int16"),
+        ILOpCode.Ldind_u2 => TypeRef.CoreLib("System", "UInt16"),
+        ILOpCode.Ldind_i4 or ILOpCode.Stind_i4 => TypeRef.CoreLib("System", "Int32"),
+        ILOpCode.Ldind_u4 => TypeRef.CoreLib("System", "UInt32"),
+        ILOpCode.Ldind_i8 or ILOpCode.Stind_i8 => TypeRef.CoreLib("System", "Int64"),
+        ILOpCode.Ldind_r4 or ILOpCode.Stind_r4 => TypeRef.CoreLib("System", "Single"),
+        ILOpCode.Ldind_r8 or ILOpCode.Stind_r8 => TypeRef.CoreLib("System", "Double"),
+        ILOpCode.Ldind_i or ILOpCode.Stind_i => TypeRef.CoreLib("System", "IntPtr"),
+        _ => null,  // ldind.ref / stind.ref
+    };
+
+    static TypeRef? ElementTypeOf(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Ldelem_i1 or ILOpCode.Stelem_i1 => TypeRef.CoreLib("System", "SByte"),
+        ILOpCode.Ldelem_u1 => TypeRef.CoreLib("System", "Byte"),
+        ILOpCode.Ldelem_i2 or ILOpCode.Stelem_i2 => TypeRef.CoreLib("System", "Int16"),
+        ILOpCode.Ldelem_u2 => TypeRef.CoreLib("System", "UInt16"),
+        ILOpCode.Ldelem_i4 or ILOpCode.Stelem_i4 => TypeRef.CoreLib("System", "Int32"),
+        ILOpCode.Ldelem_u4 => TypeRef.CoreLib("System", "UInt32"),
+        ILOpCode.Ldelem_i8 or ILOpCode.Stelem_i8 => TypeRef.CoreLib("System", "Int64"),
+        ILOpCode.Ldelem_r4 or ILOpCode.Stelem_r4 => TypeRef.CoreLib("System", "Single"),
+        ILOpCode.Ldelem_r8 or ILOpCode.Stelem_r8 => TypeRef.CoreLib("System", "Double"),
+        ILOpCode.Ldelem_i or ILOpCode.Stelem_i => TypeRef.CoreLib("System", "IntPtr"),
+        _ => null,  // ldelem.ref / stelem.ref
+    };
 
     static StoreArgument MakeStoreArgument(ImportedMethod method, int index, IrExpression value)
     {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -7,9 +7,10 @@ namespace DotnetInspector.Decompiler.Pipeline;
 /// <summary>
 /// Builds the typed IR for one method while its <see cref="MetadataSource"/>
 /// is alive; the resulting <see cref="IrFunction"/> is fully materialized.
-/// Slice scope: branching bodies whose evaluation stack is empty at every
-/// block boundary (no exception regions, no stack-carrying edges). IL
-/// outside the slice becomes an explicit <see cref="UnsupportedNode"/> with
+/// Slice scope: branching bodies including stack-carrying edges (values
+/// crossing block boundaries materialize through stack slots); exception
+/// regions and function-pointer IL remain outside the slice. IL outside
+/// the slice becomes an explicit <see cref="UnsupportedNode"/> with
 /// a <see cref="DiagnosticIds.UnsupportedConstruct"/> diagnostic and import
 /// stops — fidelity degrades honestly, output never guesses.
 /// </summary>
@@ -104,7 +105,8 @@ public static class IrImporter
         => new(GenericParameterNames(reader, typeDef.GetGenericParameters()),
                GenericParameterNames(reader, method.GetGenericParameters()));
 
-    static IrFunction Build(MetadataSource source, ImportedMethod method, GenericScope callerScope)
+    /// <summary>Internal for tests: synthetic IL can exercise join shapes C# never compiles to.</summary>
+    internal static IrFunction Build(MetadataSource source, ImportedMethod method, GenericScope callerScope)
     {
         var container = new BlockContainer();
         var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -323,11 +323,15 @@ public sealed class Call : IrExpression
 
     public MethodRef Callee { get; }
     public bool IsVirtual { get; }
+
+    /// <summary>The constrained. prefix type for constrained callvirt; null otherwise.</summary>
+    public TypeRef? ConstrainedTo { get; init; }
     /// <summary>Arguments including the receiver for instance calls.</summary>
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
     public override TypeRef? ResultType => Callee.ReturnType;
     public override IEnumerable<TypeRef> DirectTypes
-        => Callee.ParameterTypes.Concat(Callee.TypeArguments).Append(Callee.DeclaringType).Append(Callee.ReturnType);
+        => Callee.ParameterTypes.Concat(Callee.TypeArguments).Append(Callee.DeclaringType).Append(Callee.ReturnType)
+            .Concat(ConstrainedTo is null ? [] : [ConstrainedTo]);
 
     public override string Describe()
         => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
@@ -371,6 +375,7 @@ public sealed class LoadField : IrExpression
     }
 
     public FieldRef Field { get; }
+    public bool IsVolatile { get; init; }
     public IrExpression? Instance => Children.Count > 0 ? (IrExpression)Children[0] : null;
     public override TypeRef? ResultType => Field.Type;
     public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
@@ -391,6 +396,7 @@ public sealed class StoreField : IrNode
     }
 
     public FieldRef Field { get; }
+    public bool IsVolatile { get; init; }
     public bool HasInstance { get; }
     public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
     public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
@@ -549,6 +555,229 @@ public sealed class LoadToken : IrExpression
     public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
 
     public override string Describe() => $"LoadToken {Kind} {Display}";
+}
+
+/// <summary>The address of a local — the receiver form for value-type calls and ref/out arguments.</summary>
+public sealed class LoadLocalAddress : IrExpression
+{
+    public LoadLocalAddress(int index, TypeRef type)
+    {
+        Index = index;
+        Type = type;
+    }
+
+    public int Index { get; }
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => TypeRef.ByRef(Type);
+
+    public override string Describe() => $"LoadLocalAddress {Index} ({Type.ToDisplayString()})";
+}
+
+public sealed class LoadArgumentAddress : IrExpression
+{
+    public LoadArgumentAddress(int index, string name, TypeRef type)
+    {
+        Index = index;
+        Name = name;
+        Type = type;
+    }
+
+    public int Index { get; }
+    public string Name { get; }
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => TypeRef.ByRef(Type);
+
+    public override string Describe() => $"LoadArgumentAddress {Index} ({Type.ToDisplayString()} {Name})";
+}
+
+public sealed class LoadFieldAddress : IrExpression
+{
+    public LoadFieldAddress(FieldRef field, IrExpression? instance)
+    {
+        Field = field;
+        if (instance is not null)
+            AddChild(instance);
+    }
+
+    public FieldRef Field { get; }
+    public IrExpression? Instance => Children.Count > 0 ? (IrExpression)Children[0] : null;
+    public override TypeRef? ResultType => TypeRef.ByRef(Field.Type);
+    public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
+
+    public override string Describe() => $"LoadFieldAddress {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
+}
+
+public sealed class LoadElementAddress : IrExpression
+{
+    public LoadElementAddress(TypeRef elementType, IrExpression array, IrExpression index, bool isReadOnly)
+    {
+        ElementType = elementType;
+        IsReadOnly = isReadOnly;
+        AddChild(array);
+        AddChild(index);
+    }
+
+    public TypeRef ElementType { get; }
+    /// <summary>The readonly. prefix: no type check, address usable only for reads.</summary>
+    public bool IsReadOnly { get; }
+    public IrExpression Array => (IrExpression)Children[0];
+    public IrExpression Index => (IrExpression)Children[1];
+    public override TypeRef? ResultType => TypeRef.ByRef(ElementType);
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType];
+
+    public override string Describe() => $"LoadElementAddress {ElementType.ToDisplayString()}{(IsReadOnly ? " readonly" : "")}";
+}
+
+/// <summary>Load through an address (ldobj and the ldind.* family). A null type means the opcode does not encode one (ldind.ref).</summary>
+public sealed class LoadIndirect : IrExpression
+{
+    public LoadIndirect(TypeRef? type, IrExpression address)
+    {
+        Type = type;
+        AddChild(address);
+    }
+
+    public TypeRef? Type { get; }
+    public bool IsVolatile { get; init; }
+    public IrExpression Address => (IrExpression)Children[0];
+    public override TypeRef? ResultType
+        => Type ?? (Address.ResultType is { Kind: TypeRefKind.ByRef } byRef ? byRef.ElementType : null);
+    public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
+
+    public override string Describe() => $"LoadIndirect {ResultType?.ToDisplayString() ?? "?"}{(IsVolatile ? " volatile" : "")}";
+}
+
+public sealed class StoreIndirect : IrNode
+{
+    public StoreIndirect(TypeRef? type, IrExpression address, IrExpression value)
+    {
+        Type = type;
+        AddChild(address);
+        AddChild(value);
+    }
+
+    public TypeRef? Type { get; }
+    public bool IsVolatile { get; init; }
+    public IrExpression Address => (IrExpression)Children[0];
+    public IrExpression Value => (IrExpression)Children[1];
+    public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
+
+    public override string Describe() => $"StoreIndirect {Type?.ToDisplayString() ?? "?"}{(IsVolatile ? " volatile" : "")}";
+}
+
+/// <summary>initobj: default-initialize the storage at an address.</summary>
+public sealed class InitObject : IrNode
+{
+    public InitObject(TypeRef type, IrExpression address)
+    {
+        Type = type;
+        AddChild(address);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Address => (IrExpression)Children[0];
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"InitObject {Type.ToDisplayString()}";
+}
+
+public sealed class LoadElement : IrExpression
+{
+    public LoadElement(TypeRef? elementType, IrExpression array, IrExpression index)
+    {
+        ElementType = elementType;
+        AddChild(array);
+        AddChild(index);
+    }
+
+    /// <summary>Null when the opcode does not encode one (ldelem.ref); the array's element type stands in.</summary>
+    public TypeRef? ElementType { get; }
+    public IrExpression Array => (IrExpression)Children[0];
+    public IrExpression Index => (IrExpression)Children[1];
+    public override TypeRef? ResultType
+        => ElementType ?? (Array.ResultType is { Kind: TypeRefKind.SzArray } array ? array.ElementType : null);
+    public override IEnumerable<TypeRef> DirectTypes => ElementType is null ? [] : [ElementType];
+
+    public override string Describe() => $"LoadElement {ResultType?.ToDisplayString() ?? "?"}";
+}
+
+public sealed class StoreElement : IrNode
+{
+    public StoreElement(TypeRef? elementType, IrExpression array, IrExpression index, IrExpression value)
+    {
+        ElementType = elementType;
+        AddChild(array);
+        AddChild(index);
+        AddChild(value);
+    }
+
+    public TypeRef? ElementType { get; }
+    public IrExpression Array => (IrExpression)Children[0];
+    public IrExpression Index => (IrExpression)Children[1];
+    public IrExpression Value => (IrExpression)Children[2];
+    public override IEnumerable<TypeRef> DirectTypes => ElementType is null ? [] : [ElementType];
+
+    public override string Describe() => $"StoreElement {ElementType?.ToDisplayString() ?? "?"}";
+}
+
+public sealed class SizeOf : IrExpression
+{
+    public SizeOf(TypeRef type) => Type = type;
+
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Int32");
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"SizeOf {Type.ToDisplayString()}";
+}
+
+/// <summary>The switch opcode: jump to Targets[value], else fall through.</summary>
+public sealed class SwitchBranch : IrNode
+{
+    public SwitchBranch(IrExpression value, ImmutableArray<int> targetOffsets)
+    {
+        TargetOffsets = targetOffsets;
+        AddChild(value);
+    }
+
+    public IrExpression Value => (IrExpression)Children[0];
+    public ImmutableArray<int> TargetOffsets { get; }
+
+    public override string Describe()
+        => $"SwitchBranch [{string.Join(", ", TargetOffsets.Select(t => $"IL_{t:X4}"))}]";
+}
+
+/// <summary>unbox: a managed pointer into the box (distinct from unbox.any, which loads the value).</summary>
+public sealed class Unbox : IrExpression
+{
+    public Unbox(TypeRef type, IrExpression operand)
+    {
+        Type = type;
+        AddChild(operand);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.ByRef(Type);
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"Unbox {Type.ToDisplayString()}";
+}
+
+public sealed class UnboxAny : IrExpression
+{
+    public UnboxAny(TypeRef type, IrExpression operand)
+    {
+        Type = type;
+        AddChild(operand);
+    }
+
+    public TypeRef Type { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"UnboxAny {Type.ToDisplayString()}";
 }
 
 /// <summary>

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -4,9 +4,11 @@ The differential harness from [docs/decompiler-pipeline.md](../../docs/decompile
 
 ## Modes
 
-**Inventory** (default, until the `next` pipeline exists): sweeps every method body in the given assemblies through one pipeline and reports render rate plus exceptions bucketed by type and topmost decompiler frame, so one bug is one bucket.
+**Inventory** (default): sweeps every method body in the given assemblies through the current pipeline and reports render rate plus exceptions bucketed by type and topmost decompiler frame, so one bug is one bucket.
 
-**Diff** (`--candidate <name>`): runs two pipelines over every method and reports agreement, categorized first-line diffs, and one-sided failures.
+**Replacement-pipeline inventory** (`--pipeline next`): sweeps through the new importer and reports the fidelity histogram plus stop-reason buckets — the prioritized slice roadmap. Exits nonzero if any importer bug (DEC0001) appears.
+
+**Diff** (`--candidate <name>`): runs two pipelines over every method and reports agreement, categorized first-line diffs, and one-sided failures. Diffing against `next` activates when it grows its C# printer.
 
 **Stage dump** (`--dump 'Type::Method'`): JitDump for the decompiler — prints every stage of one method's analysis as projections of the shared `MethodAnalysis`: raw IL, typed IL (per-instruction stack states), structured IL (blocks and exception regions), then C#. The IL projections come from pre-transform stages, so the output is exactly what each pipeline layer saw.
 


### PR DESCRIPTION
## Summary

Slice 4, continuing in stop-histogram order: the address-of family (~4,900 methods) and its consumer cluster.

- **Address nodes**: `LoadLocalAddress` / `LoadArgumentAddress` / `LoadFieldAddress` / `LoadElementAddress` (with `readonly.`), all typed `ByRef` of their element — the receiver form for value-type calls and ref/out arguments
- **Indirection**: `LoadIndirect` / `StoreIndirect` (ldobj/stobj + the typed `ldind`/`stind` families; `.ref` forms defer to the address's element type), `InitObject`
- **Elements**: `LoadElement` / `StoreElement` in both typed-opcode and token forms
- **`Unbox`** (managed pointer into the box) and **`UnboxAny`**
- **Prefixes as pending state**: `constrained.` → `ConstrainedTo` on the next `callvirt`; `volatile.` → flag on the next field/indirect access; `readonly.` → flag on `ldelema`; `unaligned.` consumed as the JIT hint it is. A prefix landing on an instruction that doesn't accept it stops honestly.
- **Histogram-surfaced trivia**: `ldc.r4`/`ldc.r8` (float constants — never added until the sweep said so), `sizeof`, and **`switch`** (`SwitchBranch` with absolute targets, targets registered as leaders, entry stacks propagated to all successors)

## Numbers

| | #468 | this PR |
| --- | --- | --- |
| CoreLib Full fidelity | 75.6% | **94.0%** (38,683/41,159) |
| Importer bugs | 0 | 0 |

The remainder decomposes into exactly three designed work items: **exception regions** (1,059 — slice 5, the structural one), **function-pointer/custom-modifier `TypeRef` coverage** (939 — these are honest type-driven `Partial`s with no stop node, the fidelity scan from the review rounds doing its job), and the `localloc`/`ldftn`/`calli` tail (~470).

## Validation

- Decompiler suite 296/296 in both Debug and Release (new fixtures: `TryParse` out-argument → `LoadLocalAddress` in the call args, typed element load/store, switch-expression → `SwitchBranch` with every target verified as a block leader)
- `--pipeline next` harness inventory reproduces the sweep numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)