### PR TITLE
Binary.ResultType: ECMA-335 binary numeric promotion

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -202,3 +202,32 @@ public class TypeRefTests
         Assert.False(TypeRef.GenericInstance(listDef, [TypeRef.CoreLib("System", "Int32")]).ContainsUnsupported);
     }
 }
+
+public class TypeFamiliesTests
+{
+    static string? Result(string leftName, string rightName)
+        => TypeFamilies.BinaryResult(
+            TypeRef.CoreLib("System", leftName), TypeRef.CoreLib("System", rightName))?.ToDisplayString();
+
+    [Fact]
+    public void BinaryResult_PromotesToWiderFamily_PreservingExactType()
+    {
+        // Cross-family: the wider operand wins, exact type kept (no canonical loss).
+        Assert.Equal("long", Result("Int32", "Int64"));
+        Assert.Equal("long", Result("Int64", "Int32"));
+        Assert.Equal("nint", Result("Int32", "IntPtr"));
+        Assert.Equal("double", Result("Int32", "Double"));
+
+        // Known family-granularity limit: Single and Double are both family F,
+        // so float + double keeps the left (float). Same as the prior behavior
+        // — not a regression, and float/double rarely mix in real arithmetic.
+        Assert.Equal("float", Result("Single", "Double"));
+
+        // Same family: the left type survives — signedness and width are not lost.
+        Assert.Equal("uint", Result("UInt32", "UInt32"));
+        Assert.Equal("int", Result("Int32", "UInt32"));       // both I4 → left
+
+        // Unknown (non-numeric) operand → left type, the prior behavior.
+        Assert.Equal("int", Result("Int32", "Object"));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -550,8 +550,8 @@ public sealed class Binary : IrExpression
     public IrExpression Left => (IrExpression)Children[0];
     public IrExpression Right => (IrExpression)Children[1];
 
-    /// <summary>Result typing follows the left operand for the slice; full ECMA-335 binary numeric promotion arrives with the type pass.</summary>
-    public override TypeRef? ResultType => Left.ResultType;
+    /// <summary>ECMA-335 III.1.5 binary numeric promotion: the wider operand wins (see <see cref="TypeFamilies.BinaryResult"/>).</summary>
+    public override TypeRef? ResultType => TypeFamilies.BinaryResult(Left.ResultType, Right.ResultType);
 
     public override string Describe()
         => $"Binary.{Kind}{(IsChecked ? " checked" : "")}{(IsUnsigned ? " unsigned" : "")}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -39,6 +39,32 @@ public static class TypeFamilies
         };
     }
 
+    /// <summary>
+    /// The result type of a binary numeric op, per ECMA-335 III.1.5: the wider
+    /// operand family wins (F over all, I8 over I4/I, I over I4). Returns the
+    /// wider operand's EXACT type, not a canonical one, so signedness and width
+    /// survive (<c>uint + uint</c> stays <c>uint</c>); a same-family pair or an
+    /// unknown operand keeps the left type, the prior behavior. Only genuine
+    /// cross-family pairs (<c>int + long</c>) change — the left-operand shortcut
+    /// was wrong for exactly those.
+    /// </summary>
+    public static TypeRef? BinaryResult(TypeRef? left, TypeRef? right)
+    {
+        var leftFamily = Of(left);
+        var rightFamily = Of(right);
+        if (leftFamily is not { } lf || rightFamily is not { } rf || lf == rf)
+            return left;
+        return Wider(lf, rf) == rf ? right : left;
+    }
+
+    static StackFamily Wider(StackFamily a, StackFamily b) => (a, b) switch
+    {
+        (StackFamily.F, _) or (_, StackFamily.F) => StackFamily.F,
+        (StackFamily.I8, _) or (_, StackFamily.I8) => StackFamily.I8,
+        (StackFamily.I, _) or (_, StackFamily.I) => StackFamily.I,
+        _ => a,
+    };
+
     public static bool IsFloat(TypeRef? type) => Of(type) == StackFamily.F;
 
     /// <summary>True when the family is a known integer (I4/I8/I).</summary>


### PR DESCRIPTION
Plan item #2 from the external review — and the gate measurement reshaped the claim.

`Binary.ResultType` followed the left operand, wrong for cross-family pairs (`int + long` typed as `int`). `TypeFamilies.BinaryResult` now applies ECMA-335 III.1.5 promotion — wider family wins (F over all, I8 over I4/I, I over I4) — returning the **wider operand's exact type** so signedness and width survive (`uint + uint` stays `uint`; only genuine cross-family pairs change). This is deliberately *not* the `Canonical(Wider(...))` the review proposed, which would have collapsed `uint+uint` to `int` and lost it.

## Gate: zero output impact

I gated this on "the categorizer showing real output impact." It shows **none** — parity and every bucket are byte-identical on the CoreLib sweep. The wrong typing was **latent**: it never reached a visibly-wrong rendering. So the review's "wrong casts *now*" is really "wrong *types*, not currently visible."

Shipping it anyway as a **foundation fix**: it keeps the typed IR honest for the control-flow and sugar passes (plan item #3) that will read `Binary.ResultType`, rather than fixing anything today. Cheap, correct, low-risk — but I want to be clear it moves no output.

Known family-granularity limit (unchanged): `Single`/`Double` are both family F, so `float + double` keeps `float`. Not a regression. 364/364 both configs; unit tests pin the promotion table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)