### PR TITLE
Polish discovery ergonomics

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -330,6 +330,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_PlatformPrefixBrowse_WildcardNote_DoesNotDoubleStar()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text*", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("System.Text.StringBuilder", output);
+        Assert.Contains("find \"System.Text*\" --platform", error);
+        Assert.DoesNotContain("System.Text**", error);
+    }
+
+    [Fact]
     public async Task Type_PlatformPrefixBrowse_AllMissProjection_ReportsCleanError()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -350,6 +362,45 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("System.Text.StringBuilder", output);
         Assert.Contains("note: 1 field has no data: Library", error);
+    }
+
+    [Fact]
+    public async Task Type_BareSimpleTypeMiss_SuggestsFind()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "Regex", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Package 'Regex' not found", error);
+        Assert.Contains("find Regex --platform", error);
+    }
+
+    [Fact]
+    public async Task Find_NamespaceExactMiss_RetriesAsPrefix()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "find", "System.Text", "--platform", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("No exact matches for 'System.Text'", error);
+        Assert.Contains("System.Text*", error);
+        Assert.Contains("StringBuilder", output);
+        Assert.Contains("System.Text.Json", output);
+        Assert.DoesNotContain("TextInfo", output);
+    }
+
+    [Fact]
+    public async Task Source_TypeListing_FormatsGenericTypeNames()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "System.Text.Json", "--tips", "q", "--rows", "-n", "200");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Text.Json.Serialization.JsonConverter&lt;T&gt;", output);
+        Assert.Contains("System.Text.Json.Serialization.Metadata.FSharpCoreReflectionProxy.StructGetter&lt;TStruct, TResult&gt;", output);
+        Assert.DoesNotContain("&#96;", output);
     }
 
     [Fact]
@@ -440,6 +491,44 @@ public class CommandExecutionTests
         Assert.Contains("looks like a namespace prefix", extensionsError);
         Assert.Contains("type System.Text", extensionsError);
         Assert.Contains("find \"System.Text*\" --platform", extensionsError);
+    }
+
+    [Fact]
+    public async Task SourceAndDepends_NamespacePrefixInputs_PrintPrefixBrowseHint()
+    {
+        var (sourceExit, sourceOutput, sourceError) = await RunAppAsync(
+            "source", "System.Text", "--tips", "q");
+
+        Assert.Equal(1, sourceExit);
+        Assert.Empty(sourceOutput);
+        Assert.Contains("Package 'System.Text' not found", sourceError);
+        Assert.Contains("looks like a namespace prefix", sourceError);
+        Assert.Contains("type System.Text", sourceError);
+        Assert.Contains("find \"System.Text*\" --platform", sourceError);
+
+        var (dependsExit, dependsOutput, dependsError) = await RunAppAsync(
+            "depends", "System.Text", "--tips", "q");
+
+        Assert.Equal(1, dependsExit);
+        Assert.Empty(dependsOutput);
+        Assert.Contains("Could not resolve 'System.Text'", dependsError);
+        Assert.Contains("looks like a namespace prefix", dependsError);
+        Assert.Contains("type System.Text", dependsError);
+        Assert.Contains("find \"System.Text*\" --platform", dependsError);
+    }
+
+    [Fact]
+    public async Task Member_NamespacePrefixInput_PrintsPrefixBrowseHint()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Text", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("member requires a type name", error);
+        Assert.Contains("looks like a namespace prefix", error);
+        Assert.Contains("type System.Text", error);
+        Assert.Contains("find \"System.Text*\" --platform", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -129,7 +129,13 @@ public static class SourceOptionsParser
                 {
                     var exactImplicitQualifiedType = !sourceSelection.HasExplicitSource
                         && sourceSelection.Args.Length == 1
-                        && SourceResolver.TryResolveQualifiedTypeName(sourceSelection.Args[0], allowPlatformPrefixFallback: false) != null;
+                        && source.PackagePath == null
+                        && source.PlatformAssembly != null
+                        && (string.Equals(
+                                ILInspector.Metadata.TypeMatcher.Normalize(sourceSelection.Args[0]),
+                                typeName,
+                                StringComparison.OrdinalIgnoreCase)
+                            || SourceResolver.TryResolveQualifiedTypeName(sourceSelection.Args[0], allowPlatformPrefixFallback: false) != null);
 
                     var qualifiedSplit = sourceSelection.HasExplicitSource
                         ? SharedParsers.TrySplitQualifiedTypeMember(typeName, allowPlatformPrefixFallback: true)

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -139,6 +139,7 @@ public class DependsCommand
                 if (!outcome.IsSuccess)
                 {
                     Console.Error.WriteLine($"Error: Could not resolve '{libraryName}' as a file, platform library, or NuGet package.");
+                    NamespacePrefixHints.WriteIfLikelyNamespacePrefix(libraryName);
                     return 1;
                 }
                 tempDir = outcome.Result!.TempDir;

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -24,6 +24,7 @@ public static class MemberCommand
             Console.Error.WriteLine("Error: member requires a type name.");
             Console.Error.WriteLine("Usage: dotnet-inspect member <type> --package <pkg>");
             Console.Error.WriteLine("   or: dotnet-inspect member -m Type.Member --package <pkg>");
+            NamespacePrefixHints.WriteIfLikelyNamespacePrefix(options.PackagePath ?? options.PlatformAssembly ?? "");
             return 1;
         }
 

--- a/src/dotnet-inspect/Commands/NamespacePrefixHints.cs
+++ b/src/dotnet-inspect/Commands/NamespacePrefixHints.cs
@@ -12,9 +12,27 @@ internal static class NamespacePrefixHints
         Console.Error.WriteLine($"Note: '{value}' looks like a namespace prefix. Use `type {value}` to browse matching platform types, or `find \"{value}*\" --platform` to see source libraries.");
     }
 
