### PR TITLE
Constructor-chain rendering and identity-convert elision

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1050,3 +1050,31 @@ public sealed class CfgNullableTarget
         set => Value = value + index;
     }
 }
+
+/// <summary>Base type for constructor-chain fixtures (base(...) targets).</summary>
+public class CtorChainBase
+{
+    public CtorChainBase() { }
+
+    public CtorChainBase(string? message) => Message = message;
+
+    public string? Message { get; }
+}
+
+/// <summary>
+/// Constructor shapes the chain pass must render: a plain base call, a base
+/// call whose argument carries control flow (the spilled-this <c>??</c>
+/// shape), a <c>this(...)</c> delegation, and an implicit parameterless base.
+/// </summary>
+public sealed class CtorChainSamples : CtorChainBase
+{
+    public CtorChainSamples() { }                       // implicit base()
+
+    public CtorChainSamples(string message) : base(message) { }
+
+    public CtorChainSamples(int code) : base(code > 0 ? "positive" : null) { }
+
+    public CtorChainSamples(string message, bool _) : base(message ?? "default") { }
+
+    public CtorChainSamples(long value) : this(value.ToString()) { }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1105,4 +1105,21 @@ public class IdentityConvertTests
 
         Assert.Equal("return (int)x;", CSharpPrinter.PrintRaised(function).Output!.Trim());
     }
