### PR TITLE
Add member Calls section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | ---------- | -------- | ---------- |
 | Package inventory | `package` | Metadata, versions, TFMs, file layout, dependency tree, metadata audit, vulnerability data, custom feeds, NuGet config support. |
 | Library audit | `library` | Assembly identity, public key token, trim/AOT metadata, unsafe/interoperability signals, OpenTelemetry support, symbols/PDBs, SourceLink and determinism audit, references, resources, async method classification. |
-| API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, source/decompiled/IL drill-in. |
+| API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls, source/decompiled/IL drill-in. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type filters. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. |
 | Source mapping | `source`, `member -S "Original Source"` | SourceLink URLs, member line numbers, source fetching, URL verification, token+IL-offset to source-line resolution. |
@@ -127,6 +127,7 @@ dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
+dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
 dotnet-inspect source JsonSerializer --package System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
 dotnet-inspect depends Stream --markdown --mermaid

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -24,7 +24,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect a type | `type Type --package Foo` | Add `--all` for non-public, hidden, and extra members. |
 | Inspect members and overloads | `member Type --package Foo -m Name --show-index` | Use `Name:N` selectors for a specific overload. |
 | Compare API versions | `diff --package Foo@old..new --breaking` | Use `--additive` for new APIs or `-t Type` to narrow. |
-| Locate source or implementation | `source Type --package Foo` | For a selected overload use `member Type Member:1 -S "Original Source"` or `-S IL`. |
+| Locate source or implementation | `source Type --package Foo` | For a selected overload use `member Type Member:1 -S "Original Source"`, `-S Calls`, or `-S IL`. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package, platform, or project scope as needed. |
 
 ## Output modes
@@ -103,11 +103,12 @@ dnx dotnet-inspect -y -- diff --platform System.Runtime@9.0.0..10.0.0 --additive
 
 ## Source and implementation workflow
 
-Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, or `-S IL` / `-S "IL (Annotated)"` for IL.
+Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, or `-S IL` / `-S "IL (Annotated)"` for IL.
 
 ```bash
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
 ```
 
 A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need specific implementation evidence.

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -126,13 +126,13 @@ public sealed class LibraryBodyIndex
                     {
                         int token = ReadInt32(il, ref position, offset);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
-                        calls.Add(new DirectCall(caller, callee, offset, ToCallKind(opcode)));
+                        calls.Add(new DirectCall(caller, callee, offset, token, ToCallKind(opcode)));
                         break;
                     }
                     case ILOpCode.Calli:
                     {
                         int token = ReadInt32(il, ref position, offset);
-                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, CallKind.CallIndirect));
+                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, token, CallKind.CallIndirect));
                         break;
                     }
                     default:

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -48,6 +48,7 @@ public sealed record DirectCall(
     MethodIdentity Caller,
     MemberRef Callee,
     int ILOffset,
+    int OperandToken,
     CallKind Kind);
 
 public sealed class MemberPattern

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -240,6 +240,12 @@ public class ApiMember
     public string? ReturnType { get; set; }
     public string? Signature { get; set; }
 
