### PR TITLE
Consolidate type families and condition negation

### DIFF
--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -284,7 +284,7 @@ public sealed class CSharpPrinter
             && kind is ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
                 or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual)
         {
-            return $"!({Operand(left)} {ComparisonOperator(Inverse(kind))} {Operand(right)})";
+            return $"!({Operand(left)} {ComparisonOperator(Conditions.Inverse(kind))} {Operand(right)})";
         }
         return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
@@ -292,30 +292,22 @@ public sealed class CSharpPrinter
     }
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)
-        => IsFloat(left.ResultType) || IsFloat(right.ResultType);
-
-    static bool IsFloat(TypeRef? type)
-        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Single" or "Double" };
+        => TypeFamilies.IsFloat(left.ResultType) || TypeFamilies.IsFloat(right.ResultType);
 
     /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
     string UnsignedOperand(IrExpression operand)
     {
-        string? cast = operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } type
-            ? type.Name switch
-            {
-                "SByte" or "Int16" or "Int32" => "uint",
-                "Int64" => "ulong",
-                "IntPtr" => "nuint",
-                _ => null,
-            }
-            : null;
+        string? cast = TypeFamilies.UnsignedCastKeyword(operand.ResultType);
         return cast is null ? Operand(operand) : $"({cast}){Operand(operand)}";
     }
 
-    /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds to the inverse form, preserving unsigned operand casts.</summary>
+    /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch
     {
-        LogicalNot { Operand: Comparison c } => ComparisonText(Inverse(c.Kind), c.IsUnsigned, c.Left, c.Right),
+        LogicalNot { Operand: Comparison c } => ComparisonText(
+            Conditions.Inverse(c.Kind),
+            IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
+            c.Left, c.Right),
         // brtrue/brfalse test any I4/ref value; C# conditions need bool —
         // non-bool operands spell the comparison the branch performs.
         LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
@@ -338,30 +330,14 @@ public sealed class CSharpPrinter
             return null;
 
         string text = Operand(operand);
-        if (type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
+        return TypeFamilies.Of(type) switch
         {
-            if (type.Name is "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
-                or "Int64" or "UInt64" or "Char" or "IntPtr" or "UIntPtr")
-            {
-                return ($"{text} != 0", $"{text} == 0");
-            }
-            if (type.Name is "String" or "Object")
-                return ($"{text} != null", $"{text} == null");
-        }
-        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
-            return ($"{text} != null", $"{text} == null");
-        return null;
+            // Boolean was filtered above, so an I4 family here is a real integer (or char).
+            StackFamily.I4 or StackFamily.I8 or StackFamily.I => ($"{text} != 0", $"{text} == 0"),
+            StackFamily.O => ($"{text} != null", $"{text} == null"),
+            _ => null,
+        };
     }
-
-    static ComparisonKind Inverse(ComparisonKind kind) => kind switch
-    {
-        ComparisonKind.Equal => ComparisonKind.NotEqual,
-        ComparisonKind.NotEqual => ComparisonKind.Equal,
-        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
-        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThan,
-        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
-        _ => ComparisonKind.LessThan,
-    };
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -856,38 +856,11 @@ public static class IrImporter
     {
         if (Equals(a, b))
             return a;
-        var familyA = StackFamilyOf(a);
-        var familyB = StackFamilyOf(b);
+        var familyA = TypeFamilies.Of(a);
+        var familyB = TypeFamilies.Of(b);
         if (familyA != familyB || familyA is null)
             return null;
-        return familyA switch
-        {
-            StackFamily.I4 => TypeRef.CoreLib("System", "Int32"),
-            StackFamily.I8 => TypeRef.CoreLib("System", "Int64"),
-            StackFamily.F => TypeRef.CoreLib("System", "Double"),
-            StackFamily.I => TypeRef.CoreLib("System", "IntPtr"),
-            _ => TypeRef.CoreLib("System", "Object"),
-        };
-    }
-
-    enum StackFamily { I4, I8, F, I, O }
-
-    /// <summary>The ECMA evaluation-stack family of a type, where it can be known without resolution; null when it cannot (a bare definition may be struct or class).</summary>
-    static StackFamily? StackFamilyOf(TypeRef type)
-    {
-        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
-            return StackFamily.O;
-        if (type.Kind != TypeRefKind.Definition || type.Assembly != TypeRef.CoreLibrary || type.Namespace != "System")
-            return null;
-        return type.Name switch
-        {
-            "Boolean" or "Char" or "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32" => StackFamily.I4,
-            "Int64" or "UInt64" => StackFamily.I8,
-            "Single" or "Double" => StackFamily.F,
-            "IntPtr" or "UIntPtr" => StackFamily.I,
-            "Object" or "String" => StackFamily.O,
-            _ => null,
-        };
+        return TypeFamilies.Canonical(familyA.Value);
     }
 
     /// <summary>A block whose entry expects stack values is a stack-carrying edge — out of slice, reported honestly via the importer's stop path.</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -1,0 +1,115 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>The ECMA-335 evaluation-stack families.</summary>
