### PR TITLE
First C# printer for the replacement pipeline; parity scoreboard live

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -393,3 +393,52 @@ public class JoinTypeConflictTests : IDisposable
         function.CheckInvariant();
     }
 }
+
+public class CSharpPrinterTests
+{
+    static string PrintFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        var result = CSharpPrinter.Print(function);
+        Assert.True(result.Succeeded);
+        return result.Output!.ReplaceLineEndings("\n");
+    }
+
+    [Fact]
+    public void StraightLine_PrintsCurrentStyle()
+    {
+        Assert.Equal("return a + b;\n", PrintFixture(nameof(CfgSampleClass.Add)));
+    }
+
+    [Fact]
+    public void Branches_PrintAsHonestLabelsAndGotos()
+    {
+        string output = PrintFixture(nameof(CfgSampleClass.AbsShort));
+
+        Assert.Contains("goto IL_", output);
+        Assert.Contains(":", output);
+        Assert.DoesNotContain("/* ", output);  // every node has a rendering
+    }
+
+    [Fact]
+    public void Parity_StraightLineCoreLibMethod_MatchesCurrentEmitter()
+    {
+        // The first parity class: methods needing no raising at all.
+        using var stream = File.OpenRead(typeof(object).Assembly.Location);
+        using var peReader = new System.Reflection.PortableExecutable.PEReader(stream);
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+
+        var context = MethodBodyContext.Create(peReader, "System.Collections.Generic.List`1", "get_Count");
+        var function = IrImporter.Import(source, "System.Collections.Generic.List`1", "get_Count");
+        Assert.NotNull(context);
+        Assert.NotNull(function);
+
+        string baseline = CSharpEmitter.Emit(context).ReplaceLineEndings("\n").TrimEnd();
+        string candidate = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal(baseline, candidate);
+        Assert.Equal("return _size;", candidate);
+    }
+}

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -318,6 +318,17 @@ public class JoinTypeConflictTests : IDisposable
     }
 
     [Fact]
+    public void TrailingLabeledReturn_IsNotTrimmedToADanglingLabel()
+    {
+        // br.s to the final 'return;' — the return is a branch target's only
+        // statement, so trimming it would strand the label as invalid C#.
+        var function = BuildSynthetic([0x2B, 0x00, 0x2A]);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("IL_0002:\nreturn;", output);
+    }
+
+    [Fact]
     public void JoinTypeConflict_BeforeJoinIsBuilt_MergesToHonestUnknown()
     {
         // ldc.i4.1; brtrue.s L1; ldc.i4.0; br.s J; L1: ldnull; J: pop; ret
@@ -420,6 +431,48 @@ public class CSharpPrinterTests
         Assert.Contains("goto IL_", output);
         Assert.Contains(":", output);
         Assert.DoesNotContain("/* ", output);  // every node has a rendering
+    }
+
+    [Fact]
+    public void UnsignedOperations_CastSignedOperands_PlainWhenAlreadyUnsigned()
+    {
+        var signedInt = new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32"));
+        var signedInt2 = new LoadArgument(1, "b", TypeRef.CoreLib("System", "Int32"));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: true, signedInt, signedInt2)));
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "UInt32"),
+            [new Parameter("a", TypeRef.CoreLib("System", "Int32")), new Parameter("b", TypeRef.CoreLib("System", "Int32"))],
+            HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return (uint)a / (uint)b;", CSharpPrinter.Print(function).Output!.Trim());
+
+        // Already-unsigned operands print plain — div.un's semantics are
+        // already conveyed by the types.
+        var unsignedArg = new LoadArgument(0, "a", TypeRef.CoreLib("System", "UInt32"));
+        var unsignedArg2 = new LoadArgument(1, "b", TypeRef.CoreLib("System", "UInt32"));
+        var container2 = new BlockContainer();
+        var block2 = new Block(0);
+        container2.Add(block2);
+        block2.Add(new Return(new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: true, unsignedArg, unsignedArg2)));
+        var function2 = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container2);
+
+        Assert.Equal("return a / b;", CSharpPrinter.Print(function2).Output!.Trim());
+    }
+
+    [Fact]
+    public void Constructor_ThisReceiver_PrintsBaseCall()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, ".ctor");
+
+        Assert.NotNull(function);
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("base();", output);
+        Assert.DoesNotContain(".ctor", output);
     }
 
     [Fact]

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -12,13 +12,17 @@ namespace DotnetInspector.Decompiler.Pipeline;
 /// raising passes close the goto gap from here; this printer is the
 /// scoreboard's starting line.
 /// </summary>
