### PR TITLE
Fix facade bare-name routing

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using NuGet.Versioning;
 
@@ -931,6 +933,58 @@ public static class PlatformResolver
         }
 
         return forwarderMatch;
+    }
+
+    /// <summary>
+    /// Returns true when an assembly is a facade-only surface: it has metadata,
+    /// one or more type forwarders, and no meaningful public type definitions.
+    /// </summary>
+    public static bool IsFacadeOnlyAssembly(string assemblyPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return false;
+
+            var reader = peReader.GetMetadataReader();
+            bool hasForwarders = false;
+            foreach (var handle in reader.ExportedTypes)
+            {
+                if (reader.GetExportedType(handle).IsForwarder)
+                {
+                    hasForwarders = true;
+                    break;
+                }
+            }
+
+            if (!hasForwarders)
+                return false;
+
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(handle);
+                if (IsMeaningfulPublicType(reader, typeDef))
+                    return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsMeaningfulPublicType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var visibility = typeDef.Attributes & TypeAttributes.VisibilityMask;
+        if (visibility is not (TypeAttributes.Public or TypeAttributes.NestedPublic))
+            return false;
+
+        var name = reader.GetString(typeDef.Name);
+        return name.Length > 0 && !name.StartsWith('<') && !name.StartsWith("__", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3211,6 +3211,50 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_FacadePlatformBareName_RoutesToForwardedType()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime.CompilerServices.Unsafe");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Runtime.CompilerServices.Unsafe not available: {error}");
+            return;
+        }
+
+        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+            "System.Runtime.CompilerServices.Unsafe is not facade-only in this runtime.");
+
+        var (exit, output, runError) = await RunAppAsync(
+            "System.Runtime.CompilerServices.Unsafe", "--markdown", "-v:q", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.Contains("# System.Runtime.CompilerServices.Unsafe", output);
+        Assert.DoesNotContain("# System.Runtime.CompilerServices.Unsafe.dll", output);
+        Assert.Contains("Kind: class", output);
+    }
+
+    [Fact]
+    public async Task Router_NonFacadePlatformBareName_RoutesToLibrary()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Text.Json");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Text.Json not available: {error}");
+            return;
+        }
+
+        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+
+        var (exit, output, runError) = await RunAppAsync(
+            "System.Text.Json", "--markdown", "-v:q", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.Contains("# System.Text.Json.dll", output);
+        Assert.Contains("Name: System.Text.Json", output);
+    }
+
+    [Fact]
     public async Task LibraryCommand_PlatformVersion_DoesNotFallbackToPackageVersion()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -169,6 +169,32 @@ public class PlatformResolverTests
     }
 
     [Fact]
