### PR TITLE
Spelling cluster: typeof folding, operator sugar, default initialization

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -848,6 +848,34 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void TypeOfAndOperatorSugar_PrintSourceForms()
+    {
+        // typeof folding plus op_Equality spelling: the generic-dispatch
+        // idiom prints as the source writes it.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.Numerics.Vector", "AllWhereAllBitsSet");
+        Assert.NotNull(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Contains("typeof(T) == typeof(float)", output);
+        Assert.DoesNotContain("GetTypeFromHandle", output);
+        Assert.DoesNotContain("op_Equality", output);
+    }
+
+    [Fact]
+    public void DefaultInitialization_MergesIntoDeclaration()
+    {
+        // initobj over a local address: 'CancellationToken V_0 = default;',
+        // not '*(ref V_0) = default(...)' nor a separate declaration.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.Threading.CancellationToken", "get_None");
+        Assert.NotNull(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal("CancellationToken V_0 = default;\nreturn V_0;", output);
+    }
+
+    [Fact]
     public void Passes_PreserveInvariants_AcrossCoreLibSample()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -114,7 +114,10 @@ public sealed class CSharpPrinter
         }
         foreach (int index in locals)
         {
-            if (!_declaringStores.OfType<StoreLocal>().Any(s => s.Index == index))
+            bool declaredAtStore = _declaringStores.Any(s =>
+                s is StoreLocal store && store.Index == index
+                || s is InitObject { Address: LoadLocalAddress init } && init.Index == index);
+            if (!declaredAtStore)
                 yield return $"{TypeText(function.Locals[index])} V_{index};";
         }
         foreach (var (slot, type) in slots)
@@ -152,6 +155,14 @@ public sealed class CSharpPrinter
                         // C# scoping demands the declaration stay outside.
                         _declaringStores.Add(store);
                     }
+                    break;
+                case InitObject { Address: LoadLocalAddress initTarget } init when !seenLocals.Contains(initTarget.Index):
+                    // Descendants yields the InitObject before its address
+                    // child, so this fires before the address marks the
+                    // local as seen.
+                    seenLocals.Add(initTarget.Index);
+                    if (entryStatements.Contains(init))
+                        _declaringStores.Add(init);
                     break;
                 case LoadLocal load: seenLocals.Add(load.Index); break;
                 case LoadLocalAddress address: seenLocals.Add(address.Index); break;
@@ -263,6 +274,13 @@ public sealed class CSharpPrinter
         StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
         StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
+        // default-initialization of a named place spells through the place,
+        // not its address.
+        InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
+            ? $"{TypeText(init.Type)} V_{local.Index} = default;"
+            : $"V_{local.Index} = default;",
+        InitObject { Address: LoadArgumentAddress argument } => $"{argument.Name} = default;",
+        InitObject { Address: LoadFieldAddress field } o2 => $"{FieldTarget(field.Field, field.Instance)} = default;",
         InitObject o => $"*{Operand(o.Address)} = default({TypeText(o.Type)});",
         Return { Value: { } value } => $"return {Expression(value)};",
         Return => "return;",
@@ -308,6 +326,7 @@ public sealed class CSharpPrinter
         LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
         LoadIndirect l => $"*{Operand(l.Address)}",
         SizeOf s => $"sizeof({TypeText(s.Type)})",
+        TypeOf t => $"typeof({TypeText(t.Type)})",
         LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
             ? $"typeof({TypeText(t.Type)})"
             : $"/* {t.Describe()} */",
@@ -413,7 +432,7 @@ public sealed class CSharpPrinter
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty;
+            or LoadProperty or TypeOf;
         return atomic ? text : $"({text})";
     }
 
@@ -464,6 +483,40 @@ public sealed class CSharpPrinter
         _ => false,
     };
 
+    /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
+    string? OperatorSpelling(Call call)
+    {
+        var arguments = call.Arguments;
+        if (arguments.Count == 2)
+        {
+            string? op = call.Callee.Name switch
+            {
+                "op_Equality" => "==", "op_Inequality" => "!=",
+                "op_LessThan" => "<", "op_LessThanOrEqual" => "<=",
+                "op_GreaterThan" => ">", "op_GreaterThanOrEqual" => ">=",
+                "op_Addition" => "+", "op_Subtraction" => "-",
+                "op_Multiply" => "*", "op_Division" => "/", "op_Modulus" => "%",
+                "op_BitwiseAnd" => "&", "op_BitwiseOr" => "|", "op_ExclusiveOr" => "^",
+                "op_LeftShift" => "<<", "op_RightShift" => ">>",
+                _ => null,
+            };
+            return op is null ? null : $"{Operand(arguments[0])} {op} {Operand(arguments[1])}";
+        }
+        if (arguments.Count == 1)
+        {
+            return call.Callee.Name switch
+            {
+                "op_UnaryNegation" => $"-{Operand(arguments[0])}",
+                "op_UnaryPlus" => $"+{Operand(arguments[0])}",
+                "op_LogicalNot" => $"!{Operand(arguments[0])}",
+                "op_OnesComplement" => $"~{Operand(arguments[0])}",
+                "op_Implicit" or "op_Explicit" => $"({TypeText(call.Callee.ReturnType)}){Operand(arguments[0])}",
+                _ => null,
+            };
+        }
+        return null;
+    }
+
     string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
     {
         null => $"{TypeText(field.DeclaringType)}.{field.Name}",
@@ -503,7 +556,13 @@ public sealed class CSharpPrinter
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
         if (!call.Callee.HasThis)
+        {
+            // C# compiles user-defined operators TO these calls; the
+            // operator spelling is the faithful inverse.
+            if (call.Callee.IsSpecialName && OperatorSpelling(call) is { } op)
+                return op;
             return $"{TypeText(call.Callee.DeclaringType)}.{call.Callee.Name}{typeArguments}({Arguments(arguments)})";
+        }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1));
         if (call.Callee.Name == ".ctor" && receiver is LoadArgument { Index: 0, Name: "this" })

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -660,6 +660,18 @@ public sealed class NewArray : IrExpression
     public override string Describe() => $"NewArray {ElementType.ToDisplayString()}[]";
 }
 
