### PR TITLE
Enum-constant naming via the same-assembly member map

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -360,6 +360,19 @@ public class CfgSampleClass
         return gate.Value;
     }
 
+    // Passes an enum constant into an enum parameter position: the ldc.i4.2
+    // retypes to CfgPriority (defined in this assembly) and the printer names
+    // it CfgPriority.High from the resolved member map, not the raw 2.
+    public static void TakesPriority(CfgPriority priority) { _ = priority; }
+
+    public static void CallWithHighPriority() => TakesPriority(CfgPriority.High);
+
+    public static void TakesFlags(CfgFlags flags) { _ = flags; }
+
+    // CfgFlags.Top = 0x80000000 emits as the signed int -2147483648; the
+    // member-map key must reinterpret the uint the same way to name it.
+    public static void CallWithTopFlag() => TakesFlags(CfgFlags.Top);
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;
@@ -1053,6 +1066,11 @@ public class CfgSampleClass
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
+
+// uint-underlying with a high-bit member: the value 0x80000000 emits as the
+// signed int -2147483648, the case the member-map key must agree on.
+[System.Flags]
+public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
 
 public sealed class CfgNullableTarget
 {

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1364,3 +1364,87 @@ public class TypeShapeTruthinessTests
         Assert.Contains("V_0", output);   // still references the operand, raw
     }
 }
