### PR TITLE
Add facade library info

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -113,7 +113,8 @@ public class ApiSurface
     public List<TypeForwarder> TypeForwarders { get; set; } = [];
 
     /// <summary>
-    /// True if this assembly is a type-forwarding assembly (types resolved from target assemblies).
+    /// True if this assembly is a facade/type-forwarding assembly whose listed
+    /// types were resolved from target assemblies.
     /// </summary>
     public bool IsTypeForwardingAssembly { get; set; }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -364,6 +364,47 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task TypeListing_FacadePlatformLibrary_ShowsTypeForwardingDescription()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Runtime not available: {error}");
+            return;
+        }
+
+        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+            "System.Runtime is not facade-only in this runtime.");
+
+        var (exit, output, runError) = await RunAppAsync(
+            "type", "--platform", "System.Runtime", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.Contains("This is a type-forwarding library", output);
+    }
+
+    [Fact]
+    public async Task TypeListing_NonFacadePlatformLibrary_DoesNotShowTypeForwardingDescription()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Text.Json");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Text.Json not available: {error}");
+            return;
+        }
+
+        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+
+        var (exit, output, runError) = await RunAppAsync(
+            "type", "--platform", "System.Text.Json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.DoesNotContain("This is a type-forwarding library", output);
+    }
+
+    [Fact]
     public async Task Type_SingleType_SelectSection_RendersSectionNotShape()
     {
         var options = new TypeOptions
@@ -2053,6 +2094,58 @@ public class CommandExecutionTests
         Assert.DoesNotContain("## Extension Methods", output);
         Assert.DoesNotContain("## Resources", output);
         Assert.DoesNotContain("## Type Forwarders", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_PlatformFacade_LibraryInfoShowsFacadeAssemblyYes()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime.CompilerServices.Unsafe");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Runtime.CompilerServices.Unsafe not available: {error}");
+            return;
+        }
+
+        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+            "System.Runtime.CompilerServices.Unsafe is not facade-only in this runtime.");
+
+        var (exit, output, runError) = await RunAppAsync(
+            "library", "System.Runtime.CompilerServices.Unsafe", "-S", "Library Info", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.Contains("| Facade | Yes |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_PlatformNonFacade_LibraryInfoShowsFacadeAssemblyNo()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Text.Json");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Text.Json not available: {error}");
+            return;
+        }
+
+        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+
+        var (exit, output, runError) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Library Info", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.Contains("| Facade | No |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_NonPlatformLibraryInfo_DoesNotShowFacadeAssembly()
+    {
+        var (exit, output, runError) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Library Info", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runError);
+        Assert.DoesNotContain("| Facade |", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -433,7 +433,7 @@ internal static class ApiServices
 
         if (resolvedCount > 0)
         {
-            api.IsTypeForwardingAssembly = true;
+            api.IsTypeForwardingAssembly = PlatformResolver.IsFacadeOnlyAssembly(dllPath);
             api.PublicTypeCount = api.Types.Count;
             api.Types = api.Types.OrderBy(t => t.FullName).ToList();
             logger.Log($"Resolved {resolvedCount} types from forwarded libraries.");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -64,6 +64,7 @@ internal static class LibraryMetadataService
             {
                 FileName = Path.GetFileName(path),
                 FileType = "dll",
+                IsFacadeAssembly = isPlatformAssembly ? PlatformResolver.IsFacadeOnlyAssembly(path) : null,
                 UseDependenciesView = options.IncludeDependencies
             };
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -72,6 +72,12 @@ public class LibraryInspection
     public string? PlatformVersion { get; set; }
 
     /// <summary>
+    /// Whether a platform assembly is a facade-only assembly.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsFacadeAssembly { get; set; }
+
+    /// <summary>
     /// File last modified timestamp.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -134,6 +134,7 @@ public class LibraryInspectionView
         FileSize = _data.FileSize > 0 ? ByteSizeFormatter.FormatBytes(_data.FileSize) : null,
         InformationalVersion = info.InformationalVersion,
         Integrations = CountIntegrations(_data),
+        Facade = _data.IsFacadeAssembly,
         Methods = info.MethodDefinitionCount > 0 ? info.MethodDefinitionCount.ToString("N0") : null,
         Modified = _data.LastModified?.ToString("yyyy-MM-dd"),
         Name = info.AssemblyName,
@@ -750,6 +751,8 @@ public class LibraryInfoSection
     public string? FileSize { get; init; }
     public string? InformationalVersion { get; init; }
     public int Integrations { get; init; }
+    [MarkoutBoolFormat("Yes", "No")]
+    public bool? Facade { get; init; }
     public string? Methods { get; init; }
     public string? Modified { get; init; }
     public string? Name { get; init; }


### PR DESCRIPTION
## Summary
- add platform-only `Facade` Library Info field backed by facade-only metadata detection
- keep Type Forwarders as the separate has-forwarders count
- use the facade-only check for the type-listing "type-forwarding library" description

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_PlatformFacade_LibraryInfoShowsFacadeAssemblyYes -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_PlatformNonFacade_LibraryInfoShowsFacadeAssemblyNo -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_NonPlatformLibraryInfo_DoesNotShowFacadeAssembly -method DotnetInspector.Tests.CommandExecutionTests.TypeListing_FacadePlatformLibrary_ShowsTypeForwardingDescription -method DotnetInspector.Tests.CommandExecutionTests.TypeListing_NonFacadePlatformLibrary_DoesNotShowTypeForwardingDescription