### PR TITLE
Slice 5: exception regions import flat with typed handler entries

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -250,6 +250,20 @@ public class CfgSampleClass
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
+    public static int TryFinallyAdd(int x)
+    {
+        try { return x + 1; }
+        finally { LastValue = x; }
+    }
+
+    public static int LastValue;
+
+    public static int FilteredLength(string s)
+    {
+        try { return s.Length; }
+        catch (Exception e) when (e.Message.Length > 0) { return 0; }
+    }
+
     public static int PowerOfTwo(int x) => x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 };
 
     [System.Runtime.InteropServices.DllImport("nonexistent")]

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -332,6 +332,47 @@ public class JoinTypeConflictTests : IDisposable
         function.CheckInvariant();
     }
 
+    IrFunction BuildSyntheticWithRegion(byte[] il, HandlerRegion region)
+    {
+        var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        _disposables.Push(source);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var method = new ImportedMethod(
+            TypeRef.CoreLib("Synthetic", "T"), "M", signature,
+            new MethodBody([.. il], MaxStack: 8, Locals: [], LocalNames: [], Handlers: [region]));
+        return IrImporter.Build(source, method, GenericScope.Empty);
+    }
+
+    [Fact]
+    public void Endfinally_NonEmptyStack_IsMalformed_StopsHonestly()
+    {
+        // try { leave } finally { ldc.i4.1; endfinally }  — ECMA requires an
+        // empty stack at endfinally; the stray value must not import as Full.
+        var function = BuildSyntheticWithRegion(
+            [0xDE, 0x02, 0x17, 0xDC, 0x2A],
+            new HandlerRegion(HandlerKind.Finally, 0, 2, 2, 2, 0, null));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Contains("endfinally", diagnostic.Message);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void Endfilter_MoreThanVerdict_IsMalformed_StopsHonestly()
+    {
+        // Filter code that never consumes the CLR-pushed exception: after
+        // popping the verdict the exception remains — malformed per ECMA.
+        var function = BuildSyntheticWithRegion(
+            [0xDE, 0x06, 0x17, 0xFE, 0x11, 0x26, 0xDE, 0x00, 0x2A],
+            new HandlerRegion(HandlerKind.Filter, 0, 2, 5, 3, 2, null));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Contains("filter verdict", diagnostic.Message);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void JoinTypeConflict_AfterJoinIsBuilt_StopsHonestly()
     {

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -77,15 +77,20 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void ExceptionRegions_StopHonestly_WithUnsupportedNode()
+    public void ExceptionRegions_ImportFlat_WithTypedHandlerEntry()
     {
         var function = ImportFixture(nameof(CfgSampleClass.ChecksThenTry));
 
-        var unsupported = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
-        Assert.Contains("exception regions", unsupported.Reason);
-        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
-        var diagnostic = Assert.Single(function.Diagnostics);
-        Assert.Equal(DiagnosticIds.UnsupportedConstruct, diagnostic.Id);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var region = Assert.Single(function.Regions);
+        Assert.Equal(HandlerKind.Catch, region.Kind);
+        // Region boundaries are block leaders in the flat container.
+        Assert.True(function.Body.IndexOfOffset(region.TryOffset) >= 0);
+        Assert.True(function.Body.IndexOfOffset(region.HandlerOffset) >= 0);
+        // The handler's first block consumes the CLR-pushed exception.
+        var caught = function.Descendants.OfType<CaughtException>().First();
+        Assert.Equal(region.CatchType, caught.Type);
+        Assert.NotEmpty(function.Descendants.OfType<Leave>());
         function.CheckInvariant();
     }
 
@@ -225,6 +230,29 @@ public class IrImporterTests
         // Every switch target starts a block.
         Assert.All(switchBranch.TargetOffsets,
             target => Assert.True(function.Body.IndexOfOffset(target) >= 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void TryFinally_ImportsWithEndFinally()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.TryFinallyAdd));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(HandlerKind.Finally, Assert.Single(function.Regions).Kind);
+        Assert.Single(function.Descendants.OfType<EndFinally>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ExceptionFilter_ImportsWithEndFilter()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.FilteredLength));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(HandlerKind.Filter, Assert.Single(function.Regions).Kind);
+        Assert.Single(function.Descendants.OfType<EndFilter>());
+        Assert.NotEmpty(function.Descendants.OfType<CaughtException>());
         function.CheckInvariant();
     }
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -109,19 +109,24 @@ public static class IrImporter
     internal static IrFunction Build(MetadataSource source, ImportedMethod method, GenericScope callerScope)
     {
         var container = new BlockContainer();
-        var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container);
-
-        if (!method.Body.Handlers.IsEmpty)
+        var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container)
         {
-            var block = new Block(0);
-            container.Add(block);
-            Stop(function, block, new Stack<IrExpression>(), 0, "(exception regions)", "exception regions are outside the slice");
-            return function;
-        }
-
+            Regions = method.Body.Handlers,
+        };
         var span = method.Body.IL.AsSpan();
