### PR TITLE
Centralize full API loading

### DIFF
--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -55,15 +55,18 @@ public static class MemberCommand
 
         try
         {
-            var (api, apiDllPath) = ApiServices.ExtractFullApi(searchPath, logger, options.IncludeAll);
-            if (api == null)
+            var loaded = ApiServices.LoadFullApi(
+                searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
+                apiSource, source.ApiVersion, selectedTfm, logger, options.IncludeAll);
+            if (loaded == null)
             {
                 Console.Error.WriteLine("Error: Could not extract API from library.");
                 return 1;
             }
 
-            if (apiDllPath != null)
-                ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
+            var api = loaded.Api;
+            var apiDllPath = loaded.ApiDllPath;
+            var pdbLookupPath = loaded.PdbLookupPath;
 
             var allTypeNames = api.Types.Select(t => t.FullName).ToList();
             var lookupResult = TypeMatcher.Lookup(allTypeNames, typeName!);
@@ -245,7 +248,6 @@ public static class MemberCommand
             if (effectiveOptions.OverloadIndex.HasValue && apiDllPath != null
                 && NeedsMemberSourceResolution(apiType, effectiveOptions))
             {
-                var pdbLookupPath = runtimeAssemblyPath ?? apiDllPath;
                 bool fetchSource = ApiCommand.GetRequestedMemberSections(apiType, effectiveOptions)
                     .Contains(SectionNames.OriginalSource);
                 var selectedMember = apiType.Members.Count == 1 ? apiType.Members[0] : null;

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -63,22 +63,19 @@ public static class SourceCommand
             }
 
             // Extract all types
-            var (api, apiDllPath) = ApiServices.ExtractFullApi(searchPath, logger, options.IncludeAll);
-            if (api == null)
+            var loaded = ApiServices.LoadFullApi(
+                searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
+                source.ApiSource, source.ApiVersion, selectedTfm, logger, options.IncludeAll);
+            if (loaded == null)
             {
                 Console.Error.WriteLine("Error: Could not extract API from library.");
                 return 1;
             }
 
-            if (apiDllPath != null)
-                ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
+            var api = loaded.Api;
+            var apiDllPath = loaded.ApiDllPath;
 
-            var dllPath = runtimeAssemblyPath ?? apiDllPath;
-            if (dllPath == null)
-            {
-                Console.Error.WriteLine("Error: No library found.");
-                return 1;
-            }
+            var dllPath = loaded.PdbLookupPath;
 
             // Open SourceLink service and acquire PDB
             using var service = SourceLinkService.Open(dllPath, logger.Log);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -72,31 +72,17 @@ public static class TypeCommand
             if (string.IsNullOrEmpty(typeName))
             {
                 // No type specified - list all types
-                var (api, apiDllPath) = ApiServices.ExtractFullApi(searchPath, logger, options.IncludeAll);
-                if (api == null)
+                var loaded = ApiServices.LoadFullApi(
+                    searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
+                    apiSource, apiVersion, selectedTfm, logger, options.IncludeAll);
+                if (loaded == null)
                 {
                     Console.Error.WriteLine("Error: Could not extract API from library.");
                     return 1;
                 }
 
-                if (apiDllPath != null)
-                    ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
-
-                if (!string.IsNullOrEmpty(options.PackagePath))
-                {
-                    var (pkgName, _) = PackageExtractor.ParsePackageReference(options.PackagePath);
-                    api.Name = pkgName;
-                }
-                else if (apiDllPath != null)
-                {
-                    api.Name = Path.GetFileNameWithoutExtension(apiDllPath);
-                }
-
-                var pdbLookupPath = runtimeAssemblyPath ?? apiDllPath;
-                api.Tfm = selectedTfm;
-                api.Source = apiSource;
-                api.Version = apiVersion;
-                api.Library = apiDllPath != null ? Path.GetFileName(apiDllPath) : null;
+                var api = loaded.Api;
+                var pdbLookupPath = loaded.PdbLookupPath;
 
                 // --columns Description implicitly enables doc enrichment (local XML only)
                 var listOptions = options;
@@ -150,15 +136,17 @@ public static class TypeCommand
             }
             else
             {
-                var (api, apiDllPath) = ApiServices.ExtractFullApi(searchPath, logger, options.IncludeAll);
-                if (api == null)
+                var loaded = ApiServices.LoadFullApi(
+                    searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
+                    apiSource, apiVersion, selectedTfm, logger, options.IncludeAll);
+                if (loaded == null)
                 {
                     Console.Error.WriteLine("Error: Could not extract API from library.");
                     return 1;
                 }
 
-                if (apiDllPath != null)
-                    ApiServices.ResolveForwardedTypes(api, apiDllPath, logger, options.IncludeAll);
+                var api = loaded.Api;
+                var apiDllPath = loaded.ApiDllPath;
 
                 var allTypeNames = api.Types.Select(t => t.FullName).ToList();
                 var lookupResult = TypeMatcher.Lookup(allTypeNames, typeName);

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -14,6 +14,46 @@ internal static class ApiServices
 {
     // ===== Extraction Pipeline =====
 
+    internal sealed record LoadedApiSurface(
+        ApiSurface Api,
+        string ApiDllPath,
+        string PdbLookupPath);
+
+    internal static LoadedApiSurface? LoadFullApi(
+        string searchPath,
+        string? runtimeAssemblyPath,
+        string? packagePath,
+        string? packageName,
+        string? apiSource,
+        string? apiVersion,
+        string? selectedTfm,
+        VerboseLogger logger,
+        bool includeAll)
+    {
+        var (api, apiDllPath) = ExtractFullApi(searchPath, logger, includeAll);
+        if (api == null || apiDllPath == null)
+            return null;
+
+        ResolveForwardedTypes(api, apiDllPath, logger, includeAll);
+
+        if (!string.IsNullOrEmpty(packagePath))
+        {
+            var (parsedPackageName, _) = PackageExtractor.ParsePackageReference(packagePath);
+            api.Name = packageName ?? parsedPackageName;
+        }
+        else
+        {
+            api.Name = Path.GetFileNameWithoutExtension(apiDllPath);
+        }
+
+        api.Tfm = selectedTfm;
+        api.Source = apiSource;
+        api.Version = apiVersion;
+        api.Library = Path.GetFileName(apiDllPath);
+
+        return new LoadedApiSurface(api, apiDllPath, runtimeAssemblyPath ?? apiDllPath);
+    }
+
     /// <summary>
     /// Extracts a specific type from a package or assembly, with full path info.
     /// Used by api command and source command.


### PR DESCRIPTION
## Summary
- add `ApiServices.LoadFullApi` to combine full API extraction, type-forwarder resolution, and surface metadata annotation
- update `type`, `member`, and `source` command paths to use the shared loader
- preserve command-specific docs/source/PDB behavior while reducing duplicate load boilerplate

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- focused tests covering type/member/source platform, package, forwarded, and decompiled-source flows