### PR TITLE
Add IL body analysis call-site scanner

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,7 @@ This project uses **xunit v3** with `OutputType Exe`. Tests MUST be run with `do
 
 ```bash
 dotnet run --project src/dotnet-inspect.Tests
+dotnet run --project src/ILInspector.Analysis.Tests
 dotnet run --project src/ILInspector.Decompiler.Tests
 dotnet run --project src/DotnetInspector.Services.Tests
 dotnet run --project tests/ILInspector.Metadata.Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,11 @@ dotnet build src/dotnet-inspect -c Release
 
 ```bash
 dotnet run --project src/dotnet-inspect.Tests -c Release
-dotnet run --project src/DotnetInspector.Decompiler.Tests -c Release
+dotnet run --project src/ILInspector.Analysis.Tests -c Release
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 dotnet run --project src/DotnetInspector.Services.Tests -c Release
-dotnet run --project tests/DotnetInspector.Metadata.Tests -c Release
+dotnet run --project tests/ILInspector.Metadata.Tests -c Release
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
 ```
 
 Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if not installed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,6 +8,8 @@ It is built for both humans and agents. Markdown is the default output because h
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details.
+- `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites without decompiling to C#.
+- `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and annotated IL from method bodies.

--- a/src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj
+++ b/src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -6,12 +6,13 @@ var options = Parse(args);
 if (options is null)
     return 1;
 
-using var index = LibraryBodyIndex.Open(options.AssemblyPath);
+var index = LibraryBodyIndex.Open(options.AssemblyPath);
 var matches = index.FindCalls(MemberPattern.Method(options.DeclaringType, options.MemberName));
 
 Console.WriteLine($"Assembly: {options.AssemblyPath}");
 Console.WriteLine($"Methods with IL: {index.Methods.Length:N0}");
 Console.WriteLine($"Direct call edges: {index.DirectCalls.Length:N0}");
+Console.WriteLine($"Diagnostics: {index.Diagnostics.Length:N0}");
 Console.WriteLine($"Target: {options.DeclaringType}.{options.MemberName}");
 Console.WriteLine($"Matches: {matches.Length:N0}");
 Console.WriteLine();