-public static class CSharpPrinter
+public sealed class CSharpPrinter
 {
+    readonly IrFunction _function;
+
+    CSharpPrinter(IrFunction function) => _function = function;
+
     public static DecompilerResult Print(IrFunction function)
     {
         try
         {
-            string output = PrintBody(function);
+            string output = new CSharpPrinter(function).PrintBody(function);
             return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics]);
         }
         catch (Exception ex)
@@ -27,7 +31,7 @@ public static class CSharpPrinter
         }
     }
 
-    static string PrintBody(IrFunction function)
+    string PrintBody(IrFunction function)
     {
         var sb = new StringBuilder();
         var blocks = function.Body.Blocks;
@@ -44,11 +48,15 @@ public static class CSharpPrinter
             var block = blocks[i];
             if (labelTargets.Contains(block.StartOffset))
                 sb.AppendLine($"IL_{block.StartOffset:X4}:");
+            // The trailing 'return;' trims, current-style — unless it is a
+            // labeled block's only statement, where trimming would strand
+            // the label as invalid C#.
+            bool labeledReturnOnly = labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
             foreach (var statement in block.Children)
             {
                 bool isLast = i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
-                if (isLast && statement is Return { Value: null })
-                    break;  // trailing 'return;' trims, current-style
+                if (isLast && !labeledReturnOnly && statement is Return { Value: null })
+                    break;
                 sb.AppendLine(Statement(statement));
             }
         }
@@ -92,7 +100,7 @@ public static class CSharpPrinter
             yield return $"{(type is null ? "var" : TypeText(type))} S_{slot};";
     }
 
-    static string Statement(IrNode node) => node switch
+    string Statement(IrNode node) => node switch
     {
         ExpressionStatement e => e.Expression is UnsupportedNode u
             ? $"/* {u.Describe()} */"
@@ -116,15 +124,15 @@ public static class CSharpPrinter
         _ => $"/* {node.Describe()} */",
     };
 
-    static string Expression(IrExpression node) => node switch
+    string Expression(IrExpression node) => node switch
     {
         LoadArgument a => a.Name,
         LoadLocal l => $"V_{l.Index}",
         LoadStackSlot s => $"S_{s.Slot}",
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
-        Binary b => $"{Operand(b.Left)} {BinaryOperator(b)} {Operand(b.Right)}",
-        Comparison c => $"{Operand(c.Left)} {ComparisonOperator(c.Kind)} {Operand(c.Right)}",
+        Binary b => BinaryText(b),
+        Comparison c => ComparisonText(c),
         LogicalNot n => $"!{Operand(n.Operand)}",
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
@@ -153,8 +161,40 @@ public static class CSharpPrinter
         _ => $"/* {node.Describe()} */",
     };
 
