### PR TITLE
Ctor-chain cluster: coalesce raising, base. qualification, spill hygiene

### DIFF
--- a/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/DotnetInspector.Decompiler.Tests/IrImporterTests.cs
@@ -336,15 +336,15 @@ public class JoinTypeConflictTests : IDisposable
         // merges to null (honest unknown), never a guessed type.
         var function = BuildSynthetic([0x17, 0x2D, 0x03, 0x16, 0x2B, 0x01, 0x14, 0x26, 0x2A]);
 
-        var load = Assert.Single(function.Descendants.OfType<LoadStackSlot>(),
-            l => l.Parent is ExpressionStatement);
-        Assert.Null(load.Type);
-        // An unknown type anywhere is a fidelity signal: the merged-null
-        // slot caps the function at Partial, with a join-type diagnostic
-        // saying which types disagreed.
-        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        // The join-type diagnostic records the disagreement; the only
+        // consumer of the unknown value was a pop of a pure load, which
+        // elides — so no unknown-typed expression survives into the tree
+        // and fidelity stays Full while the diagnostic preserves the trace.
         var diagnostic = Assert.Single(function.Diagnostics);
         Assert.Contains("(join-type)", diagnostic.Message);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(),
+            l => l.Parent is ExpressionStatement);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
         function.CheckInvariant();
     }
 

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -271,7 +271,7 @@ public sealed class CSharpPrinter
                 && load.Field.Name == s.Field.Name
                 && Equals(load.Field.DeclaringType, s.Field.DeclaringType)
                 && SamePlace(load.Instance, s.Instance)),
-        StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName)} = {Expression(s.Value)};",
+        StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
         StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
         // default-initialization of a named place spells through the place,
@@ -306,11 +306,12 @@ public sealed class CSharpPrinter
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
         Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
+        Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
-        LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName),
+        LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
@@ -524,10 +525,13 @@ public sealed class CSharpPrinter
         _ => $"{ReceiverText(instance)}.{field.Name}",
     };
 
-    string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name)
+    string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {
         string receiver = instance switch
         {
+            // A NON-virtual this-receiver access to a base-declared member is
+            // C#'s base. — the call opcode deliberately skips dispatch.
+            LoadArgument { Index: 0, Name: "this" } when !isVirtual && IsCrossType(accessor.DeclaringType) => "base",
             null => TypeText(accessor.DeclaringType),
             LoadArgument { Index: 0, Name: "this" } => "",
             _ => ReceiverText(instance),
@@ -538,6 +542,14 @@ public sealed class CSharpPrinter
             return $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]";
         string dotted = receiver.Length == 0 ? name : $"{receiver}.{name}";
         return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
+    }
+
+    /// <summary>True when the member's declaring DEFINITION differs from the function's — self-calls in generic types arrive as instantiations (List&lt;!0&gt;) and must not count as cross-type.</summary>
+    bool IsCrossType(TypeRef memberDeclaringType)
+    {
+        static TypeRef Definition(TypeRef type)
+            => type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition } ? definition : type;
+        return !Equals(Definition(memberDeclaringType), Definition(_function.DeclaringType));
     }
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
@@ -571,9 +583,15 @@ public sealed class CSharpPrinter
             string keyword = Equals(call.Callee.DeclaringType, _function.DeclaringType) ? "this" : "base";
             return $"{keyword}({rest})";
         }
-        return receiver is LoadArgument { Index: 0, Name: "this" }
-            ? $"{call.Callee.Name}{typeArguments}({rest})"
-            : $"{ReceiverText(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
+        if (receiver is LoadArgument { Index: 0, Name: "this" })
+        {
+            // Non-virtual this-receiver call to a base-declared method is
+            // C#'s base.M() — the call opcode deliberately skips dispatch.
+            return !call.IsVirtual && IsCrossType(call.Callee.DeclaringType)
+                ? $"base.{call.Callee.Name}{typeArguments}({rest})"
+                : $"{call.Callee.Name}{typeArguments}({rest})";
+        }
+        return $"{ReceiverText(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
     }
 
     string Arguments(IEnumerable<IrExpression> arguments)

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -224,7 +224,13 @@ public static class IrImporter
         stack.Clear();
         var types = values.Select(v => v.ResultType).ToList();
         for (int i = 0; i < values.Length; i++)
