### PR TITLE
Boolean folding: short-circuit chains, ternaries, bool-constant folds

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -248,6 +248,20 @@ public class CfgSampleClass
 
     public static int Reused(int x) { var n = x + 1; return n * n; }
 
+    public static bool BothPositive(int a, int b)
+    {
+        if (a > 0)
+        {
+            if (b > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int Pick(bool c, int a, int b) => c ? a : b;
+
     public static int DoWhileSum(int n)
     {
         int s = 0;

--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -747,18 +747,53 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void Structuring_GuardShape_RaisesToIf()
+    public void BooleanFolding_GuardReturn_FoldsToSourceForm()
     {
+        // The corpus front door, character-identical to the dotnet/runtime
+        // source: return value == null || value.Length == 0; (is-form per
+        // the taste doc).
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);
         string output = PrintWithPasses("System.String", "IsNullOrEmpty", source);
 
+        Assert.Equal("return value is null || value.Length == 0;\n", output + "\n");
+    }
+
+    [Fact]
+    public void BooleanFolding_GuardAndBoolComparison_FoldToAndChain()
+    {
+        // The && lowering plus the ceq-with-zero value form, folded back to
+        // the exact dotnet/runtime source: _size != 0 && IndexOf(item) >= 0.
+        // (Release-compiled CoreLib: the Debug result-local pattern with a
+        // shared failure tail is a later structuring slice.)
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        string output = PrintWithPasses("System.Collections.Generic.List`1", "Contains", source);
+
+        Assert.Equal("return _size != 0 && IndexOf(item) >= 0;", output);
+    }
+
+    [Fact]
+    public void BooleanFolding_TernarySource_PerConfigShape()
+    {
+        // Debug lowers the ternary through a stack-slot diamond, which folds
+        // back to the ternary (with the double-negative unwrapped and arms
+        // swapped). Release lowers it as dual returns, which stay in
+        // statement form — the same negation-shaped rule the baseline
+        // applies (old pipeline PR #421).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.Pick), source);
+
+#if DEBUG
+        Assert.Equal("return c ? a : b;", output);
+#else
         Assert.Equal("""
-            if (value is not null)
+            if (!c)
             {
-                return value.Length == 0;
+                return b;
             }
-            return true;
+            return a;
             """.ReplaceLineEndings("\n"), output);
+#endif
     }
 
     [Fact]

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -286,6 +286,8 @@ public sealed class CSharpPrinter
         Binary b => BinaryText(b),
         Comparison c => ComparisonText(c),
         LogicalNot n => $"!{Operand(n.Operand)}",
+        LogicalBinary l => LogicalText(l),
+        Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
@@ -413,6 +415,28 @@ public sealed class CSharpPrinter
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
             or LoadProperty;
         return atomic ? text : $"({text})";
+    }
+
+    /// <summary>
+    /// Short-circuit composition prints comparisons and nots bare (they bind
+    /// tighter than &amp;&amp;/||); same-kind chains associate without parens;
+    /// mixed kinds parenthesize.
+    /// </summary>
+    string LogicalText(LogicalBinary logical)
+    {
+        // Sides are condition positions: Condition() owns truthiness (a
+        // string operand spells 'is not null', never '!value') and the
+        // negation folds. Same-kind chains associate bare; mixed kinds
+        // and ternaries parenthesize.
+        string Side(IrExpression side) => side switch
+        {
+            LogicalBinary nested when nested.Kind == logical.Kind => LogicalText(nested),
+            LogicalBinary nested => $"({LogicalText(nested)})",
+            Conditional => $"({Expression(side)})",
+            _ => Condition(side),
+        };
+        string op = logical.Kind == LogicalKind.And ? "&&" : "||";
+        return $"{Side(logical.Left)} {op} {Side(logical.Right)}";
     }
 
     /// <summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -228,6 +228,48 @@ public sealed class Comparison : IrExpression
 }
 
 /// <summary>Logical negation of a truth-valued operand (the brfalse lowering; raising passes refine to comparisons).</summary>
+public enum LogicalKind { And, Or }
+
+/// <summary>
+/// Short-circuit boolean composition (&amp;&amp;/||) — distinct from the
+/// bitwise <see cref="Binary"/> forms. Raised by boolean folding from
+/// guard-return chains and nested guards; IL has no direct encoding.
+/// </summary>
+public sealed class LogicalBinary : IrExpression
+{
+    public LogicalBinary(LogicalKind kind, IrExpression left, IrExpression right)
+    {
+        Kind = kind;
+        AddChild(left);
+        AddChild(right);
+    }
+
+    public LogicalKind Kind { get; }
+    public IrExpression Left => (IrExpression)Children[0];
+    public IrExpression Right => (IrExpression)Children[1];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+
+    public override string Describe() => $"Logical{Kind}";
+}
+
+/// <summary>A raised ternary: condition selects between two values (the slot-diamond shape).</summary>
+public sealed class Conditional : IrExpression
+{
+    public Conditional(IrExpression condition, IrExpression whenTrue, IrExpression whenFalse)
+    {
+        AddChild(condition);
+        AddChild(whenTrue);
+        AddChild(whenFalse);
+    }
+
+    public IrExpression Condition => (IrExpression)Children[0];
+    public IrExpression WhenTrue => (IrExpression)Children[1];
+    public IrExpression WhenFalse => (IrExpression)Children[2];
+    public override TypeRef? ResultType => WhenTrue.ResultType ?? WhenFalse.ResultType;
+
+    public override string Describe() => "Conditional";
+}
+
 public sealed class LogicalNot : IrExpression
 {
     public LogicalNot(IrExpression operand) => AddChild(operand);

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -1,0 +1,153 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds structured shapes into short-circuit boolean expressions and
+/// ternaries — the inverse of the compiler's condition lowering, running
+/// after structuring so the shapes are tree nodes:
+///
+/// 1. Nested guards: <c>if (a) { if (b) { T } }</c> → <c>if (a &amp;&amp; b) { T }</c>.
+/// 2. Guard-return chains: <c>if (c) return A; return true;</c> →
+///    <c>return !c || A;</c> (and the &amp;&amp;/constant-arm duals).
+/// 3. Slot diamonds: <c>if (c) { S = A } else { S = B }</c> → <c>S = c ? A : B;</c>
+///    (a later inlining run collapses the slot into its use).
+///
+/// Runs to fixpoint so chains compose.
+/// </summary>
+public sealed class BooleanFoldingPass : IIrPass
+{
+    public string Name => "boolean-folding";
+
+    public void Run(IrFunction function)
+    {
+        while (FoldOnce(function))
+        {
+        }
+    }
+
+    static bool FoldOnce(IrFunction function)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            if (node.Parent is null)
+                continue;
+            bool folded = node switch
+            {
+                IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement) || FoldSlotDiamond(statement),
+                Comparison comparison => FoldBoolConstantComparison(comparison),
+                _ => false,
+            };
+            if (folded)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>X == false → !X (via the type-aware duals), X == true → X, and the != duals — the ceq-with-zero value form of boolean tests.</summary>
+    static bool FoldBoolConstantComparison(Comparison comparison)
+    {
+        if (comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
+            return false;
+        if (comparison.Left.ResultType is not { Namespace: "System", Name: "Boolean" }
+            || comparison.Right is not Constant { Value: bool constant })
+        {
+            return false;
+        }
+        var operand = comparison.Left;
+        comparison.DetachChildren();
+        bool keepIdentity = constant == (comparison.Kind == ComparisonKind.Equal);
+        comparison.ReplaceWith(keepIdentity ? operand : Conditions.Negate(operand));
+        return true;
+    }
+
+    /// <summary>if (a) { if (b) { T } } → if (a &amp;&amp; b) { T }</summary>
+    static bool FoldNestedGuard(IfStatement outer)
+    {
+        if (outer.HasElse || outer.Then.Children.Count != 1
+            || outer.Then.Children[0] is not IfStatement { HasElse: false } inner)
+        {
+            return false;
+        }
+        var outerCondition = outer.Condition;
+        outerCondition.Detach();
+        var innerParts = inner.DetachChildren();  // [condition, then]
+        outer.ReplaceWith(new IfStatement(
+            new LogicalBinary(LogicalKind.And, outerCondition, (IrExpression)innerParts[0]),
+            (Block)innerParts[1],
+            null));
+        return true;
+    }
+
+    /// <summary>if (c) return A; return B; → short-circuit when either side is a bool constant.</summary>
+    static bool FoldGuardReturn(IfStatement guard)
+    {
+        if (guard.HasElse || guard.Parent is not Block container)
+            return false;
+        if (guard.Then.Children.Count != 1 || guard.Then.Children[0] is not Return { Value: { } thenValue })
+            return false;
+        if (guard.ChildIndex + 1 >= container.Children.Count
+            || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
+        {
+            return false;
+        }
+        if (thenValue.ResultType is not { Namespace: "System", Name: "Boolean" }
+            || tailValue.ResultType is not { Namespace: "System", Name: "Boolean" })
+        {
+            return false;
+        }
+
+        IrExpression folded;
+        var condition = guard.Condition;
+        condition.Detach();
+        if (tailValue is Constant { Value: bool tailBool })
+        {
+            thenValue.Detach();
+            // if (c) return A; return true;  ≡ return !c || A;
+            // if (c) return A; return false; ≡ return c && A;
+            folded = tailBool
+                ? new LogicalBinary(LogicalKind.Or, Conditions.Negate(condition), thenValue)
+                : new LogicalBinary(LogicalKind.And, condition, thenValue);
+        }
+        else if (thenValue is Constant { Value: bool thenBool })
+        {
+            tailValue.Detach();
+            // if (c) return true;  return X; ≡ return c || X;
+            // if (c) return false; return X; ≡ return !c && X;
+            folded = thenBool
+                ? new LogicalBinary(LogicalKind.Or, condition, tailValue)
+                : new LogicalBinary(LogicalKind.And, Conditions.Negate(condition), tailValue);
+        }
+        else
+        {
+            return false;  // general ternary returns are a separate decision
+        }
+
+        tailReturn.Detach();
+        guard.ReplaceWith(new Return(folded));
+        return true;
+    }
+
+    /// <summary>if (c) { S = A } else { S = B } → S = c ? A : B;</summary>
+    static bool FoldSlotDiamond(IfStatement diamond)
+    {
+        if (diamond.Else is not { Children.Count: 1 } elseArm
+            || diamond.Then.Children.Count != 1
+            || diamond.Then.Children[0] is not StoreStackSlot thenStore
+            || elseArm.Children[0] is not StoreStackSlot elseStore
+            || thenStore.Slot != elseStore.Slot)
+        {
+            return false;
+        }
+        var condition = diamond.Condition;
+        condition.Detach();
+        var whenTrue = (IrExpression)thenStore.DetachChildren()[0];
+        var whenFalse = (IrExpression)elseStore.DetachChildren()[0];
+        if (condition is LogicalNot doubleNegative)
+        {
+            // !c ? b : a reads backwards; unwrap and swap the arms.
+            condition = (IrExpression)doubleNegative.DetachChildren()[0];
+            (whenTrue, whenFalse) = (whenFalse, whenTrue);
+        }
+        diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse)));
+        return true;
+    }
+}

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -30,6 +30,10 @@ public static class IrPasses
         new PropertySugarPass(),
         new StructuringPass(),
         new ForLoopPass(),
