### PR TITLE
For-recognition and assignment sugar: the loop spellings land

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -775,8 +775,11 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void Structuring_GuardedWhile_RaisesToWhileLoop()
+    public void Structuring_GuardedWhile_RaisesToForLoop()
     {
+        // The full composition: guard, for-recognition with the declaration
+        // in the initializer, increment sugar, indexer — character-identical
+        // to the current emitter's rendering of this method.
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);
         string output = PrintWithPasses("System.String", "IsNullOrWhiteSpace", source);
 
@@ -785,14 +788,12 @@ public class RaisingPassTests
             {
                 return true;
             }
-            int V_0 = 0;
-            while (V_0 < value.Length)
+            for (int V_0 = 0; V_0 < value.Length; V_0++)
             {
                 if (!char.IsWhiteSpace(value[V_0]))
                 {
                     return false;
                 }
-                V_0 = V_0 + 1;
             }
             return true;
             """.ReplaceLineEndings("\n"), output);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -144,6 +144,14 @@ public sealed class CSharpPrinter
                     seenLocals.Add(store.Index);
                     if (entryStatements.Contains(store))
                         _declaringStores.Add(store);
+                    else if (store is { Parent: ForLoop forLoop, ChildIndex: 0 }
+                        && LastReferenceIsInside(function, store.Index, forLoop))
+                    {
+                        // A for-initializer declares its variable only when
+                        // every reference lives inside the loop — otherwise
+                        // C# scoping demands the declaration stay outside.
+                        _declaringStores.Add(store);
+                    }
                     break;
                 case LoadLocal load: seenLocals.Add(load.Index); break;
                 case LoadLocalAddress address: seenLocals.Add(address.Index); break;
@@ -157,10 +165,43 @@ public sealed class CSharpPrinter
         }
     }
 
+    /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
+    static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
+    {
+        IrNode? last = null;
+        foreach (var node in function.Descendants)
+        {
+            if (node is LoadLocal load && load.Index == localIndex
+                || node is StoreLocal store && store.Index == localIndex
+                || node is LoadLocalAddress address && address.Index == localIndex)
+            {
+                last = node;
+            }
+        }
+        for (var current = last; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, subtree))
+                return true;
+        }
+        return false;
+    }
+
     /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
     void AppendStatement(StringBuilder sb, IrNode node, int indent)
     {
         string pad = new(' ', indent * 4);
+        if (node is ForLoop forLoop)
+        {
+            string initializer = Statement(forLoop.Initializer)?.TrimEnd(';') ?? "";
+            string increment = Statement(forLoop.Increment)?.TrimEnd(';') ?? "";
+            sb.Append(pad).Append("for (").Append(initializer).Append("; ")
+                .Append(Condition(forLoop.Condition)).Append("; ").Append(increment).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            foreach (var statement in forLoop.Body.Children)
+                AppendStatement(sb, statement, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is WhileLoop whileLoop)
         {
             sb.Append(pad).Append("while (").Append(Condition(whileLoop.Condition)).AppendLine(")");
@@ -208,12 +249,17 @@ public sealed class CSharpPrinter
             : $"{Expression(e.Expression)};",
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} V_{s.Index} = {Expression(s.Value)};"
-            : $"V_{s.Index} = {Expression(s.Value)};",
-        StoreArgument s => $"{s.Name} = {Expression(s.Value)};",
+            : AssignmentText($"V_{s.Index}", s.Value, left => left is LoadLocal load && load.Index == s.Index),
+        StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index),
         StoreStackSlot s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Value.ResultType!)} S_{s.Slot} = {Expression(s.Value)};"
-            : $"S_{s.Slot} = {Expression(s.Value)};",
-        StoreField s => $"{FieldTarget(s.Field, s.Instance)} = {Expression(s.Value)};",
+            : AssignmentText($"S_{s.Slot}", s.Value, left => left is LoadStackSlot load && load.Slot == s.Slot),
+        StoreField s => AssignmentText(
+            FieldTarget(s.Field, s.Instance), s.Value,
+            left => left is LoadField load
+                && load.Field.Name == s.Field.Name
+                && Equals(load.Field.DeclaringType, s.Field.DeclaringType)
+                && SamePlace(load.Instance, s.Instance)),
         StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
         StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
@@ -357,6 +403,31 @@ public sealed class CSharpPrinter
             or LoadProperty;
         return atomic ? text : $"({text})";
     }
+
+    /// <summary>
+    /// Assignment spelling with compound/increment sugar: when the value is
+    /// an unchecked binary whose left operand reads the assignment target,
+    /// the runtime style is x++/x-- for ±1 and x op= rest otherwise.
+    /// </summary>
+    string AssignmentText(string target, IrExpression value, Func<IrExpression, bool> readsTarget)
+    {
+        if (value is Binary { IsChecked: false } binary && readsTarget(binary.Left))
+        {
+            if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
+                return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
+            return $"{target} {BinaryOperator(binary)}= {Operand(binary.Right)};";
+        }
+        return $"{target} = {Expression(value)};";
+    }
+
+    /// <summary>Structural same-place check for compound-assignment receivers; conservative (this/locals/arguments/static only).</summary>
+    static bool SamePlace(IrExpression? a, IrExpression? b) => (a, b) switch
+    {
+        (null, null) => true,
+        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
+        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
+        _ => false,
+    };
 
     string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
     {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -157,6 +157,30 @@ public sealed class WhileLoop : IrNode
     public override string Describe() => "WhileLoop";
 }
 
+/// <summary>
+/// A raised for loop: initializer statement, stay-in-loop condition,
+/// increment statement, body. Produced from a WhileLoop whose preceding
+/// statement initializes the condition variable and whose body ends by
+/// stepping it.
+/// </summary>
+public sealed class ForLoop : IrNode
+{
+    public ForLoop(IrNode initializer, IrExpression condition, IrNode increment, Block body)
+    {
+        AddChild(initializer);
+        AddChild(condition);
+        AddChild(increment);
+        AddChild(body);
+    }
+
+    public IrNode Initializer => Children[0];
+    public IrExpression Condition => (IrExpression)Children[1];
+    public IrNode Increment => Children[2];
+    public Block Body => (Block)Children[3];
+
+    public override string Describe() => "ForLoop";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
@@ -1,0 +1,52 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises while loops to for loops — the inverse of the compiler's for
+/// lowering. The shape is structural, not heuristic: the statement
+/// immediately before a <see cref="WhileLoop"/> stores the variable the
+/// condition reads, and the body's last statement steps that same variable.
+/// Runs after structuring; the loop must already be a tree node.
+/// </summary>
+public sealed class ForLoopPass : IIrPass
+{
+    public string Name => "for-loops";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var loop in function.Descendants.OfType<WhileLoop>().ToList())
+        {
+            if (loop.Parent is not Block container)
+                continue;
+            int slot = loop.ChildIndex;
+            if (slot == 0)
+                continue;
+            if (container.Children[slot - 1] is not StoreLocal initializer)
+                continue;
+            if (loop.Body.Children.Count == 0
+                || loop.Body.Children[^1] is not StoreLocal increment
+                || increment.Index != initializer.Index)
+            {
+                continue;
+            }
+            if (!ConditionReads(loop.Condition, initializer.Index))
+                continue;
+
+            increment.Detach();
+            var parts = loop.DetachChildren();  // [condition, body]
+            initializer.Detach();               // reindexes the loop's slot
+            loop.ReplaceWith(new ForLoop(initializer, (IrExpression)parts[0], increment, (Block)parts[1]));
+        }
+    }
+
+    static bool ConditionReads(IrExpression condition, int localIndex)
+    {
+        if (condition is LoadLocal { } load && load.Index == localIndex)
+            return true;
+        foreach (var node in condition.Descendants)
+        {
+            if (node is LoadLocal inner && inner.Index == localIndex)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -29,6 +29,7 @@ public static class IrPasses
         new TypedConstantsPass(),
         new PropertySugarPass(),
         new StructuringPass(),
+        new ForLoopPass(),
     ];
 
     public static void Run(IrFunction function) => Run(function, Default);


### PR DESCRIPTION
## Summary

The two spellings #484 set up:

- **`ForLoopPass`** — while loops whose preceding statement initializes the condition variable and whose body ends by stepping it raise to `ForLoop` nodes. Structural shape, not heuristic; runs after structuring so the loop is already a tree node. The scoping rule is enforced where it belongs: a for-initializer *declares* its variable only when every reference lives inside the loop — otherwise the declaration stays outside and the header renders the bare assignment.
- **Assignment sugar** shared by all four store kinds: an unchecked binary whose left operand reads the target spells `x++`/`x--` for ±1 and `x op= rest` otherwise. Field receivers use a structural same-place check (this/locals/arguments/static only) — rendered-text equality could equate different places.

## The milestone

`String.IsNullOrWhiteSpace` through `next`, both configs, pinned as exact text — **character-identical to the current emitter**:

```csharp
if (value == null)
{
    return true;
}
for (int V_0 = 0; V_0 < value.Length; V_0++)
{
    if (!char.IsWhiteSpace(value[V_0]))
    {
        return false;
    }
}
return true;
```

That's the first loop-bearing method where the greenfield pipeline and the 9,500-line emitter agree byte-for-byte — via typed import, six raising passes, and a printer, instead of side-channel state.

Parity **40.61% → 40.73%**; the remaining top buckets are expression-folding (`||` chains, ternaries via slot rewrites), `typeof` folding, and the `var S_0 = this;` ctor-chain bucket.

## Validation

- 326/326 both configs; inventory steady, zero importer bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)