### PR TITLE
Loop slice: csc's guarded while shape raises to WhileLoop

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -248,6 +248,13 @@ public class CfgSampleClass
 
     public static int Reused(int x) { var n = x + 1; return n * n; }
 
+    public static int DoWhileSum(int n)
+    {
+        int s = 0;
+        do { s += n; n--; } while (n > 0);
+        return s;
+    }
+
     public static void Noop() { }
 
     public static int ParseOrZero(string s) => int.TryParse(s, out var v) ? v : 0;

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -775,12 +775,37 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void Structuring_Loops_KeepHonestFlatForm()
+    public void Structuring_GuardedWhile_RaisesToWhileLoop()
     {
-        // Backward branches are outside this slice; the function keeps the
-        // always-correct flat rendering rather than guessed structure.
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);
         string output = PrintWithPasses("System.String", "IsNullOrWhiteSpace", source);
+
+        Assert.Equal("""
+            if (value == null)
+            {
+                return true;
+            }
+            int V_0 = 0;
+            while (V_0 < value.Length)
+            {
+                if (!char.IsWhiteSpace(value[V_0]))
+                {
+                    return false;
+                }
+                V_0 = V_0 + 1;
+            }
+            return true;
+            """.ReplaceLineEndings("\n"), output);
+    }
+
+    [Fact]
+    public void Structuring_BottomTestedLoop_KeepsHonestFlatForm()
+    {
+        // do-while is bottom-tested with no guard jump — outside this slice;
+        // the function keeps the always-correct flat rendering.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.DoWhileSum), source);
 
         Assert.Contains("goto", output);
         Assert.Contains("IL_", output);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -161,6 +161,15 @@ public sealed class CSharpPrinter
     void AppendStatement(StringBuilder sb, IrNode node, int indent)
     {
         string pad = new(' ', indent * 4);
+        if (node is WhileLoop whileLoop)
+        {
+            sb.Append(pad).Append("while (").Append(Condition(whileLoop.Condition)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            foreach (var statement in whileLoop.Body.Children)
+                AppendStatement(sb, statement, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is IfStatement ifStatement)
         {
             sb.Append(pad).Append("if (").Append(Condition(ifStatement.Condition)).AppendLine(")");
@@ -364,10 +373,12 @@ public sealed class CSharpPrinter
             LoadArgument { Index: 0, Name: "this" } => "",
             _ => ReceiverText(instance),
         };
+        // An instance property accessor with index arguments IS an indexer,
+        // whatever its metadata name (String's is Chars, not Item).
+        if (instance is not null && indexArguments.Count > 0)
+            return $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]";
         string dotted = receiver.Length == 0 ? name : $"{receiver}.{name}";
-        return name == "Item" && indexArguments.Count > 0
-            ? $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]"
-            : indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
+        return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
     }
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -138,6 +138,25 @@ public sealed class IfStatement : IrNode
     public override string Describe() => HasElse ? "IfStatement (with else)" : "IfStatement";
 }
 
+/// <summary>
+/// A raised while loop: csc's canonical guarded form (entry jump to the
+/// condition, body, bottom-tested backward branch). The condition is the
+/// stay-in-loop test as the IL wrote it — no negation involved.
+/// </summary>
+public sealed class WhileLoop : IrNode
+{
+    public WhileLoop(IrExpression condition, Block body)
+    {
+        AddChild(condition);
+        AddChild(body);
+    }
+
+    public IrExpression Condition => (IrExpression)Children[0];
+    public Block Body => (Block)Children[1];
+
+    public override string Describe() => "WhileLoop";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -59,15 +59,24 @@ public sealed class StructuringPass : IIrPass
                     i++;
                     break;
                 case Branch branch:
-                    // Only the region-exit goto is in the slice; it must be
-                    // the region's last block.
-                    if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget)
-                        || branchTarget != joinIndex || i + 1 != stop)
-                    {
+                {
+                    if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget))
                         return false;
+                    // csc's guarded while: br COND; BODY...; COND: brtrue BODY.
+                    if (FindWhileShape(blocks, offsetToIndex, i, branchTarget, stop) is { } loop)
+                    {
+                        if (!Validate(blocks, offsetToIndex, i + 1, branchTarget, joinIndex: branchTarget))
+                            return false;
+                        i = loop.ContinueAt;
+                        break;
                     }
