### PR TITLE
Truthiness: null-test a generic-instance branch operand

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -342,6 +342,15 @@ public class CfgSampleClass
 
     public static bool IsPositive(int x) => x > 0;
 
+    // Null-check on a generic instance: the brtrue operand is List<int>, a
+    // reference type by IL well-formedness, so the guard renders `is null`.
+    public static int CountOrZero(System.Collections.Generic.List<int> items)
+    {
+        if (items == null)
+            return 0;
+        return items.Count;
+    }
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -598,6 +598,19 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void GenericInstanceNullCheck_RendersIsNull()
+    {
+        // A brtrue/brfalse operand can never be a struct value, so a generic
+        // instance (List<int>) is soundly a reference type: null-test it,
+        // never the uncompilable !items.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.CountOrZero), source);
+
+        Assert.Contains("items is null", output);
+        Assert.DoesNotContain("!items", output);
+    }
+
+    [Fact]
     public void NestedGenericType_RendersInnermostName_NotOuter()
     {
         // List<T>.GetEnumerator returns the nested List`1+Enumerator. The old

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -476,10 +476,14 @@ public sealed class CSharpPrinter
 
     /// <summary>
     /// Spellings for a non-bool branch operand: <c>!= 0</c> for known integer
-    /// families, <c>!= null</c> for KNOWN reference shapes only (arrays,
-    /// string, object). A bare definition could be a struct or an enum —
-    /// TypeRef cannot yet tell — so unknowns return null and print as the
-    /// raw value rather than a guessed comparison that might not compile.
+    /// families, <c>is null</c>/<c>is not null</c> for reference shapes. The
+    /// operand is a <c>brfalse</c>/<c>brtrue</c> value, so the CLI constrains
+    /// it to int, native int, object reference, or managed pointer — never a
+    /// struct value. A generic instance here is therefore always a reference
+    /// type (generic value types cannot be branch operands, and enums are
+    /// never generic), so it null-tests soundly with no type resolution. A
+    /// bare non-generic definition is still reference-or-enum and TypeRef
+    /// cannot yet tell, so it returns null and prints raw rather than guess.
     /// </summary>
     (string Direct, string Inverted)? Truthiness(IrExpression operand)
     {
@@ -488,6 +492,9 @@ public sealed class CSharpPrinter
             return null;
 
         string text = Operand(operand);
+        if (type.Kind == TypeRefKind.GenericInstance)
+            return ($"{text} is not null", $"{text} is null");
+
         return TypeFamilies.Of(type) switch
         {
             // Boolean was filtered above, so an I4 family here is a real integer (or char).


### PR DESCRIPTION
`if (!field)` where `field` is a reference type like `Dictionary<,>` rendered the **uncompilable `!field`** — `TypeFamilies.Of` classifies only arrays and corelib `System` primitives, so a generic instance fell through to the raw value. It now renders `is null` / `is not null`.

## Soundness

The operand is a `brfalse`/`brtrue` value, which the CLI constrains to int, native int, object reference, or managed pointer — **never a struct value** (ECMA III.3.17). A generic instance there is therefore *always* a reference type:

- generic value types (`Nullable<T>`, `ImmutableArray<T>`, user generic structs) cannot be branch operands, and
- enums are never generic.

So the null-test is sound with **no type resolution**. The non-generic-`Definition` case stays reference-or-enum (TypeRef can't yet tell a class from an enum) and still prints raw — that's the part the future `IsValueType` resolution unblocks. `Truthiness` is reached only through `Condition()`, whose every caller is a branch or ternary condition, so the `brfalse`/`brtrue` constraint always holds.

## Result

Parity **46.36% → 46.38%**, zero regressions. The bump is small because many affected methods (the lock family) still differ on co-occurring lines — but the output is now *valid C#* where it previously wasn't, and this is the first sound step into the truthiness gap without paying for the resolution architecture. Pinned with a `CountOrZero(List<int>)` fixture (`items is null`, never `!items`); 355/355 both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)