### PR TITLE
Same-assembly type-shape resolution; finish definition truthiness

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -351,6 +351,15 @@ public class CfgSampleClass
         return items.Count;
     }
 
+    // Null-check on a non-generic reference type (CfgNullableTarget is defined
+    // in this assembly) — same-assembly shape resolution renders `is null`.
+    public static int GateOrZero(CfgNullableTarget gate)
+    {
+        if (gate == null)
+            return 0;
+        return gate.Value;
+    }
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -611,6 +611,19 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void SameAssemblyReferenceNullCheck_RendersIsNull()
+    {
+        // CfgNullableTarget is a non-generic reference type defined in this
+        // assembly; same-assembly shape resolution proves it a reference, so
+        // the guard null-tests rather than printing the uncompilable !gate.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.GateOrZero), source);
+
+        Assert.Contains("gate is null", output);
+        Assert.DoesNotContain("!gate", output);
+    }
+
+    [Fact]
     public void NestedGenericType_RendersInnermostName_NotOuter()
     {
         // List<T>.GetEnumerator returns the nested List`1+Enumerator. The old
@@ -1296,5 +1309,58 @@ public class LockSugarSoundnessTests
 
         Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
         Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+}
+
+/// <summary>
+/// The printer's shape-driven truthiness: given a resolved TypeShape for a
+/// non-generic definition branch operand, an enum zero-tests and a reference
+/// null-tests. Built directly with a TypeShapes map so the rendering is tested
+/// independent of csc codegen (enum brfalse is Release-only).
+/// </summary>
+public class TypeShapeTruthinessTests
+{
+    static string PrintConditionOn(TypeRef conditionType, TypeShape shape)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var then = new Block(0);
+        then.Add(new Return(new Constant(1, intType)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(new LoadLocal(0, conditionType), then, null));
+        entry.Add(new Return(new Constant(0, intType)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var signature = new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [conditionType], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [conditionType] = shape },
+        };
+        return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+    }
+
+    [Fact]
+    public void EnumShape_ZeroTests()
+    {
+        var enumType = TypeRef.Definition("asm", "NS", "MyEnum");
+        Assert.Contains("if (V_0 != 0)", PrintConditionOn(enumType, TypeShape.Enum));
+    }
+
+    [Fact]
+    public void ReferenceShape_NullTests()
+    {
+        var classType = TypeRef.Definition("asm", "NS", "MyClass");
+        Assert.Contains("if (V_0 is not null)", PrintConditionOn(classType, TypeShape.Reference));
+    }
+
+    [Fact]
+    public void UnknownShape_StaysRaw()
+    {
+        // A cross-assembly definition resolves to Unknown — print raw, no guess.
+        var classType = TypeRef.Definition("other-asm", "NS", "Mystery");
+        string output = PrintConditionOn(classType, TypeShape.Unknown);
+
+        Assert.DoesNotContain("is null", output);
+        Assert.DoesNotContain("!= 0", output);
+        Assert.Contains("V_0", output);   // still references the operand, raw
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -475,15 +475,16 @@ public sealed class CSharpPrinter
     };
 
     /// <summary>
-    /// Spellings for a non-bool branch operand: <c>!= 0</c> for known integer
-    /// families, <c>is null</c>/<c>is not null</c> for reference shapes. The
+    /// Spellings for a non-bool branch operand: <c>!= 0</c> for integers and
+    /// enums, <c>is null</c>/<c>is not null</c> for reference shapes. The
     /// operand is a <c>brfalse</c>/<c>brtrue</c> value, so the CLI constrains
     /// it to int, native int, object reference, or managed pointer — never a
-    /// struct value. A generic instance here is therefore always a reference
-    /// type (generic value types cannot be branch operands, and enums are
-    /// never generic), so it null-tests soundly with no type resolution. A
-    /// bare non-generic definition is still reference-or-enum and TypeRef
-    /// cannot yet tell, so it returns null and prints raw rather than guess.
+    /// struct value. A generic instance is therefore always a reference type
+    /// (generic value types cannot be branch operands, and enums are never
+    /// generic), so it null-tests with no resolution. A bare definition is
+    /// reference-or-enum; the importer's same-assembly shape resolution tells
+    /// them apart where it can, and an unresolved (cross-assembly) definition
+    /// still prints raw rather than guess.
     /// </summary>
     (string Direct, string Inverted)? Truthiness(IrExpression operand)
     {
@@ -492,15 +493,30 @@ public sealed class CSharpPrinter
             return null;
 
         string text = Operand(operand);
-        if (type.Kind == TypeRefKind.GenericInstance)
-            return ($"{text} is not null", $"{text} is null");
+        (string, string) reference = ($"{text} is not null", $"{text} is null");
+        (string, string) integer = ($"{text} != 0", $"{text} == 0");
 
-        return TypeFamilies.Of(type) switch
+        switch (TypeFamilies.Of(type))
         {
             // Boolean was filtered above, so an I4 family here is a real integer (or char).
-            StackFamily.I4 or StackFamily.I8 or StackFamily.I => ($"{text} != 0", $"{text} == 0"),
-            StackFamily.O => ($"{text} is not null", $"{text} is null"),
-            _ => null,
+            case StackFamily.I4 or StackFamily.I8 or StackFamily.I:
+                return integer;
+            case StackFamily.O:
+                return reference;
+            case StackFamily.F:
+                return null;   // a float is never a branch operand
+        }
+
+        // No primitive family. A generic instance is provably a reference; a
+        // bare definition resolves by its same-assembly shape.
+        if (type.Kind == TypeRefKind.GenericInstance)
+            return reference;
+
+        return _function.TypeShapes.GetValueOrDefault(type) switch
+        {
+            TypeShape.Reference => reference,
+            TypeShape.Enum => integer,
+            _ => null,   // a struct cannot be a branch operand; unknown stays raw
         };
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -137,8 +137,32 @@ public static class IrImporter
                 return function;  // honest stop already recorded
         }
 
+        function.TypeShapes = ResolveShapes(source, function);
         function.CheckInvariant();
         return function;
+    }
+
+    /// <summary>
+    /// Resolves the same-assembly shape of every definition-typed expression
+    /// result, materialized for the metadata-free printer. Lean by intent:
+    /// only result types (the truthiness inputs) are resolved, not every type
+    /// the function mentions.
+    /// </summary>
+    static IReadOnlyDictionary<TypeRef, TypeShape> ResolveShapes(MetadataSource source, IrFunction function)
+    {
+        Dictionary<TypeRef, TypeShape>? shapes = null;
+        foreach (var expression in function.Descendants.OfType<IrExpression>())
+        {
+            if (expression.ResultType is { Kind: TypeRefKind.Definition } type)
+            {
+                shapes ??= [];
+                if (!shapes.ContainsKey(type))
+                    shapes[type] = source.ResolveShape(type);
+            }
+        }
+        return shapes is null
+            ? System.Collections.Immutable.ImmutableDictionary<TypeRef, TypeShape>.Empty
+            : shapes;
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -53,6 +53,17 @@ public sealed class IrFunction : IrNode
     /// </summary>
     public ImmutableArray<HandlerRegion> Regions { get; set; } = [];
 
+    /// <summary>
+    /// Resolved C# shapes for the definition types this function references,
+    /// materialized at import (the printer is metadata-free). Same-assembly
+    /// only; cross-assembly types are absent and read as
+    /// <see cref="TypeShape.Unknown"/>. Lets the printer null-test a reference
+    /// definition and zero-test an enum where <see cref="TypeFamilies.Of"/>
+    /// cannot classify a bare definition.
+    /// </summary>
+    public IReadOnlyDictionary<TypeRef, TypeShape> TypeShapes { get; set; }
+        = ImmutableDictionary<TypeRef, TypeShape>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -4,6 +4,14 @@ namespace ILInspector.Decompiler.Pipeline;
 public enum StackFamily { I4, I8, F, I, O }
 
 /// <summary>
+/// A type's C#-relevant shape, knowable only by resolving the definition (its
+/// base type): the distinction <see cref="TypeFamilies.Of"/> cannot make for a
+/// bare definition. <see cref="Unknown"/> covers the unresolved cases — a
+/// cross-assembly type with no loaded definition, or anything not a definition.
+/// </summary>
+public enum TypeShape { Unknown, Reference, ValueType, Enum }
+
+/// <summary>
 /// The single home for type-family classification (review consolidation:
 /// this knowledge previously lived in the importer's slot merging, the
 /// structuring pass's float detection, and three printer spellings). When

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -57,6 +57,65 @@ public sealed class MetadataSource : IDisposable
         }
     }
 
