### PR TITLE
Add workflow section categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ Sections and fields are queryable without a template language:
 dotnet-inspect library System.Net.Security -S "Async*"
 dotnet-inspect member JsonSerializer --package System.Text.Json -D
 dotnet-inspect member JsonSerializer --package System.Text.Json -D --schema
+dotnet-inspect member JsonSerializer --package System.Text.Json -S @MemberIndex
 dotnet-inspect type --package System.Text.Json --columns Kind,Name
 dotnet-inspect library System.Text.Json -S Symbols --fields "PDB*;SourceLink"
-dotnet-inspect library System.Text.Json -S "Unsafe Members"
+dotnet-inspect library System.Text.Json -S @Audit
 dotnet-inspect library System.Text.Json -S "Async*" --count
 dotnet-inspect package Microsoft.Extensions.Logging.Abstractions --library -S Integrations
 dotnet-inspect library Microsoft.Extensions.Logging.Abstractions -S Integrations
@@ -114,7 +115,7 @@ dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S Signals
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` and `@MemberIndex` expand to scenario-focused section groups.
 
 ## Common examples
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Sections and fields are queryable without a template language:
 dotnet-inspect library System.Net.Security -S "Async*"
 dotnet-inspect member JsonSerializer --package System.Text.Json -D
 dotnet-inspect member JsonSerializer --package System.Text.Json -D --schema
-dotnet-inspect member JsonSerializer --package System.Text.Json -S @MemberIndex
 dotnet-inspect type --package System.Text.Json --columns Kind,Name
 dotnet-inspect library System.Text.Json -S Symbols --fields "PDB*;SourceLink"
 dotnet-inspect library System.Text.Json -S @Audit
@@ -115,7 +114,7 @@ dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S Signals
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` and `@MemberIndex` expand to scenario-focused section groups.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` expand to scenario-focused section groups.
 
 ## Common examples
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -53,12 +53,11 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D --t
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D "Method Groups" --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -D Methods --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature"
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -S @MemberIndex
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
 
-`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Workflow categories such as `@Audit` and `@MemberIndex`, plus focused categories such as `@Integrations` and `@Switches`, expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
+`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Workflow categories such as `@Audit`, plus focused categories such as `@Integrations` and `@Switches`, expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
 
 ## General tips
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,6 +25,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect members and overloads | `member Type --package Foo -m Name --show-index` | Use `Name:N` selectors for a specific overload. |
 | Compare API versions | `diff --package Foo@old..new --breaking` | Use `--additive` for new APIs or `-t Type` to narrow. |
 | Locate source or implementation | `source Type --package Foo` | For a selected overload use `member Type Member:1 -S "Original Source"`, `-S Calls`, or `-S IL`. |
+| Audit unsafe calls | `library MyLib.dll -S @Audit` | Drill into a selected member with `member Type Method:N --library MyLib.dll -S @Audit`. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package, platform, or project scope as needed. |
 
 ## Output modes
@@ -123,6 +124,18 @@ dnx dotnet-inspect -y -- type Stack --platform System.Collections -S "Decompiled
 Fidelity expectations: `Original Source` is the SourceLink-backed original source when available. `Decompiled Source` is lowered C#, a best-effort readable reconstruction from IL that helps explain intent; it uses PDB debug information such as local names when available, but is not guaranteed to match original syntax or compiler transformations. Raw IL and annotated IL are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.
+
+## Unsafe call audit workflow
+
+Start with the library/type roll-up, then drill into a selected overload for exact evidence.
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
+dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S @Audit
+dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S "Calls,IL"
+```
+
+At library/type scope, `@Audit` surfaces unsafe members, P/Invoke, and switch evidence. On a selected member, `@Audit` expands to signature, direct calls, unsafe operations, and IL; use the `IL` offsets and metadata tokens to confirm the exact binary evidence.
 
 ## Package, library, integrations, and Signals workflow
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -53,11 +53,12 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D --t
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -D "Method Groups" --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -D Methods --tsv
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize -S Methods --columns "Name;Signature"
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -S @MemberIndex
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
 
