### PR TITLE
Initialize up-front locals to default (IL zero-init)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -904,6 +904,26 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void UpFrontLocal_InitializesToDefault()
+    {
+        // A local referenced with no defining store relies on IL's zero-init;
+        // it declares `= default` so C#'s definite-assignment accepts it (a bare
+        // `int V_0;` then `return V_0;` is CS0165).
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new LoadLocal(0, intType)));
+        container.Add(block);
+        var signature = new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("V_0 = default;", output);
+    }
+
+    [Fact]
     public void LocalFunctionCall_DemanglesToSourceName()
     {
         // A call to the compiler-generated local function <Outer>g__Helper|0_0

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -132,7 +132,19 @@ public sealed class CSharpPrinter
                 s is StoreLocal store && store.Index == index
                 || s is InitObject { Address: LoadLocalAddress init } && init.Index == index);
             if (!declaredAtStore && !clauseDeclared.Contains(index))
-                yield return $"{TypeText(function.Locals[index])} V_{index};";
+            {
+                // An up-front local is referenced before a defining store, so
+                // it relies on IL's zero-initialization of locals (localsinit).
+                // Spell that as `= default` — both faithful and what C#'s
+                // definite-assignment requires (a bare declaration is CS0165 on
+                // any path that reads before assigning). A ref local can't take
+                // `= default`; it needs `= ref …` (a separate slice), so it
+                // stays bare.
+                var type = function.Locals[index];
+                yield return type.Kind == TypeRefKind.ByRef
+                    ? $"{TypeText(type)} V_{index};"
+                    : $"{TypeText(type)} V_{index} = default;";
+            }
         }
         foreach (var (slot, type) in slots)
         {


### PR DESCRIPTION
## What

A local referenced before any defining store was declared bare (`int V_0;`), which C#'s definite-assignment rejects on a read-before-assign path (**CS0165**) — the compile-check's next-largest semantic family. IL zero-initializes locals (`localsinit`), so the faithful spelling is `= default`: it matches the runtime semantics *and* satisfies C#.

```csharp
// before:  int V_0;        ... return V_0;   // CS0165
// after:   int V_0 = default; ... return V_0;
```

A `ref` local can't take `= default` (it needs `= ref …`, a separate slice — CS8174), so it stays bare.

## Impact

- **CS0165: 178 → 22** occurrences in CoreLib (the remainder are `ref` locals); **48 methods become fully valid**.
- Decompiler 374 (new synthetic `UpFrontLocal_InitializesToDefault`) · `dotnet-inspect` 1062. No regressions.

Third semantic fix off the validity docket (#530), after the managed-ref `*`-deref (#532) and local-function de-mangling (#534). Remaining: `out`-args not marked `out` (CS1620, needs importer param-attribute support) and `base(...)`-as-statement (CS0175, a cross-layer initializer concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)