### PR TITLE
Structuring pass: forward branch regions raise to nested IfStatements

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -728,6 +728,25 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void FloatUnorderedOrdering_PrintsNegatedOrderedDual()
+    {
+        // 'a >= b unordered' over doubles: C#'s >= is ordered, so the honest
+        // spelling is !(a < b) — NaN inputs take the same path as the IL.
+        var doubleType = TypeRef.CoreLib("System", "Double");
+        var comparison = new Comparison(ComparisonKind.GreaterThanOrEqual, isUnsigned: true,
+            new LoadArgument(0, "a", doubleType), new LoadArgument(1, "b", doubleType));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(comparison));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Boolean"),
+            [new Parameter("a", doubleType), new Parameter("b", doubleType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return !(a < b);", CSharpPrinter.Print(function).Output!.Trim());
+    }
+
+    [Fact]
     public void Structuring_GuardShape_RaisesToIf()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -728,6 +728,46 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void Structuring_GuardShape_RaisesToIf()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        string output = PrintWithPasses("System.String", "IsNullOrEmpty", source);
+
+        Assert.Equal("""
+            if (value != null)
+            {
+                return value.Length == 0;
+            }
+            return true;
+            """.ReplaceLineEndings("\n"), output);
+    }
+
+    [Fact]
+    public void Structuring_NestedGuards_NestAndDropGotos()
+    {
+        using var fixtureSource = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.AbsShort), fixtureSource);
+
+        Assert.DoesNotContain("goto", output);
+        Assert.Contains("if (", output);
+        // The inner overflow guard nests inside the outer negative guard.
+        Assert.Contains("    if (", output);
+    }
+
+    [Fact]
+    public void Structuring_Loops_KeepHonestFlatForm()
+    {
+        // Backward branches are outside this slice; the function keeps the
+        // always-correct flat rendering rather than guessed structure.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        string output = PrintWithPasses("System.String", "IsNullOrWhiteSpace", source);
+
+        Assert.Contains("goto", output);
+        Assert.Contains("IL_", output);
+    }
+
+    [Fact]
     public void Passes_PreserveInvariants_AcrossCoreLibSample()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -75,8 +75,7 @@ public sealed class CSharpPrinter
                 bool isLast = i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
                 if (isLast && !labeledReturnOnly && statement is Return { Value: null })
                     break;
-                if (Statement(statement) is { } line)
-                    sb.AppendLine(line);
+                AppendStatement(sb, statement, 0);
             }
         }
         return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
@@ -156,6 +155,31 @@ public sealed class CSharpPrinter
                 case LoadStackSlot slotLoad: seenSlots.Add(slotLoad.Slot); break;
             }
         }
