### PR TITLE
Broaden simple type discovery

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -356,6 +356,20 @@ public static class TypeMatcher
                 if (arityMatch != null)
                     return new LookupResult(arityMatch, []);
             }
+
+            var normalizedPattern = Normalize(pattern);
+            var exactSimpleNameMatch = matches.FirstOrDefault(c =>
+                GetGenericArity(GetSimpleName(c)) == 0
+                && GetSimpleName(c).Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase));
+            if (exactSimpleNameMatch != null)
+                return new LookupResult(exactSimpleNameMatch, []);
+
+            var exactFullNameMatch = matches.FirstOrDefault(c =>
+                GetGenericArity(c) == 0
+                && c.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase));
+            if (exactFullNameMatch != null)
+                return new LookupResult(exactFullNameMatch, []);
+
             // Otherwise return first match (existing behavior for non-generic patterns)
             return new LookupResult(matches[0], []);
         }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -377,6 +377,31 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "Regex", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Text.RegularExpressions.Regex", output);
+        Assert.Contains("Library: System.Text.RegularExpressions", output);
+        Assert.Contains("Note: Type 'Regex' resolved via platform find", error);
+    }
+
+    [Fact]
+    public async Task Type_BareSimpleTypeMiss_PrefersPlatformTypeOverSameNamedPackage()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonSerializer", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Text.Json.JsonSerializer", output);
+        Assert.Contains("Library: System.Text.Json", output);
+        Assert.DoesNotContain("Package 'JsonSerializer'", error);
+        Assert.Contains("Note: Type 'JsonSerializer' resolved via platform find", error);
+    }
+
+    [Fact]
     public async Task Type_BareSimpleTypeMiss_PrefersExactNonGenericMatch()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -388,6 +413,42 @@ public class CommandExecutionTests
         Assert.Contains("## Method Groups", output);
         Assert.DoesNotContain("## Type Parameters", output);
         Assert.Contains("Note: Type 'FrozenDictionary' resolved via platform find", error);
+    }
+
+    [Fact]
+    public async Task Type_BareCoreLibSimpleName_PrefersNonGenericExactMatch()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "Task", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("# System.Threading.Tasks.Task", output);
+        Assert.DoesNotContain("# System.Threading.Tasks.Task&lt;TResult&gt;", output);
+    }
+
+    [Fact]
+    public async Task Member_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "Regex", "-m", "Match", "--show-index", "--rows", "-n", "4", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Text.RegularExpressions.Regex", output);
+        Assert.Contains("`Match:1`", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Source_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "Regex", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# System.Text.RegularExpressions.Regex", output);
+        Assert.Contains("Library: System.Text.RegularExpressions", output);
+        Assert.DoesNotContain("Package 'Regex' not found", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -105,7 +105,7 @@ public static class RouterCommandDefinition
                     return await ExecuteMemberCommandAsync(route, opts, parseResult, commandArgs);
 
                 case RouterOptionsParser.RouteToPackage route:
-                    return await ExecutePackageCommandAsync(route);
+                    return await ExecutePackageCommandAsync(route, parseResult, opts);
 
                 default:
                     return 1;
@@ -496,8 +496,43 @@ public static class RouterCommandDefinition
         };
     }
 