+                    // Otherwise only the region-exit goto is in the slice; it
+                    // must be the region's last block.
+                    if (branchTarget != joinIndex || i + 1 != stop)
+                        return false;
                     i = stop;
                     break;
+                }
                 case ConditionalBranch conditional:
                 {
                     if (!offsetToIndex.TryGetValue(conditional.TargetOffset, out int target) || target <= i)
@@ -105,6 +114,30 @@ public sealed class StructuringPass : IIrPass
             }
         }
         return true;
+    }
+
+    /// <summary>
+    /// csc's guarded while at block <paramref name="i"/>: it ends with
+    /// <c>br COND</c> (forward), and the condition block COND consists of a
+    /// single <c>ConditionalBranch</c> back to the body start (i+1). The
+    /// body (i+1, COND) is its own region whose exits are the condition
+    /// block. Multi-statement condition blocks and loop breaks are outside
+    /// this slice — the function stays flat.
+    /// </summary>
+    static (int ContinueAt, ConditionalBranch BackBranch)? FindWhileShape(
+        IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int i, int conditionIndex, int stop)
+    {
+        if (conditionIndex <= i + 1 || conditionIndex >= stop)
+            return null;
+        var conditionBlock = blocks[conditionIndex];
+        if (conditionBlock.Children.Count != 1
+            || conditionBlock.Children[0] is not ConditionalBranch backBranch
+            || !offsetToIndex.TryGetValue(backBranch.TargetOffset, out int bodyStart)
+            || bodyStart != i + 1)
+        {
+            return null;
+        }
+        return (conditionIndex + 1, backBranch);
     }
 
     /// <summary>The diamond join: the false arm's last block ends with a goto past the true arm; null means guard shape.</summary>
@@ -146,9 +179,20 @@ public sealed class StructuringPass : IIrPass
                     result.Add(last);
                     i++;
                     break;
-                case Branch:
+                case Branch branch:
+                {
+                    int branchTarget = offsetToIndex[branch.TargetOffset];
+                    if (FindWhileShape(blocks, offsetToIndex, i, branchTarget, stop) is { } loop)
+                    {
+                        var body = BuildRegion(blocks, offsetToIndex, i + 1, branchTarget, joinIndex: branchTarget);
+                        var condition = (IrExpression)loop.BackBranch.DetachChildren()[0];
+                        result.Add(new WhileLoop(condition, body));
+                        i = loop.ContinueAt;
+                        break;
+                    }
                     i = stop;  // the region-exit goto disappears into structure
                     break;
+                }
                 case ConditionalBranch conditional:
                 {
                     int target = offsetToIndex[conditional.TargetOffset];


### PR DESCRIPTION
## Summary

Loops arrive in the structuring pass: csc's canonical guarded `while` (`br COND; BODY…; COND: brtrue BODY`) raises to a `WhileLoop` node inside the same two-phase transactional walk. The body is its own recursive region whose exits target the condition block — plain fallthrough and `continue` (a goto to the condition) both come out structured. The condition is the stay-in-loop test exactly as the IL wrote it.

Out-of-slice shapes keep the honest flat form: bottom-tested `do-while` (pinned by a new fixture), multi-statement condition blocks, and loop breaks.

## The output

`String.IsNullOrWhiteSpace` through `next`, both configs, pinned as exact text:

```csharp
if (value == null)
{
    return true;
}
int V_0 = 0;
while (V_0 < value.Length)
{
    if (!char.IsWhiteSpace(value[V_0]))
    {
        return false;
    }
    V_0 = V_0 + 1;
}
return true;
```

Guard, merged declaration, loop, nested if — every prior slice composing. (`value[V_0]` is a rode-along fix: an instance accessor with index arguments **is** an indexer whatever its metadata name — String's is `Chars`, not `Item`.)

## The honest parity note

40.60% → 40.61%. Loop *structure* now matches; loop *spellings* don't yet — `for` vs `while`, `V_0++` vs `V_0 = V_0 + 1`. Those are exactly the next two pieces of the docket, and they convert structures this pass now provides; the parity payoff for loops lands with them rather than here. (Same pattern as inlining-before-structuring: prerequisite first, measured honestly.)

## Validation

- 326/326 both configs; inventory steady at 95.9% Full, zero importer bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)