+    }
+
+    /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
+    void AppendStatement(StringBuilder sb, IrNode node, int indent)
+    {
+        string pad = new(' ', indent * 4);
+        if (node is IfStatement ifStatement)
+        {
+            sb.Append(pad).Append("if (").Append(Condition(ifStatement.Condition)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            foreach (var statement in ifStatement.Then.Children)
+                AppendStatement(sb, statement, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            if (ifStatement.Else is { } elseArm)
+            {
+                sb.Append(pad).AppendLine("else");
+                sb.Append(pad).AppendLine("{");
+                foreach (var statement in elseArm.Children)
+                    AppendStatement(sb, statement, indent + 1);
+                sb.Append(pad).AppendLine("}");
+            }
+            return;
+        }
+        if (Statement(node) is { } line)
+            sb.Append(pad).AppendLine(line);
     }
 
     /// <summary>Null means the statement has no body spelling: a no-argument base-constructor call is implicit in C#.</summary>
@@ -326,7 +350,8 @@ public sealed class CSharpPrinter
     {
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
-            or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken;
+            or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
+            or LoadProperty;
         return atomic ? text : $"({text})";
     }
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -275,9 +275,27 @@ public sealed class CSharpPrinter
         => ComparisonText(comparison.Kind, comparison.IsUnsigned, comparison.Left, comparison.Right);
 
     string ComparisonText(ComparisonKind kind, bool isUnsigned, IrExpression left, IrExpression right)
-        => isUnsigned
+    {
+        // On floats .un means UNORDERED, and C#'s ordering operators are
+        // ordered — 'a >= b unordered' must print as !(a < b) or NaN inputs
+        // execute the wrong path. Equality needs no special form: C#'s ==
+        // is beq and != is bne.un already.
+        if (isUnsigned && IsFloatComparison(left, right)
+            && kind is ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
+                or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual)
+        {
+            return $"!({Operand(left)} {ComparisonOperator(Inverse(kind))} {Operand(right)})";
+        }
+        return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
+    }
+
+    static bool IsFloatComparison(IrExpression left, IrExpression right)
+        => IsFloat(left.ResultType) || IsFloat(right.ResultType);
+
+    static bool IsFloat(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Single" or "Double" };
 
     /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
     string UnsignedOperand(IrExpression operand)

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -114,6 +114,30 @@ public sealed class Block : IrNode
     public override string Describe() => $"Block IL_{StartOffset:X4}";
 }
 
+/// <summary>
+/// A raised conditional: condition, then-arm, optional else-arm. Produced by
+/// the structuring pass from forward branch regions; the flat Branch and
+/// ConditionalBranch forms it consumed are gone from the structured tree.
+/// </summary>
+public sealed class IfStatement : IrNode
+{
+    public IfStatement(IrExpression condition, Block thenArm, Block? elseArm)
+    {
+        HasElse = elseArm is not null;
+        AddChild(condition);
+        AddChild(thenArm);
+        if (elseArm is not null)
+            AddChild(elseArm);
+    }
+
+    public bool HasElse { get; }
+    public IrExpression Condition => (IrExpression)Children[0];
+    public Block Then => (Block)Children[1];
+    public Block? Else => HasElse ? (Block)Children[2] : null;
+
+    public override string Describe() => HasElse ? "IfStatement (with else)" : "IfStatement";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -28,6 +28,7 @@ public static class IrPasses
         // bool return); typed constants run again to catch them.
         new TypedConstantsPass(),
         new PropertySugarPass(),
+        new StructuringPass(),
     ];
 
     public static void Run(IrFunction function) => Run(function, Default);

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1,0 +1,229 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises forward branch regions into nested <see cref="IfStatement"/>s —
+/// the first structuring slice. Guard shapes (<c>if (c) goto M; …body…; M:</c>)
+/// and diamonds (<c>if (c) goto T; …false…; goto M; T: …true…; M:</c>) nest
+/// recursively. The pass is two-phase: the whole function is validated
+/// against the slice (forward branches only — loops, switch, and EH stay
+/// flat) before any mutation, so a function either structures completely or
+/// keeps the always-correct flat form. Conditions render the fallthrough
+/// arm first, matching the current emitter's guard style.
+/// </summary>
+public sealed class StructuringPass : IIrPass
+{
+    public string Name => "structuring";
+
+    public void Run(IrFunction function)
+    {
+        if (!function.Regions.IsEmpty)
+            return;  // flat EH model structures in a later slice
+        var blocks = function.Body.Blocks;
+        if (blocks.Count <= 1)
+            return;
+
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        if (!Validate(blocks, offsetToIndex, 0, blocks.Count, joinIndex: blocks.Count))
+            return;
+
+        var structured = BuildRegion(blocks, offsetToIndex, 0, blocks.Count, joinIndex: blocks.Count);
+        var container = new BlockContainer();
+        container.Add(structured);
+        function.Body.ReplaceWith(container);
+    }
+
+    /// <summary>Phase 1: pure shape check over block indices — no mutation until the whole function fits the slice.</summary>
+    static bool Validate(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int start, int stop, int joinIndex)
+    {
+        int i = start;
+        while (i < stop)
+        {
+            var block = blocks[i];
+            if (block.Children.Count == 0)
+            {
+                // Nop-only label landing pads (Debug builds): pure fallthrough.
+                i++;
+                continue;
+            }
+            for (int s = 0; s < block.Children.Count - 1; s++)
+            {
+                if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                    return false;  // mid-block control flow is outside the slice
+            }
+            switch (block.Children[^1])
+            {
+                case Return or Throw:
+                    i++;
+                    break;
+                case Branch branch:
+                    // Only the region-exit goto is in the slice; it must be
+                    // the region's last block.
+                    if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget)
+                        || branchTarget != joinIndex || i + 1 != stop)
+                    {
+                        return false;
+                    }
+                    i = stop;
+                    break;
+                case ConditionalBranch conditional:
+                {
+                    if (!offsetToIndex.TryGetValue(conditional.TargetOffset, out int target) || target <= i)
+                        return false;  // backward = loop, later slice
+                    if (target > stop)
+                        return false;
+                    // Guard: if (c) goto M with M ending this region's view.
+                    // Diamond: the fallthrough arm ends with goto M past the
+                    // true arm.
+                    int falseStart = i + 1;
+                    if (FindDiamondJoin(blocks, offsetToIndex, falseStart, target, stop) is { } join)
+                    {
+                        // False arm exits by goto join; true arm falls (or
+                        // returns) into join.
+                        if (!Validate(blocks, offsetToIndex, falseStart, target, joinIndex: join)
+                            || !Validate(blocks, offsetToIndex, target, join, joinIndex: join))
+                        {
+                            return false;
+                        }
+                        i = join;
+                        break;
+                    }
+                    // Guard form: arm is (i+1, target), continues at target.
+                    if (!Validate(blocks, offsetToIndex, falseStart, target, joinIndex: target))
+                        return false;
+                    i = target;
+                    break;
+                }
+                default:
+                    // A block that falls through to its successor.
+                    if (i + 1 >= stop && stop != joinIndex)
+                        return false;
+                    i++;
+                    break;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>The diamond join: the false arm's last block ends with a goto past the true arm; null means guard shape.</summary>
+    static int? FindDiamondJoin(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int falseStart, int trueStart, int stop)
+    {
+        if (falseStart >= trueStart)
+            return null;
+        if (blocks[trueStart - 1].Children.Count == 0)
+            return null;
+        if (blocks[trueStart - 1].Children[^1] is Branch branch
+            && offsetToIndex.TryGetValue(branch.TargetOffset, out int join)
+            && join > trueStart && join <= stop)
+        {
+            return join;
+        }
+        return null;
+    }
+
+    /// <summary>Phase 2: same walk, moving statements into the structured tree. Mirrors Validate exactly; shapes were already proven.</summary>
+    static Block BuildRegion(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int start, int stop, int joinIndex)
+    {
+        var result = new Block(blocks[start].StartOffset);
+        int i = start;
+        while (i < stop)
+        {
+            var block = blocks[i];
+            if (block.Children.Count == 0)
+            {
+                i++;
+                continue;
+            }
+            var statements = block.DetachChildren();
+            var last = statements[^1];
+            for (int s = 0; s < statements.Count - 1; s++)
+                result.Add(statements[s]);
+            switch (last)
+            {
+                case Return or Throw:
+                    result.Add(last);
+                    i++;
+                    break;
+                case Branch:
+                    i = stop;  // the region-exit goto disappears into structure
+                    break;
+                case ConditionalBranch conditional:
+                {
+                    int target = offsetToIndex[conditional.TargetOffset];
+                    var condition = (IrExpression)conditional.DetachChildren()[0];
+                    int falseStart = i + 1;
+                    if (FindDiamondJoin(blocks, offsetToIndex, falseStart, target, stop) is { } join)
+                    {
+                        // Fallthrough arm first, current-emitter guard style:
+                        // the negated condition selects it.
+                        var thenArm = BuildRegion(blocks, offsetToIndex, falseStart, target, joinIndex: join);
+                        var elseArm = BuildRegion(blocks, offsetToIndex, target, join, joinIndex: join);
+                        result.Add(new IfStatement(Negate(condition), thenArm, elseArm));
+                        i = join;
+                        break;
+                    }
+                    var guardArm = BuildRegion(blocks, offsetToIndex, falseStart, target, joinIndex: target);
+                    result.Add(new IfStatement(Negate(condition), guardArm, null));
+                    i = target;
+                    break;
+                }
+                default:
+                    result.Add(last);
+                    i++;
+                    break;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Negates a detached condition with the type-aware IL duals (the old
+    /// pipeline's NaN lesson): integer comparisons invert their kind; float
+    /// comparisons invert kind AND flip the unordered flag (NOT(a &lt; b) is
+    /// a &gt;= b unordered, never plain a &gt;= b); unknown operand types
+    /// wrap in LogicalNot — honest, never a guess. Double negation unwraps.
+    /// </summary>
+    static IrExpression Negate(IrExpression condition) => condition switch
+    {
+        LogicalNot not => (IrExpression)not.DetachChildren()[0],
+        Comparison comparison => InvertComparison(comparison),
+        _ => new LogicalNot(condition),
+    };
+
+    static IrExpression InvertComparison(Comparison comparison)
+    {
+        bool? isFloat = OperandFloatness(comparison);
+        if (isFloat is null && comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
+            return new LogicalNot(comparison);  // ordering duals need known operand types
+
+        var operands = comparison.DetachChildren();
+        var kind = comparison.Kind switch
+        {
+            ComparisonKind.Equal => ComparisonKind.NotEqual,
+            ComparisonKind.NotEqual => ComparisonKind.Equal,
+            ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
+            ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThan,
+            ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
+            _ => ComparisonKind.LessThan,
+        };
+        bool isUnsigned = isFloat == true ? !comparison.IsUnsigned : comparison.IsUnsigned;
+        return new Comparison(kind, isUnsigned, (IrExpression)operands[0], (IrExpression)operands[1]);
+    }
+
+    /// <summary>True = float operands, false = integer, null = unknown.</summary>
+    static bool? OperandFloatness(Comparison comparison)
+    {
+        bool? Of(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            ? type.Name switch
+            {
+                "Single" or "Double" => true,
+                "Boolean" or "Char" or "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
+                    or "Int64" or "UInt64" or "IntPtr" or "UIntPtr" => false,
+                _ => null,
+            }
+            : null;
+        return Of(comparison.Left.ResultType) ?? Of(comparison.Right.ResultType);
+    }
+}


### PR DESCRIPTION
## Summary

The structuring layer begins: `StructuringPass` raises forward branch regions into nested `IfStatement` nodes — guard shapes and diamonds, recursively — and the printer renders nested braces. The flat `Branch`/`ConditionalBranch` forms disappear from structured trees.

Three design points carried from the old pipeline's hardest lessons:

- **Two-phase, transactional**: the whole function validates against the slice *before any statement moves* — a function either structures completely or keeps the always-correct flat form. No partially-mutated middle state, ever.
- **Type-aware negation duals** (the #395 NaN lesson): integer comparisons invert their kind; float comparisons invert kind **and flip the unordered flag** (`NOT(a < b)` is `a >= b unordered`, never plain `a >= b`); unknown operand types wrap in `LogicalNot` honestly; double negation unwraps.
- **Out-of-slice stays flat**: loops (backward branches), `switch`, `leave`/EH regions — honest gotos until their own slices. Pinned by a loop-method test asserting the flat form survives.

## Output

`String.IsNullOrEmpty`, structured by the new pipeline:

```csharp
if (value != null)
{
    return value.Length == 0;
}
return true;
```

One `||`-fold away from the source form. `AbsShort`'s nested guards nest with zero gotos in **both** configs (Debug's nop-only label landing pads count as pure fallthrough).

## Numbers

Parity **39.63% → 40.60%**. The modest aggregate hides the shape change: the structured subset now disagrees with `current` mostly on *expression folding* (`||` chains, ternaries) rather than control flow. The big remaining structural bucket is loops (`for (...)` at 52+ and friends) — next slice.

## Validation

- 324/324 in both Debug and Release (structured guard exact-text, nested guards with zero gotos, loops-stay-flat)
- Inventory steady: 95.9% Full, zero importer bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)