+    string BinaryText(Binary binary)
+    {
+        // div.un/rem.un compute on unsigned operands; shr.un shifts an
+        // unsigned left operand. Operands that are already unsigned (or
+        // float, where .un means unordered, not unsigned) print plain.
+        bool castBoth = binary.IsUnsigned && binary.Kind is BinaryKind.Divide or BinaryKind.Remainder;
+        bool castLeft = castBoth || (binary.IsUnsigned && binary.Kind is BinaryKind.ShiftRight);
+        string left = castLeft ? UnsignedOperand(binary.Left) : Operand(binary.Left);
+        string right = castBoth ? UnsignedOperand(binary.Right) : Operand(binary.Right);
+        return $"{left} {BinaryOperator(binary)} {right}";
+    }
+
+    string ComparisonText(Comparison comparison)
+        => comparison.IsUnsigned
+            ? $"{UnsignedOperand(comparison.Left)} {ComparisonOperator(comparison.Kind)} {UnsignedOperand(comparison.Right)}"
+            : $"{Operand(comparison.Left)} {ComparisonOperator(comparison.Kind)} {Operand(comparison.Right)}";
+
+    /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
+    string UnsignedOperand(IrExpression operand)
+    {
+        string? cast = operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } type
+            ? type.Name switch
+            {
+                "SByte" or "Int16" or "Int32" => "uint",
+                "Int64" => "ulong",
+                "IntPtr" => "nuint",
+                _ => null,
+            }
+            : null;
+        return cast is null ? Operand(operand) : $"({cast}){Operand(operand)}";
+    }
+
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds to the inverse text-free form later (raising work, not printing work).</summary>
-    static string Condition(IrExpression condition) => condition switch
+    string Condition(IrExpression condition) => condition switch
     {
         LogicalNot { Operand: Comparison c } => $"{Operand(c.Left)} {ComparisonOperator(Inverse(c.Kind))} {Operand(c.Right)}",
         _ => Expression(condition),
@@ -171,7 +211,7 @@ public static class CSharpPrinter
     };
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
-    static string Operand(IrExpression node)
+    string Operand(IrExpression node)
     {
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
@@ -179,14 +219,14 @@ public static class CSharpPrinter
         return atomic ? text : $"({text})";
     }
 
-    static string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
+    string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
     {
         null => $"{TypeText(field.DeclaringType)}.{field.Name}",
         LoadArgument { Index: 0, Name: "this" } => field.Name,
         _ => $"{Operand(instance)}.{field.Name}",
     };
 
-    static string CallText(Call call)
+    string CallText(Call call)
     {
         var arguments = call.Arguments;
         string typeArguments = call.Callee.TypeArguments.IsEmpty
@@ -196,15 +236,21 @@ public static class CSharpPrinter
             return $"{TypeText(call.Callee.DeclaringType)}.{call.Callee.Name}{typeArguments}({Arguments(arguments)})";
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1));
+        if (call.Callee.Name == ".ctor" && receiver is LoadArgument { Index: 0, Name: "this" })
+        {
+            // A this-receiver constructor call is C#'s base(...)/this(...).
+            string keyword = Equals(call.Callee.DeclaringType, _function.DeclaringType) ? "this" : "base";
+            return $"{keyword}({rest})";
+        }
         return receiver is LoadArgument { Index: 0, Name: "this" }
             ? $"{call.Callee.Name}{typeArguments}({rest})"
             : $"{Operand(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
     }
 
-    static string Arguments(IEnumerable<IrExpression> arguments)
+    string Arguments(IEnumerable<IrExpression> arguments)
         => string.Join(", ", arguments.Select(Expression));
 
