### PR TITLE
See through custom modifiers in the IR importer (95.80% -> 98.26% Full)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1099,6 +1099,17 @@ public class CfgSampleClass
     // (DEC0005) diagnostic naming the reason — otherwise the method is Partial
     // with no diagnostic, invisible to the harness roadmap.
     public static unsafe void TakesFunctionPointer(delegate*<int, int> callback) { _ = callback; }
+
+    // An `in` parameter carries modreq(InAttribute) on the byref. The importer
+    // sees through the modifier, so the body imports at Full fidelity and the
+    // underlying ByRef(int) shape stays intact for the load-indirect unwrap.
+    public static int InParameterSum(in int x, in int y) => x + y;
+
+    // A volatile field's type carries modreq(IsVolatile); reading it must still
+    // import at Full fidelity once the modifier is seen through.
+    public static volatile int VolatileFlag;
+
+    public static int ReadVolatileFlag() => VolatileFlag;
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -155,6 +155,29 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void InParameter_SeesThroughModifier_ImportsAtFull()
+    {
+        // modreq(InAttribute) on the byref is a declaration-site concern that
+        // never appears in the body; seeing through it lets a fully
+        // representable method import at Full instead of being capped.
+        var function = ImportFixture(nameof(CfgSampleClass.InParameterSum));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Diagnostics);
+    }
+
+    [Fact]
+    public void VolatileField_SeesThroughModifier_ImportsAtFull()
+    {
+        // modreq(IsVolatile) on the field type is likewise transparent to the
+        // body, which references the field by name.
+        var function = ImportFixture(nameof(CfgSampleClass.ReadVolatileFlag));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Diagnostics);
+    }
+
+    [Fact]
     public void CoreLib_IsNullOrEmpty_ImportsAtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -104,8 +104,29 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     public TypeRef GetFunctionPointerType(MethodSignature<TypeRef> signature)
         => TypeRef.Unsupported("function pointer");
 
+    /// <summary>
+    /// Custom modifiers are seen through to the unmodified type. The three that
+    /// occur in practice — <c>modreq(InAttribute)</c> (an <c>in</c>/<c>ref readonly</c>
+    /// parameter or return), <c>modreq(IsVolatile)</c> (a <c>volatile</c> field),
+    /// and <c>modreq(IsExternalInit)</c> (an <c>init</c> accessor) — are
+    /// declaration-site concerns the signature renderer reads from metadata; they
+    /// never appear in a method body, where types surface only as local
+    /// declarations, casts, and call arguments over the *unmodified* type. Seeing
+    /// through keeps the underlying shape intact (an <c>in T</c> stays
+    /// <c>ByRef(T)</c>, so every <c>ByRef</c>/<c>Pointer</c> unwrap site still
+    /// matches) and lets a fully-representable body import at
+    /// <see cref="DecompilationFidelity.Full"/> instead of being capped by a
+    /// modifier that the C# never spells here.
+    ///
+    /// This is the "no infrastructure without a customer" choice
+    /// (docs/decompiler-pipeline.md): the design contract has type identity carry
+    /// modifiers through the tree, but no body consumer reads them today, and
+    /// wrapping the byref of an <c>in</c> parameter would break the structural
+    /// <c>Kind == ByRef</c> checks. When an IR-based signature renderer needs the
+    /// distinction, model it then.
+    /// </summary>
     public TypeRef GetModifiedType(TypeRef modifier, TypeRef unmodifiedType, bool isRequired)
-        => TypeRef.Unsupported($"custom modifier ({(isRequired ? "modreq" : "modopt")} {modifier.ToDisplayString()})");
+        => unmodifiedType;
 
     static string NameAt(ImmutableArray<string> names, int index)
         => index >= 0 && index < names.Length ? names[index] : "";


### PR DESCRIPTION
## What

`modreq`/`modopt` custom modifiers decoded to `TypeRef.Unsupported`, capping `IrFunction.Fidelity` at `Partial` for ~1004 CoreLib methods that were otherwise fully representable. (Surfaced as the dominant type-level gap by the DEC0005 diagnostics from #543.) The three modifiers that occur in practice are all **declaration-site** concerns the signature renderer reads from metadata, and that **never appear in a method body**:

| modifier | C# meaning | count |
| --- | --- | --- |
| `modreq(InAttribute)` | `in` / `ref readonly` parameter or return | 667 |
| `modreq(IsVolatile)` | `volatile` field | 326 |
| `modreq(IsExternalInit)` | `init` accessor | 23 |

`TypeRefDecoder.GetModifiedType` now **sees through** to the unmodified type. This keeps the underlying shape intact — an `in T` stays `ByRef(T)`, so every structural `Kind == ByRef`/`Pointer` unwrap site still matches — and lets these bodies import at `Full`.

## No rendering change, no parity churn

The modifier was never rendered in a method body (types surface there only as local declarations, casts, and call arguments over the *unmodified* type). I verified three representative methods (an `in`-param P/Invoke wrapper, an `init` setter, a `volatile`-field `.ctor`) render byte-identical before and after — only the fidelity flag flips. So these methods don't change output; they simply become honestly `Full` and **enter** the differential comparison (candidate `Partial` 1710 → 706).

## Design note

Per [docs/decompiler-pipeline.md](docs/decompiler-pipeline.md) this is the "no infrastructure without a customer" choice. The design contract has type identity carry modifiers through the tree, but no body consumer reads them today, and wrapping the byref of an `in` parameter in a modifier shape would break the structural `Kind == ByRef` checks across the pipeline. When an IR-based signature renderer needs the `in`/`volatile`/`init` distinction, model it then; the signature line is rendered from metadata today, independent of this path.

## Results

Inventory sweep of CoreLib (`--pipeline next`):

```
before: 38957/40667 Full (95.80%)   994  type custom modifier
after:  39961/40667 Full (98.26%)   (bucket gone)
```

Remaining roadmap: `localloc` 319, `ldftn` 178, `(join-type)` 95, `(typed)` 45, `calli` 38, `type function pointer` 22.

## Testing

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` and `-c Debug` — **377 passed** (added `in`-parameter and `volatile`-field fixtures + Full-fidelity assertions).
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 141 passed.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 1068 passed, 9 skipped, 1 pre-existing failure (`Type_SingleType_NormalVerbosity_StaysShapeAndExpandsOverloads` — a version-sensitive `JsonSerializer` overload count; fails identically on `main` without this change).
- Differential harness diff run to confirm the flipped methods are newly-comparable, not newly-divergent.

(IL round-trip suite requires the external ILAssembler vendor restore, unavailable in this environment; it exercises IL disassembly, not decompiled C#, and is unaffected by this change.)