+        {
+            // Re-spilling a slot into itself (S_0 = S_0) happens whenever an
+            // edge re-propagates values it loaded from the same slots.
+            if (values[i] is LoadStackSlot identity && identity.Slot == i)
+                continue;
             body.Add(new StoreStackSlot(i, values[i]));
+        }
         foreach (int target in targets)
         {
             if (state.EntryStacks.TryGetValue(target, out var existing))
@@ -729,8 +735,14 @@ public static class IrImporter
                 }
 
                 case ILOpCode.Pop:
-                    body.Add(new ExpressionStatement(Pop(stack)));
+                {
+                    // Popping a side-effect-free value (the dup/coalesce
+                    // lowering discards copies constantly) needs no statement.
+                    var popped = Pop(stack);
+                    if (popped is not (Constant or LoadArgument or LoadLocal or LoadStackSlot))
+                        body.Add(new ExpressionStatement(popped));
                     break;
+                }
 
                 case ILOpCode.Br or ILOpCode.Br_s:
                 {

--- a/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -252,6 +252,22 @@ public sealed class LogicalBinary : IrExpression
     public override string Describe() => $"Logical{Kind}";
 }
 
+/// <summary>The raised null-coalescing operator: left when non-null, else right.</summary>
+public sealed class Coalesce : IrExpression
+{
+    public Coalesce(IrExpression left, IrExpression right)
+    {
+        AddChild(left);
+        AddChild(right);
+    }
+
+    public IrExpression Left => (IrExpression)Children[0];
+    public IrExpression Right => (IrExpression)Children[1];
+    public override TypeRef? ResultType => Left.ResultType ?? Right.ResultType;
+
+    public override string Describe() => "Coalesce";
+}
+
 /// <summary>A raised ternary: condition selects between two values (the slot-diamond shape).</summary>
 public sealed class Conditional : IrExpression
 {
@@ -714,6 +730,9 @@ public sealed class LoadProperty : IrExpression
     }
 
     public MethodRef Accessor { get; }
+
+    /// <summary>Whether the accessor call was virtual; non-virtual cross-type this-receiver access spells base.</summary>
+    public bool IsVirtual { get; init; }
     public bool HasInstance { get; }
     public string PropertyName => Accessor.Name["get_".Length..];
     public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
@@ -741,6 +760,9 @@ public sealed class StoreProperty : IrNode
     }
 
     public MethodRef Accessor { get; }
+
+    /// <summary>Whether the accessor call was virtual; non-virtual cross-type this-receiver access spells base.</summary>
+    public bool IsVirtual { get; init; }
     public bool HasInstance { get; }
     public string PropertyName => Accessor.Name["set_".Length..];
     public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -32,7 +32,8 @@ public sealed class BooleanFoldingPass : IIrPass
                 continue;
             bool folded = node switch
             {
-                IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement) || FoldSlotDiamond(statement),
+                IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement)
+                    || FoldSlotDiamond(statement) || FoldCoalesce(statement),
                 Comparison comparison => FoldBoolConstantComparison(comparison),
                 _ => false,
             };
@@ -128,6 +129,68 @@ public sealed class BooleanFoldingPass : IIrPass
         guard.ReplaceWith(new Return(folded));
         return true;
     }
