### PR TITLE
First raising passes: pass infrastructure, typed constants, property sugar

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -242,6 +242,8 @@ public class CfgSampleClass
 {
     public static byte ToByte(int x) => (byte)x;
 
+    public static int LengthOf(string s) => s.Length;
+
     public static void Noop() { }
 
     public static int ParseOrZero(string s) => int.TryParse(s, out var v) ? v : 0;

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -434,6 +434,53 @@ public class CSharpPrinterTests
     }
 
     [Fact]
+    public void UnsignedConversion_CastsSignedSource()
+    {
+        // conv.r.un on a signed int: the source reads as unsigned, so the
+        // C# spelling needs the (uint) cast or the value is wrong for
+        // negative inputs.
+        var convert = new Pipeline.Convert(
+            TypeRef.CoreLib("System", "Double"), isChecked: false, isUnsigned: true,
+            new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32")));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(convert));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Double"),
+            [new Parameter("a", TypeRef.CoreLib("System", "Int32"))], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return (double)(uint)a;", CSharpPrinter.Print(function).Output!.Trim());
+    }
+
+    [Fact]
+    public void TypedConstants_BoxedAndElementConstants_Retype()
+    {
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var boxed = new Box(boolType, new Constant(1, TypeRef.CoreLib("System", "Int32")));
+        block.Add(new ExpressionStatement(boxed));
+        block.Add(new StoreElement(boolType,
+            new LoadArgument(0, "flags", TypeRef.SzArray(boolType)),
+            new Constant(0, TypeRef.CoreLib("System", "Int32")),
+            new Constant(1, TypeRef.CoreLib("System", "Int32"))));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("flags", TypeRef.SzArray(boolType))], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        new TypedConstantsPass().Run(function);
+
+        Assert.Equal(true, ((Constant)boxed.Operand).Value);
+        var store = function.Descendants.OfType<StoreElement>().Single();
+        Assert.Equal(true, ((Constant)store.Value).Value);
+        // The index constant stays int — element typing applies to the value.
+        Assert.Equal(0, ((Constant)store.Index).Value);
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void UnsignedOperations_CastSignedOperands_PlainWhenAlreadyUnsigned()
     {
         var signedInt = new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32"));

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -464,15 +464,42 @@ public class CSharpPrinterTests
     }
 
     [Fact]
-    public void Constructor_ThisReceiver_PrintsBaseCall()
+    public void Constructor_ImplicitBaseCall_IsSuppressed()
     {
+        // A no-argument base-constructor call is implicit in C#; only the
+        // field initializer remains in the body. (Argumentful base(...)
+        // still prints until constructor initializers are modeled.)
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, ".ctor");
 
         Assert.NotNull(function);
         string output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("base();", output);
+        Assert.DoesNotContain("base(", output);
         Assert.DoesNotContain(".ctor", output);
+        Assert.Contains("_shadowed = 1;", output);
+    }
+
+    [Fact]
+    public void UnsignedComparison_InverseCondition_KeepsUnsignedCasts()
+    {
+        // brfalse over an unsigned comparison folds to the inverse operator;
+        // the unsigned operand casts must survive the fold.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var comparison = new Comparison(ComparisonKind.LessThan, isUnsigned: true,
+            new LoadArgument(0, "a", intType), new LoadArgument(1, "b", intType));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ConditionalBranch(new LogicalNot(comparison), 4));
+        var target = new Block(4);
+        container.Add(target);
+        target.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("if ((uint)a >= (uint)b) goto IL_0004;", output);
     }
 
     [Fact]

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -495,3 +495,49 @@ public class CSharpPrinterTests
         Assert.Equal("return _size;", candidate);
     }
 }
+
+public class RaisingPassTests
+{
+    static string PrintWithPasses(string typeName, string methodName, MetadataSource source)
+    {
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+        var result = CSharpPrinter.Print(function);
+        Assert.True(result.Succeeded);
+        return result.Output!.ReplaceLineEndings("\n").TrimEnd();
+    }
+
+    [Fact]
+    public void TypedConstants_BoolReturn_PrintsFalse()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        Assert.Equal("return false;", PrintWithPasses("System.Array", "get_IsReadOnly", source));
+    }
+
+    [Fact]
+    public void PropertySugar_GetterCall_PrintsPropertyAccess()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        Assert.Equal("return s.Length;",
+            PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.LengthOf), source));
+    }
+
+    [Fact]
+    public void Passes_PreserveInvariants_AcrossCoreLibSample()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        foreach (var (type, method) in new[]
+        {
+            ("System.String", "IsNullOrEmpty"),
+            ("System.Collections.Generic.Dictionary`2", "ContainsValue"),
+            ("System.Text.StringBuilder", "Clear"),
+        })
+        {
+            var function = IrImporter.Import(source, type, method);
+            Assert.NotNull(function);
+            IrPasses.Run(function);  // CheckInvariant runs after every pass in debug
+            Assert.True(CSharpPrinter.Print(function).Succeeded);
+        }
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -57,7 +57,8 @@ public sealed class CSharpPrinter
                 bool isLast = i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
                 if (isLast && !labeledReturnOnly && statement is Return { Value: null })
                     break;
