### PR TITLE
Add unsafe member evidence sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
-dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe Operations"
+dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe*"
 dotnet-inspect source JsonSerializer --package System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
 dotnet-inspect depends Stream --markdown --mermaid

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ dotnet-inspect member JsonSerializer --package System.Text.Json -D
 dotnet-inspect member JsonSerializer --package System.Text.Json -D --schema
 dotnet-inspect type --package System.Text.Json --columns Kind,Name
 dotnet-inspect library System.Text.Json -S Symbols --fields "PDB*;SourceLink"
+dotnet-inspect library System.Text.Json -S "Unsafe Members"
 dotnet-inspect library System.Text.Json -S "Async*" --count
 dotnet-inspect package Microsoft.Extensions.Logging.Abstractions --library -S Integrations
 dotnet-inspect library Microsoft.Extensions.Logging.Abstractions -S Integrations
@@ -128,6 +129,7 @@ dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
+dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe Operations"
 dotnet-inspect source JsonSerializer --package System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
 dotnet-inspect depends Stream --markdown --mermaid

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -103,7 +103,7 @@ dnx dotnet-inspect -y -- diff --platform System.Runtime@9.0.0..10.0.0 --additive
 
 ## Source and implementation workflow
 
-Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, `-S "Unsafe Operations"` for unsafe-relevant body evidence, or `-S IL` / `-S "IL (Annotated)"` for IL.
+Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, `-S "Unsafe*"` for unsafe API-member and operation evidence, or `-S IL` / `-S "IL (Annotated)"` for IL.
 
 ```bash
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -103,12 +103,13 @@ dnx dotnet-inspect -y -- diff --platform System.Runtime@9.0.0..10.0.0 --additive
 
 ## Source and implementation workflow
 
-Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, or `-S IL` / `-S "IL (Annotated)"` for IL.
+Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's lowered C# body, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, `-S "Unsafe Operations"` for unsafe-relevant body evidence, or `-S IL` / `-S "IL (Annotated)"` for IL.
 
 ```bash
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
+dnx dotnet-inspect -y -- library MyLib.dll -S "Unsafe Members"
 ```
 
 A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need specific implementation evidence.
@@ -125,7 +126,7 @@ For crash/stack diagnostics that include a MethodDef token plus IL offset, `sour
 
 ## Package, library, integrations, and Signals workflow
 
