### PR TITLE
Add find-if-miss for type discovery

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -365,15 +365,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_BareSimpleTypeMiss_SuggestsFind()
+    public async Task Type_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
     {
         var (exit, output, error) = await RunAppAsync(
-            "type", "Regex", "--tips", "q");
+            "type", "Regex", "--markdown", "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("Package 'Regex' not found", error);
-        Assert.Contains("find Regex --platform", error);
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Text.RegularExpressions.Regex", output);
+        Assert.Contains("Library: System.Text.RegularExpressions", output);
+        Assert.Contains("Note: Type 'Regex' resolved via platform find", error);
+    }
+
+    [Fact]
+    public async Task Type_BareSimpleTypeMiss_PrefersExactNonGenericMatch()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "FrozenDictionary", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("Library: System.Collections.Immutable", output);
+        Assert.Contains("## Method Groups", output);
+        Assert.DoesNotContain("## Type Parameters", output);
+        Assert.Contains("Note: Type 'FrozenDictionary' resolved via platform find", error);
     }
 
     [Fact]
@@ -388,6 +402,48 @@ public class CommandExecutionTests
         Assert.Contains("StringBuilder", output);
         Assert.Contains("System.Text.Json", output);
         Assert.DoesNotContain("TextInfo", output);
+    }
+
+    [Fact]
+    public async Task Diff_TypeFilter_LongNamespacePrefixMatchesChangedTypes()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--package", "System.Text.Json@9.0.0..10.0.0",
+            "-t", "System.Text.Json.Serialization", "--additive", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Summary", output);
+        Assert.Contains("5 additive", output);
+        Assert.Contains("JsonKnownReferenceHandler", output);
+        Assert.DoesNotContain("JsonSerializer |", output);
+    }
+
+    [Fact]
+    public async Task Diff_TypeFilter_ShortNamespacePrefixMatchesChangedTypes()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--package", "System.Text.Json@9.0.0..10.0.0",
+            "-t", "Serialization", "--additive", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("5 additive", output);
+        Assert.Contains("JsonKnownReferenceHandler", output);
+        Assert.DoesNotContain("JsonSerializer |", output);
+    }
+
+    [Fact]
+    public async Task Diff_TypeFilter_NoMatches_PrintsNote()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--package", "System.Text.Json@9.0.0..10.0.0",
+            "-t", "DefinitelyMissingNamespace", "--additive", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Summary", output);
+        Assert.Contains("no changes", output);
+        Assert.Contains("type filter matched no changed types", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -235,12 +235,39 @@ public class DiffCommand
         if (options.TypeFilter.Count > 0)
         {
             typeDiffs = typeDiffs
-                .Where(td => TypeMatcher.MatchesAnyTypeFilter(td.TypeFullName, options.TypeFilter))
+                .Where(td => MatchesAnyDiffTypeFilter(td.TypeFullName, options.TypeFilter))
                 .ToList();
+
+            if (typeDiffs.Count == 0)
+                Console.Error.WriteLine($"Note: type filter matched no changed types: {string.Join(", ", options.TypeFilter)}.");
         }
 
         // Apply classification filter
         return FilterByClassification(typeDiffs, options);
+    }
+
+    private static bool MatchesAnyDiffTypeFilter(string typeFullName, IEnumerable<string> filters)
+    {
+        foreach (var filter in filters)
+        {
+            if (MatchesDiffTypeFilter(typeFullName, filter))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool MatchesDiffTypeFilter(string typeFullName, string filter)
+    {
+        if (TypeMatcher.MatchesTypeFilter(typeFullName, filter))
+            return true;
+
+        if (filter.Contains('*') || filter.Contains('?'))
+            return false;
+
+        var normalizedFilter = TypeMatcher.Normalize(filter);
+        return typeFullName.StartsWith(normalizedFilter + ".", StringComparison.OrdinalIgnoreCase)
+               || typeFullName.Contains("." + normalizedFilter + ".", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string RenderDiff(string name, ApiDiff diff, string fromVersion, string toVersion, DiffOptions options)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -37,6 +37,8 @@ public static class TypeCommand
         {
             if (await TryExecutePlatformPrefixBrowseAsync(options, typePipeline) is { } prefixBrowseExitCode)
                 return prefixBrowseExitCode;
+            if (await TryExecuteFindIfMissAsync(options) is { } findIfMissExitCode)
+                return findIfMissExitCode;
         }
         catch (Exception ex)
         {
@@ -431,6 +433,89 @@ public static class TypeCommand
            && !options.Count
            && !options.HasSectionQuery
            && options.Verbosity == Verbosity.Quiet;
+
+    private static async Task<int?> TryExecuteFindIfMissAsync(TypeOptions options)
+    {
+        var query = options.OriginalTypeQuery ?? options.PackagePath ?? options.TypeName;
+        if (options.AssemblyPath != null || options.PlatformAssembly != null || options.TypeName != null)
+            return null;
+        if (!LooksLikeSimpleTypeQuery(query))
+            return null;
+
+        var context = new CommandContext(options.Verbose);
+        var logger = context.Logger;
+        if (await PackageExistsAsync(query!, options, context))
+            return null;
+
+        List<string> tempDirs = [];
+        try
+        {
+            var findOptions = new FindOptions
+            {
+                Pattern = query!,
+                PlatformFrameworks = CommandLineBuilder.PlatformFrameworkNames,
+                IncludeAll = options.IncludeAll,
+                Limit = options.Limit,
+                SourceOptions = options.SourceOptions
+            };
+            var results = await TypeSearchService.FindTypesAsync(
+                findOptions,
+                [query!],
+                logger,
+                tempDirs,
+                context.HttpClient);
+
+            var exactMatches = results
+                .Where(r => r.Match == MatchKind.Exact)
+                .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var exactSimpleNameMatches = exactMatches
+                .Where(r => string.Equals(TypeMatcher.GetSimpleName(r.FullName), query, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var candidateMatches = exactSimpleNameMatches.Count > 0 ? exactSimpleNameMatches : exactMatches;
+
+            if (candidateMatches.Count == 1)
+            {
+                var match = candidateMatches[0];
+                Console.Error.WriteLine($"Note: Type '{query}' resolved via platform find to {match.FullName} in {match.Library}.");
+                var routeOptions = options with
+                {
+                    TypeName = match.FullName,
+                    PackagePath = null,
+                    PlatformAssembly = match.Library,
+                    PlatformFramework = match.Source,
+                    OriginalTypeQuery = match.FullName,
+                    PlatformPrefixQuery = null,
+                    AllowPlatformPrefixFallback = false
+                };
+                return await ExecuteAsync(routeOptions);
+            }
+
+            if (candidateMatches.Count > 1)
+            {
+                Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
+                return 1;
+            }
+        }
+        finally
+        {
+            AssemblyCollector.CleanupTempDirs(tempDirs);
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeSimpleTypeQuery(string? query)
+        => query is { Length: > 0 }
+           && char.IsUpper(query[0])
+           && !query.Contains('.')
+           && !query.Contains('*')
+           && !query.Contains('?')
+           && !query.Contains('<')
+           && !query.Contains('`')
+           && !query.Contains('@')
+           && !query.Contains('/')
+           && !query.Contains('\\');
 
     internal static async Task<int?> TryExecutePlatformPrefixBrowseAsync(
         TypeOptions options,


### PR DESCRIPTION
## Summary
- make `type Regex` and similar simple type misses route through platform `find` when there is a unique exact platform match
- prefer exact non-generic simple-name matches for families such as `FrozenDictionary`
- make `diff -t` match namespace/type prefixes, including long forms like `System.Text.Json.Serialization` and short contextual forms like `Serialization`
- emit a note when a diff type filter matches no changed types

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused tests for `type Regex`, `type FrozenDictionary`, and diff namespace-prefix filters