+    public void IsFacadeOnlyAssembly_UnsafeFacade_ReturnsTrue()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime.CompilerServices.Unsafe");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Runtime.CompilerServices.Unsafe not available: {error}");
+            return;
+        }
+
+        Assert.True(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+    }
+
+    [Fact]
+    public void IsFacadeOnlyAssembly_SystemTextJson_ReturnsFalse()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Text.Json");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Text.Json not available: {error}");
+            return;
+        }
+
+        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+    }
+
+    [Fact]
     public void ResolveFramework_UnknownFramework_ReturnsError()
     {
         var (refPath, version, error) = PlatformResolver.ResolveFramework("unknownframework");

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -130,6 +130,18 @@ public static class RouterCommandDefinition
 
         if (resolvedPath != null && resolvedError == null)
         {
+            if (PlatformResolver.IsFacadeOnlyAssembly(resolvedPath))
+            {
+                var facadeRouteExitCode = await TryExecuteTypeOrMemberAsync(
+                    route,
+                    opts,
+                    parseResult,
+                    commandArgs,
+                    allowPlatformPrefixFallback: false);
+                if (facadeRouteExitCode.HasValue)
+                    return facadeRouteExitCode.Value;
+            }
+
             var assemblyExitCode = await LibraryCommand.ExecuteAsync(route.Options);
 
             if (assemblyExitCode == 0 && !route.Options.FormatExplicitlySet && !route.Options.IsRawOutput)
@@ -142,55 +154,14 @@ public static class RouterCommandDefinition
             return assemblyExitCode;
         }
 
-        var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(route.BareName, allowPlatformPrefixFallback: true);
-        if (memberSplit != null)
-        {
-            var memberOptions = BuildMemberOptions(
-                memberSplit.Value.Probe,
-                memberSplit.Value.MemberName,
-                opts,
-                parseResult,
-                commandArgs);
-            return await MemberCommand.ExecuteAsync(memberOptions);
-        }
-
-        // Platform resolution failed - check if this is a qualified type name
-        // e.g., System.Text.Json.JsonSerializer -> type JsonSerializer --platform System.Text.Json
-        // Probes exact local types first, then keeps a platform prefix for typo-friendly type suggestions.
-        var probe = SourceResolver.TryResolveQualifiedTypeName(route.BareName, allowPlatformPrefixFallback: true);
-        if (probe != null)
-        {
-            var typeOptions = new TypeOptions
-            {
-                TypeName = probe.Remainder,
-                PlatformAssembly = probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
-                PackagePath = probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
-                JsonOutput = route.Options.JsonOutput,
-                PlainText = route.Options.Format == OutputFormat.PlainText,
-                OneLine = route.OneLine,
-                Tsv = route.Options.Tsv,
-                Jsonl = route.Options.Jsonl,
-                OneLineExplicitlySet = route.Options.OneLineExplicitlySet,
-                FormatExplicitlySet = route.Options.FormatExplicitlySet,
-                MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
-                NoHeader = route.NoHeader,
-                CompactJson = parseResult.GetValue(commandArgs.CompactOption),
-                Verbose = route.Options.Verbose,
-                Verbosity = route.Verbosity,
-                IncludeSections = null,
-                Discover = route.Options.Discover,
-                Tree = route.Options.Tree,
-                Select = route.Options.Select,
-                Columns = route.Options.Columns,
-                Fields = route.Options.Fields,
-                Count = route.Options.Count,
-                Schema = opts.ParseSchema(parseResult),
-                SourceOptions = route.Options.SourceOptions,
-                TipLevel = route.Options.FormatExplicitlySet || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null ? TipLevel.Quiet : opts.ParseTipLevel(parseResult)
-            };
-
-            return await ApiCommand.ExecuteAsync(typeOptions);
-        }
+        var routedExitCode = await TryExecuteTypeOrMemberAsync(
+            route,
+            opts,
+            parseResult,
+            commandArgs,
+            allowPlatformPrefixFallback: true);
+        if (routedExitCode.HasValue)
+            return routedExitCode.Value;
 
         // Fall through to package command.
         // Names like "System.CommandLine" are platform candidates (because they start with "System.")
@@ -227,6 +198,72 @@ public static class RouterCommandDefinition
             TipWriter.WritePackageTips(route.BareName, tipLevel, options.Verbosity);
 
         return exitCode;
+    }
+
+    private static async Task<int?> TryExecuteTypeOrMemberAsync(
+        RouterOptionsParser.RouteToPlatformLibrary route,
+        SharedOptions opts,
+        ParseResult parseResult,
+        RouterOptionsParser.RouterCommandArgs commandArgs,
+        bool allowPlatformPrefixFallback)
+    {
+        var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(route.BareName, allowPlatformPrefixFallback);
+        if (memberSplit != null)
+        {
+            var memberOptions = BuildMemberOptions(
+                memberSplit.Value.Probe,
+                memberSplit.Value.MemberName,
+                opts,
+                parseResult,
+                commandArgs);
+            return await MemberCommand.ExecuteAsync(memberOptions);
+        }
+
+        // e.g., System.Text.Json.JsonSerializer -> type JsonSerializer --platform System.Text.Json.
+        // Prefix fallback is only for unresolved platform candidates, where it preserves typo suggestions.
+        var probe = SourceResolver.TryResolveQualifiedTypeName(route.BareName, allowPlatformPrefixFallback);
+        if (probe == null)
+            return null;
+
+        var typeOptions = BuildTypeOptions(route, probe, opts, parseResult, commandArgs);
+        return await ApiCommand.ExecuteAsync(typeOptions);
+    }
+
+    private static TypeOptions BuildTypeOptions(
+        RouterOptionsParser.RouteToPlatformLibrary route,
+        SourceResolver.LocalProbeResult probe,
+        SharedOptions opts,
+        ParseResult parseResult,
+        RouterOptionsParser.RouterCommandArgs commandArgs)
+    {
+        return new TypeOptions
+        {
+            TypeName = probe.Remainder,
+            PlatformAssembly = probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
+            PackagePath = probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
+            JsonOutput = route.Options.JsonOutput,
+            PlainText = route.Options.Format == OutputFormat.PlainText,
+            OneLine = route.OneLine,
+            Tsv = route.Options.Tsv,
+            Jsonl = route.Options.Jsonl,
+            OneLineExplicitlySet = route.Options.OneLineExplicitlySet,
+            FormatExplicitlySet = route.Options.FormatExplicitlySet,
+            MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
+            NoHeader = route.NoHeader,
+            CompactJson = parseResult.GetValue(commandArgs.CompactOption),
+            Verbose = route.Options.Verbose,
+            Verbosity = route.Verbosity,
+            IncludeSections = null,
+            Discover = route.Options.Discover,
+            Tree = route.Options.Tree,
+            Select = route.Options.Select,
+            Columns = route.Options.Columns,
+            Fields = route.Options.Fields,
+            Count = route.Options.Count,
+            Schema = opts.ParseSchema(parseResult),
+            SourceOptions = route.Options.SourceOptions,
+            TipLevel = route.Options.FormatExplicitlySet || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null ? TipLevel.Quiet : opts.ParseTipLevel(parseResult)
+        };
     }
 
     private static async Task<int> ExecuteVersionQueryAsync(


### PR DESCRIPTION
Fixes #509.

## Summary
- add cheap metadata-only facade-only platform assembly detection
- route facade platform bare names through exact type/member probing before library fallback
- preserve direct library routing for non-facade platform assemblies such as System.Text.Json

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/DotnetInspector.Services.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- System.Runtime.CompilerServices.Unsafe --markdown -v:q --tips q
- dotnet run --project src/dotnet-inspect -c Release -- System.Text.Json --markdown -v:q --tips q