-    static string ConvertText(Convert convert)
+    string ConvertText(Convert convert)
     {
         string cast = $"({TypeText(convert.Target)}){Operand(convert.Operand)}";
         return convert.IsChecked ? $"checked({cast})" : cast;

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1,0 +1,254 @@
+using System.Globalization;
+using System.Text;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// First C# projection of the IR: honest lowered output. Structure that has
+/// not been raised renders as what it is — flat blocks with labels and
+/// gotos — never as guessed sugar. Formatting follows the current emitter's
+/// style (bare this-members, V_N/S_N names, trimmed trailing return) so the
+/// harness diff measures structural distance, not whitespace noise. The
+/// raising passes close the goto gap from here; this printer is the
+/// scoreboard's starting line.
+/// </summary>
+public static class CSharpPrinter
+{
+    public static DecompilerResult Print(IrFunction function)
+    {
+        try
+        {
+            string output = PrintBody(function);
+            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics]);
+        }
+        catch (Exception ex)
+        {
+            return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    static string PrintBody(IrFunction function)
+    {
+        var sb = new StringBuilder();
+        var blocks = function.Body.Blocks;
+        var labelTargets = CollectBranchTargets(function);
+
+        // Locals and slots referenced anywhere declare up front, current-style.
+        foreach (var declaration in CollectDeclarations(function))
+            sb.AppendLine(declaration);
+        if (sb.Length > 0)
+            sb.AppendLine();
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            var block = blocks[i];
+            if (labelTargets.Contains(block.StartOffset))
+                sb.AppendLine($"IL_{block.StartOffset:X4}:");
+            foreach (var statement in block.Children)
+            {
+                bool isLast = i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
+                if (isLast && statement is Return { Value: null })
+                    break;  // trailing 'return;' trims, current-style
+                sb.AppendLine(Statement(statement));
+            }
+        }
+        return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
+    }
+
+    static HashSet<int> CollectBranchTargets(IrFunction function)
+    {
+        var targets = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case Branch branch: targets.Add(branch.TargetOffset); break;
+                case ConditionalBranch conditional: targets.Add(conditional.TargetOffset); break;
+                case Leave leave: targets.Add(leave.TargetOffset); break;
+                case SwitchBranch sw: foreach (int t in sw.TargetOffsets) targets.Add(t); break;
+            }
+        }
+        return targets;
+    }
+
+    static IEnumerable<string> CollectDeclarations(IrFunction function)
+    {
+        var locals = new SortedSet<int>();
+        var slots = new SortedDictionary<int, TypeRef?>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case LoadLocal l: locals.Add(l.Index); break;
+                case StoreLocal s: locals.Add(s.Index); break;
+                case LoadLocalAddress a: locals.Add(a.Index); break;
+                case LoadStackSlot ls: slots.TryAdd(ls.Slot, ls.Type); break;
+                case StoreStackSlot ss: slots.TryAdd(ss.Slot, ss.Value.ResultType); break;
+            }
+        }
+        foreach (int index in locals)
+            yield return $"{TypeText(function.Locals[index])} V_{index};";
+        foreach (var (slot, type) in slots)
+            yield return $"{(type is null ? "var" : TypeText(type))} S_{slot};";
+    }
+
+    static string Statement(IrNode node) => node switch
+    {
+        ExpressionStatement e => e.Expression is UnsupportedNode u
+            ? $"/* {u.Describe()} */"
+            : $"{Expression(e.Expression)};",
+        StoreLocal s => $"V_{s.Index} = {Expression(s.Value)};",
+        StoreArgument s => $"{s.Name} = {Expression(s.Value)};",
+        StoreStackSlot s => $"S_{s.Slot} = {Expression(s.Value)};",
+        StoreField s => $"{FieldTarget(s.Field, s.Instance)} = {Expression(s.Value)};",
+        StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
+        StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
+        InitObject o => $"*{Operand(o.Address)} = default({TypeText(o.Type)});",
+        Return { Value: { } value } => $"return {Expression(value)};",
+        Return => "return;",
+        Throw t => $"throw {Expression(t.Value)};",
+        Branch b => $"goto IL_{b.TargetOffset:X4};",
+        ConditionalBranch c => $"if ({Condition(c.Condition)}) goto IL_{c.TargetOffset:X4};",
+        SwitchBranch s => $"switch ({Expression(s.Value)}) goto [{string.Join(", ", s.TargetOffsets.Select(t => $"IL_{t:X4}"))}];",
+        Leave l => $"goto IL_{l.TargetOffset:X4}; // leave",
+        EndFinally => "// endfinally",
+        EndFilter f => $"// endfilter({Expression(f.Value)})",
+        _ => $"/* {node.Describe()} */",
+    };
+
+    static string Expression(IrExpression node) => node switch
+    {
+        LoadArgument a => a.Name,
+        LoadLocal l => $"V_{l.Index}",
+        LoadStackSlot s => $"S_{s.Slot}",
+        Constant c => ConstantText(c),
+        LoadField f => FieldTarget(f.Field, f.Instance),
+        Binary b => $"{Operand(b.Left)} {BinaryOperator(b)} {Operand(b.Right)}",
+        Comparison c => $"{Operand(c.Left)} {ComparisonOperator(c.Kind)} {Operand(c.Right)}",
+        LogicalNot n => $"!{Operand(n.Operand)}",
+        Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
+        Unary u => $"~{Operand(u.Operand)}",
+        Convert v => ConvertText(v),
+        Call c => CallText(c),
+        NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
+        ArrayLength l => $"{Operand(l.Array)}.Length",
+        LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
+        Box b => Expression(b.Operand),
+        IsInstance i => $"{Operand(i.Operand)} as {TypeText(i.Type)}",
+        CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
+        UnboxAny u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
+        Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
+        LoadLocalAddress a => $"ref V_{a.Index}",
+        LoadArgumentAddress a => $"ref {a.Name}",
+        LoadFieldAddress f => $"ref {FieldTarget(f.Field, f.Instance)}",
+        LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
+        LoadIndirect l => $"*{Operand(l.Address)}",
+        SizeOf s => $"sizeof({TypeText(s.Type)})",
+        LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
+            ? $"typeof({TypeText(t.Type)})"
+            : $"/* {t.Describe()} */",
+        CaughtException => "__exception",
+        UnsupportedNode u => $"/* {u.Describe()} */",
+        _ => $"/* {node.Describe()} */",
+    };
+
+    /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds to the inverse text-free form later (raising work, not printing work).</summary>
+    static string Condition(IrExpression condition) => condition switch
+    {
+        LogicalNot { Operand: Comparison c } => $"{Operand(c.Left)} {ComparisonOperator(Inverse(c.Kind))} {Operand(c.Right)}",
+        _ => Expression(condition),
+    };
+
+    static ComparisonKind Inverse(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.Equal => ComparisonKind.NotEqual,
+        ComparisonKind.NotEqual => ComparisonKind.Equal,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
+        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThan,
+        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
+        _ => ComparisonKind.LessThan,
+    };
+
+    /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
+    static string Operand(IrExpression node)
+    {
+        string text = Expression(node);
+        bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
+            or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken;
+        return atomic ? text : $"({text})";
+    }
+
+    static string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
+    {
+        null => $"{TypeText(field.DeclaringType)}.{field.Name}",
+        LoadArgument { Index: 0, Name: "this" } => field.Name,
+        _ => $"{Operand(instance)}.{field.Name}",
+    };
+
+    static string CallText(Call call)
+    {
+        var arguments = call.Arguments;
+        string typeArguments = call.Callee.TypeArguments.IsEmpty
+            ? ""
+            : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
+        if (!call.Callee.HasThis)
+            return $"{TypeText(call.Callee.DeclaringType)}.{call.Callee.Name}{typeArguments}({Arguments(arguments)})";
+        var receiver = arguments[0];
+        string rest = Arguments(arguments.Skip(1));
+        return receiver is LoadArgument { Index: 0, Name: "this" }
+            ? $"{call.Callee.Name}{typeArguments}({rest})"
+            : $"{Operand(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
+    }
+
+    static string Arguments(IEnumerable<IrExpression> arguments)
+        => string.Join(", ", arguments.Select(Expression));
+
+    static string ConvertText(Convert convert)
+    {
+        string cast = $"({TypeText(convert.Target)}){Operand(convert.Operand)}";
+        return convert.IsChecked ? $"checked({cast})" : cast;
+    }
+
+    static string ConstantText(Constant constant) => constant.Value switch
+    {
+        null => "null",
+        string s => $"\"{s.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"",
+        int i => i.ToString(CultureInfo.InvariantCulture),
+        long l => l.ToString(CultureInfo.InvariantCulture),
+        float f => $"{f.ToString("R", CultureInfo.InvariantCulture)}f",
+        double d => $"{d.ToString("R", CultureInfo.InvariantCulture)}d",
+        _ => constant.Value.ToString() ?? "?",
+    };
+
+    static string BinaryOperator(Binary binary) => binary.Kind switch
+    {
+        BinaryKind.Add => "+",
+        BinaryKind.Subtract => "-",
+        BinaryKind.Multiply => "*",
+        BinaryKind.Divide => "/",
+        BinaryKind.Remainder => "%",
+        BinaryKind.And => "&",
+        BinaryKind.Or => "|",
+        BinaryKind.Xor => "^",
+        BinaryKind.ShiftLeft => "<<",
+        _ => ">>",
+    };
+
+    static string ComparisonOperator(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.Equal => "==",
+        ComparisonKind.NotEqual => "!=",
+        ComparisonKind.LessThan => "<",
+        ComparisonKind.LessThanOrEqual => "<=",
+        ComparisonKind.GreaterThan => ">",
+        _ => ">=",
+    };
+
+    static string TypeText(TypeRef type)
+    {
+        string text = type.ToDisplayString();
+        int tick = text.IndexOf('`');
+        return tick < 0 ? text : text[..tick];
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -55,22 +55,21 @@ static class Program
             }
         }
 
