### PR TITLE
Raise delegate construction from ldftn (98.26% -> 98.71% Full)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1110,6 +1110,18 @@ public class CfgSampleClass
     public static volatile int VolatileFlag;
 
     public static int ReadVolatileFlag() => VolatileFlag;
+
+    static void Tick() { }
+    void Instance() { }
+
+    // A static method group: `ldftn Tick; newobj Action::.ctor(object, native
+    // int)` with a null target. The DelegateConstructionPass raises this to
+    // `new Action(Tick)` at Full fidelity.
+    public static System.Action StaticMethodGroup() => new System.Action(Tick);
+
+    // An instance method group: the target is `this`, so the method group drops
+    // the qualifier to `new Action(Instance)`.
+    public System.Action InstanceMethodGroup() => new System.Action(Instance);
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -636,6 +636,50 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void DelegateConstruction_StaticMethodGroup_PrintsNewDelegate()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        Assert.Equal("return new Action(CfgSampleClass.Tick);",
+            PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StaticMethodGroup), source));
+    }
+
+    [Fact]
+    public void DelegateConstruction_InstanceMethodGroup_DropsThisQualifier()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        Assert.Equal("return new Action(Instance);",
+            PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.InstanceMethodGroup), source));
+    }
+
+    [Fact]
+    public void DelegateConstruction_RaisesToTypedNode_AtFullFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StaticMethodGroup));
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+
+        var creation = Assert.Single(function.Descendants.OfType<DelegateCreation>());
+        Assert.Equal("Action", creation.DelegateType.ToDisplayString());
+        Assert.Equal("Tick", creation.Method.Name);
+        Assert.Empty(function.Descendants.OfType<LoadFunctionPointer>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void LoadFunctionPointer_BeforeRaising_ImportsAtPartialFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StaticMethodGroup));
+        Assert.NotNull(function);
+
+        // Before the pass runs, the bare function-pointer load has no C#
+        // spelling, so the unraised tree is honestly Partial.
+        Assert.Single(function.Descendants.OfType<LoadFunctionPointer>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
     public void GenericInstanceNullCheck_RendersIsNull()
     {
         // A brtrue/brfalse operand can never be a struct value, so a generic

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -58,6 +58,15 @@ public static class DiagnosticIds
     /// node-level diagnostic of its own.
     /// </summary>
     public const string UnsupportedType = "DEC0005";
+
+    /// <summary>
+    /// A bare function-pointer load (<c>ldftn</c>/<c>ldvirtftn</c>) that no pass
+    /// consumed — it fed something other than a delegate constructor (a
+    /// <c>calli</c>, a native callback registration). C# has no spelling for it,
+    /// so it renders as a comment and lowers fidelity. The delegate-construction
+    /// pattern is raised away before this is recorded; only the residue remains.
+    /// </summary>
+    public const string UnsupportedFunctionPointer = "DEC0006";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -443,6 +443,8 @@ public sealed class CSharpPrinter
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
+        DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
+        LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
@@ -588,7 +590,7 @@ public sealed class CSharpPrinter
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf;
+            or LoadProperty or TypeOf or DelegateCreation;
         return atomic ? text : $"({text})";
     }
 
@@ -734,6 +736,21 @@ public sealed class CSharpPrinter
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
         _ => Operand(receiver),
     };
+
+    /// <summary>
+    /// A method group for a delegate creation: a null target is a static
+    /// method group (Type.Method); a this-receiver drops the qualifier to match
+    /// instance-call spelling; any other receiver qualifies the name.
+    /// </summary>
+    string MethodGroupText(MethodRef method, IrExpression target)
+    {
+        string name = MethodName(method.Name);
+        if (target is Constant { Value: null })
+            return $"{TypeText(method.DeclaringType)}.{name}";
+        if (target is LoadArgument { Index: 0, Name: "this" })
+            return name;
+        return $"{ReceiverText(target)}.{name}";
+    }
 
     /// <summary>
     /// The source name of a call target. A compiler-generated local function

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -931,6 +931,21 @@ public static class IrImporter
                     body.Add(new Return(stack.Count > 0 ? Pop(stack) : null));
                     break;
 