+        new BooleanFoldingPass(),
+        // Folding merges slot diamonds into single stores; a second inlining
+        // run collapses those slots into their uses (ternaries inline).
+        new ExpressionInliningPass(),
     ];
 
     public static void Run(IrFunction function) => Run(function, Default);


### PR DESCRIPTION
## Summary

The biggest remaining bucket: expression folding. `BooleanFoldingPass` runs after structuring, to fixpoint, with four folds:

1. **Nested guards** → `if (a && b)` (the tree-level descendant of the old `AbsorbChainedGuards`)
2. **Guard-return chains** with a bool-constant arm → `||`/`&&` via the shared `Conditions` duals
3. **Slot diamonds** → a single `Conditional` store; the second inlining run collapses the slot into its use (double-negative conditions unwrap with arm swap)
4. **`(X < 0) == false`** (the ceq-with-zero value form) → `X >= 0`

New nodes `LogicalBinary` (short-circuit, distinct from bitwise `Binary` — IL has no direct encoding, this is pure raising) and `Conditional`. Printer-side, logical sides and ternary conditions route through `Condition()` so truthiness holds inside chains — a string operand spells `is not null`, never `!value`.

## The milestone

The corpus front doors print **source-identical**:

```csharp
return value is null || value.Length == 0;     // String.IsNullOrEmpty
return _size != 0 && IndexOf(item) >= 0;       // List<T>.Contains
```

Per-config ternary behavior matches the baseline's statement-form rule: Debug's slot diamond folds to `c ? a : b`; Release's dual-return keeps the if-form (the negation-shaped rule from old PR #421), pinned per config.

## Numbers

Parity **40.73% → 41.26%**. One honest dip: ~127 methods moved to `Partial` because folded ternaries over merged-null slots now surface their unknown typing through the null-ResultType fidelity rule — previously those slots hid behind separate statements. The `TypeRef.IsValueType`/resolution work recovers them.

Stacked on #486 (the is-forms change); merges cleanly after it.

## Validation

- 328/328 in both Debug and Release (source-identical pins for both front doors, per-config ternary shapes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)