### PR TITLE
EH structuring: try/catch/finally raising with tail-leave trimming

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -293,6 +293,46 @@ public class CfgSampleClass
 
     public static int PowerOfTwo(int x) => x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 };
 
+    // --- EH structuring fixtures ---
+
+    public static int CatchLogs(string s)
+    {
+        try { return int.Parse(s); }
+        catch (FormatException e) { Console.WriteLine(e.Message); return -1; }
+    }
+
+    public static int CatchDiscards(string s)
+    {
+        try { return int.Parse(s); }
+        catch (FormatException) { return 0; }
+    }
+
+    public static int CatchEverything(string s)
+    {
+        try { return int.Parse(s); }
+        catch { return 0; }
+    }
+
+    public static int LogAndRethrow(string s)
+    {
+        try { return int.Parse(s); }
+        catch (FormatException) { Console.WriteLine("bad"); throw; }
+    }
+
+    public static int TwoCatches(string s)
+    {
+        try { return int.Parse(s); }
+        catch (FormatException) { return -1; }
+        catch (OverflowException) { return -2; }
+    }
+
+    public static int ParseWithCleanup(string s, Action done)
+    {
+        try { return int.Parse(s); }
+        catch (FormatException) { return 0; }
+        finally { done(); }
+    }
+
     [System.Runtime.InteropServices.DllImport("nonexistent")]
     private static extern void Overloaded(int x);
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -893,3 +893,123 @@ public class RaisingPassTests
         }
     }
 }