+/// <summary>The raised typeof(T): GetTypeFromHandle over a type token, folded.</summary>
+public sealed class TypeOf : IrExpression
+{
+    public TypeOf(TypeRef type) => Type = type;
+
+    public TypeRef Type { get; }
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Type");
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"TypeOf {Type.ToDisplayString()}";
+}
+
 public enum RuntimeTokenKind { Type, Method, Field }
 
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -95,10 +95,17 @@ public sealed class BooleanFoldingPass : IIrPass
             return false;
         }
 
-        IrExpression folded;
+        // Decide the shape COMPLETELY before any detach: bailing after a
+        // mutation leaves a mutilated IfStatement whose slots have shifted.
+        bool? tailConstant = tailValue is Constant { Value: bool tail } ? tail : null;
+        bool? thenConstant = thenValue is Constant { Value: bool then } ? then : null;
+        if (tailConstant is null && thenConstant is null)
+            return false;  // general ternary returns are a separate decision
+
         var condition = guard.Condition;
         condition.Detach();
-        if (tailValue is Constant { Value: bool tailBool })
+        IrExpression folded;
+        if (tailConstant is { } tailBool)
         {
             thenValue.Detach();
             // if (c) return A; return true;  ≡ return !c || A;
@@ -107,18 +114,14 @@ public sealed class BooleanFoldingPass : IIrPass
                 ? new LogicalBinary(LogicalKind.Or, Conditions.Negate(condition), thenValue)
                 : new LogicalBinary(LogicalKind.And, condition, thenValue);
         }
-        else if (thenValue is Constant { Value: bool thenBool })
+        else
         {
             tailValue.Detach();
             // if (c) return true;  return X; ≡ return c || X;
             // if (c) return false; return X; ≡ return !c && X;
-            folded = thenBool
+            folded = thenConstant == true
                 ? new LogicalBinary(LogicalKind.Or, condition, tailValue)
                 : new LogicalBinary(LogicalKind.And, Conditions.Negate(condition), tailValue);
-        }
-        else
-        {
-            return false;  // general ternary returns are a separate decision
         }
 
         tailReturn.Detach();

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -28,6 +28,7 @@ public static class IrPasses
         // bool return); typed constants run again to catch them.
         new TypedConstantsPass(),
         new PropertySugarPass(),
+        new TypeOfFoldingPass(),
         new StructuringPass(),
         new ForLoopPass(),
         new BooleanFoldingPass(),

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
@@ -1,0 +1,26 @@
+namespace DotnetInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds Type.GetTypeFromHandle(ldtoken T) to typeof(T) — the inverse of
+/// the compiler's typeof lowering, which always emits exactly this pair.
+/// </summary>
+public sealed class TypeOfFoldingPass : IIrPass
+{
+    public string Name => "typeof-folding";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            if (call.Parent is null)
+                continue;
+            if (call.Callee is { Name: "GetTypeFromHandle", HasThis: false, ParameterTypes.Length: 1 }
+                && call.Callee.DeclaringType is { Namespace: "System", Name: "Type" }
+                && call.Children.Count == 1
+                && call.Children[0] is LoadToken { Kind: RuntimeTokenKind.Type, Type: { } type })
+            {
+                call.ReplaceWith(new TypeOf(type));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three pre-counted buckets in one coherent spelling pass:

- **`TypeOfFoldingPass`**: `Type.GetTypeFromHandle(ldtoken T)` → `TypeOf` node → `typeof(T)`. The lowering always emits exactly this pair; the fold is its inverse.
- **Operator sugar** (printer): `op_*` calls spell as operators — binary, unary, and `op_Implicit`/`op_Explicit` as casts. C# compiles user-defined operators *to* these calls, so the operator form is the faithful inverse. Names without a C# spelling (`op_True`…) stay as calls. Combined with typeof folding, the generic-dispatch idiom prints as written: `if (typeof(T) == typeof(float))`.
- **`default` initialization**: `initobj` over a named place spells through the place (`V_0 = default;`), merges into the declaration when it's the entry-block first reference (`CancellationToken V_0 = default;`), and keeps the indirection form for raw pointers.

## A bug found, and a narrative corrected

The typeof test initially returned `Failed` — tracing it found a **check-before-mutate violation in #487's `FoldGuardReturn`**: it detached the condition before discovering neither return arm was constant, bailing with a mutilated `IfStatement` (slots shifted; the printer later cast a Block where the condition belonged). Fixed by deciding the shape completely before any detach.

This also corrects #487's "honest dip" claim: the 127 methods that moved to `Partial` were **not** surfacing unknown typing — they were this bug failing `PrintRaised`. The comparable set is restored to 37,859. (The two-phase rule the structuring pass enforces structurally is exactly what the fold violated ad-hoc — argument for the plan-then-execute consolidation when these passes grow.)

## Numbers

Parity **41.26% → 42.54%** (16,105 agreeing, on the restored full comparable set). 330/330 both configs; new pins: the generic-dispatch idiom and `CancellationToken.get_None` exact text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)