+    /// <summary>
+    /// MethodDef metadata token for method-like members when known.
+    /// Used for stable body evidence lookups such as call-site sections.
+    /// </summary>
+    public int? MetadataToken { get; set; }
+
     public bool IsStatic { get; set; }
     public bool IsVirtual { get; set; }
     public bool IsAbstract { get; set; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Metadata;
@@ -195,6 +196,7 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverride,
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     Signature = signature,
+                    MetadataToken = MetadataTokens.GetToken(methodHandle),
                     IsUnsafe = HasUnsafeSignature(signature),
                     Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
@@ -489,6 +491,7 @@ public static class ApiSurfaceExtractor
                     Kind = "extension-method",
                     ReturnType = extension.ReturnType,
                     Signature = extension.Signature,
+                    MetadataToken = extension.MetadataToken,
                     IsStatic = extension.IsStatic,
                     IsVirtual = extension.IsVirtual,
                     IsAbstract = extension.IsAbstract,

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -1,0 +1,80 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class MemberCallsSectionTests
+{
+    [Fact]
+    public async Task CallsSection_RendersOneRowPerCallSite()
+    {
+        var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsWriteLineTwice));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Calls", result.Output);
+        Assert.Equal(2, CountOccurrences(result.Output, "`System.Console.WriteLine(string)`"));
+        Assert.Contains("`IL_", result.Output);
+        Assert.Contains("`0x0A", result.Output);
+    }
+
+    [Fact]
+    public async Task CallsSection_KeepsInterfaceCallvirtAsDeclaredTarget()
+    {
+        var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsInterfaceItem));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("`System.Collections.Generic.IList<int>.get_Item(int)`", result.Output);
+        Assert.Contains("| callvirt |", result.Output);
+    }
+
+    [Fact]
+    public async Task CallsSection_TsvUsesPlainNormalizedValues()
+    {
+        var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsWriteLineTwice), tsv: true);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("callee\tkind\til\ttoken", result.Output);
+        Assert.DoesNotContain('`', result.Output);
+        Assert.Equal(2, CountOccurrences(result.Output, "System.Console.WriteLine(string)"));
+    }
+
+    static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false)
+        => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallsFixture).FullName,
+            AssemblyPath = typeof(MemberCallsFixture).Assembly.Location,
+            MemberFilter = [memberName],
+            IncludeSections = [SectionNames.Calls],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = tsv,
+            Tsv = tsv,
+            OneLineExplicitlySet = tsv,
+            FormatExplicitlySet = true,
+        }));
+
+    static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+}
+
+public static class MemberCallsFixture
+{
+    public static void CallsWriteLineTwice()
+    {
+        Console.WriteLine("first");
+        Console.WriteLine("second");
+    }
+
+    public static int CallsInterfaceItem(IList<int> values) => values[0];
+}

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -40,7 +40,16 @@ public class MemberCallsSectionTests
         Assert.Equal(2, CountOccurrences(result.Output, "System.Console.WriteLine(string)"));
     }
 
-    static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false)
+    [Fact]
+    public async Task EffectiveDiscovery_ListsCallsForSelectedMember()
+    {
+        var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsWriteLineTwice), discover: true);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Calls\tsection", result.Output);
+    }
+
+    static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
             TypeName = typeof(MemberCallsFixture).FullName,
@@ -48,10 +57,11 @@ public class MemberCallsSectionTests
             MemberFilter = [memberName],
             IncludeSections = [SectionNames.Calls],
             TipLevel = TipLevel.Quiet,
+            Discover = discover ? [] : null,
             Verbosity = Verbosity.Minimal,
-            OneLine = tsv,
-            Tsv = tsv,
-            OneLineExplicitlySet = tsv,
+            OneLine = tsv || discover,
+            Tsv = tsv || discover,
+            OneLineExplicitlySet = tsv || discover,
             FormatExplicitlySet = true,
         }));
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -486,8 +486,11 @@ public class ApiCommand
         if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
             return schema;
 