-    private static async Task<int> ExecutePackageCommandAsync(RouterOptionsParser.RouteToPackage route)
+    private static async Task<int> ExecutePackageCommandAsync(
+        RouterOptionsParser.RouteToPackage route,
+        ParseResult parseResult,
+        SharedOptions opts)
     {
+        if (route.Options.PackageLibrary == null)
+        {
+            var findIfMissOptions = new TypeOptions
+            {
+                PackagePath = route.BareName,
+                OriginalTypeQuery = route.BareName,
+                JsonOutput = route.Options.JsonOutput,
+                OneLine = route.Options.OneLine,
+                Tsv = route.Options.Tsv,
+                Jsonl = route.Options.Jsonl,
+                OneLineExplicitlySet = route.Options.OneLineExplicitlySet,
+                FormatExplicitlySet = route.Options.FormatExplicitlySet,
+                MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
+                NoHeader = route.Options.NoHeader,
+                Verbose = route.Options.Verbose,
+                Verbosity = route.Verbosity,
+                Discover = route.Options.Discover,
+                Tree = route.Options.Tree,
+                Select = route.Options.Select,
+                Columns = route.Options.Columns,
+                Fields = route.Options.Fields,
+                Count = route.Options.Count,
+                Rows = route.Options.Rows,
+                Schema = route.Options.Schema,
+                SourceOptions = route.Options.SourceOptions,
+                TipLevel = route.Options.TipLevel
+            };
+            var typeExitCode = await TypeCommand.TryExecuteFindIfMissAsync(findIfMissOptions);
+            if (typeExitCode.HasValue)
+                return typeExitCode.Value;
+        }
+
         var exitCode = await PackageCommand.ExecuteAsync(route.Options);
 
         if (exitCode == 0 && route.Options.PackageLibrary == null && !route.Options.FormatExplicitlySet && !route.Options.IsRawOutput)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -21,6 +21,9 @@ public static class MemberCommand
         // Validate that member command has a type argument
         if (string.IsNullOrEmpty(options.TypeName))
         {
+            if (await TryExecuteFindIfMissAsync(options) is { } findIfMissExitCode)
+                return findIfMissExitCode;
+
             Console.Error.WriteLine("Error: member requires a type name.");
             Console.Error.WriteLine("Usage: dotnet-inspect member <type> --package <pkg>");
             Console.Error.WriteLine("   or: dotnet-inspect member -m Type.Member --package <pkg>");
@@ -340,6 +343,39 @@ public static class MemberCommand
                 try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
         }
+    }
+
+    private static async Task<int?> TryExecuteFindIfMissAsync(MemberOptions options)
+    {
+        if (options.PackagePath == null || options.AssemblyPath != null || options.PlatformAssembly != null)
+            return null;
+
+        var context = new CommandContext(options.Verbose);
+        var resolution = await TypeFindIfMissResolver.ResolvePlatformAsync(
+            options.PackagePath,
+            options.IncludeAll,
+            options.SourceOptions,
+            context.HttpClient,
+            context.Logger);
+
+        return resolution.Status switch
+        {
+            TypeFindIfMissStatus.Found => await ExecuteAsync(options with
+            {
+                TypeName = resolution.Match!.FullName,
+                PackagePath = null,
+                PlatformAssembly = resolution.Match.Library,
+                PlatformFramework = resolution.Match.Source
+            }),
+            TypeFindIfMissStatus.Ambiguous => WriteFindIfMissAmbiguousError(resolution.Query),
+            _ => null
+        };
+    }
+
+    private static int WriteFindIfMissAmbiguousError(string query)
+    {
+        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
+        return 1;
     }
 
     private static bool ShouldAutoSelectSingleOverload(MemberOptions options)

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -34,6 +34,9 @@ public static class SourceCommand
             SourceOptions = options.NuGetOptions
         };
 
+        if (await TryExecuteFindIfMissAsync(options) is { } findIfMissExitCode)
+            return findIfMissExitCode;
+
         var (source, sourceError) = await ApiCommand.ResolveSourceAsync(apiOptions);
         if (sourceError.HasValue)
         {
@@ -576,6 +579,39 @@ public static class SourceCommand
             return false;
 
         return ilOffset >= 0;
+    }
+
+    private static async Task<int?> TryExecuteFindIfMissAsync(SourceOptions options)
+    {
+        if (options.TypeName != null || options.PackagePath == null || options.AssemblyPath != null || options.PlatformAssembly != null)
+            return null;
+
+        var context = new CommandContext(options.Verbose);
+        var resolution = await TypeFindIfMissResolver.ResolvePlatformAsync(
+            options.PackagePath,
+            options.IncludeAll,
+            options.NuGetOptions,
+            context.HttpClient,
+            context.Logger);
+
+        return resolution.Status switch
+        {
+            TypeFindIfMissStatus.Found => await ExecuteAsync(options with
+            {
+                TypeName = resolution.Match!.FullName,
+                PackagePath = null,
+                PlatformAssembly = resolution.Match.Library,
+                PlatformFramework = resolution.Match.Source
+            }),
+            TypeFindIfMissStatus.Ambiguous => WriteFindIfMissAmbiguousError(resolution.Query),
+            _ => null
+        };
+    }
+
+    private static int WriteFindIfMissAmbiguousError(string query)
+    {
+        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
+        return 1;
     }
 
     private static bool TryParseHexOrDecimal(string value, out int result)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -434,88 +434,43 @@ public static class TypeCommand
            && !options.HasSectionQuery
            && options.Verbosity == Verbosity.Quiet;
 
