### PR TITLE
Add the decimal keyword; build the harness on net11

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -153,6 +153,9 @@ public class TypeRefTests
         var listDef = TypeRef.CoreLib("System.Collections.Generic", "List`1");
 
         Assert.Equal("int", intRef.ToDisplayString());
+        // The full primitive-keyword set, decimal included (System.Decimal
+        // has a C# keyword like the others — it was the one omission).
+        Assert.Equal("decimal", TypeRef.CoreLib("System", "Decimal").ToDisplayString());
         Assert.Equal("List<int>", TypeRef.GenericInstance(listDef, [intRef]).ToDisplayString());
         Assert.Equal("int[]", TypeRef.SzArray(intRef).ToDisplayString());
         Assert.Equal("int[,]", TypeRef.MdArray(intRef, 2).ToDisplayString());

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -260,6 +260,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
         ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
         ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
+        ["Decimal"] = "decimal",
         ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
         ["Object"] = "object", ["Void"] = "void",
     };

--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Two small fixes the net11 sweep surfaced.

## `decimal` keyword (printer)

`System.Decimal` was the one C# primitive missing from the type-name keyword table — every other primitive (`bool`…`double`, `nint`, `nuint`, `string`, `object`, `void`) was present. So static calls and locals rendered `Decimal.Parse(...)` / `Decimal V_0` instead of `decimal.Parse(...)` / `decimal V_0`.

One line completes the set (all 18 primitive keywords). Parity **46.19% → 46.36% (+68 methods)** — `decimal` is well-used across `Parse`, arithmetic operators, and conversions.

## Harness builds on net11 (tooling)

`tools/DecompilerHarness` was the only project hardcoding `<TargetFramework>net10.0</TargetFramework>`; all ten others use `$(DefaultTargetFramework)`. Once the resolved max runtime advanced to net11, the net10-pinned harness could no longer reference the (now net11) decompiler project — NU1201 — and the parity sweep stopped building. Aligning it to the default restores the sweep. (No behavior change; it's a dev tool, not shipped.)

## Notes

The neighbouring enum-constant bucket (`ThrowArgumentNullException(17)` should be `ThrowArgumentNullException(ExceptionArgument.s)`; `Decimal.Parse(s, 111, ...)` should be `NumberStyles.Number`) is deferred: it needs enum detection + composite-flag decomposition over resolved enum metadata — the same `IsValueType`-style TypeRef-resolution capability tracked as the receiver-purity/truthiness foundation, and worth doing properly there rather than as a one-off.

All suites green: 347/347 decompiler (both configs), 999 CLI, 158 services, 141 metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)