### PR TITLE
Add type prefix browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 Single-type `type X` output is tree-shaped by default. Use `-v:n` or `-v:d`
 to grow that tree to overload leaves; use `--markdown -v:q` when you want the
 compact Markdown section view instead.
+When an exact type is not found, `type` treats the query as a best-effort
+namespace/type prefix browse within the resolved package, library, or platform
+scope.
 
 ## Signals
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -278,6 +278,92 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_PrefixBrowse_InferredPlatformTypo_ListsBestEffortMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Runtime.CompilerService", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort prefix matches", error);
+        Assert.Contains("System.Runtime.CompilerService", error);
+        Assert.Contains("System.Runtime.CompilerServices.CompilerGeneratedAttribute", output);
+    }
+
+    [Fact]
+    public async Task Router_PrefixBrowse_InferredPlatformTypo_ListsBestEffortMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Runtime.CompilerService", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort prefix matches", error);
+        Assert.Contains("System.Runtime.CompilerService", error);
+        Assert.Contains("System.Runtime.CompilerServices.CompilerGeneratedAttribute", output);
+    }
+
+    [Fact]
+    public async Task Router_ExactPlatformAssembly_StillRoutesToLibrary()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Runtime", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Field", output);
+        Assert.Contains("Value", output);
+        Assert.Contains("Name", output);
+        Assert.Contains("System.Runtime", output);
+        Assert.Contains("Type Forwarders", output);
+    }
+
+    [Fact]
+    public async Task Type_PrefixBrowse_ExplicitPlatformNamespace_ListsBestEffortMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text.Json.Serialization", "--platform", "System.Text.Json", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort prefix matches", error);
+        Assert.Contains("System.Text.Json.Serialization", error);
+        Assert.Contains("System.Text.Json.Serialization.JsonConverter", output);
+    }
+
+    [Fact]
+    public async Task Type_PrefixBrowse_ExplicitLibraryNamespace_ListsBestEffortMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "DotnetInspector.Tests.Sample", "--library", TestAssemblyPath, "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort prefix matches", error);
+        Assert.Contains("DotnetInspector.Tests.Sample", error);
+        Assert.Contains("DotnetInspector.Tests.SampleClassForTesting", output);
+        Assert.Contains("DotnetInspector.Tests.SampleGenericClass", output);
+    }
+
+    [Fact]
+    public async Task Type_PrefixBrowse_ExplicitPackageNamespace_ListsBestEffortMatches()
+    {
+        var (packagePath, tempDir) = CreateLocalPrimaryLibPackage();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "type", "DotnetInspector.Tests.Sample", "--package", packagePath,
+                "--library", "Test.Primary.dll", "--table", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("best-effort prefix matches", error);
+            Assert.Contains("DotnetInspector.Tests.Sample", error);
+            Assert.Contains("DotnetInspector.Tests.SampleClassForTesting", output);
+            Assert.Contains("DotnetInspector.Tests.SampleGenericClass", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Type_SingleType_SelectSection_RendersSectionNotShape()
     {
         var options = new TypeOptions

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Commands;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
@@ -188,6 +189,11 @@ public class FindCommandTests
 [Collection("Console")]
 public class FindCommandIntegrationTests
 {
+    public FindCommandIntegrationTests()
+    {
+        NuGetCache.Initialize("dotnet-inspect");
+    }
+
     // ── Framework coverage tests ─────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -239,6 +239,7 @@ public static class RouterCommandDefinition
         return new TypeOptions
         {
             TypeName = probe.Remainder,
+            OriginalTypeQuery = route.BareName,
             PlatformAssembly = probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
             PackagePath = probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
             JsonOutput = route.Options.JsonOutput,
@@ -350,6 +351,12 @@ public static class RouterCommandDefinition
         var typeOptions = new TypeOptions
         {
             TypeName = source.TypeName,
+            OriginalTypeQuery = route.Args.Length switch
+            {
+                1 => route.Args[0],
+                >= 2 => route.Args[1],
+                _ => source.TypeName
+            },
             PackagePath = source.PackagePath,
             PlatformAssembly = source.PlatformAssembly,
             PlatformFramework = source.FrameworkOverride,

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -112,6 +112,7 @@ public static class TypeOptionsParser
         var options = new TypeOptions
         {
             TypeName = source.TypeName,
+            OriginalTypeQuery = GetOriginalTypeQuery(sourceSelection, source.TypeName),
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
@@ -158,5 +159,21 @@ public static class TypeOptionsParser
         };
 
         return new Success(options);
+    }
+
+    private static string? GetOriginalTypeQuery(SharedParsers.SourceSelection sourceSelection, string? resolvedTypeName)
+    {
+        if (string.IsNullOrEmpty(resolvedTypeName))
+            return null;
+
+        if (sourceSelection.HasExplicitSource)
+            return sourceSelection.Args.FirstOrDefault();
+
+        return sourceSelection.Args.Length switch
+        {
+            1 => sourceSelection.Args[0],
+            >= 2 => sourceSelection.Args[1],
+            _ => resolvedTypeName
+        };
     }
 }

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -46,6 +46,7 @@ public static class TypeCommand
         var selectedTfm = source.SelectedTfm;
         var tempDir = source.TempDir;
         var typeName = source.TypeName;
+        var originalTypeQuery = options.OriginalTypeQuery ?? options.TypeName;
         var context = source.Context;
         var logger = context.Logger;
 
@@ -311,48 +312,48 @@ public static class TypeCommand
                         Hints.WriteTips(effectiveOptions.TipLevel, [.. tips]);
                     }
                 }
-                else if (lookupResult.Suggestions.Count > 0)
+                else if (!TryWritePrefixBrowse(
+                    api,
+                    apiDllPath,
+                    originalTypeQuery,
+                    typeName,
+                    packageName,
+                    apiSource,
+                    apiVersion,
+                    selectedTfm,
+                    options))
                 {
-                    bool isGlob = typeName.Contains('*') || typeName.Contains('?');
-                    if (isGlob)
+                    if (lookupResult.Suggestions.Count > 0)
                     {
-                        // Glob matched multiple types — show types view with filter
-                        if (!string.IsNullOrEmpty(options.PackagePath))
+                        bool isGlob = typeName.Contains('*') || typeName.Contains('?');
+                        if (isGlob)
                         {
-                            var (pkgName, _) = PackageExtractor.ParsePackageReference(options.PackagePath);
-                            api.Name = pkgName;
-                        }
-                        else if (apiDllPath != null)
-                        {
-                            api.Name = Path.GetFileNameWithoutExtension(apiDllPath);
-                        }
-                        api.Tfm = selectedTfm;
-                        api.Source = apiSource;
-                        api.Version = apiVersion;
-                        api.Library = apiDllPath != null ? Path.GetFileName(apiDllPath) : null;
+                            // Glob matched multiple types — show types view with filter
+                            AnnotateSurface(api, options, apiDllPath, packageName, apiSource, apiVersion, selectedTfm);
 
-                        options = options with
-                        {
-                            TypeFilter = typeName,
-                            Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
-                        };
+                            options = options with
+                            {
+                                TypeFilter = typeName,
+                                Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
+                            };
 
-                        ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                            ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
+                            Console.Error.WriteLine();
+                            Console.Error.WriteLine("Did you mean:");
+                            foreach (var s in lookupResult.Suggestions)
+                                Console.Error.WriteLine($"  {s}");
+                            return 1;
+                        }
                     }
                     else
                     {
                         Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                        Console.Error.WriteLine();
-                        Console.Error.WriteLine("Did you mean:");
-                        foreach (var s in lookupResult.Suggestions)
-                            Console.Error.WriteLine($"  {s}");
                         return 1;
                     }
-                }
-                else
-                {
-                    Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                    return 1;
                 }
             }
 
