### PR TITLE
Consolidate projected table rendering

### DIFF
--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -602,21 +602,16 @@ public class ApiCommand
         {
             var writerOptions = ApiOutputFormatter.BuildWriterOptions(api, options);
             var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions);
-            markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+            markdown = OutputFormatter.ApplyRowLimit(markdown, options.Rows);
             CountOutput.WriteCountFromMarkdown(markdown);
         }
         else if (options.OneLine)
         {
             var (oneLineView, _) = ApiOutputFormatter.BuildSurfaceOneLineView(api, options);
-            var writerOpts = new MarkoutWriterOptions
-            {
-                Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-            };
-            OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-            var sw = new StringWriter();
-            OutputFormatter.WriteTable(sw, !options.NoHeader,
-                (writer, formatter) => MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOpts));
-            var rendered = sw.ToString();
+            var rendered = OutputFormatter.RenderProjectedTable(!options.NoHeader, options.Tsv, options.Jsonl,
+                options.Columns, options.Fields,
+                (writer, formatter, writerOptions) =>
+                    MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOptions));
             ProjectionDiagnostics.DiagnoseRendered(options.Fields ?? options.Columns, rendered);
             Console.Out.Write(rendered);
         }
@@ -629,8 +624,8 @@ public class ApiCommand
             }
             else
             {
-                var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions).TrimEnd();
-                Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+                OutputFormatter.WriteLimitedMarkdown(Console.Out,
+                    MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions), options.Rows);
             }
         }
     }
@@ -926,7 +921,7 @@ public class ApiCommand
                 view, eventsView, methodGroupsView, methodsView, operatorsView,
                 explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
             writer.Flush();
-            CountOutput.WriteCountFromMarkdown(MarkdownTableRowLimiter.Apply(sw.ToString(), options.Rows));
+            CountOutput.WriteCountFromMarkdown(OutputFormatter.ApplyRowLimit(sw.ToString(), options.Rows));
         }
         else if (options.OneLine)
         {
@@ -947,13 +942,10 @@ public class ApiCommand
             else
             {
                 var (oneLineView, _) = ApiOutputFormatter.BuildTypeOneLineView(type, options);
-                var writerOpts = new MarkoutWriterOptions
-                {
-                    Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-                };
-                OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-                OutputFormatter.WriteTable(sink, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOpts));
+                OutputFormatter.WriteProjectedTable(sink, !options.NoHeader, options.Tsv, options.Jsonl,
+                    options.Columns, options.Fields,
+                    (writer, formatter, writerOptions) =>
+                        MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOptions));
             }
         }
         else
@@ -986,7 +978,7 @@ public class ApiCommand
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);
                 }
-                sink.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+                sink.WriteLine(OutputFormatter.ApplyRowLimit(markdown, options.Rows));
             }
         }
     }

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -278,7 +278,7 @@ public class DependsCommand
 
     private static void WriteMarkdown(PackageDependenciesView view, int? rows)
     {
-        var markdown = MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default).TrimEnd();
-        Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
+        OutputFormatter.WriteLimitedMarkdown(Console.Out,
+            MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default), rows);
     }
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -91,13 +91,10 @@ public class DiffCommand
             {
                 var typeDiffs = ApplyFilters(diff, options);
                 var view = DiffOutputFormatter.BuildOneLineView(name, typeDiffs, fromVersion, toVersion);
-                var writerOpts = new MarkoutWriterOptions
-                {
-                    Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-                };
-                OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-                OutputFormatter.WriteTable(Console.Out, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOpts));
+                OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                    options.Columns, options.Fields,
+                    (writer, formatter, writerOptions) =>
+                        MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions));
             }
             else
             {
@@ -285,7 +282,7 @@ public class DiffCommand
         }
 
         var markdown = DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