-                sb.AppendLine(Statement(statement));
+                if (Statement(statement) is { } line)
+                    sb.AppendLine(line);
             }
         }
         return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
@@ -100,8 +101,18 @@ public sealed class CSharpPrinter
             yield return $"{(type is null ? "var" : TypeText(type))} S_{slot};";
     }
 
-    string Statement(IrNode node) => node switch
+    /// <summary>Null means the statement has no body spelling: a no-argument base-constructor call is implicit in C#.</summary>
+    string? Statement(IrNode node) => node switch
     {
+        ExpressionStatement
+        {
+            Expression: Call
+            {
+                Callee: { Name: ".ctor", HasThis: true, ParameterTypes.IsEmpty: true } callee,
+            } call,
+        } when call.Arguments[0] is LoadArgument { Index: 0, Name: "this" }
+            && !Equals(callee.DeclaringType, _function.DeclaringType)
+            => null,
         ExpressionStatement e => e.Expression is UnsupportedNode u
             ? $"/* {u.Describe()} */"
             : $"{Expression(e.Expression)};",
@@ -176,9 +187,12 @@ public sealed class CSharpPrinter
     }
 
     string ComparisonText(Comparison comparison)
-        => comparison.IsUnsigned
-            ? $"{UnsignedOperand(comparison.Left)} {ComparisonOperator(comparison.Kind)} {UnsignedOperand(comparison.Right)}"
-            : $"{Operand(comparison.Left)} {ComparisonOperator(comparison.Kind)} {Operand(comparison.Right)}";
+        => ComparisonText(comparison.Kind, comparison.IsUnsigned, comparison.Left, comparison.Right);
+
+    string ComparisonText(ComparisonKind kind, bool isUnsigned, IrExpression left, IrExpression right)
+        => isUnsigned
+            ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
+            : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
 
     /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
     string UnsignedOperand(IrExpression operand)
@@ -195,10 +209,10 @@ public sealed class CSharpPrinter
         return cast is null ? Operand(operand) : $"({cast}){Operand(operand)}";
     }
 
-    /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds to the inverse text-free form later (raising work, not printing work).</summary>
+    /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds to the inverse form, preserving unsigned operand casts.</summary>
     string Condition(IrExpression condition) => condition switch
     {
-        LogicalNot { Operand: Comparison c } => $"{Operand(c.Left)} {ComparisonOperator(Inverse(c.Kind))} {Operand(c.Right)}",
+        LogicalNot { Operand: Comparison c } => ComparisonText(Inverse(c.Kind), c.IsUnsigned, c.Left, c.Right),
         _ => Expression(condition),
     };
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -109,6 +109,7 @@ public sealed class CSharpPrinter
         StoreArgument s => $"{s.Name} = {Expression(s.Value)};",
         StoreStackSlot s => $"S_{s.Slot} = {Expression(s.Value)};",
         StoreField s => $"{FieldTarget(s.Field, s.Instance)} = {Expression(s.Value)};",
+        StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
         StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
         InitObject o => $"*{Operand(o.Address)} = default({TypeText(o.Type)});",
@@ -138,6 +139,7 @@ public sealed class CSharpPrinter
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
+        LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
@@ -223,7 +225,30 @@ public sealed class CSharpPrinter
     {
         null => $"{TypeText(field.DeclaringType)}.{field.Name}",
         LoadArgument { Index: 0, Name: "this" } => field.Name,
-        _ => $"{Operand(instance)}.{field.Name}",
+        _ => $"{ReceiverText(instance)}.{field.Name}",
+    };
+
+    string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name)
+    {
+        string receiver = instance switch
+        {
+            null => TypeText(accessor.DeclaringType),
+            LoadArgument { Index: 0, Name: "this" } => "",
+            _ => ReceiverText(instance),
+        };
+        string dotted = receiver.Length == 0 ? name : $"{receiver}.{name}";
+        return name == "Item" && indexArguments.Count > 0
+            ? $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]"
+            : indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
+    }
+
+    /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
+    string ReceiverText(IrExpression receiver) => receiver switch
+    {
+        LoadLocalAddress a => $"V_{a.Index}",
+        LoadArgumentAddress a => a.Name,
+        LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
+        _ => Operand(receiver),
     };
 
     string CallText(Call call)