+public enum StackFamily { I4, I8, F, I, O }
+
+/// <summary>
+/// The single home for type-family classification (review consolidation:
+/// this knowledge previously lived in the importer's slot merging, the
+/// structuring pass's float detection, and three printer spellings). When
+/// <c>IsValueType</c> knowledge arrives via resolution, it lands here too.
+/// </summary>
+public static class TypeFamilies
+{
+    /// <summary>The stack family, where it is knowable without resolution; null when it is not (a bare definition may be struct, enum, or class).</summary>
+    public static StackFamily? Of(TypeRef? type)
+    {
+        if (type is null)
+            return null;
+        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
+            return StackFamily.O;
+        if (type.Kind != TypeRefKind.Definition || type.Assembly != TypeRef.CoreLibrary || type.Namespace != "System")
+            return null;
+        return type.Name switch
+        {
+            "Boolean" or "Char" or "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32" => StackFamily.I4,
+            "Int64" or "UInt64" => StackFamily.I8,
+            "Single" or "Double" => StackFamily.F,
+            "IntPtr" or "UIntPtr" => StackFamily.I,
+            "Object" or "String" => StackFamily.O,
+            _ => null,
+        };
+    }
+
+    public static bool IsFloat(TypeRef? type) => Of(type) == StackFamily.F;
+
+    /// <summary>True when the family is a known integer (I4/I8/I).</summary>
+    public static bool IsInteger(TypeRef? type) => Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I;
+
+    /// <summary>The canonical TypeRef for a family — what the evaluation stack physically carries at a join.</summary>
+    public static TypeRef Canonical(StackFamily family) => family switch
+    {
+        StackFamily.I4 => TypeRef.CoreLib("System", "Int32"),
+        StackFamily.I8 => TypeRef.CoreLib("System", "Int64"),
+        StackFamily.F => TypeRef.CoreLib("System", "Double"),
+        StackFamily.I => TypeRef.CoreLib("System", "IntPtr"),
+        _ => TypeRef.CoreLib("System", "Object"),
+    };
+
+    /// <summary>
+    /// The C# cast keyword that reinterprets a signed-integer type as its
+    /// unsigned counterpart; null when the type is already unsigned, float
+    /// (.un means unordered there), or unknown.
+    /// </summary>
+    public static string? UnsignedCastKeyword(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            ? type.Name switch
+            {
+                "SByte" or "Int16" or "Int32" => "uint",
+                "Int64" => "ulong",
+                "IntPtr" => "nuint",
+                _ => null,
+            }
+            : null;
+}
+
+/// <summary>
+/// The single home for condition negation — the type-aware IL duals (the
+/// old pipeline's NaN lesson): integer comparisons invert their kind; float
+/// comparisons invert kind AND flip the unordered flag (NOT(a &lt; b) is
+/// a &gt;= b unordered, never plain a &gt;= b); unknown operand types wrap
+/// in LogicalNot honestly; double negation unwraps.
+/// </summary>
+public static class Conditions
+{
+    public static ComparisonKind Inverse(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.Equal => ComparisonKind.NotEqual,
+        ComparisonKind.NotEqual => ComparisonKind.Equal,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
+        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThan,
+        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
+        _ => ComparisonKind.LessThan,
+    };
+
+    /// <summary>Negates a DETACHED condition, producing a detached result ready for adoption.</summary>
+    public static IrExpression Negate(IrExpression condition) => condition switch
+    {
+        LogicalNot not => (IrExpression)not.DetachChildren()[0],
+        Comparison comparison => InvertComparison(comparison),
+        _ => new LogicalNot(condition),
+    };
+
+    static IrExpression InvertComparison(Comparison comparison)
+    {
+        bool? isFloat = OperandFloatness(comparison);
+        if (isFloat is null && comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
+            return new LogicalNot(comparison);  // ordering duals need known operand types
+
+        var operands = comparison.DetachChildren();
+        bool isUnsigned = isFloat == true ? !comparison.IsUnsigned : comparison.IsUnsigned;
+        return new Comparison(Inverse(comparison.Kind), isUnsigned, (IrExpression)operands[0], (IrExpression)operands[1]);
+    }
+
+    /// <summary>True = float operands, false = known integer, null = unknown.</summary>
+    static bool? OperandFloatness(Comparison comparison)
+    {
+        bool? Of(TypeRef? type) => TypeFamilies.Of(type) switch
+        {
+            StackFamily.F => true,
+            StackFamily.I4 or StackFamily.I8 or StackFamily.I => false,
+            _ => null,
+        };
+        return Of(comparison.Left.ResultType) ?? Of(comparison.Right.ResultType);
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -178,52 +178,6 @@ public sealed class StructuringPass : IIrPass
         return result;
     }
 
-    /// <summary>
-    /// Negates a detached condition with the type-aware IL duals (the old
-    /// pipeline's NaN lesson): integer comparisons invert their kind; float
-    /// comparisons invert kind AND flip the unordered flag (NOT(a &lt; b) is
-    /// a &gt;= b unordered, never plain a &gt;= b); unknown operand types
-    /// wrap in LogicalNot — honest, never a guess. Double negation unwraps.
-    /// </summary>
-    static IrExpression Negate(IrExpression condition) => condition switch
-    {
-        LogicalNot not => (IrExpression)not.DetachChildren()[0],
-        Comparison comparison => InvertComparison(comparison),
-        _ => new LogicalNot(condition),
-    };
-
-    static IrExpression InvertComparison(Comparison comparison)
-    {
-        bool? isFloat = OperandFloatness(comparison);
-        if (isFloat is null && comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
-            return new LogicalNot(comparison);  // ordering duals need known operand types
-
-        var operands = comparison.DetachChildren();
-        var kind = comparison.Kind switch
-        {
-            ComparisonKind.Equal => ComparisonKind.NotEqual,
-            ComparisonKind.NotEqual => ComparisonKind.Equal,
-            ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
-            ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThan,
-            ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
-            _ => ComparisonKind.LessThan,
-        };
-        bool isUnsigned = isFloat == true ? !comparison.IsUnsigned : comparison.IsUnsigned;
-        return new Comparison(kind, isUnsigned, (IrExpression)operands[0], (IrExpression)operands[1]);
-    }
-
-    /// <summary>True = float operands, false = integer, null = unknown.</summary>
-    static bool? OperandFloatness(Comparison comparison)
-    {
-        bool? Of(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
-            ? type.Name switch
-            {
-                "Single" or "Double" => true,
-                "Boolean" or "Char" or "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
-                    or "Int64" or "UInt64" or "IntPtr" or "UIntPtr" => false,
-                _ => null,
-            }
-            : null;
-        return Of(comparison.Left.ResultType) ?? Of(comparison.Right.ResultType);
-    }
+    /// <summary>Negation delegates to the shared type-aware duals (see <see cref="Conditions"/>).</summary>
+    static IrExpression Negate(IrExpression condition) => Conditions.Negate(condition);
 }


### PR DESCRIPTION
## Summary

The structuring review's findings 3–4, done now because the loop slice builds directly on both:

- **`TypeFamilies`** — single home for ECMA stack-family classification, replacing four divergent copies (importer slot-merge enum, structuring float detection, printer unsigned-cast/truthiness/float switches). Exposes `Of`, `IsFloat`, `IsInteger`, `Canonical`, and `UnsignedCastKeyword`. This is also the landing site for `IsValueType` when resolution provides it — the single future fix for receiver purity and truthiness unknowns.
- **`Conditions`** — single home for the type-aware negation duals (`Inverse`, `Negate`); the structuring pass delegates.

One behavior change rode along, and it's a correctness fix the consolidation exposed: the printer's `LogicalNot`-over-comparison fold (the *flat* path) inverted the kind but never flipped the unordered flag — so unstructured `brfalse` over a float ordering comparison missed the NaN-correct `!(a < b)` spelling that #482's pass-side duals got right. Both paths now route through the shared logic. This was exactly review finding 3's predicted failure mode ("the printer's copy lacks the float dual handling"), caught by the consolidation it recommended.

## Validation

- Decompiler 325/325 both configs, CLI 999
- Parity steady at 40.60% (consolidation, not bucket movement)

Next: the loop slice, on CFG/dominator facts per the review's altitude note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)