@@ -26,6 +27,9 @@ foreach (var call in matches.OrderBy(c => c.Caller.DeclaringType.ToQualifiedDisp
 
 if (matches.Length > options.Limit)
     Console.WriteLine($"... {matches.Length - options.Limit:N0} more matches");
+
+foreach (var diagnostic in index.Diagnostics.Take(options.Limit))
+    Console.Error.WriteLine($"diagnostic 0x{diagnostic.MethodToken:X8} {diagnostic.Method}: {diagnostic.Message}");
 
 return 0;
 

--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+
+using ILInspector.Analysis;
+
+var options = Parse(args);
+if (options is null)
+    return 1;
+
+using var index = LibraryBodyIndex.Open(options.AssemblyPath);
+var matches = index.FindCalls(MemberPattern.Method(options.DeclaringType, options.MemberName));
+
+Console.WriteLine($"Assembly: {options.AssemblyPath}");
+Console.WriteLine($"Methods with IL: {index.Methods.Length:N0}");
+Console.WriteLine($"Direct call edges: {index.DirectCalls.Length:N0}");
+Console.WriteLine($"Target: {options.DeclaringType}.{options.MemberName}");
+Console.WriteLine($"Matches: {matches.Length:N0}");
+Console.WriteLine();
+
+foreach (var call in matches.OrderBy(c => c.Caller.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
+             .ThenBy(c => c.Caller.Name, StringComparer.Ordinal)
+             .ThenBy(c => c.ILOffset)
+             .Take(options.Limit))
+{
+    Console.WriteLine($"{MethodDisplay(call.Caller)} IL_{call.ILOffset:X4} {call.Kind} -> {MemberDisplay(call.Callee)}");
+}
+
+if (matches.Length > options.Limit)
+    Console.WriteLine($"... {matches.Length - options.Limit:N0} more matches");
+
+return 0;
+
+static AppOptions? Parse(string[] args)
+{
+    string assemblyPath = Assembly.GetExecutingAssembly().Location;
+    string target = "System.Console.WriteLine";
+    int limit = 40;
+
+    if (args.Length > 0 && args[0] is "-h" or "--help")
+    {
+        WriteUsage();
+        return null;
+    }
+
+    if (args.Length > 0)
+        assemblyPath = args[0];
+    if (args.Length > 1)
+        target = args[1];
+    if (args.Length > 2 && (!int.TryParse(args[2], out limit) || limit <= 0))
+    {
+        Console.Error.WriteLine("Error: limit must be a positive integer.");
+        WriteUsage();
+        return null;
+    }
+
+    if (!File.Exists(assemblyPath))
+    {
+        Console.Error.WriteLine($"Error: assembly not found: {assemblyPath}");
+        WriteUsage();
+        return null;
+    }
+
+    if (!TryParseTarget(target, out var declaringType, out var memberName))
+    {
+        Console.Error.WriteLine($"Error: target must be Type.Member or Type::Member: {target}");
+        WriteUsage();
+        return null;
+    }
+
+    return new AppOptions(assemblyPath, declaringType, memberName, limit);
+}
+
+static bool TryParseTarget(string target, out string declaringType, out string memberName)
+{
+    int separator = target.LastIndexOf("::", StringComparison.Ordinal);
+    int memberStart = separator >= 0 ? separator + 2 : -1;
+    if (separator < 0)
+    {
+        separator = target.LastIndexOf('.');
+        memberStart = separator + 1;
+    }
+
+    if (separator <= 0 || memberStart >= target.Length)
+    {
+        declaringType = "";
+        memberName = "";
+        return false;
+    }
+
+    declaringType = target[..separator];
+    memberName = target[memberStart..];
+    return true;
+}
+
+static string MethodDisplay(MethodIdentity method)
+    => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+
+static string MemberDisplay(MemberRef member)
+    => $"{member.DeclaringType.ToQualifiedDisplayString()}.{member.Name}({string.Join(", ", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+
+static void WriteUsage()
+{
+    Console.Error.WriteLine("Usage:");
+    Console.Error.WriteLine("  dotnet run --project src/ILInspector.Analysis.App -c Release");
+    Console.Error.WriteLine("  dotnet run --project src/ILInspector.Analysis.App -c Release -- <assembly-path> [Type.Member|Type::Member] [limit]");
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("Defaults: scan this app for System.Console.WriteLine, limit 40.");
+}
+
+sealed record AppOptions(string AssemblyPath, string DeclaringType, string MemberName, int Limit);

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -9,19 +9,20 @@ public class LibraryBodyIndexTests
     [Fact]
     public void FindCalls_FindsConsoleWriteLine()
     {
-        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
 
         var calls = index.FindCalls(MemberPattern.Method("System.Console", "WriteLine"));
 
         var call = Assert.Single(calls.Where(c => c.Caller.Name == nameof(CallSiteFixtures.CallsConsoleWriteLine)));
         Assert.Equal(CallKind.Call, call.Kind);
         Assert.Equal(TypeRef.CoreLib("System", "String"), Assert.Single(call.Callee.ParameterTypes));
+        Assert.Empty(index.Diagnostics);
     }
 
     [Fact]
     public void DirectCalls_RecordVirtualCallEvidenceWithoutInferringTargets()
     {
-        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
 
         var call = Assert.Single(index.DirectCalls.Where(c =>
             c.Caller.Name == nameof(CallSiteFixtures.CallsVirtualToString)
@@ -34,7 +35,7 @@ public class LibraryBodyIndexTests
     [Fact]
     public void MemberReferences_InstantiateGenericDeclaringTypeArguments()
     {
-        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
 
         var call = Assert.Single(index.DirectCalls.Where(c =>
             c.Caller.Name == nameof(CallSiteFixtures.CallsListAdd)
@@ -53,9 +54,15 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void DisplayStrings_RenderDecimalKeyword()
+    {
+        Assert.Equal("decimal", TypeRef.CoreLib("System", "Decimal").ToDisplayString());
+    }
+
+    [Fact]
     public void FindCalls_CanMatchFullParameterShape()
     {
-        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
 
         var calls = index.FindCalls(MemberPattern.Method(
             TypeRef.Definition("System.Console", "System", "Console"),
@@ -63,6 +70,25 @@ public class LibraryBodyIndexTests
             ImmutableArray.Create(TypeRef.CoreLib("System", "String"))));
 
         Assert.Contains(calls, c => c.Caller.Name == nameof(CallSiteFixtures.CallsConsoleWriteLine));
+    }
+
+    [Fact]
+    public void Open_DoesNotKeepAssemblyFileLocked()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"analysis-lock-{Guid.NewGuid():N}.dll");
+        File.Copy(typeof(CallSiteFixtures).Assembly.Location, path);
+        try
+        {
+            var index = LibraryBodyIndex.Open(path);
+
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            Assert.NotEmpty(index.Methods);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests;
+
+public class LibraryBodyIndexTests
+{
+    [Fact]
+    public void FindCalls_FindsConsoleWriteLine()
+    {
+        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var calls = index.FindCalls(MemberPattern.Method("System.Console", "WriteLine"));
+
+        var call = Assert.Single(calls.Where(c => c.Caller.Name == nameof(CallSiteFixtures.CallsConsoleWriteLine)));
+        Assert.Equal(CallKind.Call, call.Kind);
+        Assert.Equal(TypeRef.CoreLib("System", "String"), Assert.Single(call.Callee.ParameterTypes));
+    }
+
+    [Fact]
+    public void DirectCalls_RecordVirtualCallEvidenceWithoutInferringTargets()
+    {
+        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var call = Assert.Single(index.DirectCalls.Where(c =>
+            c.Caller.Name == nameof(CallSiteFixtures.CallsVirtualToString)
+            && c.Callee.DeclaringType.Equals(TypeRef.CoreLib("System", "Object"))
+            && c.Callee.Name == "ToString"));
+
+        Assert.Equal(CallKind.CallVirtual, call.Kind);
+    }
+
+    [Fact]
+    public void MemberReferences_InstantiateGenericDeclaringTypeArguments()
+    {
+        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var call = Assert.Single(index.DirectCalls.Where(c =>
+            c.Caller.Name == nameof(CallSiteFixtures.CallsListAdd)
+            && c.Callee.Name == "Add"));
+
+        Assert.Equal("System.Collections.Generic.List<int>", call.Callee.DeclaringType.ToQualifiedDisplayString());
+        Assert.Equal(TypeRef.CoreLib("System", "Int32"), Assert.Single(call.Callee.ParameterTypes));
+    }
+
+    [Fact]
+    public void TypeIdentity_CanonicalizesCoreLibraryFacadeAssemblies()
+    {
+        Assert.Equal(
+            TypeRef.CoreLib("System", "String"),
+            TypeRef.Definition("System.Runtime", "System", "String"));
+    }
+
+    [Fact]
+    public void FindCalls_CanMatchFullParameterShape()
+    {
+        using var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var calls = index.FindCalls(MemberPattern.Method(
+            TypeRef.Definition("System.Console", "System", "Console"),
+            "WriteLine",
+            ImmutableArray.Create(TypeRef.CoreLib("System", "String"))));
+
+        Assert.Contains(calls, c => c.Caller.Name == nameof(CallSiteFixtures.CallsConsoleWriteLine));
+    }
+}
+
+public static class CallSiteFixtures
+{
+    public static void CallsConsoleWriteLine() => Console.WriteLine("hello");
+
+    public static string? CallsVirtualToString(object value) => value.ToString();
+
+    public static void CallsListAdd(List<int> values) => values.Add(42);
+}

--- a/src/ILInspector.Analysis/AnalysisDiagnostic.cs
+++ b/src/ILInspector.Analysis/AnalysisDiagnostic.cs
@@ -1,0 +1,6 @@
+namespace ILInspector.Analysis;
+
+public sealed record AnalysisDiagnostic(
+    int MethodToken,
+    string Method,
+    string Message);

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>IL body analysis and evidence indexing for .NET assemblies</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <!-- System.Reflection.Metadata is part of net10.0 BCL -->
+
+</Project>

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1,0 +1,253 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Analysis;
+
+/// <summary>Materialized IL body evidence for one assembly.</summary>
+public sealed class LibraryBodyIndex : IDisposable
+{
+    readonly FileStream _stream;
+    readonly PEReader _peReader;
+
+    LibraryBodyIndex(string path, FileStream stream, PEReader peReader, ImmutableArray<MethodIdentity> methods, ImmutableArray<DirectCall> directCalls)
+    {
+        Path = path;
+        _stream = stream;
+        _peReader = peReader;
+        Methods = methods;
+        DirectCalls = directCalls;
+    }
+
+    public string Path { get; }
+    public ImmutableArray<MethodIdentity> Methods { get; }
+    public ImmutableArray<DirectCall> DirectCalls { get; }
+
+    public static LibraryBodyIndex Open(string path)
+    {
+        var stream = File.OpenRead(path);
+        PEReader? peReader = null;
+        try
+        {
+            peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                throw new BadImageFormatException($"No managed metadata: {path}");
+            var reader = peReader.GetMetadataReader();
+            var builder = new IndexBuilder(path, reader, peReader);
+            var index = builder.Build();
+            return new LibraryBodyIndex(path, stream, peReader, index.Methods, index.DirectCalls);
+        }
+        catch
+        {
+            peReader?.Dispose();
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
+        => [.. DirectCalls.Where(call => pattern.Matches(call.Callee))];
+
+    public void Dispose()
+    {
+        _peReader.Dispose();
+        _stream.Dispose();
+    }
+
+    sealed class IndexBuilder
+    {
+        readonly string _path;
+        readonly MetadataReader _reader;
+        readonly PEReader _peReader;
+        readonly string _assemblyName;
+        readonly Guid _mvid;
+
+        public IndexBuilder(string path, MetadataReader reader, PEReader peReader)
+        {
+            _path = path;
+            _reader = reader;
+            _peReader = peReader;
+            _assemblyName = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : System.IO.Path.GetFileNameWithoutExtension(path);
+            _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        }
+
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls) Build()
+        {
+            var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
+            var calls = ImmutableArray.CreateBuilder<DirectCall>();
+
+            foreach (var typeHandle in _reader.TypeDefinitions)
+            {
+                var typeDef = _reader.GetTypeDefinition(typeHandle);
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var methodDef = _reader.GetMethodDefinition(methodHandle);
+                    if (methodDef.RelativeVirtualAddress == 0)
+                        continue;
+
+                    var caller = CreateMethodIdentity(typeHandle, methodHandle, typeDef, methodDef);
+                    methods.Add(caller);
+                    var scope = CreateScope(typeDef, methodDef);
+                    var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
+                    var il = body.GetILBytes() ?? [];
+                    ScanCalls(il, caller, scope, calls);
+                }
+            }
+
+            return (methods.ToImmutable(), calls.ToImmutable());
+        }
+
+        MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, TypeDefinition typeDef, MethodDefinition methodDef)
+        {
+            var scope = CreateScope(typeDef, methodDef);
+            var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
+            var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+            return new MethodIdentity(
+                _assemblyName,
+                _mvid,
+                declaringType,
+                _reader.GetString(methodDef.Name),
+                signature.ParameterTypes,
+                signature.ReturnType,
+                MetadataTokens.GetToken(methodHandle),
+                (methodDef.Attributes & MethodAttributes.Static) != 0);
+        }
+
+        void ScanCalls(byte[] il, MethodIdentity caller, GenericScope callerScope, ImmutableArray<DirectCall>.Builder calls)
+        {
+            int position = 0;
+            while (position < il.Length)
+            {
+                int offset = position;
+                var opcode = ReadOpcode(il, ref position);
+                switch (opcode)
+                {
+                    case ILOpCode.Call:
+                    case ILOpCode.Callvirt:
+                    case ILOpCode.Newobj:
+                    case ILOpCode.Ldftn:
+                    case ILOpCode.Ldvirtftn:
+                    {
+                        int token = ReadInt32(il, ref position, offset);
+                        var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                        calls.Add(new DirectCall(caller, callee, offset, ToCallKind(opcode)));
+                        break;
+                    }
+                    case ILOpCode.Calli:
+                    {
+                        int token = ReadInt32(il, ref position, offset);
+                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, CallKind.CallIndirect));
+                        break;
+                    }
+                    default:
+                        SkipOperand(il, opcode, ref position, offset);
+                        break;
+                }
+            }
+        }
+
+        static CallKind ToCallKind(ILOpCode opcode) => opcode switch
+        {
+            ILOpCode.Call => CallKind.Call,
+            ILOpCode.Callvirt => CallKind.CallVirtual,
+            ILOpCode.Newobj => CallKind.NewObject,
+            ILOpCode.Ldftn => CallKind.LoadFunction,
+            _ => CallKind.LoadVirtualFunction,
+        };
+
+        GenericScope CreateScope(TypeDefinition typeDef, MethodDefinition methodDef)
+            => new(GenericParameterNames(typeDef.GetGenericParameters()), GenericParameterNames(methodDef.GetGenericParameters()));
+
+        ImmutableArray<string> GenericParameterNames(GenericParameterHandleCollection handles)
+        {
+            if (handles.Count == 0)
+                return [];
+            var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+            foreach (var handle in handles)
+                names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
+            return names.MoveToImmutable();
+        }
+
+        static ILOpCode ReadOpcode(byte[] il, ref int position)
+        {
+            byte first = ReadByte(il, ref position, position);
+            if (first != 0xFE)
+                return (ILOpCode)first;
+            byte second = ReadByte(il, ref position, position - 1);
+            return (ILOpCode)(0xFE00 | second);
+        }
+
+        void SkipOperand(byte[] il, ILOpCode opcode, ref int position, int offset)
+        {
+            switch (opcode)
+            {
+                case ILOpCode.Switch:
+                {
+                    int count = ReadInt32(il, ref position, offset);
+                    if (count < 0 || position + checked(count * 4) > il.Length)
+                        throw new BadImageFormatException($"Malformed switch at IL_{offset:X4} in method body from {_path}");
+                    position += count * 4;
+                    break;
+                }
+                case ILOpCode.Br_s or ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s
+                    or ILOpCode.Bge_s or ILOpCode.Bgt_s or ILOpCode.Ble_s or ILOpCode.Blt_s
+                    or ILOpCode.Bne_un_s or ILOpCode.Bge_un_s or ILOpCode.Bgt_un_s
+                    or ILOpCode.Ble_un_s or ILOpCode.Blt_un_s or ILOpCode.Leave_s
+                    or ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
+                    or ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
+                    or ILOpCode.Ldc_i4_s or ILOpCode.Unaligned:
+                    Advance(il, ref position, 1, offset);
+                    break;
+                case ILOpCode.Ldarg or ILOpCode.Ldarga or ILOpCode.Starg
+                    or ILOpCode.Ldloc or ILOpCode.Ldloca or ILOpCode.Stloc:
+                    Advance(il, ref position, 2, offset);
+                    break;
+                case ILOpCode.Br or ILOpCode.Brfalse or ILOpCode.Brtrue or ILOpCode.Beq
+                    or ILOpCode.Bge or ILOpCode.Bgt or ILOpCode.Ble or ILOpCode.Blt
+                    or ILOpCode.Bne_un or ILOpCode.Bge_un or ILOpCode.Bgt_un
+                    or ILOpCode.Ble_un or ILOpCode.Blt_un or ILOpCode.Leave
+                    or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4
+                    or ILOpCode.Jmp or ILOpCode.Ldstr
+                    or ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld
+                    or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
+                    or ILOpCode.Cpobj or ILOpCode.Ldobj or ILOpCode.Castclass
+                    or ILOpCode.Isinst or ILOpCode.Unbox or ILOpCode.Stobj
+                    or ILOpCode.Box or ILOpCode.Newarr or ILOpCode.Ldelema
+                    or ILOpCode.Ldelem or ILOpCode.Stelem or ILOpCode.Unbox_any
+                    or ILOpCode.Refanyval or ILOpCode.Mkrefany or ILOpCode.Initobj
+                    or ILOpCode.Constrained or ILOpCode.Sizeof or ILOpCode.Ldtoken:
+                    Advance(il, ref position, 4, offset);
+                    break;
+                case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
+                    Advance(il, ref position, 8, offset);
+                    break;
+            }
+        }
+
+        static void Advance(byte[] il, ref int position, int bytes, int offset)
+        {
+            if (position + bytes > il.Length)
+                throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
+            position += bytes;
+        }
+
+        static byte ReadByte(byte[] il, ref int position, int offset)
+        {
+            if (position >= il.Length)
+                throw new BadImageFormatException($"Malformed IL at IL_{offset:X4}");
+            return il[position++];
+        }
+
+        static int ReadInt32(byte[] il, ref int position, int offset)
+        {
+            if (position + 4 > il.Length)
+                throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
+            int value = BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(position));
+            position += 4;
+            return value;
+        }
+    }
+}

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -8,57 +8,40 @@ using System.Reflection.PortableExecutable;
 namespace ILInspector.Analysis;
 
 /// <summary>Materialized IL body evidence for one assembly.</summary>
-public sealed class LibraryBodyIndex : IDisposable
+public sealed class LibraryBodyIndex
 {
-    readonly FileStream _stream;
-    readonly PEReader _peReader;
-
-    LibraryBodyIndex(string path, FileStream stream, PEReader peReader, ImmutableArray<MethodIdentity> methods, ImmutableArray<DirectCall> directCalls)
+    LibraryBodyIndex(string path, ImmutableArray<MethodIdentity> methods, ImmutableArray<DirectCall> directCalls, ImmutableArray<AnalysisDiagnostic> diagnostics)
     {
         Path = path;
-        _stream = stream;
-        _peReader = peReader;
         Methods = methods;
         DirectCalls = directCalls;
+        Diagnostics = diagnostics;
     }
 
     public string Path { get; }
     public ImmutableArray<MethodIdentity> Methods { get; }
     public ImmutableArray<DirectCall> DirectCalls { get; }
+    public ImmutableArray<AnalysisDiagnostic> Diagnostics { get; }
 
     public static LibraryBodyIndex Open(string path)
     {
-        var stream = File.OpenRead(path);
-        PEReader? peReader = null;
-        try
-        {
-            peReader = new PEReader(stream);
-            if (!peReader.HasMetadata)
-                throw new BadImageFormatException($"No managed metadata: {path}");
-            var reader = peReader.GetMetadataReader();
-            var builder = new IndexBuilder(path, reader, peReader);
-            var index = builder.Build();
-            return new LibraryBodyIndex(path, stream, peReader, index.Methods, index.DirectCalls);
-        }
-        catch
-        {
-            peReader?.Dispose();
-            stream.Dispose();
-            throw;
-        }
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        if (!peReader.HasMetadata)
+            throw new BadImageFormatException($"No managed metadata: {path}");
+        var reader = peReader.GetMetadataReader();
+        var builder = new IndexBuilder(path, reader, peReader);
+        var index = builder.Build();
+        return new LibraryBodyIndex(path, index.Methods, index.DirectCalls, index.Diagnostics);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
         => [.. DirectCalls.Where(call => pattern.Matches(call.Callee))];
 
-    public void Dispose()
-    {
-        _peReader.Dispose();
-        _stream.Dispose();
-    }
-
     sealed class IndexBuilder
     {
+        const ILOpCode NoPrefix = (ILOpCode)0xFE19;
+
         readonly string _path;
         readonly MetadataReader _reader;
         readonly PEReader _peReader;
@@ -74,35 +57,45 @@ public sealed class LibraryBodyIndex : IDisposable
             _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<AnalysisDiagnostic> Diagnostics) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
+            var diagnostics = ImmutableArray.CreateBuilder<AnalysisDiagnostic>();
 
             foreach (var typeHandle in _reader.TypeDefinitions)
             {
                 var typeDef = _reader.GetTypeDefinition(typeHandle);
                 foreach (var methodHandle in typeDef.GetMethods())
                 {
-                    var methodDef = _reader.GetMethodDefinition(methodHandle);
-                    if (methodDef.RelativeVirtualAddress == 0)
-                        continue;
+                    try
+                    {
+                        var methodDef = _reader.GetMethodDefinition(methodHandle);
+                        if (methodDef.RelativeVirtualAddress == 0)
+                            continue;
 
-                    var caller = CreateMethodIdentity(typeHandle, methodHandle, typeDef, methodDef);
-                    methods.Add(caller);
-                    var scope = CreateScope(typeDef, methodDef);
-                    var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
-                    var il = body.GetILBytes() ?? [];
-                    ScanCalls(il, caller, scope, calls);
+                        var scope = CreateScope(typeDef, methodDef);
+                        var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
+                        methods.Add(caller);
+                        var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
+                        var il = body.GetILBytes() ?? [];
+                        ScanCalls(il, caller, scope, calls);
+                    }
+                    catch (Exception ex) when (IsRecoverableMethodFailure(ex))
+                    {
+                        diagnostics.Add(new AnalysisDiagnostic(
+                            MetadataTokens.GetToken(methodHandle),
+                            MethodLabel(typeHandle, methodHandle),
+                            $"{ex.GetType().Name}: {ex.Message}"));
+                    }
                 }
             }
 
-            return (methods.ToImmutable(), calls.ToImmutable());
+            return (methods.ToImmutable(), calls.ToImmutable(), diagnostics.ToImmutable());
         }
 
-        MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, TypeDefinition typeDef, MethodDefinition methodDef)
+        MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
         {
-            var scope = CreateScope(typeDef, methodDef);
             var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
             var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
             return new MethodIdentity(
@@ -224,6 +217,9 @@ public sealed class LibraryBodyIndex : IDisposable
                 case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
                     Advance(il, ref position, 8, offset);
                     break;
+                case NoPrefix:
+                    Advance(il, ref position, 1, offset);
+                    break;
             }
         }
 
@@ -249,5 +245,26 @@ public sealed class LibraryBodyIndex : IDisposable
             position += 4;
             return value;
         }
+
+        string MethodLabel(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle)
+        {
+            try
+            {
+                var typeDef = _reader.GetTypeDefinition(typeHandle);
+                string ns = _reader.GetString(typeDef.Namespace);
+                string typeName = _reader.GetString(typeDef.Name);
+                string methodName = _reader.GetString(_reader.GetMethodDefinition(methodHandle).Name);
+                string fullTypeName = ns.Length == 0 ? typeName : $"{ns}.{typeName}";
+                return $"{fullTypeName}::{methodName}";
+            }
+            catch (Exception ex) when (IsRecoverableMethodFailure(ex))
+            {
+                return $"0x{MetadataTokens.GetToken(methodHandle):X8}";
+            }
+        }
+
+        static bool IsRecoverableMethodFailure(Exception ex)
+            => ex is BadImageFormatException or InvalidOperationException or ArgumentException
+                or ArgumentOutOfRangeException or IndexOutOfRangeException;
     }
 }

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+public enum MemberKind
+{
+    Method,
+    Constructor,
+    FunctionPointer,
+    Unsupported,
+}
+
+public enum CallKind
+{
+    Call,
+    CallVirtual,
+    NewObject,
+    LoadFunction,
+    LoadVirtualFunction,
+    CallIndirect,
+}
+
+public sealed record MethodIdentity(
+    string AssemblyName,
+    Guid ModuleVersionId,
+    TypeRef DeclaringType,
+    string Name,
+    ImmutableArray<TypeRef> ParameterTypes,
+    TypeRef ReturnType,
+    int MetadataToken,
+    bool IsStatic);
+
+public sealed record MemberRef(
+    TypeRef DeclaringType,
+    string Name,
+    ImmutableArray<TypeRef> ParameterTypes,
+    TypeRef ReturnType,
+    MemberKind Kind)
+{
+    public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
+
+    public static MemberRef Unsupported(string reason)
+        => new(TypeRef.Unsupported(reason), "?", [], TypeRef.Unsupported("unknown return"), MemberKind.Unsupported);
+}
+
+/// <summary>This IL instruction definitely references this metadata token.</summary>
+public sealed record DirectCall(
+    MethodIdentity Caller,
+    MemberRef Callee,
+    int ILOffset,
+    CallKind Kind);
+
+public sealed class MemberPattern
+{
+    readonly TypeRef? _declaringType;
+    readonly string? _declaringTypeName;
+
+    MemberPattern(TypeRef? declaringType, string? declaringTypeName, string name, ImmutableArray<TypeRef> parameterTypes, bool matchParameterTypes)
+    {
+        _declaringType = declaringType;
+        _declaringTypeName = declaringTypeName;
+        Name = name;
+        ParameterTypes = parameterTypes;
+        MatchParameterTypes = matchParameterTypes;
+    }
+
+    public string Name { get; }
+    public ImmutableArray<TypeRef> ParameterTypes { get; }
+    public bool MatchParameterTypes { get; }
+
+    public static MemberPattern Method(string declaringType, string name)
+        => new(null, declaringType, name, [], matchParameterTypes: false);
+
+    public static MemberPattern Method(TypeRef declaringType, string name)
+        => new(declaringType, null, name, [], matchParameterTypes: false);
+
+    public static MemberPattern Method(string declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
+        => new(null, declaringType, name, parameterTypes, matchParameterTypes: true);
+
+    public static MemberPattern Method(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
+        => new(declaringType, null, name, parameterTypes, matchParameterTypes: true);
+
+    public bool Matches(MemberRef member)
+    {
+        bool declaringMatches = _declaringType is not null
+            ? member.DeclaringType.Equals(_declaringType)
+            : string.Equals(member.DeclaringType.ToQualifiedDisplayString(), _declaringTypeName, StringComparison.Ordinal);
+        if (!declaringMatches || !string.Equals(member.Name, Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        return !MatchParameterTypes || member.ParameterTypes.SequenceEqual(ParameterTypes);
+    }
+}

--- a/src/ILInspector.Analysis/MemberResolver.cs
+++ b/src/ILInspector.Analysis/MemberResolver.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Analysis;
+
+internal static class MemberResolver
+{
+    public static MemberRef ResolveMethod(MetadataReader reader, EntityHandle handle, GenericScope callerScope)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+            {
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+                var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, method.GetDeclaringType(), 0);
+                var typeScope = new GenericScope(
+                    GenericParameterNames(reader, declaringType.GetGenericParameters()),
+                    GenericParameterNames(reader, method.GetGenericParameters()));
+                var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
+                string name = reader.GetString(method.Name);
+                return new MemberRef(declaring, name, signature.ParameterTypes, signature.ReturnType, KindFor(name));
+            }
+            case HandleKind.MemberReference:
+            {
+                var member = reader.GetMemberReference((MemberReferenceHandle)handle);
+                var declaring = ResolveParentType(reader, member.Parent, callerScope);
+                var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
+                string name = reader.GetString(member.Name);
+                return new MemberRef(
+                    declaring,
+                    name,
+                    [.. signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, []))],
+                    signature.ReturnType.Instantiate(typeArguments, []),
+                    KindFor(name));
+            }
+            case HandleKind.MethodSpecification:
+            {
+                var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                var generic = ResolveMethod(reader, spec.Method, callerScope);
+                var methodArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope);
+                return generic with
+                {
+                    TypeArguments = methodArguments,
+                    ReturnType = generic.ReturnType.Instantiate([], methodArguments),
+                    ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
+                };
+            }
+            default:
+                return MemberRef.Unsupported($"callee handle kind {handle.Kind}");
+        }
+    }
+
+    static MemberKind KindFor(string name) => name is ".ctor" or ".cctor" ? MemberKind.Constructor : MemberKind.Method;
+
+    static TypeRef ResolveParentType(MetadataReader reader, EntityHandle parent, GenericScope callerScope) => parent.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)parent, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)parent, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, callerScope, (TypeSpecificationHandle)parent, 0),
+        _ => TypeRef.Unsupported($"member parent kind {parent.Kind}"),
+    };
+
+    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+}

