### PR TITLE
Make type-level unsupported reasons honest diagnostics (DEC0005)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1092,6 +1092,13 @@ public class CfgSampleClass
             return (nuint)p;
         }
     }
+
+    // A function-pointer parameter has no slice representation, so its presence
+    // in the signature caps fidelity. Unlike an out-of-slice body opcode it
+    // carries no node-level stop, so the importer must surface a typed
+    // (DEC0005) diagnostic naming the reason — otherwise the method is Partial
+    // with no diagnostic, invisible to the harness roadmap.
+    public static unsafe void TakesFunctionPointer(delegate*<int, int> callback) { _ = callback; }
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -140,6 +140,21 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void UnsupportedSignatureType_ReportsTypedDiagnostic()
+    {
+        // A function-pointer parameter sinks fidelity through the signature but
+        // carries no node-level stop, so the importer must surface a DEC0005
+        // diagnostic naming the reason — otherwise it is Partial-with-no-reason,
+        // invisible to the harness roadmap.
+        var function = ImportFixture(nameof(CfgSampleClass.TakesFunctionPointer));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedType, diagnostic.Id);
+        Assert.Contains("function pointer", diagnostic.Message);
+    }
+
+    [Fact]
     public void CoreLib_IsNullOrEmpty_ImportsAtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -49,6 +49,15 @@ public static class DiagnosticIds
 
     /// <summary>IL the pipeline does not represent; rendered explicitly, lowers fidelity.</summary>
     public const string UnsupportedConstruct = "DEC0004";
+
+    /// <summary>
+    /// A type the slice cannot represent (a function pointer, a custom modifier)
+    /// appears in a signature, local, or node — lowering fidelity. Distinct from
+    /// <see cref="UnsupportedConstruct"/> (an opcode in a body): the cause is the
+    /// type surface, not the instruction stream, and it otherwise carries no
+    /// node-level diagnostic of its own.
+    /// </summary>
+    public const string UnsupportedType = "DEC0005";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -159,8 +159,52 @@ public static class IrImporter
         }
 
         ResolveTypeInfo(source, function);
+        RecordUnsupportedTypeDiagnostics(function);
         function.CheckInvariant();
         return function;
+    }
+
+    /// <summary>
+    /// Ensures every type the slice cannot represent reports *why* it lowered
+    /// fidelity. A function-pointer parameter or a custom-modifier local sinks
+    /// <see cref="IrFunction.Fidelity"/> through <see cref="TypeRef.ContainsUnsupported"/>,
+    /// but unlike an out-of-slice opcode it carries no node-level stop — so
+    /// without this the method counts as Partial with no diagnostic, invisible
+    /// to the harness roadmap. One <see cref="DiagnosticIds.UnsupportedType"/>
+    /// per distinct reason, deduped against reasons already reported, so a type
+    /// repeated across many parameters reports once.
+    /// </summary>
+    static void RecordUnsupportedTypeDiagnostics(IrFunction function)
+    {
+        var reasons = new HashSet<string>();
+        void Consider(TypeRef? type)
+        {
+            if (type is null || !type.ContainsUnsupported)
+                return;
+            foreach (var reason in type.UnsupportedReasons())
+                reasons.Add(reason);
+        }
+
+        foreach (var node in function.Descendants.Prepend(function))
+        {
+            foreach (var type in node.DirectTypes)
+                Consider(type);
+            if (node is IrExpression expression)
+                Consider(expression.ResultType);
+        }
+
+        if (reasons.Count == 0)
+            return;
+
+        var alreadyReported = function.Diagnostics
+            .Select(d => d.Message)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var reason in reasons.OrderBy(r => r, StringComparer.Ordinal))
+        {
+            var message = $"type {reason}";
+            if (alreadyReported.Add(message))
+                function.Diagnostics.Add(new DecompilerDiagnostic(DiagnosticIds.UnsupportedType, message));
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -147,6 +147,25 @@ public sealed class TypeRef : IEquatable<TypeRef>
         || ElementType?.ContainsUnsupported == true
         || TypeArguments.Any(a => a.ContainsUnsupported);
 
+    /// <summary>
+    /// The reasons of every <see cref="TypeRefKind.Unsupported"/> shape reachable
+    /// from this type (element types and type arguments included), in pre-order.
+    /// Drives the importer's type-level diagnostics so a signature the slice
+    /// cannot represent (a function pointer, a custom modifier) reports *why* it
+    /// lowered fidelity instead of sinking it silently.
+    /// </summary>
+    public IEnumerable<string> UnsupportedReasons()
+    {
+        if (Kind == TypeRefKind.Unsupported)
+            yield return UnsupportedReason;
+        if (ElementType is { } element)
+            foreach (var reason in element.UnsupportedReasons())
+                yield return reason;
+        foreach (var argument in TypeArguments)
+            foreach (var reason in argument.UnsupportedReasons())
+                yield return reason;
+    }
+
     public bool Equals(TypeRef? other)
     {
         if (other is null)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -164,7 +164,7 @@ static class Program
                     Console.Error.WriteLine($"IMPORTER BUG: {diagnostic.Message}");
                     continue;
                 }
-                string bucket = diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
+                string bucket = BucketFor(diagnostic);
                 stops[bucket] = stops.GetValueOrDefault(bucket) + 1;
             }
         }
