### PR TITLE
Escape control characters in string and char literals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1448,3 +1448,39 @@ public class EnumConstantTests
         }
     }
 }
+
+/// <summary>
+/// String and char literal escaping: control characters, quotes, and
+/// backslashes are escaped so the rendered literal always compiles. A raw
+/// newline or tab in the output would be invalid C#.
+/// </summary>
+public class StringEscapingTests
+{
+    static string PrintStringConstant(string value)
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var block = new Block(0);
+        block.Add(new Return(new Constant(value, stringType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(stringType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    [Fact]
+    public void ControlCharacters_QuotesAndBackslashes_AreEscaped()
+    {
+        Assert.Equal("return \"a\\nb\";", PrintStringConstant("a\nb"));
+        Assert.Equal("return \"\\t\\r\\0\";", PrintStringConstant("\t\r\0"));
+        Assert.Equal("return \"say \\\"hi\\\"\";", PrintStringConstant("say \"hi\""));
+        Assert.Equal("return \"c:\\\\tmp\";", PrintStringConstant("c:\\tmp"));
+    }
+
+    [Fact]
+    public void OtherControlChar_UsesUnicodeEscape()
+    {
+        //  has no recognized short escape.
+        Assert.Equal("return \"x\\u0001y\";", PrintStringConstant("xy"));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -716,7 +716,7 @@ public sealed class CSharpPrinter
     static string ConstantText(Constant constant) => constant.Value switch
     {
         null => "null",
-        string s => $"\"{s.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"",
+        string s => StringText(s),
         bool b => b ? "true" : "false",
         char c => CharText(c),
         int i => i.ToString(CultureInfo.InvariantCulture),
@@ -726,16 +726,38 @@ public sealed class CSharpPrinter
         _ => constant.Value.ToString() ?? "?",
     };
 
-    static string CharText(char c) => c switch
+    static string CharText(char c) => $"'{EscapeChar(c, inString: false)}'";
+
+    /// <summary>A C# string literal with every char that needs escaping escaped — control chars, quotes, backslashes — so the output always compiles.</summary>
+    static string StringText(string value)
     {
-        '\\' => "'\\\\'",
-        '\'' => "'\\''",
-        '\t' => "'\\t'",
-        '\n' => "'\\n'",
-        '\r' => "'\\r'",
-        '\0' => "'\\0'",
-        _ when char.IsControl(c) => $"'\\u{(int)c:x4}'",
-        _ => $"'{c}'",
+        var sb = new StringBuilder(value.Length + 2).Append('"');
+        foreach (char c in value)
+            sb.Append(EscapeChar(c, inString: true));
+        return sb.Append('"').ToString();
+    }
+
+    /// <summary>
+    /// The single home for C# character escaping, shared by char and string
+    /// literals. The active delimiter is escaped (<c>"</c> in a string,
+    /// <c>'</c> in a char); every control character gets a recognized escape
+    /// or a <c>\u</c> sequence so a raw newline or tab never reaches the output.
+    /// </summary>
+    static string EscapeChar(char c, bool inString) => c switch
+    {
+        '\\' => "\\\\",
+        '"' when inString => "\\\"",
+        '\'' when !inString => "\\'",
+        '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\v' => "\\v",
+        _ when char.IsControl(c) => $"\\u{(int)c:x4}",
+        _ => c.ToString(),
     };
 
     static string BinaryOperator(Binary binary) => binary.Kind switch


### PR DESCRIPTION
Tier-1 correctness fix from the external review — the "simplest and most embarrassing" one, and confirmed real.

`ConstantText` escaped only `\` and `"`, so a string constant with an embedded newline/tab/NUL produced a literal with a **raw control character — invalid C# that doesn't compile**:

```
before:  return "line1
line2";              // raw newline → does not compile
after:   return "line1\nline2";
```

Both string and char literals now route through one `EscapeChar` (consolidating the char path, which already escaped correctly): the active delimiter, backslash, the recognized short escapes (`\0\a\b\f\n\r\t\v`), and any other control char as `\uXXXX`.

## Parity: −12, and that's the good kind

47.10% → 47.07%. The **old emitter shares the same bug** — it appends the `ldstr` operand without escaping interior characters (`CSharpEmitter.cs:6796`) — so those methods were *agreeing on shared invalid output*. The candidate now emits valid C# where both previously didn't: a candidate-better divergence. (The categorizer files these under "uncertain" today, since it has no raw-control-char tell — a possible future refinement.)

365/365 both configs, with synthetic fixtures covering newline/tab/NUL, embedded quotes, backslash, and `\uXXXX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)