### PR TITLE
Bump package version to 0.10.7

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -21,7 +21,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.6</VersionPrefix>
+    <VersionPrefix>0.10.7</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump `dotnet-inspect` package version prefix to `0.10.7`

## Notes
- SKILL.md already includes `--all-libraries` guidance for package-wide scans and row-mode usage.

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo