### PR TITLE
Share type route prefix policy

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -385,6 +385,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_PlatformPrefixBrowse_NarrowSourceMissFallsBackToWidePlatformMatches()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Collections.Frozen", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("best-effort platform prefix matches", error);
+        Assert.Contains("System.Collections.Frozen", error);
+        Assert.Contains("System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("System.Collections.Frozen.FrozenSet", output);
+    }
+
+    [Fact]
     public async Task Type_PrefixBrowse_ExplicitPlatformNamespace_ListsBestEffortMatches()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -212,10 +212,12 @@ public static class RouterCommandDefinition
         ParseResult parseResult,
         RouterOptionsParser.RouterCommandArgs commandArgs)
     {
-        return new TypeOptions
+        var routePolicy = TypeRoutePolicy.ResolveImplicit(
+            route.BareName,
+            new SourceResolver.ResolvedSource(route.BareName, null, null, null, null));
+
+        return routePolicy.ApplyTo(new TypeOptions
         {
-            PlatformPrefixQuery = route.BareName,
-            OriginalTypeQuery = route.BareName,
             JsonOutput = route.Options.JsonOutput,
             PlainText = route.Options.Format == OutputFormat.PlainText,
             OneLine = route.OneLine,
@@ -240,7 +242,7 @@ public static class RouterCommandDefinition
             TipLevel = route.Options.FormatExplicitlySet || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null
                 ? TipLevel.Quiet
                 : opts.ParseTipLevel(parseResult)
-        };
+        });
     }
 
     private static async Task<int?> TryExecuteTypeOrMemberAsync(
@@ -279,10 +281,17 @@ public static class RouterCommandDefinition
         ParseResult parseResult,
         RouterOptionsParser.RouterCommandArgs commandArgs)
     {
-        return new TypeOptions
+        var source = new SourceResolver.ResolvedSource(
+            probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
+            null,
+            probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
+            null,
+            probe.Remainder);
+        var routePolicy = TypeRoutePolicy.ResolveImplicit(route.BareName, source);
+
+        return routePolicy.ApplyTo(new TypeOptions
         {
             TypeName = probe.Remainder,
-            OriginalTypeQuery = route.BareName,
             PlatformAssembly = probe.Kind == SourceResolver.LocalSourceKind.Platform ? probe.SourceName : null,
             PackagePath = probe.Kind == SourceResolver.LocalSourceKind.CachedPackage ? probe.SourceName : null,
             JsonOutput = route.Options.JsonOutput,
@@ -307,7 +316,7 @@ public static class RouterCommandDefinition
             Schema = opts.ParseSchema(parseResult),
             SourceOptions = route.Options.SourceOptions,
             TipLevel = route.Options.FormatExplicitlySet || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null ? TipLevel.Quiet : opts.ParseTipLevel(parseResult)
-        };
+        });
     }
 
     private static async Task<int> ExecuteVersionQueryAsync(
@@ -390,16 +399,11 @@ public static class RouterCommandDefinition
         }
 
         var verbosity = opts.ParseVerbosity(parseResult);
+        var routePolicy = TypeRoutePolicy.Resolve(route.Args, hasExplicitSource: false, source);
 
-        var typeOptions = new TypeOptions
+        var typeOptions = routePolicy.ApplyTo(new TypeOptions
         {
             TypeName = source.TypeName,
-            OriginalTypeQuery = route.Args.Length switch
-            {
-                1 => route.Args[0],
-                >= 2 => route.Args[1],
-                _ => source.TypeName
-            },
             PackagePath = source.PackagePath,
             PlatformAssembly = source.PlatformAssembly,
             PlatformFramework = source.FrameworkOverride,
@@ -424,7 +428,7 @@ public static class RouterCommandDefinition
             Schema = opts.ParseSchema(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             TipLevel = opts.IsFormatExplicitlySet(parseResult) || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null ? TipLevel.Quiet : opts.ParseTipLevel(parseResult)
-        };
+        });
 
         return await ApiCommand.ExecuteAsync(typeOptions);
     }

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -108,13 +108,11 @@ public static class TypeOptionsParser
 
         var kindValues = parseResult.GetValue(args.KindOption) ?? [];
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
+        var routePolicy = TypeRoutePolicy.Resolve(sourceSelection.Args, sourceSelection.HasExplicitSource, source);
 
-        var options = new TypeOptions
+        var options = routePolicy.ApplyTo(new TypeOptions
         {
             TypeName = source.TypeName,
-            OriginalTypeQuery = GetOriginalTypeQuery(sourceSelection, source.TypeName),
-            PlatformPrefixQuery = GetPlatformPrefixQuery(sourceSelection, source),
-            AllowPlatformPrefixFallback = IsImplicitPlatformPrefixQuery(sourceSelection),
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
@@ -152,7 +150,7 @@ public static class TypeOptionsParser
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
-        };
+        });
 
         options = options with
         {
@@ -162,40 +160,4 @@ public static class TypeOptionsParser
 
         return new Success(options);
     }