@@ -394,4 +395,87 @@ public static class TypeCommand
            && !options.Count
            && !options.HasSectionQuery
            && options.Verbosity == Verbosity.Quiet;
+
+    private static bool TryWritePrefixBrowse(
+        ApiSurface api,
+        string? apiDllPath,
+        string? originalTypeQuery,
+        string resolvedTypeName,
+        string? packageName,
+        string? apiSource,
+        string? apiVersion,
+        string? selectedTfm,
+        TypeOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(originalTypeQuery))
+            return false;
+        if (originalTypeQuery.Contains('*') || originalTypeQuery.Contains('?'))
+            return false;
+
+        var matches = FindPrefixMatches(api.Types, originalTypeQuery);
+        if (matches.Count == 0)
+            return false;
+
+        api.Types = matches;
+        RecomputeSurfaceCounts(api);
+        AnnotateSurface(api, options, apiDllPath, packageName, apiSource, apiVersion, selectedTfm);
+
+        var browseOptions = options with
+        {
+            TypeFilter = null,
+            ShapeOutput = false,
+            ShapeExplicitlySet = false,
+            Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
+        };
+
+        Console.Error.WriteLine($"Note: Type '{resolvedTypeName}' not found. Showing best-effort prefix matches for '{originalTypeQuery}'.");
+        ApiCommand.WriteFullApiOutput(api, browseOptions, selectedTfm);
+        return true;
+    }
+
+    private static List<ApiType> FindPrefixMatches(IEnumerable<ApiType> types, string query)
+    {
+        var normalized = TypeMatcher.Normalize(query.Trim());
+        return types
+            .Where(type => IsPrefixMatch(type.FullName, normalized) || IsPrefixMatch(type.Name, normalized))
+            .ToList();
+    }
+
+    private static bool IsPrefixMatch(string candidate, string prefix)
+        => candidate.Length > prefix.Length
+           && candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+
+    private static void AnnotateSurface(
+        ApiSurface api,
+        TypeOptions options,
+        string? apiDllPath,
+        string? packageName,
+        string? apiSource,
+        string? apiVersion,
+        string? selectedTfm)
+    {
+        if (!string.IsNullOrEmpty(options.PackagePath))
+        {
+            var (pkgName, _) = PackageExtractor.ParsePackageReference(options.PackagePath);
+            api.Name = pkgName;
+        }
+        else if (apiDllPath != null)
+        {
+            api.Name = Path.GetFileNameWithoutExtension(apiDllPath);
+        }
+
+        api.Tfm = selectedTfm;
+        api.Source = apiSource;
+        api.Version = apiVersion;
+        api.Library = apiDllPath != null ? Path.GetFileName(apiDllPath) : null;
+    }
+
+    private static void RecomputeSurfaceCounts(ApiSurface api)
+    {
+        api.PublicTypeCount = api.Types.Count;
+        api.PublicMethodCount = api.Types.Sum(t => t.Members.Count(ApiMemberSectionDescriptors.IsMethodLike));
+        api.PublicPropertyCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "property"));
+        api.PublicFieldCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "field"));
+        api.PublicEventCount = api.Types.Sum(t => t.Members.Count(m => m.Kind == "event"));
+    }
 }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -122,6 +122,7 @@ public partial record ApiOptions
 public record TypeOptions : ApiOptions
 {
     public string? TypeFilter { get; init; }
+    public string? OriginalTypeQuery { get; init; }
     public bool ShapeOutput { get; init; }
     public bool MarkdownExplicitlySet { get; init; }
 


### PR DESCRIPTION
## Summary
- let `type` fall back to best-effort namespace/type prefix browsing when exact type lookup misses
- preserve the original query through explicit source and bare-router flows so low-level framework namespace probes remain useful
- add prefix browsing coverage for inferred platform, explicit platform, library, package, and bare-router scenarios
- initialize NuGet cache in find integration tests to avoid global cache state races
- document the new `type` fallback behavior

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- targeted prefix/router xUnit executable tests
- npx markdownlint-cli README.md