-`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Categories such as `@Integrations` and `@Switches` expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
+`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Workflow categories such as `@Audit` and `@MemberIndex`, plus focused categories such as `@Integrations` and `@Switches`, expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
 
 ## General tips
 
@@ -109,7 +110,7 @@ Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
-dnx dotnet-inspect -y -- library MyLib.dll -S "Unsafe Members"
+dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
 ```
 
 A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source`, `IL`, or `IL (Annotated)` when you need specific implementation evidence.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2150,6 +2150,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_DiscoverAuditCategory_ListsAuditWorkflowSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-D", "@Audit", "--table");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Switches", output);
+        Assert.DoesNotContain("Signals", output);
+        Assert.DoesNotContain("Integrations", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
     public async Task LibraryCommand_IntegrationOpportunities_ForAwsS3_ShowsCloudClientSuggestions()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -470,6 +470,21 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void LibraryPipeline_AuditCategory_MapsToAuditWorkflowSections()
+    {
+        var categories = LibrarySections.CreatePipeline().GetCategoryMap();
+
+        Assert.True(categories.TryGetValue(SectionCategoryNames.Audit, out var sections));
+        Assert.Equal(
+            [
+                SectionNames.UnsafeMembers,
+                "P/Invoke Methods",
+                "Switches"
+            ],
+            sections);
+    }
+
+    [Fact]
     public void LibraryPipeline_TargetedSection_OnlyRequiredScanner()
     {
         var pipeline = LibrarySections.CreatePipeline();
@@ -1288,12 +1303,51 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void ApiMemberPipeline_WorkflowCategories_MapToTypeLevelAuditAndIndexSections()
+    {
+        var categories = ApiMemberSectionDescriptors.CreatePipeline().GetCategoryMap();
+
+        Assert.Equal([SectionNames.UnsafeMembers], categories[SectionCategoryNames.Audit]);
+        Assert.Equal(
+            [
+                SectionNames.Constructors,
+                SectionNames.Fields,
+                SectionNames.Properties,
+                SectionNames.MethodGroups,
+                SectionNames.Operators,
+                SectionNames.ExplicitInterfaceImplementations,
+                SectionNames.ExtensionMethods,
+                SectionNames.Events
+            ],
+            categories[SectionCategoryNames.MemberIndex]);
+    }
+
+    [Fact]
     public void ApiMemberOverloadPipeline_InfoPreset_UsesMethods()
     {
         var pipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
 
         Assert.Contains("Methods", pipeline.InfoSectionNames);
         Assert.DoesNotContain("Method Groups", pipeline.InfoSectionNames);
+    }
+
+    [Fact]
+    public void ApiMemberOverloadPipeline_MemberIndexCategory_UsesOverloadRows()
+    {
+        var categories = ApiMemberOverloadSectionDescriptors.CreatePipeline().GetCategoryMap();
+
+        Assert.Equal(
+            [
+                SectionNames.Constructors,
+                SectionNames.Fields,
+                SectionNames.Properties,
+                SectionNames.Methods,
+                SectionNames.Operators,
+                SectionNames.ExplicitInterfaceImplementations,
+                SectionNames.ExtensionMethods,
+                SectionNames.Events
+            ],
+            categories[SectionCategoryNames.MemberIndex]);
     }
 
     [Fact]
@@ -1330,5 +1384,20 @@ public class SectionPipelineTests
         var pipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
 
         Assert.Equal(["Signature", "Decompiled Source"], pipeline.InfoSectionNames);
+    }
+
+    [Fact]
+    public void ApiMemberDetailPipeline_AuditCategory_MapsToSelectedMemberEvidenceSections()
+    {
+        var categories = ApiMemberDetailSectionDescriptors.CreatePipeline().GetCategoryMap();
+
+        Assert.Equal(
+            [
+                SectionNames.Signature,
+                SectionNames.Calls,
+                SectionNames.UnsafeOperations,
+                SectionNames.IL
+            ],
+            categories[SectionCategoryNames.Audit]);
     }
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1303,51 +1303,12 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void ApiMemberPipeline_WorkflowCategories_MapToTypeLevelAuditAndIndexSections()
-    {
-        var categories = ApiMemberSectionDescriptors.CreatePipeline().GetCategoryMap();
-
-        Assert.Equal([SectionNames.UnsafeMembers], categories[SectionCategoryNames.Audit]);
-        Assert.Equal(
-            [
-                SectionNames.Constructors,
-                SectionNames.Fields,
-                SectionNames.Properties,
-                SectionNames.MethodGroups,
-                SectionNames.Operators,
-                SectionNames.ExplicitInterfaceImplementations,
-                SectionNames.ExtensionMethods,
-                SectionNames.Events
-            ],
-            categories[SectionCategoryNames.MemberIndex]);
-    }
-
-    [Fact]
     public void ApiMemberOverloadPipeline_InfoPreset_UsesMethods()
     {
         var pipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
 
         Assert.Contains("Methods", pipeline.InfoSectionNames);
         Assert.DoesNotContain("Method Groups", pipeline.InfoSectionNames);
-    }
-
-    [Fact]
-    public void ApiMemberOverloadPipeline_MemberIndexCategory_UsesOverloadRows()
-    {
-        var categories = ApiMemberOverloadSectionDescriptors.CreatePipeline().GetCategoryMap();
-
-        Assert.Equal(
-            [
-                SectionNames.Constructors,
-                SectionNames.Fields,
-                SectionNames.Properties,
-                SectionNames.Methods,
-                SectionNames.Operators,
-                SectionNames.ExplicitInterfaceImplementations,
-                SectionNames.ExtensionMethods,
-                SectionNames.Events
-            ],
-            categories[SectionCategoryNames.MemberIndex]);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -48,6 +48,28 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
+    public async Task MemberAuditCategory_RendersSelectedMemberEvidenceSections()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            MemberFilter = [nameof(SampleUnsafeClass.UnsafePointerMethod)],
+            OverloadIndex = 1,
+            Select = [SectionCategoryNames.Audit],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Signature", result.Output);
+        Assert.Contains("## Unsafe Operations", result.Output);
+        Assert.Contains("## IL", result.Output);
+        Assert.DoesNotContain("## Decompiled Source", result.Output);
+    }
+
+    [Fact]
     public async Task MemberUnsafeOperations_DiscoverListsColumns()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -174,6 +196,24 @@ public class UnsafeMembersSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("Unsafe Members\tsection", result.Output);
+    }
+
+    [Fact]
+    public async Task MemberIndexCategory_RendersMemberIndexSections()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(SampleUnsafeClass).FullName,
+            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
+            Select = [SectionCategoryNames.MemberIndex],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Method Groups", result.Output);
+        Assert.DoesNotContain("## Unsafe Members", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -199,24 +199,6 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
-    public async Task MemberIndexCategory_RendersMemberIndexSections()
-    {
-        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
-        {
-            TypeName = typeof(SampleUnsafeClass).FullName,
-            AssemblyPath = typeof(SampleUnsafeClass).Assembly.Location,
-            Select = [SectionCategoryNames.MemberIndex],
-            TipLevel = TipLevel.Quiet,
-            Verbosity = Verbosity.Minimal,
-            FormatExplicitlySet = true,
-        }));
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Contains("## Method Groups", result.Output);
-        Assert.DoesNotContain("## Unsafe Members", result.Output);
-    }
-
-    [Fact]
     public async Task MemberTypeUnsafeMembers_FiltersToSelectedType()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -94,7 +94,17 @@ public static class ApiMemberSectionDescriptors
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<ILBody>()
-            .Add<AnnotatedIL>();
+            .Add<AnnotatedIL>()
+            .AddCategory(SectionCategoryNames.Audit, SectionNames.UnsafeMembers)
+            .AddCategory(SectionCategoryNames.MemberIndex,
+                SectionNames.Constructors,
+                SectionNames.Fields,
+                SectionNames.Properties,
+                SectionNames.MethodGroups,
+                SectionNames.Operators,
+                SectionNames.ExplicitInterfaceImplementations,
+                SectionNames.ExtensionMethods,
+                SectionNames.Events);
     }
 
     // ===== Declarative sections (rendered via Markout [MarkoutSection]) =====