+    public static void WriteIfLikelyBareTypeName(string value)
+    {
+        if (!LooksLikeBareTypeName(value))
+            return;
+
+        Console.Error.WriteLine($"Note: If '{value}' is a type name, use `find {value} --platform` to locate its library, or add --package/--library/--platform.");
+    }
+
     private static bool LooksLikePlatformNamespacePrefix(string value)
         => value.Contains('.')
            && !value.Contains('*')
            && !value.Contains('?')
            && PlatformResolver.IsPlatformCandidate(value);
+
+    private static bool LooksLikeBareTypeName(string value)
+        => value.Length > 0
+           && char.IsUpper(value[0])
+           && !value.Contains('.')
+           && !value.Contains('*')
+           && !value.Contains('?')
+           && !value.Contains('@')
+           && !value.Contains('/')
+           && !value.Contains('\\');
 }

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -35,7 +35,11 @@ public static class SourceCommand
         };
 
         var (source, sourceError) = await ApiCommand.ResolveSourceAsync(apiOptions);
-        if (sourceError.HasValue) return sourceError.Value;
+        if (sourceError.HasValue)
+        {
+            NamespacePrefixHints.WriteIfLikelyNamespacePrefix(options.PackagePath ?? options.TypeName ?? "");
+            return sourceError.Value;
+        }
 
         var searchPath = source.SearchPath;
         var runtimeAssemblyPath = source.RuntimeAssemblyPath;
@@ -150,6 +154,7 @@ public static class SourceCommand
 
         foreach (var type in typeList)
         {
+            var typeDisplayName = ApiOutputFormatter.FormatGenericFullName(type);
             var sourceInfo = service.ResolveTypeSource(type.FullName);
 
             // Follow type forwarder if source not found in the original assembly
@@ -173,9 +178,9 @@ public static class SourceCommand
 
             if (sourceInfo == null)
             {
-                rows.Add(new SourceFileRow(type.FullName, null));
+                rows.Add(new SourceFileRow(typeDisplayName, null));
                 if (options.Verify)
-                    verifiedRows.Add(new VerifiedSourceFileRow(type.FullName, null, "—"));
+                    verifiedRows.Add(new VerifiedSourceFileRow(typeDisplayName, null, "—"));
                 continue;
             }
 
@@ -183,18 +188,18 @@ public static class SourceCommand
                 ? sourceInfo.GitHubBrowseUrl
                 : sourceInfo.SourceUrl;
 
-            rows.Add(new SourceFileRow(type.FullName, url));
+            rows.Add(new SourceFileRow(typeDisplayName, url));
             if (options.Verify)
-                verifiedRows.Add(new VerifiedSourceFileRow(type.FullName, url, "pending"));
+                verifiedRows.Add(new VerifiedSourceFileRow(typeDisplayName, url, "pending"));
 
             foreach (var partial in sourceInfo.AdditionalSourceFiles)
             {
                 var partialUrl = options.BrowsableUrls
                     ? partial.GitHubBrowseUrl
                     : partial.SourceUrl;
-                rows.Add(new SourceFileRow(type.FullName, partialUrl));
+                rows.Add(new SourceFileRow(typeDisplayName, partialUrl));
                 if (options.Verify)
-                    verifiedRows.Add(new VerifiedSourceFileRow(type.FullName, partialUrl, "pending"));
+                    verifiedRows.Add(new VerifiedSourceFileRow(typeDisplayName, partialUrl, "pending"));
             }
         }
 

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -46,7 +46,11 @@ public static class TypeCommand
 
         // Shared source resolution
         var (source, sourceError) = await ApiCommand.ResolveSourceAsync(options);
-        if (sourceError.HasValue) return sourceError.Value;
+        if (sourceError.HasValue)
+        {
+            NamespacePrefixHints.WriteIfLikelyBareTypeName(options.OriginalTypeQuery ?? options.PackagePath ?? options.TypeName ?? "");
+            return sourceError.Value;
+        }
 
         var searchPath = source.SearchPath;
         var runtimeAssemblyPath = source.RuntimeAssemblyPath;
