### PR TITLE
Consolidate assembly scanning for relationship commands

### DIFF
--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -18,7 +18,6 @@ public class ExtensionsCommand
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        List<string> tempDirs = [];
         var targetType = options.TargetType;
 
         try
@@ -33,45 +32,24 @@ public class ExtensionsCommand
                 };
             }
 
-            List<ExtensionMethodResult> results = [];
-
-            // Collect all assembly paths from various sources
-            var assemblyInfos = await AssemblyCollector.CollectAsync(context.HttpClient, options, tempDirs, logger, "inspect-ext");
-
-            // Scan assemblies for extension methods
-            foreach (var asmInfo in assemblyInfos)
-            {
-                var extensions = ScanForExtensions(asmInfo.Path, targetType, options.IncludeAll, logger);
-                foreach (var ext in extensions)
-                {
-                    ext.Source = asmInfo.Source;
-                    ext.SourceVersion = asmInfo.Version;
-                }
-                results.AddRange(extensions);
-            }
-
-            // If --reachable, find extensions on reachable types
+            List<ExtensionMethodResult> results;
             if (options.Reachable)
             {
-                var assemblyPaths = assemblyInfos.Select(a => a.Path).ToList();
-                var reachableTypes = ExtensionMethodScanner.FindReachableTypes(targetType, assemblyPaths, options.Depth);
-                foreach (var (reachableType, path) in reachableTypes)
-                {
-                    if (reachableType == targetType) continue;
-
-                    foreach (var asmInfo in assemblyInfos)
+                results = await ScanReachableExtensionsAsync(options, context, logger, targetType);
+            }
+            else
+            {
+                results = await AssemblyCollector.ScanAsync(
+                    context.HttpClient,
+                    options,
+                    logger,
+                    "inspect-ext",
+                    assemblyInfo => ScanForExtensions(assemblyInfo.Path, targetType, options.IncludeAll, logger),
+                    (result, assemblyInfo) =>
                     {
-                        var extensions = ScanForExtensions(asmInfo.Path, reachableType, options.IncludeAll, logger);
-                        foreach (var ext in extensions)
-                        {
-                            ext.Source = asmInfo.Source;
-                            ext.SourceVersion = asmInfo.Version;
-                            ext.ReachablePath = path;
-                            ext.ReachableFromType = reachableType;
-                        }
-                        results.AddRange(extensions);
-                    }
-                }
+                        result.Source = assemblyInfo.Source;
+                        result.SourceVersion = assemblyInfo.Version;
+                    });
             }
 
             // Apply limit
@@ -103,10 +81,60 @@ public class ExtensionsCommand
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 1;
         }
-        finally
-        {
-            AssemblyCollector.CleanupTempDirs(tempDirs);
-        }
+    }
+
+    private static async Task<List<ExtensionMethodResult>> ScanReachableExtensionsAsync(
+        ExtensionsOptions options,
+        CommandContext context,
+        VerboseLogger logger,
+        string targetType)
+    {
+        return await AssemblyCollector.WithAssembliesAsync(
+            context.HttpClient,
+            options,
+            logger,
+            "inspect-ext",
+            assemblyInfos =>
+            {
+                List<ExtensionMethodResult> results = [];
+
+                void Stamp(ExtensionMethodResult ext, AssemblyCollector.AssemblyInfo asmInfo)
+                {
+                    ext.Source = asmInfo.Source;
+                    ext.SourceVersion = asmInfo.Version;
+                }
+
+                foreach (var asmInfo in assemblyInfos)
+                {
+                    var extensions = ScanForExtensions(asmInfo.Path, targetType, options.IncludeAll, logger);
+                    foreach (var ext in extensions)
+                    {
+                        Stamp(ext, asmInfo);
+                        results.Add(ext);
+                    }
+                }
+
+                var assemblyPaths = assemblyInfos.Select(a => a.Path).ToList();
+                var reachableTypes = ExtensionMethodScanner.FindReachableTypes(targetType, assemblyPaths, options.Depth);
+                foreach (var (reachableType, path) in reachableTypes)
+                {
+                    if (reachableType == targetType) continue;
+
+                    foreach (var asmInfo in assemblyInfos)
+                    {
+                        var extensions = ScanForExtensions(asmInfo.Path, reachableType, options.IncludeAll, logger);
+                        foreach (var ext in extensions)
+                        {
+                            Stamp(ext, asmInfo);
+                            ext.ReachablePath = path;
+                            ext.ReachableFromType = reachableType;
+                            results.Add(ext);
+                        }
+                    }
+                }
+
+                return results;
+            });
     }
 
     private static List<ExtensionMethodResult> ScanForExtensions(

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -18,7 +18,6 @@ public class ImplementsCommand
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        List<string> tempDirs = [];
         var targetType = options.TargetType;
 
         try
@@ -42,24 +41,18 @@ public class ImplementsCommand
                 };
             }
 