--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -219,6 +219,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
         ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
         ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
+        ["Decimal"] = "decimal",
         ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
         ["Object"] = "object", ["Void"] = "void",
     };

--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -1,0 +1,225 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+public enum TypeRefKind
+{
+    Definition,
+    GenericInstance,
+    SzArray,
+    Array,
+    ByRef,
+    Pointer,
+    Pinned,
+    GenericParameter,
+    MethodGenericParameter,
+    Unsupported,
+}
+
+/// <summary>
+/// Semantic type identity for IL analysis. Display names are for humans; equality
+/// is structural and canonicalizes core-library facade spellings.
+/// </summary>
+public sealed class TypeRef : IEquatable<TypeRef>
+{
+    public const string CoreLibrary = "corelib";
+
+    TypeRef(TypeRefKind kind)
+    {
+        Kind = kind;
+        Assembly = "";
+        Namespace = "";
+        Name = "";
+        TypeArguments = [];
+    }
+
+    public TypeRefKind Kind { get; private init; }
+    public string Assembly { get; private init; }
+    public string Namespace { get; private init; }
+    public string Name { get; private init; }
+    public TypeRef? ElementType { get; private init; }
+    public ImmutableArray<TypeRef> TypeArguments { get; private init; }
+    public int Rank { get; private init; }
+    public int GenericParameterIndex { get; private init; } = -1;
+    public string GenericParameterName { get; private init; } = "";
+    public string UnsupportedReason { get; private init; } = "";
+
+    public static TypeRef Definition(string assembly, string ns, string name)
+        => new(TypeRefKind.Definition) { Assembly = CanonicalAssembly(assembly), Namespace = ns, Name = name };
+
+    public static TypeRef CoreLib(string ns, string name) => Definition(CoreLibrary, ns, name);
+
+    public static TypeRef GenericInstance(TypeRef definition, ImmutableArray<TypeRef> typeArguments)
+        => new(TypeRefKind.GenericInstance) { ElementType = definition, TypeArguments = typeArguments };
+
+    public static TypeRef SzArray(TypeRef element) => new(TypeRefKind.SzArray) { ElementType = element };
+    public static TypeRef MdArray(TypeRef element, int rank) => new(TypeRefKind.Array) { ElementType = element, Rank = rank };
+    public static TypeRef ByRef(TypeRef element) => new(TypeRefKind.ByRef) { ElementType = element };
+    public static TypeRef Pointer(TypeRef element) => new(TypeRefKind.Pointer) { ElementType = element };
+    public static TypeRef Pinned(TypeRef element) => new(TypeRefKind.Pinned) { ElementType = element };
+    public static TypeRef GenericParameter(int index, string name = "")
+        => new(TypeRefKind.GenericParameter) { GenericParameterIndex = index, GenericParameterName = name };
+    public static TypeRef MethodGenericParameter(int index, string name = "")
+        => new(TypeRefKind.MethodGenericParameter) { GenericParameterIndex = index, GenericParameterName = name };
+    public static TypeRef Unsupported(string reason) => new(TypeRefKind.Unsupported) { UnsupportedReason = reason };
+
+    public TypeRef Instantiate(ImmutableArray<TypeRef> typeArguments, ImmutableArray<TypeRef> methodArguments)
+    {
+        switch (Kind)
+        {
+            case TypeRefKind.GenericParameter when GenericParameterIndex >= 0 && GenericParameterIndex < typeArguments.Length:
+                return typeArguments[GenericParameterIndex];
+            case TypeRefKind.MethodGenericParameter when GenericParameterIndex >= 0 && GenericParameterIndex < methodArguments.Length:
+                return methodArguments[GenericParameterIndex];
+            case TypeRefKind.SzArray or TypeRefKind.Array or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+            {
+                var element = ElementType!.Instantiate(typeArguments, methodArguments);
+                return ReferenceEquals(element, ElementType) ? this : new TypeRef(Kind) { ElementType = element, Rank = Rank };
+            }
+            case TypeRefKind.GenericInstance:
+            {
+                var definition = ElementType!.Instantiate(typeArguments, methodArguments);
+                bool changed = !ReferenceEquals(definition, ElementType);
+                var builder = ImmutableArray.CreateBuilder<TypeRef>(TypeArguments.Length);
+                foreach (var argument in TypeArguments)
+                {
+                    var substituted = argument.Instantiate(typeArguments, methodArguments);
+                    changed |= !ReferenceEquals(substituted, argument);
+                    builder.Add(substituted);
+                }
+                return changed ? GenericInstance(definition, builder.MoveToImmutable()) : this;
+            }
+            default:
+                return this;
+        }
+    }
+
+    public string ToDisplayString() => Kind switch
+    {
+        TypeRefKind.Definition => DisplayName(),
+        TypeRefKind.GenericInstance => RenderGenericInstance(qualified: false),
+        TypeRefKind.SzArray => $"{ElementType!.ToDisplayString()}[]",
+        TypeRefKind.Array => $"{ElementType!.ToDisplayString()}[{new string(',', Rank - 1)}]",
+        TypeRefKind.ByRef => $"ref {ElementType!.ToDisplayString()}",
+        TypeRefKind.Pointer => $"{ElementType!.ToDisplayString()}*",
+        TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString()}",
+        TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter =>
+            GenericParameterName.Length > 0 ? GenericParameterName : $"!{GenericParameterIndex}",
+        _ => $"<unsupported: {UnsupportedReason}>",
+    };
+
+    public string ToQualifiedDisplayString() => Kind switch
+    {
+        TypeRefKind.Definition => QualifiedDisplayName(),
+        TypeRefKind.GenericInstance => RenderGenericInstance(qualified: true),
+        TypeRefKind.SzArray => $"{ElementType!.ToQualifiedDisplayString()}[]",
+        TypeRefKind.Array => $"{ElementType!.ToQualifiedDisplayString()}[{new string(',', Rank - 1)}]",
+        TypeRefKind.ByRef => $"ref {ElementType!.ToQualifiedDisplayString()}",
+        TypeRefKind.Pointer => $"{ElementType!.ToQualifiedDisplayString()}*",
+        TypeRefKind.Pinned => $"pinned {ElementType!.ToQualifiedDisplayString()}",
+        _ => ToDisplayString(),
+    };
+
+    public override string ToString() => ToDisplayString();
+
+    public bool Equals(TypeRef? other)
+    {
+        if (other is null)
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
+        if (Kind != other.Kind
+            || Assembly != other.Assembly
+            || Namespace != other.Namespace
+            || Name != other.Name
+            || Rank != other.Rank
+            || GenericParameterIndex != other.GenericParameterIndex
+            || UnsupportedReason != other.UnsupportedReason
+            || !Equals(ElementType, other.ElementType)
+            || TypeArguments.Length != other.TypeArguments.Length)
+        {
+            return false;
+        }
+        for (int i = 0; i < TypeArguments.Length; i++)
+        {
+            if (!TypeArguments[i].Equals(other.TypeArguments[i]))
+                return false;
+        }
+        return true;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as TypeRef);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Kind);
+        hash.Add(Assembly);
+        hash.Add(Namespace);
+        hash.Add(Name);
+        hash.Add(Rank);
+        hash.Add(GenericParameterIndex);
+        hash.Add(UnsupportedReason);
+        hash.Add(ElementType);
+        foreach (var argument in TypeArguments)
+            hash.Add(argument);
+        return hash.ToHashCode();
+    }
+
+    string DisplayName()
+    {
+        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.TryGetValue(Name, out var keyword))
+            return keyword;
+        int nested = Name.LastIndexOf('+');
+        string innermost = nested < 0 ? Name : Name[(nested + 1)..];
+        return StripArity(innermost);
+    }
+
+    string QualifiedDisplayName()
+    {
+        string display = DisplayName();
+        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.ContainsKey(Name))
+            return display;
+        return Namespace.Length == 0 || display.StartsWith('<') ? display : $"{Namespace}.{display}";
+    }
+
+    string RenderGenericInstance(bool qualified)
+    {
+        int nested = ElementType!.Name.LastIndexOf('+');
+        string innermost = nested < 0 ? ElementType.Name : ElementType.Name[(nested + 1)..];
+        int ownArity = ArityOf(innermost);
+        string simpleName = qualified ? ElementType.QualifiedDisplayName() : ElementType.DisplayName();
+        if (ownArity == 0)
+            return simpleName;
+        var ownArguments = TypeArguments.Skip(Math.Max(0, TypeArguments.Length - ownArity));
+        string arguments = string.Join(", ", ownArguments.Select(a => qualified ? a.ToQualifiedDisplayString() : a.ToDisplayString()));
+        return $"{simpleName}<{arguments}>";
+    }
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
+    }
+
+    static int ArityOf(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 && int.TryParse(name[(tick + 1)..], out int arity) ? arity : 0;
+    }
+
+    internal static string CanonicalAssembly(string assemblyName)
+        => assemblyName is "System.Private.CoreLib" or "System.Runtime" or "mscorlib" or "netstandard" or "System.Runtime.Extensions"
+            ? CoreLibrary
+            : assemblyName;
+
+    static readonly Dictionary<string, string> s_keywords = new()
+    {
+        ["Boolean"] = "bool", ["Byte"] = "byte", ["SByte"] = "sbyte",
+        ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
+        ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
+        ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
+        ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
+        ["Object"] = "object", ["Void"] = "void",
+    };
+}

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Analysis;
+
+internal sealed record GenericScope(ImmutableArray<string> TypeParameters, ImmutableArray<string> MethodParameters)
+{
+    public static readonly GenericScope Empty = new([], []);
+}
+
+internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericScope>
+{
+    public static readonly TypeRefDecoder Instance = new();
+
+    public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
+        => TypeRef.CoreLib("System", typeCode switch
+        {
+            PrimitiveTypeCode.Boolean => "Boolean",
+            PrimitiveTypeCode.Byte => "Byte",
+            PrimitiveTypeCode.SByte => "SByte",
+            PrimitiveTypeCode.Char => "Char",
+            PrimitiveTypeCode.Int16 => "Int16",
+            PrimitiveTypeCode.UInt16 => "UInt16",
+            PrimitiveTypeCode.Int32 => "Int32",
+            PrimitiveTypeCode.UInt32 => "UInt32",
+            PrimitiveTypeCode.Int64 => "Int64",
+            PrimitiveTypeCode.UInt64 => "UInt64",
+            PrimitiveTypeCode.Single => "Single",
+            PrimitiveTypeCode.Double => "Double",
+            PrimitiveTypeCode.IntPtr => "IntPtr",
+            PrimitiveTypeCode.UIntPtr => "UIntPtr",
+            PrimitiveTypeCode.String => "String",
+            PrimitiveTypeCode.Object => "Object",
+            PrimitiveTypeCode.Void => "Void",
+            PrimitiveTypeCode.TypedReference => "TypedReference",
+            _ => typeCode.ToString(),
+        });
+
+    public TypeRef GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(typeDef.Name);
+        string ns = reader.GetString(typeDef.Namespace);
+        if (typeDef.IsNested)
+        {
+            var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
+            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}");
+        }
+        string assembly = reader.IsAssembly
+            ? reader.GetString(reader.GetAssemblyDefinition().Name)
+            : "";
+        return TypeRef.Definition(assembly, ns, name);
+    }
+
+    public TypeRef GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        string name = reader.GetString(typeRef.Name);
+        string ns = reader.GetString(typeRef.Namespace);
+        return typeRef.ResolutionScope.Kind switch
+        {
+            HandleKind.AssemblyReference => TypeRef.Definition(
+                reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope).Name), ns, name),
+            HandleKind.TypeReference => NestedReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, name),
+            _ => TypeRef.Definition("", ns, name),
+        };
+    }
+
+    public TypeRef GetTypeFromSpecification(MetadataReader reader, GenericScope genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public TypeRef GetSZArrayType(TypeRef elementType) => TypeRef.SzArray(elementType);
+    public TypeRef GetArrayType(TypeRef elementType, ArrayShape shape) => TypeRef.MdArray(elementType, shape.Rank);
+    public TypeRef GetByReferenceType(TypeRef elementType) => TypeRef.ByRef(elementType);
+    public TypeRef GetPointerType(TypeRef elementType) => TypeRef.Pointer(elementType);
+    public TypeRef GetPinnedType(TypeRef elementType) => TypeRef.Pinned(elementType);
+    public TypeRef GetGenericInstantiation(TypeRef genericType, ImmutableArray<TypeRef> typeArguments)
+        => TypeRef.GenericInstance(genericType, typeArguments);
+    public TypeRef GetGenericTypeParameter(GenericScope genericContext, int index)
+        => TypeRef.GenericParameter(index, NameAt(genericContext.TypeParameters, index));
+    public TypeRef GetGenericMethodParameter(GenericScope genericContext, int index)
+        => TypeRef.MethodGenericParameter(index, NameAt(genericContext.MethodParameters, index));
+    public TypeRef GetFunctionPointerType(MethodSignature<TypeRef> signature) => TypeRef.Unsupported("function pointer");
+    public TypeRef GetModifiedType(TypeRef modifier, TypeRef unmodifiedType, bool isRequired)
+        => TypeRef.Unsupported($"custom modifier ({(isRequired ? "modreq" : "modopt")} {modifier.ToDisplayString()})");
+
+    static TypeRef NestedReference(MetadataReader reader, TypeReferenceHandle declaringHandle, string nestedName)
+    {
+        var declaring = Instance.GetTypeFromReference(reader, declaringHandle, 0);
+        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}");
+    }
+
+    static string NameAt(ImmutableArray<string> names, int index)
+        => index >= 0 && index < names.Length ? names[index] : "";
+}


### PR DESCRIPTION
## Summary

- add standalone ILInspector.Analysis project for direct IL call-site evidence indexing
- add semantic TypeRef/MemberRef identities plus LibraryBodyIndex and MemberPattern queries
- add executable Analysis tests and a temporary Analysis.App harness until CLI wiring exists
- update repo docs/test guidance for the new project

## Validation

- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal
- dotnet build src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release
- dotnet run --project src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj -c Release -- artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll System.Console.WriteLine 10