### PR TITLE
Rename ILReaderLite to ILReader

### DIFF
--- a/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
+++ b/src/DotnetInspector.Decompiler/AnnotatedILEmitter.cs
@@ -93,7 +93,7 @@ public static class AnnotatedILEmitter
 
     static void EmitRaw(MethodBodyContext context, StringBuilder sb)
     {
-        var reader = new ILReaderLite(context.ILBytes);
+        var reader = new ILReader(context.ILBytes);
 
         while (reader.HasNext)
         {
@@ -119,7 +119,7 @@ public static class AnnotatedILEmitter
         // Emit locals header if present
         EmitLocalsHeader(context, simResult, sb);
 
-        var reader = new ILReaderLite(context.ILBytes);
+        var reader = new ILReader(context.ILBytes);
 
         while (reader.HasNext)
         {
@@ -171,7 +171,7 @@ public static class AnnotatedILEmitter
         var regionEnds = new Dictionary<int, string>();
         BuildExceptionRegionMarkers(context, regionStarts, regionEnds);
 
-        var reader = new ILReaderLite(context.ILBytes);
+        var reader = new ILReader(context.ILBytes);
         int currentIndent = 1;
 
         while (reader.HasNext)
@@ -439,7 +439,7 @@ public static class AnnotatedILEmitter
 
     // --- Operand decoding (mirrors ILDisassembler) ---
 
-    static string DecodeOperand(MethodBodyContext context, ref ILReaderLite reader, ILOpCode opcode, int instructionOffset)
+    static string DecodeOperand(MethodBodyContext context, ref ILReader reader, ILOpCode opcode, int instructionOffset)
     {
         switch (opcode)
         {

--- a/src/DotnetInspector.Decompiler/ControlFlowGraph.cs
+++ b/src/DotnetInspector.Decompiler/ControlFlowGraph.cs
@@ -140,7 +140,7 @@ public sealed class ControlFlowGraph
         var cfg = new ControlFlowGraph(bbs);
 
         // Link basic blocks by analyzing branch targets and fall-through
-        var reader = new ILReaderLite(ilBytes);
+        var reader = new ILReader(ilBytes);
         foreach (BasicBlock bb in cfg.BasicBlocks)
         {
             reader.Seek(bb.Start);
@@ -236,7 +236,7 @@ public sealed class ControlFlowGraph
     static HashSet<int> GetBasicBlockStarts(MethodBodyContext context)
     {
         var ilBytes = context.ILBytes.AsSpan();
-        var reader = new ILReaderLite(ilBytes);
+        var reader = new ILReader(ilBytes);
         HashSet<int> bbStarts = [0];
 
         while (reader.HasNext)

--- a/src/DotnetInspector.Decompiler/ILAstBuilder.cs
+++ b/src/DotnetInspector.Decompiler/ILAstBuilder.cs
@@ -58,7 +58,7 @@ public static class ILAstBuilder
         ILAstBlock block)
     {
         var ilBytes = context.ILBytes.AsSpan(bb.Start, bb.Size);
-        var reader = new ILReaderLite(ilBytes, baseOffset: bb.Start);
+        var reader = new ILReader(ilBytes, baseOffset: bb.Start);
         var stack = new Stack<ILAstExpression>();
 
         // Push entry stack values as synthetic ldloc-like expressions
@@ -291,7 +291,7 @@ public static class ILAstBuilder
 
     static ILAstExpression? DecodeInstruction(
         MethodBodyContext context,
-        ref ILReaderLite reader,
+        ref ILReader reader,
         ILOpCode opcode,
         int offset,
         Stack<ILAstExpression> stack)
@@ -932,7 +932,7 @@ public static class ILAstBuilder
     }
 
     static ILAstExpression HandleGeneric(
-        MethodBodyContext context, ref ILReaderLite reader,
+        MethodBodyContext context, ref ILReader reader,
         ILOpCode opcode, int offset, Stack<ILAstExpression> stack)
     {
         // Determine pop/push from the opcode category

--- a/src/DotnetInspector.Decompiler/ILReader.cs
+++ b/src/DotnetInspector.Decompiler/ILReader.cs
@@ -9,10 +9,13 @@ using System.Reflection.Metadata;
 namespace DotnetInspector.Decompiler;
 
 /// <summary>
-/// Lightweight IL byte reader that decodes opcodes and operands from raw IL bytes.
-/// Ported from dotnet/runtime Internal.IL.ILReader, adapted to use BCL's ILOpCode enum.
+/// IL byte reader: decodes opcodes and operands from raw IL bytes. Ported
+/// from dotnet/runtime Internal.IL.ILReader (the same reader ILVerify and
+/// the ILC type system build on), retargeted to the BCL's ILOpCode enum and
+/// extended with peeking, skipping, and branch-destination helpers. Shared
+/// by both decompiler pipelines.
 /// </summary>
-internal ref struct ILReaderLite
+internal ref struct ILReader
 {
     private int _currentOffset;
     private readonly ReadOnlySpan<byte> _ilBytes;
@@ -24,7 +27,7 @@ internal ref struct ILReaderLite
     public readonly int Size => _ilBytes.Length;
     public readonly bool HasNext => _currentOffset < _ilBytes.Length;
 
-    public ILReaderLite(ReadOnlySpan<byte> ilBytes, int currentOffset = 0, int baseOffset = 0)
+    public ILReader(ReadOnlySpan<byte> ilBytes, int currentOffset = 0, int baseOffset = 0)
     {
         _ilBytes = ilBytes;
         _currentOffset = currentOffset;

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -156,7 +156,7 @@ public static class IrImporter
             if (region.Kind == HandlerKind.Filter)
                 leaders.Add(region.FilterOffset);
         }
-        var reader = new ILReaderLite(il);
+        var reader = new ILReader(il);
         while (reader.HasNext)
         {
             var opcode = reader.ReadILOpcode();
@@ -275,7 +275,7 @@ public static class IrImporter
         ReadOnlySpan<byte> il, int start, int end, GenericScope callerScope, BuildState state)
     {
         var stack = new Stack<IrExpression>();
-        var reader = new ILReaderLite(il[..end], currentOffset: start);
+        var reader = new ILReader(il[..end], currentOffset: start);
         int offset = start;
         TypeRef? constrainedTo = null;
         bool volatilePrefix = false, readonlyPrefix = false;

--- a/src/DotnetInspector.Decompiler/StackHeightCalculator.cs
+++ b/src/DotnetInspector.Decompiler/StackHeightCalculator.cs
@@ -38,7 +38,7 @@ internal static class StackHeightCalculator
 
     static int Compute(MethodBodyContext context, int[]? heightsOut)
     {
-        var ilReader = new ILReaderLite(context.ILBytes);
+        var ilReader = new ILReader(context.ILBytes);
         int stackHeight = 0;
         int maxStack = 0;
 

--- a/src/DotnetInspector.Decompiler/StackSimulator.cs
+++ b/src/DotnetInspector.Decompiler/StackSimulator.cs
@@ -164,7 +164,7 @@ internal static class StackSimulator
     static StackState SimulateBlock(MethodBodyContext context, BasicBlock block, StackState state)
     {
         var ilBytes = context.ILBytes.AsSpan(block.Start, block.Size);
-        var reader = new ILReaderLite(ilBytes);
+        var reader = new ILReader(ilBytes);
 
         while (reader.HasNext)
         {
@@ -184,7 +184,7 @@ internal static class StackSimulator
     {
         var result = new Dictionary<int, StackState>();
         var ilBytes = context.ILBytes.AsSpan(block.Start, block.Size);
-        var reader = new ILReaderLite(ilBytes);
+        var reader = new ILReader(ilBytes);
         var state = entryState;
 
         while (reader.HasNext)
@@ -203,7 +203,7 @@ internal static class StackSimulator
     /// <summary>
     /// Apply a single opcode to the stack state, returning the new state.
     /// </summary>
-    static StackState ApplyOpcode(MethodBodyContext context, ref ILReaderLite reader, ILOpCode opcode, StackState state)
+    static StackState ApplyOpcode(MethodBodyContext context, ref ILReader reader, ILOpCode opcode, StackState state)
     {
         // Check if this opcode has a known result kind
         var resultKind = opcode.ResultKind();
@@ -1071,7 +1071,7 @@ internal static class StackSimulator
     {
         // Check if the edge from source→target crosses an exception region boundary via leave
         var ilBytes = context.ILBytes.AsSpan(source.Start, source.Size);
-        var reader = new ILReaderLite(ilBytes);
+        var reader = new ILReader(ilBytes);
         ILOpCode lastOpcode = ILOpCode.Nop;
         while (reader.HasNext)
         {


### PR DESCRIPTION
## Summary

Mechanical rename, motivated by the recognizability prime directive. The "Lite" suffix dated from the original port in #139, when it distinguished the bare byte cursor from `ILDisassembler`'s resolved instructions and signaled that the runtime's TypeSystem coupling had been dropped.

Side-by-side with upstream, though, ours is `Internal.IL.ILReader` method-for-method — the same reader that ILVerify and the ILC type system build on — retargeted to the BCL `ILOpCode` enum and *extended* (peek, skip, branch destinations, base offsets), not reduced. "Lite" suggests a difference that doesn't exist and hides exactly the lineage a runtime engineer would recognize on sight.

Internal type, zero public-surface impact; the doc comment now states the lineage explicitly. Decompiler suite 302, CLI suite 994, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)