### PR TITLE
Fix nested type display

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -24,19 +24,21 @@ public static class ApiSurfaceExtractor
             if (!typeDef.IsPublic)
                 continue;
 
-            string typeName = reader.GetString(typeDef.Name);
+            string metadataName = reader.GetString(typeDef.Name);
 
             // Skip compiler-generated types
-            if (typeName.StartsWith("<") || typeName.StartsWith("__"))
+            if (metadataName.StartsWith("<") || metadataName.StartsWith("__"))
                 continue;
 
             // Skip EditorBrowsable(Never) and Obsolete types unless --all
             if (!includeAll && AttributeReader.HasHiddenAttribute(reader, typeDef.GetCustomAttributes()))
                 continue;
 
+            var (typeNamespace, typeName) = GetApiTypeNameParts(reader, typeDef);
+
             var apiType = new ApiType
             {
-                Namespace = reader.GetString(typeDef.Namespace),
+                Namespace = typeNamespace,
                 Name = typeName,
                 IsSealed = (attributes & TypeAttributes.Sealed) != 0,
                 IsAbstract = (attributes & TypeAttributes.Abstract) != 0,
@@ -438,6 +440,28 @@ public static class ApiSurfaceExtractor
         }
 
         return surface;
+    }
+
+    private static (string? Namespace, string Name) GetApiTypeNameParts(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var fullName = reader.GetFullTypeName(typeDef);
+        var rootNamespace = GetRootNamespace(reader, typeDef);
+        if (rootNamespace.Length == 0)
+            return (null, fullName);
+
+        var prefix = rootNamespace + ".";
+        return fullName.StartsWith(prefix, StringComparison.Ordinal)
+            ? (rootNamespace, fullName[prefix.Length..])
+            : (rootNamespace, fullName);
+    }
+
+    private static string GetRootNamespace(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var declaringType = typeDef.GetDeclaringType();
+        if (!declaringType.IsNil)
+            return GetRootNamespace(reader, reader.GetTypeDefinition(declaringType));
+
+        return reader.GetString(typeDef.Namespace);
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(

--- a/src/ILInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/ILInspector.Metadata/MetadataReaderExtensions.cs
@@ -19,6 +19,10 @@ public static class MetadataReaderExtensions
         /// </summary>
         public string GetFullTypeName(TypeDefinition typeDef)
         {
+            var declaringType = typeDef.GetDeclaringType();
+            if (!declaringType.IsNil)
+                return $"{reader.GetFullTypeName(reader.GetTypeDefinition(declaringType))}.{reader.GetString(typeDef.Name)}";
+
             string ns = reader.GetString(typeDef.Namespace);
             string name = reader.GetString(typeDef.Name);
             return TypeResolver.GetFullName(ns, name);

--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -112,14 +112,33 @@ public static class TypeMatcher
     }
 
     /// <summary>
-    /// Gets the base name without generic arity suffix.
-    /// "List`1" → "List"
-    /// "Dictionary`2" → "Dictionary"
+    /// Gets the base name without generic arity suffixes.
+    /// "List`1" → "List"; "Dictionary`2.KeyCollection" → "Dictionary.KeyCollection".
     /// </summary>
     public static string GetBaseName(string typeName)
     {
         var backtickIdx = typeName.IndexOf('`');
-        return backtickIdx >= 0 ? typeName[..backtickIdx] : typeName;
+        if (backtickIdx < 0)
+            return typeName;
+
+        var result = new System.Text.StringBuilder(typeName.Length);
+        for (var i = 0; i < typeName.Length; i++)
+        {
+            if (typeName[i] != '`')
+            {
+                result.Append(typeName[i]);
+                continue;
+            }
+
+            i++;
+            while (i < typeName.Length && char.IsDigit(typeName[i]))
+                i++;
+
+            if (i < typeName.Length)
+                result.Append(typeName[i]);
+        }
+
+        return result.ToString();
     }
 
     /// <summary>
@@ -205,13 +224,14 @@ public static class TypeMatcher
         if (backtickIdx < 0)
             return 0;
 
-        var arityStr = typeName[(backtickIdx + 1)..];
-        // Handle cases like "List`1+Enumerator"
-        var plusIdx = arityStr.IndexOf('+');
-        if (plusIdx >= 0)
-            arityStr = arityStr[..plusIdx];
+        var digitStart = backtickIdx + 1;
+        var digitEnd = digitStart;
+        while (digitEnd < typeName.Length && char.IsDigit(typeName[digitEnd]))
+            digitEnd++;
 
-        return int.TryParse(arityStr, out var arity) ? arity : 0;
+        return digitEnd > digitStart && int.TryParse(typeName.AsSpan(digitStart, digitEnd - digitStart), out var arity)
+            ? arity
+            : 0;
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2928,7 +2928,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("## Integrations", output);
         Assert.Contains("| Dependency Injection | 4 |", output);
-        Assert.Contains("| HTTP Client | 10 |", output);
+        Assert.Contains("| HTTP Client | 11 |", output);
         Assert.DoesNotContain("OpenTelemetry", output);
         Assert.Contains("## HTTP Client", output);
         Assert.Contains("| Kind | API |", output);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1249,6 +1249,33 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task TypeListing_NestedTypes_ShowDeclaringTypeContext()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "--platform", "System.Collections", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection", output);
+        Assert.Contains("System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection", output);
+        Assert.Contains("System.Collections.Generic.Stack<T>.Enumerator", output);
+        Assert.DoesNotContain("class   KeyCollection", output);
+        Assert.DoesNotContain("struct  Enumerator", output);
+    }
+
+    [Fact]
+    public async Task TypeListing_NestedDelegate_ShowsFullDeclaringTypeContext()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text.Json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("`System.Text.Json.Serialization.Metadata.FSharpCoreReflectionProxy.StructGetter<TStruct, TResult>`", output);
+        Assert.DoesNotContain("| `StructGetter<TStruct, TResult>` |", output);
+    }
+
+    [Fact]
     public async Task Type_DecompiledSource_Enum_RendersValuesListing()
     {
         // Enums have no method bodies; the listing renders the declaration

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -29,6 +29,29 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void GetBaseName_WithNestedGenericType_PreservesNestedSuffix()
+    {
+        var result = TypeMatcher.GetBaseName("System.Collections.Generic.SortedDictionary`2.KeyCollection");
+        Assert.Equal("System.Collections.Generic.SortedDictionary.KeyCollection", result);
+    }
+
+    [Fact]
+    public void Matches_NestedGenericType_DoesNotMatchDeclaringType()
+    {
+        Assert.False(TypeMatcher.Matches(
+            "System.Collections.Generic.SortedDictionary`2",
+            "System.Collections.Generic.SortedDictionary<TKey,TValue>.KeyCollection"));
+    }
+
+    [Fact]
+    public void Matches_NestedGenericType_MatchesNestedType()
+    {
+        Assert.True(TypeMatcher.Matches(
+            "System.Collections.Generic.SortedDictionary`2.KeyCollection",
+            "System.Collections.Generic.SortedDictionary<TKey,TValue>.KeyCollection"));
+    }
+
+    [Fact]
     public void ApiType_FullName_WithNamespace_ReturnsFullName()
     {
         var type = new ApiType { Name = "JsonSerializer", Namespace = "System.Text.Json" };

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -92,7 +92,7 @@ public static class ApiOutputFormatter
                     desc = desc.ReplaceLineEndings(" ");
                     if (desc.Length > 80) desc = desc[..77] + "...";
                 }
-                return new TypeSummaryRow(group.Key, fullName, members, desc);
+                return new TypeSummaryRow(group.Key, MarkoutInline.Code(fullName), members, desc);
             }).ToList();
 
             switch (group.Key)