+
+/// <summary>
+/// Enum-constant naming: an integer flowing into an enum position retypes to
+/// the enum and prints as EnumType.Member from the resolved same-assembly
+/// member map. Exact matches only; composite/unnamed values stay raw.
+/// </summary>
+public class EnumConstantTests
+{
+    [Fact]
+    public void EnumArgument_RendersMemberName()
+    {
+        // TakesPriority(CfgPriority.High) — the ldc.i4.2 names as High, not 2.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.CallWithHighPriority), source);
+
+        Assert.Contains("CfgPriority.High", output);
+        Assert.DoesNotContain("TakesPriority(2)", output);
+    }
+
+    [Fact]
+    public void HighBitUnsignedEnumMember_Names()
+    {
+        // CfgFlags.Top = 0x80000000 (uint) emits as int -2147483648. The
+        // member-map key must reinterpret the uint as a signed int to match,
+        // or this falls back to the raw -2147483648.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.CallWithTopFlag), source);
+
+        Assert.Contains("CfgFlags.Top", output);
+        Assert.DoesNotContain("-2147483648", output);
+    }
+
+    [Fact]
+    public void ExactMember_Names_UnmatchedValue_StaysRaw()
+    {
+        var enumType = TypeRef.Definition("asm", "NS", "Color");
+        var members = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+        {
+            [enumType] = new Dictionary<long, string> { [1] = "Red", [2] = "Green" },
+        };
+
+        Assert.Equal("Color.Red", PrintEnumConstant(1, enumType, members));
+        Assert.Equal("Color.Green", PrintEnumConstant(2, enumType, members));
+        // 3 names no member (would be a composite/cast) — raw, never guessed.
+        Assert.Equal("3", PrintEnumConstant(3, enumType, members));
+    }
+
+    [Fact]
+    public void EnumWithNoResolvedMembers_StaysRaw()
+    {
+        // A cross-assembly enum is absent from the map → raw integer.
+        var enumType = TypeRef.Definition("other", "NS", "Mystery");
+        Assert.Equal("5", PrintEnumConstant(5, enumType, new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()));
+    }
+
+    static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
+    {
+        var block = new Block(0);
+        block.Add(new Return(new Constant(value, enumType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(enumType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container)
+        {
+            EnumMembers = members,
+        };
+        // Strip the leading "return " and trailing ";" to get the operand text.
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+        return output["return ".Length..].TrimEnd(';');
+    }
+
+    sealed class RaisingPassTestsAccessor
+    {
+        public string Print(string typeName, string methodName, MetadataSource source)
+        {
+            var function = IrImporter.Import(source, typeName, methodName);
+            Assert.NotNull(function);
+            IrPasses.Run(function);
+            return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -369,6 +369,7 @@ public sealed class CSharpPrinter
         LoadArgument a => a.Name,
         LoadLocal l => $"V_{l.Index}",
         LoadStackSlot s => $"S_{s.Slot}",
+        Constant { Value: int } c when EnumMemberName(c) is { } named => named,
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),
@@ -698,6 +699,19 @@ public sealed class CSharpPrinter
         string cast = $"({TypeText(convert.Target)}){operand}";
         return convert.IsChecked ? $"checked({cast})" : cast;
     }
+
+    /// <summary>
+    /// A retyped enum constant renders <c>EnumType.Member</c> when its value
+    /// names exactly one member of the resolved (same-assembly) enum. Composite
+    /// flag values and unnamed casts have no exact member and fall through to
+    /// the raw integer — naming those is a later slice.
+    /// </summary>
+    string? EnumMemberName(Constant constant)
+        => constant.Value is int value
+            && _function.EnumMembers.TryGetValue(constant.Type, out var members)
+            && members.TryGetValue(value, out var name)
+            ? $"{TypeText(constant.Type)}.{name}"
+            : null;
 
     static string ConstantText(Constant constant) => constant.Value switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -137,32 +137,49 @@ public static class IrImporter
                 return function;  // honest stop already recorded
         }
 
-        function.TypeShapes = ResolveShapes(source, function);
+        ResolveTypeInfo(source, function);
         function.CheckInvariant();
         return function;
     }
 
     /// <summary>
-    /// Resolves the same-assembly shape of every definition-typed expression
-    /// result, materialized for the metadata-free printer. Lean by intent:
-    /// only result types (the truthiness inputs) are resolved, not every type
-    /// the function mentions.
+    /// Resolves the same-assembly shape of every definition type the function
+    /// references, and the member map of every enum among them — materialized
+    /// for the metadata-free printer. Walks both expression result types (the
+    /// truthiness inputs) and node DirectTypes, so an enum that only appears as
+    /// a call parameter type still resolves while metadata is live, before a
+    /// later pass retypes its constant.
     /// </summary>
-    static IReadOnlyDictionary<TypeRef, TypeShape> ResolveShapes(MetadataSource source, IrFunction function)
+    static void ResolveTypeInfo(MetadataSource source, IrFunction function)
     {
-        Dictionary<TypeRef, TypeShape>? shapes = null;
-        foreach (var expression in function.Descendants.OfType<IrExpression>())
+        var shapes = new Dictionary<TypeRef, TypeShape>();
+        Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? enums = null;
+
+        void Consider(TypeRef? type)
         {
-            if (expression.ResultType is { Kind: TypeRefKind.Definition } type)
+            if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
+                return;
+            var shape = source.ResolveShape(type);
+            shapes[type] = shape;
+            if (shape == TypeShape.Enum && source.ResolveEnumMembers(type) is { } members)
             {
-                shapes ??= [];
-                if (!shapes.ContainsKey(type))
-                    shapes[type] = source.ResolveShape(type);
+                enums ??= [];
+                enums[type] = members;
             }
         }
-        return shapes is null
-            ? System.Collections.Immutable.ImmutableDictionary<TypeRef, TypeShape>.Empty
-            : shapes;
+
+        foreach (var node in function.Descendants)
+        {
+            foreach (var type in node.DirectTypes)
+                Consider(type);
+            if (node is IrExpression expression)
+                Consider(expression.ResultType);
+        }
+
+        if (shapes.Count > 0)
+            function.TypeShapes = shapes;
+        if (enums is not null)
+            function.EnumMembers = enums;
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -64,6 +64,14 @@ public sealed class IrFunction : IrNode
     public IReadOnlyDictionary<TypeRef, TypeShape> TypeShapes { get; set; }
         = ImmutableDictionary<TypeRef, TypeShape>.Empty;
 
+    /// <summary>
+    /// Named members (value → name) of the same-assembly enum types this
+    /// function references, materialized at import. Lets the printer render an
+    /// enum constant as <c>EnumType.Member</c> instead of its raw integer.
+    /// </summary>
+    public IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> EnumMembers { get; set; }
+        = ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -58,6 +58,7 @@ public sealed class MetadataSource : IDisposable
     }
 
     Dictionary<TypeRef, TypeShape>? _shapes;
+    Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? _enumMembers;
 
     /// <summary>
     /// The C# shape of a type defined in THIS assembly — enum, struct, or
@@ -71,21 +72,85 @@ public sealed class MetadataSource : IDisposable
     {
         if (type.Kind != TypeRefKind.Definition)
             return TypeShape.Unknown;
-        _shapes ??= BuildShapeMap();
-        return _shapes.GetValueOrDefault(type, TypeShape.Unknown);
+        EnsureTypeMaps();
+        return _shapes!.GetValueOrDefault(type, TypeShape.Unknown);
     }
 
-    Dictionary<TypeRef, TypeShape> BuildShapeMap()
+    /// <summary>
+    /// The named members of a same-assembly enum, as value → name (every
+    /// underlying integer width normalized to <see cref="long"/>). Null for a
+    /// non-enum or cross-assembly type. Aliases keep the first declared name.
+    /// </summary>
+    internal IReadOnlyDictionary<long, string>? ResolveEnumMembers(TypeRef type)
     {
-        var map = new Dictionary<TypeRef, TypeShape>();
+        if (type.Kind != TypeRefKind.Definition)
+            return null;
+        EnsureTypeMaps();
+        return _enumMembers!.GetValueOrDefault(type);
+    }
+
+    void EnsureTypeMaps()
+    {
+        if (_shapes is not null)
+            return;
+        var shapes = new Dictionary<TypeRef, TypeShape>();
+        var enums = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>();
         foreach (var handle in Reader.TypeDefinitions)
         {
+            var typeDef = Reader.GetTypeDefinition(handle);
             // The decoder produces the same nested-aware TypeRef the IR
             // carries, so the map keys match by semantic equality.
             var key = TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, handle, 0);
-            map[key] = ClassifyShape(Reader.GetTypeDefinition(handle));
+            var shape = ClassifyShape(typeDef);
+            shapes[key] = shape;
+            if (shape == TypeShape.Enum)
+                enums[key] = BuildEnumMembers(typeDef);
         }
-        return map;
+        _enumMembers = enums;
+        _shapes = shapes;   // assign last: ResolveShape gates on _shapes
+    }
+
+    Dictionary<long, string> BuildEnumMembers(TypeDefinition enumType)
+    {
+        var members = new Dictionary<long, string>();
+        foreach (var fieldHandle in enumType.GetFields())
+        {
+            var field = Reader.GetFieldDefinition(fieldHandle);
+            // The named constants are the literal static fields; the special
+            // instance value__ field carries no default value and is skipped.
+            if ((field.Attributes & System.Reflection.FieldAttributes.Literal) == 0)
+                continue;
+            if (ReadConstant(field.GetDefaultValue()) is { } value)
+                members.TryAdd(value, Reader.GetString(field.Name));
+        }
+        return members;
+    }
+
+    long? ReadConstant(ConstantHandle handle)
+    {
+        if (handle.IsNil)
+            return null;
+        var constant = Reader.GetConstant(handle);
+        var blob = Reader.GetBlobReader(constant.Value);
+        // The lookup key is the member's ldc.i4 form widened from int, so a
+        // 32-bit unsigned value with the high bit set must be keyed by its
+        // signed-int reinterpretation (UInt32 0x80000000 -> int -2147483648),
+        // or it would never match. 64-bit enums emit ldc.i8 and are not retyped
+        // by the int-only constant pass, so their true long value is fine.
+        return constant.TypeCode switch
+        {
+            ConstantTypeCode.SByte => blob.ReadSByte(),
+            ConstantTypeCode.Byte => blob.ReadByte(),
+            ConstantTypeCode.Int16 => blob.ReadInt16(),
+            ConstantTypeCode.UInt16 => blob.ReadUInt16(),
+            ConstantTypeCode.Int32 => blob.ReadInt32(),
+            ConstantTypeCode.UInt32 => unchecked((int)blob.ReadUInt32()),
+            ConstantTypeCode.Int64 => blob.ReadInt64(),
+            ConstantTypeCode.UInt64 => unchecked((long)blob.ReadUInt64()),
+            ConstantTypeCode.Char => blob.ReadChar(),
+            ConstantTypeCode.Boolean => blob.ReadBoolean() ? 1L : 0L,
+            _ => null,
+        };
     }
 
     TypeShape ClassifyShape(TypeDefinition typeDef)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -12,68 +12,76 @@ public sealed class TypedConstantsPass : IIrPass
 
     public void Run(IrFunction function)
     {
+        var shapes = function.TypeShapes;
         foreach (var node in function.Descendants.ToList())
         {
             switch (node)
             {
                 case Return { Value: Constant constant }:
-                    Retype(constant, function.Signature.ReturnType);
+                    Retype(constant, function.Signature.ReturnType, shapes);
                     break;
                 case StoreLocal { Value: Constant constant } store:
-                    Retype(constant, store.Type);
+                    Retype(constant, store.Type, shapes);
                     break;
                 case StoreArgument { Value: Constant constant } store:
-                    Retype(constant, store.Type);
+                    Retype(constant, store.Type, shapes);
                     break;
                 case StoreField { Value: Constant constant } store:
-                    Retype(constant, store.Field.Type);
+                    Retype(constant, store.Field.Type, shapes);
                     break;
                 case Call call:
-                    RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0);
+                    RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, shapes);
                     break;
                 case NewObject ctor:
-                    RetypeArguments(ctor.Constructor, ctor.Arguments, 0);
+                    RetypeArguments(ctor.Constructor, ctor.Arguments, 0, shapes);
                     break;
                 case Comparison { Left: { } left, Right: Constant constant }
                     when left is not Constant && left.ResultType is { } leftType:
-                    Retype(constant, leftType);
+                    Retype(constant, leftType, shapes);
                     break;
                 case Box { Operand: Constant constant } box:
-                    Retype(constant, box.Type);
+                    Retype(constant, box.Type, shapes);
                     break;
                 case StoreElement { Value: Constant constant, ElementType: { } elementType }:
-                    Retype(constant, elementType);
+                    Retype(constant, elementType, shapes);
                     break;
                 case StoreIndirect { Value: Constant constant, Type: { } indirectType }:
-                    Retype(constant, indirectType);
+                    Retype(constant, indirectType, shapes);
                     break;
             }
         }
     }
 
