### PR TITLE
docs: soundness checklist for IR-mutating passes

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -61,3 +61,28 @@ Correctness is anchored by construction plus weight of evidence — "pounds of I
 - **The head-to-head grading doc** measures how often our canonical representative coincides with what runtime engineers wrote; ILSpy serves as a local second reference there to distinguish information lost in compilation from gaps in our pipeline.
 
 A proposed rendering change should arrive with: the IL shape it targets, the argument for its class under the three-class rule, a fixture covering both configurations, and a full-corpus diff showing exactly the intended changes.
+
+## Soundness checklist for IR-mutating passes
+
+Reviews of the raising passes have converged on three recurring questions; an
+author who answers them before requesting review collapses the serial
+round-trips. Any pass that detaches, replaces, or rewrites IR nodes states its
+answers in the PR (a short "Soundness" note), and the review verifies them
+rather than rediscovering them:
+
+1. **Prove preconditions whole-function, not locally.** A rewrite that removes
+   a node's defining store (or any binding) must prove the affected locals,
+   slots, and stack positions are referenced *only* by the nodes it consumes —
+   scanned across the whole function, not just the matched neighbourhood.
+   Hand-written or obfuscated IL can wear the shape without being the pattern.
+2. **Preserve semantics exactly.** A conversion, comparison, or identity match
+   keeps checked/unsigned/overflow behaviour and produces valid C# (no CS-error
+   spellings). Match metadata members on assembly identity and exact signature,
+   not just namespace/name and call-site argument shapes.
+3. **Isolate per-item failure.** A sweep over many methods (or assemblies)
+   guards each item so one malformed input yields a diagnostic, not a lost
+   batch; results that escape their source hold no live readers.
+
+The default first reviewer is the author: run the high-effort self-review over
+the branch before opening the PR, so the first external pass starts from a
+clean sheet instead of round one.


### PR DESCRIPTION
Codifies the review loop we just discussed into a standing practice.

Reviews of the raising passes (identity-convert #492, nested-type #494, lock-sugar #497) all landed in three recurring buckets, and every finding was real. The inefficiency was serial round-trips, not bad findings — so the fix is to front-load the lens as a checklist the author applies before requesting review:

1. **Prove preconditions whole-function** — a rewrite that removes a binding proves the affected locals/slots are referenced only by consumed nodes, scanned across the whole function (the lock-sugar local-leak finding).
2. **Preserve semantics exactly** — keep checked/unsigned/overflow, produce valid C#, match members by assembly identity + exact signature (the identity-convert and nested-type findings).
3. **Isolate per-item failure** — sweeps guard each item; escaping results hold no live readers (the analysis-indexer findings).

And makes self-review-before-PR the default, so the first external review starts from a clean sheet.

Docs-only; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)