+                case ILOpCode.Ldftn:
+                {
+                    var target = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    stack.Push(new LoadFunctionPointer(target, isVirtual: false, instance: null));
+                    break;
+                }
+
+                case ILOpCode.Ldvirtftn:
+                {
+                    var target = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var instance = Pop(stack);
+                    stack.Push(new LoadFunctionPointer(target, isVirtual: true, instance));
+                    break;
+                }
+
                 default:
                     Stop(function, body, stack, offset, opcode.ToString().ToLowerInvariant(),
                         "opcode is outside the slice");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -88,6 +88,7 @@ public sealed class IrFunction : IrNode
     public DecompilationFidelity Fidelity
         => Descendants.Prepend(this).Any(n =>
             n is UnsupportedNode
+            || n is LoadFunctionPointer
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || n is IrExpression { ResultType: null }
             || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
@@ -669,6 +670,62 @@ public sealed class NewObject : IrExpression
         => Constructor.ParameterTypes.Append(Constructor.DeclaringType);
 
     public override string Describe() => $"NewObject {Constructor.DeclaringType.ToDisplayString()}";
+}
+
+/// <summary>
+/// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native
+/// int. C# has no spelling for a bare function-pointer load, so this only
+/// reaches print as a comment; the dominant case — feeding a delegate
+/// constructor — is raised to <see cref="DelegateCreation"/> by a pass.
+/// </summary>
+public sealed class LoadFunctionPointer : IrExpression
+{
+    public LoadFunctionPointer(MethodRef method, bool isVirtual, IrExpression? instance)
+    {
+        Method = method;
+        IsVirtual = isVirtual;
+        if (instance is not null)
+            AddChild(instance);
+    }
+
+    public MethodRef Method { get; }
+    public bool IsVirtual { get; }
+
+    /// <summary>The receiver dispatched on for ldvirtftn; null for ldftn.</summary>
+    public IrExpression? Instance => Children.Count > 0 ? (IrExpression)Children[0] : null;
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "IntPtr");
+    public override IEnumerable<TypeRef> DirectTypes
+        => Method.ParameterTypes.Append(Method.DeclaringType).Append(Method.ReturnType);
+
+    public override string Describe()
+        => $"{(IsVirtual ? "LoadVirtualFunctionPointer" : "LoadFunctionPointer")} {Method.DeclaringType.ToDisplayString()}.{Method.Name}";
+}
+
+/// <summary>
+/// A delegate instance from a method group — the inverse of the compiler's
+/// <c>ldftn; newobj DelegateType::.ctor(object, native int)</c> lowering. The
+/// target is the receiver object (a null constant for a static method group).
+/// </summary>
+public sealed class DelegateCreation : IrExpression
+{
+    public DelegateCreation(TypeRef delegateType, MethodRef method, bool isVirtual, IrExpression target)
+    {
+        DelegateType = delegateType;
+        Method = method;
+        IsVirtual = isVirtual;
+        AddChild(target);
+    }
+
+    public TypeRef DelegateType { get; }
+    public MethodRef Method { get; }
+    public bool IsVirtual { get; }
+    public IrExpression Target => (IrExpression)Children[0];
+    public override TypeRef? ResultType => DelegateType;
+    public override IEnumerable<TypeRef> DirectTypes
+        => Method.ParameterTypes.Append(Method.DeclaringType).Append(Method.ReturnType).Append(DelegateType);
+
+    public override string Describe()
+        => $"DelegateCreation {DelegateType.ToDisplayString()} <- {Method.DeclaringType.ToDisplayString()}.{Method.Name}";
 }
 
 public sealed class Throw : IrNode

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DelegateConstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DelegateConstructionPass.cs
@@ -1,0 +1,43 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a method group to delegate creation — the inverse of the compiler's
+/// <c>ldftn/ldvirtftn; newobj DelegateType::.ctor(object, native int)</c>
+/// lowering. The <c>(object, native int)</c> constructor shape fed a
+/// <see cref="LoadFunctionPointer"/> is the same evidence ILSpy and the runtime
+/// use; the result is a typed <see cref="DelegateCreation"/> node, not name
+/// surgery at print time.
+/// </summary>
+public sealed class DelegateConstructionPass : IIrPass
+{
+    public string Name => "delegate-construction";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
+        {
+            if (newObject.Parent is null)
+                continue;  // detached by an earlier rewrite in this walk
+            if (!IsDelegateConstructor(newObject.Constructor))
+                continue;
+            if (newObject.Children.Count != 2 || newObject.Children[1] is not LoadFunctionPointer)
+                continue;
+
+            var children = newObject.DetachChildren().Cast<IrExpression>().ToList();
+            var target = children[0];
+            var pointer = (LoadFunctionPointer)children[1];
+            newObject.ReplaceWith(new DelegateCreation(
+                newObject.Constructor.DeclaringType, pointer.Method, pointer.IsVirtual, target));
+        }
+    }
+
+    // The delegate constructor's universal shape: an instance .ctor taking
+    // (object target, native int method). Only delegate types carry it, and the
+    // C# compiler only ever feeds an ldftn result as its second argument.
+    static bool IsDelegateConstructor(MethodRef constructor)
+        => constructor.Name == ".ctor"
+            && constructor.HasThis
+            && constructor.ParameterTypes.Length == 2
+            && constructor.ParameterTypes[0] is { Namespace: "System", Name: "Object" }
+            && constructor.ParameterTypes[1] is { Namespace: "System", Name: "IntPtr" };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
@@ -1,0 +1,27 @@
+using ILInspector.Decompiler;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Records a <see cref="DiagnosticIds.UnsupportedFunctionPointer"/> diagnostic
+/// for every <see cref="LoadFunctionPointer"/> that survived raising — the
+/// residue the <see cref="DelegateConstructionPass"/> could not consume
+/// (function pointers feeding <c>calli</c> or native callbacks). Running last,
+/// it keeps these honest, visible gaps off the silent-Partial path: a method
+/// with a bare function-pointer load is Partial, and now says why.
+/// </summary>
+public sealed class FunctionPointerDiagnosticsPass : IIrPass
+{
+    public string Name => "function-pointer-diagnostics";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var pointer in function.Descendants.OfType<LoadFunctionPointer>())
+        {
+            // The second whitespace token (ldftn:) is the harness roadmap bucket.
+            function.Diagnostics.Add(new DecompilerDiagnostic(
+                DiagnosticIds.UnsupportedFunctionPointer,
+                $"function-pointer ldftn: {pointer.Method.DeclaringType.ToDisplayString()}.{pointer.Method.Name} is not a delegate construction"));
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -41,6 +41,10 @@ public static class IrPasses
         new ConstructorChainPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
+        // Raise method-group delegate creation (ldftn + delegate ctor) once
+        // inlining has placed the function-pointer load in the ctor's argument
+        // slot — the inverse of the compiler's delegate lowering.
+        new DelegateConstructionPass(),
         // Consume conditional back edges into do-while loops before
         // structuring, which leaves any back-edge container flat. The loop
         // body becomes a container the structuring pass then raises.
@@ -61,6 +65,9 @@ public static class IrPasses
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // Last: any function-pointer load still standing fed something other
+        // than a delegate constructor — record the honest residual diagnostic.
+        new FunctionPointerDiagnosticsPass(),
     ];
 
     public static void Run(IrFunction function) => Run(function, Default);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -140,7 +140,10 @@ static class Program
 
     /// <summary>
     /// Inventory sweep of the replacement pipeline: fidelity histogram plus