@@ -1296,21 +1296,44 @@ public static class ApiOutputFormatter
 
     internal static string FormatGenericTypeName(string name, List<TypeParameter>? typeParameters)
     {
+        if (!name.Contains('`'))
+            return name;
+
+        var typeParameterIndex = 0;
+        var segments = name.Split('.');
+        for (var i = 0; i < segments.Length; i++)
+            segments[i] = FormatGenericTypeNameSegment(segments[i], typeParameters, ref typeParameterIndex);
+
+        return string.Join(".", segments);
+    }
+
+    private static string FormatGenericTypeNameSegment(
+        string name,
+        List<TypeParameter>? typeParameters,
+        ref int typeParameterIndex)
+    {
         int backtickIndex = name.IndexOf('`');
         if (backtickIndex < 0)
             return name;
 
         var baseName = name[..backtickIndex];
-        if (typeParameters is { Count: > 0 })
-            return $"{baseName}<{string.Join(", ", typeParameters.Select(tp => tp.Name))}>";
+        if (!int.TryParse(name[(backtickIndex + 1)..], out int arity) || arity <= 0)
+            return name;
 
-        if (int.TryParse(name[(backtickIndex + 1)..], out int arity) && arity > 0)
+        if (typeParameters is { Count: > 0 } && typeParameterIndex + arity <= typeParameters.Count)
         {
-            var names = arity == 1 ? "T" : string.Join(", ", Enumerable.Range(1, arity).Select(i => $"T{i}"));
-            return $"{baseName}<{names}>";
+            var names = typeParameters
+                .Skip(typeParameterIndex)
+                .Take(arity)
+                .Select(tp => tp.Name);
+            typeParameterIndex += arity;
+            return $"{baseName}<{string.Join(", ", names)}>";
         }
 
-        return name;
+        var fallbackNames = arity == 1
+            ? "T"
+            : string.Join(", ", Enumerable.Range(1, arity).Select(i => $"T{i}"));
+        return $"{baseName}<{fallbackNames}>";
     }
 
     internal static string FormatGenericFullName(ApiType type)
@@ -1493,7 +1516,7 @@ public static class ApiOutputFormatter
                 }
                 return new ApiSurfaceOneLineRow(
                     t.Kind,
-                    FormatGenericFullName(t),
+                    MarkoutInline.Code(FormatGenericFullName(t)),
                     t.Members.Count.ToString(),
                     desc);
             })


### PR DESCRIPTION
## Summary
- preserve declaring-type context for public nested types in API surfaces
- keep type listings fully qualified while disambiguating nested rows such as `SortedDictionary<TKey, TValue>.KeyCollection`
- fix nested generic type matching so declaring-type queries do not match the parent type
- render Markdown type-list generics as code so generic brackets remain readable

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.TypeListing_NestedTypes_ShowDeclaringTypeContext -method DotnetInspector.Tests.CommandExecutionTests.TypeListing_NestedDelegate_ShowsFullDeclaringTypeContext -method DotnetInspector.Tests.DiffCommandTests.GetBaseName_WithNestedGenericType_PreservesNestedSuffix -method DotnetInspector.Tests.DiffCommandTests.Matches_NestedGenericType_DoesNotMatchDeclaringType -method DotnetInspector.Tests.DiffCommandTests.Matches_NestedGenericType_MatchesNestedType