### PR TITLE
Lift constructor base/this chains to the signature initializer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1256,7 +1256,7 @@ public class EhStructuringTests
 /// </summary>
 public class ConstructorChainTests
 {
-    static string RaiseCtor(int overloadIndex)
+    static (string Body, string? Chain) RaiseCtor(int overloadIndex)
     {
         using var source = MetadataSource.Open(typeof(CtorChainSamples).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CtorChainSamples).FullName!, ".ctor", overloadIndex);
@@ -1264,44 +1264,51 @@ public class ConstructorChainTests
         IrPasses.Run(function);
         var result = CSharpPrinter.Print(function);
         Assert.True(result.Succeeded);
-        return result.Output!.ReplaceLineEndings("\n").TrimEnd();
+        return (result.Output!.ReplaceLineEndings("\n").TrimEnd(), result.ConstructorChain);
     }
 
     [Fact]
     public void ImplicitParameterlessBase_IsSuppressed()
     {
-        // ctor#0: public CtorChainSamples() { } — base() is implicit.
-        Assert.Equal("", RaiseCtor(0));
+        // ctor#0: public CtorChainSamples() { } — base() is implicit: no body
+        // statement and no initializer.
+        var (body, chain) = RaiseCtor(0);
+        Assert.Equal("", body);
+        Assert.Null(chain);
     }
 
     [Fact]
-    public void BaseCall_RendersBaseWithArguments()
+    public void BaseCall_LiftsToInitializer()
     {
-        // ctor#1: : base(message)
-        Assert.Equal("base(message);", RaiseCtor(1));
+        // ctor#1: : base(message) — the explicit chain lifts out of the body to
+        // a signature initializer (a base(...) body statement is CS0175).
+        var (body, chain) = RaiseCtor(1);
+        Assert.Equal("base(message)", chain);
+        Assert.DoesNotContain("base(", body);
     }
 
     [Fact]
     public void SpilledThis_CoalesceArgument_CanonicalizesToBase()
     {
-        // ctor#3: : base(message ?? "default") — the ?? forces a this spill
-        // the inliner cannot dissolve; the chain pass renames it to this.
-        string output = RaiseCtor(3);
+        // ctor#3: base(message ?? "default") — the ?? spill keeps the base call
+        // off the first statement, so it stays a (still-canonical) body call
+        // rather than lifting; never the invalid S_0..ctor form.
+        var (body, _) = RaiseCtor(3);
 
-        Assert.Contains("base(", output);
-        Assert.DoesNotContain("..ctor", output);   // never the invalid S_0..ctor form
-        Assert.DoesNotContain("= this;", output);   // the dead spill is gone
+        Assert.Contains("base(", body);
+        Assert.DoesNotContain("..ctor", body);
+        Assert.DoesNotContain("= this;", body);
     }
 
     [Fact]
-    public void ThisDelegation_RendersThis()
+    public void ThisDelegation_LiftsToInitializer()
     {
-        // ctor#4: : this(value.ToString())
-        string output = RaiseCtor(4);
+        // ctor#4: : this(value.ToString()) — lifts to the signature initializer.
+        var (_, chain) = RaiseCtor(4);
 
-        Assert.StartsWith("this(", output);
-        Assert.DoesNotContain("base(", output);
-        Assert.DoesNotContain("..ctor", output);
+        Assert.StartsWith("this(", chain);
+        Assert.DoesNotContain("base(", chain);
+        Assert.DoesNotContain("..ctor", chain);
     }
 }
 

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -64,6 +64,15 @@ public sealed record DecompilerResult(
 {
     public bool Succeeded => Output is not null;
 
+    /// <summary>
+    /// For a constructor whose body opens with an explicit chain call, the C#
+    /// initializer — <c>base(args)</c> or <c>this(args)</c> — lifted out of
+    /// <see cref="Output"/> (a base/this call is valid only as an initializer
+    /// on the signature, never as a body statement). The formatter that renders
+    /// the signature places it; null when there is none.
+    /// </summary>
+    public string? ConstructorChain { get; init; }
+
     public static DecompilerResult Success(string output)
         => new(output, DecompilationFidelity.Full, []);
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -36,8 +36,12 @@ public sealed class CSharpPrinter
     {
         try
         {
-            string output = new CSharpPrinter(function).PrintBody(function);
-            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics]);
+            var printer = new CSharpPrinter(function);
+            string output = printer.PrintBody(function);
+            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics])
+            {
+                ConstructorChain = printer._constructorChain,
+            };
         }
         catch (Exception ex)
         {
@@ -51,11 +55,27 @@ public sealed class CSharpPrinter
     /// <summary>Offsets some surviving goto targets — labels print wherever the block lives, top-level or inside a flat EH body.</summary>
     HashSet<int> _labelTargets = [];
 
+    /// <summary>An explicit base/this chain call lifted out of a constructor body to its signature initializer (base/this calls are invalid as body statements).</summary>
+    string? _constructorChain;
+    IrNode? _chainStatement;
+
     string PrintBody(IrFunction function)
     {
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
         CollectDeclaringStores(function);
+
+        // An explicit base(...)/this(...) chain opens a constructor body; lift
+        // it to a signature initializer so the body stays valid C# (a base/this
+        // call as a body statement is CS0175).
+        if (function.Body.Blocks is [{ Children: [var first, ..] }, ..]
+            && first is ExpressionStatement { Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call }
+            && call.Arguments is [LoadArgument { Index: 0 }, ..]
+            && ConstructorChainText(callee, call) is { } chain)
+        {
+            _constructorChain = chain.TrimEnd(';');
+            _chainStatement = first;
+        }
 
         // Remaining locals and slots declare up front, current-style.
         foreach (var declaration in CollectDeclarations(function))
@@ -82,6 +102,8 @@ public sealed class CSharpPrinter
             bool labeledReturnOnly = _labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
             foreach (var statement in block.Children)
             {
+                if (ReferenceEquals(statement, _chainStatement))
+                    continue;   // lifted to the signature initializer
                 bool isLast = topLevel && i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
                 if (isLast && !labeledReturnOnly && statement is Return { Value: null })
                     break;

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -237,9 +237,10 @@ public static class TypeSourceComposer
                     first = false;
                     any = true;
 
+                    string? constructorChain = null;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, type.FullName, member, index, bodyNamespaces);
+                        : DecompileBody(pipelineSource, type.FullName, member, index, bodyNamespaces, out constructorChain);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -287,7 +288,7 @@ public static class TypeSourceComposer
                         break;
                     }
 
-                    AppendMember(sb, MethodDeclaration(type, member), body);
+                    AppendMember(sb, MethodDeclaration(type, member), body, constructorChain);
                     break;
                 }
 