-    /// the stop-reason buckets that ARE the prioritized slice roadmap.
+    /// the stop-reason buckets that ARE the prioritized slice roadmap. Fidelity
+    /// is read from the FINISHED tree — passes run first, exactly as the product
+    /// path does — so a gap a raising pass closes (delegate construction) leaves
+    /// the roadmap, and only the genuine residue remains.
     /// </summary>
     static int SweepNext(List<string> assemblies)
     {
@@ -152,6 +155,16 @@ static class Program
             foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
             {
                 total++;
+                try
+                {
+                    IrPasses.Run(function);
+                }
+                catch (Exception ex)
+                {
+                    crashes++;
+                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message}");
+                    continue;
+                }
                 if (function.Fidelity == DecompilationFidelity.Full)
                 {
                     full++;


### PR DESCRIPTION
## What

The IR importer stopped on `ldftn`/`ldvirtftn`, sinking every method that builds a delegate to Partial fidelity. This raises the method-group → delegate pattern the way ILSpy and the runtime recognize it, then renders it as idiomatic C#.

## How

- **Importer** — `ldftn`/`ldvirtftn` now push a typed `LoadFunctionPointer` instead of stopping (`ldvirtftn` pops its receiver). No importer stop.
- **`DelegateConstructionPass`** (new) — rewrites `newobj DelegateType::.ctor(target, LoadFunctionPointer)` into a typed `DelegateCreation`, matched on the universal `(System.Object, System.IntPtr)` constructor shape. Printed as `new DelegateType(methodGroup)`:
  - null target → static group `Type.Method`
  - `this` receiver → bare `Method` (matches instance-call spelling)
  - any other receiver → `receiver.Method`
- **`FunctionPointerDiagnosticsPass`** (new, runs last) — a bare function-pointer load that no pass consumed (it fed a `calli` or native callback) has no C# spelling, so `LoadFunctionPointer` keeps a method Partial. This records **DEC0006** for the residue so it stays a visible, honest gap rather than a silent Partial.
- **Harness** — the inventory sweep now measures the **finished (post-pass)** tree, matching the product path, so a gap a raising pass closes leaves the roadmap (and raised methods don't become a silent `(typed)` sink).

## Numbers (CoreLib)

| | Full | % |
|---|---|---|
| before | 39961/40667 | 98.26% |
| after | **40141/40667** | **98.71%** (+180) |

- 266 delegate constructions raised; 28 function-pointer loads legitimately survive (calli / native callbacks, now DEC0006).
- Post-pass roadmap buckets sum exactly to the Partial count — no silent sink. `ldftn` is gone from the roadmap; `(typed)` drops 213 → 45.

Example (`System.Type::.cctor`):

    Type.FilterAttribute = new MemberFilter(Type.FilterAttributeImpl);
    Type.FilterName = new MemberFilter(<>c.<>9.<.cctor>b__291_0);

## Soundness

1. **Preconditions whole-function** — the rewrite consumes only the matched `newobj` and its `LoadFunctionPointer` argument; it replaces a single expression, removing no defining store or binding, so no other reader observes the change.
2. **Semantics exact** — the delegate constructor is matched on its universal `(System.Object, System.IntPtr)` signature and `.ctor` name, not a loose shape; the rendered `new D(methodGroup)` is valid C# naming the exact target; `ldvirtftn` keeps `IsVirtual`.
3. **Per-item failure isolated** — passes run per function inside the sweep's guard; a throw is one reported failure, never a lost batch.

## Tests

- `ILInspector.Decompiler.Tests`: 381 pass (Debug + Release), including new static/instance method-group fixtures and pre/post-pass fidelity assertions.
- `dotnet-inspect.Tests`: only the pre-existing version-sensitive `JsonSerializer` overload-count failure remains (unrelated).
