### PR TITLE
Raise break out of do-while loops (the search/retry exit shape)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -888,16 +888,19 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void DoWhileWithBreak_StaysFlat()
+    public void DoWhileWithBreak_RaisesBreak()
     {
-        // The break is a forward exit branch out of the loop — out of the
-        // do-while slice, so the loop is not raised and stays flat (goto).
+        // The conditional exit out of the loop raises to `if (...) break;`
+        // inside a structured do-while — no goto, no label.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(
             typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.DoWhileWithBreak), source);
 
-        Assert.Contains("goto", output);
-        Assert.DoesNotContain("do", output);
+        Assert.Contains("do", output);
+        Assert.Contains("while (", output);
+        Assert.Contains("break;", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -364,6 +364,7 @@ public sealed class CSharpPrinter
         // The rethrow: the raw caught value thrown back is C#'s bare throw.
         Throw { Value: CaughtException } => "throw;",
         Throw t => $"throw {Expression(t.Value)};",
+        Break => "break;",
         Branch b => $"goto IL_{b.TargetOffset:X4};",
         ConditionalBranch c => $"if ({Condition(c.Condition)}) goto IL_{c.TargetOffset:X4};",
         SwitchBranch s => $"switch ({Expression(s.Value)}) goto [{string.Join(", ", s.TargetOffsets.Select(t => $"IL_{t:X4}"))}];",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -325,6 +325,16 @@ public sealed class ConditionalBranch : IrNode
     public override string Describe() => $"ConditionalBranch IL_{TargetOffset:X4}";
 }
 
+/// <summary>
+/// A C# <c>break</c>: an in-loop branch the loop-structuring pass raised from a
+/// goto to the loop's single exit block. Childless terminator, like
+/// <see cref="Branch"/>.
+/// </summary>
+public sealed class Break : IrNode
+{
+    public override string Describe() => "Break";
+}
+
 public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }
 
 public sealed class Comparison : IrExpression

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
@@ -10,9 +10,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// container holding a back edge flat.
 ///
 /// Transactional and conservative: the loop is raised only when it is a clean
-/// single-entry region with no exit branch (a break), no second back edge
-/// (nested or irreducible), and no EH leave inside — otherwise it stays flat.
-/// Innermost loops wrap first, so nested do-whiles compose across the fixpoint.
+/// single-entry region with one back edge, no EH leave inside, and exits only
+/// to its single canonical exit block — those exits raise to <c>break;</c> (an
+/// unconditional branch) or <c>if (cond) break;</c> (a conditional one). A
+/// second back edge (nested or irreducible) or a second distinct exit target
+/// (which would need a labeled break) keeps it flat. Innermost loops wrap
+/// first, so nested do-whiles compose across the fixpoint.
 /// </summary>
 public sealed class DoWhileLoopPass : IIrPass
 {
@@ -59,11 +62,21 @@ public sealed class DoWhileLoopPass : IIrPass
         return false;
     }
 