-        var leaders = FindLeaders(span);
+        var leaders = FindLeaders(span, method.Body.Handlers);
         var state = new BuildState();
+        foreach (var region in method.Body.Handlers)
+        {
+            // The CLR pushes the exception on entry to catch and filter code.
+            if (region.Kind is HandlerKind.Catch)
+                state.HandlerEntries[region.HandlerOffset] = region.CatchType;
+            else if (region.Kind is HandlerKind.Filter)
+            {
+                state.HandlerEntries[region.FilterOffset] = null;
+                state.HandlerEntries[region.HandlerOffset] = null;
+            }
+        }
 
         foreach (int leader in leaders)
         {
@@ -135,15 +140,26 @@ public static class IrImporter
         return function;
     }
 
-    /// <summary>Block leaders: entry, branch targets, and instructions following a branch.</summary>
-    static SortedSet<int> FindLeaders(ReadOnlySpan<byte> il)
+    /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>
+    static SortedSet<int> FindLeaders(ReadOnlySpan<byte> il, System.Collections.Immutable.ImmutableArray<HandlerRegion> handlers)
     {
         var leaders = new SortedSet<int> { 0 };
+        foreach (var region in handlers)
+        {
+            leaders.Add(region.TryOffset);
+            leaders.Add(region.HandlerOffset);
+            if (region.TryOffset + region.TryLength < il.Length)
+                leaders.Add(region.TryOffset + region.TryLength);
+            if (region.HandlerOffset + region.HandlerLength < il.Length)
+                leaders.Add(region.HandlerOffset + region.HandlerLength);
+            if (region.Kind == HandlerKind.Filter)
+                leaders.Add(region.FilterOffset);
+        }
         var reader = new ILReaderLite(il);
         while (reader.HasNext)
         {
             var opcode = reader.ReadILOpcode();
-            if (IsBranch(opcode))
+            if (IsBranch(opcode) || opcode is ILOpCode.Leave or ILOpCode.Leave_s)
             {
                 leaders.Add(reader.ReadBranchDestination(opcode));
                 if (reader.Offset < il.Length)
@@ -164,8 +180,11 @@ public static class IrImporter
             else
             {
                 reader.Skip(opcode);
-                if (opcode is ILOpCode.Ret or ILOpCode.Throw && reader.Offset < il.Length)
+                if (opcode is ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Endfinally or ILOpCode.Endfilter
+                    && reader.Offset < il.Length)
+                {
                     leaders.Add(reader.Offset);
+                }
             }
         }
         return leaders;
@@ -187,6 +206,9 @@ public static class IrImporter
         public Dictionary<int, List<TypeRef?>> EntryStacks { get; } = [];
         public HashSet<int> Built { get; } = [];
         public int NextDupSlot { get; set; } = StoreStackSlot.DupSlotBase;
+
+        /// <summary>Catch/filter entry offsets and their exception types — the CLR-pushed value, not a slot load.</summary>
+        public Dictionary<int, TypeRef?> HandlerEntries { get; } = [];
     }
 
     /// <summary>
@@ -257,12 +279,21 @@ public static class IrImporter
         TypeRef? constrainedTo = null;
         bool volatilePrefix = false, readonlyPrefix = false;
 
-        // Entry values arrive in position-indexed slots stored by predecessors.
+        // Entry values arrive in position-indexed slots stored by predecessors —
+        // except handler entries, where the CLR pushes the exception itself.
         state.Built.Add(start);
-        var entry = state.EntryStacks.TryGetValue(start, out var carried) ? carried : [];
-        state.EntryStacks[start] = entry;
-        for (int i = 0; i < entry.Count; i++)
-            stack.Push(new LoadStackSlot(i, entry[i]));
+        if (state.HandlerEntries.TryGetValue(start, out var exceptionType))
+        {
+            stack.Push(new CaughtException(exceptionType));
+            state.EntryStacks[start] = [];
+        }
+        else
+        {
+            var entry = state.EntryStacks.TryGetValue(start, out var carried) ? carried : [];
+            state.EntryStacks[start] = entry;
+            for (int i = 0; i < entry.Count; i++)
+                stack.Push(new LoadStackSlot(i, entry[i]));
+        }
 
         try
         {
@@ -715,6 +746,34 @@ public static class IrImporter
                     body.Add(new ConditionalBranch(new Comparison(kind, isUnsigned, left, right), target));
                     break;
                 }
+
+                case ILOpCode.Leave or ILOpCode.Leave_s:
+                {
+                    // leave empties the evaluation stack; pending values'
+                    // side effects already happened, so they spill as
+                    // statements in evaluation order.
+                    int target = reader.ReadBranchDestination(opcode);
+                    foreach (var pending in stack.Reverse())
+                        body.Add(new ExpressionStatement(pending));
+                    stack.Clear();
+                    body.Add(new Leave(target));
+                    break;
+                }
+
+                case ILOpCode.Endfinally:
+                    foreach (var pending in stack.Reverse())
+                        body.Add(new ExpressionStatement(pending));
+                    stack.Clear();
+                    body.Add(new EndFinally());
+                    break;
+
+                case ILOpCode.Endfilter:
+                    body.Add(new EndFilter(Pop(stack)));
+                    break;
+
+                case ILOpCode.Rethrow:
+                    body.Add(new Throw(new CaughtException(null)));
+                    break;
 
                 case ILOpCode.Ret:
                     body.Add(new Return(stack.Count > 0 ? Pop(stack) : null));

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -8,8 +8,9 @@ namespace DotnetInspector.Decompiler.Pipeline;
 /// Builds the typed IR for one method while its <see cref="MetadataSource"/>
 /// is alive; the resulting <see cref="IrFunction"/> is fully materialized.
 /// Slice scope: branching bodies including stack-carrying edges (values
-/// crossing block boundaries materialize through stack slots); exception
-/// regions and function-pointer IL remain outside the slice. IL outside
+/// crossing block boundaries materialize through stack slots) and exception
+/// regions (imported flat; nesting is raising-pass work). Function-pointer
+/// IL (ldftn/calli) and localloc remain outside the slice. IL outside
 /// the slice becomes an explicit <see cref="UnsupportedNode"/> with
 /// a <see cref="DiagnosticIds.UnsupportedConstruct"/> diagnostic and import
 /// stops — fidelity degrades honestly, output never guesses.
@@ -761,15 +762,31 @@ public static class IrImporter
                 }
 
                 case ILOpCode.Endfinally:
