### PR TITLE
Improve discovery ergonomics

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -330,6 +330,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_PlatformPrefixBrowse_AllMissProjection_ReportsCleanError()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text", "--table", "--columns", "Library", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("No columns matched projection: Library", error);
+        Assert.DoesNotContain("Unhandled exception", error);
+    }
+
+    [Fact]
+    public async Task Type_PlatformPrefixBrowse_PartialProjection_WarnsForMissingColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text", "--table", "--columns", "Type,Library,Members", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("System.Text.StringBuilder", output);
+        Assert.Contains("note: 1 field has no data: Library", error);
+    }
+
+    [Fact]
     public async Task Router_PlatformPrefixBrowse_UnresolvedNamespace_ListsPlatformMatches()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -395,6 +418,28 @@ public class CommandExecutionTests
         Assert.Contains("System.Collections.Frozen", error);
         Assert.Contains("System.Collections.Frozen.FrozenDictionary", output);
         Assert.Contains("System.Collections.Frozen.FrozenSet", output);
+    }
+
+    [Fact]
+    public async Task RelationshipCommands_NamespacePrefixInputs_PrintPrefixBrowseHint()
+    {
+        var (implementsExit, implementsOutput, implementsError) = await RunAppAsync(
+            "implements", "System.Text", "--tips", "q");
+
+        Assert.Equal(0, implementsExit);
+        Assert.Empty(implementsOutput);
+        Assert.Contains("looks like a namespace prefix", implementsError);
+        Assert.Contains("type System.Text", implementsError);
+        Assert.Contains("find \"System.Text*\" --platform", implementsError);
+
+        var (extensionsExit, extensionsOutput, extensionsError) = await RunAppAsync(
+            "extensions", "System.Text", "--tips", "q");
+
+        Assert.Equal(0, extensionsExit);
+        Assert.Contains("No extension methods found", extensionsOutput);
+        Assert.Contains("looks like a namespace prefix", extensionsError);
+        Assert.Contains("type System.Text", extensionsError);
+        Assert.Contains("find \"System.Text*\" --platform", extensionsError);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/Parsers/SourceOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SourceOptionsParserTests.cs
@@ -108,6 +108,17 @@ public class SourceOptionsParserTests
     }
 
     [Fact]
+    public async Task Positional_QualifiedPlatformTypeOnly_DoesNotSplitTrailingTypeName()
+    {
+        var options = await ParseSuccessAsync("source", "System.Text.StringBuilder");
+
+        Assert.Equal("System.Text.StringBuilder", options.TypeName);
+        Assert.Equal("System.Private.CoreLib", options.PlatformAssembly);
+        Assert.Null(options.PackagePath);
+        Assert.Null(options.MemberName);
+    }
+
+    [Fact]
     public async Task ExplicitPlatform_WithLocalDottedMember_SplitsTypeAndMember()
     {
         var options = await ParseSuccessAsync(

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -127,6 +127,10 @@ public static class SourceOptionsParser
                 var typeName = source.TypeName;
                 if (typeName != null && typeName.Contains('.') && positionalMembers.Count == 0)
                 {
+                    var exactImplicitQualifiedType = !sourceSelection.HasExplicitSource
+                        && sourceSelection.Args.Length == 1
+                        && SourceResolver.TryResolveQualifiedTypeName(sourceSelection.Args[0], allowPlatformPrefixFallback: false) != null;
+
                     var qualifiedSplit = sourceSelection.HasExplicitSource
                         ? SharedParsers.TrySplitQualifiedTypeMember(typeName, allowPlatformPrefixFallback: true)
                         : null;
@@ -135,7 +139,7 @@ public static class SourceOptionsParser
                         positionalMembers.Add(qualifiedSplit.Value.MemberName);
                         source = source with { TypeName = qualifiedSplit.Value.Probe.Remainder };
                     }
-                    else if (!IsExplicitSourceQualifiedTypeName(sourceSelection, typeName))
+                    else if (!exactImplicitQualifiedType && !IsExplicitSourceQualifiedTypeName(sourceSelection, typeName))
                     {
                         var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
                         if (splitMemberName != null)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -613,8 +613,12 @@ public class ApiCommand
                 Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
             };
             OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-            OutputFormatter.WriteTable(Console.Out, !options.NoHeader,
+            var sw = new StringWriter();
+            OutputFormatter.WriteTable(sw, !options.NoHeader,
                 (writer, formatter) => MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOpts));
+            var rendered = sw.ToString();
+            ProjectionDiagnostics.DiagnoseRendered(options.Fields ?? options.Columns, rendered);
+            Console.Out.Write(rendered);
         }
         else
         {

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -83,6 +83,9 @@ public class ExtensionsCommand
             // Collapse overloads into single entries
             results = CollapseOverloads(results);
 
+            if (results.Count == 0)
+                NamespacePrefixHints.WriteIfLikelyNamespacePrefix(targetType);
+
             // Output results
             if (options.JsonOutput)
             {

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -73,6 +73,9 @@ public class ImplementsCommand
                 results = results.Take(options.Limit.Value).ToList();
             }
 
+            if (results.Count == 0)
+                NamespacePrefixHints.WriteIfLikelyNamespacePrefix(targetType);
+
             // Output results
             if (options.JsonOutput)
             {

--- a/src/dotnet-inspect/Commands/NamespacePrefixHints.cs
+++ b/src/dotnet-inspect/Commands/NamespacePrefixHints.cs
@@ -1,0 +1,20 @@
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Commands;
+
+internal static class NamespacePrefixHints
+{
+    public static void WriteIfLikelyNamespacePrefix(string value)
+    {
+        if (!LooksLikePlatformNamespacePrefix(value))
+            return;
+
+        Console.Error.WriteLine($"Note: '{value}' looks like a namespace prefix. Use `type {value}` to browse matching platform types, or `find \"{value}*\" --platform` to see source libraries.");
+    }
+
+    private static bool LooksLikePlatformNamespacePrefix(string value)
+        => value.Contains('.')
+           && !value.Contains('*')
+           && !value.Contains('?')
+           && PlatformResolver.IsPlatformCandidate(value);
+}

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -33,8 +33,16 @@ public static class TypeCommand
         var typePipeline = preamble.TypePipeline;
         var memberPipeline = preamble.MemberPipeline;
 
-        if (await TryExecutePlatformPrefixBrowseAsync(options, typePipeline) is { } prefixBrowseExitCode)
-            return prefixBrowseExitCode;
+        try
+        {
+            if (await TryExecutePlatformPrefixBrowseAsync(options, typePipeline) is { } prefixBrowseExitCode)
+                return prefixBrowseExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
 
         // Shared source resolution
         var (source, sourceError) = await ApiCommand.ResolveSourceAsync(options);


### PR DESCRIPTION
## Summary
- shape prefix-browse projection failures as clean errors instead of stack traces
- warn when partially requested full type-list columns do not render
- preserve exact qualified source type inputs such as `source System.Text.StringBuilder`
- add namespace-prefix hints for no-result relationship commands such as `implements System.Text` and `extensions System.Text`

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused regression tests for projection diagnostics, source qualified type parsing, and relationship namespace hints