### PR TITLE
Support fully qualified platform member routing

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -401,6 +401,30 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_FullyQualifiedPlatformMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.String.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("IndexOf", output);
+        Assert.Contains("public int IndexOf(char value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_FullyQualifiedPlatformMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String.IndexOf", "--table", "--show-index", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("IndexOf:1", output);
+        Assert.Contains("public int IndexOf(char value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Type_BareSimpleTypeMiss_PrefersPlatformTypeOverSameNamedPackage()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -119,6 +120,7 @@ public static class RouterCommandDefinition
         new VersionProbe(),
         new ExactPlatformLibraryProbe(),
         new QualifiedTypeOrMemberProbe(),
+        new PlatformMemberFindIfMissProbe(),
         new TypeFindIfMissProbe(),
         new PlatformPrefixBrowseProbe(),
         new PackageProbe()
@@ -237,6 +239,32 @@ public static class RouterCommandDefinition
                 return Task.FromResult<int?>(null);
 
             return TypeCommand.TryExecuteFindIfMissAsync(BuildFindIfMissTypeOptions(context));
+        }
+    }
+
+    private sealed class PlatformMemberFindIfMissProbe : IRouterRouteProbe
+    {
+        public async Task<int?> TryExecuteAsync(RouterRouteContext context)
+        {
+            var request = context.Request;
+            if (request.IsVersionQuery || request.PackageLibrary != null || request.Args.Length != 1)
+                return null;
+
+            var commandContext = new CommandContext(context.ParseResult.GetValue(context.Options.Verbose));
+            var resolution = await TypeFindIfMissResolver.ResolvePlatformMemberAsync(
+                request.BareName,
+                includeAll: false,
+                context.Options.ParseNuGetSourceOptions(context.ParseResult),
+                commandContext.HttpClient,
+                commandContext.Logger);
+
+            return resolution.Status switch
+            {
+                TypeFindIfMissStatus.Found => await MemberCommand.ExecuteAsync(
+                    resolution.ApplyTo(BuildFindIfMissMemberOptions(context))),
+                TypeFindIfMissStatus.Ambiguous => resolution.WriteAmbiguousError(),
+                _ => null
+            };
         }
     }
 
@@ -700,6 +728,42 @@ public static class RouterCommandDefinition
             Count = parseResult.GetValue(opts.Count),
             Rows = opts.ParseRows(parseResult),
             Schema = opts.ParseSchema(parseResult),
