### PR TITLE
Centralize find-if-miss route application

### DIFF
--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -360,22 +360,10 @@ public static class MemberCommand
 
         return resolution.Status switch
         {
-            TypeFindIfMissStatus.Found => await ExecuteAsync(options with
-            {
-                TypeName = resolution.Match!.FullName,
-                PackagePath = null,
-                PlatformAssembly = resolution.Match.Library,
-                PlatformFramework = resolution.Match.Source
-            }),
-            TypeFindIfMissStatus.Ambiguous => WriteFindIfMissAmbiguousError(resolution.Query),
+            TypeFindIfMissStatus.Found => await ExecuteAsync(resolution.ApplyTo(options)),
+            TypeFindIfMissStatus.Ambiguous => resolution.WriteAmbiguousError(),
             _ => null
         };
-    }
-
-    private static int WriteFindIfMissAmbiguousError(string query)
-    {
-        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
-        return 1;
     }
 
     private static bool ShouldAutoSelectSingleOverload(MemberOptions options)

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -596,22 +596,10 @@ public static class SourceCommand
 
         return resolution.Status switch
         {
-            TypeFindIfMissStatus.Found => await ExecuteAsync(options with
-            {
-                TypeName = resolution.Match!.FullName,
-                PackagePath = null,
-                PlatformAssembly = resolution.Match.Library,
-                PlatformFramework = resolution.Match.Source
-            }),
-            TypeFindIfMissStatus.Ambiguous => WriteFindIfMissAmbiguousError(resolution.Query),
+            TypeFindIfMissStatus.Found => await ExecuteAsync(resolution.ApplyTo(options)),
+            TypeFindIfMissStatus.Ambiguous => resolution.WriteAmbiguousError(),
             _ => null
         };
-    }
-
-    private static int WriteFindIfMissAmbiguousError(string query)
-    {
-        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
-        return 1;
     }
 
     private static bool TryParseHexOrDecimal(string value, out int result)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -455,21 +455,10 @@ public static class TypeCommand
         {
             var match = resolution.Match!;
             Console.Error.WriteLine($"Note: Type '{query}' resolved via platform find to {match.FullName} in {match.Library}.");
-            var routeOptions = options with
-            {
-                TypeName = match.FullName,
-                PackagePath = null,
-                PlatformAssembly = match.Library,
-                PlatformFramework = match.Source,
-                OriginalTypeQuery = match.FullName,
-                PlatformPrefixQuery = null,
-                AllowPlatformPrefixFallback = false
-            };
-            return await ExecuteAsync(routeOptions);
+            return await ExecuteAsync(resolution.ApplyTo(options));
         }
 
-        Console.Error.WriteLine($"Error: Type '{query}' matched multiple platform types. Use `find {query} --platform` to choose a source library.");
-        return 1;
+        return resolution.WriteAmbiguousError();
     }
 
     internal static async Task<int?> TryExecutePlatformPrefixBrowseAsync(

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -22,6 +22,51 @@ internal sealed record TypeFindIfMissResult(
     public static TypeFindIfMissResult None(string query) => new(TypeFindIfMissStatus.None, query, null, []);
     public static TypeFindIfMissResult Found(string query, TypeFindResult match) => new(TypeFindIfMissStatus.Found, query, match, [match]);
     public static TypeFindIfMissResult Ambiguous(string query, IReadOnlyList<TypeFindResult> matches) => new(TypeFindIfMissStatus.Ambiguous, query, null, matches);
+
+    public TypeOptions ApplyTo(TypeOptions options)
+    {
+        var match = Match ?? throw new InvalidOperationException("Cannot apply a non-found type route.");
+        return options with
+        {
+            TypeName = match.FullName,
+            PackagePath = null,
+            PlatformAssembly = match.Library,
+            PlatformFramework = match.Source,
+            OriginalTypeQuery = match.FullName,
+            PlatformPrefixQuery = null,
+            AllowPlatformPrefixFallback = false
+        };
+    }
+
+    public MemberOptions ApplyTo(MemberOptions options)
+    {
+        var match = Match ?? throw new InvalidOperationException("Cannot apply a non-found type route.");
+        return options with
+        {
+            TypeName = match.FullName,
+            PackagePath = null,
+            PlatformAssembly = match.Library,
+            PlatformFramework = match.Source
+        };
+    }
+
+    public SourceOptions ApplyTo(SourceOptions options)
+    {
+        var match = Match ?? throw new InvalidOperationException("Cannot apply a non-found type route.");
+        return options with
+        {
+            TypeName = match.FullName,
+            PackagePath = null,
+            PlatformAssembly = match.Library,
+            PlatformFramework = match.Source
+        };
+    }
+
+    public int WriteAmbiguousError()
+    {
+        Console.Error.WriteLine($"Error: Type '{Query}' matched multiple platform types. Use `find {Query} --platform` to choose a source library.");
+        return 1;
+    }
 }
 
 internal static class TypeFindIfMissResolver


### PR DESCRIPTION
## Summary
- move platform type find-if-miss route application into `TypeFindIfMissResult`
- update `type`, `member`, and `source` to use the shared result instead of rebuilding platform type options independently
- keep existing behavior while reducing command-level drift in simple type discovery

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused route tests for type/router/member/source simple type find-if-miss behavior