### PR TITLE
Raise localloc to stackalloc (98.71% -> 99.49% Full)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1122,6 +1122,15 @@ public class CfgSampleClass
     // An instance method group: the target is `this`, so the method group drops
     // the qualifier to `new Action(Instance)`.
     public System.Action InstanceMethodGroup() => new System.Action(Instance);
+
+    // localloc: `stackalloc byte[n]` lowers to a byte count, `localloc`, and a
+    // pointer store. The importer raises localloc to a StackAllocate node so the
+    // body imports at Full fidelity and prints `stackalloc byte[...]`.
+    public static unsafe byte StackAllocFirst(int n)
+    {
+        byte* buffer = stackalloc byte[n];
+        return buffer[0];
+    }
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -680,6 +680,27 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void StackAlloc_ImportsToTypedNode_AtFullFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StackAllocFirst));
+        Assert.NotNull(function);
+
+        var alloc = Assert.Single(function.Descendants.OfType<StackAllocate>());
+        Assert.Equal("byte*", alloc.ResultType?.ToDisplayString());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Diagnostics);
+    }
+
+    [Fact]
+    public void StackAlloc_Prints_StackallocByteCount()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StackAllocFirst), source);
+        Assert.Contains("stackalloc byte[", output);
+    }
+
+    [Fact]
     public void GenericInstanceNullCheck_RendersIsNull()
     {
         // A brtrue/brfalse operand can never be a struct value, so a generic

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -450,6 +450,7 @@ public sealed class CSharpPrinter
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
+        StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} as {TypeText(i.Type)}",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -946,6 +946,19 @@ public static class IrImporter
                     break;
                 }
 
+                case ILOpCode.Localloc:
+                {
+                    // localloc's operand is a native-int byte count; C#'s
+                    // stackalloc takes the logical count, so strip the widening
+                    // conversion the compiler emits to feed localloc.
+                    var size = Pop(stack);
+                    if (size is Convert conversion
+                        && conversion.Target is { Namespace: "System", Name: "IntPtr" or "UIntPtr" })
+                        size = (IrExpression)conversion.DetachChildren()[0];
+                    stack.Push(new StackAllocate(size));
+                    break;
+                }
+
                 default:
                     Stop(function, body, stack, offset, opcode.ToString().ToLowerInvariant(),
                         "opcode is outside the slice");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -901,6 +901,22 @@ public sealed class NewArray : IrExpression
     public override string Describe() => $"NewArray {ElementType.ToDisplayString()}[]";
 }
 
+/// <summary>
+/// <c>localloc</c>: a stack-allocated block of <see cref="Size"/> bytes, the
+/// inverse of the compiler's <c>stackalloc byte[n]</c> lowering. localloc
+/// allocates raw bytes and yields a pointer, so the faithful element type is
+/// <c>byte</c> and the result is <c>byte*</c>.
+/// </summary>
+public sealed class StackAllocate : IrExpression
+{
+    public StackAllocate(IrExpression size) => AddChild(size);
+
+    public IrExpression Size => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+
+    public override string Describe() => "StackAllocate byte[]";
+}
+
 /// <summary>The raised typeof(T): GetTypeFromHandle over a type token, folded.</summary>
 public sealed class TypeOf : IrExpression
 {


### PR DESCRIPTION
## What

The IR importer stopped on `localloc`, sinking every method that stack-allocates a buffer to Partial fidelity — including the entire `[LibraryImport]` marshalling-stub family. `localloc` allocates a block of raw bytes and yields a pointer, so it is exactly C#'s `stackalloc byte[n]`.

## How

- New **`StackAllocate`** IR node, ResultType `byte*`, pushed by the importer's `localloc` case.
- The native-int byte count the compiler converts to feed `localloc` is unwrapped to its logical count (stripping the `conv` to `IntPtr`/`UIntPtr`), so the printed length is a plain `int`, not a CS-error `(nuint)` index.
- Printer renders `stackalloc byte[size]`.

## Numbers (CoreLib)

| | Full | % |
|---|---|---|
| before | 40141/40667 | 98.71% |
| after | **40460/40667** | **99.49%** (+319) |

`localloc` was the **sole** blocker for every method in the bucket — all 319 reached Full, and the bucket is now empty.

Example (`Interop.Sys::ChMod`, a `LibraryImport` stub):

    V_5 = new Span<byte>(stackalloc byte[V_4], V_4);
    V_2.FromManaged(V_3, V_5);

## Soundness

1. **Preconditions whole-function** — the rewrite pops exactly `localloc`'s single size operand and pushes one node; it removes no store or binding, so no other reader is affected. The conv-unwrap reuses the operand via `DetachChildren` (no double-parent).
2. **Semantics exact** — `localloc` allocates `size` bytes and returns a pointer; `stackalloc byte[size]` is the precise inverse. Stripping the widening `conv` to native int preserves the byte count and yields valid C# (ILSpy does the same).
3. **Per-item failure isolated** — unchanged; the importer's per-method guard still turns any malformed input into a diagnostic, not a lost batch.

## Tests

- `ILInspector.Decompiler.Tests`: 383 pass (Release), including a new `stackalloc byte[n]` fixture asserting a `StackAllocate` node, `byte*` result type, Full fidelity, and `stackalloc byte[` rendering.
- `dotnet-inspect.Tests`: only the pre-existing version-sensitive `JsonSerializer` overload-count failure remains (unrelated).