@@ -457,7 +461,7 @@ public static class TypeCommand
         };
 
         Console.Error.WriteLine($"Note: Showing best-effort platform prefix matches for '{query}'.");
-        Console.Error.WriteLine($"Note: Use `find \"{query}*\" --platform` to see source libraries.");
+        Console.Error.WriteLine($"Note: Use `find \"{ToFindPrefixPattern(query)}\" --platform` to see source libraries.");
 
         if (browseOptions.EffectiveDiscovery)
         {
@@ -473,6 +477,9 @@ public static class TypeCommand
         ApiCommand.WriteFullApiOutput(api, browseOptions);
         return 0;
     }
+
+    private static string ToFindPrefixPattern(string query)
+        => query.EndsWith('*') ? query : $"{query}*";
 
     private static async Task<bool> PackageExistsAsync(string packageName, TypeOptions options, CommandContext context)
     {

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -74,6 +74,13 @@ internal static class TypeSearchService
             }
             else if (!pattern.Contains('*') && !pattern.Contains('?'))
             {
+                if (TryGetNamespacePrefixMatches(pattern, allTypes, options, out var prefixPattern, out var prefixMatches))
+                {
+                    Console.Error.WriteLine($"Note: No exact matches for '{pattern}'. Showing prefix matches for '{prefixPattern}'.");
+                    resultsByPattern[prefixPattern] = prefixMatches;
+                    continue;
+                }
+
                 var suggestions = TypeMatcher.FindClosest(typeNames, pattern, minSimilarity: 0.5, maxResults: 5).ToList();
                 if (suggestions.Count > 0)
                 {
@@ -101,6 +108,30 @@ internal static class TypeSearchService
         return ConvertToFindResults(resultsByPattern, partialMatchesByPattern, notFoundPatterns, similarityByPattern);
     }
 
+    private static bool TryGetNamespacePrefixMatches(
+        string pattern,
+        List<TypeSearchResult> allTypes,
+        FindOptions options,
+        out string prefixPattern,
+        out List<TypeSearchResult> prefixMatches)
+    {
+        prefixPattern = $"{pattern}*";
+        prefixMatches = [];
+        if (!LooksLikeNamespacePrefix(pattern))
+            return false;
+
+        var localPrefixPattern = prefixPattern;
+        prefixMatches = allTypes
+            .Where(t => TypeMatcher.MatchesTypeFilter(t.FullName, localPrefixPattern))
+            .DistinctBy(t => t.FullName)
+            .ToList();
+
+        if (options.Limit.HasValue && prefixMatches.Count > options.Limit.Value)
+            prefixMatches = prefixMatches.Take(options.Limit.Value).ToList();
+
+        return prefixMatches.Count > 0;
+    }
+
     private static async Task<List<TypeFindResult>> FindSinglePatternAsync(
         string pattern,
         FindOptions options,
@@ -116,6 +147,17 @@ internal static class TypeSearchService
         {
             var allTypes = await CollectTypesAsync(options, null, logger, tempDirs, httpClient);
             var typeNames = allTypes.Select(t => t.FullName).Distinct().ToList();
+
+            if (TryGetNamespacePrefixMatches(pattern, allTypes, options, out var prefixPattern, out var prefixResults))
+            {
+                Console.Error.WriteLine($"Note: No exact matches for '{pattern}'. Showing prefix matches for '{prefixPattern}'.");
+                return ConvertToFindResults(
+                    new Dictionary<string, List<TypeSearchResult>> { [prefixPattern] = prefixResults },
+                    [],
+                    [],
+                    null);
+            }
+
             var suggestions = TypeMatcher.FindClosest(typeNames, pattern, minSimilarity: 0.5, maxResults: 5).ToList();
 
             if (suggestions.Count > 0)
@@ -145,6 +187,9 @@ internal static class TypeSearchService
             [],
             similarityByPattern);
     }
+
+    private static bool LooksLikeNamespacePrefix(string pattern)
+        => pattern.Contains('.') && !pattern.Contains('<') && !pattern.Contains('`');
 
     /// <summary>
     /// Converts separate result dictionaries into a unified flat list of TypeFindResult.


### PR DESCRIPTION
## Summary
- format generic type names in `source` type listings without raw metadata backticks
- add namespace-prefix hints for `source`, `member`, and `depends` no-result/error paths
- add simple bare-type miss hint pointing to `find <Type> --platform`
- avoid doubled `*` in type prefix browse find hints
- make `find System.Text --platform` retry as `System.Text*` before fuzzy matching
- keep prefix-browse projection errors/warnings shaped cleanly

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused regression tests for source formatting, namespace hints, find prefix retry, and projection diagnostics