@@ -244,7 +269,7 @@ public sealed class CSharpPrinter
         }
         return receiver is LoadArgument { Index: 0, Name: "this" }
             ? $"{call.Callee.Name}{typeArguments}({rest})"
-            : $"{Operand(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
+            : $"{ReceiverText(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
     }
 
     string Arguments(IEnumerable<IrExpression> arguments)
@@ -260,11 +285,25 @@ public sealed class CSharpPrinter
     {
         null => "null",
         string s => $"\"{s.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"",
+        bool b => b ? "true" : "false",
+        char c => CharText(c),
         int i => i.ToString(CultureInfo.InvariantCulture),
         long l => l.ToString(CultureInfo.InvariantCulture),
         float f => $"{f.ToString("R", CultureInfo.InvariantCulture)}f",
         double d => $"{d.ToString("R", CultureInfo.InvariantCulture)}d",
         _ => constant.Value.ToString() ?? "?",
+    };
+
+    static string CharText(char c) => c switch
+    {
+        '\\' => "'\\\\'",
+        '\'' => "'\\''",
+        '\t' => "'\\t'",
+        '\n' => "'\\n'",
+        '\r' => "'\\r'",
+        '\0' => "'\\0'",
+        _ when char.IsControl(c) => $"'\\u{(int)c:x4}'",
+        _ => $"'{c}'",
     };
 
     static string BinaryOperator(Binary binary) => binary.Kind switch

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -291,7 +291,10 @@ public sealed class CSharpPrinter
 
     string ConvertText(Convert convert)
     {
-        string cast = $"({TypeText(convert.Target)}){Operand(convert.Operand)}";
+        // conv.r.un and conv.ovf.*.un interpret the SOURCE as unsigned —
+        // a signed operand needs its unsigned cast or the value is wrong.
+        string operand = convert.IsUnsigned ? UnsignedOperand(convert.Operand) : Operand(convert.Operand);
+        string cast = $"({TypeText(convert.Target)}){operand}";
         return convert.IsChecked ? $"checked({cast})" : cast;
     }
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -373,7 +373,10 @@ public static class IrImporter
                     break;
 
                 case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8:
-                    stack.Push(new Constant(opcode - ILOpCode.Ldc_i4_0, TypeRef.CoreLib("System", "Int32")));
+                    // Enum subtraction yields the enum's underlying ushort —
+                    // box an actual int or every typed-position check downstream
+                    // sees a value that lies about its own type.
+                    stack.Push(new Constant((int)(opcode - ILOpCode.Ldc_i4_0), TypeRef.CoreLib("System", "Int32")));
                     break;
                 case ILOpCode.Ldc_i4_s:
                     stack.Push(new Constant((int)(sbyte)reader.ReadILByte(), TypeRef.CoreLib("System", "Int32")));

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1040,7 +1040,10 @@ public static class IrImporter
                 var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, method.GetDeclaringType(), 0);
                 var typeScope = new GenericScope(GenericParameterNames(reader, reader.GetTypeDefinition(method.GetDeclaringType()).GetGenericParameters()), []);
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
-                return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance);
+                return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
+                {
+                    IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
+                };
             }
             case HandleKind.MemberReference:
             {
@@ -1051,12 +1054,21 @@ public static class IrImporter
                 // instantiate them against the parent's type arguments so a
                 // call on List<int> reports int, not T.
                 var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
+                string memberName = reader.GetString(member.Name);
                 return new MethodRef(
                     declaring,
-                    reader.GetString(member.Name),
+                    memberName,
                     signature.ReturnType.Instantiate(typeArguments, []),
                     [.. signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, []))],