+
+    /// <summary>
+    /// T = X; if (X is null) { T = Y; } → T = X ?? Y; — the compiler's
+    /// null-coalescing lowering. X must be a plain load matching the tested
+    /// operand exactly; both stores must target the same place.
+    /// </summary>
+    static bool FoldCoalesce(IfStatement guard)
+    {
+        if (guard.HasElse || guard.Parent is not Block container || guard.ChildIndex == 0)
+            return false;
+        // The null test arrives as a comparison (ceq lowering) or as
+        // brfalse over the reference (LogicalNot after structuring).
+        IrExpression? tested = guard.Condition switch
+        {
+            Comparison { Kind: ComparisonKind.Equal, Right: Constant { Value: null } } c => c.Left,
+            LogicalNot { Operand: { } operand } => operand,
+            _ => null,
+        };
+        if (tested is null || guard.Then.Children.Count != 1)
+            return false;
+        // ?? is reference-only; brfalse over a known integer/bool means == 0.
+        if (TypeFamilies.Of(tested.ResultType) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+            return false;
+        var previous = container.Children[guard.ChildIndex - 1];
+        var inner = guard.Then.Children[0];
+
+        // Same place, both stores; tested operand is the same load as the
+        // first store's value.
+        bool match = (previous, inner) switch
+        {
+            (StoreStackSlot p, StoreStackSlot i) when p.Slot == i.Slot
+                => SameLoad(tested, p.Value),
+            (StoreLocal p, StoreLocal i) when p.Index == i.Index
+                => SameLoad(tested, p.Value),
+            _ => false,
+        };
+        if (!match)
+            return false;
+
+        var first = previous.DetachChildren()[0];
+        var fallback = inner.DetachChildren()[0];
+        var coalesce = new Coalesce((IrExpression)first, (IrExpression)fallback);
+        guard.Detach();
+        switch (previous)
+        {
+            case StoreStackSlot slot:
+                previous.ReplaceWith(new StoreStackSlot(slot.Slot, coalesce));
+                break;
+            case StoreLocal local:
+                previous.ReplaceWith(new StoreLocal(local.Index, local.Type, coalesce));
+                break;
+        }
+        return true;
+    }
+
+    static bool SameLoad(IrExpression tested, IrExpression stored) => (tested, stored) switch
+    {
+        (LoadStackSlot a, LoadStackSlot b) => a.Slot == b.Slot,
+        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
+        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
+        _ => false,
+    };
 
     /// <summary>if (c) { S = A } else { S = B } → S = c ? A : B;</summary>
     static bool FoldSlotDiamond(IfStatement diamond)

--- a/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/DotnetInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -23,7 +23,7 @@ public sealed class PropertySugarPass : IIrPass
                     var children = call.DetachChildren().Cast<IrExpression>().ToList();
                     var instance = call.Callee.HasThis ? children[0] : null;
                     var indexArguments = children.Skip(call.Callee.HasThis ? 1 : 0).ToList();
-                    call.ReplaceWith(new LoadProperty(call.Callee, instance, indexArguments));
+                    call.ReplaceWith(new LoadProperty(call.Callee, instance, indexArguments) { IsVirtual = call.IsVirtual });
                     break;
                 }
                 case ExpressionStatement { Expression: Call call } statement when IsSetter(call.Callee):
@@ -33,7 +33,7 @@ public sealed class PropertySugarPass : IIrPass
                     int skip = call.Callee.HasThis ? 1 : 0;
                     var value = children[^1];
                     var indexArguments = children.Skip(skip).Take(children.Count - skip - 1).ToList();
-                    statement.ReplaceWith(new StoreProperty(call.Callee, instance, indexArguments, value));
+                    statement.ReplaceWith(new StoreProperty(call.Callee, instance, indexArguments, value) { IsVirtual = call.IsVirtual });
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

One probe (`AccessViolationException..ctor`, the 170-method bucket) exposed four interlocking issues; this PR fixes all four:

- **`??` raising**: `T = X; if (X is null) { T = Y; }` → `T = X ?? Y` (`Coalesce` node). Matches both null-test forms (ceq comparison, post-structuring `LogicalNot`); excludes known integer/float operands where `brfalse` means `== 0`.
- **`base.` qualification**: non-virtual this-receiver calls and property accesses to base-declared members spell `base.M()`/`base.HResult` — the `call` opcode deliberately skips dispatch. Virtual stays bare (dispatch is real). The cross-type check compares declaring **definitions**: generic self-calls arrive as TypeSpecs (`List<!0>::IndexOf`) and the first attempt printed `base.IndexOf(item)` inside `List<T>.Contains` itself — caught immediately by the exact-text pin from #487, which is the pinned-corpus methodology earning its keep.
- **Spill hygiene**: identity edge re-spills (`S_0 = S_0;`) and pops of side-effect-free values no longer emit statements.

## Output delta on the probe

```csharp
// before                          // after
string S_256 = message;            string S_256 = message;
AccessViolationException S_0 = this;
string S_1 = S_256;                AccessViolationException S_0 = this;
if (S_256 is null)                 string S_1 = S_256 ?? SR.Arg_AccessViolationException;
{                                  S_0..ctor(S_1);
    S_1;                           base.HResult = -2147467261;
    S_0 = S_0;
    S_1 = SR.Arg_AccessViolationException;
}
S_0..ctor(S_1);
HResult = -2147467261;
```

(The remaining `S_0..ctor(S_1)` wart is the ctor-initializer modeling both pipelines defer — the baseline prints the same.)

## Numbers

Parity **42.54% → 43.32%** (16,401). One test re-pin with its reasoning recorded: a dead unknown value that nothing consumes now elides, so the join-type diagnostic preserves the trace while fidelity stays `Full` — diagnostics record history, fidelity describes the tree.

330/330 both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)