+    Dictionary<TypeRef, TypeShape>? _shapes;
+
+    /// <summary>
+    /// The C# shape of a type defined in THIS assembly — enum, struct, or
+    /// reference — read from its base type. Cross-assembly types and non
+    /// -definitions return <see cref="TypeShape.Unknown"/>: resolving them
+    /// would need an assembly loader the SRM-only pipeline deliberately does
+    /// not carry. The same-assembly map covers the whole single-assembly
+    /// sweep (every CoreLib type resolves against CoreLib). Built once, lazily.
+    /// </summary>
+    internal TypeShape ResolveShape(TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.Definition)
+            return TypeShape.Unknown;
+        _shapes ??= BuildShapeMap();
+        return _shapes.GetValueOrDefault(type, TypeShape.Unknown);
+    }
+
+    Dictionary<TypeRef, TypeShape> BuildShapeMap()
+    {
+        var map = new Dictionary<TypeRef, TypeShape>();
+        foreach (var handle in Reader.TypeDefinitions)
+        {
+            // The decoder produces the same nested-aware TypeRef the IR
+            // carries, so the map keys match by semantic equality.
+            var key = TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, handle, 0);
+            map[key] = ClassifyShape(Reader.GetTypeDefinition(handle));
+        }
+        return map;
+    }
+
+    TypeShape ClassifyShape(TypeDefinition typeDef)
+    {
+        if ((typeDef.Attributes & System.Reflection.TypeAttributes.Interface) != 0)
+            return TypeShape.Reference;
+        var baseHandle = typeDef.BaseType;
+        if (baseHandle.IsNil)
+            return TypeShape.Reference;   // System.Object itself
+        var (ns, name) = BaseName(baseHandle);
+        if (ns == "System" && name == "Enum")
+            return TypeShape.Enum;
+        if (ns == "System" && name == "ValueType")
+            return TypeShape.ValueType;   // a non-enum struct
+        return TypeShape.Reference;       // any class base, or a generic (TypeSpec) base
+    }
+
+    (string Namespace, string Name) BaseName(EntityHandle handle) => handle.Kind switch
+    {
+        HandleKind.TypeReference => NameOf(Reader.GetTypeReference((TypeReferenceHandle)handle)),
+        HandleKind.TypeDefinition => NameOf(Reader.GetTypeDefinition((TypeDefinitionHandle)handle)),
+        _ => ("", ""),   // a TypeSpec base is never System.Enum/ValueType
+    };
+
+    (string, string) NameOf(TypeReference reference)
+        => (Reader.GetString(reference.Namespace), Reader.GetString(reference.Name));
+
+    (string, string) NameOf(TypeDefinition definition)
+        => (Reader.GetString(definition.Namespace), Reader.GetString(definition.Name));
+
     public void Dispose()
     {
         Pe.Dispose();


### PR DESCRIPTION
The first type resolution in the pipeline — and it closes the non-generic-`Definition` half of the truthiness gap (`if (field)` on a reference type was rendering the **uncompilable `!field`**).

## What it does

`MetadataSource` classifies every type defined in the current assembly as reference / struct / enum by reading its base type (`System.Enum` → Enum, `System.ValueType` → struct, else Reference), built once and cached. The importer resolves the shapes of a function's definition-typed expression results and materializes them onto `IrFunction` as a `TypeRef → TypeShape` dictionary; the metadata-free printer consults it in `Truthiness`.

- `if (field)` on a non-generic reference type → `field is null`/`is not null` (was `!field`).
- An enum branch operand → `field != 0` / `== 0`.
- Generic instances were already handled (#499); **cross-assembly** definitions stay `Unknown` → raw, since resolving them needs an assembly loader the SRM-only pipeline deliberately doesn't carry. The same-assembly map covers the entire single-assembly CoreLib sweep.

## Architecture note

This is the *same-assembly* foundation only — deliberately. It needs **no external assembly loader**, so it does not touch the cross-assembly/standalone architecture question. Cross-assembly resolution (a user method null-checking a BCL type) remains the larger, separately-scoped piece; it degrades honestly to raw today. The `TypeShape` enum lives in `TypeFamilies.cs`, where the file already anticipated "when `IsValueType` knowledge arrives via resolution, it lands here."

## Soundness (self-reviewed with the high-effort pass, per #498)

- **Classification:** enum/struct bases are always `System.Enum`/`System.ValueType` TypeRefs; a generic (TypeSpec) base is never either, so it falls to reference — no misclassification. Interfaces and nil-base (`System.Object`) are reference.
- **Key-matching:** the map is keyed by the decoder's own `GetTypeFromDefinition` output — the same nested-aware (`Outer+Inner`) TypeRef the IR carries — so lookups match by semantic equality, top-level and nested alike; no collisions.
- **Lifetime:** the dict holds only TypeRefs and a value enum — no metadata handles escape, and it is populated while the source is live, consistent with the `MetadataSource` materialization rule.
- **Truthiness restructure:** preserves every primitive-family case and only adds the shape lookup on the no-family definition path; a struct cannot be a branch operand, so `ValueType`/`Unknown` stay raw.

The adversarial finder pass (9 angles) returned no bugs.

## Result

Parity **46.38% → 46.49% (+45)**, **zero regressions** — the prior raw `!field`/`!enum` was invalid C# that never matched the baseline, so these can only improve or stay-disagreeing. 359/359 both configs, including an end-to-end reference fixture (`GateOrZero`) and synthetic enum/reference/unknown printer tests.

This also lays the resolver that enum-constant naming will reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)