### PR TITLE
Add platform namespace prefix browsing

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -63,6 +63,7 @@ dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ## General tips
 
 - Built-in aliases and common BCL types such as `string`, `int`, and `List<T>` resolve without `--package`, `--platform`, or `--library`; start with `type string` or `type 'List<T>'`.
+- `type` supports URL-like namespace probing: unresolved namespace-ish names such as `System.Text` produce best-effort prefix matches, while exact package/library/platform matches keep normal precedence.
 - After `find`, reuse the package/library it reports in follow-up commands. Use explicit `--platform`, `--package`, or `--library` when the source matters; for multi-library packages, include the `--library` value shown by `find`.
 - Always quote generic type names in shell commands: `type 'List<T>'`, `member 'Dictionary<TKey,TValue>'`, or `type 'INumber<TSelf>'`. Use `<T>` rather than `<>` for generic type queries.
 - Wildcards are supported for type names and section/schema selection; quote shell patterns, such as `type 'Json*' --package System.Text.Json`, `-S "Async*"`, or `-D "SourceLink*"`.
@@ -77,6 +78,7 @@ Use `find` when you do not know the package, library, or exact namespace.
 
 ```bash
 dnx dotnet-inspect -y -- find JsonSerializer
+dnx dotnet-inspect -y -- type System.Text
 dnx dotnet-inspect -y -- type JsonSerializer --package System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -m Serialize --show-index
 dnx dotnet-inspect -y -- depends Stream

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -302,6 +302,34 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_PlatformPrefixBrowse_UnresolvedNamespace_ListsPlatformMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort platform prefix matches", error);
+        Assert.Contains("System.Text", error);
+        Assert.Contains("System.Text.StringBuilder", output);
+        Assert.Contains("System.Text.Json.JsonSerializer", output);
+        Assert.DoesNotContain("Package 'System.Text' not found", error);
+    }
+
+    [Fact]
+    public async Task Router_PlatformPrefixBrowse_UnresolvedNamespace_ListsPlatformMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort platform prefix matches", error);
+        Assert.Contains("System.Text", error);
+        Assert.Contains("System.Text.StringBuilder", output);
+        Assert.Contains("System.Text.Json.JsonSerializer", output);
+        Assert.DoesNotContain("Package 'system.text' not found", error);
+    }
+
+    [Fact]
     public async Task Router_ExactPlatformAssembly_StillRoutesToLibrary()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -314,6 +342,19 @@ public class CommandExecutionTests
         Assert.Contains("Name", output);
         Assert.Contains("System.Runtime", output);
         Assert.Contains("Type Forwarders", output);
+    }
+
+    [Fact]
+    public async Task Type_ExactPlatformAssembly_DoesNotUseWidePlatformPrefixBrowse()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Collections.Generic.Dictionary<TKey, TValue>", output);
+        Assert.DoesNotContain("System.Collections.Immutable.ImmutableArray", output);
+        Assert.DoesNotContain("best-effort platform prefix matches", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -163,6 +163,12 @@ public static class RouterCommandDefinition
         if (routedExitCode.HasValue)
             return routedExitCode.Value;
 
+        var prefixBrowseExitCode = await TypeCommand.TryExecutePlatformPrefixBrowseAsync(
+            BuildPlatformPrefixTypeOptions(route, opts, parseResult, commandArgs),
+            ApiTypeSectionDescriptors.CreatePipeline());
+        if (prefixBrowseExitCode.HasValue)
+            return prefixBrowseExitCode.Value;
+
         // Fall through to package command.
         // Names like "System.CommandLine" are platform candidates (because they start with "System.")
         // but aren't actually platform libraries. When platform resolution fails, we fall through here.
@@ -198,6 +204,43 @@ public static class RouterCommandDefinition
             TipWriter.WritePackageTips(route.BareName, tipLevel, options.Verbosity);
 
         return exitCode;
+    }
+
+    private static TypeOptions BuildPlatformPrefixTypeOptions(
+        RouterOptionsParser.RouteToPlatformLibrary route,
+        SharedOptions opts,
+        ParseResult parseResult,
+        RouterOptionsParser.RouterCommandArgs commandArgs)
+    {
+        return new TypeOptions
+        {
+            PlatformPrefixQuery = route.BareName,
+            OriginalTypeQuery = route.BareName,
+            JsonOutput = route.Options.JsonOutput,
+            PlainText = route.Options.Format == OutputFormat.PlainText,
+            OneLine = route.OneLine,
+            Tsv = route.Options.Tsv,
+            Jsonl = route.Options.Jsonl,
+            OneLineExplicitlySet = route.Options.OneLineExplicitlySet,
+            FormatExplicitlySet = route.Options.FormatExplicitlySet,
+            MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
+            NoHeader = route.NoHeader,
+            CompactJson = parseResult.GetValue(commandArgs.CompactOption),
+            Verbose = route.Options.Verbose,
+            Verbosity = route.Verbosity,
+            Discover = route.Options.Discover,
+            Tree = route.Options.Tree,
+            Select = route.Options.Select,
+            Columns = route.Options.Columns,
+            Fields = route.Options.Fields,
+            Count = route.Options.Count,
+            Schema = opts.ParseSchema(parseResult),
+            Rows = route.Options.Rows,
+            SourceOptions = route.Options.SourceOptions,
+            TipLevel = route.Options.FormatExplicitlySet || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null
+                ? TipLevel.Quiet
+                : opts.ParseTipLevel(parseResult)
+        };
     }
 
     private static async Task<int?> TryExecuteTypeOrMemberAsync(

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -113,6 +113,7 @@ public static class TypeOptionsParser
         {
             TypeName = source.TypeName,
             OriginalTypeQuery = GetOriginalTypeQuery(sourceSelection, source.TypeName),
+            PlatformPrefixQuery = GetPlatformPrefixQuery(sourceSelection, source),
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
@@ -175,5 +176,20 @@ public static class TypeOptionsParser
             >= 2 => sourceSelection.Args[1],
             _ => resolvedTypeName
         };
+    }
+
+    private static string? GetPlatformPrefixQuery(
+        SharedParsers.SourceSelection sourceSelection,
+        SourceResolver.ResolvedSource source)
+    {
+        if (sourceSelection.HasExplicitSource || sourceSelection.Args.Length != 1)
+            return null;
+
+        var query = sourceSelection.Args[0];
+        return source is { TypeName: null, PlatformAssembly: null, AssemblyPath: null }
+               && source.PackagePath != null
+               && PlatformResolver.IsPlatformCandidate(query)
+            ? query
+            : null;
     }
 }

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -33,6 +33,9 @@ public static class TypeCommand
         var typePipeline = preamble.TypePipeline;
         var memberPipeline = preamble.MemberPipeline;
 
+        if (await TryExecutePlatformPrefixBrowseAsync(options, typePipeline) is { } prefixBrowseExitCode)
+            return prefixBrowseExitCode;
+
         // Shared source resolution
         var (source, sourceError) = await ApiCommand.ResolveSourceAsync(options);
         if (sourceError.HasValue) return sourceError.Value;
@@ -395,6 +398,151 @@ public static class TypeCommand
            && !options.Count
            && !options.HasSectionQuery
            && options.Verbosity == Verbosity.Quiet;
+
+    internal static async Task<int?> TryExecutePlatformPrefixBrowseAsync(
+        TypeOptions options,
+        SectionPipeline<ApiSurface> typePipeline)
+    {
+        var query = options.PlatformPrefixQuery;
+        if (string.IsNullOrWhiteSpace(query))
+            return null;
+
+        var context = new CommandContext(options.Verbose);
+        var logger = context.Logger;
+
+        if (await PackageExistsAsync(query, options, context))
+            return null;
+
+        var api = await BuildPlatformPrefixSurfaceAsync(query, options, context, logger);
+        if (api == null || api.Types.Count == 0)
+            return null;
+
+        var browseOptions = options with
+        {
+            PackagePath = null,
+            PlatformPrefixQuery = null,
+            TypeFilter = null,
+            ShapeOutput = false,
+            ShapeExplicitlySet = false,
+            Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
+        };
+
+        Console.Error.WriteLine($"Note: No exact package or platform library matched '{query}'. Showing best-effort platform prefix matches.");
+
+        if (browseOptions.EffectiveDiscovery)
+        {
+            var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
+            var effective = typePipeline.GetAvailableSections(api, browseOptions.IncludeSections);
+            return DiscoverOutput.ExecuteEffective(browseOptions.Discover, effective, schema,
+                tree: browseOptions.Tree, json: browseOptions.JsonOutput, tsv: browseOptions.Tsv, jsonl: browseOptions.Jsonl, markdown: !browseOptions.OneLine && !browseOptions.JsonOutput,
+                verbosity: (int)browseOptions.Verbosity,
+                sectionCostAnnotations: typePipeline.GetCostAnnotations(),
+                sectionCategories: typePipeline.GetCategoryMap());
+        }
+
+        ApiCommand.WriteFullApiOutput(api, browseOptions);
+        return 0;
+    }
+
+    private static async Task<bool> PackageExistsAsync(string packageName, TypeOptions options, CommandContext context)
+    {
+        if (NuGetCache.TryGetLatestCachedVersion(packageName) != null)
+            return true;
+
+        try
+        {
+            var versions = await PackageExtractor.GetVersionsAsync(
+                context.HttpClient,
+                packageName,
+                includePrerelease: true,
+                limit: 1,
+                log: context.Logger.Log,
+                sourceOptions: options.SourceOptions);
+            return versions is { Count: > 0 };
+        }
+        catch (Exception ex)
+        {
+            context.Logger.Log($"Could not query package versions for '{packageName}': {ex.Message}");
+            return false;
+        }
+    }
+
+    private static async Task<ApiSurface?> BuildPlatformPrefixSurfaceAsync(
+        string query,
+        TypeOptions options,
+        CommandContext context,
+        VerboseLogger logger)
+    {
+        var pattern = query.EndsWith('*') ? query : $"{query}*";
+        var findOptions = new FindOptions
+        {
+            Pattern = pattern,
+            PlatformFrameworks = CommandLineBuilder.PlatformFrameworkNames,
+            IncludeAll = options.IncludeAll,
+            Limit = options.Limit,
+            SourceOptions = options.SourceOptions
+        };
+
+        List<string> tempDirs = [];
+        var searchResults = await TypeSearchService.CollectTypesAsync(findOptions, pattern, logger, tempDirs, context.HttpClient);
+        AssemblyCollector.CleanupTempDirs(tempDirs);
+
+        var distinctResults = searchResults
+            .Where(r => r.Assembly != null && r.Source != null)
+            .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (distinctResults.Count == 0)
+            return null;
+
+        var resultNamesByAssembly = distinctResults
+            .GroupBy(r => (Framework: r.Source!, Assembly: r.Assembly!, Version: r.SourceVersion))
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => r.FullName).ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+        var merged = new ApiSurface
+        {
+            Name = query,
+            Source = SourceKind.Platform,
+            Version = string.Join(", ", distinctResults.Select(r => $"{r.Source}@{r.SourceVersion}").Distinct()),
+            Tfm = "platform"
+        };
+
+        foreach (var ((framework, assembly, _), fullNames) in resultNamesByAssembly)
+        {
+            var (assemblyPath, _, _, error) = await PlatformResolver.ResolveAssemblyAsync(
+                assembly,
+                context.HttpClient,
+                logger.Log,
+                framework);
+            if (assemblyPath == null || error != null)
+            {
+                logger.Log($"Warning: Could not resolve platform library '{assembly}' in {framework}: {error}");
+                continue;
+            }
+
+            var api = AssemblyReader.ExtractApiSurface(assemblyPath, options.IncludeAll);
+            if (api == null)
+                continue;
+
+            ApiServices.ResolveForwardedTypes(api, assemblyPath, logger, options.IncludeAll);
+
+            foreach (var type in api.Types.Where(t => fullNames.Contains(t.FullName)))
+            {
+                type.SourceAssemblyPath = assemblyPath;
+                merged.Types.Add(type);
+            }
+        }
+
+        merged.Types = merged.Types
+            .DistinctBy(t => t.FullName, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(t => t.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        RecomputeSurfaceCounts(merged);
+        return merged;
+    }
 
     private static bool TryWritePrefixBrowse(
         ApiSurface api,

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -123,6 +123,7 @@ public record TypeOptions : ApiOptions
 {
     public string? TypeFilter { get; init; }
     public string? OriginalTypeQuery { get; init; }
+    public string? PlatformPrefixQuery { get; init; }
     public bool ShapeOutput { get; init; }
     public bool MarkdownExplicitlySet { get; init; }
 


### PR DESCRIPTION
## Summary
- let unresolved platform-looking `type` queries such as `System.Text` fall back to best-effort platform prefix browsing
- expose the same fallback through the bare router for unresolved names
- preserve exact platform assembly precedence, so names like `System.Collections` still inspect the exact assembly
- follow type forwarders when building platform prefix browse results
- document URL-like namespace probing in `SKILL.md`

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- npx markdownlint-cli skills/dotnet-inspect/SKILL.md