-Use `package` for NuGet package structure and registry-backed signals. Use `library` for assembly metadata, APIs, PDB/SourceLink evidence, and direct references.
+Use `package` for NuGet package structure and registry-backed signals. Use `library` for assembly metadata, APIs, PDB/SourceLink evidence, direct references, and unsafe-member audits.
 
 ```bash
 dnx dotnet-inspect -y -- package System.Text.Json -S Signals

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using ILInspector.Analysis;
 
@@ -90,6 +92,27 @@ public class LibraryBodyIndexTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public void UnsafeEvidence_FindsSignatureOperationsAndUnsafeCalls()
+    {
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        Assert.Contains(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead)
+            && evidence.Reason == "Unsafe signature"
+            && evidence.Detail.Contains("int*", StringComparison.Ordinal));
+        Assert.Contains(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead)
+            && evidence is { Reason: "Unsafe operation", Detail: "ldind.i4", Kind: "opcode", ILOffset: not null });
+        Assert.Contains(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)
+            && evidence.Reason == "Unsafe call"
+            && evidence.Detail.Contains("System.Runtime.CompilerServices.Unsafe.As<int, uint>", StringComparison.Ordinal)
+            && evidence.OperandToken is not null);
+        Assert.DoesNotContain(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == nameof(UnsafeEvidenceFixtures.PInvokeOnly));
+    }
 }
 
 public static class CallSiteFixtures
@@ -99,4 +122,14 @@ public static class CallSiteFixtures
     public static string? CallsVirtualToString(object value) => value.ToString();
 
     public static void CallsListAdd(List<int> values) => values.Add(42);
+}
+
+public static partial class UnsafeEvidenceFixtures
+{
+    public static unsafe int UnsafePointerRead(int* value) => *value;
+
+    public static uint CallsUnsafeAs(ref int value) => Unsafe.As<int, uint>(ref value);
+
+    [DllImport("kernel32.dll")]
+    public static extern int PInvokeOnly();
 }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -113,6 +113,17 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain(index.UnsafeEvidence, evidence =>
             evidence.Member.Name == nameof(UnsafeEvidenceFixtures.PInvokeOnly));
     }
+
+    [Fact]
+    public void UnsafeEvidence_ClassifiesMembersDeclaredOnUnsafeApi()
+    {
+        var index = LibraryBodyIndex.Open(typeof(Unsafe).Assembly.Location);
+
+        Assert.Contains(index.UnsafeEvidence, evidence =>
+            evidence.Member.DeclaringType is { Namespace: "System.Runtime.CompilerServices", Name: "Unsafe" }
+            && evidence.Member.Name == "Add"
+            && evidence is { Reason: "Unsafe API member", Kind: "api" });
+    }
 }
 
 public static class CallSiteFixtures

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -81,6 +81,7 @@ public sealed class LibraryBodyIndex
                         var methodDef = _reader.GetMethodDefinition(methodHandle);
                         var scope = CreateScope(typeDef, methodDef);
                         var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
+                        bool hasUnsafeApiMember = AddUnsafeApiMemberEvidence(caller, unsafeEvidence);
                         bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, unsafeEvidence);
                         if (methodDef.RelativeVirtualAddress == 0)
                             continue;
@@ -89,7 +90,8 @@ public sealed class LibraryBodyIndex
                         var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
                         var il = body.GetILBytes() ?? [];
                         bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
-                        ScanBody(il, caller, scope, calls, unsafeEvidence, includeIndirectOpcodes: hasUnsafeSignature || hasUnsafeLocals);
+                        ScanBody(il, caller, scope, calls, unsafeEvidence,
+                            includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals);
                     }
                     catch (Exception ex) when (IsRecoverableMethodFailure(ex))
                     {
@@ -117,6 +119,21 @@ public sealed class LibraryBodyIndex
                 signature.ReturnType,
                 MetadataTokens.GetToken(methodHandle),
                 (methodDef.Attributes & MethodAttributes.Static) != 0);
+        }
+
+        bool AddUnsafeApiMemberEvidence(MethodIdentity method, ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence)
+        {
+            if (!IsUnsafeApi(method.DeclaringType))
+                return false;
+
+            unsafeEvidence.Add(new UnsafeEvidence(
+                method,
+                "Unsafe API member",
+                FormatMethod(method),
+                "api",
+                ILOffset: null,
+                OperandToken: null));
+            return true;
         }
 
         bool AddUnsafeSignatureEvidence(MethodIdentity method, ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence)
@@ -218,8 +235,10 @@ public sealed class LibraryBodyIndex
         static bool IsUnsafeCall(MemberRef member)
             => IsUnsafeApi(member) || member.ParameterTypes.Append(member.ReturnType).Any(ContainsUnsafeType);
 
-        static bool IsUnsafeApi(MemberRef member)
-            => member.DeclaringType is { Namespace: "System.Runtime.CompilerServices", Name: "Unsafe" };
+        static bool IsUnsafeApi(MemberRef member) => IsUnsafeApi(member.DeclaringType);
+
+        static bool IsUnsafeApi(TypeRef type)
+            => type is { Namespace: "System.Runtime.CompilerServices", Name: "Unsafe" };
 
         static bool ContainsUnsafeType(TypeRef type)
         {
@@ -243,6 +262,9 @@ public sealed class LibraryBodyIndex
                 name += $"<{string.Join(", ", member.TypeArguments.Select(t => t.ToQualifiedDisplayString()))}>";
             return $"{member.DeclaringType.ToQualifiedDisplayString()}.{name}({string.Join(", ", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
         }
+
+        static string FormatMethod(MethodIdentity method)
+            => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
         static string FormatCallKind(CallKind kind) => kind switch
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -10,17 +10,24 @@ namespace ILInspector.Analysis;
 /// <summary>Materialized IL body evidence for one assembly.</summary>
 public sealed class LibraryBodyIndex
 {
-    LibraryBodyIndex(string path, ImmutableArray<MethodIdentity> methods, ImmutableArray<DirectCall> directCalls, ImmutableArray<AnalysisDiagnostic> diagnostics)
+    LibraryBodyIndex(
+        string path,
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        ImmutableArray<UnsafeEvidence> unsafeEvidence,
+        ImmutableArray<AnalysisDiagnostic> diagnostics)
     {
         Path = path;
         Methods = methods;
         DirectCalls = directCalls;
+        UnsafeEvidence = unsafeEvidence;
         Diagnostics = diagnostics;
     }
 
     public string Path { get; }
     public ImmutableArray<MethodIdentity> Methods { get; }
     public ImmutableArray<DirectCall> DirectCalls { get; }
+    public ImmutableArray<UnsafeEvidence> UnsafeEvidence { get; }
     public ImmutableArray<AnalysisDiagnostic> Diagnostics { get; }
 
     public static LibraryBodyIndex Open(string path)
@@ -32,7 +39,7 @@ public sealed class LibraryBodyIndex
         var reader = peReader.GetMetadataReader();
         var builder = new IndexBuilder(path, reader, peReader);
         var index = builder.Build();
-        return new LibraryBodyIndex(path, index.Methods, index.DirectCalls, index.Diagnostics);
+        return new LibraryBodyIndex(path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -57,10 +64,11 @@ public sealed class LibraryBodyIndex
             _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<AnalysisDiagnostic> Diagnostics) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
+            var unsafeEvidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
             var diagnostics = ImmutableArray.CreateBuilder<AnalysisDiagnostic>();
 
             foreach (var typeHandle in _reader.TypeDefinitions)
@@ -71,15 +79,17 @@ public sealed class LibraryBodyIndex
                     try
                     {
                         var methodDef = _reader.GetMethodDefinition(methodHandle);
+                        var scope = CreateScope(typeDef, methodDef);
+                        var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
+                        bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, unsafeEvidence);
                         if (methodDef.RelativeVirtualAddress == 0)
                             continue;
 
-                        var scope = CreateScope(typeDef, methodDef);
-                        var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
                         methods.Add(caller);
                         var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
                         var il = body.GetILBytes() ?? [];
-                        ScanCalls(il, caller, scope, calls);
+                        bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
+                        ScanBody(il, caller, scope, calls, unsafeEvidence, includeIndirectOpcodes: hasUnsafeSignature || hasUnsafeLocals);
                     }
                     catch (Exception ex) when (IsRecoverableMethodFailure(ex))
                     {
@@ -91,7 +101,7 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            return (methods.ToImmutable(), calls.ToImmutable(), diagnostics.ToImmutable());
+            return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable());
         }
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
@@ -109,7 +119,57 @@ public sealed class LibraryBodyIndex
                 (methodDef.Attributes & MethodAttributes.Static) != 0);
         }
 
-        void ScanCalls(byte[] il, MethodIdentity caller, GenericScope callerScope, ImmutableArray<DirectCall>.Builder calls)
+        bool AddUnsafeSignatureEvidence(MethodIdentity method, ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence)
+        {
+            var unsafeTypes = method.ParameterTypes
+                .Append(method.ReturnType)
+                .Where(ContainsUnsafeType)
+                .Select(t => t.ToQualifiedDisplayString())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (unsafeTypes.Count == 0)
+                return false;
+
+            unsafeEvidence.Add(new UnsafeEvidence(
+                method,
+                "Unsafe signature",
+                string.Join(", ", unsafeTypes),
+                "signature",
+                ILOffset: null,
+                OperandToken: null));
+            return true;
+        }
+
+        bool ScanLocals(MethodBodyBlock body, MethodIdentity member, GenericScope scope, ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence)
+        {
+            if (body.LocalSignature.IsNil)
+                return false;
+
+            bool found = false;
+            var signature = _reader.GetStandaloneSignature(body.LocalSignature);
+            var locals = signature.DecodeLocalSignature(TypeRefDecoder.Instance, scope);
+            for (int i = 0; i < locals.Length; i++)
+            {
+                var local = locals[i];
+                if (local.Kind == TypeRefKind.Pinned)
+                {
+                    unsafeEvidence.Add(new UnsafeEvidence(member, "Pinned local", $"V_{i}: {local.ToQualifiedDisplayString()}", "local", null, null));
+                    found = true;
+                    continue;
+                }
+                if (ContainsUnsafeType(local))
+                {
+                    unsafeEvidence.Add(new UnsafeEvidence(member, "Pointer local", $"V_{i}: {local.ToQualifiedDisplayString()}", "local", null, null));
+                    found = true;
+                }
+            }
+            return found;
+        }
+
+        void ScanBody(byte[] il, MethodIdentity caller, GenericScope callerScope,
+            ImmutableArray<DirectCall>.Builder calls,
+            ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence,
+            bool includeIndirectOpcodes)
         {
             int position = 0;
             while (position < il.Length)
@@ -127,20 +187,99 @@ public sealed class LibraryBodyIndex
                         int token = ReadInt32(il, ref position, offset);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                         calls.Add(new DirectCall(caller, callee, offset, token, ToCallKind(opcode)));
+                        if (IsUnsafeCall(callee))
+                        {
+                            unsafeEvidence.Add(new UnsafeEvidence(
+                                caller,
+                                "Unsafe call",
+                                FormatMember(callee),
+                                FormatCallKind(ToCallKind(opcode)),
+                                offset,
+                                token));
+                        }
                         break;
                     }
                     case ILOpCode.Calli:
                     {
                         int token = ReadInt32(il, ref position, offset);
                         calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, token, CallKind.CallIndirect));
+                        unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", "calli", "calli", offset, token));
                         break;
                     }
                     default:
+                        if (UnsafeOpcodeName(opcode, includeIndirectOpcodes) is { } unsafeOpcode)
+                            unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", unsafeOpcode, "opcode", offset, null));
                         SkipOperand(il, opcode, ref position, offset);
                         break;
                 }
             }
         }
+
+        static bool IsUnsafeCall(MemberRef member)
+            => IsUnsafeApi(member) || member.ParameterTypes.Append(member.ReturnType).Any(ContainsUnsafeType);
+
+        static bool IsUnsafeApi(MemberRef member)
+            => member.DeclaringType is { Namespace: "System.Runtime.CompilerServices", Name: "Unsafe" };
+
+        static bool ContainsUnsafeType(TypeRef type)
+        {
+            if (type.Kind is TypeRefKind.Pointer or TypeRefKind.Pinned)
+                return true;
+            if (type.Kind == TypeRefKind.Unsupported
+                && type.UnsupportedReason.Contains("function pointer", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (type.ElementType is not null && ContainsUnsafeType(type.ElementType))
+                return true;
+            return type.TypeArguments.Any(ContainsUnsafeType);
+        }
+
+        static string FormatMember(MemberRef member)
+        {
+            if (member.Kind == MemberKind.Unsupported)
+                return member.DeclaringType.ToDisplayString();
+
+            string name = member.Name;
+            if (member.TypeArguments.Length > 0)
+                name += $"<{string.Join(", ", member.TypeArguments.Select(t => t.ToQualifiedDisplayString()))}>";
+            return $"{member.DeclaringType.ToQualifiedDisplayString()}.{name}({string.Join(", ", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+        }
+
+        static string FormatCallKind(CallKind kind) => kind switch
+        {
+            CallKind.Call => "call",
+            CallKind.CallVirtual => "callvirt",
+            CallKind.NewObject => "newobj",
+            CallKind.LoadFunction => "ldftn",
+            CallKind.LoadVirtualFunction => "ldvirtftn",
+            _ => "calli",
+        };
+
+        static string? UnsafeOpcodeName(ILOpCode opcode, bool includeIndirectOpcodes) => opcode switch
+        {
+            ILOpCode.Localloc => "localloc",
+            ILOpCode.Cpblk => "cpblk",
+            ILOpCode.Initblk => "initblk",
+            ILOpCode.Ldind_i1 when includeIndirectOpcodes => "ldind.i1",
+            ILOpCode.Ldind_u1 when includeIndirectOpcodes => "ldind.u1",
+            ILOpCode.Ldind_i2 when includeIndirectOpcodes => "ldind.i2",
+            ILOpCode.Ldind_u2 when includeIndirectOpcodes => "ldind.u2",
+            ILOpCode.Ldind_i4 when includeIndirectOpcodes => "ldind.i4",
+            ILOpCode.Ldind_u4 when includeIndirectOpcodes => "ldind.u4",
+            ILOpCode.Ldind_i8 when includeIndirectOpcodes => "ldind.i8",
+            ILOpCode.Ldind_i when includeIndirectOpcodes => "ldind.i",
+            ILOpCode.Ldind_r4 when includeIndirectOpcodes => "ldind.r4",
+            ILOpCode.Ldind_r8 when includeIndirectOpcodes => "ldind.r8",
+            ILOpCode.Ldind_ref when includeIndirectOpcodes => "ldind.ref",
+            ILOpCode.Stind_ref when includeIndirectOpcodes => "stind.ref",
+            ILOpCode.Stind_i1 when includeIndirectOpcodes => "stind.i1",
+            ILOpCode.Stind_i2 when includeIndirectOpcodes => "stind.i2",
+            ILOpCode.Stind_i4 when includeIndirectOpcodes => "stind.i4",
+            ILOpCode.Stind_i8 when includeIndirectOpcodes => "stind.i8",
+            ILOpCode.Stind_i when includeIndirectOpcodes => "stind.i",
+            ILOpCode.Stind_r4 when includeIndirectOpcodes => "stind.r4",
+            ILOpCode.Stind_r8 when includeIndirectOpcodes => "stind.r8",
+            _ => null,
+        };
 
         static CallKind ToCallKind(ILOpCode opcode) => opcode switch
         {

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -51,6 +51,14 @@ public sealed record DirectCall(
     int OperandToken,
     CallKind Kind);
 
+public sealed record UnsafeEvidence(
+    MethodIdentity Member,
+    string Reason,
+    string Detail,
+    string Kind,
+    int? ILOffset,
+    int? OperandToken);
+
 public sealed class MemberPattern
 {
     readonly TypeRef? _declaringType;

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -224,6 +224,13 @@ public class ApiType
     public bool IsForwarded { get; set; }
 
     /// <summary>
+    /// Assembly path that supplied this type's metadata, when extracted from a file.
+    /// Used internally to route body/evidence sections for forwarded platform types.
+    /// </summary>
+    [JsonIgnore]
+    public string? SourceAssemblyPath { get; set; }
+
+    /// <summary>
     /// Full name of the type (Namespace.Name, or just Name if no namespace).
     /// </summary>
     public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";

--- a/src/ILInspector.Metadata/AssemblyReader.cs
+++ b/src/ILInspector.Metadata/AssemblyReader.cs
@@ -19,7 +19,13 @@ public static class AssemblyReader
         try
         {
             using var stream = File.OpenRead(dllPath);
-            return ExtractApiSurface(stream, includeAll, typesOnly);
+            var surface = ExtractApiSurface(stream, includeAll, typesOnly);
+            if (surface != null)
+            {
+                foreach (var type in surface.Types)
+                    type.SourceAssemblyPath = dllPath;
+            }
+            return surface;
         }
         catch
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2026,7 +2026,8 @@ public class CommandExecutionTests
                 "SourceLink Integrity",
                 "SourceLink Missing Files",
                 "Switches",
-                "Type Forwarders"
+                "Type Forwarders",
+                "Unsafe Members"
             ],
             optInNames);
         Assert.DoesNotContain(lines, line => line.StartsWith("Missing Source Files", StringComparison.Ordinal));

--- a/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
@@ -171,6 +171,7 @@ public static class SampleUnsafeClass
 {
     public static unsafe int UnsafePointerMethod(int* ptr) => *ptr;
     public static unsafe int* UnsafeReturnPointer(int[] arr) { fixed (int* p = arr) return p; }
+    public static uint CallsUnsafeAs(ref int value) => Unsafe.As<int, uint>(ref value);
     public static string SafeMethod() => "safe";
 }
 

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -545,10 +545,10 @@ public class OutputFormatterTests
     public void SingleAudit_MethodSections_AreSortedByTypeThenName()
     {
         var inspection = CreateTestAudit("Test.dll", "net9.0");
-        inspection.UnsafeMethods =
+        inspection.UnsafeMembers =
         [
-            new ClassifiedMethodSummary { DeclaringType = "B.Type", MethodName = "A", Signature = "void A()" },
-            new ClassifiedMethodSummary { DeclaringType = "A.Type", MethodName = "Z", Signature = "void Z()" }
+            new UnsafeMemberSummary { Member = "B.Type.A()", Reason = "Unsafe signature", Detail = "void A()", Kind = "signature" },
+            new UnsafeMemberSummary { Member = "A.Type.Z()", Reason = "Unsafe signature", Detail = "void Z()", Kind = "signature" }
         ];
         inspection.ExtensionMethods =
         [
@@ -558,8 +558,8 @@ public class OutputFormatterTests
 
         var output = Serialize(inspection);
 
-        Assert.True(output.IndexOf("| Z | A.Type |", StringComparison.Ordinal)
-            < output.IndexOf("| A | B.Type |", StringComparison.Ordinal));
+        Assert.True(output.IndexOf("| `A.Type.Z()` |", StringComparison.Ordinal)
+            < output.IndexOf("| `B.Type.A()` |", StringComparison.Ordinal));
         Assert.True(output.IndexOf("| Z | method | A.Type |", StringComparison.Ordinal)
             < output.IndexOf("| A | method | B.Type |", StringComparison.Ordinal));
     }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -457,14 +457,15 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_SharedScannerKey_Deduplicated()
+    public void LibraryPipeline_UnsafeMembers_UsesOwnScanner()
     {
         var pipeline = LibrarySections.CreatePipeline();
-        var include = new HashSet<string> { "Unsafe Methods", "P/Invoke Methods" };
+        var include = new HashSet<string> { "Unsafe Members", "P/Invoke Methods" };
 
         var scanners = pipeline.GetRequiredScanners(Verbosity.Minimal, include);
 
-        Assert.Single(scanners);
+        Assert.Equal(2, scanners.Count);
+        Assert.Contains(LibrarySections.ScannerUnsafeMembers, scanners);
         Assert.Contains(LibrarySections.ScannerClassifiedMethods, scanners);
     }
 
@@ -572,7 +573,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void CanRender_UnsafeMethods_UsesPresenceFlag()
+    public void CanRender_UnsafeMembers_UsesPresenceFlag()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var model = new LibraryInspection
@@ -581,9 +582,12 @@ public class SectionPipelineTests
             HasUnsafeCode = true
         };
 
-        var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+        var effective = pipeline.GetEffectiveSections(
+            model,
+            Verbosity.Detailed,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Unsafe Members" });
 
-        Assert.Contains("Unsafe Methods", effective);
+        Assert.Contains("Unsafe Members", effective);
     }
 
     [Fact]
@@ -762,7 +766,7 @@ public class SectionPipelineTests
         Assert.Contains("Library Info", effective);
         Assert.Contains("Symbols", effective);
         Assert.DoesNotContain("Extension Methods", effective);
-        Assert.DoesNotContain("Unsafe Methods", effective);
+        Assert.DoesNotContain("Unsafe Members", effective);
         Assert.DoesNotContain("P/Invoke Methods", effective);
         Assert.DoesNotContain("Resources", effective);
         Assert.DoesNotContain("Custom Attributes", effective);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1125,7 +1125,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(18, pipeline.AllSectionNames.Length);
+        Assert.Equal(19, pipeline.AllSectionNames.Length);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -73,6 +73,49 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
+    public async Task MemberUnsafeOperations_ListsUnsafeApiMembersWithoutBodies()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "System.Runtime.CompilerServices.Unsafe",
+            PlatformAssembly = "System.Runtime",
+            MemberFilter = ["Add"],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.UnsafeOperations],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe Operations", result.Output);
+        Assert.Contains("| Unsafe API member |", result.Output);
+        Assert.Contains("System.Runtime.CompilerServices.Unsafe.Add", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberEffectiveDiscovery_ListsUnsafeOperationsForUnsafeApiMember()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "System.Runtime.CompilerServices.Unsafe",
+            PlatformAssembly = "System.Runtime",
+            MemberFilter = ["Add"],
+            OverloadIndex = 1,
+            Discover = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = true,
+            Tsv = true,
+            OneLineExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Unsafe Operations\tsection", result.Output);
+    }
+
+    [Fact]
     public async Task TypeUnsafeMembers_FiltersToSelectedType()
     {
         var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -1,0 +1,74 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class UnsafeMembersSectionTests
+{
+    [Fact]
+    public async Task LibraryUnsafeMembers_IncludesSignaturesCallsAndOpcodes()
+    {
+        var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions
+        {
+            AssemblyName = typeof(SampleUnsafeClass).Assembly.Location,
+            IncludeSections = [ "Unsafe Members" ],
+            Markdown = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe Members", result.Output);
+        Assert.Contains("`DotnetInspector.Tests.SampleUnsafeClass.UnsafePointerMethod(int*)`", result.Output);
+        Assert.Contains("| Unsafe signature |", result.Output);
+        Assert.Contains("| Unsafe operation | `ldind.i4` | opcode |", result.Output);
+        Assert.Contains("`DotnetInspector.Tests.SampleUnsafeClass.CallsUnsafeAs(ref int)`", result.Output);
+        Assert.Contains("System.Runtime.CompilerServices.Unsafe.As<int, uint>", result.Output);
+        Assert.DoesNotContain("SamplePInvokeClass.GetCurrentProcessId", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberUnsafeOperations_ShowsSelectedMemberEvidence()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            MemberFilter = [nameof(SampleUnsafeClass.UnsafePointerMethod)],
+            IncludeSections = [SectionNames.UnsafeOperations],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe Operations", result.Output);
+        Assert.Contains("| Unsafe signature | `int*` | signature |", result.Output);
+        Assert.Contains("| Unsafe operation | `ldind.i4` | opcode |", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberUnsafeOperations_DiscoverListsColumns()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            MemberFilter = [nameof(SampleUnsafeClass.CallsUnsafeAs)],
+            IncludeSections = [SectionNames.UnsafeOperations],
+            Discover = ["Unsafe Operations"],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = true,
+            Tsv = true,
+            OneLineExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Reason\tcolumn", result.Output);
+        Assert.Contains("Detail\tcolumn", result.Output);
+        Assert.Contains("IL\tcolumn", result.Output);
+        Assert.Contains("Token\tcolumn", result.Output);
+    }
+}

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -94,6 +94,26 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
+    public async Task TypeEffectiveDiscovery_ListsUnsafeMembers()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            Discover = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = true,
+            Tsv = true,
+            OneLineExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Unsafe Members\tsection", result.Output);
+    }
+
+    [Fact]
     public async Task MemberTypeUnsafeMembers_FiltersToSelectedType()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -71,4 +71,44 @@ public class UnsafeMembersSectionTests
         Assert.Contains("IL\tcolumn", result.Output);
         Assert.Contains("Token\tcolumn", result.Output);
     }
+
+    [Fact]
+    public async Task TypeUnsafeMembers_FiltersToSelectedType()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            IncludeSections = [SectionNames.UnsafeMembers],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            MarkdownExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe Members", result.Output);
+        Assert.Contains("`UnsafePointerMethod(int*)`", result.Output);
+        Assert.Contains("`CallsUnsafeAs(ref int)`", result.Output);
+        Assert.DoesNotContain("SamplePInvokeClass", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberTypeUnsafeMembers_FiltersToSelectedType()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            IncludeSections = [SectionNames.UnsafeMembers],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe Members", result.Output);
+        Assert.Contains("`UnsafePointerMethod(int*)`", result.Output);
+        Assert.Contains("`CallsUnsafeAs(ref int)`", result.Output);
+    }
 }

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -73,7 +73,7 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
-    public async Task MemberUnsafeApiMember_ListsUnsafeApiMembersWithoutBodies()
+    public async Task MemberUnsafeOperations_ListsUnsafeApiMembersInSummaryWithoutBodies()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -81,20 +81,19 @@ public class UnsafeMembersSectionTests
             PlatformAssembly = "System.Runtime",
             MemberFilter = ["Add"],
             OverloadIndex = 1,
-            IncludeSections = [SectionNames.UnsafeApiMember],
+            IncludeSections = [SectionNames.UnsafeOperations],
             TipLevel = TipLevel.Quiet,
             Verbosity = Verbosity.Minimal,
             FormatExplicitlySet = true,
         }));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("## Unsafe API Member", result.Output);
-        Assert.Contains("| Member |", result.Output);
-        Assert.Contains("System.Runtime.CompilerServices.Unsafe.Add", result.Output);
+        Assert.Contains("Member: System.Runtime.CompilerServices.Unsafe.Add(ref T, int)", result.Output);
+        Assert.DoesNotContain("## Unsafe Operations", result.Output);
     }
 
     [Fact]
-    public async Task MemberUnsafeWildcard_SplitsApiMemberFromOperations()
+    public async Task MemberUnsafeWildcard_RendersApiMemberInSummaryAndOperationsInTable()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -102,22 +101,20 @@ public class UnsafeMembersSectionTests
             PlatformAssembly = "System.Runtime",
             MemberFilter = ["BitCast"],
             OverloadIndex = 1,
-            IncludeSections = [SectionNames.UnsafeApiMember, SectionNames.UnsafeOperations],
+            IncludeSections = [SectionNames.UnsafeOperations],
             TipLevel = TipLevel.Quiet,
             Verbosity = Verbosity.Minimal,
             FormatExplicitlySet = true,
         }));
-
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("## Unsafe API Member", result.Output);
+        Assert.Contains("Member: System.Runtime.CompilerServices.Unsafe.BitCast(TFrom)", result.Output);
         Assert.Contains("## Unsafe Operations", result.Output);
-        Assert.Contains("System.Runtime.CompilerServices.Unsafe.BitCast", result.Output);
         Assert.Contains("| Unsafe call |", result.Output);
         Assert.DoesNotContain("| Unsafe API member |", result.Output);
     }
 
     [Fact]
-    public async Task MemberEffectiveDiscovery_ListsUnsafeApiMemberForUnsafeApiMember()
+    public async Task MemberEffectiveDiscovery_ListsUnsafeOperationsForUnsafeApiMember()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -135,7 +132,7 @@ public class UnsafeMembersSectionTests
         }));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("Unsafe API Member\tsection", result.Output);
+        Assert.Contains("Unsafe Operations\tsection", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -73,7 +73,7 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
-    public async Task MemberUnsafeOperations_ListsUnsafeApiMembersWithoutBodies()
+    public async Task MemberUnsafeApiMember_ListsUnsafeApiMembersWithoutBodies()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -81,20 +81,43 @@ public class UnsafeMembersSectionTests
             PlatformAssembly = "System.Runtime",
             MemberFilter = ["Add"],
             OverloadIndex = 1,
-            IncludeSections = [SectionNames.UnsafeOperations],
+            IncludeSections = [SectionNames.UnsafeApiMember],
             TipLevel = TipLevel.Quiet,
             Verbosity = Verbosity.Minimal,
             FormatExplicitlySet = true,
         }));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("## Unsafe Operations", result.Output);
-        Assert.Contains("| Unsafe API member |", result.Output);
+        Assert.Contains("## Unsafe API Member", result.Output);
+        Assert.Contains("| Member |", result.Output);
         Assert.Contains("System.Runtime.CompilerServices.Unsafe.Add", result.Output);
     }
 
     [Fact]
-    public async Task MemberEffectiveDiscovery_ListsUnsafeOperationsForUnsafeApiMember()
+    public async Task MemberUnsafeWildcard_SplitsApiMemberFromOperations()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "System.Runtime.CompilerServices.Unsafe",
+            PlatformAssembly = "System.Runtime",
+            MemberFilter = ["BitCast"],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.UnsafeApiMember, SectionNames.UnsafeOperations],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Unsafe API Member", result.Output);
+        Assert.Contains("## Unsafe Operations", result.Output);
+        Assert.Contains("System.Runtime.CompilerServices.Unsafe.BitCast", result.Output);
+        Assert.Contains("| Unsafe call |", result.Output);
+        Assert.DoesNotContain("| Unsafe API member |", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberEffectiveDiscovery_ListsUnsafeApiMemberForUnsafeApiMember()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -112,7 +135,7 @@ public class UnsafeMembersSectionTests
         }));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("Unsafe Operations\tsection", result.Output);
+        Assert.Contains("Unsafe API Member\tsection", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -846,7 +846,8 @@ public class ApiCommand
             {
                 var requestedSections = GetRequestedMemberSections(type, mo4);
                 var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method" && !m.IsAbstract)
+                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
+                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
@@ -1138,7 +1139,8 @@ public class ApiCommand
             {
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
                 var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method" && !m.IsAbstract)
+                    .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
+                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -490,6 +490,8 @@ public class ApiCommand
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
         if (detailSchema.GetSection(SectionNames.Calls) == null)
             detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
+        if (detailSchema.GetSection(SectionNames.UnsafeApiMember) == null)
+            detailSchema.Add(SectionNames.UnsafeApiMember, "column", "Member");
         if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
             detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
         return detailSchema;
@@ -847,7 +849,9 @@ public class ApiCommand
                 var requestedSections = GetRequestedMemberSections(type, mo4);
                 var methods = type.Members
                     .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
+                        && (!m.IsAbstract
+                            || requestedSections.Contains(SectionNames.UnsafeApiMember)
+                            || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
@@ -1140,7 +1144,9 @@ public class ApiCommand
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
                 var methods = type.Members
                     .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
+                        && (!m.IsAbstract
+                            || requestedSections.Contains(SectionNames.UnsafeApiMember)
+                            || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -853,6 +853,12 @@ public class ApiCommand
                         mo4.OverloadIndex.Value - 1, requestedSections, mo4.PdbPath);
             }
 
+            if (options.DllPath is { } unsafeDllPath
+                && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
+            {
+                ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
+            }
+
             // Source code (already resolved in command layer)
             if (options is MemberOptions { MethodSource: not null } mo5
                 && GetRequestedMemberSections(type, mo5).Contains(SectionNames.OriginalSource))
@@ -1138,6 +1144,12 @@ public class ApiCommand
                     view.MemberCode ??= new MemberCodeView();
                     view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", memberOptions.MethodSource.SourceCode);
                 }
+            }
+
+            if (renderOptions.DllPath is { } unsafeDllPath
+                && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))
+            {
+                ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
             }
         }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1027,8 +1027,11 @@ public class ApiCommand
         var filteredType = BuildFilteredTypeForSections(apiType, options);
         var effective = memberPipeline.GetAvailableSections(filteredType, options.IncludeSections);
         effective = DiscoverOutput.RestrictToSchemaSections(effective, fullSchema);
-        var discoveryRenderSections = options is MemberOptions { OverloadIndex: not null }
-            ? effective
+        var bareDiscover = options.Discover is null or { Length: 0 };
+        var discoveryRenderSections = bareDiscover
+            ? options is MemberOptions { OverloadIndex: not null }
+                ? effective
+                : [.. effective.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
             : null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
         effective = DiscoverOutput.RestrictToRenderedSections(effective, fullSchema, rendered);
@@ -1050,6 +1053,17 @@ public class ApiCommand
     /// </summary>
     internal static string RenderTypeSectionsMarkdown(ApiType type, ApiOptions options, IReadOnlyCollection<string>? discoverySections = null)
     {
+        if (discoverySections is { Count: > 0 })
+        {
+            var baseText = RenderTypeSectionsMarkdown(type, options with { Discover = null }, discoverySections: null);
+            var explicitText = RenderTypeSectionsMarkdown(type, options with
+            {
+                Discover = null,
+                IncludeSections = new HashSet<string>(discoverySections, StringComparer.OrdinalIgnoreCase),
+            }, discoverySections: null);
+            return string.Concat(baseText, Environment.NewLine, explicitText);
+        }
+
         var renderOptions = options with
         {
             Columns = null,
@@ -1058,14 +1072,6 @@ public class ApiCommand
             JsonOutput = false,
             OneLine = false,
         };
-        if (discoverySections is { Count: > 0 })
-        {
-            var include = renderOptions.IncludeSections is null
-                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                : new HashSet<string>(renderOptions.IncludeSections, StringComparer.OrdinalIgnoreCase);
-            include.UnionWith(discoverySections);
-            renderOptions = renderOptions with { IncludeSections = include };
-        }
         if (options.Discover is { Length: > 0 } discover)
         {
             var pipeline = ApiMemberSectionPipelines.Create(options);

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -490,6 +490,8 @@ public class ApiCommand
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
         if (detailSchema.GetSection(SectionNames.Calls) == null)
             detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
+        if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
+            detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
         return detailSchema;
     }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -490,8 +490,6 @@ public class ApiCommand
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
         if (detailSchema.GetSection(SectionNames.Calls) == null)
             detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
-        if (detailSchema.GetSection(SectionNames.UnsafeApiMember) == null)
-            detailSchema.Add(SectionNames.UnsafeApiMember, "column", "Member");
         if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
             detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
         return detailSchema;
@@ -849,9 +847,7 @@ public class ApiCommand
                 var requestedSections = GetRequestedMemberSections(type, mo4);
                 var methods = type.Members
                     .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract
-                            || requestedSections.Contains(SectionNames.UnsafeApiMember)
-                            || requestedSections.Contains(SectionNames.UnsafeOperations)))
+                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
@@ -1040,6 +1036,13 @@ public class ApiCommand
             : null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
         effective = DiscoverOutput.RestrictToRenderedSections(effective, fullSchema, rendered);
+        if (!effective.Contains(SectionNames.UnsafeOperations, StringComparer.OrdinalIgnoreCase)
+            && options is MemberOptions { OverloadIndex: not null, DllPath: { } memberDllPath }
+            && fullSchema.GetSection(SectionNames.UnsafeOperations) != null
+            && ApiOutputFormatter.HasSelectedUnsafeApiMemberEvidence(filteredType, memberDllPath))
+        {
+            effective.Add(SectionNames.UnsafeOperations);
+        }
         var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(effective, fullSchema, rendered);
         return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine && !options.JsonOutput,
@@ -1144,9 +1147,7 @@ public class ApiCommand
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
                 var methods = type.Members
                     .Where(m => m.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract
-                            || requestedSections.Contains(SectionNames.UnsafeApiMember)
-                            || requestedSections.Contains(SectionNames.UnsafeOperations)))
+                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -221,6 +221,13 @@ public static class MemberCommand
                 };
             }
 
+            if (effectiveOptions.OverloadIndex is null
+                && effectiveOptions.IncludeSections?.Contains(SectionNames.UnsafeMembers) == true
+                && (runtimeAssemblyPath ?? apiDllPath) is { } unsafeDllPath)
+            {
+                effectiveOptions = effectiveOptions with { DllPath = unsafeDllPath };
+            }
+
             // Enrich with local XML docs only (source info is in the source command)
             {
                 var dllPath = runtimeAssemblyPath ?? apiDllPath;

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -349,6 +349,7 @@ public static class MemberCommand
                || sections.Contains(SectionNames.DecompiledSource)
                || sections.Contains(SectionNames.OriginalSource)
                || sections.Contains(SectionNames.Calls)
+               || sections.Contains(SectionNames.UnsafeOperations)
                || sections.Contains(SectionNames.IL)
                || sections.Contains(SectionNames.ILAnnotated);
     }

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -157,9 +157,10 @@ public static class MemberCommand
 
                 var selected = displayOverloads[idx - 1];
                 apiType.Members = [selected];
+                var detailDllPath = apiType.SourceAssemblyPath ?? apiDllPath;
                 effectiveOptions = effectiveOptions with
                 {
-                    DllPath = apiDllPath,
+                    DllPath = detailDllPath,
                     OverloadIndex = overloads.IndexOf(selected) + 1
                 };
             }
@@ -214,9 +215,10 @@ public static class MemberCommand
 
                 var (selectedMember, overloadIdx) = matches[0];
                 apiType.Members = [selectedMember];
+                var detailDllPath = apiType.SourceAssemblyPath ?? apiDllPath;
                 effectiveOptions = effectiveOptions with
                 {
-                    DllPath = apiDllPath,
+                    DllPath = detailDllPath,
                     OverloadIndex = overloadIdx + 1
                 };
             }

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -358,7 +358,6 @@ public static class MemberCommand
                || sections.Contains(SectionNames.DecompiledSource)
                || sections.Contains(SectionNames.OriginalSource)
                || sections.Contains(SectionNames.Calls)
-               || sections.Contains(SectionNames.UnsafeApiMember)
                || sections.Contains(SectionNames.UnsafeOperations)
                || sections.Contains(SectionNames.IL)
                || sections.Contains(SectionNames.ILAnnotated);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -358,6 +358,7 @@ public static class MemberCommand
                || sections.Contains(SectionNames.DecompiledSource)
                || sections.Contains(SectionNames.OriginalSource)
                || sections.Contains(SectionNames.Calls)
+               || sections.Contains(SectionNames.UnsafeApiMember)
                || sections.Contains(SectionNames.UnsafeOperations)
                || sections.Contains(SectionNames.IL)
                || sections.Contains(SectionNames.ILAnnotated);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -190,7 +190,7 @@ public static class TypeCommand
 
                     // The resolved assembly path enables decompiler-backed
                     // sections (whole-type Decompiled Source).
-                    effectiveOptions = effectiveOptions with { DllPath = runtimeAssemblyPath ?? apiDllPath };
+                    effectiveOptions = effectiveOptions with { DllPath = apiType.SourceAssemblyPath ?? runtimeAssemblyPath ?? apiDllPath };
 
                     // Real local names for the listing: acquire the portable
                     // PDB the same way the member command does — only when the

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -415,6 +415,7 @@ internal static class ApiServices
                     if (forwardedTypeNames.Contains(type.FullName))
                     {
                         type.IsForwarded = true;
+                        type.SourceAssemblyPath = targetPath;
                         api.Types.Add(type);
                         api.PublicMethodCount += type.Members.Count(DotnetInspector.Sections.ApiMemberSectionDescriptors.IsMethodLike);
                         api.PublicPropertyCount += type.Members.Count(m => m.Kind == "property");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -9,6 +9,7 @@ using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using AssemblyReference = ILInspector.Metadata.AssemblyReference;
+using Analysis = ILInspector.Analysis;
 
 namespace DotnetInspector.Inspectors;
 
@@ -538,6 +539,42 @@ internal static class LibraryMetadataService
             logger.Log($"Warning: Error scanning classified methods in {path}: {ex.Message}");
         }
     }
+
+    internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(string path, VerboseLogger logger)
+    {
+        try
+        {
+            var index = Analysis.LibraryBodyIndex.Open(path);
+            var rows = index.UnsafeEvidence
+                .Select(evidence => new UnsafeMemberSummary
+                {
+                    Member = FormatMethod(evidence.Member),
+                    Reason = evidence.Reason,
+                    Detail = evidence.Detail,
+                    Kind = evidence.Kind,
+                    IL = evidence.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
+                    Token = evidence.OperandToken is { } token ? $"0x{token:X8}" : null,
+                })
+                .OrderBy(row => row.Member, StringComparer.Ordinal)
+                .ThenBy(row => row.IL ?? "", StringComparer.Ordinal)
+                .ThenBy(row => row.Reason, StringComparer.Ordinal)
+                .ThenBy(row => row.Detail, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var diagnostic in index.Diagnostics)
+                logger.Log($"Warning: unsafe analysis skipped {diagnostic.Method}: {diagnostic.Message}");
+
+            return rows.Count > 0 ? rows : null;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning unsafe members in {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string FormatMethod(Analysis.MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
     internal static List<IntegrationSignal>? ScanOpenTelemetry(string path, VerboseLogger logger)
     {

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -15,7 +15,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool IL, bool AnnotatedIL, bool Attributes, bool Calls);
+    internal sealed record Request(bool DecompiledSource, bool IL, bool AnnotatedIL, bool Attributes, bool Calls, bool UnsafeOperations);
 
     /// <summary>
     /// Code content for one member. Body and diagnostic are mutually

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -26,6 +26,8 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(List<IntegrationOpportunityInfo>))]
 [JsonSerializable(typeof(SwitchInfo))]
 [JsonSerializable(typeof(List<SwitchInfo>))]
+[JsonSerializable(typeof(UnsafeMemberSummary))]
+[JsonSerializable(typeof(List<UnsafeMemberSummary>))]
 [JsonSerializable(typeof(RidPackageReference))]
 public partial class JsonContext : JsonSerializerContext
 {

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -191,6 +191,13 @@ public class LibraryInspection
     public List<ClassifiedMethodSummary>? UnsafeMethods { get; set; }
 
     /// <summary>
+    /// Members with unsafe signature or body-level unsafe evidence.
+    /// P/Invoke-only methods are excluded and remain in P/Invoke Methods.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<UnsafeMemberSummary>? UnsafeMembers { get; set; }
+
+    /// <summary>
     /// Public P/Invoke (DllImport/LibraryImport) methods.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -456,6 +463,21 @@ public record class ClassifiedMethodSummary
     public string Signature { get; init; } = "";
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ModuleName { get; init; }
+}
+
+/// <summary>
+/// Summary of a member with unsafe signature or body evidence.
+/// </summary>
+public record class UnsafeMemberSummary
+{
+    public string Member { get; init; } = "";
+    public string Reason { get; init; } = "";
+    public string Detail { get; init; } = "";
+    public string Kind { get; init; } = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IL { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Token { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -930,25 +930,47 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.UnsafeOperations && methods is [{ MetadataToken: { } unsafeToken }])
+        if ((request.UnsafeOperations || requestedSections.Contains(SectionNames.UnsafeApiMember))
+            && methods is [{ MetadataToken: { } unsafeToken }])
         {
             var index = Analysis.LibraryBodyIndex.Open(dllPath);
-            var rows = index.UnsafeEvidence
+            var evidence = index.UnsafeEvidence
                 .Where(evidence => evidence.Member.MetadataToken == unsafeToken)
                 .OrderBy(evidence => evidence.ILOffset ?? -1)
                 .ThenBy(evidence => evidence.Reason, StringComparer.Ordinal)
                 .ThenBy(evidence => evidence.Detail, StringComparer.Ordinal)
-                .Select(evidence => new UnsafeOperationRow(
-                    evidence.Reason,
-                    MarkoutInline.Code(evidence.Detail),
-                    evidence.Kind,
-                    evidence.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null,
-                    evidence.OperandToken is { } token ? MarkoutInline.Code($"0x{token:X8}") : null))
                 .ToList();
-            if (rows.Count > 0)
+
+            if (requestedSections.Contains(SectionNames.UnsafeApiMember))
             {
-                memberCode.UnsafeOperationRows = rows;
-                hasCode = true;
+                var apiMemberRows = evidence
+                    .Where(IsUnsafeApiMemberEvidence)
+                    .Select(evidence => new UnsafeApiMemberRow(MarkoutInline.Code(evidence.Detail)))
+                    .DistinctBy(row => row.Member)
+                    .ToList();
+                if (apiMemberRows.Count > 0)
+                {
+                    memberCode.UnsafeApiMemberRows = apiMemberRows;
+                    hasCode = true;
+                }
+            }
+
+            if (request.UnsafeOperations)
+            {
+                var rows = evidence
+                    .Where(evidence => !IsUnsafeApiMemberEvidence(evidence))
+                    .Select(evidence => new UnsafeOperationRow(
+                        evidence.Reason,
+                        MarkoutInline.Code(evidence.Detail),
+                        evidence.Kind,
+                        evidence.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null,
+                        evidence.OperandToken is { } token ? MarkoutInline.Code($"0x{token:X8}") : null))
+                    .ToList();
+                if (rows.Count > 0)
+                {
+                    memberCode.UnsafeOperationRows = rows;
+                    hasCode = true;
+                }
             }
         }
 
@@ -1007,6 +1029,9 @@ public static class ApiOutputFormatter
         Analysis.CallKind.LoadVirtualFunction => "ldvirtftn",
         _ => "calli",
     };
+
+    static bool IsUnsafeApiMemberEvidence(Analysis.UnsafeEvidence evidence)
+        => evidence is { Reason: "Unsafe API member", Kind: "api" };
 
     static string FormatCallee(Analysis.MemberRef member)
     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1013,12 +1013,54 @@ public static class ApiOutputFormatter
         if (member.Kind == Analysis.MemberKind.Unsupported)
             return member.DeclaringType.ToDisplayString();
 
-        string declaringType = member.DeclaringType.ToQualifiedDisplayString();
-        string name = member.Name;
-        if (member.TypeArguments.Length > 0)
-            name += $"<{string.Join(", ", member.TypeArguments.Select(t => t.ToQualifiedDisplayString()))}>";
-        return $"{declaringType}.{name}({string.Join(", ", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+        return FormatMember(member.DeclaringType, member.Name, member.ParameterTypes, member.TypeArguments);
     }
+
+    internal static void PopulateUnsafeMembers(TypeView view, ApiType type, string dllPath)
+    {
+        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var rows = index.UnsafeEvidence
+            .Where(evidence => SameType(evidence.Member.DeclaringType, type))
+            .OrderBy(evidence => evidence.Member.Name, StringComparer.Ordinal)
+            .ThenBy(evidence => evidence.ILOffset ?? -1)
+            .ThenBy(evidence => evidence.Reason, StringComparer.Ordinal)
+            .ThenBy(evidence => evidence.Detail, StringComparer.Ordinal)
+            .Select(evidence => ToUnsafeMemberRow(evidence, includeDeclaringType: false))
+            .ToList();
+        if (rows.Count > 0)
+            view.UnsafeMemberRows = rows;
+    }
+
+    internal static UnsafeMemberRow ToUnsafeMemberRow(Analysis.UnsafeEvidence evidence, bool includeDeclaringType)
+    {
+        string member = includeDeclaringType
+            ? FormatMethod(evidence.Member)
+            : FormatMember(null, evidence.Member.Name, evidence.Member.ParameterTypes, []);
+        return new UnsafeMemberRow(
+            MarkoutInline.Code(member),
+            evidence.Reason,
+            MarkoutInline.Code(evidence.Detail),
+            evidence.Kind,
+            evidence.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null,
+            evidence.OperandToken is { } token ? MarkoutInline.Code($"0x{token:X8}") : null);
+    }
+
+    static string FormatMethod(Analysis.MethodIdentity method)
+        => FormatMember(method.DeclaringType, method.Name, method.ParameterTypes, []);
+
+    static string FormatMember(Analysis.TypeRef? declaringType, string name, IEnumerable<Analysis.TypeRef> parameterTypes, IEnumerable<Analysis.TypeRef> typeArguments)
+    {
+        var typeArgs = typeArguments.ToList();
+        if (typeArgs.Count > 0)
+            name += $"<{string.Join(", ", typeArgs.Select(t => t.ToQualifiedDisplayString()))}>";
+        string signature = $"{name}({string.Join(", ", parameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+        return declaringType is null ? signature : $"{declaringType.ToQualifiedDisplayString()}.{signature}";
+    }
+
+    static bool SameType(Analysis.TypeRef typeRef, ApiType type)
+        => typeRef.Kind == Analysis.TypeRefKind.Definition
+           && string.Equals(typeRef.Namespace, type.Namespace ?? "", StringComparison.Ordinal)
+           && string.Equals(typeRef.Name, type.Name, StringComparison.Ordinal);
 
     private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, IReadOnlyList<string>? methodGenericParameters, string lowered)
     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -930,8 +930,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        if ((request.UnsafeOperations || requestedSections.Contains(SectionNames.UnsafeApiMember))
-            && methods is [{ MetadataToken: { } unsafeToken }])
+        if (request.UnsafeOperations && methods is [{ MetadataToken: { } unsafeToken }])
         {
             var index = Analysis.LibraryBodyIndex.Open(dllPath);
             var evidence = index.UnsafeEvidence
@@ -941,19 +940,13 @@ public static class ApiOutputFormatter
                 .ThenBy(evidence => evidence.Detail, StringComparer.Ordinal)
                 .ToList();
 
-            if (requestedSections.Contains(SectionNames.UnsafeApiMember))
-            {
-                var apiMemberRows = evidence
-                    .Where(IsUnsafeApiMemberEvidence)
-                    .Select(evidence => new UnsafeApiMemberRow(MarkoutInline.Code(evidence.Detail)))
-                    .DistinctBy(row => row.Member)
-                    .ToList();
-                if (apiMemberRows.Count > 0)
-                {
-                    memberCode.UnsafeApiMemberRows = apiMemberRows;
-                    hasCode = true;
-                }
-            }
+            var apiMember = evidence
+                .Where(IsUnsafeApiMemberEvidence)
+                .Select(evidence => evidence.Detail)
+                .Distinct(StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (!string.IsNullOrEmpty(apiMember))
+                AddOrReplaceSummaryField(view, "Member", apiMember);
 
             if (request.UnsafeOperations)
             {
@@ -1020,6 +1013,17 @@ public static class ApiOutputFormatter
             view.MemberCode = memberCode;
     }
 
+    static void AddOrReplaceSummaryField(TypeView view, string name, string value)
+    {
+        view.Summary ??= [];
+        int index = view.Summary.FindIndex(field => string.Equals(field.Key, name, StringComparison.OrdinalIgnoreCase));
+        var field = new MarkoutField(name, value);
+        if (index >= 0)
+            view.Summary[index] = field;
+        else
+            view.Summary.Add(field);
+    }
+
     static string FormatCallKind(Analysis.CallKind kind) => kind switch
     {
         Analysis.CallKind.Call => "call",
@@ -1054,6 +1058,16 @@ public static class ApiOutputFormatter
             .ToList();
         if (rows.Count > 0)
             view.UnsafeMemberRows = rows;
+    }
+
+    internal static bool HasSelectedUnsafeApiMemberEvidence(ApiType type, string dllPath)
+    {
+        if (type.Members is not [{ MetadataToken: { } token }])
+            return false;
+
+        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        return index.UnsafeEvidence.Any(evidence =>
+            evidence.Member.MetadataToken == token && IsUnsafeApiMemberEvidence(evidence));
     }
 
     internal static UnsafeMemberRow ToUnsafeMemberRow(Analysis.UnsafeEvidence evidence, bool includeDeclaringType)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -905,7 +905,8 @@ public static class ApiOutputFormatter
             IL: requestedSections.Contains(SectionNames.IL),
             AnnotatedIL: requestedSections.Contains(SectionNames.ILAnnotated),
             Attributes: requestedSections.Contains(SectionNames.CustomAttributes),
-            Calls: requestedSections.Contains(SectionNames.Calls));
+            Calls: requestedSections.Contains(SectionNames.Calls),
+            UnsafeOperations: requestedSections.Contains(SectionNames.UnsafeOperations));
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
@@ -925,6 +926,28 @@ public static class ApiOutputFormatter
             if (rows.Count > 0)
             {
                 memberCode.CallRows = rows;
+                hasCode = true;
+            }
+        }
+
+        if (request.UnsafeOperations && methods is [{ MetadataToken: { } unsafeToken }])
+        {
+            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var rows = index.UnsafeEvidence
+                .Where(evidence => evidence.Member.MetadataToken == unsafeToken)
+                .OrderBy(evidence => evidence.ILOffset ?? -1)
+                .ThenBy(evidence => evidence.Reason, StringComparer.Ordinal)
+                .ThenBy(evidence => evidence.Detail, StringComparer.Ordinal)
+                .Select(evidence => new UnsafeOperationRow(
+                    evidence.Reason,
+                    MarkoutInline.Code(evidence.Detail),
+                    evidence.Kind,
+                    evidence.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null,
+                    evidence.OperandToken is { } token ? MarkoutInline.Code($"0x{token:X8}") : null))
+                .ToList();
+            if (rows.Count > 0)
+            {
+                memberCode.UnsafeOperationRows = rows;
                 hasCode = true;
             }
         }

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -90,6 +90,7 @@ public static class ApiMemberSectionDescriptors
             .Add<ExtensionMethods>()
             .Add<Events>()
             .Add<MethodAttributes>()
+            .Add<UnsafeMembers>()
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<ILBody>()
@@ -234,6 +235,16 @@ public static class ApiMemberSectionDescriptors
     {
         public static string Name => "Custom Attributes";
         public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(IsMethodLike);
+    }
+
+    public sealed class UnsafeMembers : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.UnsafeMembers;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(IsMethodLike);

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -377,6 +377,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<Calls>()
+            .Add<UnsafeApiMember>()
             .Add<UnsafeOperations>()
             .Add<ILBody>()
             .Add<AnnotatedIL>();
@@ -454,6 +455,16 @@ public static class ApiMemberDetailSectionDescriptors
     public sealed class UnsafeOperations : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.UnsafeOperations;
+        public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Count == 1
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class UnsafeApiMember : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.UnsafeApiMember;
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -366,6 +366,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<Calls>()
+            .Add<UnsafeOperations>()
             .Add<ILBody>()
             .Add<AnnotatedIL>();
     }
@@ -432,6 +433,16 @@ public static class ApiMemberDetailSectionDescriptors
     public sealed class Calls : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.Calls;
+        public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Count == 1
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class UnsafeOperations : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.UnsafeOperations;
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -377,7 +377,6 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<Calls>()
-            .Add<UnsafeApiMember>()
             .Add<UnsafeOperations>()
             .Add<ILBody>()
             .Add<AnnotatedIL>();
@@ -455,16 +454,6 @@ public static class ApiMemberDetailSectionDescriptors
     public sealed class UnsafeOperations : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.UnsafeOperations;
-        public static bool IsExpensive => false;
-        public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model)
-            => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
-    }
-
-    public sealed class UnsafeApiMember : ISectionDescriptor<ApiType>
-    {
-        public static string Name => SectionNames.UnsafeApiMember;
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -23,6 +23,7 @@ public static class LibrarySections
     public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
     public const string ScannerIntegrationOpportunities = "IntegrationOpportunities";
     public const string ScannerSwitches = "Switches";
+    public const string ScannerUnsafeMembers = "UnsafeMembers";
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
@@ -53,7 +54,7 @@ public static class LibrarySections
             .Add<References>()
             .Add<Dependencies>()
             .Add<ExtensionMethods>()
-            .Add<UnsafeMethods>()
+            .Add<UnsafeMembers>()
             .Add<PInvokeMethods>()
             .Add<AsyncMethods>()
             .Add<Resources>()
@@ -84,6 +85,8 @@ public static class LibrarySections
                 AuditSignalBuilder.PopulateLibraryAudit(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerSwitches, ctx =>
                 ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
+            .Add(ScannerUnsafeMembers, ctx =>
+                ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>
@@ -343,13 +346,14 @@ public static class LibrarySections
             => model.ExtensionMethods is { Count: > 0 } || model.HasExtensionTypes;
     }
 
-    public sealed class UnsafeMethods : ISectionDescriptor<LibraryInspection>
+    public sealed class UnsafeMembers : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => "Unsafe Methods";
+        public static string Name => "Unsafe Members";
         public static bool IsExpensive => false;
-        public static string? ScannerKey => ScannerClassifiedMethods;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerUnsafeMembers;
         public static bool CanRender(LibraryInspection model)
-            => model.UnsafeMethods is { Count: > 0 } || model.HasUnsafeCode;
+            => model.UnsafeMembers is { Count: > 0 } || model.HasUnsafeCode;
     }
 
     public sealed class PInvokeMethods : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -93,9 +93,6 @@ public static class SectionNames
     /// <summary>Section for unsafe-relevant members in a type.</summary>
     public const string UnsafeMembers = "Unsafe Members";
 
-    /// <summary>Section for a selected member that is itself an unsafe API member.</summary>
-    public const string UnsafeApiMember = "Unsafe API Member";
-
     /// <summary>Section for unsafe-relevant evidence from the selected member body.</summary>
     public const string UnsafeOperations = "Unsafe Operations";
 

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -90,4 +90,7 @@ public static class SectionNames
     /// <summary>Section for direct call-site evidence from the selected member body.</summary>
     public const string Calls = "Calls";
 
+    /// <summary>Section for unsafe-relevant evidence from the selected member body.</summary>
+    public const string UnsafeOperations = "Unsafe Operations";
+
 }

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -93,6 +93,9 @@ public static class SectionNames
     /// <summary>Section for unsafe-relevant members in a type.</summary>
     public const string UnsafeMembers = "Unsafe Members";
 
+    /// <summary>Section for a selected member that is itself an unsafe API member.</summary>
+    public const string UnsafeApiMember = "Unsafe API Member";
+
     /// <summary>Section for unsafe-relevant evidence from the selected member body.</summary>
     public const string UnsafeOperations = "Unsafe Operations";
 

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -90,6 +90,9 @@ public static class SectionNames
     /// <summary>Section for direct call-site evidence from the selected member body.</summary>
     public const string Calls = "Calls";
 
+    /// <summary>Section for unsafe-relevant members in a type.</summary>
+    public const string UnsafeMembers = "Unsafe Members";
+
     /// <summary>Section for unsafe-relevant evidence from the selected member body.</summary>
     public const string UnsafeOperations = "Unsafe Operations";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -174,6 +174,10 @@ public class TypeView
     [JsonIgnore]
     public List<MethodAttributeRow>? MethodAttributeRows { get; set; }
 
+    [MarkoutSection(Name = "Unsafe Members")]
+    [JsonIgnore]
+    public List<UnsafeMemberRow>? UnsafeMemberRows { get; set; }
+
     // Member code sections (populated by member command only, serialized separately)
     [MarkoutIgnore]
     [JsonIgnore]
@@ -568,6 +572,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(MemberRow))]
 [MarkoutContext(typeof(MemberSignatureRow))]
 [MarkoutContext(typeof(MethodAttributeRow))]
+[MarkoutContext(typeof(UnsafeMemberRow))]
 [MarkoutContext(typeof(ConstructorOverloadView))]
 [MarkoutContext(typeof(ConstructorParameterRow))]
 [MarkoutContext(typeof(EnumValueRow))]
@@ -588,6 +593,15 @@ public record CallSiteRow(string Callee, string Kind, string IL, string Token);
 
 [MarkoutSerializable]
 public record UnsafeOperationRow(
+    string Reason,
+    string Detail,
+    string Kind,
+    [property: MarkoutSkipNull] string? IL,
+    [property: MarkoutSkipNull] string? Token);
+
+[MarkoutSerializable]
+public record UnsafeMemberRow(
+    string Member,
     string Reason,
     string Detail,
     string Kind,

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -540,9 +540,6 @@ public class MemberCodeView
     [MarkoutSection(Name = "Calls")]
     public List<CallSiteRow>? CallRows { get; set; }
 
-    [MarkoutSection(Name = "Unsafe API Member")]
-    public List<UnsafeApiMemberRow>? UnsafeApiMemberRows { get; set; }
-
     [MarkoutSection(Name = "Unsafe Operations")]
     public List<UnsafeOperationRow>? UnsafeOperationRows { get; set; }
 
@@ -569,7 +566,6 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(ExtensionMethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
 [MarkoutContext(typeof(CallSiteRow))]
-[MarkoutContext(typeof(UnsafeApiMemberRow))]
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
@@ -594,9 +590,6 @@ public partial class ApiViewContext : MarkoutSerializerContext
 
 [MarkoutSerializable]
 public record CallSiteRow(string Callee, string Kind, string IL, string Token);
-
-[MarkoutSerializable]
-public record UnsafeApiMemberRow(string Member);
 
 [MarkoutSerializable]
 public record UnsafeOperationRow(

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -540,6 +540,9 @@ public class MemberCodeView
     [MarkoutSection(Name = "Calls")]
     public List<CallSiteRow>? CallRows { get; set; }
 
+    [MarkoutSection(Name = "Unsafe API Member")]
+    public List<UnsafeApiMemberRow>? UnsafeApiMemberRows { get; set; }
+
     [MarkoutSection(Name = "Unsafe Operations")]
     public List<UnsafeOperationRow>? UnsafeOperationRows { get; set; }
 
@@ -566,6 +569,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(ExtensionMethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
 [MarkoutContext(typeof(CallSiteRow))]
+[MarkoutContext(typeof(UnsafeApiMemberRow))]
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
@@ -590,6 +594,9 @@ public partial class ApiViewContext : MarkoutSerializerContext
 
 [MarkoutSerializable]
 public record CallSiteRow(string Callee, string Kind, string IL, string Token);
+
+[MarkoutSerializable]
+public record UnsafeApiMemberRow(string Member);
 
 [MarkoutSerializable]
 public record UnsafeOperationRow(

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -536,6 +536,9 @@ public class MemberCodeView
     [MarkoutSection(Name = "Calls")]
     public List<CallSiteRow>? CallRows { get; set; }
 
+    [MarkoutSection(Name = "Unsafe Operations")]
+    public List<UnsafeOperationRow>? UnsafeOperationRows { get; set; }
+
     [MarkoutSection(Name = "IL")]
     public CodeSection ILCode { get; set; }
 
@@ -559,6 +562,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(ExtensionMethodsView))]
 [MarkoutContext(typeof(MemberCodeView))]
 [MarkoutContext(typeof(CallSiteRow))]
+[MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
 [MarkoutContext(typeof(MemberRow))]
@@ -581,3 +585,11 @@ public partial class ApiViewContext : MarkoutSerializerContext
 
 [MarkoutSerializable]
 public record CallSiteRow(string Callee, string Kind, string IL, string Token);
+
+[MarkoutSerializable]
+public record UnsafeOperationRow(
+    string Reason,
+    string Detail,
+    string Kind,
+    [property: MarkoutSkipNull] string? IL,
+    [property: MarkoutSkipNull] string? Token);

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -529,15 +529,22 @@ public class LibraryInspectionView
             .ToList();
 
     [MarkoutIgnore]
-    public bool HasUnsafeMethods => _data.UnsafeMethods is { Count: > 0 };
+    public bool HasUnsafeMembers => _data.UnsafeMembers is { Count: > 0 };
 
-    [MarkoutSection(Name = "Unsafe Methods", ShowWhenProperty = nameof(HasUnsafeMethods))]
-    public List<ClassifiedMethodRow>? UnsafeMethodsSection =>
-        _data.UnsafeMethods?
-            .OrderBy(m => m.DeclaringType, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(m => m.MethodName, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(m => m.Signature, StringComparer.OrdinalIgnoreCase)
-            .Select(m => new ClassifiedMethodRow(m.MethodName, m.DeclaringType, m.Signature))
+    [MarkoutSection(Name = "Unsafe Members", ShowWhenProperty = nameof(HasUnsafeMembers))]
+    public List<UnsafeMemberRow>? UnsafeMembersSection =>
+        _data.UnsafeMembers?
+            .OrderBy(m => m.Member, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.IL, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.Reason, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.Detail, StringComparer.OrdinalIgnoreCase)
+            .Select(m => new UnsafeMemberRow(
+                MarkoutInline.Code(m.Member),
+                m.Reason,
+                MarkoutInline.Code(m.Detail),
+                m.Kind,
+                m.IL is null ? null : MarkoutInline.Code(m.IL),
+                m.Token is null ? null : MarkoutInline.Code(m.Token)))
             .ToList();
 
     /// <summary>
@@ -663,6 +670,15 @@ public record ClassifiedMethodRow(
     string Name,
     [property: MarkoutPropertyName("Declaring Type")] string DeclaringType,
     string Signature);
+
+[MarkoutSerializable]
+public record UnsafeMemberRow(
+    string Member,
+    string Reason,
+    string Detail,
+    string Kind,
+    [property: MarkoutSkipNull] string? IL,
+    [property: MarkoutSkipNull] string? Token);
 
 [MarkoutSerializable]
 public record PInvokeMethodRow(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -539,12 +539,8 @@ public class LibraryInspectionView
             .ThenBy(m => m.Reason, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.Detail, StringComparer.OrdinalIgnoreCase)
             .Select(m => new UnsafeMemberRow(
-                MarkoutInline.Code(m.Member),
-                m.Reason,
-                MarkoutInline.Code(m.Detail),
-                m.Kind,
-                m.IL is null ? null : MarkoutInline.Code(m.IL),
-                m.Token is null ? null : MarkoutInline.Code(m.Token)))
+                MarkoutInline.Code(m.Member), m.Reason, MarkoutInline.Code(m.Detail), m.Kind,
+                m.IL is null ? null : MarkoutInline.Code(m.IL), m.Token is null ? null : MarkoutInline.Code(m.Token)))
             .ToList();
 
     /// <summary>
@@ -670,15 +666,6 @@ public record ClassifiedMethodRow(
     string Name,
     [property: MarkoutPropertyName("Declaring Type")] string DeclaringType,
     string Signature);
-
-[MarkoutSerializable]
-public record UnsafeMemberRow(
-    string Member,
-    string Reason,
-    string Detail,
-    string Kind,
-    [property: MarkoutSkipNull] string? IL,
-    [property: MarkoutSkipNull] string? Token);
 
 [MarkoutSerializable]
 public record PInvokeMethodRow(


### PR DESCRIPTION
## Summary

- replace the signature-only Unsafe Methods surface with a broader `Unsafe Members` library audit section
- add selected-member `Unsafe Operations` drill-in backed by `ILInspector.Analysis`
- classify unsafe signatures, Unsafe.* calls, unsafe-signature callees, calli, localloc/cpblk/initblk, pointer/pinned locals, and pointer indirection when unsafe storage is present
- keep P/Invoke-only methods in `P/Invoke Methods`; they appear in `Unsafe Members` only with independent unsafe evidence
- update docs/skill guidance and add focused tests

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release`
- `dotnet run --project src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release -- -class DotnetInspector.Tests.UnsafeMembersSectionTests -class DotnetInspector.Tests.SectionPipelineTests -class DotnetInspector.Tests.OutputFormatterTests -class DotnetInspector.Tests.MethodClassificationScannerTests`
- `dotnet run --project src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release -- -class- DotnetInspector.Tests.FindCommandIntegrationTests`
- `npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md`

Note: the full `dotnet-inspect.Tests` run still fails in this environment only in unrelated `FindCommandIntegrationTests`; the non-Find test suite and affected tests pass.