+        var assemblies = ResolveAssemblies(inputs);
+        if (assemblies.Count == 0)
+            return Fail("No managed assemblies found in the given inputs.");
+
+        if (candidateName?.Equals("next", StringComparison.OrdinalIgnoreCase) == true)
+            return DiffNext(assemblies, maxExamples, reportPath);
+
+        if (pipelineName.Equals("next", StringComparison.OrdinalIgnoreCase))
+            return dumpMethod is not null ? DumpNext(assemblies, dumpMethod) : SweepNext(assemblies);
+
         if (!Pipelines.TryGetValue(baselineName, out var baseline))
             return Fail($"Unknown baseline pipeline '{baselineName}'. Known: {string.Join(", ", Pipelines.Keys)}");
         Func<MethodBodyContext, string>? candidate = null;
         if (candidateName is not null && !Pipelines.TryGetValue(candidateName, out candidate))
             return Fail($"Unknown candidate pipeline '{candidateName}'. Known: {string.Join(", ", Pipelines.Keys)}");
-
-        var assemblies = ResolveAssemblies(inputs);
-        if (assemblies.Count == 0)
-            return Fail("No managed assemblies found in the given inputs.");
-
-        if (pipelineName.Equals("next", StringComparison.OrdinalIgnoreCase))
-        {
-            if (candidateName is not null)
-                return Fail("Diff mode against 'next' arrives with its C# printer; today 'next' supports inventory and --dump.");
-            return dumpMethod is not null ? DumpNext(assemblies, dumpMethod) : SweepNext(assemblies);
-        }
 
         if (dumpMethod is not null)
             return DumpStages(assemblies, dumpMethod);