-                    foreach (var pending in stack.Reverse())
-                        body.Add(new ExpressionStatement(pending));
-                    stack.Clear();
+                    // ECMA-335 III.3.35: the evaluation stack must be empty.
+                    // Unlike leave (defined to empty the stack), a non-empty
+                    // stack here is malformed IL — stop honestly.
+                    if (stack.Count > 0)
+                    {
+                        Stop(function, body, stack, offset, "endfinally",
+                            "evaluation stack is not empty at endfinally (malformed IL)");
+                        return false;
+                    }
                     body.Add(new EndFinally());
                     break;
 
                 case ILOpCode.Endfilter:
-                    body.Add(new EndFilter(Pop(stack)));
+                {
+                    // ECMA-335 III.3.34: the stack holds exactly the verdict.
+                    var verdict = Pop(stack);
+                    if (stack.Count > 0)
+                    {
+                        Stop(function, body, stack, offset, "endfilter",
+                            "evaluation stack holds more than the filter verdict (malformed IL)");
+                        return false;
+                    }
+                    body.Add(new EndFilter(verdict));
                     break;
+                }
 
                 case ILOpCode.Rethrow:
                     body.Add(new Throw(new CaughtException(null)));

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -36,11 +36,19 @@ public sealed class IrFunction : IrNode
     public BlockContainer Body => (BlockContainer)Children[0];
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 
+    /// <summary>
+    /// Exception regions over the flat block container, by IL offset. The
+    /// importer keeps blocks flat (region boundaries are block leaders);
+    /// nesting into try/catch structure is raising-pass work.
+    /// </summary>
+    public ImmutableArray<HandlerRegion> Regions { get; init; } = [];
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)
             .Append(DeclaringType)
