### PR TITLE
Null result types cap fidelity; join slots merge by ECMA stack family

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -325,10 +325,15 @@ public class JoinTypeConflictTests : IDisposable
         // merges to null (honest unknown), never a guessed type.
         var function = BuildSynthetic([0x17, 0x2D, 0x03, 0x16, 0x2B, 0x01, 0x14, 0x26, 0x2A]);
 
-        Assert.Empty(function.Diagnostics);
         var load = Assert.Single(function.Descendants.OfType<LoadStackSlot>(),
             l => l.Parent is ExpressionStatement);
         Assert.Null(load.Type);
+        // An unknown type anywhere is a fidelity signal: the merged-null
+        // slot caps the function at Partial, with a join-type diagnostic
+        // saying which types disagreed.
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Contains("(join-type)", diagnostic.Message);
         function.CheckInvariant();
     }
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -245,15 +245,29 @@ public static class IrImporter
                             existing[i] = types[i];
                         continue;
                     }
+                    // ECMA stack-type model: bool and int are the same I4
+                    // stack entry, float and double the same F entry — the
+                    // family-canonical type IS the ground truth there.
+                    var merged = MergeSlotTypes(existing[i]!, types[i]!);
                     if (state.Built.Contains(target))
                     {
-                        // The join was already built with the first type; a
-                        // conflicting later edge cannot be retyped honestly.
-                        Stop(function, body, stack, offset, "(join)",
-                            "evaluation-stack types disagree between paths into a join, outside the slice");
-                        return false;
+                        if (merged is null)
+                        {
+                            // The join was already built with the first type; a
+                            // cross-family edge cannot be retyped honestly.
+                            Stop(function, body, stack, offset, "(join)",
+                                "evaluation-stack types disagree between paths into a join, outside the slice");
+                            return false;
+                        }
+                        continue;
                     }
-                    existing[i] = null;  // unknown — honest, never a guess
+                    if (merged is null)
+                    {
+                        function.Diagnostics.Add(new DecompilerDiagnostic(
+                            DiagnosticIds.UnsupportedConstruct,
+                            $"IL_{offset:X4} (join-type): slot {i} type unknown — paths carry {existing[i]!.ToDisplayString()} and {types[i]!.ToDisplayString()}"));
+                    }
+                    existing[i] = merged;  // family-canonical, or null — never a guess
                 }
             }
             else if (state.Built.Contains(target) && types.Count > 0)
@@ -828,6 +842,49 @@ public static class IrImporter
             return PropagateAndSpill(function, body, stack, state, [end], end);
         }
         return true;
+    }
+
+    /// <summary>
+    /// Merges two slot types per the ECMA stack-type model: equal types keep;
+    /// same stack family yields the family-canonical type (the stack really
+    /// does carry an int32 where bool and int join); cross-family yields null.
+    /// </summary>
+    static TypeRef? MergeSlotTypes(TypeRef a, TypeRef b)
+    {
+        if (Equals(a, b))
+            return a;
+        var familyA = StackFamilyOf(a);
+        var familyB = StackFamilyOf(b);
+        if (familyA != familyB || familyA is null)
+            return null;
+        return familyA switch
+        {
+            StackFamily.I4 => TypeRef.CoreLib("System", "Int32"),
+            StackFamily.I8 => TypeRef.CoreLib("System", "Int64"),
+            StackFamily.F => TypeRef.CoreLib("System", "Double"),
+            StackFamily.I => TypeRef.CoreLib("System", "IntPtr"),
+            _ => TypeRef.CoreLib("System", "Object"),
+        };
+    }
+
+    enum StackFamily { I4, I8, F, I, O }
+
+    /// <summary>The ECMA evaluation-stack family of a type, where it can be known without resolution; null when it cannot (a bare definition may be struct or class).</summary>
+    static StackFamily? StackFamilyOf(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
+            return StackFamily.O;
+        if (type.Kind != TypeRefKind.Definition || type.Assembly != TypeRef.CoreLibrary || type.Namespace != "System")
+            return null;
+        return type.Name switch
+        {
+            "Boolean" or "Char" or "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32" => StackFamily.I4,
+            "Int64" or "UInt64" => StackFamily.I8,
+            "Single" or "Double" => StackFamily.F,
+            "IntPtr" or "UIntPtr" => StackFamily.I,
+            "Object" or "String" => StackFamily.O,
+            _ => null,
+        };
     }
 
     /// <summary>A block whose entry expects stack values is a stack-carrying edge — out of slice, reported honestly via the importer's stop path.</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -50,11 +50,17 @@ public sealed class IrFunction : IrNode
             .Concat(Locals)
             .Concat(Regions.Where(r => r.CatchType is not null).Select(r => r.CatchType!));
 
-    /// <summary>Computed from the tree, never asserted: any unsupported node or any unsupported type referenced anywhere ⇒ at most <see cref="DecompilationFidelity.Partial"/>.</summary>
+    /// <summary>
+    /// Computed from the tree, never asserted: any unsupported node, any
+    /// unsupported type referenced anywhere, or any expression whose result
+    /// type the pipeline does not know (null — e.g. a join slot merged from
+    /// conflicting types) ⇒ at most <see cref="DecompilationFidelity.Partial"/>.
+    /// </summary>
     public DecompilationFidelity Fidelity
         => Descendants.Prepend(this).Any(n =>
             n is UnsupportedNode
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
+            || n is IrExpression { ResultType: null }
             || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
             ? DecompilationFidelity.Partial
             : DecompilationFidelity.Full;


### PR DESCRIPTION
## Summary

From the latest review round: `IrFunction.Fidelity` ignored `ResultType == null` even though the IR doc declares null a fidelity signal — and join merging *deliberately* produces nulls, so methods carrying unknown types reported `Full`. Both halves of the suggested fix landed: the blanket rule (any null-typed expression caps at `Partial`) and an explicit `(join-type)` diagnostic naming the disagreeing types.

## What the fix taught us

The first diagnostic the new rule produced was `paths carry int and bool` — at an exception filter's verdict join, where one arm yields a comparison (`bool`) and the other a constant (`int`). On the IL evaluation stack those are the **same I4 entry**; calling that "unknown" isn't honesty, it's ignorance of ECMA's stack-type model. So join slots now merge by stack family:

- Equal types keep; **same family → family-canonical type** (`bool`+`int` → `Int32`, `float`+`double` → `Double`, `string`+`object` → `Object`) — ground truth, since that's what the stack physically carries
- **Cross-family → null + diagnostic**, capping fidelity
- Bare type definitions stay unmergeable: a `TypeRef` can't yet tell struct from class, so their family is unknowable without resolution — honest null
- The post-build join stop relaxes accordingly: a `bool`-then-`int` edge into a built join is fine; only cross-family edges stop

## Numbers

96.0% → **95.7%** — 128 methods honestly reclassified (103 cross-family joins, the rest null-typed indirections), while 245 formerly null-typed same-family joins now carry correct canonical types. The 0.3% drop is the honest number; the previous figure included methods with types the pipeline didn't actually know.

## Validation

- 302/302 both configs; the synthetic join-conflict test now asserts `Partial` + the `(join-type)` diagnostic (the reviewer's requested regression assertion), and the filter fixture is back to `Full` via the I4 merge
- Zero importer bugs throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)