@@ -349,7 +359,16 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.OriginalSource>()
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
-            .Add<ApiMemberSectionDescriptors.AnnotatedIL>();
+            .Add<ApiMemberSectionDescriptors.AnnotatedIL>()
+            .AddCategory(SectionCategoryNames.MemberIndex,
+                SectionNames.Constructors,
+                SectionNames.Fields,
+                SectionNames.Properties,
+                SectionNames.Methods,
+                SectionNames.Operators,
+                SectionNames.ExplicitInterfaceImplementations,
+                SectionNames.ExtensionMethods,
+                SectionNames.Events);
     }
 
     public sealed class Methods : ISectionDescriptor<ApiType>
@@ -379,7 +398,12 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<Calls>()
             .Add<UnsafeOperations>()
             .Add<ILBody>()
-            .Add<AnnotatedIL>();
+            .Add<AnnotatedIL>()
+            .AddCategory(SectionCategoryNames.Audit,
+                SectionNames.Signature,
+                SectionNames.Calls,
+                SectionNames.UnsafeOperations,
+                SectionNames.IL);
     }
 
     public sealed class Summary : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -95,16 +95,7 @@ public static class ApiMemberSectionDescriptors
             .Add<OriginalSource>()
             .Add<ILBody>()
             .Add<AnnotatedIL>()