-        return MergeSchemas(schema,
+        var detailSchema = MergeSchemas(schema,
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
+        if (detailSchema.GetSection(SectionNames.Calls) == null)
+            detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
+        return detailSchema;
     }
 
     private static DocumentSchema MergeSchemas(params DocumentSchema[] schemas)
@@ -566,7 +569,17 @@ public class ApiCommand
     internal static HashSet<string> GetRequestedMemberSections(ApiType type, ApiOptions options)
     {
         var pipeline = ApiMemberSectionPipelines.Create(options);
-        return [.. pipeline.GetEffectiveSections(type, options.Verbosity, options.IncludeSections)];
+        var sections = new HashSet<string>(
+            pipeline.GetEffectiveSections(type, options.Verbosity, options.IncludeSections),
+            StringComparer.OrdinalIgnoreCase);
+        if (options.Discover is { Length: > 0 } discover)
+        {
+            var resolved = SelectResolver.ResolveSelectAsSections(
+                discover, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+            if (!resolved.HasError && resolved.Sections is { Count: > 0 })
+                sections.UnionWith(resolved.Sections);
+        }
+        return sections;
     }
 
     // ===== Full API Surface Rendering =====
@@ -1034,6 +1047,20 @@ public class ApiCommand
             JsonOutput = false,
             OneLine = false,
         };
+        if (options.Discover is { Length: > 0 } discover)
+        {
+            var pipeline = ApiMemberSectionPipelines.Create(options);
+            var resolved = SelectResolver.ResolveSelectAsSections(
+                discover, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+            if (!resolved.HasError && resolved.Sections is { Count: > 0 })
+            {
+                var include = renderOptions.IncludeSections is null
+                    ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>(renderOptions.IncludeSections, StringComparer.OrdinalIgnoreCase);
+                include.UnionWith(resolved.Sections);
+                renderOptions = renderOptions with { IncludeSections = include };
+            }
+        }
 
         var view = ApiOutputFormatter.BuildTypeView(type, null, null, null, null, null, renderOptions);
         EventsView? eventsView = null;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1019,7 +1019,10 @@ public class ApiCommand
         var filteredType = BuildFilteredTypeForSections(apiType, options);
         var effective = memberPipeline.GetAvailableSections(filteredType, options.IncludeSections);
         effective = DiscoverOutput.RestrictToSchemaSections(effective, fullSchema);
-        var rendered = RenderTypeSectionsMarkdown(filteredType, options);
+        var discoveryRenderSections = options is MemberOptions { OverloadIndex: not null }
+            ? effective
+            : null;
+        var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
         effective = DiscoverOutput.RestrictToRenderedSections(effective, fullSchema, rendered);
         var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(effective, fullSchema, rendered);
         return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
@@ -1037,7 +1040,7 @@ public class ApiCommand
     /// only with --show-index). Projection (--columns/--fields) is intentionally dropped so
     /// the result reflects all renderable columns, not a user-narrowed subset.
     /// </summary>
-    internal static string RenderTypeSectionsMarkdown(ApiType type, ApiOptions options)
+    internal static string RenderTypeSectionsMarkdown(ApiType type, ApiOptions options, IReadOnlyCollection<string>? discoverySections = null)
     {
         var renderOptions = options with
         {
@@ -1047,6 +1050,14 @@ public class ApiCommand
             JsonOutput = false,
             OneLine = false,
         };
+        if (discoverySections is { Count: > 0 })
+        {
+            var include = renderOptions.IncludeSections is null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(renderOptions.IncludeSections, StringComparer.OrdinalIgnoreCase);
+            include.UnionWith(discoverySections);
+            renderOptions = renderOptions with { IncludeSections = include };
+        }
         if (options.Discover is { Length: > 0 } discover)
         {
             var pipeline = ApiMemberSectionPipelines.Create(options);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -348,6 +348,7 @@ public static class MemberCommand
                || sections.Contains(SectionNames.CustomAttributes)
                || sections.Contains(SectionNames.DecompiledSource)
                || sections.Contains(SectionNames.OriginalSource)
+               || sections.Contains(SectionNames.Calls)
                || sections.Contains(SectionNames.IL)
                || sections.Contains(SectionNames.ILAnnotated);
     }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -15,7 +15,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool IL, bool AnnotatedIL, bool Attributes);
+    internal sealed record Request(bool DecompiledSource, bool IL, bool AnnotatedIL, bool Attributes, bool Calls);
 
     /// <summary>
     /// Code content for one member. Body and diagnostic are mutually

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -7,6 +7,7 @@ using DotnetInspector.Views;
 using Markout;
 
 using Decompiler = ILInspector.Decompiler;
+using Analysis = ILInspector.Analysis;
 
 namespace DotnetInspector.Output;
 
@@ -903,10 +904,30 @@ public static class ApiOutputFormatter
             DecompiledSource: requestedSections.Contains(SectionNames.DecompiledSource),
             IL: requestedSections.Contains(SectionNames.IL),
             AnnotatedIL: requestedSections.Contains(SectionNames.ILAnnotated),
-            Attributes: requestedSections.Contains(SectionNames.CustomAttributes));
+            Attributes: requestedSections.Contains(SectionNames.CustomAttributes),
+            Calls: requestedSections.Contains(SectionNames.Calls));
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
+
+        if (request.Calls && methods is [{ MetadataToken: { } token }])
+        {
+            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var rows = index.DirectCalls
+                .Where(call => call.Caller.MetadataToken == token)
+                .OrderBy(call => call.ILOffset)
+                .Select(call => new CallSiteRow(
+                    MarkoutInline.Code(FormatCallee(call.Callee)),
+                    FormatCallKind(call.Kind),
+                    MarkoutInline.Code($"IL_{call.ILOffset:X4}"),
+                    MarkoutInline.Code($"0x{call.OperandToken:X8}")))
+                .ToList();
+            if (rows.Count > 0)
+            {
+                memberCode.CallRows = rows;
+                hasCode = true;
+            }
+        }
 
         foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath))
         {
@@ -952,6 +973,28 @@ public static class ApiOutputFormatter
 
         if (hasCode)
             view.MemberCode = memberCode;
+    }
+
+    static string FormatCallKind(Analysis.CallKind kind) => kind switch
+    {
+        Analysis.CallKind.Call => "call",
+        Analysis.CallKind.CallVirtual => "callvirt",
+        Analysis.CallKind.NewObject => "newobj",
+        Analysis.CallKind.LoadFunction => "ldftn",
+        Analysis.CallKind.LoadVirtualFunction => "ldvirtftn",
+        _ => "calli",
+    };
+
+    static string FormatCallee(Analysis.MemberRef member)
+    {
+        if (member.Kind == Analysis.MemberKind.Unsupported)
+            return member.DeclaringType.ToDisplayString();
+
+        string declaringType = member.DeclaringType.ToQualifiedDisplayString();
+        string name = member.Name;
+        if (member.TypeArguments.Length > 0)
+            name += $"<{string.Join(", ", member.TypeArguments.Select(t => t.ToQualifiedDisplayString()))}>";
+        return $"{declaringType}.{name}({string.Join(", ", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
     }
 
     private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, IReadOnlyList<string>? methodGenericParameters, string lowered)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -336,6 +336,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.MethodAttributes>()
             .Add<ApiMemberSectionDescriptors.DecompiledSource>()
             .Add<ApiMemberSectionDescriptors.OriginalSource>()
