### PR TITLE
Widen platform prefix browsing after source misses

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -278,6 +278,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_SingleType_MarkdownMinimal_IncludesLibraryContext()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections.FrozenDictionary", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("# System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("Library: System.Collections.Immutable", output);
+        Assert.Contains("Source: Platform", output);
+        Assert.Contains("## Method Groups", output);
+    }
+
+    [Fact]
     public async Task Type_PrefixBrowse_InferredPlatformTypo_ListsBestEffortMatches()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -358,6 +358,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_PlatformPrefixBrowse_NarrowSourceMissFallsBackToWidePlatformMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections.Frozen", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort platform prefix matches", error);
+        Assert.Contains("System.Collections.Frozen", error);
+        Assert.Contains("System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("System.Collections.Frozen.FrozenSet", output);
+    }
+
+    [Fact]
     public async Task Type_PrefixBrowse_ExplicitPlatformNamespace_ListsBestEffortMatches()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -114,6 +114,7 @@ public static class TypeOptionsParser
             TypeName = source.TypeName,
             OriginalTypeQuery = GetOriginalTypeQuery(sourceSelection, source.TypeName),
             PlatformPrefixQuery = GetPlatformPrefixQuery(sourceSelection, source),
+            AllowPlatformPrefixFallback = IsImplicitPlatformPrefixQuery(sourceSelection),
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
@@ -188,8 +189,13 @@ public static class TypeOptionsParser
         var query = sourceSelection.Args[0];
         return source is { TypeName: null, PlatformAssembly: null, AssemblyPath: null }
                && source.PackagePath != null
-               && PlatformResolver.IsPlatformCandidate(query)
+               && IsImplicitPlatformPrefixQuery(sourceSelection)
             ? query
             : null;
     }
+
+    private static bool IsImplicitPlatformPrefixQuery(SharedParsers.SourceSelection sourceSelection)
+        => !sourceSelection.HasExplicitSource
+           && sourceSelection.Args.Length == 1
+           && PlatformResolver.IsPlatformCandidate(sourceSelection.Args[0]);
 }

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -326,6 +326,10 @@ public static class TypeCommand
                     selectedTfm,
                     options))
                 {
+                    var widePrefixExitCode = await TryExecuteWidePlatformPrefixFallbackAsync(options, originalTypeQuery, typePipeline);
+                    if (widePrefixExitCode.HasValue)
+                        return widePrefixExitCode.Value;
+
                     if (lookupResult.Suggestions.Count > 0)
                     {
                         bool isGlob = typeName.Contains('*') || typeName.Contains('?');
@@ -374,6 +378,23 @@ public static class TypeCommand
                 try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
         }
+    }
+
+    private static Task<int?> TryExecuteWidePlatformPrefixFallbackAsync(
+        TypeOptions options,
+        string? originalTypeQuery,
+        SectionPipeline<ApiSurface> typePipeline)
+    {
+        if (!options.AllowPlatformPrefixFallback || string.IsNullOrWhiteSpace(originalTypeQuery))
+            return Task.FromResult<int?>(null);
+        if (originalTypeQuery.Contains('*') || originalTypeQuery.Contains('?'))
+            return Task.FromResult<int?>(null);
+
+        return TryExecutePlatformPrefixBrowseAsync(options with
+        {
+            PlatformPrefixQuery = originalTypeQuery,
+            AllowPlatformPrefixFallback = false
+        }, typePipeline);
     }
 
     private static bool ShouldDefaultToShape(TypeOptions options)
@@ -427,7 +448,7 @@ public static class TypeCommand
             Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
         };
 
-        Console.Error.WriteLine($"Note: No exact package or platform library matched '{query}'. Showing best-effort platform prefix matches.");
+        Console.Error.WriteLine($"Note: Showing best-effort platform prefix matches for '{query}'.");
 
         if (browseOptions.EffectiveDiscovery)
         {

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -449,6 +449,7 @@ public static class TypeCommand
         };
 
         Console.Error.WriteLine($"Note: Showing best-effort platform prefix matches for '{query}'.");
+        Console.Error.WriteLine($"Note: Use `find \"{query}*\" --platform` to see source libraries.");
 
         if (browseOptions.EffectiveDiscovery)
         {

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -124,6 +124,7 @@ public record TypeOptions : ApiOptions
     public string? TypeFilter { get; init; }
     public string? OriginalTypeQuery { get; init; }
     public string? PlatformPrefixQuery { get; init; }
+    public bool AllowPlatformPrefixFallback { get; init; }
     public bool ShapeOutput { get; init; }
     public bool MarkdownExplicitlySet { get; init; }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -353,7 +353,8 @@ public static class ApiOutputFormatter
             baseclassRows = [new BaseclassRow { Type = baseType }];
         }
 
-        bool topFieldsOnly = options.Verbosity == Verbosity.Quiet;
+        bool topFieldsOnly = options.Verbosity == Verbosity.Quiet
+            || (options is TypeOptions { MarkdownExplicitlySet: true } && !memberDetail);
         var title = memberDetail
             ? $"{FormatGenericFullName(type)}.{OperatorNames.FormatDisplayName(selectedMember!.Name)}"
             : $"{FormatGenericFullName(type)}{packageInfo}";


### PR DESCRIPTION
## Summary
- extend platform namespace prefix browsing when an implicit exact source prefix resolves but has no matching types
- enables queries such as `type System.Collections.Frozen` to find `System.Collections.Frozen.*` types in sibling platform assemblies
- keeps exact assembly queries such as `type System.Collections` scoped to the exact assembly

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.Type_PlatformPrefixBrowse_NarrowSourceMissFallsBackToWidePlatformMatches -method DotnetInspector.Tests.CommandExecutionTests.Type_PlatformPrefixBrowse_UnresolvedNamespace_ListsPlatformMatches -method DotnetInspector.Tests.CommandExecutionTests.Router_PlatformPrefixBrowse_UnresolvedNamespace_ListsPlatformMatches -method DotnetInspector.Tests.CommandExecutionTests.Type_ExactPlatformAssembly_DoesNotUseWidePlatformPrefixBrowse