-    static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset)
+    static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
     {
         for (int i = 0; i < callee.ParameterTypes.Length && i + receiverOffset < arguments.Count; i++)
         {
             if (arguments[i + receiverOffset] is Constant constant)
-                Retype(constant, callee.ParameterTypes[i]);
+                Retype(constant, callee.ParameterTypes[i], shapes);
         }
     }
 
-    static void Retype(Constant constant, TypeRef target)
+    static void Retype(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
     {
         if (constant.Value is not int value)
             return;
-        if (target is not { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
-            return;
-        switch (target.Name)
+        if (target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
         {
-            case "Boolean" when value is 0 or 1:
-                constant.ReplaceWith(new Constant(value == 1, target));
-                break;
-            case "Char" when value >= char.MinValue && value <= char.MaxValue:
-                constant.ReplaceWith(new Constant((char)value, target));
-                break;
+            switch (target.Name)
+            {
+                case "Boolean" when value is 0 or 1:
+                    constant.ReplaceWith(new Constant(value == 1, target));
+                    return;
+                case "Char" when value >= char.MinValue && value <= char.MaxValue:
+                    constant.ReplaceWith(new Constant((char)value, target));
+                    return;
+            }
         }
+
+        // An integer flowing into an enum position carries the enum's identity;
+        // the printer names it from the resolved member map. The value is kept
+        // (still an int); only the constant's type changes.
+        if (shapes.GetValueOrDefault(target) == TypeShape.Enum)
+            constant.ReplaceWith(new Constant(value, target));
     }
 }


### PR DESCRIPTION
An integer flowing into an enum position now renders `EnumType.Member` instead of its raw value:

```
ThrowArgumentNullException(17)          → ThrowArgumentNullException(ExceptionArgument.s)
Decimal.Parse(s, 111, null)             → Decimal.Parse(s, NumberStyles.Number, null)
status == 1                             → status == ParsingStatus.Failed
```

## How

Reuses #500's resolver. `TypedConstantsPass` extends past bool/char: an int constant in an enum position (recognized via `TypeShapes`) retypes to the enum — value kept, type changed. `MetadataSource` resolves each same-assembly enum's members (value → name from its literal fields), materialized onto `IrFunction.EnumMembers`; the metadata-free printer names exact matches.

**Exact matches only.** A composite flag value with no matching member, and unnamed casts, stay raw — the printer never emits a member name for a value that isn't exactly that member's, so output is always sound. Flag decomposition (`A | B`) is a later slice.

## The review earned its keep

The high-effort self-review (#498 discipline, run before this PR) found a real **sign-extension bug**: `ReadConstant` zero-extended a `UInt32` member like `0x80000000` to a *positive* long, but its `ldc.i4` constant is the signed int `-2147483648`, which the lookup sign-extends to a *negative* long — keys disagree, name silently missed. Fixed by keying on the signed-int reinterpretation; pinned with an end-to-end high-bit `uint` fixture that fails without it. (A missing-name gap, never a wrong name — but real for unsigned/high-bit Flags enums.)

Other soundness (verified): aliased members keep the first declared name; lifetime holds only TypeRefs/longs/strings (no handles escape, resolved while source is live); the maps build once and cache.

## Result

Parity **46.49% → 47.10% (net +239)** — enum constants are pervasive and the baseline names them too, so most flip to agreement. Honest nuance: a minority where the *baseline* shows the raw int now diverge as **candidate-better** (a named member, e.g. `ParsingStatus.Failed` vs `1`). 363/363 both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)