-            .AddCategory(SectionCategoryNames.Audit, SectionNames.UnsafeMembers)
-            .AddCategory(SectionCategoryNames.MemberIndex,
-                SectionNames.Constructors,
-                SectionNames.Fields,
-                SectionNames.Properties,
-                SectionNames.MethodGroups,
-                SectionNames.Operators,
-                SectionNames.ExplicitInterfaceImplementations,
-                SectionNames.ExtensionMethods,
-                SectionNames.Events);
+            .AddCategory(SectionCategoryNames.Audit, SectionNames.UnsafeMembers);
     }
 
     // ===== Declarative sections (rendered via Markout [MarkoutSection]) =====
@@ -359,16 +350,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.OriginalSource>()
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
-            .Add<ApiMemberSectionDescriptors.AnnotatedIL>()
-            .AddCategory(SectionCategoryNames.MemberIndex,
-                SectionNames.Constructors,
-                SectionNames.Fields,
-                SectionNames.Properties,
-                SectionNames.Methods,
-                SectionNames.Operators,
-                SectionNames.ExplicitInterfaceImplementations,
-                SectionNames.ExtensionMethods,
-                SectionNames.Events);
+            .Add<ApiMemberSectionDescriptors.AnnotatedIL>();
     }
 
     public sealed class Methods : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -61,6 +61,10 @@ public static class LibrarySections
             .Add<CustomAttributes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
+            .AddCategory(SectionCategoryNames.Audit,
+                SectionNames.UnsafeMembers,
+                "P/Invoke Methods",
+                "Switches")
             .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities"])
             .AddCategory("@Switches", "Switches");
     }

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -1,0 +1,10 @@
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Well-known section category names used by <c>-S</c> and <c>-D</c>.
+/// </summary>
+public static class SectionCategoryNames
+{
+    public const string Audit = "@Audit";
+    public const string MemberIndex = "@MemberIndex";
+}

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -6,5 +6,4 @@ namespace DotnetInspector.Sections;
 public static class SectionCategoryNames
 {
     public const string Audit = "@Audit";
-    public const string MemberIndex = "@MemberIndex";
 }


### PR DESCRIPTION
Add @Audit and @MemberIndex category presets for audit and member-index workflows, plus tests and docs covering the new scenario-oriented selectors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