+
+/// <summary>
+/// The EH structuring slice: flat regions raise to TryCatch/TryFinally with
+/// consumed regions, entry stores fold into clause variables, tail leaves
+/// trim to fallthrough — and out-of-slice shapes (filters) keep the flat
+/// form with regions intact.
+/// </summary>
+public class EhStructuringTests
+{
+    static (IrFunction Function, string Output) RaiseFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+        var result = CSharpPrinter.Print(function);
+        Assert.True(result.Succeeded);
+        return (function, result.Output!.ReplaceLineEndings("\n").TrimEnd());
+    }
+
+    [Fact]
+    public void TryFinally_RaisesToStructuredForm()
+    {
+        var (function, output) = RaiseFixture(nameof(CfgSampleClass.TryFinallyAdd));
+
+        Assert.Empty(function.Regions);
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("finally", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("endfinally", output);
+    }
+
+    [Fact]
+    public void Catch_EntryStore_FoldsIntoClauseVariable()
+    {
+        var (function, output) = RaiseFixture(nameof(CfgSampleClass.CatchLogs));
+
+#if DEBUG
+        // Debug stores the catch variable at handler entry; the store folds
+        // into the clause header.
+        var clause = Assert.Single(function.Descendants.OfType<CatchClause>());
+        Assert.NotNull(clause.VariableIndex);
+        Assert.Matches(@"catch \(FormatException V_\d+\)", output);
+        Assert.DoesNotContain("__exception", output);
+        // The clause owns the declaration — nothing declares the local up front.
+        Assert.DoesNotMatch(@"FormatException V_\d+;", output);
+#else
+        // Release consumes the exception inline (callvirt get_Message on the
+        // raw stack value, no store) — outside the slice, honestly flat.
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+#endif
+        // ldc.i4.m1 must print -1, not the ushort-wrapped 65535.
+        Assert.Contains("-1;", output);
+        Assert.DoesNotContain("65535", output);
+    }
+
+    [Fact]
+    public void Catch_DiscardedException_PrintsBareType()
+    {
+        var (function, output) = RaiseFixture(nameof(CfgSampleClass.CatchDiscards));
+
+        var clause = Assert.Single(function.Descendants.OfType<CatchClause>());
+        Assert.Null(clause.VariableIndex);
+        Assert.Matches(@"(?m)^catch \(FormatException\)$", output);
+    }
+
+    [Fact]
+    public void CatchAll_PrintsBareCatch()
+    {
+        var (_, output) = RaiseFixture(nameof(CfgSampleClass.CatchEverything));
+
+        Assert.Matches(@"(?m)^catch$", output);
+    }
+
+    [Fact]
+    public void Rethrow_PrintsBareThrow()
+    {
+        var (_, output) = RaiseFixture(nameof(CfgSampleClass.LogAndRethrow));
+
+        Assert.Contains("throw;", output);
+        Assert.DoesNotContain("__exception", output);
+    }
+
+    [Fact]
+    public void MultiCatch_PreservesClauseOrder()
+    {
+        var (function, output) = RaiseFixture(nameof(CfgSampleClass.TwoCatches));
+
+        var tryCatch = Assert.Single(function.Descendants.OfType<TryCatch>());
+        Assert.Equal(2, tryCatch.Clauses.Count);
+        Assert.True(output.IndexOf("FormatException", StringComparison.Ordinal)
+            < output.IndexOf("OverflowException", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TryCatchFinally_TailLeaves_TrimThroughNestedConstructs()
+    {
+        // The arms of the inner try/catch leave straight past the outer
+        // finally; in tail position that is plain fallthrough, so no goto
+        // and no label survive.
+        var (function, output) = RaiseFixture(nameof(CfgSampleClass.ParseWithCleanup));
+
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Single(function.Descendants.OfType<TryCatch>());
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void Filter_StaysFlatWithRegionsIntact()
+    {
+        var (function, _) = RaiseFixture(nameof(CfgSampleClass.FilteredLength));
+
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -48,11 +48,13 @@ public sealed class CSharpPrinter
     /// <summary>Stores that double as declarations: the local's first program-order reference, at statement level in the entry block.</summary>
     readonly HashSet<IrNode> _declaringStores = [];
 
+    /// <summary>Offsets some surviving goto targets — labels print wherever the block lives, top-level or inside a flat EH body.</summary>
+    HashSet<int> _labelTargets = [];
+
     string PrintBody(IrFunction function)
     {
         var sb = new StringBuilder();
-        var blocks = function.Body.Blocks;
-        var labelTargets = CollectBranchTargets(function);
+        _labelTargets = CollectBranchTargets(function);
         CollectDeclaringStores(function);
 
         // Remaining locals and slots declare up front, current-style.
@@ -61,24 +63,31 @@ public sealed class CSharpPrinter
         if (sb.Length > 0)
             sb.AppendLine();
 
+        AppendContainer(sb, function.Body, 0, topLevel: true);
+        return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
+    }
+
+    void AppendContainer(StringBuilder sb, BlockContainer container, int indent, bool topLevel = false)
+    {
+        string pad = new(' ', indent * 4);
+        var blocks = container.Blocks;
         for (int i = 0; i < blocks.Count; i++)
         {
             var block = blocks[i];
-            if (labelTargets.Contains(block.StartOffset))
-                sb.AppendLine($"IL_{block.StartOffset:X4}:");
+            if (_labelTargets.Contains(block.StartOffset))
+                sb.Append(pad).AppendLine($"IL_{block.StartOffset:X4}:");
             // The trailing 'return;' trims, current-style — unless it is a
             // labeled block's only statement, where trimming would strand
             // the label as invalid C#.
-            bool labeledReturnOnly = labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
+            bool labeledReturnOnly = _labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
             foreach (var statement in block.Children)
             {
-                bool isLast = i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
+                bool isLast = topLevel && i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
                 if (isLast && !labeledReturnOnly && statement is Return { Value: null })
                     break;
-                AppendStatement(sb, statement, 0);
+                AppendStatement(sb, statement, indent);
             }
         }
-        return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
     }
 
     static HashSet<int> CollectBranchTargets(IrFunction function)
@@ -101,6 +110,11 @@ public sealed class CSharpPrinter
     {
         var locals = new SortedSet<int>();
         var slots = new SortedDictionary<int, TypeRef?>();
+        // Catch variables declare in their clause header, not up front.
+        var clauseDeclared = function.Descendants.OfType<CatchClause>()
+            .Where(clause => clause.VariableIndex is not null)
+            .Select(clause => clause.VariableIndex!.Value)
+            .ToHashSet();
         foreach (var node in function.Descendants)
         {
             switch (node)
@@ -117,7 +131,7 @@ public sealed class CSharpPrinter
             bool declaredAtStore = _declaringStores.Any(s =>
                 s is StoreLocal store && store.Index == index
                 || s is InitObject { Address: LoadLocalAddress init } && init.Index == index);
-            if (!declaredAtStore)
+            if (!declaredAtStore && !clauseDeclared.Contains(index))
                 yield return $"{TypeText(function.Locals[index])} V_{index};";
         }
         foreach (var (slot, type) in slots)
@@ -222,6 +236,33 @@ public sealed class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             return;
         }
+        if (node is TryCatch tryCatch)
+        {
+            sb.Append(pad).AppendLine("try");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, tryCatch.TryBody, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            foreach (var clause in tryCatch.Clauses)
+            {
+                sb.Append(pad).AppendLine(CatchHeader(clause));
+                sb.Append(pad).AppendLine("{");
+                AppendContainer(sb, clause.Body, indent + 1);
+                sb.Append(pad).AppendLine("}");
+            }
+            return;
+        }
+        if (node is TryFinally tryFinally)
+        {
+            sb.Append(pad).AppendLine("try");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, tryFinally.TryBody, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            sb.Append(pad).AppendLine("finally");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, tryFinally.FinallyBody, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is IfStatement ifStatement)
         {
             sb.Append(pad).Append("if (").Append(Condition(ifStatement.Condition)).AppendLine(")");
@@ -242,6 +283,14 @@ public sealed class CSharpPrinter
         if (Statement(node) is { } line)
             sb.Append(pad).AppendLine(line);
     }
+
+    /// <summary>Baseline-style clause headers: bare <c>catch</c> for object (the catch-all), the variable form when the entry store folded into the clause.</summary>
+    string CatchHeader(CatchClause clause)
+        => clause.ExceptionType is { Namespace: "System", Name: "Object" }
+            ? "catch"
+            : clause.VariableIndex is { } index
+                ? $"catch ({TypeText(clause.ExceptionType)} V_{index})"
+                : $"catch ({TypeText(clause.ExceptionType)})";
 
     /// <summary>Null means the statement has no body spelling: a no-argument base-constructor call is implicit in C#.</summary>
     string? Statement(IrNode node) => node switch
@@ -284,6 +333,8 @@ public sealed class CSharpPrinter
         InitObject o => $"*{Operand(o.Address)} = default({TypeText(o.Type)});",
         Return { Value: { } value } => $"return {Expression(value)};",
         Return => "return;",
+        // The rethrow: the raw caught value thrown back is C#'s bare throw.
+        Throw { Value: CaughtException } => "throw;",
         Throw t => $"throw {Expression(t.Value)};",
         Branch b => $"goto IL_{b.TargetOffset:X4};",
         ConditionalBranch c => $"if ({Condition(c.Condition)}) goto IL_{c.TargetOffset:X4};",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -379,10 +379,10 @@ public static class IrImporter
                     break;
 
                 case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8:
-                    // Enum subtraction yields the enum's underlying ushort —
-                    // box an actual int or every typed-position check downstream
-                    // sees a value that lies about its own type.
-                    stack.Push(new Constant((int)(opcode - ILOpCode.Ldc_i4_0), TypeRef.CoreLib("System", "Int32")));
+                    // Subtract as int, not as the enum: ushort enum
+                    // subtraction wraps Ldc_i4_m1 - Ldc_i4_0 to 65535 before
+                    // any cast can repair it, and -1 must stay -1.
+                    stack.Push(new Constant((int)opcode - (int)ILOpCode.Ldc_i4_0, TypeRef.CoreLib("System", "Int32")));
                     break;
                 case ILOpCode.Ldc_i4_s:
                     stack.Push(new Constant((int)(sbyte)reader.ReadILByte(), TypeRef.CoreLib("System", "Int32")));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -47,9 +47,11 @@ public sealed class IrFunction : IrNode
     /// <summary>
     /// Exception regions over the flat block container, by IL offset. The
     /// importer keeps blocks flat (region boundaries are block leaders);
-    /// nesting into try/catch structure is raising-pass work.
+    /// the EH structuring pass consumes these into <see cref="TryCatch"/>/
+    /// <see cref="TryFinally"/> nodes and clears the list — non-empty regions
+    /// mean the flat form is still the truth.
     /// </summary>
-    public ImmutableArray<HandlerRegion> Regions { get; init; } = [];
+    public ImmutableArray<HandlerRegion> Regions { get; set; } = [];
 
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
@@ -179,6 +181,65 @@ public sealed class ForLoop : IrNode
     public Block Body => (Block)Children[3];
 
     public override string Describe() => "ForLoop";
+}
+
+/// <summary>
+/// A raised try with one or more catch clauses (the same protected range in
+/// IL). Produced by the EH structuring pass from flat regions; bodies are
+/// containers so inner structuring composes per-container.
+/// </summary>
+public sealed class TryCatch : IrNode
+{
+    public TryCatch(BlockContainer tryBody, IEnumerable<CatchClause> clauses)
+    {
+        AddChild(tryBody);
+        foreach (var clause in clauses)
+            AddChild(clause);
+    }
+
+    public BlockContainer TryBody => (BlockContainer)Children[0];
+    public IReadOnlyList<CatchClause> Clauses => Children.Skip(1).Cast<CatchClause>().ToList();
+
+    public override string Describe() => $"TryCatch ({Children.Count - 1} clauses)";
+}
+
+/// <summary>
+/// One catch clause: the exception type, an optional variable binding (the
+/// handler-entry store the pass folded into the header), and the body.
+/// </summary>
+public sealed class CatchClause : IrNode
+{
+    public CatchClause(TypeRef exceptionType, BlockContainer body)
+    {
+        ExceptionType = exceptionType;
+        AddChild(body);
+    }
+
+    public TypeRef ExceptionType { get; }
+
+    /// <summary>Local the handler stores the caught exception into; null when the exception is discarded.</summary>
+    public int? VariableIndex { get; init; }
+
+    public BlockContainer Body => (BlockContainer)Children[0];
+
+    public override IEnumerable<TypeRef> DirectTypes => [ExceptionType];
+
+    public override string Describe() => $"CatchClause ({ExceptionType.ToDisplayString()})";
+}
+
+/// <summary>A raised try/finally.</summary>
+public sealed class TryFinally : IrNode
+{
+    public TryFinally(BlockContainer tryBody, BlockContainer finallyBody)
+    {
+        AddChild(tryBody);
+        AddChild(finallyBody);
+    }
+
+    public BlockContainer TryBody => (BlockContainer)Children[0];
+    public BlockContainer FinallyBody => (BlockContainer)Children[1];
+
+    public override string Describe() => "TryFinally";
 }
 
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -1,0 +1,432 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises flat exception regions into <see cref="TryCatch"/> and
+/// <see cref="TryFinally"/> statements. Two-phase and transactional like
+/// <see cref="StructuringPass"/>: the whole function is validated against the
+/// slice before any mutation, so a function either raises completely or keeps
+/// the always-correct flat form with <see cref="IrFunction.Regions"/> intact.
+/// On success the regions clear — the nesting in the tree is then the truth.
+///
+/// The slice: catch and finally handlers (filter and fault stay flat), every
+/// <c>leave</c> targeting the continuation of an enclosing construct, every
+/// branch staying inside its region segment, and <c>endfinally</c> closing
+/// its handler from the final block only. Bodies become nested containers,
+/// which the later structuring pass raises independently — a goto-heavy try
+/// body stays honestly flat inside a structured try/catch shell.
+/// </summary>
+public sealed class EhStructuringPass : IIrPass
+{
+    public string Name => "eh-structuring";
+
+    /// <summary>One try with its contiguous handlers: a TryCatch's clauses share the protected range; a finally is always sole.</summary>
+    sealed class Construct
+    {
+        public required int TryStart { get; init; }
+        public required int TryEnd { get; init; }
+        public required List<HandlerRegion> Handlers { get; init; }
+        public int End => Handlers[^1].HandlerOffset + Handlers[^1].HandlerLength;
+        public List<Construct> Children { get; } = [];
+
+        public bool Contains(int offset) => offset >= TryStart && offset < End;
+        public bool Contains(Construct other) => other.TryStart >= TryStart && other.End <= End;
+        public bool IsFinally => Handlers is [{ Kind: HandlerKind.Finally }];
+    }
+
+    public void Run(IrFunction function)
+    {
+        if (function.Regions.IsEmpty)
+            return;
+        if (function.Regions.Any(r => r.Kind is HandlerKind.Filter or HandlerKind.Fault))
+            return;
+        if (function.Regions.Any(r => r.Kind is HandlerKind.Catch && r.CatchType is null))
+            return;
+
+        var blocks = function.Body.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        if (BuildForest(function.Regions, offsetToIndex) is not { } forest)
+            return;
+        if (!Validate(blocks, forest.All))
+            return;
+
+        function.Body.DetachChildren();
+        var continuations = new Dictionary<IrNode, int>();
+        var rebuilt = BuildContainer(blocks, 0, blocks.Count, forest.Roots, offsetToIndex, continuations);
+        TrimTailLeaves(rebuilt, continuations);
+        function.Body.ReplaceWith(rebuilt);
+        function.Regions = [];
+    }
+
+    /// <summary>
+    /// A leave in tail position falls through instead of printing a goto:
+    /// walking up from the leave, every level sits flush at its container's
+    /// end, so falling out of the construct chain reaches the same
+    /// continuation the leave names — including the intervening finallys,
+    /// exactly the leave's semantics.
+    /// </summary>
+    static void TrimTailLeaves(BlockContainer root, Dictionary<IrNode, int> continuations)
+    {
+        foreach (var leave in root.Descendants.OfType<Leave>().ToList())
+        {
+            IrNode statement = leave;
+            while (true)
+            {
+                if (statement.Parent is not Block block || !ReferenceEquals(block.Children[^1], statement))
+                    break;
+                if (block.Parent is not BlockContainer container || !IsTailBlock(container, block))
+                    break;
+                // Falling out of this container exits which construct?
+                // (Never a finally body: leave inside one fails validation.)
+                IrNode? construct = container.Parent switch
+                {
+                    TryCatch tryCatch when ReferenceEquals(tryCatch.TryBody, container) => tryCatch,
+                    CatchClause clause => clause.Parent,
+                    TryFinally tryFinally when ReferenceEquals(tryFinally.TryBody, container) => tryFinally,
+                    _ => null,
+                };
+                if (construct is null || !continuations.TryGetValue(construct, out int end))
+                    break;
+                if (leave.TargetOffset == end)
+                {
+                    leave.Detach();
+                    break;
+                }
+                statement = construct;
+            }
+        }
+    }
+
+    /// <summary>Last block of its container, ignoring trailing nop landing pads.</summary>
+    static bool IsTailBlock(BlockContainer container, Block block)
+    {
+        for (int i = block.ChildIndex + 1; i < container.Children.Count; i++)
+        {
+            if (container.Children[i].Children.Count > 0)
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Groups regions sharing a protected range into constructs and nests
+    /// them by containment. Null when the shapes are outside the slice:
+    /// non-contiguous handlers, mixed handler kinds on one range, partial
+    /// overlap, or boundaries that are not block leaders.
+    /// </summary>
+    static (List<Construct> Roots, List<Construct> All)? BuildForest(
+        ImmutableArray<HandlerRegion> regions, Dictionary<int, int> offsetToIndex)
+    {
+        var all = new List<Construct>();
+        foreach (var group in regions.GroupBy(r => (r.TryOffset, r.TryLength)))
+        {
+            var handlers = group.OrderBy(r => r.HandlerOffset).ToList();
+            if (handlers.Count > 1 && handlers.Any(h => h.Kind != HandlerKind.Catch))
+                return null;
+            var construct = new Construct
+            {
+                TryStart = group.Key.TryOffset,
+                TryEnd = group.Key.TryOffset + group.Key.TryLength,
+                Handlers = handlers,
+            };
+            int expected = construct.TryEnd;
+            foreach (var handler in handlers)
+            {
+                if (handler.HandlerOffset != expected)
+                    return null;
+                expected = handler.HandlerOffset + handler.HandlerLength;
+            }
+            if (!offsetToIndex.ContainsKey(construct.TryStart)
+                || !offsetToIndex.ContainsKey(construct.TryEnd)
+                || handlers.Any(h => !offsetToIndex.ContainsKey(h.HandlerOffset)))
+            {
+                return null;
+            }
+            all.Add(construct);
+        }
+
+        // Outer-first ordering, then a containment stack builds the forest.
+        all.Sort((a, b) => a.TryStart != b.TryStart ? a.TryStart - b.TryStart : b.End - a.End);
+        var roots = new List<Construct>();
+        var stack = new Stack<Construct>();
+        foreach (var construct in all)
+        {
+            while (stack.Count > 0 && !stack.Peek().Contains(construct))
+            {
+                if (construct.TryStart < stack.Peek().End)
+                    return null;
+                stack.Pop();
+            }
+            if (stack.Count > 0)
+            {
+                // A nested construct must sit wholly inside the parent's try
+                // or wholly inside one handler — never straddle.
+                var parent = stack.Peek();
+                bool placed = construct.End <= parent.TryEnd && construct.TryStart >= parent.TryStart
+                    || parent.Handlers.Any(h =>
+                        construct.TryStart >= h.HandlerOffset
+                        && construct.End <= h.HandlerOffset + h.HandlerLength);
+                if (!placed)
+                    return null;
+                parent.Children.Add(construct);
+            }
+            else
+            {
+                roots.Add(construct);
+            }
+            stack.Push(construct);
+        }
+        return (roots, all);
+    }
+
+    /// <summary>Phase 1: pure checks over the flat blocks — no mutation until the whole function fits the slice.</summary>
+    static bool Validate(IReadOnlyList<Block> blocks, List<Construct> all)
+    {
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            var block = blocks[i];
+            int offset = block.StartOffset;
+            for (int s = 0; s < block.Children.Count; s++)
+            {
+                var statement = block.Children[s];
+                bool isLast = s == block.Children.Count - 1;
+                switch (statement)
+                {
+                    case Leave leave:
+                    {
+                        if (!isLast)
+                            return false;
+                        // leave exits to the continuation of an enclosing
+                        // construct — possibly through several (it runs the
+                        // intervening finallys, exactly C# goto-out-of-try).
+                        bool enclosed = false, targetsContinuation = false;
+                        foreach (var construct in all)
+                        {
+                            if (!construct.Contains(offset))
+                                continue;
+                            enclosed = true;
+                            if (construct.IsFinally && offset >= construct.TryEnd)
+                                return false;  // leave out of a finally is not valid IL
+                            if (leave.TargetOffset == construct.End)
+                                targetsContinuation = true;
+                        }
+                        if (!enclosed || !targetsContinuation)
+                            return false;
+                        break;
+                    }
+                    case EndFinally:
+                    {
+                        // Exactly the canonical close: last statement of the
+                        // final block of its finally range.
+                        if (!isLast)
+                            return false;
+                        var owner = all.FirstOrDefault(c =>
+                            c.IsFinally && offset >= c.TryEnd && offset < c.End);
+                        if (owner is null)
+                            return false;
+                        if (i + 1 < blocks.Count && blocks[i + 1].StartOffset < owner.End)
+                            return false;
+                        break;
+                    }
+                    case EndFilter:
+                        return false;
+                    case Branch branch:
+                        if (!SameZone(all, offset, branch.TargetOffset))
+                            return false;
+                        break;
+                    case ConditionalBranch conditional:
+                        if (!SameZone(all, offset, conditional.TargetOffset))
+                            return false;
+                        break;
+                    case SwitchBranch sw:
+                        if (sw.TargetOffsets.Any(t => !SameZone(all, offset, t)))
+                            return false;
+                        break;
+                }
+            }
+        }
+        return ValidateCaughtExceptions(blocks, all);
+    }
+
+    /// <summary>
+    /// The caught exception may appear exactly two ways: the handler-entry
+    /// consumption (a store the transform folds into the clause header, or
+    /// the discard pop) and the bare rethrow. Anything else — the value
+    /// flowing across blocks, inline consumption — is outside the slice.
+    /// </summary>
+    static bool ValidateCaughtExceptions(IReadOnlyList<Block> blocks, List<Construct> all)
+    {
+        foreach (var block in blocks)
+        {
+            var handler = InnermostCatchHandler(all, block.StartOffset);
+            for (int s = 0; s < block.Children.Count; s++)
+            {
+                var statement = block.Children[s];
+                bool isEntry = handler is not null && block.StartOffset == handler.HandlerOffset && s == 0;
+                bool entryConsumption = isEntry && statement switch
+                {
+                    StoreLocal { Value: CaughtException } => true,
+                    ExpressionStatement { Expression: CaughtException } => true,
+                    _ => false,
+                };
+                if (entryConsumption)
+                    continue;
+                if (statement is Throw { Value: CaughtException { Type: null } } && handler is not null)
+                    continue;  // rethrow
+                foreach (var node in statement.Descendants.Prepend(statement))
+                {
+                    if (node is CaughtException)
+                        return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static HandlerRegion? InnermostCatchHandler(List<Construct> all, int offset)
+    {
+        Construct? best = null;
+        HandlerRegion? bestHandler = null;
+        foreach (var construct in all)
+        {
+            foreach (var handler in construct.Handlers)
+            {
+                if (handler.Kind != HandlerKind.Catch
+                    || offset < handler.HandlerOffset
+                    || offset >= handler.HandlerOffset + handler.HandlerLength)
+                {
+                    continue;
+                }
+                if (best is null || best.Contains(construct))
+                {
+                    best = construct;
+                    bestHandler = handler;
+                }
+            }
+        }
+        return bestHandler;
+    }
+
+    /// <summary>
+    /// True when both offsets sit in the same segment of the same innermost
+    /// construct — branches never cross a region boundary in the slice.
+    /// </summary>
+    static bool SameZone(List<Construct> all, int offsetA, int offsetB)
+        => Zone(all, offsetA) == Zone(all, offsetB);
+
+    static (Construct? Construct, int Segment) Zone(List<Construct> all, int offset)
+    {
+        Construct? best = null;
+        foreach (var construct in all)
+        {
+            if (construct.Contains(offset) && (best is null || best.Contains(construct)))
+                best = construct;
+        }
+        if (best is null)
+            return (null, -2);
+        if (offset < best.TryEnd)
+            return (best, -1);
+        for (int h = 0; h < best.Handlers.Count; h++)
+        {
+            var handler = best.Handlers[h];
+            if (offset >= handler.HandlerOffset && offset < handler.HandlerOffset + handler.HandlerLength)
+                return (best, h);
+        }
+        return (best, -2);
+    }
+
+    /// <summary>Phase 2: rebuilds a block range as a container, nesting each construct into its statement node. Shapes were already proven.</summary>
+    static BlockContainer BuildContainer(
+        IReadOnlyList<Block> blocks, int startIndex, int endIndex,
+        List<Construct> constructs, Dictionary<int, int> offsetToIndex,
+        Dictionary<IrNode, int> continuations)
+    {
+        var container = new BlockContainer();
+        int i = startIndex;
+        foreach (var construct in constructs.OrderBy(c => c.TryStart))
+        {
+            for (; i < offsetToIndex[construct.TryStart]; i++)
+                container.Add(blocks[i]);
+            var holder = new Block(construct.TryStart);
+            holder.Add(BuildConstruct(blocks, construct, offsetToIndex, endIndex, continuations));
+            container.Add(holder);
+            i = offsetToIndex.TryGetValue(construct.End, out int continuation) ? continuation : endIndex;
+        }
+        for (; i < endIndex; i++)
+            container.Add(blocks[i]);
+        return container;
+    }
+
+    static IrNode BuildConstruct(
+        IReadOnlyList<Block> blocks, Construct construct,
+        Dictionary<int, int> offsetToIndex, int sliceEnd,
+        Dictionary<IrNode, int> continuations)
+    {
+        var inTry = construct.Children.Where(c => c.End <= construct.TryEnd).ToList();
+        var tryBody = BuildContainer(
+            blocks, offsetToIndex[construct.TryStart], offsetToIndex[construct.TryEnd], inTry, offsetToIndex, continuations);
+
+        IrNode node;
+        if (construct.IsFinally)
+        {
+            var handler = construct.Handlers[0];
+            var finallyBody = BuildHandlerBody(blocks, construct, handler, offsetToIndex, sliceEnd, continuations);
+            TrimTrailingEndFinally(finallyBody);
+            node = new TryFinally(tryBody, finallyBody);
+        }
+        else
+        {
+            var clauses = new List<CatchClause>();
+            foreach (var handler in construct.Handlers)
+            {
+                var body = BuildHandlerBody(blocks, construct, handler, offsetToIndex, sliceEnd, continuations);
+                int? variable = FoldEntryConsumption(body);
+                clauses.Add(new CatchClause(handler.CatchType!, body) { VariableIndex = variable });
+            }
+            node = new TryCatch(tryBody, clauses);
+        }
+        continuations[node] = construct.End;
+        return node;
+    }
+
+    static BlockContainer BuildHandlerBody(
+        IReadOnlyList<Block> blocks, Construct construct, HandlerRegion handler,
+        Dictionary<int, int> offsetToIndex, int sliceEnd,
+        Dictionary<IrNode, int> continuations)
+    {
+        int handlerEnd = handler.HandlerOffset + handler.HandlerLength;
+        int endIndex = offsetToIndex.TryGetValue(handlerEnd, out int index) ? index : sliceEnd;
+        var children = construct.Children
+            .Where(c => c.TryStart >= handler.HandlerOffset && c.End <= handlerEnd)
+            .ToList();
+        return BuildContainer(blocks, offsetToIndex[handler.HandlerOffset], endIndex, children, offsetToIndex, continuations);
+    }
+
+    static void TrimTrailingEndFinally(BlockContainer body)
+    {
+        if (body.Blocks is [.., var last] && last.Children is [.., EndFinally end])
+            end.Detach();
+    }
+
+    /// <summary>Folds the handler-entry store into the clause's variable; the discard pop just disappears.</summary>
+    static int? FoldEntryConsumption(BlockContainer body)
+    {
+        if (body.Blocks is not [var first, ..] || first.Children.Count == 0)
+            return null;
+        switch (first.Children[0])
+        {
+            case StoreLocal { Value: CaughtException } store:
+                store.Detach();
+                return store.Index;
+            case ExpressionStatement { Expression: CaughtException } discard:
+                discard.Detach();
+                return null;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -95,7 +95,13 @@ public sealed class ExpressionInliningPass : IIrPass
     /// </summary>
     static IrNode? FallthroughFirstStatement(IrFunction function, Block block)
     {
-        var blocks = function.Body.Blocks;
+        // The block's own container, not function.Body: after EH structuring
+        // blocks live in nested containers, and indexing the top-level list
+        // with a nested ChildIndex would alias an unrelated block. Staying
+        // inside one container also keeps the edge inside one region.
+        if (block.Parent is not BlockContainer container)
+            return null;
+        var blocks = container.Blocks;
         int index = block.ChildIndex;
         if (index + 1 >= blocks.Count)
             return null;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -23,6 +23,12 @@ public static class IrPasses
     [
         new TypedConstantsPass(),
         new RedundantBranchEliminationPass(),
+        // EH before inlining: the catch-entry store must still be the
+        // handler's first statement when the pass folds it into the clause
+        // header — inlining would dissolve it into its use site. Regions
+        // become TryCatch/TryFinally shells whose body containers the
+        // structuring pass later raises independently.
+        new EhStructuringPass(),
         new ExpressionInliningPass(),
         // Inlining exposes new typed positions (a slot constant landing in a
         // bool return); typed constants run again to catch them.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -17,9 +17,27 @@ public sealed class StructuringPass : IIrPass
     public void Run(IrFunction function)
     {
         if (!function.Regions.IsEmpty)
-            return;  // flat EH model structures in a later slice
-        var blocks = function.Body.Blocks;
+            return;  // unconsumed regions: the flat form is still the truth
+        // Surviving leaves are the one cross-container goto (an early exit
+        // through outer constructs); their target blocks must keep printing
+        // a label, so their containers stay flat.
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        // Containers are independent regions: the function body plus every
+        // try/catch/finally body the EH pass nested. Each structures (or
+        // stays flat) on its own — a goto-heavy handler does not flatten
+        // the rest of the method.
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+            Structure(container, leaveTargets);
+    }
+
+    static void Structure(BlockContainer container, HashSet<int> leaveTargets)
+    {
+        var blocks = container.Blocks;
         if (blocks.Count <= 1)
+            return;
+        if (leaveTargets.Count > 0 && blocks.Any(b => leaveTargets.Contains(b.StartOffset)))
             return;
 
         var offsetToIndex = new Dictionary<int, int>();
@@ -30,9 +48,9 @@ public sealed class StructuringPass : IIrPass
             return;
 
         var structured = BuildRegion(blocks, offsetToIndex, 0, blocks.Count, joinIndex: blocks.Count);
-        var container = new BlockContainer();
-        container.Add(structured);
-        function.Body.ReplaceWith(container);
+        var replacement = new BlockContainer();
+        replacement.Add(structured);
+        container.ReplaceWith(replacement);
     }
 
     /// <summary>Phase 1: pure shape check over block indices — no mutation until the whole function fits the slice.</summary>
@@ -58,6 +76,11 @@ public sealed class StructuringPass : IIrPass
                 case Return or Throw:
                     i++;
                     break;
+                case Leave or EndFinally or EndFilter:
+                    // Survivors of the EH pass (an early exit through outer
+                    // constructs) keep their container flat: structure would
+                    // erase the label their goto needs.
+                    return false;
                 case Branch branch:
                 {
                     if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget))


### PR DESCRIPTION
The last big structural block in the parity docket. Flat exception regions now raise into `TryCatch`/`TryFinally` IR nodes, printed as structured C#.

## Design

`EhStructuringPass` follows the structuring pass's two-phase transactional pattern: the whole function validates against the slice **before any mutation** — a function either raises completely or keeps the always-correct flat form with `Regions` intact. On success `Regions` clears; the tree nesting is then the truth (fidelity flows through `CatchClause.DirectTypes`).

**The slice (validate phase):**

- Catch and finally handlers; filter and fault stay flat for a later slice
- Constructs built by grouping regions on a shared protected range (multi-catch) and nesting by containment; partial overlap, non-contiguous handlers, and mixed kinds on one range bail
- Every `leave` targets the continuation of an *enclosing* construct (multi-level early exits allowed — they print as gotos, C#'s legal goto-out-of-try)
- Branches confined to their region segment (zone check); `endfinally` only as the canonical close

**Transform phase:** bodies become nested `BlockContainer`s. The handler-entry store folds into the clause header (`catch (FormatException V_1)`), the discard pop disappears, and the raw rethrow prints as bare `throw;` — all matching the frozen baseline's spellings, including bare `catch` for `System.Object`.

**Tail-leave trimming:** a `leave` in tail position trims to fallthrough even through arbitrarily nested constructs — falling out of the construct chain runs the same finallys and reaches the same continuation the leave names. This is what lets inner bodies structure fully: `try/catch/finally` and nested-`using` methods print goto-free, and the freed containers cascade through the later passes (a nested using body now raises to `V_2 = V_1.ReadLine() ?? "";`).

**StructuringPass generalizes to per-container operation.** Every EH body structures (or stays flat) independently — a goto-heavy handler no longer flattens the rest of the method. Containers holding a surviving leave's target stay flat so the label keeps printing.

**Pass order:** EH runs before inlining, because the catch-entry store must still be the handler's first statement when the pass folds it (inlining dissolves it into its use site — Release csc does this itself, which is why inline-consumed exceptions are honestly out of slice).

## Bugs fixed along the way

- `ldc.i4.m1` printed `65535`: ushort enum subtraction wraps before any cast can repair it — subtract as `int`. Pre-existing importer bug, exposed by `return -1` catch arms; now pinned in tests.
- Inlining's fallthrough probe indexed `function.Body.Blocks` with a nested block's `ChildIndex` — latent aliasing once blocks live in nested containers; now resolves through the block's own parent container.

## Numbers

- Corelib: **751 of 1,059 region-bearing methods (70.9%) raise structurally**; 27 filter/fault excluded by design; zero crashes across the 39,468-method sweep
- Parity 43.32% → **43.59%**; the remaining EH-method diffs are adjacent gaps (`using`/`lock` sugar the baseline raises, unknown-definition truthiness), not structure
- All suites green: 338/338 decompiler (both configs, one per-config pin documenting the Release inline-consumption divergence), 999 CLI, 158 services, 141 metadata, 20 round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)