### PR TITLE
Improve member-like bare router inputs

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -95,6 +95,23 @@ public static class TypeMatcher
         return $"{baseName}`{arity}{suffix}";
     }
 
+    /// <summary>
+    /// Normalizes a member selector by removing C# generic method type arguments.
+    /// "Deserialize&lt;TValue&gt;" -> "Deserialize". Malformed/non-generic names pass through unchanged.
+    /// </summary>
+    public static string NormalizeMemberName(string memberName)
+    {
+        var angleIdx = memberName.IndexOf('<');
+        if (angleIdx <= 0)
+            return memberName;
+
+        var closeIdx = memberName.LastIndexOf('>');
+        if (closeIdx <= angleIdx || closeIdx != memberName.Length - 1)
+            return memberName;
+
+        return memberName[..angleIdx];
+    }
+
     private static int CountTypeParameters(ReadOnlySpan<char> typeParams)
     {
         if (typeParams.IsEmpty || typeParams.IsWhiteSpace())

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -425,6 +425,42 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_SimplePlatformMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "String.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("IndexOf", output);
+        Assert.Contains("public int IndexOf(char value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_GenericMemberSelector_NormalizesGenericTypeArguments()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "JsonSerializer.Deserialize<TValue>", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Deserialize", output);
+        Assert.Contains("Deserialize<TValue>", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_GenericMemberSelector_NormalizesGenericTypeArguments()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "-m", "Deserialize<TValue>", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Deserialize", output);
+        Assert.Contains("Deserialize<TValue>", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Type_BareSimpleTypeMiss_PrefersPlatformTypeOverSameNamedPackage()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.Services;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.CommandLine;
 
@@ -119,7 +120,7 @@ public static class SharedParsers
         if (values.Length == 1 && int.TryParse(values[0], out var limit))
             return ([], limit);
 
-        return (new HashSet<string>(values, StringComparer.OrdinalIgnoreCase), null);
+        return (new HashSet<string>(values.Select(TypeMatcher.NormalizeMemberName), StringComparer.OrdinalIgnoreCase), null);
     }
 
     /// <summary>
@@ -131,8 +132,8 @@ public static class SharedParsers
     {
         var colonIdx = value.LastIndexOf(':');
         if (colonIdx > 0 && int.TryParse(value[(colonIdx + 1)..], out var idx))
-            return (value[..colonIdx], idx);
-        return (value, null);
+            return (TypeMatcher.NormalizeMemberName(value[..colonIdx]), idx);
+        return (TypeMatcher.NormalizeMemberName(value), null);
     }
 
     /// <summary>
@@ -222,9 +223,9 @@ public static class SharedParsers
 
             // Check for overload shorthand (Name:N)
             var (name, index) = ParseOverloadShorthand(members[i]);
+            members[i] = name;
             if (index != null)
             {
-                members[i] = name;
                 overloadIndex = index;
             }
         }

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -155,11 +155,18 @@ internal static class TypeFindIfMissResolver
                 .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
+            var normalizedQuery = TypeMatcher.Normalize(query!);
+            var exactDisplayNameMatches = exactMatches
+                .Where(r => string.Equals(TypeMatcher.Normalize(r.Type), normalizedQuery, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
             var exactSimpleNameMatches = exactMatches
                 .Where(r => string.Equals(TypeMatcher.GetSimpleName(r.FullName), query, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
-            var candidateMatches = exactSimpleNameMatches.Count > 0 ? exactSimpleNameMatches : exactMatches;
+            var candidateMatches = exactDisplayNameMatches.Count > 0 ? exactDisplayNameMatches
+                : exactSimpleNameMatches.Count > 0 ? exactSimpleNameMatches
+                : exactMatches;
 
             return candidateMatches.Count switch
             {
@@ -214,9 +221,9 @@ internal static class TypeFindIfMissResolver
         if (colonIdx > 0 && colonIdx < value.Length - 1 &&
             int.TryParse(value[(colonIdx + 1)..], out var idx) && idx > 0)
         {
-            return (value[..colonIdx], idx);
+            return (TypeMatcher.NormalizeMemberName(value[..colonIdx]), idx);
         }
 
-        return (value, null);
+        return (TypeMatcher.NormalizeMemberName(value), null);
     }
 }


### PR DESCRIPTION
## Summary
- prefer exact displayed platform type names in find-if-miss, so String.IndexOf resolves to System.String instead of ambiguous nested String matches
- normalize generic method selectors such as Deserialize<TValue> to metadata member names
- cover router and member command paths for simple type/member and generic method selector inputs

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- String.IndexOf --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- System.String.IndexOf:7 --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- List<T>.Add --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- System.Collections.Generic.List<T>.Add --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- JsonSerializer.Deserialize<TValue> --table --tips q --head 6
- dotnet run --project src/dotnet-inspect -c Release -- member JsonSerializer -m Deserialize<TValue> --table --tips q --head 8
- dotnet run --project src/dotnet-inspect -c Release -- Regex --versions -n 2 (expected package-not-found exit)