### PR TITLE
Render managed-ref dereference without the pointer star

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -904,6 +904,33 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void Indirect_ThroughManagedRef_HasNoPointerStar()
+    {
+        // *x = *x + 1 where x is a ref int param: a managed ref dereferences
+        // implicitly in C#, so no `*` — `*x` would be CS0193.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        LoadArgument X() => new(0, "x", refInt);
+
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreIndirect(intType, X(),
+            new Binary(BinaryKind.Add, false, false, new LoadIndirect(intType, X()), new Constant(1, intType))));
+        block.Add(new Return(null));
+        container.Add(block);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("x", refInt)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("x = ", output);
+        Assert.Contains("+ 1", output);
+        Assert.DoesNotContain("*", output);
+    }
+
+    [Fact]
     public void OrChainGuard_FoldsToSingleGuard()
     {
         // The csc OR-chain shape, built directly so the test is independent of

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -367,7 +367,7 @@ public sealed class CSharpPrinter
                 && SamePlace(load.Instance, s.Instance)),
         StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
-        StoreIndirect s => $"*{Operand(s.Address)} = {Expression(s.Value)};",
+        StoreIndirect s => $"{Deref(s.Address)} = {Expression(s.Value)};",
         // default-initialization of a named place spells through the place,
         // not its address.
         InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
@@ -375,7 +375,7 @@ public sealed class CSharpPrinter
             : $"V_{local.Index} = default;",
         InitObject { Address: LoadArgumentAddress argument } => $"{argument.Name} = default;",
         InitObject { Address: LoadFieldAddress field } o2 => $"{FieldTarget(field.Field, field.Instance)} = default;",
-        InitObject o => $"*{Operand(o.Address)} = default({TypeText(o.Type)});",
+        InitObject o => $"{Deref(o.Address)} = default({TypeText(o.Type)});",
         Return { Value: { } value } => $"return {Expression(value)};",
         Return => "return;",
         // The rethrow: the raw caught value thrown back is C#'s bare throw.
@@ -423,7 +423,7 @@ public sealed class CSharpPrinter
         LoadArgumentAddress a => $"ref {a.Name}",
         LoadFieldAddress f => $"ref {FieldTarget(f.Field, f.Instance)}",
         LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
-        LoadIndirect l => $"*{Operand(l.Address)}",
+        LoadIndirect l => Deref(l.Address),
         SizeOf s => $"sizeof({TypeText(s.Type)})",
         TypeOf t => $"typeof({TypeText(t.Type)})",
         LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
@@ -557,6 +557,25 @@ public sealed class CSharpPrinter
             or LoadProperty or TypeOf;
         return atomic ? text : $"({text})";
     }
+
+    /// <summary>
+    /// The C# place a load/store-indirect reads or writes. Dereferencing a
+    /// managed reference is implicit in C#: the address of a place (ref local,
+    /// ref argument, ref field, ref element) reads back as the place, and a
+    /// ref/out parameter or ref local reads as itself — no <c>*</c>. Only a
+    /// genuine unmanaged pointer takes the <c>*</c>; an unknown reference keeps
+    /// it rather than guess.
+    /// </summary>
+    string Deref(IrExpression address) => address switch
+    {
+        LoadLocalAddress a => $"V_{a.Index}",
+        LoadArgumentAddress a => a.Name,
+        LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
+        LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        { ResultType.Kind: TypeRefKind.Pointer } => $"*{Operand(address)}",
+        { ResultType.Kind: TypeRefKind.ByRef } => Operand(address),
+        _ => $"*{Operand(address)}",
+    };
 
     /// <summary>
     /// Short-circuit composition prints comparisons and nots bare (they bind


### PR DESCRIPTION
## What

The printer rendered every load/store-indirect as `*addr`. But dereferencing a **managed reference** is implicit in C# — `*pos` where `pos` is a `ref`/`out` parameter is **CS0193** ("the `*` operator must be applied to a pointer"). The new `--compile-check` flagged this as the **single biggest invalid-output family** (832 occurrences in CoreLib).

New `Deref` helper decides how an indirection renders:
- address of a place (`ref` local / argument / field / element) → the **place** itself (`*(&V_0)` → `V_0`);
- a `ref`/`out` parameter or ref-typed value → **itself** (`*pos` → `pos`);
- a genuine unmanaged **pointer** → keeps `*`;
- an unknown reference → keeps `*` rather than guess.

Used by `LoadIndirect`, `StoreIndirect`, and the `InitObject` fallback.

```csharp
// before:  *pos = *pos + 1;   // CS0193
// after:   pos  =  pos + 1;
```

## Impact

- **CS0193: 832 → 252** occurrences (the remainder are pointer- or unknown-typed refs, kept conservatively); **71 methods become fully valid**.
- Real pointer derefs still print `*` (`Buffer.Memmove`'s `Unsafe.As` keeps its shape).
- All suites green: `ILInspector.Decompiler.Tests` 372 (new synthetic `Indirect_ThroughManagedRef_HasNoPointerStar`) · `dotnet-inspect.Tests` 1061. No new error families in the compile-check.

First fix off the validity docket (#530). Next: `out`-args not marked `out` (CS1620), `base(...)` as a statement (CS0175), and local-function call de-mangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)