### PR TITLE
Lock-sugar: raise the Monitor lockTaken lowering to lock (obj) { ... }

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1078,3 +1078,25 @@ public sealed class CtorChainSamples : CtorChainBase
 
     public CtorChainSamples(long value) : this(value.ToString()) { }
 }
+
+/// <summary>Lock shapes the lock-sugar pass must raise: a void lock, a lock with a value body, and a lock on a parameter.</summary>
+public sealed class LockFixtureSamples
+{
+    readonly object _root = new();
+    int _value;
+
+    public void IncrementUnderLock()
+    {
+        lock (_root) { _value++; }
+    }
+
+    public int ReadUnderLock()
+    {
+        lock (_root) { return _value; }
+    }
+
+    public void LockOnParameter(object gate)
+    {
+        lock (gate) { _value = 1; }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1191,3 +1191,82 @@ public class LockSugarTests
         return function;
     }
 }
+
+/// <summary>
+/// Soundness of the lock-sugar match, on shapes the C# compiler never emits
+/// but hand-written or obfuscated IL could: a lockTaken local read after the
+/// try/finally, and a same-named Monitor from a non-BCL assembly. Both must
+/// leave the construct flat. Built directly in the post-structuring shape and
+/// run through LockSugarPass alone.
+/// </summary>
+public class LockSugarSoundnessTests
+{
+    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef)
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var objType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var monitor = monitorAssembly == TypeRef.CoreLibrary
+            ? TypeRef.CoreLib("System.Threading", "Monitor")
+            : TypeRef.Definition(monitorAssembly, "System.Threading", "Monitor");
+        var enterRef = new MethodRef(monitor, "Enter", voidType, [objType, TypeRef.ByRef(boolType)], HasThis: false);
+        var exitRef = new MethodRef(monitor, "Exit", voidType, [objType], HasThis: false);
+
+        var tryBlock = new Block(0);
+        tryBlock.Add(new ExpressionStatement(new Call(enterRef, false,
+            [new LoadLocal(0, objType), new LoadLocalAddress(1, boolType)])));
+        var tryBody = new BlockContainer();
+        tryBody.Add(tryBlock);
+
+        var thenBlock = new Block(0);
+        thenBlock.Add(new ExpressionStatement(new Call(exitRef, false, [new LoadLocal(0, objType)])));
+        var finallyBlock = new Block(0);
+        finallyBlock.Add(new IfStatement(new LoadLocal(1, boolType), thenBlock, null));
+        var finallyBody = new BlockContainer();
+        finallyBody.Add(finallyBlock);
+
+        var entry = new Block(0);
+        entry.Add(new StoreLocal(0, objType, new Constant(null, objType)));
+        entry.Add(new StoreLocal(1, boolType, new Constant(0, boolType)));
+        entry.Add(new TryFinally(tryBody, finallyBody));
+        if (strayTakenRef)
+            entry.Add(new ExpressionStatement(new LoadLocal(1, boolType)));   // reads V_1 after the lock
+        var body = new BlockContainer();
+        body.Add(entry);
+
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [objType, boolType], body);
+    }
+
+    [Fact]
+    public void CleanShape_Raises()   // positive control: the synthetic shape is well-formed
+    {
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false);
+        new LockSugarPass().Run(function);
+
+        Assert.Single(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void LockTakenReadAfterTryFinally_StaysFlat()
+    {
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: true);
+        new LockSugarPass().Run(function);
+
+        // Detaching the stores would strand the later read of V_1.
+        Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void MonitorFromOtherAssembly_StaysFlat()
+    {
+        var function = BuildLock("SomeUserAssembly", strayTakenRef: false);
+        new LockSugarPass().Run(function);
+
+        Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1201,7 +1201,7 @@ public class LockSugarTests
 /// </summary>
 public class LockSugarSoundnessTests
 {
-    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef)
+    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef, bool malformedEnterSignature = false)
     {
         var voidType = TypeRef.CoreLib("System", "Void");
         var objType = TypeRef.CoreLib("System", "Object");
@@ -1209,7 +1209,10 @@ public class LockSugarSoundnessTests
         var monitor = monitorAssembly == TypeRef.CoreLibrary
             ? TypeRef.CoreLib("System.Threading", "Monitor")
             : TypeRef.Definition(monitorAssembly, "System.Threading", "Monitor");
-        var enterRef = new MethodRef(monitor, "Enter", voidType, [objType, TypeRef.ByRef(boolType)], HasThis: false);
+        // A malformed Enter returns object instead of void — same name, type,
+        // and argument node shapes, wrong signature.
+        var enterReturn = malformedEnterSignature ? objType : voidType;
+        var enterRef = new MethodRef(monitor, "Enter", enterReturn, [objType, TypeRef.ByRef(boolType)], HasThis: false);
         var exitRef = new MethodRef(monitor, "Exit", voidType, [objType], HasThis: false);
 
         var tryBlock = new Block(0);
@@ -1264,6 +1267,18 @@ public class LockSugarSoundnessTests
     public void MonitorFromOtherAssembly_StaysFlat()
     {
         var function = BuildLock("SomeUserAssembly", strayTakenRef: false);
+        new LockSugarPass().Run(function);
+
+        Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void WrongMonitorSignature_StaysFlat()
+    {
+        // Right name, type, and argument shapes — but Enter returns object,
+        // not void. The signature check rejects it.
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false, malformedEnterSignature: true);
         new LockSugarPass().Run(function);
 
         Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1136,3 +1136,58 @@ public class IdentityConvertTests
         Assert.Equal("return checked((int)(uint)x);", CSharpPrinter.PrintRaised(function).Output!.Trim());
     }
 }
+
+/// <summary>
+/// The lock-sugar pass: the csc Monitor lockTaken lowering raises to a
+/// lock (obj) { ... } statement, the synthetic V_object/V_taken locals
+/// disappear, and the lock object is the original expression.
+/// </summary>
+public class LockSugarTests
+{
+    static string RaiseLock(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(LockFixtureSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(LockFixtureSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+        var result = CSharpPrinter.Print(function);
+        Assert.True(result.Succeeded);
+        return result.Output!.ReplaceLineEndings("\n").TrimEnd();
+    }
+
+    [Fact]
+    public void VoidLock_RaisesToLockStatement()
+    {
+        var (function, output) = (IrImportFor(nameof(LockFixtureSamples.IncrementUnderLock)), RaiseLock(nameof(LockFixtureSamples.IncrementUnderLock)));
+
+        Assert.Single(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Empty(function.Descendants.OfType<TryFinally>());            // the try/finally is consumed
+        Assert.DoesNotContain("Monitor", output);                          // no Monitor.Enter/Exit left
+        Assert.Matches(@"lock \(_root\)", output);
+        Assert.DoesNotContain("bool V_", output);                          // the lockTaken local is gone
+    }
+
+    [Fact]
+    public void LockOnParameter_UsesParameterExpression()
+    {
+        Assert.Contains("lock (gate)", RaiseLock(nameof(LockFixtureSamples.LockOnParameter)));
+    }
+
+    [Fact]
+    public void LockBody_IsStillRaised()
+    {
+        // The body inside the lock continues through later passes.
+        string output = RaiseLock(nameof(LockFixtureSamples.ReadUnderLock));
+        Assert.Contains("lock (_root)", output);
+        Assert.DoesNotContain("Monitor", output);
+    }
+
+    static IrFunction IrImportFor(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(LockFixtureSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(LockFixtureSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+        return function;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -251,6 +251,14 @@ public sealed class CSharpPrinter
             }
             return;
         }
+        if (node is Lock lockStatement)
+        {
+            sb.Append(pad).Append("lock (").Append(Expression(lockStatement.LockObject)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, lockStatement.Body, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is TryFinally tryFinally)
         {
             sb.Append(pad).AppendLine("try");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -242,6 +242,25 @@ public sealed class TryFinally : IrNode
     public override string Describe() => "TryFinally";
 }
 
+/// <summary>
+/// A raised <c>lock</c> statement. Produced by the lock-sugar pass from the
+/// csc Monitor lowering — <c>Monitor.Enter(obj, ref taken)</c> in a try whose
+/// finally is <c>if (taken) Monitor.Exit(obj)</c>.
+/// </summary>
+public sealed class Lock : IrNode
+{
+    public Lock(IrExpression lockObject, BlockContainer body)
+    {
+        AddChild(lockObject);
+        AddChild(body);
+    }
+
+    public IrExpression LockObject => (IrExpression)Children[0];
+    public BlockContainer Body => (BlockContainer)Children[1];
+
+    public override string Describe() => "Lock";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -42,6 +42,9 @@ public static class IrPasses
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
         new StructuringPass(),
+        // After structuring the finally guard is an IfStatement, so the
+        // Monitor lock lowering is matchable as lock (obj) { ... }.
+        new LockSugarPass(),
         new ForLoopPass(),
         new BooleanFoldingPass(),
         // Folding merges slot diamonds into single stores; a second inlining

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -42,6 +42,22 @@ public sealed class LockSugarPass : IIrPass
                 if (TryMatch(children[i], children[i + 1], children[i + 2]) is not { } match)
                     continue;
 
+                // Soundness: the two synthetic locals must be referenced ONLY
+                // by the nodes this rewrite consumes — the defining stores, the
+                // Monitor.Enter we remove, and the whole finally we discard.
+                // Any other reference (in the lock body, before the lock, or
+                // anywhere else in the function) means these are not throwaway
+                // lock temporaries; detaching their stores would strand it.
+                var consumed = new IrNode[]
+                {
+                    match.StoreObject, match.StoreTaken, match.EnterStatement, match.TryFinally.FinallyBody,
+                };
+                if (!ReferencedOnlyWithin(function, match.StoreObject.Index, consumed)
+                    || !ReferencedOnlyWithin(function, match.StoreTaken.Index, consumed))
+                {
+                    continue;
+                }
+
                 var lockObject = (IrExpression)match.StoreObject.DetachChildren()[0];
                 match.EnterStatement.Detach();
                 var body = match.TryFinally.TryBody;
@@ -95,29 +111,28 @@ public sealed class LockSugarPass : IIrPass
             return null;
         }
 
-        // The synthetic locals must not appear in the body (everything in the
-        // try body except the Monitor.Enter we are about to remove).
-        if (LeaksLocal(tryFinally.TryBody, storeObject.Index, firstStatement)
-            || LeaksLocal(tryFinally.TryBody, storeTaken.Index, firstStatement))
-        {
-            return null;
-        }
-
         return new Match(storeObject, storeTaken, tryFinally, (ExpressionStatement)firstStatement, storeObject.Value);
     }
 
+    /// <summary>
+    /// The real <c>System.Threading.Monitor</c> only — matched on assembly
+    /// identity, not just namespace/name, so a same-named type in a user
+    /// assembly is never sugared into a C# <c>lock</c>. Monitor lives in
+    /// corelib (covered by the canonical facade set) but is exposed through
+    /// the <c>System.Threading</c> contract, which is the scope a caller
+    /// actually references, so both are accepted.
+    /// </summary>
     static bool IsMonitorCall(Call call, string method)
         => !call.IsVirtual
             && call.Callee.Name == method
-            && call.Callee.DeclaringType is { Namespace: "System.Threading", Name: "Monitor" };
+            && call.Callee.DeclaringType is
+                { Namespace: "System.Threading", Name: "Monitor", Assembly: TypeRef.CoreLibrary or "System.Threading" };
 
-    /// <summary>True when a local index is referenced anywhere in the subtree outside the excluded node.</summary>
-    static bool LeaksLocal(IrNode subtree, int index, IrNode excluded)
+    /// <summary>True when every reference to <paramref name="index"/> in the function sits inside one of the allowed subtrees.</summary>
+    static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
     {
-        foreach (var node in subtree.Descendants)
+        foreach (var node in function.Descendants)
         {
-            if (IsInside(node, excluded))
-                continue;
             bool references = node switch
             {
                 LoadLocal load => load.Index == index,
@@ -125,10 +140,10 @@ public sealed class LockSugarPass : IIrPass
                 LoadLocalAddress address => address.Index == index,
                 _ => false,
             };
-            if (references)
-                return true;
+            if (references && !allowed.Any(root => IsInside(node, root)))
+                return false;
         }
-        return false;
+        return true;
     }
 
     static bool IsInside(IrNode node, IrNode root)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -1,0 +1,143 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the csc Monitor lock lowering into a <see cref="Lock"/> statement.
+/// The lockTaken shape, after EH structuring and the guard structuring pass:
+/// <code>
+///   object V_0 = obj;
+///   bool V_1 = false;
+///   try { Monitor.Enter(V_0, ref V_1); BODY }
+///   finally { if (V_1) Monitor.Exit(V_0); }
+/// </code>
+/// becomes <c>lock (obj) { BODY }</c>. Runs after structuring so the finally
+/// guard is an <see cref="IfStatement"/>. Transactional: the whole shape,
+/// including that the two synthetic locals appear nowhere in BODY, is proven
+/// before anything is detached — otherwise the construct is left flat.
+/// </summary>
+public sealed class LockSugarPass : IIrPass
+{
+    public string Name => "lock-sugar";
+
+    public void Run(IrFunction function)
+    {
+        while (TransformOne(function))
+        {
+        }
+    }
+
+    sealed record Match(
+        StoreLocal StoreObject,
+        StoreLocal StoreTaken,
+        TryFinally TryFinally,
+        ExpressionStatement EnterStatement,
+        IrExpression LockObject);
+
+    static bool TransformOne(IrFunction function)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 2 < children.Count; i++)
+            {
+                if (TryMatch(children[i], children[i + 1], children[i + 2]) is not { } match)
+                    continue;
+
+                var lockObject = (IrExpression)match.StoreObject.DetachChildren()[0];
+                match.EnterStatement.Detach();
+                var body = match.TryFinally.TryBody;
+                body.Detach();                          // reparent the try body into the lock
+                var lockNode = new Lock(lockObject, body);
+                match.TryFinally.ReplaceWith(lockNode); // slot i+2 → Lock
+                match.StoreTaken.Detach();              // drop synthetic locals (high index first)
+                match.StoreObject.Detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Matches the three-statement lock shape; null when it does not fit.</summary>
+    static Match? TryMatch(IrNode first, IrNode second, IrNode third)
+    {
+        if (first is not StoreLocal storeObject
+            || second is not StoreLocal storeTaken
+            || third is not TryFinally tryFinally)
+        {
+            return null;
+        }
+        // bool lockTaken = false
+        if (storeTaken.Value is not Constant { Value: 0 or false })
+            return null;
+
+        // try body must lead with Monitor.Enter(V_object, ref V_taken)
+        if (tryFinally.TryBody.Blocks is not [{ Children: [var firstStatement, ..] }, ..])
+            return null;
+        if (firstStatement is not ExpressionStatement { Expression: Call enter }
+            || !IsMonitorCall(enter, "Enter")
+            || enter.Arguments is not [LoadLocal enterObject, LoadLocalAddress enterTaken]
+            || enterObject.Index != storeObject.Index
+            || enterTaken.Index != storeTaken.Index)
+        {
+            return null;
+        }
+
+        // finally must be exactly: if (V_taken) Monitor.Exit(V_object);
+        if (tryFinally.FinallyBody.Blocks is not [{ Children: [IfStatement guard] }])
+            return null;
+        if (guard.Else is not null
+            || guard.Condition is not LoadLocal { } takenLoad
+            || takenLoad.Index != storeTaken.Index
+            || guard.Then.Children is not [ExpressionStatement { Expression: Call exit }]
+            || !IsMonitorCall(exit, "Exit")
+            || exit.Arguments is not [LoadLocal exitObject]
+            || exitObject.Index != storeObject.Index)
+        {
+            return null;
+        }
+
+        // The synthetic locals must not appear in the body (everything in the
+        // try body except the Monitor.Enter we are about to remove).
+        if (LeaksLocal(tryFinally.TryBody, storeObject.Index, firstStatement)
+            || LeaksLocal(tryFinally.TryBody, storeTaken.Index, firstStatement))
+        {
+            return null;
+        }
+
+        return new Match(storeObject, storeTaken, tryFinally, (ExpressionStatement)firstStatement, storeObject.Value);
+    }
+
+    static bool IsMonitorCall(Call call, string method)
+        => !call.IsVirtual
+            && call.Callee.Name == method
+            && call.Callee.DeclaringType is { Namespace: "System.Threading", Name: "Monitor" };
+
+    /// <summary>True when a local index is referenced anywhere in the subtree outside the excluded node.</summary>
+    static bool LeaksLocal(IrNode subtree, int index, IrNode excluded)
+    {
+        foreach (var node in subtree.Descendants)
+        {
+            if (IsInside(node, excluded))
+                continue;
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                StoreLocal store => store.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                _ => false,
+            };
+            if (references)
+                return true;
+        }
+        return false;
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -89,7 +89,7 @@ public sealed class LockSugarPass : IIrPass
         if (tryFinally.TryBody.Blocks is not [{ Children: [var firstStatement, ..] }, ..])
             return null;
         if (firstStatement is not ExpressionStatement { Expression: Call enter }
-            || !IsMonitorCall(enter, "Enter")
+            || !IsMonitorEnter(enter)
             || enter.Arguments is not [LoadLocal enterObject, LoadLocalAddress enterTaken]
             || enterObject.Index != storeObject.Index
             || enterTaken.Index != storeTaken.Index)
@@ -104,7 +104,7 @@ public sealed class LockSugarPass : IIrPass
             || guard.Condition is not LoadLocal { } takenLoad
             || takenLoad.Index != storeTaken.Index
             || guard.Then.Children is not [ExpressionStatement { Expression: Call exit }]
-            || !IsMonitorCall(exit, "Exit")
+            || !IsMonitorExit(exit)
             || exit.Arguments is not [LoadLocal exitObject]
             || exitObject.Index != storeObject.Index)
         {
@@ -114,17 +114,39 @@ public sealed class LockSugarPass : IIrPass
         return new Match(storeObject, storeTaken, tryFinally, (ExpressionStatement)firstStatement, storeObject.Value);
     }
 
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
+
+    /// <summary>The exact static <c>void Monitor.Enter(object, ref bool)</c>.</summary>
+    static bool IsMonitorEnter(Call call)
+        => IsMonitorCall(call, "Enter")
+            && call.Callee.ParameterTypes is [var obj, var taken]
+            && obj.Equals(s_object)
+            && taken.Equals(s_refBool);
+
+    /// <summary>The exact static <c>void Monitor.Exit(object)</c>.</summary>
+    static bool IsMonitorExit(Call call)
+        => IsMonitorCall(call, "Exit")
+            && call.Callee.ParameterTypes is [var obj]
+            && obj.Equals(s_object);
+
     /// <summary>
     /// The real <c>System.Threading.Monitor</c> only — matched on assembly
-    /// identity, not just namespace/name, so a same-named type in a user
-    /// assembly is never sugared into a C# <c>lock</c>. Monitor lives in
-    /// corelib (covered by the canonical facade set) but is exposed through
-    /// the <c>System.Threading</c> contract, which is the scope a caller
-    /// actually references, so both are accepted.
+    /// identity (not just namespace/name), a static <c>void</c> non-generic
+    /// shape, and the exact name, so neither a same-named type in a user
+    /// assembly nor a malformed same-named member is sugared into a C#
+    /// <c>lock</c>. Monitor lives in corelib (the canonical facade set) but is
+    /// referenced through the <c>System.Threading</c> contract — the scope a
+    /// caller actually binds — so both assemblies are accepted; the parameter
+    /// shapes are checked by the callers.
     /// </summary>
     static bool IsMonitorCall(Call call, string method)
         => !call.IsVirtual
             && call.Callee.Name == method
+            && !call.Callee.HasThis
+            && call.Callee.TypeArguments.IsEmpty
+            && call.Callee.ReturnType.Equals(s_void)
             && call.Callee.DeclaringType is
                 { Namespace: "System.Threading", Name: "Monitor", Assembly: TypeRef.CoreLibrary or "System.Threading" };
 


### PR DESCRIPTION
The csc lock lowering now raises to a `lock` statement. Recognizes the lockTaken shape (post EH-structuring):

```csharp
object V_0 = obj;
bool V_1 = false;
try { Monitor.Enter(V_0, ref V_1); BODY }
finally { if (V_1) Monitor.Exit(V_0); }
```

→ `lock (obj) { BODY }`.

## Design

`LockSugarPass` runs **after** `StructuringPass` (so the finally guard is an `IfStatement`) and is transactional like the other structural passes: the whole shape — the two synthetic-local stores, the `Monitor.Enter(obj, ref taken)` lead, the `if (taken) Monitor.Exit(obj)` finally, **and** that neither synthetic local leaks into `BODY` — is proven before anything is detached. An unmatched shape stays honestly flat: a lock whose body leaves via an early `return` (so EH structuring left it flat) keeps its explicit `Monitor` calls rather than being half-raised.

The lock body continues through the later loop/boolean/inlining passes, and the synthetic `V_object`/`V_taken` locals disappear (no remaining references → not declared).

Verified on CoreLib: `AppContext.SetData`/`GetData`/`SetSwitch` and peers raise cleanly.

## Parity: unchanged (and that's expected)

46.36%, **zero regressions**. The lock methods still differ from the baseline on *co-occurring* lines — most importantly the `!field` vs `== null` **truthiness gap** (the candidate can't yet prove a field is a reference type), plus explicit type arguments — so they stay in the disagree bucket even with the lock now correct. This is the same shape as the constructor-chain PR: a real, necessary correctness improvement the scoreboard can't credit until the *other* diffs in those methods close. The lock itself is now right, which is the prerequisite; the truthiness gap (the `IsValueType`-resolution foundation) is the keystone gating this whole method family, and is the natural next slice.

A decompiler that doesn't recognize `lock` is a conspicuous gap regardless of the parity number — this closes it.

All suites green: 350/350 decompiler (both configs, 3 new lock fixtures), 999 CLI, 158 services, 141 metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)