### PR TITLE
De-mangle local-function names at call sites

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -904,6 +904,31 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void LocalFunctionCall_DemanglesToSourceName()
+    {
+        // A call to the compiler-generated local function <Outer>g__Helper|0_0
+        // renders its source name Helper, not the invalid mangled identifier.
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var callee = new MethodRef(TypeRef.CoreLib("Synthetic", "Owner"),
+            "<Outer>g__Helper|0_0", voidType, [], HasThis: false);
+
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(new Call(callee, isVirtual: false, [])));
+        block.Add(new Return(null));
+        container.Add(block);
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "Owner"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("Helper()", output);
+        Assert.DoesNotContain("g__", output);
+        Assert.DoesNotContain("<", output);
+    }
+
+    [Fact]
     public void Indirect_ThroughManagedRef_HasNoPointerStar()
     {
         // *x = *x + 1 where x is a ref int param: a managed ref dereferences

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -701,6 +701,24 @@ public sealed class CSharpPrinter
         _ => Operand(receiver),
     };
 
+    /// <summary>
+    /// The source name of a call target. A compiler-generated local function
+    /// carries the metadata name <c>&lt;Enclosing&gt;g__Local|N_M</c>, which is
+    /// not a valid C# identifier; the source name is the segment between
+    /// <c>g__</c> and the <c>|</c> ordinal suffix.
+    /// </summary>
+    static string MethodName(string name)
+    {
+        if (!name.StartsWith('<'))
+            return name;
+        int marker = name.IndexOf("g__", StringComparison.Ordinal);
+        if (marker < 0)
+            return name;
+        int start = marker + 3;
+        int bar = name.IndexOf('|', start);
+        return bar > start ? name[start..bar] : name[start..];
+    }
+
     string CallText(Call call)
     {
         var arguments = call.Arguments;
@@ -713,7 +731,7 @@ public sealed class CSharpPrinter
             // operator spelling is the faithful inverse.
             if (call.Callee.IsSpecialName && OperatorSpelling(call) is { } op)
                 return op;
-            return $"{TypeText(call.Callee.DeclaringType)}.{call.Callee.Name}{typeArguments}({Arguments(arguments)})";
+            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments)})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1));
@@ -728,10 +746,10 @@ public sealed class CSharpPrinter
             // Non-virtual this-receiver call to a base-declared method is
             // C#'s base.M() — the call opcode deliberately skips dispatch.
             return !call.IsVirtual && IsCrossType(call.Callee.DeclaringType)
-                ? $"base.{call.Callee.Name}{typeArguments}({rest})"
-                : $"{call.Callee.Name}{typeArguments}({rest})";
+                ? $"base.{MethodName(call.Callee.Name)}{typeArguments}({rest})"
+                : $"{MethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
-        return $"{ReceiverText(receiver)}.{call.Callee.Name}{typeArguments}({rest})";
+        return $"{ReceiverText(receiver)}.{MethodName(call.Callee.Name)}{typeArguments}({rest})";
     }
 
     string Arguments(IEnumerable<IrExpression> arguments)


### PR DESCRIPTION
## What

A call to a compiler-generated local function rendered its **raw metadata name**:

```csharp
Interop.<GetExceptionForIoErrno>g__ParentDirectoryExists|19_0(path)   // CS1001 — won't parse
```

`<…>g__…|N` isn't a valid identifier, so the whole body fails to *parse* — the most severe kind of invalid output. `--compile-check` (#530) surfaced this as the largest **syntactic** invalid family.

New `MethodName` helper extracts the source name from the `<Enclosing>g__Local|N_M` mangling (the segment between `g__` and `|`), applied at every call-target render site in `CallText`:

```csharp
Interop.ParentDirectoryExists(path)   // parses
```

## Impact

- **Full malformed (won't parse): 2141 → 1900** in CoreLib.
- Decompiler 373 (new synthetic `LocalFunctionCall_DemanglesToSourceName`) · `dotnet-inspect` 1061. No regressions.

Second fix off the validity docket (after the managed-ref `*`-deref, #532). Remaining: `out`-args not marked `out` (CS1620), missing `= default` (CS0165), `base(...)` as a statement (CS0175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)