-            .Concat(Locals);
+            .Concat(Locals)
+            .Concat(Regions.Where(r => r.CatchType is not null).Select(r => r.CatchType!));
 
     /// <summary>Computed from the tree, never asserted: any unsupported node or any unsupported type referenced anywhere ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
     public DecompilationFidelity Fidelity
@@ -555,6 +563,45 @@ public sealed class LoadToken : IrExpression
     public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
 
     public override string Describe() => $"LoadToken {Kind} {Display}";
+}
+
+/// <summary>The exception value the CLR pushes on entry to a catch or filter handler.</summary>
+public sealed class CaughtException : IrExpression
+{
+    public CaughtException(TypeRef? type) => Type = type;
+
+    /// <summary>The region's catch type; null in filters and untyped contexts (object stands in).</summary>
+    public TypeRef? Type { get; }
+    public override TypeRef? ResultType => Type ?? TypeRef.CoreLib("System", "Object");
+    public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
+
+    public override string Describe() => $"CaughtException ({ResultType!.ToDisplayString()})";
+}
+
+/// <summary>leave: exits one or more protected regions toward the target, running finallies; the evaluation stack empties.</summary>
+public sealed class Leave : IrNode
+{
+    public Leave(int targetOffset) => TargetOffset = targetOffset;
+
+    public int TargetOffset { get; }
+
+    public override string Describe() => $"Leave IL_{TargetOffset:X4}";
+}
+
+/// <summary>endfinally / endfault: returns control from the handler to the EH machinery.</summary>
+public sealed class EndFinally : IrNode
+{
+    public override string Describe() => "EndFinally";
+}
+
+/// <summary>endfilter: yields the filter's verdict (nonzero = handle).</summary>
+public sealed class EndFilter : IrNode
+{
+    public EndFilter(IrExpression value) => AddChild(value);
+
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => "EndFilter";
 }
 
 /// <summary>The address of a local — the receiver form for value-type calls and ref/out arguments.</summary>


### PR DESCRIPTION
## Summary

The last structural importer slice: exception regions (1,059 methods).

**Design choice, worth a moment of review**: regions import *flat*. Blocks stay offset-based in the `BlockContainer`; the materialized `HandlerRegion` data rides on `IrFunction.Regions`; and every region boundary — try start/end, handler start/end, filter start — is a block leader, so no block straddles a boundary. The nesting into try/catch containers is raising-pass work, the same way `if`/`while` structure is. This keeps the importer's output the ground-truth projection (the flat form *is* what the IL says) and leaves structure where the pipeline doc puts it: in passes.

Handler mechanics:

- Catch and filter entries push a typed **`CaughtException`** — the CLR-pushed value, deliberately not a stack-slot load since no predecessor stored it
- **`Leave`** is an explicit terminator distinct from `Branch` (crosses regions, runs finallies); it empties the stack, spilling pending side effects as statements in evaluation order
- **`EndFinally`** (covers endfault), **`EndFilter`** (with its verdict operand), and `rethrow` as `Throw(CaughtException)`
- Region catch types feed the fidelity scan via `DirectTypes`

## Numbers

| | #469 | this PR |
| --- | --- | --- |
| CoreLib Full fidelity | 94.0% | **96.0%** (39,529/41,159) |
| Importer bugs | 0 | 0 |

Remainder: function-pointer/custom-modifier `TypeRef` coverage (1,043 — honest type-driven `Partial`s), `localloc` (320), `ldftn` (181), `calli` (70), single-digit dust. **Structural importer work is done** — everything left is either type-shape coverage or the function-pointer cluster.

## Validation

- Decompiler suite 300/300 in both Debug and Release (try/catch flat import with typed handler entry and boundary-leader checks, try/finally → `EndFinally`, filter → `EndFilter` + `CaughtException`)
- The `ChecksThenTry` fixture flipped from the honest-stop test to a positive import test — the same fixture, now `Full`

With this, the importer milestone closes at 96% and the work pivots: raising passes and the C# printer, which turns on the harness's diff mode against `current`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)