-
-    private static string? GetOriginalTypeQuery(SharedParsers.SourceSelection sourceSelection, string? resolvedTypeName)
-    {
-        if (string.IsNullOrEmpty(resolvedTypeName))
-            return null;
-
-        if (sourceSelection.HasExplicitSource)
-            return sourceSelection.Args.FirstOrDefault();
-
-        return sourceSelection.Args.Length switch
-        {
-            1 => sourceSelection.Args[0],
-            >= 2 => sourceSelection.Args[1],
-            _ => resolvedTypeName
-        };
-    }
-
-    private static string? GetPlatformPrefixQuery(
-        SharedParsers.SourceSelection sourceSelection,
-        SourceResolver.ResolvedSource source)
-    {
-        if (sourceSelection.HasExplicitSource || sourceSelection.Args.Length != 1)
-            return null;
-
-        var query = sourceSelection.Args[0];
-        return source is { TypeName: null, PlatformAssembly: null, AssemblyPath: null }
-               && source.PackagePath != null
-               && IsImplicitPlatformPrefixQuery(sourceSelection)
-            ? query
-            : null;
-    }
-
-    private static bool IsImplicitPlatformPrefixQuery(SharedParsers.SourceSelection sourceSelection)
-        => !sourceSelection.HasExplicitSource
-           && sourceSelection.Args.Length == 1
-           && PlatformResolver.IsPlatformCandidate(sourceSelection.Args[0]);
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeRoutePolicy.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeRoutePolicy.cs
@@ -1,0 +1,70 @@
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.CommandLine;
+
+internal readonly record struct TypeRoutePolicyResult(
+    string? OriginalTypeQuery,
+    string? PlatformPrefixQuery,
+    bool AllowPlatformPrefixFallback)
+{
+    public TypeOptions ApplyTo(TypeOptions options) => options with
+    {
+        OriginalTypeQuery = OriginalTypeQuery,
+        PlatformPrefixQuery = PlatformPrefixQuery,
+        AllowPlatformPrefixFallback = AllowPlatformPrefixFallback
+    };
+}
+
+internal static class TypeRoutePolicy
+{
+    public static TypeRoutePolicyResult Resolve(
+        string[] args,
+        bool hasExplicitSource,
+        SourceResolver.ResolvedSource source)
+    {
+        return new TypeRoutePolicyResult(
+            GetOriginalTypeQuery(args, hasExplicitSource, source.TypeName),
+            GetPlatformPrefixQuery(args, hasExplicitSource, source),
+            IsImplicitPlatformPrefixQuery(args, hasExplicitSource));
+    }
+
+    public static TypeRoutePolicyResult ResolveImplicit(
+        string query,
+        SourceResolver.ResolvedSource source)
+        => Resolve([query], hasExplicitSource: false, source);
+
+    private static string? GetOriginalTypeQuery(string[] args, bool hasExplicitSource, string? resolvedTypeName)
+    {
+        if (hasExplicitSource)
+            return args.FirstOrDefault();
+
+        return args.Length switch
+        {
+            1 => args[0],
+            >= 2 => args[1],
+            _ => resolvedTypeName
+        };
+    }
+
+    private static string? GetPlatformPrefixQuery(
+        string[] args,
+        bool hasExplicitSource,
+        SourceResolver.ResolvedSource source)
+    {
+        if (hasExplicitSource || args.Length != 1)
+            return null;
+
+        var query = args[0];
+        return source is { TypeName: null, PlatformAssembly: null, AssemblyPath: null }
+               && source.PackagePath != null
+               && IsImplicitPlatformPrefixQuery(args, hasExplicitSource)
+            ? query
+            : null;
+    }
+
+    private static bool IsImplicitPlatformPrefixQuery(string[] args, bool hasExplicitSource)
+        => !hasExplicitSource
+           && args.Length == 1
+           && PlatformResolver.IsPlatformCandidate(args[0]);
+}


### PR DESCRIPTION
## Summary
- centralize implicit type route policy in `TypeRoutePolicy`
- apply the same original-query, platform-prefix, and wide-miss fallback rules from both `type` and the bare router
- fix bare `System.Collections.Frozen` to match `type System.Collections.Frozen` behavior

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- targeted router/type parity tests for `System.Collections.Frozen`, `System.Text`, and exact `System.Collections`

Note: the first full test run hit a transient DOTNET_ROOT/global-state failure in `VersionDisplayTests.PlatformVersion_MatchesRuntimeDirectory`; the isolated test and rerun of the full project passed.