+
+    [Fact]
+    public void CheckedUnsignedConversion_AtEqualType_IsKept()
+    {
+        // conv.ovf.i4.un of an int is Int32 -> Int32, but it reinterprets the
+        // source as unsigned and throws for negative bit patterns — eliding it
+        // would drop the overflow check. The cast must survive equal types.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new ILInspector.Decompiler.Pipeline.Convert(intType, isChecked: true, isUnsigned: true, new LoadArgument(0, "x", intType))));
+        var signature = new MethodSignature(intType, [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return checked((int)(uint)x);", CSharpPrinter.PrintRaised(function).Output!.Trim());
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1013,3 +1013,96 @@ public class EhStructuringTests
         Assert.Empty(function.Descendants.OfType<TryFinally>());
     }
 }
+
+/// <summary>
+/// Constructor-chain rendering: base/this calls print as body statements, the
+/// spilled-this receiver (control-flow argument shapes) canonicalizes back to
+/// <c>this</c>, and the implicit parameterless base call is suppressed.
+/// </summary>
+public class ConstructorChainTests
+{
+    static string RaiseCtor(int overloadIndex)
+    {
+        using var source = MetadataSource.Open(typeof(CtorChainSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CtorChainSamples).FullName!, ".ctor", overloadIndex);
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+        var result = CSharpPrinter.Print(function);
+        Assert.True(result.Succeeded);
+        return result.Output!.ReplaceLineEndings("\n").TrimEnd();
+    }
+
+    [Fact]
+    public void ImplicitParameterlessBase_IsSuppressed()
+    {
+        // ctor#0: public CtorChainSamples() { } — base() is implicit.
+        Assert.Equal("", RaiseCtor(0));
+    }
+
+    [Fact]
+    public void BaseCall_RendersBaseWithArguments()
+    {
+        // ctor#1: : base(message)
+        Assert.Equal("base(message);", RaiseCtor(1));
+    }
+
+    [Fact]
+    public void SpilledThis_CoalesceArgument_CanonicalizesToBase()
+    {
+        // ctor#3: : base(message ?? "default") — the ?? forces a this spill
+        // the inliner cannot dissolve; the chain pass renames it to this.
+        string output = RaiseCtor(3);
+
+        Assert.Contains("base(", output);
+        Assert.DoesNotContain("..ctor", output);   // never the invalid S_0..ctor form
+        Assert.DoesNotContain("= this;", output);   // the dead spill is gone
+    }
+
+    [Fact]
+    public void ThisDelegation_RendersThis()
+    {
+        // ctor#4: : this(value.ToString())
+        string output = RaiseCtor(4);
+
+        Assert.StartsWith("this(", output);
+        Assert.DoesNotContain("base(", output);
+        Assert.DoesNotContain("..ctor", output);
+    }
+}
+
+public class IdentityConvertTests
+{
+    [Fact]
+    public void ArrayLengthConversion_IsElided()
+    {
+        // ldlen yields the int-typed ArrayLength; the trailing conv.i4 is an
+        // identity conversion and must not print as a cast.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var arrayType = TypeRef.SzArray(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var length = new ArrayLength(new LoadArgument(0, "a", arrayType));
+        block.Add(new Return(new ILInspector.Decompiler.Pipeline.Convert(intType, isChecked: false, isUnsigned: false, length)));
+        var signature = new MethodSignature(intType, [new Parameter("a", arrayType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return a.Length;", CSharpPrinter.PrintRaised(function).Output!.Trim());
+    }
+
+    [Fact]
+    public void GenuineNarrowing_IsKept()
+    {
+        // conv.i4 of a long is a real narrowing — the cast stays.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var longType = TypeRef.CoreLib("System", "Int64");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new ILInspector.Decompiler.Pipeline.Convert(intType, isChecked: false, isUnsigned: false, new LoadArgument(0, "x", longType))));
+        var signature = new MethodSignature(intType, [new Parameter("x", longType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return (int)x;", CSharpPrinter.PrintRaised(function).Output!.Trim());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -284,6 +284,21 @@ public sealed class CSharpPrinter
             sb.Append(pad).AppendLine(line);
     }
 
+    /// <summary>
+    /// A constructor-chain call renders as a <c>base(args)</c> / <c>this(args)</c>
+    /// body statement (the current emitter's placement, not a header
+    /// initializer). The implicit parameterless base call — every default
+    /// chain — is suppressed.
+    /// </summary>
+    string? ConstructorChainText(MethodRef callee, Call call)
+    {
+        bool isThis = Equals(callee.DeclaringType, _function.DeclaringType);
+        var arguments = call.Arguments.Skip(1).ToList();
+        if (!isThis && arguments.Count == 0)
+            return null;  // implicit base()
+        return $"{(isThis ? "this" : "base")}({Arguments(arguments)});";
+    }
+
     /// <summary>Baseline-style clause headers: bare <c>catch</c> for object (the catch-all), the variable form when the entry store folded into the clause.</summary>
     string CatchHeader(CatchClause clause)
         => clause.ExceptionType is { Namespace: "System", Name: "Object" }
@@ -297,13 +312,9 @@ public sealed class CSharpPrinter
     {
         ExpressionStatement
         {
-            Expression: Call
-            {
-                Callee: { Name: ".ctor", HasThis: true, ParameterTypes.IsEmpty: true } callee,
-            } call,
-        } when call.Arguments[0] is LoadArgument { Index: 0, Name: "this" }
-            && !Equals(callee.DeclaringType, _function.DeclaringType)
-            => null,
+            Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call,
+        } when call.Arguments is [LoadArgument { Index: 0 }, ..]
+            => ConstructorChainText(callee, call),
         ExpressionStatement e => e.Expression is UnsupportedNode u
             ? $"/* {u.Describe()} */"
             : $"{Expression(e.Expression)};",

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
@@ -1,0 +1,95 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Canonicalizes the receiver of a constructor-chain call (<c>this..ctor</c>
+/// or <c>base..ctor</c>) back to <c>this</c>. When the base-call argument
+/// carries control flow — the ubiquitous <c>base(message ?? SR.Default)</c>
+/// exception shape — the importer spills the loaded <c>this</c> across the
+/// branch into a slot, and the inliner leaves it there: <c>this</c> is held
+/// impure because <see cref="TypeRef"/> cannot yet prove the receiver is a
+/// class rather than a mutable byref struct.
+///
+/// But the receiver of a constructor's own base/this call is the object under
+/// construction, an immutable reference for the whole body — naming it
+/// <c>this</c> at the call site is always sound regardless of intervening
+/// computation. This pass makes that one safe move the general inliner
+/// declines, then drops the now-dead spill so the printer can render
+/// <c>base(args);</c> / <c>this(args);</c> instead of <c>S_0..ctor(args);</c>.
+/// </summary>
+public sealed class ConstructorChainPass : IIrPass
+{
+    public string Name => "constructor-chain";
+
+    public void Run(IrFunction function)
+    {
+        if (!function.Signature.HasThis)
+            return;
+
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            if (call.Callee.Name != ".ctor" || !call.Callee.HasThis || call.Arguments.Count == 0)
+                continue;
+            var receiver = call.Arguments[0];
+            if (receiver is LoadArgument { Index: 0 })
+                continue;  // already canonical
+            if (ResolveThisSpill(function, receiver) is not { } spill)
+                continue;
+
+            var thisArgument = new LoadArgument(0, "this", function.DeclaringType);
+            receiver.ReplaceWith(thisArgument);
+            // The spill's sole load is gone; drop the store so it does not
+            // print as a dead `T S_0 = this;` declaration.
+            spill.Store.Detach();
+        }
+    }
+
+    /// <summary>
+    /// A receiver that is a slot or local with exactly one load (this call)
+    /// and a single store of <c>this</c>; null when it is anything else.
+    /// </summary>
+    static (IrNode Store, IrExpression Load)? ResolveThisSpill(IrFunction function, IrExpression receiver)
+    {
+        (bool IsSlot, int Index)? key = receiver switch
+        {
+            LoadStackSlot slot => (true, slot.Slot),
+            LoadLocal local => (false, local.Index),
+            _ => null,
+        };
+        if (key is not { } place)
+            return null;
+
+        IrNode? store = null;
+        int loads = 0;
+        bool storeIsThis = false;
+        foreach (var node in function.Descendants)
+        {
+            if (place.IsSlot)
+            {
+                if (node is LoadStackSlot l && l.Slot == place.Index)
+                    loads++;
+                else if (node is StoreStackSlot s && s.Slot == place.Index)
+                {
+                    if (store is not null)
+                        return null;  // multiple stores
+                    store = s;
+                    storeIsThis = s.Value is LoadArgument { Index: 0 };
+                }
+            }
+            else
+            {
+                if (node is LoadLocal l && l.Index == place.Index)
+                    loads++;
+                else if (node is LoadLocalAddress a && a.Index == place.Index)
+                    return null;  // an escaped address makes the rename unsound
+                else if (node is StoreLocal s && s.Index == place.Index)
+                {
+                    if (store is not null)
+                        return null;
+                    store = s;
+                    storeIsThis = s.Value is LoadArgument { Index: 0 };
+                }
+            }
+        }
+        return store is not null && storeIsThis && loads == 1 ? (store, receiver) : null;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
@@ -1,14 +1,20 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Removes identity conversions: a <c>conv</c> whose target type already
-/// equals its operand's result type. The canonical source is the array-length
-/// idiom — <c>ldlen</c> yields a native int that the importer models as the
-/// <c>int</c>-typed <see cref="ArrayLength"/>, and the trailing <c>conv.i4</c>
-/// then converts <c>int</c> to <c>int</c>. C# spells <c>array.Length</c> with
-/// no cast, so the conversion is pure noise (<c>((int)a.Length)</c> →
-/// <c>a.Length</c>). A genuine narrowing — <c>conv.i4</c> of a <c>long</c> —
-/// has differing types and is left untouched.
+/// Removes identity conversions: a <em>plain</em> <c>conv</c> whose target
+/// type already equals its operand's result type. The canonical source is the
+/// array-length idiom — <c>ldlen</c> yields a native int that the importer
+/// models as the <c>int</c>-typed <see cref="ArrayLength"/>, and the trailing
+/// <c>conv.i4</c> then converts <c>int</c> to <c>int</c>. C# spells
+/// <c>array.Length</c> with no cast, so the conversion is pure noise
+/// (<c>((int)a.Length)</c> → <c>a.Length</c>). A genuine narrowing —
+/// <c>conv.i4</c> of a <c>long</c> — has differing types and is left untouched.
+///
+/// Only plain (unchecked, signed) conversions qualify: a checked or unsigned
+/// conversion is not a no-op even at equal types. <c>conv.ovf.i4.un</c> on an
+/// <c>int</c> is <c>Int32 → Int32</c>, but it reinterprets the source as
+/// unsigned and throws for negative bit patterns — the printer preserves that
+/// as <c>checked((int)(uint)x)</c>, which this pass must not erase.
 /// </summary>
 public sealed class IdentityConvertPass : IIrPass
 {
@@ -20,6 +26,8 @@ public sealed class IdentityConvertPass : IIrPass
         {
             if (convert.Parent is null)
                 continue;  // already detached by an outer rewrite this pass
+            if (convert.IsChecked || convert.IsUnsigned)
+                continue;  // overflow/unsigned semantics survive equal types
             var operandType = convert.Operand.ResultType;
             if (operandType is not null && operandType.Equals(convert.Target))
             {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
@@ -1,0 +1,31 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Removes identity conversions: a <c>conv</c> whose target type already
+/// equals its operand's result type. The canonical source is the array-length
+/// idiom — <c>ldlen</c> yields a native int that the importer models as the
+/// <c>int</c>-typed <see cref="ArrayLength"/>, and the trailing <c>conv.i4</c>
+/// then converts <c>int</c> to <c>int</c>. C# spells <c>array.Length</c> with
+/// no cast, so the conversion is pure noise (<c>((int)a.Length)</c> →
+/// <c>a.Length</c>). A genuine narrowing — <c>conv.i4</c> of a <c>long</c> —
+/// has differing types and is left untouched.
+/// </summary>
+public sealed class IdentityConvertPass : IIrPass
+{
+    public string Name => "identity-convert";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var convert in function.Descendants.OfType<Convert>().ToList())
+        {
+            if (convert.Parent is null)
+                continue;  // already detached by an outer rewrite this pass
+            var operandType = convert.Operand.ResultType;
+            if (operandType is not null && operandType.Equals(convert.Target))
+            {
+                var operand = (IrExpression)convert.DetachChildren()[0];
+                convert.ReplaceWith(operand);
+            }
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -22,6 +22,9 @@ public static class IrPasses
     public static ImmutableArray<IIrPass> Default { get; } =
     [
         new TypedConstantsPass(),
+        // Drop identity conversions (the ldlen/conv.i4 array-length idiom)
+        // before structuring so loop conditions match on clean lengths.
+        new IdentityConvertPass(),
         new RedundantBranchEliminationPass(),
         // EH before inlining: the catch-entry store must still be the
         // handler's first statement when the pass folds it into the clause
@@ -33,6 +36,9 @@ public static class IrPasses
         // Inlining exposes new typed positions (a slot constant landing in a
         // bool return); typed constants run again to catch them.
         new TypedConstantsPass(),
+        // Canonicalize spilled-this constructor receivers before sugar so the
+        // base(...)/this(...) call is in its final shape for the printer.
+        new ConstructorChainPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
         new StructuringPass(),


### PR DESCRIPTION
Two printer-quality fixes, picked by triaging the parity scoreboard's top buckets (now that the orientation is confirmed: each bucket is `baseline vs candidate`).

## Constructor chains — invalid `S_0..ctor(...)` → valid `base(...)` / `this(...)`

The biggest single bucket (174 methods, every exception constructor) was the candidate emitting **`S_0..ctor(S_1);` — which doesn't compile.**

Root cause: when a base/this call's argument carries control flow — the ubiquitous `base(message ?? SR.Default)` shape — the importer spills the loaded `this` across the `??` branch into a slot, and the general inliner won't dissolve it: `this` is deliberately held *impure* because `TypeRef` can't yet prove the receiver is a class rather than a mutable byref struct (the known `IsValueType` gap).

`ConstructorChainPass` makes the one safe move the inliner declines. The receiver of a constructor's own base/this call is the object under construction — an immutable reference for the whole body — so naming it `this` at the call site is sound regardless of intervening computation. The pass canonicalizes the spilled receiver back to `LoadArgument(0)` and drops the dead spill; the printer then renders `base(args);` / `this(args);` as body statements (matching the current emitter's placement) and suppresses the implicit parameterless base.

Result, verified against the baseline:
- **Clean exception ctors** (`AccessViolationException::.ctor`): now **byte-identical** to baseline — `base(SR.Arg_AccessViolationException);`
- **`??`-argument ctors** (`InvalidOperationException::.ctor`): candidate is now **strictly better** — `base(message ?? SR...)`, valid C#, where the *baseline itself* emits the invalid `S_0..ctor(S_1)` plus an un-raised `if (message == null) { ... }`

This is the "exact-or-better" gate's good side: the scoreboard can't credit it (the baseline text these now beat is itself broken), but the candidate no longer emits uncompilable output for 170+ methods.

## Identity conversions — `((int)V_0.Length)` → `V_0.Length`

`ldlen` yields a native int that the importer models as the `int`-typed `ArrayLength`; the trailing `conv.i4` then converts `int` → `int`. C# spells `array.Length` with no cast, so the conversion is pure noise. `IdentityConvertPass` removes any `conv` whose target already equals its operand's result type — a genuine narrowing (`conv.i4` of a `long`) has differing types and is untouched. Runs before structuring so loop conditions match on clean lengths (`for (int V_1 = 0; V_1 < V_0.Length; V_1++)`).

## Numbers

- Parity **43.59% → 43.64%** (+18, all from the array-length idiom flipping to full agreement; the constructor cluster is exact-or-better but textually diverges from the broken baseline)
- All suites green: 344/344 decompiler (both configs), 999 CLI, 158 services, 141 metadata
- 6 new fixture tests (a base/derived chain fixture covering plain base, `??`/ternary spill, `this(...)` delegation, implicit base; synthetic identity-convert and genuine-narrowing cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)