@@ -162,6 +161,107 @@ static class Program
         return crashes > 0 ? 1 : 0;
     }
 
+    /// <summary>
+    /// The parity scoreboard: every method through both pipelines, compared
+    /// as trimmed C# text. Both sides enumerate metadata in the same order,
+    /// so the zip is positional. Candidate output only counts when the IR
+    /// imported at Full fidelity — Partial methods are not comparable yet.
+    /// </summary>
+    static int DiffNext(List<string> assemblies, int maxExamples, string? reportPath)
+    {
+        long agree = 0, differ = 0, baselineFailed = 0, candidatePartial = 0, total = 0;
+        var diffBuckets = new Dictionary<string, (int Count, string Example)>();
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            using var source = MetadataSource.Open(assemblyPath);
+            using var candidates = IrImporter.ImportAssembly(source).GetEnumerator();
+
+            foreach (var typeDefHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeDefHandle);
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var method = reader.GetMethodDefinition(methodHandle);
+                    if (method.RelativeVirtualAddress == 0)
+                        continue;
+                    if (!candidates.MoveNext())
+                        return Fail("pipeline enumerations diverged — importer and harness disagree about method order");
+                    var (typeName, methodName, function) = candidates.Current;
+                    total++;
+
+                    string? baseline = null;
+                    try
+                    {
+                        var context = MethodBodyContext.Create(peReader, reader, method);
+                        if (context is not null)
+                            baseline = CSharpEmitter.Emit(context);
+                    }
+                    catch
+                    {
+                        baselineFailed++;
+                        continue;
+                    }
+                    if (baseline is null)
+                        continue;
+
+                    if (function.Fidelity != DecompilationFidelity.Full)
+                    {
+                        candidatePartial++;
+                        continue;
+                    }
+                    var candidate = CSharpPrinter.Print(function);
+                    if (candidate.Output is null)
+                    {
+                        candidatePartial++;
+                        continue;
+                    }
+
+                    if (Normalize(baseline) == Normalize(candidate.Output))
+                    {
+                        agree++;
+                    }
+                    else
+                    {
+                        differ++;
+                        string bucket = FirstDiffLine(Normalize(baseline), Normalize(candidate.Output));
+                        if (!diffBuckets.TryGetValue(bucket, out var entry))
+                            entry = (0, $"{typeName}::{methodName}");
+                        diffBuckets[bucket] = (entry.Count + 1, entry.Example);
+                    }
+                }
+            }
+        }
+
+        long compared = agree + differ;
+        Console.WriteLine($"PARITY: {agree}/{compared} agree ({Percent(agree, compared)}) of comparable methods");
+        Console.WriteLine($"  total {total}; candidate Partial {candidatePartial}; baseline failed {baselineFailed}");
+        Console.WriteLine("Top differences:");
+        foreach (var bucket in diffBuckets.OrderByDescending(b => b.Value.Count).Take(maxExamples * 3))
+            Console.WriteLine($"  {bucket.Value.Count,7}  {bucket.Key}  e.g. {bucket.Value.Example}");
+
+        if (reportPath is not null)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("# Parity Report (current vs next)").AppendLine();
+            sb.AppendLine($"- Agree: {agree}/{compared} ({Percent(agree, compared)})");
+            sb.AppendLine($"- Candidate Partial (not comparable): {candidatePartial}");
+            sb.AppendLine();
+            sb.AppendLine("| Count | First difference | Example |");
+            sb.AppendLine("| --- | --- | --- |");
+            foreach (var bucket in diffBuckets.OrderByDescending(b => b.Value.Count))
+                sb.AppendLine($"| {bucket.Value.Count} | {Escape(bucket.Key)} | {Escape(bucket.Value.Example)} |");
+            File.WriteAllText(reportPath, sb.ToString());
+            Console.WriteLine($"Report: {reportPath}");
+        }
+        return 0;
+    }
+
+    static string Normalize(string text) => text.ReplaceLineEndings("\n").TrimEnd();
+
     /// <summary>Stage dump through the replacement pipeline: the IR tree with diagnostics and fidelity.</summary>
     static int DumpNext(List<string> assemblies, string dumpMethod)
     {
@@ -181,6 +281,10 @@ static class Program
             Console.WriteLine();
             Console.WriteLine("==== IR (typed tree after import) ====");
             Console.Write(IrPrinter.Dump(function));
+            Console.WriteLine();
+            Console.WriteLine("==== C# (lowered; structure not yet raised) ====");
+            var printed = CSharpPrinter.Print(function);
+            Console.WriteLine(printed.Output ?? string.Join("\n", printed.Diagnostics.Select(d => $"// {d}")));
             return 0;
         }
         return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -30,8 +30,8 @@ dotnet run --project tools/DecompilerHarness -c Release -- --pipeline next
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --pipeline next --dump 'System.String::IsNullOrEmpty'
 
