### PR TITLE
Raise do-while loops (the CAS retry shape)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -269,6 +269,22 @@ public class CfgSampleClass
         return s;
     }
 
+    // A do-while whose body breaks early: the break is a forward exit branch,
+    // so the loop is out of the do-while slice and stays honestly flat.
+    public static int DoWhileWithBreak(int n)
+    {
+        int s = 0;
+        do
+        {
+            s += n;
+            if (s > 100)
+                break;
+            n--;
+        }
+        while (n > 0);
+        return s;
+    }
+
     public static void Noop() { }
 
     public static int ParseOrZero(string s) => int.TryParse(s, out var v) ? v : 0;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -874,16 +874,30 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void Structuring_BottomTestedLoop_KeepsHonestFlatForm()
+    public void Structuring_BottomTestedLoop_RaisesToDoWhile()
     {
-        // do-while is bottom-tested with no guard jump — outside this slice;
-        // the function keeps the always-correct flat rendering.
+        // The bottom-tested back edge raises to a do-while: no goto, no label.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(
             typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.DoWhileSum), source);
 
+        Assert.Contains("do", output);
+        Assert.Contains("while (", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void DoWhileWithBreak_StaysFlat()
+    {
+        // The break is a forward exit branch out of the loop — out of the
+        // do-while slice, so the loop is not raised and stays flat (goto).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.DoWhileWithBreak), source);
+
         Assert.Contains("goto", output);
-        Assert.Contains("IL_", output);
+        Assert.DoesNotContain("do", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -236,6 +236,15 @@ public sealed class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             return;
         }
+        if (node is DoWhileLoop doWhile)
+        {
+            sb.Append(pad).AppendLine("do");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, doWhile.Body, indent + 1);
+            sb.Append(pad).Append("}").Append(Environment.NewLine).Append(pad)
+                .Append("while (").Append(Condition(doWhile.Condition)).AppendLine(");");
+            return;
+        }
         if (node is TryCatch tryCatch)
         {
             sb.Append(pad).AppendLine("try");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -179,6 +179,26 @@ public sealed class WhileLoop : IrNode
 }
 
 /// <summary>
+/// A raised do-while loop: a bottom-tested back edge with no forward entry
+/// jump (<c>BODY; if (cond) goto BODY-start;</c>). The body is a container so
+/// inner forward branches structure recursively; the condition is the
+/// stay-in-loop test exactly as the IL wrote the back-edge — no negation.
+/// </summary>
+public sealed class DoWhileLoop : IrNode
+{
+    public DoWhileLoop(BlockContainer body, IrExpression condition)
+    {
+        AddChild(body);
+        AddChild(condition);
+    }
+
+    public BlockContainer Body => (BlockContainer)Children[0];
+    public IrExpression Condition => (IrExpression)Children[1];
+
+    public override string Describe() => "DoWhileLoop";
+}
+
+/// <summary>
 /// A raised for loop: initializer statement, stay-in-loop condition,
 /// increment statement, body. Produced from a WhileLoop whose preceding
 /// statement initializes the condition variable and whose body ends by

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
@@ -1,0 +1,126 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises do-while loops — the pervasive lock-free CAS retry shape
+/// (<c>BODY; if (cond) goto BODY-start;</c>) — into <see cref="DoWhileLoop"/>.
+/// The bottom block's conditional back edge to an earlier block in the same
+/// container becomes the while condition exactly as written (it is the
+/// stay-in-loop test); the body becomes a container the structuring pass then
+/// raises. Runs before <see cref="StructuringPass"/>, which leaves any
+/// container holding a back edge flat.
+///
+/// Transactional and conservative: the loop is raised only when it is a clean
+/// single-entry region with no exit branch (a break), no second back edge
+/// (nested or irreducible), and no EH leave inside — otherwise it stays flat.
+/// Innermost loops wrap first, so nested do-whiles compose across the fixpoint.
+/// </summary>
+public sealed class DoWhileLoopPass : IIrPass
+{
+    public string Name => "do-while";
+
+    public void Run(IrFunction function)
+    {
+        while (TransformOne(function))
+        {
+        }
+    }
+
+    static bool TransformOne(IrFunction function)
+    {
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            var blocks = container.Blocks;
+            var offsetToIndex = new Dictionary<int, int>();
+            for (int i = 0; i < blocks.Count; i++)
+                offsetToIndex[blocks[i].StartOffset] = i;
+
+            // The innermost back edge (smallest region) first, so a nested loop
+            // raises before the loop that contains it.
+            (int Header, int Bottom, ConditionalBranch Edge)? best = null;
+            for (int bottom = 0; bottom < blocks.Count; bottom++)
+            {
+                if (blocks[bottom].Children is not [.., ConditionalBranch edge]
+                    || !offsetToIndex.TryGetValue(edge.TargetOffset, out int header)
+                    || header > bottom)
+                {
+                    continue;   // not a backward conditional branch
+                }
+                if (best is null || bottom - header < best.Value.Bottom - best.Value.Header)
+                    best = (header, bottom, edge);
+            }
+
+            if (best is { } loop
+                && Validate(blocks, offsetToIndex, loop.Header, loop.Bottom, loop.Edge))
+            {
+                Wrap(container, loop.Header, loop.Bottom, loop.Edge);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Pure shape check: the region [header, bottom] is a reducible single-entry loop with one back edge and no break.</summary>
+    static bool Validate(
+        IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex,
+        int header, int bottom, ConditionalBranch backEdge)
+    {
+        for (int source = 0; source < blocks.Count; source++)
+        {
+            bool sourceInside = source >= header && source <= bottom;
+            foreach (var node in blocks[source].Children)
+            {
+                // EH control flow inside the loop is outside this slice.
+                if (sourceInside && node is Leave or EndFinally or EndFilter)
+                    return false;
+
+                foreach (int targetOffset in Targets(node))
+                {
+                    if (!offsetToIndex.TryGetValue(targetOffset, out int target))
+                        return false;   // a branch leaving the container — out of slice
+                    bool targetInside = target >= header && target <= bottom;
+
+                    if (sourceInside && !targetInside)
+                        return false;   // an exit branch — a break, the next slice
+                    if (!sourceInside && targetInside)
+                        return false;   // an external jump into the loop body
+                    if (sourceInside && !ReferenceEquals(node, backEdge) && target <= source)
+                        return false;   // a second back edge — nested or irreducible
+                }
+            }
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        _ => [],
+    };
+
+    static void Wrap(BlockContainer container, int header, int bottom, ConditionalBranch backEdge)
+    {
+        var blocks = container.Blocks;
+        var condition = (IrExpression)backEdge.DetachChildren()[0];
+        backEdge.Detach();   // strip the back edge from the bottom block
+
+        foreach (var block in blocks)
+            block.Detach();
+
+        var body = new BlockContainer();
+        for (int i = header; i <= bottom; i++)
+            body.Add(blocks[i]);
+        var holder = new Block(blocks[header].StartOffset);
+        holder.Add(new DoWhileLoop(body, condition));
+
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i < header; i++)
+            rebuilt.Add(blocks[i]);
+        rebuilt.Add(holder);
+        for (int i = bottom + 1; i < blocks.Count; i++)
+            rebuilt.Add(blocks[i]);
+
+        container.ReplaceWith(rebuilt);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -41,6 +41,10 @@ public static class IrPasses
         new ConstructorChainPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
+        // Consume conditional back edges into do-while loops before
+        // structuring, which leaves any back-edge container flat. The loop
+        // body becomes a container the structuring pass then raises.
+        new DoWhileLoopPass(),
         new StructuringPass(),
         // After structuring the finally guard is an IfStatement, so the
         // Monitor lock lowering is matchable as lock (obj) { ... }.


### PR DESCRIPTION
Plan item #3, first slice — the dominant un-raised control-flow shape the categorizer pointed at.

`DoWhileLoopPass` consumes a **conditional back edge** (a block whose last statement branches to an earlier block in the same container) into a `DoWhileLoop`, before `StructuringPass` (which leaves any back-edge container flat). The back edge becomes the `while` condition as written (the stay-in-loop test, no negation); the loop blocks become a body container the structuring pass then raises.

```csharp
// before                              // after
V_0 = field;                           V_0 = field;
IL_0006:                               do
V_1 = V_0;                             {
V_2 = Combine(V_1, value);                 V_1 = V_0;
V_0 = CompareExchange(...);                V_2 = Combine(V_1, value);
if (V_0 != V_1) goto IL_0006;              V_0 = CompareExchange(...);
                                       }
                                       while (V_0 != V_1);
```

This is the lock-free CAS retry loop — pervasive across event add/remove and `Interlocked` patterns.

## Conservative by design

Raises only a clean single-entry region with **no exit branch** (a break), **no second back edge** (continue / nested / irreducible), and **no EH leave** inside; otherwise it stays flat. Innermost loops wrap first, so nested do-whiles compose across the fixpoint. A `DoWhileWithBreak` fixture pins the stays-flat boundary.

## Burndown

candidate-worse **1,728 → 1,663 (−65)**; known real-gap **8.47% → 8.31%**. Raw `agree` barely moves because the same methods carry the baseline's `::` bug and namespace verbosity — the loop *structure* now matches the baseline's do-while, and the residual diffs are candidate-better/cosmetic. The burndown is the metric that matters for retiring the old emitter, and it dropped.

## Soundness (high-effort self-review, per #498)

The adversarial pass confirmed: break (exit branch) and continue (second back edge to the header) are both rejected; external entry and EH leaves bail; `Wrap` detaches and re-adopts every block before `ReplaceWith` (CheckInvariant passes); the holder reusing the header offset is the established `EhStructuringPass` pattern and is unique within its container (the header block moves into the body). 364/364 both configs.

Next sub-slices: breaks/continues, then switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)