-            List<ImplementerResult> results = [];
-
-            // Collect all assembly paths from various sources
-            var assemblyInfos = await AssemblyCollector.CollectAsync(context.HttpClient, options, tempDirs, logger, "inspect-impl");
-
-            logger.Log($"Scanning {assemblyInfos.Count} libraries for types implementing {targetType}");
-
-            // Scan assemblies for implementers
-            foreach (var asmInfo in assemblyInfos)
-            {
-                var implementers = ScanForImplementers(asmInfo.Path, targetType, options.IncludeAll, logger);
-                foreach (var impl in implementers)
+            var results = await AssemblyCollector.ScanAsync(
+                context.HttpClient,
+                options,
+                logger,
+                "inspect-impl",
+                assemblyInfo => ScanForImplementers(assemblyInfo.Path, targetType, options.IncludeAll, logger),
+                (result, assemblyInfo) =>
                 {
-                    impl.Source = asmInfo.Source;
-                    impl.SourceVersion = asmInfo.Version;
-                }
-                results.AddRange(implementers);
-            }
+                    result.Source = assemblyInfo.Source;
+                    result.SourceVersion = assemblyInfo.Version;
+                },
+                assemblyInfos => logger.Log($"Scanning {assemblyInfos.Count} libraries for types implementing {targetType}"));
 
             // Deduplicate by type name + source (same type from multiple TFM folders)
             results = results
@@ -92,10 +85,6 @@ public class ImplementsCommand
         {
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 1;
-        }
-        finally
-        {
-            AssemblyCollector.CleanupTempDirs(tempDirs);
         }
     }
 

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -127,6 +127,64 @@ public static class AssemblyCollector
     }
 
     /// <summary>
+    /// Collects assemblies, runs the supplied operation, and cleans up temporary package extraction directories.
+    /// </summary>
+    public static async Task<TResult> WithAssembliesAsync<TResult>(
+        HttpClient httpClient,
+        IAssemblySourceOptions options,
+        VerboseLogger logger,
+        string tempDirPrefix,
+        Func<IReadOnlyList<AssemblyInfo>, TResult> operation)
+    {
+        List<string> tempDirs = [];
+        try
+        {
+            var assemblyInfos = await CollectAsync(httpClient, options, tempDirs, logger, tempDirPrefix);
+            return operation(assemblyInfos);
+        }
+        finally
+        {
+            CleanupTempDirs(tempDirs);
+        }
+    }
+
+    /// <summary>
+    /// Collects assemblies, scans each one, stamps source metadata onto each result, and cleans up temporary package extraction directories.
+    /// </summary>
+    public static Task<List<TResult>> ScanAsync<TResult>(
+        HttpClient httpClient,
+        IAssemblySourceOptions options,
+        VerboseLogger logger,
+        string tempDirPrefix,
+        Func<AssemblyInfo, IEnumerable<TResult>> scan,
+        Action<TResult, AssemblyInfo> stamp,
+        Action<IReadOnlyList<AssemblyInfo>>? beforeScan = null)
+    {
+        return WithAssembliesAsync(
+            httpClient,
+            options,
+            logger,
+            tempDirPrefix,
+            assemblyInfos =>
+            {
+                beforeScan?.Invoke(assemblyInfos);
+
+                List<TResult> results = [];
+                foreach (var assemblyInfo in assemblyInfos)
+                {
+                    var scanned = scan(assemblyInfo);
+                    foreach (var result in scanned)
+                    {
+                        stamp(result, assemblyInfo);
+                        results.Add(result);
+                    }
+                }
+
+                return results;
+            });
+    }
+
+    /// <summary>
     /// Cleans up temporary directories created during assembly collection.
     /// </summary>
     public static void CleanupTempDirs(List<string> tempDirs)


### PR DESCRIPTION
## Summary
- add AssemblyCollector helpers for collect/use and collect/scan/stamp flows with centralized temp cleanup
- move implements scanning onto the shared scanner while preserving verbose scan logging
- move extensions direct scanning onto the shared scanner and reachable scanning onto shared collect/cleanup handling

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.ExtensionsCommandTests
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release