### PR TITLE
Extract shared API type lookup helpers

### DIFF
--- a/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
@@ -1,0 +1,76 @@
+using DotnetInspector.Inspectors;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public class ApiTypeLookupServiceTests
+{
+    [Fact]
+    public void LookupType_MatchesSimpleTypeName()
+    {
+        var api = CreateSurface();
+
+        var result = ApiTypeLookupService.LookupType(api, "JsonSerializer");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
+        Assert.Same(api.Types[0], result.Type);
+    }
+
+    [Fact]
+    public void LookupType_MissCarriesSuggestions()
+    {
+        var result = ApiTypeLookupService.LookupType(CreateSurface(), "JsonSeralizer");
+
+        Assert.False(result.Found);
+        Assert.Contains("System.Text.Json.JsonSerializer", result.Suggestions);
+    }
+
+    [Fact]
+    public void ValidateMemberFilters_RequiresEveryFilterToMatch()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = ApiTypeLookupService.ValidateMemberFilters(type, ["Serialize", "Deserializ"]);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(["Deserializ"], result.MissedFilters);
+        Assert.Contains("Deserialize", result.Suggestions);
+    }
+
+    [Fact]
+    public void ValidateMemberFilters_AcceptsExactAndGlobFilters()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = ApiTypeLookupService.ValidateMemberFilters(type, ["Serialize", "Deserialize*"]);
+
+        Assert.True(result.IsValid);
+    }
+
+    private static ApiSurface CreateSurface()
+    {
+        return new ApiSurface
+        {
+            Types =
+            [
+                new ApiType
+                {
+                    Namespace = "System.Text.Json",
+                    Name = "JsonSerializer",
+                    Members =
+                    [
+                        new ApiMember { Name = "Serialize", Kind = "method" },
+                        new ApiMember { Name = "Deserialize", Kind = "method" }
+                    ]
+                },
+                new ApiType
+                {
+                    Namespace = "System.Text.Json",
+                    Name = "JsonDocument",
+                    Members = [new ApiMember { Name = "Parse", Kind = "method" }]
+                }
+            ]
+        };
+    }
+}

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -68,56 +68,22 @@ public static class MemberCommand
             var apiDllPath = loaded.ApiDllPath;
             var pdbLookupPath = loaded.PdbLookupPath;
 
-            var allTypeNames = api.Types.Select(t => t.FullName).ToList();
-            var lookupResult = TypeMatcher.Lookup(allTypeNames, typeName!);
-
-            if (lookupResult.Match == null)
+            var lookupResult = ApiTypeLookupService.LookupType(api, typeName!);
+            if (!lookupResult.Found)
             {
-                if (lookupResult.Suggestions.Count > 0)
-                {
-                    Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("Did you mean:");
-                    foreach (var s in lookupResult.Suggestions)
-                        Console.Error.WriteLine($"  {s}");
-                }
-                else
-                {
-                    Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                }
+                lookupResult.WriteNotFoundError(Console.Error);
                 return 1;
             }
 
-            var apiType = api.Types.First(t => t.FullName == lookupResult.Match);
+            var apiType = lookupResult.Type!;
 
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)
             {
-                var memberNames = apiType.Members.Select(m => m.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-                List<string> missedFilters = [];
-
-                foreach (var filter in options.MemberFilter)
+                var memberValidation = ApiTypeLookupService.ValidateMemberFilters(apiType, options.MemberFilter);
+                if (!memberValidation.IsValid)
                 {
-                    bool isGlob = filter.Contains('*') || filter.Contains('?');
-                    bool anyMatch = isGlob
-                        ? memberNames.Any(n => TypeMatcher.MatchesGlob(n, filter))
-                        : memberNames.Any(n => string.Equals(n, filter, StringComparison.OrdinalIgnoreCase));
-
-                    if (!anyMatch)
-                        missedFilters.Add(filter);
-                }
-
-                if (missedFilters.Count > 0)
-                {
-                    Console.Error.WriteLine($"Error: No members matched filter '{string.Join(", ", missedFilters)}'");
-                    var memberResult = TypeMatcher.LookupMembers(memberNames, missedFilters);
-                    if (memberResult.Suggestions.Count > 0)
-                    {
-                        Console.Error.WriteLine();
-                        Console.Error.WriteLine("Did you mean:");
-                        foreach (var s in memberResult.Suggestions)
-                            Console.Error.WriteLine($"  {s}");
-                    }
+                    memberValidation.WriteError(Console.Error);
                     return 1;
                 }
             }

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -278,35 +278,23 @@ public static class SourceCommand
         string? packageName, string? packageVersion, string? selectedTfm,
         VerboseLogger logger, HttpClient httpClient)
     {
-        var allTypeNames = api.Types.Select(t => t.FullName).ToList();
-        var lookupResult = TypeMatcher.Lookup(allTypeNames, typeName);
-
-        if (lookupResult.Match == null)
+        var lookupResult = ApiTypeLookupService.LookupType(api, typeName);
+        if (!lookupResult.Found)
         {
-            if (lookupResult.Suggestions.Count > 0)
-            {
-                Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine("Did you mean:");
-                foreach (var s in lookupResult.Suggestions)
-                    Console.Error.WriteLine($"  {s}");
-            }
-            else
-            {
-                Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-            }
+            lookupResult.WriteNotFoundError(Console.Error);
             return 1;
         }
 
-        var apiType = api.Types.First(t => t.FullName == lookupResult.Match);
-        var sourceInfo = service.ResolveTypeSource(lookupResult.Match);
+        var apiType = lookupResult.Type!;
+        var matchedTypeName = lookupResult.Match!;
+        var sourceInfo = service.ResolveTypeSource(matchedTypeName);
 
         // Follow type forwarders to the implementation assembly for source resolution.
         // E.g., List`1 in System.Collections is forwarded to System.Private.CoreLib at runtime.
         SourceLinkService? implService = null;
         if (sourceInfo == null)
         {
-            implService = service.OpenImplementation(lookupResult.Match);
+            implService = service.OpenImplementation(matchedTypeName);
             if (implService != null)
             {
                 logger.Log($"Following type forwarder to {Path.GetFileNameWithoutExtension(implService.Context.AssemblyPath)}");
@@ -314,7 +302,7 @@ public static class SourceCommand
                     null, null, isPlatformAssembly: true, logger.Log);
 
                 if (implService.HasPdb && implService.HasSourceLink)
-                    sourceInfo = implService.ResolveTypeSource(lookupResult.Match);
+                    sourceInfo = implService.ResolveTypeSource(matchedTypeName);
             }
         }
 