+            SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
+            TipLevel = opts.IsFormatExplicitlySet(parseResult) || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null
+                ? TipLevel.Quiet
+                : opts.ParseTipLevel(parseResult)
+        };
+    }
+
+    private static MemberOptions BuildFindIfMissMemberOptions(RouterRouteContext context)
+    {
+        var request = context.Request;
+        var opts = context.Options;
+        var parseResult = context.ParseResult;
+        var verbosity = request.Verbosity;
+        return new MemberOptions
+        {
+            PackagePath = request.BareName,
+            ShowDocs = true,
+            DocsExplicitlySet = false,
+            JsonOutput = parseResult.GetValue(opts.Json),
+            OneLine = opts.ResolveOneLine(parseResult),
+            Tsv = opts.ResolveTsv(parseResult),
+            Jsonl = opts.ResolveJsonl(parseResult),
+            OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
+            FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
+            NoHeader = request.NoHeader,
+            CompactJson = parseResult.GetValue(context.CommandArgs.CompactOption),
+            Verbose = parseResult.GetValue(opts.Verbose),
+            Verbosity = verbosity,
+            Discover = opts.ParseDiscover(parseResult),
+            Tree = parseResult.GetValue(opts.Tree),
+            Select = opts.ParseSelect(parseResult),
+            Columns = opts.ParseColumns(parseResult),
+            Fields = opts.ParseFields(parseResult),
+            Count = parseResult.GetValue(opts.Count),
+            Schema = opts.ParseSchema(parseResult),
+            Rows = opts.ParseRows(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             TipLevel = opts.IsFormatExplicitlySet(parseResult) || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null
                 ? TipLevel.Quiet

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -318,6 +318,21 @@ public static class MemberCommand
             return null;
 
         var context = new CommandContext(options.Verbose);
+        if (options.MemberFilter.Count == 0 && !options.CtorOnly)
+        {
+            var memberResolution = await TypeFindIfMissResolver.ResolvePlatformMemberAsync(
+                options.PackagePath,
+                options.IncludeAll,
+                options.SourceOptions,
+                context.HttpClient,
+                context.Logger);
+
+            if (memberResolution.Status == TypeFindIfMissStatus.Found)
+                return await ExecuteAsync(memberResolution.ApplyTo(options));
+            if (memberResolution.Status == TypeFindIfMissStatus.Ambiguous)
+                return memberResolution.WriteAmbiguousError();
+        }
+
         var resolution = await TypeFindIfMissResolver.ResolvePlatformAsync(
             options.PackagePath,
             options.IncludeAll,

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -69,12 +69,43 @@ internal sealed record TypeFindIfMissResult(
     }
 }
 
+internal sealed record TypeMemberFindIfMissResult(
+    TypeFindIfMissStatus Status,
+    string Query,
+    string TypeQuery,
+    string MemberName,
+    int? OverloadIndex,
+    TypeFindIfMissResult TypeResolution)
+{
+    public static TypeMemberFindIfMissResult None(string query) =>
+        new(TypeFindIfMissStatus.None, query, "", "", null, TypeFindIfMissResult.None(query));
+
+    public static TypeMemberFindIfMissResult FromTypeResolution(
+        string query,
+        string typeQuery,
+        string memberName,
+        int? overloadIndex,
+        TypeFindIfMissResult typeResolution) =>
+        new(typeResolution.Status, query, typeQuery, memberName, overloadIndex, typeResolution);
+
+    public MemberOptions ApplyTo(MemberOptions options)
+    {
+        var applied = TypeResolution.ApplyTo(options);
+        return applied with
+        {
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MemberName },
+            OverloadIndex = OverloadIndex
+        };
+    }
+
+    public int WriteAmbiguousError() => TypeResolution.WriteAmbiguousError();
+}
+
 internal static class TypeFindIfMissResolver
 {
     public static bool LooksLikeSimpleTypeQuery(string? query)
         => query is { Length: > 0 }
            && char.IsUpper(query[0])
-           && !query.Contains('.')
            && !query.Contains('*')
            && !query.Contains('?')
            && !query.Contains('@')
@@ -101,15 +132,26 @@ internal static class TypeFindIfMissResolver
                 IncludeAll = includeAll,
                 SourceOptions = sourceOptions
             };
-            var results = await TypeSearchService.FindTypesAsync(
+            var results = await TypeSearchService.CollectTypesAsync(
                 findOptions,
-                [query!],
+                query,
                 logger,
                 tempDirs,
                 httpClient);
 
             var exactMatches = results
-                .Where(r => r.Match == MatchKind.Exact)
+                .Select(r => new TypeFindResult
+                {
+                    Pattern = query!,
+                    Type = r.TypeName,
+                    Namespace = r.Namespace ?? "",
+                    FullName = r.FullName,
+                    Kind = r.Kind,
+                    Library = r.Assembly ?? "",
+                    Source = r.Source ?? "",
+                    SourceVersion = r.SourceVersion,
+                    Match = MatchKind.Exact
+                })
                 .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
@@ -130,5 +172,51 @@ internal static class TypeFindIfMissResolver
         {
             AssemblyCollector.CleanupTempDirs(tempDirs);
         }
+    }
+
+    public static async Task<TypeMemberFindIfMissResult> ResolvePlatformMemberAsync(
+        string? query,
+        bool includeAll,
+        NuGetSourceOptions? sourceOptions,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        if (!TrySplitMemberQuery(query, out var typeQuery, out var memberSelector))
+            return TypeMemberFindIfMissResult.None(query ?? "");
+
+        var (memberName, overloadIndex) = ParseOverloadShorthand(memberSelector);
+        var typeResolution = await ResolvePlatformAsync(typeQuery, includeAll, sourceOptions, httpClient, logger);
+        return TypeMemberFindIfMissResult.FromTypeResolution(
+            query!, typeQuery, memberName, overloadIndex, typeResolution);
+    }
+
+    private static bool TrySplitMemberQuery(string? query, out string typeQuery, out string memberSelector)
+    {
+        typeQuery = "";
+        memberSelector = "";
+
+        if (string.IsNullOrWhiteSpace(query) || query.Contains('*') || query.Contains('?')
+            || query.Contains('@') || query.Contains('/') || query.Contains('\\'))
+            return false;
+
+        var lastDot = query.LastIndexOf('.');
+        if (lastDot <= 0 || lastDot == query.Length - 1)
+            return false;
+
+        typeQuery = query[..lastDot];
+        memberSelector = query[(lastDot + 1)..];
+        return true;
+    }
+
+    private static (string Name, int? Index) ParseOverloadShorthand(string value)
+    {
+        var colonIdx = value.LastIndexOf(':');
+        if (colonIdx > 0 && colonIdx < value.Length - 1 &&
+            int.TryParse(value[(colonIdx + 1)..], out var idx) && idx > 0)
+        {
+            return (value[..colonIdx], idx);
+        }
+
+        return (value, null);
     }
 }


### PR DESCRIPTION
## Summary
- add platform type/member find-if-miss resolution for inputs like System.String.IndexOf
- route fully qualified platform members from both the bare router and member command
- switch find-if-miss to exact collection so namespace prefix browse does not get an extra find-prefix note

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- System.String.IndexOf --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- member System.String.IndexOf --table --show-index --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- System.Text --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- System.CommandLine --table --tips q --head 4