+            .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
             .Add<ApiMemberSectionDescriptors.AnnotatedIL>();
     }
@@ -364,6 +365,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
+            .Add<Calls>()
             .Add<ILBody>()
             .Add<AnnotatedIL>();
     }
@@ -425,6 +427,16 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class Calls : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.Calls;
+        public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Count == 1
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class AnnotatedIL : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -87,4 +87,7 @@ public static class SectionNames
     /// <summary>Section for annotated IL disassembly.</summary>
     public const string ILAnnotated = "IL (Annotated)";
 
+    /// <summary>Section for direct call-site evidence from the selected member body.</summary>
+    public const string Calls = "Calls";
+
 }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -533,6 +533,9 @@ public class MemberCodeView
     [MarkoutSection(Name = "Original Source")]
     public CodeSection OriginalSourceCode { get; set; }
 
+    [MarkoutSection(Name = "Calls")]
+    public List<CallSiteRow>? CallRows { get; set; }
+
     [MarkoutSection(Name = "IL")]
     public CodeSection ILCode { get; set; }
 
@@ -555,6 +558,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(ExplicitInterfaceImplementationsView))]
 [MarkoutContext(typeof(ExtensionMethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
+[MarkoutContext(typeof(CallSiteRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
 [MarkoutContext(typeof(MemberRow))]
@@ -574,3 +578,6 @@ public partial class TypeViewContext : MarkoutSerializerContext
 public partial class ApiViewContext : MarkoutSerializerContext
 {
 }
+
+[MarkoutSerializable]
+public record CallSiteRow(string Callee, string Kind, string IL, string Token);

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />


### PR DESCRIPTION
## Summary

- add selected-member `-S Calls` output backed by `ILInspector.Analysis`
- render one row per direct call site with columns `Callee`, `Kind`, `IL`, and `Token`
- carry method and operand metadata tokens through the API/analysis models for stable evidence matching
- update docs/skill guidance and add focused tests for repeated calls, interface `callvirt`, TSV output, and effective discovery

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal`
- `dotnet run --project src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release`
- `npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md`