@@ -329,7 +317,7 @@ public static class SourceCommand
         if (!string.IsNullOrEmpty(options.MemberName) && sourceInfo != null)
         {
             var methodInfo = effectiveService.ResolveMethodSource(
-                lookupResult.Match, options.MemberName,
+                matchedTypeName, options.MemberName,
                 options.OverloadIndex ?? 0, publicOnly: false);
 
             if (methodInfo != null)
@@ -430,7 +418,7 @@ public static class SourceCommand
                 PlatformAssembly = options.PlatformAssembly,
                 PackagePath = options.PackagePath
             };
-            await SourceEnricher.EnrichDocsAsync(apiType, lookupResult.Match, service.Context.AssemblyPath, enrichOptions, logger, httpClient);
+            await SourceEnricher.EnrichDocsAsync(apiType, matchedTypeName, service.Context.AssemblyPath, enrichOptions, logger, httpClient);
 
             if (apiType.Documentation.Samples.Count > 0)
             {
@@ -466,7 +454,7 @@ public static class SourceCommand
                 var simpleName = apiType.FullName.Contains('.')
                     ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
 
-                Console.Error.WriteLine($"No source URLs found for '{lookupResult.Match}'.");
+                Console.Error.WriteLine($"No source URLs found for '{matchedTypeName}'.");
                 Console.Error.WriteLine("The PDB may not contain SourceLink document mappings.");
                 Console.Error.WriteLine($"Try: source {sourceFlag} {simpleName} -v:q");
                 return 0;

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -148,41 +148,19 @@ public static class TypeCommand
                 var api = loaded.Api;
                 var apiDllPath = loaded.ApiDllPath;
 
-                var allTypeNames = api.Types.Select(t => t.FullName).ToList();
-                var lookupResult = TypeMatcher.Lookup(allTypeNames, typeName);
+                var lookupResult = ApiTypeLookupService.LookupType(api, typeName);
 
-                if (lookupResult.Match != null)
+                if (lookupResult.Found)
                 {
-                    var apiType = api.Types.First(t => t.FullName == lookupResult.Match);
+                    var apiType = lookupResult.Type!;
 
                     // Check each member filter before producing output
                     if (options.MemberFilter.Count > 0)
                     {
-                        var memberNames = apiType.Members.Select(m => m.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-                        List<string> missedFilters = [];
-
-                        foreach (var filter in options.MemberFilter)
+                        var memberValidation = ApiTypeLookupService.ValidateMemberFilters(apiType, options.MemberFilter);
+                        if (!memberValidation.IsValid)
                         {
-                            bool isGlob = filter.Contains('*') || filter.Contains('?');
-                            bool anyMatch = isGlob
-                                ? memberNames.Any(n => TypeMatcher.MatchesGlob(n, filter))
-                                : memberNames.Any(n => string.Equals(n, filter, StringComparison.OrdinalIgnoreCase));
-
-                            if (!anyMatch)
-                                missedFilters.Add(filter);
-                        }
-
-                        if (missedFilters.Count > 0)
-                        {
-                            Console.Error.WriteLine($"Error: No members matched filter '{string.Join(", ", missedFilters)}'");
-                            var memberResult = TypeMatcher.LookupMembers(memberNames, missedFilters);
-                            if (memberResult.Suggestions.Count > 0)
-                            {
-                                Console.Error.WriteLine();
-                                Console.Error.WriteLine("Did you mean:");
-                                foreach (var s in memberResult.Suggestions)
-                                    Console.Error.WriteLine($"  {s}");
-                            }
+                            memberValidation.WriteError(Console.Error);
                             return 1;
                         }
                     }
@@ -350,17 +328,13 @@ public static class TypeCommand
                         }
                         else
                         {
-                            Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
-                            Console.Error.WriteLine();
-                            Console.Error.WriteLine("Did you mean:");
-                            foreach (var s in lookupResult.Suggestions)
-                                Console.Error.WriteLine($"  {s}");
+                            lookupResult.WriteNotFoundError(Console.Error);
                             return 1;
                         }
                     }
                     else
                     {
-                        Console.Error.WriteLine($"Error: Type '{typeName}' not found.");
+                        lookupResult.WriteNotFoundError(Console.Error);
                         return 1;
                     }
                 }