@@ -372,14 +373,17 @@ public static class TypeSourceComposer
         return string.Join(" ", parts);
     }
 
-    static void AppendMember(StringBuilder sb, string signature, string? body)
+    static void AppendMember(StringBuilder sb, string signature, string? body, string? constructorChain = null)
     {
+        // An explicit base(...)/this(...) chain renders as a signature
+        // initializer (the printer lifted it out of the body).
+        string head = constructorChain is null ? signature : $"{signature} : {constructorChain}";
         if (body is null)
         {
-            sb.AppendLine($"    {signature};");
+            sb.AppendLine($"    {head};");
             return;
         }
-        sb.AppendLine($"    {signature}");
+        sb.AppendLine($"    {head}");
         sb.AppendLine("    {");
         AppendIndented(sb, body, "        ");
         sb.AppendLine("    }");
@@ -474,12 +478,12 @@ public static class TypeSourceComposer
 
     static string? DecompileBody(
         Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member, int overloadIndex,
-        SortedSet<string> bodyNamespaces)
+        SortedSet<string> bodyNamespaces, out string? constructorChain)
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
         // ordering the running index is built from.
         => DecompileMethod(pipelineSource, member.DeclaringType ?? typeFullName, member.Name, overloadIndex,
-            publicOnly: member.Kind != "explicit-interface-implementation", bodyNamespaces);
+            publicOnly: member.Kind != "explicit-interface-implementation", bodyNamespaces, out constructorChain);
 
     static string? DecompileAccessor(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string accessorName,
@@ -487,7 +491,7 @@ public static class TypeSourceComposer
         // Accessors are non-public special-name methods; count across all
         // visibilities (a property has one get_/set_ per name anyway).
         => DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces);
+            publicOnly: false, bodyNamespaces, out _);
 
     /// <summary>
     /// Imports one method to typed IR through the replacement pipeline, runs
@@ -499,13 +503,15 @@ public static class TypeSourceComposer
     /// </summary>
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
-        bool publicOnly, SortedSet<string> bodyNamespaces)
+        bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain)
     {
+        constructorChain = null;
         var function = Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly);
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
         var result = Pipeline.CSharpPrinter.PrintRaised(function);
+        constructorChain = result.ConstructorChain;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -114,7 +114,12 @@ internal static class MemberCodeProvider
                 {
                     var result = Decompiler.Pipeline.CSharpPrinter.PrintRaised(function);
                     if (result.Output is { } lowered)
-                        loweredBody = lowered;
+                        // A constructor's base/this chain is lifted out of the
+                        // body (it is invalid as a statement); show it as the
+                        // signature initializer so the call is not lost.
+                        loweredBody = result.ConstructorChain is { } chain
+                            ? $": {chain}{(lowered.Length == 0 ? "" : Environment.NewLine + lowered)}"
+                            : lowered;
                     else
                         loweredDiagnostic = DiagnosticComment(result);
                 }


### PR DESCRIPTION
## What

A constructor whose body opens with an explicit `base(...)` / `this(...)` call rendered it as a **body statement** — which is **CS0175** ("base/this not valid in this context"); a chain call is legal only as a `: base(...)` / `: this(...)` initializer on the signature.

```csharp
// before:  protected SafeHandle…(bool ownsHandle) { base(nint.Zero, ownsHandle); }   // CS0175
// after:   protected SafeHandle…(bool ownsHandle) : base(nint.Zero, ownsHandle) { }
```

This is the cross-layer item flagged earlier: the chain belongs to the **signature** (formatter-rendered), not the **body** (decompiler-rendered). So:

- **`DecompilerResult`** gains `ConstructorChain` — the initializer call lifted out of `Output`.
- **The printer** detects an explicit chain as the ctor body's *first statement*, surfaces it as `ConstructorChain`, and omits it from the body. The first-statement gate keeps it **sound**: nothing precedes the call, so its arguments reference only parameters/constants and are valid in an initializer. A chain pushed off the first statement by a spilled, computed argument (`base(message ?? "x")`) stays a body call — a follow-up.
- **`TypeSourceComposer`** renders `signature : base(...)`; **`MemberCodeProvider`** carries the chain into the member view so the call isn't lost.

## Impact

- **CS0175: 114 → 41** occurrences in CoreLib (the remainder are spilled-computed-arg chains).
- `FormatException() : base(SR.Arg_FormatException)` and the `SafeHandle*` ctors now render valid.
- All suites green: Decompiler 374 (ctor-chain tests updated to assert the lift) · `dotnet-inspect` 1062.

Fourth fix off the validity docket (after managed-ref `*`-deref #532, local-function de-mangling #534, missing `= default` #537).

🤖 Generated with [Claude Code](https://claude.com/claude-code)