### PR TITLE
Null tests render is-forms per the taste doc

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -724,7 +724,7 @@ public class RaisingPassTests
             [new Parameter("s", stringType)], HasThis: false, GenericParameterCount: 0);
         var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
 
-        Assert.Contains("if (s != null) goto IL_0004;", CSharpPrinter.Print(function).Output!);
+        Assert.Contains("if (s is not null) goto IL_0004;", CSharpPrinter.Print(function).Output!);
     }
 
     [Fact]
@@ -753,7 +753,7 @@ public class RaisingPassTests
         string output = PrintWithPasses("System.String", "IsNullOrEmpty", source);
 
         Assert.Equal("""
-            if (value != null)
+            if (value is not null)
             {
                 return value.Length == 0;
             }
@@ -784,7 +784,7 @@ public class RaisingPassTests
         string output = PrintWithPasses("System.String", "IsNullOrWhiteSpace", source);
 
         Assert.Equal("""
-            if (value == null)
+            if (value is null)
             {
                 return true;
             }

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -341,6 +341,17 @@ public sealed class CSharpPrinter
         {
             return $"!({Operand(left)} {ComparisonOperator(Conditions.Inverse(kind))} {Operand(right)})";
         }
+        // Null tests render the is-form (taste doc): it is always the
+        // reference test the IL performs, where == could round-trip to an
+        // op_Equality call under operator overloads.
+        if (kind is ComparisonKind.Equal or ComparisonKind.NotEqual
+            && (left is Constant { Value: null } || right is Constant { Value: null }))
+        {
+            var operand = right is Constant { Value: null } ? left : right;
+            return kind == ComparisonKind.Equal
+                ? $"{Operand(operand)} is null"
+                : $"{Operand(operand)} is not null";
+        }
         return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
@@ -389,7 +400,7 @@ public sealed class CSharpPrinter
         {
             // Boolean was filtered above, so an I4 family here is a real integer (or char).
             StackFamily.I4 or StackFamily.I8 or StackFamily.I => ($"{text} != 0", $"{text} == 0"),
-            StackFamily.O => ($"{text} != null", $"{text} == null"),
+            StackFamily.O => ($"{text} is not null", $"{text} is null"),
             _ => null,
         };
     }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -260,7 +260,17 @@ static class Program
         return 0;
     }
 
-    static string Normalize(string text) => text.ReplaceLineEndings("\n").TrimEnd();
+    /// <summary>
+    /// Canonicalizes settled taste deltas before comparison so parity
+    /// measures structure: the taste doc fixes null tests as is-forms, and
+    /// the frozen baseline still spells ==/!= — both sides canonicalize to
+    /// the is-form.
+    /// </summary>
+    static string Normalize(string text) => text
+        .ReplaceLineEndings("\n")
+        .Replace(" != null", " is not null")
+        .Replace(" == null", " is null")
+        .TrimEnd();
 
     /// <summary>Stage dump through the replacement pipeline: the IR tree with diagnostics and fidelity.</summary>
     static int DumpNext(List<string> assemblies, string dumpMethod)


### PR DESCRIPTION
## Summary

Owner taste call, already recorded in `decompiler-taste.md`: null tests render `value is null` / `value is not null`. The new printer now complies in both spelling sites — comparisons against a null constant (`ceq`/branch forms) and truthiness for reference-typed branch operands.

The form is also the fidelity-stronger one: `is null` is always the raw reference test the IL performs, while `==` round-trips to an `op_Equality` call under operator overloads. (For the record, the oracle is silent here — its rule covers `ReferenceEquals` only — and the corpus splits 1,351/1,307 on positive checks; taste decides, and did.)

The parity harness canonicalizes the pair before comparison, since the frozen baseline still spells `==`/`!=` — the metric keeps measuring structure rather than a settled taste delta. Parity holds at exactly 40.73%.

## Validation

- 326/326 both configs; pinned exact-text tests updated to the is-forms (`if (value is not null)`, `if (value is null)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)