-    private static async Task<int?> TryExecuteFindIfMissAsync(TypeOptions options)
+    internal static async Task<int?> TryExecuteFindIfMissAsync(TypeOptions options)
     {
         var query = options.OriginalTypeQuery ?? options.PackagePath ?? options.TypeName;
         if (options.AssemblyPath != null || options.PlatformAssembly != null || options.TypeName != null)
             return null;
-        if (!LooksLikeSimpleTypeQuery(query))
-            return null;
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        if (await PackageExistsAsync(query!, options, context))
+        var resolution = await TypeFindIfMissResolver.ResolvePlatformAsync(
+            query,
+            options.IncludeAll,
+            options.SourceOptions,
+            context.HttpClient,
+            logger);
+        if (resolution.Status == TypeFindIfMissStatus.None)
             return null;
 
-        List<string> tempDirs = [];
-        try
+        if (resolution.Status == TypeFindIfMissStatus.Found)
         {
-            var findOptions = new FindOptions
+            var match = resolution.Match!;
+            Console.Error.WriteLine($"Note: Type '{query}' resolved via platform find to {match.FullName} in {match.Library}.");
+            var routeOptions = options with
             {
-                Pattern = query!,
-                PlatformFrameworks = CommandLineBuilder.PlatformFrameworkNames,
-                IncludeAll = options.IncludeAll,
-                Limit = options.Limit,
-                SourceOptions = options.SourceOptions
+                TypeName = match.FullName,
+                PackagePath = null,
+                PlatformAssembly = match.Library,
+                PlatformFramework = match.Source,
+                OriginalTypeQuery = match.FullName,
+                PlatformPrefixQuery = null,
+                AllowPlatformPrefixFallback = false
             };
-            var results = await TypeSearchService.FindTypesAsync(
-                findOptions,
-                [query!],
-                logger,
-                tempDirs,
-                context.HttpClient);
-
-            var exactMatches = results
-                .Where(r => r.Match == MatchKind.Exact)
-                .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            var exactSimpleNameMatches = exactMatches
-                .Where(r => string.Equals(TypeMatcher.GetSimpleName(r.FullName), query, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var candidateMatches = exactSimpleNameMatches.Count > 0 ? exactSimpleNameMatches : exactMatches;
-
-            if (candidateMatches.Count == 1)
-            {
-                var match = candidateMatches[0];
-                Console.Error.WriteLine($"Note: Type '{query}' resolved via platform find to {match.FullName} in {match.Library}.");
-                var routeOptions = options with
-                {
-                    TypeName = match.FullName,
-                    PackagePath = null,
-                    PlatformAssembly = match.Library,
-                    PlatformFramework = match.Source,
-                    OriginalTypeQuery = match.FullName,
-                    PlatformPrefixQuery = null,
-                    AllowPlatformPrefixFallback = false
-                };
-                return await ExecuteAsync(routeOptions);
-            }
-
-            if (candidateMatches.Count > 1)
-            {
-                Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
-                return 1;
-            }
-        }
-        finally
-        {
-            AssemblyCollector.CleanupTempDirs(tempDirs);
+            return await ExecuteAsync(routeOptions);
         }
 
-        return null;
+        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
+        return 1;
     }
-
-    private static bool LooksLikeSimpleTypeQuery(string? query)
-        => query is { Length: > 0 }
-           && char.IsUpper(query[0])
-           && !query.Contains('.')
-           && !query.Contains('*')
-           && !query.Contains('?')
-           && !query.Contains('<')
-           && !query.Contains('`')
-           && !query.Contains('@')
-           && !query.Contains('/')
-           && !query.Contains('\\');
 
     internal static async Task<int?> TryExecutePlatformPrefixBrowseAsync(
         TypeOptions options,

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -1,0 +1,91 @@
+using DotnetInspector.Models;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+internal enum TypeFindIfMissStatus
+{
+    None,
+    Found,
+    Ambiguous
+}
+
+internal sealed record TypeFindIfMissResult(
+    TypeFindIfMissStatus Status,
+    string Query,
+    TypeFindResult? Match,
+    IReadOnlyList<TypeFindResult> Matches)
+{
+    public static TypeFindIfMissResult None(string query) => new(TypeFindIfMissStatus.None, query, null, []);
+    public static TypeFindIfMissResult Found(string query, TypeFindResult match) => new(TypeFindIfMissStatus.Found, query, match, [match]);
+    public static TypeFindIfMissResult Ambiguous(string query, IReadOnlyList<TypeFindResult> matches) => new(TypeFindIfMissStatus.Ambiguous, query, null, matches);
+}
+
+internal static class TypeFindIfMissResolver
+{
+    public static bool LooksLikeSimpleTypeQuery(string? query)
+        => query is { Length: > 0 }
+           && char.IsUpper(query[0])
+           && !query.Contains('.')
+           && !query.Contains('*')
+           && !query.Contains('?')
+           && !query.Contains('<')
+           && !query.Contains('`')
+           && !query.Contains('@')
+           && !query.Contains('/')
+           && !query.Contains('\\');
+
+    public static async Task<TypeFindIfMissResult> ResolvePlatformAsync(
+        string? query,
+        bool includeAll,
+        NuGetSourceOptions? sourceOptions,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        if (!LooksLikeSimpleTypeQuery(query))
+            return TypeFindIfMissResult.None(query ?? "");
+
+        List<string> tempDirs = [];
+        try
+        {
+            var findOptions = new FindOptions
+            {
+                Pattern = query!,
+                PlatformFrameworks = CommandLineBuilder.PlatformFrameworkNames,
+                IncludeAll = includeAll,
+                SourceOptions = sourceOptions
+            };
+            var results = await TypeSearchService.FindTypesAsync(
+                findOptions,
+                [query!],
+                logger,
+                tempDirs,
+                httpClient);
+
+            var exactMatches = results
+                .Where(r => r.Match == MatchKind.Exact)
+                .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var exactSimpleNameMatches = exactMatches
+                .Where(r => string.Equals(TypeMatcher.GetSimpleName(r.FullName), query, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var candidateMatches = exactSimpleNameMatches.Count > 0 ? exactSimpleNameMatches : exactMatches;
+
+            return candidateMatches.Count switch
+            {
+                0 => TypeFindIfMissResult.None(query!),
+                1 => TypeFindIfMissResult.Found(query!, candidateMatches[0]),
+                _ => TypeFindIfMissResult.Ambiguous(query!, candidateMatches)
+            };
+        }
+        finally
+        {
+            AssemblyCollector.CleanupTempDirs(tempDirs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route simple type misses through a shared platform find-if-miss resolver
- apply simple type find-if-miss to `type`, bare router, `member`, and `source`
- prefer exact non-generic simple-name matches over generic families
- prefer platform type hits over same-named weak packages such as JsonSerializer/JsonConverter/Uri
- make `diff -t` match namespace/type prefixes in long and short forms

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused tests for `type Regex`, `type JsonSerializer`, `type FrozenDictionary`, `type Task`, `member Regex`, `source Regex`, and diff namespace-prefix filters