-# Diff mode (--candidate next) activates when the replacement pipeline
-# grows its C# printer
+# Parity scoreboard: every comparable method through both pipelines
+dotnet run --project tools/DecompilerHarness -c Release -- --candidate next
 
 # Stage-by-stage dump of one method (metadata type name)
 dotnet run --project tools/DecompilerHarness -c Release -- \

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,7 +8,7 @@ The differential harness from [docs/decompiler-pipeline.md](../../docs/decompile
 
 **Replacement-pipeline inventory** (`--pipeline next`): sweeps through the new importer and reports the fidelity histogram plus stop-reason buckets — the prioritized slice roadmap. Exits nonzero if any importer bug (DEC0001) appears.
 
-**Diff** (`--candidate <name>`): runs two pipelines over every method and reports agreement, categorized first-line diffs, and one-sided failures. Diffing against `next` activates when it grows its C# printer.
+**Diff** (`--candidate <name>`): runs two pipelines over every method and reports agreement, categorized first-line diffs, and one-sided failures. `--candidate next` is the parity scoreboard: every comparable method through both pipelines as trimmed C# text, with difference buckets that double as the raising-pass docket.
 
 **Stage dump** (`--dump 'Type::Method'`): JitDump for the decompiler — prints every stage of one method's analysis as projections of the shared `MethodAnalysis`: raw IL, typed IL (per-instruction stack states), structured IL (blocks and exception regions), then C#. The IL projections come from pre-transform stages, so the output is exactly what each pipeline layer saw.
 


### PR DESCRIPTION
## Summary

The pivot PR: the replacement pipeline produces C#, and the parity race against `current` is now measured.

**`CSharpPrinter`** renders the IR in deliberately honest *lowered* form — unraised structure prints as flat blocks with labels and gotos, never guessed sugar — with formatting aimed at the current emitter's style (bare this-members, `V_N`/`S_N` names, trimmed trailing return) so the diff measures structural distance, not whitespace.

**`--candidate next`** activates: every method through both pipelines, trimmed-text comparison, positional zip of the two metadata enumerations, candidate counted only at `Full` fidelity.

## The first scoreboard

```text
PARITY: 11,630/37,859 agree (30.72%) of comparable methods
```

~31% exact agreement with **zero raising passes** — the straight-line fraction of CoreLib. The difference buckets are the raising docket, pre-counted:

| Count | Difference | Raising work |
| --- | --- | --- |
| 486 | `base(...)` vs `.ctor(...)` | base/this constructor calls |
| 505 | `return false;` vs `return 0;` | type-aware constants in typed positions |
| 217+ | `SR.Foo` vs `SR.get_Foo()` | property-accessor sugar |
| 137 | `int V_0 = 0;` vs `int V_0;` | declaration/initializer merging |
| 72 | `typeof(T) == typeof(float)` vs `Type.op_Equality(GetTypeFromHandle(...))` | typeof folding + operator sugar |
| many | `int V_1;` vs `int V_0;` | expression inlining (the big structural one) |

Two buckets cut the *other* way — the baseline prints semi-qualified names (`Threading.CancellationToken`) and even a stray `::` spelling where the IR-based printer is already cleaner. Parity against `current` is the ramp; the corpus grade against dotnet/runtime source remains the destination, and where the two conflict, the taste doc decides.

## Validation

- Decompiler suite 305/305 both configs (printer style pinned on fixtures; a parity test asserts byte-equality with `CSharpEmitter` on `List.get_Count` — the first method class where both pipelines provably agree)
- `--pipeline next --dump` now shows the C# stage after the IR tree
- Sweep unchanged: 95.7% Full, zero importer bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)