@@ -174,6 +174,25 @@ static class Program
         foreach (var stop in stops.OrderByDescending(s => s.Value).Take(15))
             Console.WriteLine($"  {stop.Value,8}  {stop.Key}");
         return crashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// The roadmap bucket for a stop. Type-level stops
+    /// (<see cref="DiagnosticIds.UnsupportedType"/>) group by their reason —
+    /// the function-pointer and custom-modifier signatures that used to sink
+    /// fidelity silently into the "(typed)" catch-all; the parenthetical detail
+    /// (the specific modifier type) is trimmed so they aggregate. Opcode-level
+    /// stops keep their second message token (the IL opcode).
+    /// </summary>
+    static string BucketFor(DecompilerDiagnostic diagnostic)
+    {
+        if (diagnostic.Id == DiagnosticIds.UnsupportedType)
+        {
+            var message = diagnostic.Message ?? "(typed)";
+            int detail = message.IndexOf('(');
+            return detail < 0 ? message : message[..detail].TrimEnd();
+        }
+        return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Type-level unsupported shapes (function pointers, custom modifiers) in a signature, local, or node lower `IrFunction.Fidelity` to `Partial` through `TypeRef.ContainsUnsupported` — but, unlike an out-of-slice opcode, they carried **no node-level stop and therefore no diagnostic**. The method counted as `Partial` with no reason attached, invisible to the differential harness roadmap, which swept ~1060 CoreLib methods into an undiagnosed `(typed)` catch-all.

This makes those failures honest, per the pipeline doc's principles ("honest failure ... never a silent `catch`", "diagnostics get stable IDs"):

- **`DiagnosticIds.UnsupportedType` (`DEC0005`)** — a new stable id, distinct from the opcode-level `DEC0004 UnsupportedConstruct`: the cause is the type surface, not the instruction stream.
- **`TypeRef.UnsupportedReasons()`** — enumerates the distinct unsupported reasons reachable through element types and type arguments.
- **Importer finishing pass** (`RecordUnsupportedTypeDiagnostics`) — after `ResolveTypeInfo`, records one `DEC0005` per distinct reason, deduped. Fidelity is **unchanged** (still computed from the tree); only the diagnostics become complete.
- **Harness** — buckets `DEC0005` by reason instead of the `(typed)` fallback.

## Payoff: the roadmap corrected itself

Inventory sweep of CoreLib (`--pipeline next`), fidelity unchanged at **95.80% Full, 0 importer bugs**:

| before | after |
| --- | --- |
| `1060  (typed)` | `994  type custom modifier` |
| | `21   type function pointer` |
| | `45   (typed)` (genuine undiagnosed residue) |

The catch-all was overwhelmingly **custom modifiers**, not function pointers — so this PR also redirects where the next type-level raising work should go.

## Testing

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — **375 passed** (added a deterministic `delegate*<int,int>` fixture + a test asserting the `DEC0005` diagnostic; kept the existing fidelity-scan test).
- `dotnet build src/dotnet-inspect -c Release` — clean.
- Harness inventory rerun shown above.

## Scope

Additive and behavior-preserving for product output: no rendering changes, no fidelity changes, no new raising. Purely diagnostic completeness + roadmap visibility.