-        return MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+        return OutputFormatter.ApplyRowLimit(markdown, options.Rows);
     }
 
     private static IReadOnlyList<TypeDiff> FilterByClassification(IReadOnlyList<TypeDiff> typeDiffs, DiffOptions options)

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -179,8 +179,8 @@ public class ExtensionsCommand
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, int? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
-        var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
-        Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
+        OutputFormatter.WriteLimitedMarkdown(Console.Out,
+            MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -85,18 +85,15 @@ public class FindCommand
 
         if (options.OneLine)
         {
-            var writerOpts = new MarkoutWriterOptions
-            {
-                Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-            };
-            OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-            OutputFormatter.WriteTable(Console.Out, !options.NoHeader,
-                (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOpts));
+            OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                options.Columns, options.Fields,
+                (writer, formatter, writerOptions) =>
+                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions));
         }
         else
         {
-            var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
-            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+            OutputFormatter.WriteLimitedMarkdown(Console.Out,
+                MarkoutSerializer.Serialize(view, SearchViewContext.Default), options.Rows);
         }
     }
 }

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -137,18 +137,14 @@ public class ImplementsCommand
 
         if (oneLine)
         {
-            var writerOpts = new MarkoutWriterOptions
-            {
-                Projection = OutputFormatter.BuildProjection(columns, fields)
-            };
-            OutputFormatter.ConfigureTableWriterOptions(writerOpts, tsv, jsonl);
-            OutputFormatter.WriteTable(Console.Out, !noHeader,
-                (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOpts));
+            OutputFormatter.WriteProjectedTable(Console.Out, !noHeader, tsv, jsonl, columns, fields,
+                (writer, formatter, writerOptions) =>
+                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions));
         }
         else
         {
-            var markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default).TrimEnd();
-            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, rows));
+            OutputFormatter.WriteLimitedMarkdown(Console.Out,
+                MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
         }
     }
 }

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -737,21 +737,15 @@ public static class SourceCommand
 
     private static void WriteOneLine<T>(T view, SourceOptions options) where T : class
     {
-        var writerOpts = new MarkoutWriterOptions
-        {
-            Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-        };
-        OutputFormatter.ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-        OutputFormatter.WriteTable(Console.Out, !options.NoHeader,
-            (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, SourceViewContext.Default, writerOpts));
+        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+            options.Columns, options.Fields,
+            (writer, formatter, writerOptions) =>
+                MarkoutSerializer.Serialize(view, writer, formatter, SourceViewContext.Default, writerOptions));
     }
 
     private static void WriteMarkdown<T>(T view, SourceOptions options) where T : class
     {
-        var writerOpts = new MarkoutWriterOptions
-        {
-            Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
-        };
+        var writerOpts = OutputFormatter.CreateProjectedWriterOptions(options.Columns, options.Fields);
         var formatter = options.PlainText ? (IMarkoutFormatter)new PlainTextFormatter() : new MarkdownFormatter();
         if (options.PlainText)
         {
@@ -759,8 +753,8 @@ public static class SourceCommand
         }
         else
         {
-            var markdown = MarkoutSerializer.Serialize(view, SourceViewContext.Default, writerOpts).TrimEnd();
-            Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+            OutputFormatter.WriteLimitedMarkdown(Console.Out,
+                MarkoutSerializer.Serialize(view, SourceViewContext.Default, writerOpts), options.Rows);
         }
     }
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -41,6 +41,42 @@ public static class OutputFormatter
     public static MarkoutWriterOptions CreateTableWriterOptions(bool tsv, bool jsonl) =>
         ConfigureTableWriterOptions(new MarkoutWriterOptions(), tsv, jsonl);
 
+    public static MarkoutWriterOptions CreateProjectedWriterOptions(string[]? columns = null, string[]? fields = null) =>
+        new()
+        {
+            Projection = BuildProjection(columns, fields)
+        };
+
+    public static string RenderProjectedTable(
+        bool showHeader,
+        bool tsv,
+        bool jsonl,
+        string[]? columns,
+        string[]? fields,
+        Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize)
+    {
+        var writerOptions = CreateProjectedWriterOptions(columns, fields);
+        ConfigureTableWriterOptions(writerOptions, tsv, jsonl);
+        return RenderTable(showHeader,
+            (writer, formatter) => serialize(writer, formatter, writerOptions));
+    }
+
+    public static void WriteProjectedTable(
+        TextWriter output,
+        bool showHeader,
+        bool tsv,
+        bool jsonl,
+        string[]? columns,
+        string[]? fields,
+        Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize) =>
+        output.Write(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize));
+
+    public static string ApplyRowLimit(string markdown, int? rows) =>
+        MarkdownTableRowLimiter.Apply(markdown.TrimEnd(), rows);
+
+    public static void WriteLimitedMarkdown(TextWriter output, string markdown, int? rows) =>
+        output.WriteLine(ApplyRowLimit(markdown, rows));
+
     public static void WriteStringList(IEnumerable<string> values, string displayName, string stableName,
         bool tsv, bool jsonl, TextWriter output)
     {


### PR DESCRIPTION
## Summary
- add shared OutputFormatter helpers for projected table rendering and row-limited markdown
- use the helpers in find, implements, diff, source, extensions, depends, and compatible api render paths
- preserve projection diagnostics by using the render-returning helper where commands need captured output

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.OutputFormatterTests
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect -c Release -- find Regex --platform --table --tsv --head 3
- dotnet run --project src/dotnet-inspect -c Release -- implements IDisposable --platform --table --jsonl --head 2
- dotnet run --project src/dotnet-inspect -c Release -- type Regex --table --fields type,library --head 3
- dotnet run --project src/dotnet-inspect -c Release -- diff --package System.Text.Json@8.0.0..9.0.0 --table --head 3
- dotnet run --project src/dotnet-inspect -c Release -- source Regex --platform System.Text.RegularExpressions --table --head 3
- dotnet run --project src/dotnet-inspect -c Release -- extensions string --platform --rows -n 3
- dotnet run --project src/dotnet-inspect -c Release -- find Regex --platform --rows -n 3
- dotnet run --project src/dotnet-inspect.Tests -c Release