### PR TITLE
Fold short-circuit OR guard chains (Unsafe.BitCast and the like)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -904,6 +904,46 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void OrChainGuard_FoldsToSingleGuard()
+    {
+        // The csc OR-chain shape, built directly so the test is independent of
+        // build-config codegen: two guards branch to the throw, the last
+        // branches past it to the return. The fold raises one || guard.
+        //   if (a < 0)  goto IL_000C;   // → throw
+        //   if (b < 0)  goto IL_000C;   // → throw
+        //   if (a <= b) goto IL_0010;   // → skip (return)
+        //   IL_000C: throw null;
+        //   IL_0010: return a;
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 12));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, B(), new Constant(0, intType)), 12));
+        var b2 = new Block(8);
+        b2.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThanOrEqual, false, A(), B()), 16));
+        var consequence = new Block(12);
+        consequence.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        var join = new Block(16);
+        join.Add(new Return(A()));
+        foreach (var block in (Block[])[b0, b1, b2, consequence, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("if (a < 0 || b < 0 || a > b)", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
     public void TopTestedLoopWithBreak_RaisesBreak()
     {
         // A forward exit out of a top-tested (while/for) loop body raises to a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -45,6 +45,10 @@ public static class IrPasses
         // structuring, which leaves any back-edge container flat. The loop
         // body becomes a container the structuring pass then raises.
         new DoWhileLoopPass(),
+        // Fold short-circuit OR guard chains (if (a || b || !c) { ... }) into a
+        // single guard so the structuring pass — which only takes single-target
+        // guard/diamond shapes — can raise them instead of leaving goto soup.
+        new OrChainGuardPass(),
         new StructuringPass(),
         // After structuring the finally guard is an IfStatement, so the
         // Monitor lock lowering is matchable as lock (obj) { ... }.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a short-circuit OR guard chain into one guard, before structuring.
+/// csc lowers <c>if (a || b || !c) { CONSEQUENCE } REST</c> to a run of
+/// single-condition blocks where every guard but the last branches to the
+/// consequence and the last branches PAST it:
+/// <code>
+///   if (a)  goto T;   // → consequence
+///   if (b)  goto T;   // → consequence
+///   if (c)  goto J;   // → skip consequence
+///   T: CONSEQUENCE    // falls through (or returns/throws) to J
+///   J: REST
+/// </code>
+/// The mixed polarity (some branches to T, one past it to J) breaks the
+/// structuring pass's single-target guard/diamond shapes — it rejects the
+/// jump-past at <c>target &gt; stop</c> and the whole method stays flat. This
+/// pass rebuilds the chain into a single <c>ConditionalBranch</c> whose
+/// condition is <c>!(a || b || !c)</c> (the skip condition) to J, leaving the
+/// consequence as the guard arm. The structuring pass then negates it back to
+/// the clean <c>if (a || b || !c) { CONSEQUENCE }</c> form.
+///
+/// Conservative and sound: only runs of pure single-condition blocks fold,
+/// the consequence must sit immediately after the chain, and nothing outside
+/// the chain may branch into the blocks it removes — otherwise it is left
+/// flat. Short-circuit evaluation order is preserved exactly: a guard's
+/// condition is still evaluated only when every earlier one fell through, just
+/// as <c>||</c> short-circuits.
+/// </summary>
+public sealed class OrChainGuardPass : IIrPass
+{
+    public string Name => "or-chain-guard";
+
+    public void Run(IrFunction function)
+    {
+        while (FoldOne(function))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function)
+    {
+        // A surviving leave (an early exit out of an EH region) may target a
+        // block this fold would drop or re-parent — including from another
+        // container, which the per-container scan below cannot see. Collecting
+        // every leave target function-wide and refusing to fold across one
+        // keeps such a goto from dangling at a vanished offset.
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            if (TryFold(container, leaveTargets))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        for (int p = 0; p < blocks.Count; p++)
+        {
+            if (Chain(blocks, offsetToIndex, p) is { } chain
+                && NoExternalEntry(blocks, p, chain.JoinIndex, leaveTargets))
+            {
+                Fold(container, p, chain.SkipGuard, chain.JoinOffset);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// The chain rooted at <paramref name="p"/>: guards [p, SkipGuard] are all
+    /// pure single-condition blocks; [p, SkipGuard-1] branch to the consequence
+    /// (the block right after the chain) and SkipGuard branches past it to a
+    /// later block (the join). Null when block p does not start such a chain.
+    /// </summary>
+    static (int SkipGuard, int JoinIndex, int JoinOffset)? Chain(
+        IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
+    {
+        if (ConditionTarget(blocks[p]) is not { } firstTarget
+            || !offsetToIndex.TryGetValue(firstTarget, out int consequence))
+        {
+            return null;
+        }
+
+        // The throw-guards [p, m] all branch to the same consequence; the skip
+        // guard is the first one in the run that branches elsewhere.
+        int m = p;
+        while (m + 1 < blocks.Count
+            && ConditionTarget(blocks[m + 1]) == firstTarget)
+        {
+            m++;
+        }
+
+        int skipGuard = m + 1;
+        if (skipGuard >= blocks.Count                       // no skip guard follows the run
+            || ConditionTarget(blocks[skipGuard]) is not { } joinOffset
+            || !offsetToIndex.TryGetValue(joinOffset, out int joinIndex))
+        {
+            return null;
+        }
+
+        // The consequence must sit immediately after the whole chain, and the
+        // skip must land strictly past it (so the consequence is the arm).
+        int consequenceStart = skipGuard + 1;
+        if (consequence != consequenceStart || joinIndex <= consequenceStart)
+            return null;
+        return (skipGuard, joinIndex, joinOffset);
+    }
+
+    /// <summary>The single branch target of a pure one-statement condition block, or null.</summary>
+    static int? ConditionTarget(Block block)
+        => block.Children is [ConditionalBranch conditional] ? conditional.TargetOffset : null;
+
+    /// <summary>
+    /// No block outside the chain-and-consequence span may branch into the
+    /// guards this fold removes or into the consequence it re-parents — those
+    /// targets would dangle or escape the guard arm. The chain entry (p) and
+    /// the join may be targeted freely; a leave from anywhere (collected
+    /// function-wide) into the span aborts the fold too.
+    /// </summary>
+    static bool NoExternalEntry(
+        IReadOnlyList<Block> blocks, int p, int joinIndex, HashSet<int> leaveTargets)
+    {
+        var forbidden = new HashSet<int>();
+        for (int idx = p + 1; idx < joinIndex; idx++)
+            forbidden.Add(blocks[idx].StartOffset);
+
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        for (int idx = 0; idx < blocks.Count; idx++)
+        {
+            if (idx >= p && idx < joinIndex)
+                continue;   // inside the chain/consequence span — internal edges are fine
+            foreach (var node in blocks[idx].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        _ => [],
+    };
+
+    static void Fold(BlockContainer container, int p, int skipGuard, int joinOffset)
+    {
+        var blocks = container.Blocks.ToList();
+
+        // Build the throw condition in evaluation order: each guard before the
+        // skip contributes its condition; the skip guard contributes the
+        // negation of its own (its taken path skips the consequence).
+        IrExpression? throwCondition = null;
+        for (int j = p; j <= skipGuard; j++)
+        {
+            var conditional = (ConditionalBranch)blocks[j].Children[0];
+            var condition = (IrExpression)conditional.DetachChildren()[0];
+            if (j == skipGuard)
+                condition = Conditions.Negate(condition);
+            throwCondition = throwCondition is null
+                ? condition
+                : new LogicalBinary(LogicalKind.Or, throwCondition, condition);
+        }
+
+        // The folded guard branches to the join when the throw condition is
+        // false; the structuring pass negates !throwCondition back to the
+        // clean `if (throwCondition) { consequence }`.
+        var folded = new Block(blocks[p].StartOffset);
+        folded.Add(new ConditionalBranch(new LogicalNot(throwCondition!), joinOffset));
+
+        foreach (var block in blocks)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx < p; idx++)
+            rebuilt.Add(blocks[idx]);
+        rebuilt.Add(folded);
+        for (int idx = skipGuard + 1; idx < blocks.Count; idx++)
+            rebuilt.Add(blocks[idx]);
+        container.ReplaceWith(rebuilt);
+    }
+}


### PR DESCRIPTION
## What

csc lowers `if (a || b || !c) { CONSEQUENCE } REST` to a run of single-condition blocks where the leading guards branch to the consequence and the **last branches past it**:

```
if (a)  goto T;   // → consequence
if (b)  goto T;   // → consequence
if (c)  goto J;   // → skip consequence
T: CONSEQUENCE
J: REST
```

That mixed polarity breaks `StructuringPass`'s single-target guard/diamond shapes — it rejects the jump-past at `target > stop`, so the whole method stays flat. And because structuring is **all-or-nothing per container**, one such chain also flattens the method's other guards. This was the biggest remaining `candidate-worse` bucket, and the user-flagged `Unsafe.BitCast`.

New `OrChainGuardPass` (runs before structuring) rebuilds the chain into a single guard:
- `throwCondition = cond0 || cond1 || … || !cond_last`
- emitted as `ConditionalBranch(!throwCondition, join)` with the consequence as the fall-through arm.
- `StructuringPass` then negates `!throwCondition` back to the clean `if (throwCondition) { CONSEQUENCE }` (its guard arm calls `Conditions.Negate`, which unwraps the `LogicalNot`).

Short-circuit evaluation order is preserved exactly — `||` short-circuits left-to-right just as the sequential branches did, so even conditions with side effects fold soundly.

### Unsafe.BitCast, now byte-for-byte to source

```csharp
public static TTo BitCast<TFrom, TTo>(TFrom source)
{
    if (sizeof(TFrom) != sizeof(TTo) || !typeof(TFrom).IsValueType || !typeof(TTo).IsValueType)
    {
        ThrowHelper.ThrowNotSupportedException();
    }
    return Unsafe.ReadUnaligned<TTo>(Unsafe.As<TFrom, byte>(ref source));
}
```

## Soundness (adversarial review)

Only runs of **pure single-condition blocks** fold; the consequence must sit immediately after the chain and the join strictly past it; nothing outside the span may branch into the blocks the fold drops. The review caught one hole: a `leave` (EH early-exit) can target into the span from **another container**, which a per-container scan can't see — so leave targets are now collected **function-wide** and a fold across one is refused (else a dropped block's label would dangle into invalid C#).

## Impact (corelib)

- `candidate-worse` **1612 → 1192** (−420) — the biggest single increment so far.
- burndown 8.19% → **7.17%**; **zero baseline failures, zero crashes**.
- Verified diverse folds: anonymous-type `Equals` (mixed `||`/`&&`), `SafeHandle.get_IsInvalid`, `ComInfo.FromObject`.

## Testing

`ILInspector.Decompiler.Tests` 369 ✅ (new `OrChainGuard_FoldsToSingleGuard`, a **synthetic-IR** test so it holds in both Debug and Release — csc's Debug lowering materializes a bool accumulator, a different shape) · `dotnet-inspect.Tests` 1041 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)