-                    signature.Header.IsInstance);
+                    signature.Header.IsInstance)
+                {
+                    // MemberRefs carry no flags; accessor-shape naming is the
+                    // strongest local evidence without assembly resolution.
+                    IsSpecialName = memberName.StartsWith("get_", StringComparison.Ordinal)
+                        || memberName.StartsWith("set_", StringComparison.Ordinal)
+                        || memberName.StartsWith("op_", StringComparison.Ordinal)
+                        || memberName is ".ctor" or ".cctor",
+                };
             }
             case HandleKind.MethodSpecification:
             {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -51,6 +51,23 @@ public abstract class IrNode
         child.ChildIndex = index;
     }
 
+    /// <summary>
+    /// Detaches and returns all children, in slot order — the re-parenting
+    /// primitive for restructuring passes (detach, build the replacement
+    /// around them, then <see cref="ReplaceWith"/>).
+    /// </summary>
+    public IReadOnlyList<IrNode> DetachChildren()
+    {
+        var detached = new List<IrNode>(_children);
+        foreach (var child in detached)
+        {
+            child.Parent = null;
+            child.ChildIndex = -1;
+        }
+        _children.Clear();
+        return detached;
+    }
+
     /// <summary>Replaces this node at its slot in the parent. The primitive rewrite — what makes "this node was consumed" a tree edit instead of side-channel state.</summary>
     public void ReplaceWith(IrNode replacement)
     {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -12,6 +12,14 @@ public sealed record MethodRef(
 {
     /// <summary>Generic method type arguments (MethodSpec instantiations); empty for non-generic callees.</summary>
     public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
+
+    /// <summary>
+    /// Metadata SpecialName evidence (accessors, operators). Exact for
+    /// same-assembly MethodDefs; cross-assembly MemberRefs carry no flags,
+    /// so the resolver falls back to accessor-shape naming — the strongest
+    /// local evidence available without assembly resolution.
+    /// </summary>
+    public bool IsSpecialName { get; init; }
 }
 
 /// <summary>A materialized field reference.</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -571,6 +571,59 @@ public sealed class LoadToken : IrExpression
     public override string Describe() => $"LoadToken {Kind} {Display}";
 }
 
+/// <summary>A raised property or indexer read (from a get_ accessor call).</summary>
+public sealed class LoadProperty : IrExpression
+{
+    public LoadProperty(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments)
+    {
+        Accessor = accessor;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        foreach (var argument in indexArguments)
+            AddChild(argument);
+    }
+
+    public MethodRef Accessor { get; }
+    public bool HasInstance { get; }
+    public string PropertyName => Accessor.Name["get_".Length..];
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IReadOnlyList<IrExpression> IndexArguments
+        => Children.Skip(HasInstance ? 1 : 0).Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => Accessor.ReturnType;
+    public override IEnumerable<TypeRef> DirectTypes
+        => Accessor.ParameterTypes.Append(Accessor.DeclaringType).Append(Accessor.ReturnType);
+
+    public override string Describe() => $"LoadProperty {Accessor.DeclaringType.ToDisplayString()}.{PropertyName}";
+}
+
+/// <summary>A raised property or indexer write (from a set_ accessor call).</summary>
+public sealed class StoreProperty : IrNode
+{
+    public StoreProperty(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, IrExpression value)
+    {
+        Accessor = accessor;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        foreach (var argument in indexArguments)
+            AddChild(argument);
+        AddChild(value);
+    }
+
+    public MethodRef Accessor { get; }
+    public bool HasInstance { get; }
+    public string PropertyName => Accessor.Name["set_".Length..];
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IReadOnlyList<IrExpression> IndexArguments
+        => Children.Skip(HasInstance ? 1 : 0).Take(Children.Count - (HasInstance ? 1 : 0) - 1).Cast<IrExpression>().ToList();
+    public IrExpression Value => (IrExpression)Children[^1];
+    public override IEnumerable<TypeRef> DirectTypes
+        => Accessor.ParameterTypes.Append(Accessor.DeclaringType);
+
+    public override string Describe() => $"StoreProperty {Accessor.DeclaringType.ToDisplayString()}.{PropertyName}";
+}
+
 /// <summary>The exception value the CLR pushes on entry to a catch or filter handler.</summary>
 public sealed class CaughtException : IrExpression
 {

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -1,0 +1,38 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// A raising pass over the IR: one class, one job, registered in
+/// <see cref="IrPasses.Default"/> — the ordered list IS the architecture
+/// document (docs/decompiler-pipeline.md). Passes rewrite the tree via
+/// <see cref="IrNode.ReplaceWith"/>; they communicate through the tree,
+/// never side-channel state.
+/// </summary>
+public interface IIrPass
+{
+    string Name { get; }
+
+    void Run(IrFunction function);
+}
+
+/// <summary>The pipeline's pass list and runner. Debug builds validate tree invariants after every pass — a violation is a pass bug, never input data.</summary>
+public static class IrPasses
+{
+    public static ImmutableArray<IIrPass> Default { get; } =
+    [
+        new TypedConstantsPass(),
+        new PropertySugarPass(),
+    ];
+
+    public static void Run(IrFunction function) => Run(function, Default);
+
+    public static void Run(IrFunction function, ImmutableArray<IIrPass> passes)
+    {
+        foreach (var pass in passes)
+        {
+            pass.Run(function);
+            function.CheckInvariant();
+        }
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -1,0 +1,53 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises accessor calls to property and indexer nodes — the inverse of the
+/// compiler's property lowering. The get_/set_ naming plus matching arity is
+/// the same evidence the current emitter uses; the result is typed nodes,
+/// not name surgery at print time.
+/// </summary>
+public sealed class PropertySugarPass : IIrPass
+{
+    public string Name => "property-sugar";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            if (node.Parent is null)
+                continue;  // detached by an earlier rewrite in this walk
+            switch (node)
+            {
+                case Call call when IsGetter(call.Callee):
+                {
+                    var children = call.DetachChildren().Cast<IrExpression>().ToList();
+                    var instance = call.Callee.HasThis ? children[0] : null;
+                    var indexArguments = children.Skip(call.Callee.HasThis ? 1 : 0).ToList();
+                    call.ReplaceWith(new LoadProperty(call.Callee, instance, indexArguments));
+                    break;
+                }
+                case ExpressionStatement { Expression: Call call } statement when IsSetter(call.Callee):
+                {
+                    var children = call.DetachChildren().Cast<IrExpression>().ToList();
+                    var instance = call.Callee.HasThis ? children[0] : null;
+                    int skip = call.Callee.HasThis ? 1 : 0;
+                    var value = children[^1];
+                    var indexArguments = children.Skip(skip).Take(children.Count - skip - 1).ToList();
+                    statement.ReplaceWith(new StoreProperty(call.Callee, instance, indexArguments, value));
+                    break;
+                }
+            }
+        }
+    }
+
+    static bool IsGetter(MethodRef callee)
+        => callee.Name.StartsWith("get_", StringComparison.Ordinal)
+            && callee.Name.Length > "get_".Length
+            && callee.ReturnType is not { Namespace: "System", Name: "Void" };
+
+    static bool IsSetter(MethodRef callee)
+        => callee.Name.StartsWith("set_", StringComparison.Ordinal)
+            && callee.Name.Length > "set_".Length
+            && callee.ParameterTypes.Length >= 1
+            && callee.ReturnType is { Namespace: "System", Name: "Void" };
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -41,12 +41,14 @@ public sealed class PropertySugarPass : IIrPass
     }
 
     static bool IsGetter(MethodRef callee)
-        => callee.Name.StartsWith("get_", StringComparison.Ordinal)
+        => callee.IsSpecialName
+            && callee.Name.StartsWith("get_", StringComparison.Ordinal)
             && callee.Name.Length > "get_".Length
             && callee.ReturnType is not { Namespace: "System", Name: "Void" };
 
     static bool IsSetter(MethodRef callee)
-        => callee.Name.StartsWith("set_", StringComparison.Ordinal)
+        => callee.IsSpecialName
+            && callee.Name.StartsWith("set_", StringComparison.Ordinal)
             && callee.Name.Length > "set_".Length
             && callee.ParameterTypes.Length >= 1
             && callee.ReturnType is { Namespace: "System", Name: "Void" };

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -38,6 +38,15 @@ public sealed class TypedConstantsPass : IIrPass
                     when left is not Constant && left.ResultType is { } leftType:
                     Retype(constant, leftType);
                     break;
+                case Box { Operand: Constant constant } box:
+                    Retype(constant, box.Type);
+                    break;
+                case StoreElement { Value: Constant constant, ElementType: { } elementType }:
+                    Retype(constant, elementType);
+                    break;
+                case StoreIndirect { Value: Constant constant, Type: { } indirectType }:
+                    Retype(constant, indirectType);
+                    break;
             }
         }
     }

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -1,0 +1,70 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Retypes integer constants by the position that consumes them: IL has no
+/// bool or char constants (ldc.i4 serves all I4 types), so a 0 returned from
+/// a bool-returning method IS false — recovering that is raising, not
+/// guessing. Inverse of the compiler's constant lowering.
+/// </summary>
+public sealed class TypedConstantsPass : IIrPass
+{
+    public string Name => "typed-constants";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            switch (node)
+            {
+                case Return { Value: Constant constant }:
+                    Retype(constant, function.Signature.ReturnType);
+                    break;
+                case StoreLocal { Value: Constant constant } store:
+                    Retype(constant, store.Type);
+                    break;
+                case StoreArgument { Value: Constant constant } store:
+                    Retype(constant, store.Type);
+                    break;
+                case StoreField { Value: Constant constant } store:
+                    Retype(constant, store.Field.Type);
+                    break;
+                case Call call:
+                    RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0);
+                    break;
+                case NewObject ctor:
+                    RetypeArguments(ctor.Constructor, ctor.Arguments, 0);
+                    break;
+                case Comparison { Left: { } left, Right: Constant constant }
+                    when left is not Constant && left.ResultType is { } leftType:
+                    Retype(constant, leftType);
+                    break;
+            }
+        }
+    }
+
+    static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset)
+    {
+        for (int i = 0; i < callee.ParameterTypes.Length && i + receiverOffset < arguments.Count; i++)
+        {
+            if (arguments[i + receiverOffset] is Constant constant)
+                Retype(constant, callee.ParameterTypes[i]);
+        }
+    }
+
+    static void Retype(Constant constant, TypeRef target)
+    {
+        if (constant.Value is not int value)
+            return;
+        if (target is not { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
+            return;
+        switch (target.Name)
+        {
+            case "Boolean" when value is 0 or 1:
+                constant.ReplaceWith(new Constant(value == 1, target));
+                break;
+            case "Char" when value >= char.MinValue && value <= char.MaxValue:
+                constant.ReplaceWith(new Constant((char)value, target));
+                break;
+        }
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -213,6 +213,7 @@ static class Program
                         candidatePartial++;
                         continue;
                     }
+                    IrPasses.Run(function);
                     var candidate = CSharpPrinter.Print(function);
                     if (candidate.Output is null)
                     {
@@ -281,6 +282,13 @@ static class Program
             Console.WriteLine();
             Console.WriteLine("==== IR (typed tree after import) ====");
             Console.Write(IrPrinter.Dump(function));
+            foreach (var pass in IrPasses.Default)
+            {
+                IrPasses.Run(function, [pass]);
+                Console.WriteLine();
+                Console.WriteLine($"==== IR (after {pass.Name}) ====");
+                Console.Write(IrPrinter.Dump(function));
+            }
             Console.WriteLine();
             Console.WriteLine("==== C# (lowered; structure not yet raised) ====");
             var printed = CSharpPrinter.Print(function);


### PR DESCRIPTION
## Summary

The raising layer begins. `IIrPass` + `IrPasses.Default` is the ordered pass list from the design doc — one class, one job, `CheckInvariant` after every pass in debug builds — with the first two passes targeting the scoreboard's largest pre-counted buckets:

- **`TypedConstantsPass`**: IL has no bool/char constants (`ldc.i4` serves all I4 types), so a `0` returned from a bool-returning method *is* `false` — recovering it is the inverse of constant lowering, applied at every typed position (returns, stores, call arguments, comparisons).
- **`PropertySugarPass`**: `get_`/`set_` accessor calls raise to typed `LoadProperty`/`StoreProperty` nodes (indexers included), using the new `IrNode.DetachChildren` re-parenting primitive — tree rewrites, not name surgery at print time. A shared `ReceiverText` helper also fixes value-type receivers arriving by address (`(ref x).M()` → `x.M()`).

## The scoreboard

```text
30.72%  →  37.07%   (+6.35 points)
```

Predicted buckets closed on schedule: bool-as-int (505), property sugar (217+), address-receivers (69+).

## The pass found an import bug on its first run

The bool bucket initially refused to close: `ldc.i4.N` constants were boxing a **`ushort`** while claiming `Int32` — C# enum subtraction (`opcode - ILOpCode.Ldc_i4_0`) yields the enum's underlying type. The pass's `is int` check correctly declined to touch a value lying about its own type, which is exactly the typed-IR discipline working: the strict check turned a silent representation bug into a visible behavior gap within minutes. Fixed at the importer.

## Validation

- 311/311 both configs (end-to-end pass tests: `return false;`, `return s.Length;`, invariant preservation across a CoreLib sample)
- `--pipeline next --dump` now prints the IR after each pass — per-pass stages, the JitDump shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)