-    /// <summary>Pure shape check: the region [header, bottom] is a reducible single-entry loop with one back edge and no break.</summary>
+    /// <summary>
+    /// Pure shape check: the region [header, bottom] is a reducible single-entry
+    /// loop whose only back edge is <paramref name="backEdge"/> and whose only
+    /// exits are breaks to the single canonical exit block (the block right
+    /// after the loop, where the back edge's false path also lands).
+    /// </summary>
     static bool Validate(
         IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex,
         int header, int bottom, ConditionalBranch backEdge)
     {
+        // The loop exits, normally, by falling through past the bottom test to
+        // the next block — so that block is the one and only place a break may
+        // target. A second distinct exit target would need a labeled break.
+        int exitIndex = bottom + 1;
+
         for (int source = 0; source < blocks.Count; source++)
         {
             bool sourceInside = source >= header && source <= bottom;
@@ -80,7 +93,11 @@ public sealed class DoWhileLoopPass : IIrPass
                     bool targetInside = target >= header && target <= bottom;
 
                     if (sourceInside && !targetInside)
-                        return false;   // an exit branch — a break, the next slice
+                    {
+                        if (target != exitIndex)
+                            return false;   // a non-canonical exit — needs a labeled break
+                        continue;           // a break to the loop's single exit
+                    }
                     if (!sourceInside && targetInside)
                         return false;   // an external jump into the loop body
                     if (sourceInside && !ReferenceEquals(node, backEdge) && target <= source)
@@ -104,6 +121,34 @@ public sealed class DoWhileLoopPass : IIrPass
         var blocks = container.Blocks;
         var condition = (IrExpression)backEdge.DetachChildren()[0];
         backEdge.Detach();   // strip the back edge from the bottom block
+
+        // Raise exit branches to break before the bodies move. The canonical
+        // exit (validated as the only exit target) is the block right after the
+        // loop; an unconditional branch there becomes `break;`, a conditional
+        // branch becomes `if (cond) break;` (the false path keeps falling
+        // through, exactly as the branch did).
+        if (bottom + 1 < blocks.Count)
+        {
+            int exitOffset = blocks[bottom + 1].StartOffset;
+            for (int i = header; i <= bottom; i++)
+            {
+                if (blocks[i].Children is not [.., var lastNode])
+                    continue;
+                if (lastNode is Branch branch && branch.TargetOffset == exitOffset)
+                {
+                    branch.Detach();
+                    blocks[i].Add(new Break());
+                }
+                else if (lastNode is ConditionalBranch exit && exit.TargetOffset == exitOffset)
+                {
+                    var breakCondition = (IrExpression)exit.DetachChildren()[0];
+                    exit.Detach();
+                    var thenArm = new Block(blocks[i].StartOffset);
+                    thenArm.Add(new Break());
+                    blocks[i].Add(new IfStatement(breakCondition, thenArm, null));
+                }
+            }
+        }
 
         foreach (var block in blocks)
             block.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -73,7 +73,9 @@ public sealed class StructuringPass : IIrPass
             }
             switch (block.Children[^1])
             {
-                case Return or Throw:
+                case Return or Throw or Break:
+                    // A straight-line terminator: the loop pass already raised
+                    // the break, so this block ends its region cleanly.
                     i++;
                     break;
                 case Leave or EndFinally or EndFilter:
@@ -198,7 +200,7 @@ public sealed class StructuringPass : IIrPass
                 result.Add(statements[s]);
             switch (last)
             {
-                case Return or Throw:
+                case Return or Throw or Break:
                     result.Add(last);
                     i++;
                     break;


### PR DESCRIPTION
## What

First increment of the **breaks/continues** slice. `DoWhileLoopPass` previously rejected any loop containing an in-loop exit branch (its `Validate` literally tagged it `// an exit branch — a break, the next slice`), so those loops fell back to flat goto soup. This lifts that restriction for the clean case.

A do-while occupies a contiguous block region `[header..bottom]`; its single legal exit is the block right after it (`bottom+1`), where the back edge's false path also lands. Now:

- **`Validate`** accepts an in-loop branch leaving the region *only* if its target is that one canonical exit. A second distinct exit target would need a labeled break → stays flat.
- **`Wrap`** raises the accepted exits: an unconditional `Branch(exit)` → `break;`; a `ConditionalBranch(cond, exit)` → `if (cond) break;` (the false path keeps falling through, exactly as the branch did).
- New childless `Break` terminator node; `StructuringPass` and the printer treat it as a clean region-ender.

```csharp
// before: do { V_0 += n; if (V_0 > 100) goto IL_0010; n--; } while (n > 0); ... IL_0010: ...
// after:
do
{
    V_0 += n;
    if (V_0 > 100)
    {
        break;
    }
    n--;
}
while (n > 0);
```

## Scope & why it's small

A corelib IR sweep shows **35 methods raise a break** (20 become fully goto-free). The strict `exit == bottom+1` rule is what keeps it sound: an early-exit to a *shared cleanup* block is a genuine goto (or labeled break), not a plain `break`, and correctly stays flat. A looser scan suggested ~323 candidates, but most of those exit somewhere other than the immediate successor.

- `candidate-worse` 1663 → 1647; burndown 8.31% → 8.27%.
- **Zero baseline failures, zero crashes** across the 41,159-method sweep.

## Soundness

Full adversarial review of the rewrite passed (11 loop shapes run through the pipeline): conditional/unconditional break, break-at-end, nested-inner break, two-breaks-same-exit, switch-in-loop, compound `&&` condition, adjacent loops. The conditional-break condition is correctly **non-negated** (branch-taken = break), and the resulting `IfStatement`-ending block lands in `StructuringPass`'s fall-through path, not its mid-block-control-flow reject. The `bottom+1 == blocks.Count` (loop-is-last) case correctly rejects any break. One noted non-bug: a switch whose only exit is `bottom+1` raises the loop but leaves the switch as a goto — correct, just unsugared (switch raising is a separate docket item).

## Next increments

Continue raising, and the while/for-form break (`StructuringPass.FindWhileShape`). The `Continue` node is deferred until its producer lands.

## Testing

`ILInspector.Decompiler.Tests` 367 ✅ · `dotnet-inspect.Tests` 1022 ✅ (the 2 `MemberOptionsParserTests` failures are the known intermittent flake — pass on re-run, unrelated to the pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)