--- a/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
@@ -1,0 +1,85 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+internal sealed record ApiTypeLookupResult(string Query, LookupResult Lookup, ApiType? Type)
+{
+    public bool Found => Type != null;
+    public string? Match => Lookup.Match;
+    public IReadOnlyList<string> Suggestions => Lookup.Suggestions;
+
+    public void WriteNotFoundError(TextWriter error)
+    {
+        error.WriteLine($"Error: Type '{Query}' not found.");
+        if (Suggestions.Count == 0)
+            return;
+
+        error.WriteLine();
+        error.WriteLine("Did you mean:");
+        foreach (var suggestion in Suggestions)
+            error.WriteLine($"  {suggestion}");
+    }
+}
+
+internal sealed record MemberFilterValidationResult(IReadOnlyList<string> MissedFilters, IReadOnlyList<string> Suggestions)
+{
+    public bool IsValid => MissedFilters.Count == 0;
+
+    public void WriteError(TextWriter error)
+    {
+        if (IsValid)
+            return;
+
+        error.WriteLine($"Error: No members matched filter '{string.Join(", ", MissedFilters)}'");
+        if (Suggestions.Count == 0)
+            return;
+
+        error.WriteLine();
+        error.WriteLine("Did you mean:");
+        foreach (var suggestion in Suggestions)
+            error.WriteLine($"  {suggestion}");
+    }
+}
+
+internal static class ApiTypeLookupService
+{
+    public static ApiTypeLookupResult LookupType(ApiSurface api, string typeName)
+    {
+        var lookup = TypeMatcher.Lookup(api.Types.Select(t => t.FullName), typeName);
+        var type = lookup.Match == null
+            ? null
+            : api.Types.First(t => t.FullName == lookup.Match);
+        return new ApiTypeLookupResult(typeName, lookup, type);
+    }
+
+    public static MemberFilterValidationResult ValidateMemberFilters(
+        ApiType type,
+        IReadOnlyCollection<string> filters)
+    {
+        if (filters.Count == 0)
+            return new MemberFilterValidationResult([], []);
+
+        var memberNames = type.Members
+            .Select(m => m.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        List<string> missedFilters = [];
+
+        foreach (var filter in filters)
+        {
+            bool isGlob = filter.Contains('*') || filter.Contains('?');
+            bool anyMatch = isGlob
+                ? memberNames.Any(n => TypeMatcher.MatchesGlob(n, filter))
+                : memberNames.Any(n => string.Equals(n, filter, StringComparison.OrdinalIgnoreCase));
+
+            if (!anyMatch)
+                missedFilters.Add(filter);
+        }
+
+        if (missedFilters.Count == 0)
+            return new MemberFilterValidationResult([], []);
+
+        var memberLookup = TypeMatcher.LookupMembers(memberNames, missedFilters);
+        return new MemberFilterValidationResult(missedFilters, memberLookup.Suggestions);
+    }
+}


### PR DESCRIPTION
## Summary
- add ApiTypeLookupService for API surface type lookup and member-filter validation
- reuse shared not-found and member-filter diagnostics from type, member, and source commands
- keep command-specific fallback behavior in the commands, including type prefix browse handling

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.ApiTypeLookupServiceTests
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect -c Release -- type Regex --table --head 3
- dotnet run --project src/dotnet-inspect -c Release -- member Regex --table --head 3
- dotnet run --project src/dotnet-inspect -c Release -- member Regex -m Match --table --head 5
- dotnet run --project src/dotnet-inspect -c Release -- member Regex -m Deserializ --table --head 5 (expected exit 1)
- dotnet run --project src/dotnet-inspect -c Release -- source Regex --platform System.Text.RegularExpressions --table --head 3
- dotnet run --project src/dotnet-inspect.Tests -c Release