### PR TITLE
Add source parity for member-like platform inputs

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -524,6 +524,40 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Source_PlatformMemberLikeInput_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "String.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("String.cs#L", output);
+        Assert.DoesNotContain("Package 'String.IndexOf' not found", error);
+    }
+
+    [Fact]
+    public async Task Source_FullyQualifiedPlatformMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "System.String.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("String.cs#L", output);
+        Assert.DoesNotContain("Package 'System.String.IndexOf' not found", error);
+    }
+
+    [Fact]
+    public async Task Source_GenericMemberSelector_NormalizesGenericTypeArguments()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "JsonSerializer.Deserialize<TValue>", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("JsonSerializer", output);
+        Assert.Contains("#L", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Find_NamespaceExactMiss_RetriesAsPrefix()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SourceOptionsParser.cs
@@ -87,6 +87,24 @@ public static class SourceOptionsParser
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 
+        string? preResolvedMemberName = null;
+        int? preResolvedOverloadIndex = null;
+        if (!sourceInputs.HasExplicitSource && sourceInputs.Args.Length == 1)
+        {
+            var split = TrySplitImplicitPlatformMember(sourceInputs.Args[0]);
+            if (split != null)
+            {
+                preResolvedMemberName = split.Value.MemberName;
+                preResolvedOverloadIndex = split.Value.OverloadIndex;
+                sourceInputs = sourceInputs with
+                {
+                    Args = split.Value.Args,
+                    ExplicitPlatform = split.Value.ExplicitPlatform,
+                    HasExplicitSource = split.Value.ExplicitPlatform != null
+                };
+            }
+        }
+
         // Resolve source
         var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
             sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
@@ -96,8 +114,8 @@ public static class SourceOptionsParser
             return new VersionError(source.VersionErrorMessage!);
 
         // Capture member name: -m/--member option, positional args, or Type.Member dot syntax
-        string? memberName = parseResult.GetValue(args.MemberOption);
-        int? overloadIndex = null;
+        string? memberName = parseResult.GetValue(args.MemberOption) ?? preResolvedMemberName;
+        int? overloadIndex = preResolvedOverloadIndex;
         {
             // Fall back to positional or dot syntax if -m not specified
             if (memberName == null)
@@ -160,15 +178,13 @@ public static class SourceOptionsParser
                     memberName = positionalMembers[0];
             }
 
-            // Parse overload index shorthand: GetValue:2
-            if (memberName != null && memberName.Contains(':'))
+            // Parse overload index shorthand and normalize generic method selectors.
+            if (memberName != null)
             {
                 var (name, idx) = SharedParsers.ParseOverloadShorthand(memberName);
                 if (idx != null)
-                {
                     overloadIndex = idx;
-                    memberName = name;
-                }
+                memberName = name;
             }
         }
 
@@ -219,6 +235,35 @@ public static class SourceOptionsParser
         };
 
         return new Success(options);
+    }
+
+    private static (string[] Args, string? ExplicitPlatform, string MemberName, int? OverloadIndex)? TrySplitImplicitPlatformMember(string value)
+    {
+        for (var i = value.Length - 1; i > 0; i--)
+        {
+            if (value[i] != '.')
+                continue;
+
+            var typeCandidate = value[..i];
+            var memberSelector = value[(i + 1)..];
+            if (string.IsNullOrWhiteSpace(memberSelector))
+                continue;
+
+            var probe = SourceResolver.TryResolveQualifiedTypeName(typeCandidate, allowPlatformPrefixFallback: true);
+            if (probe == null)
+            {
+                if (!typeCandidate.Contains('<') && !memberSelector.Contains('<'))
+                    continue;
+
+                var (genericMemberName, genericOverloadIndex) = SharedParsers.ParseOverloadShorthand(memberSelector);
+                return ([typeCandidate], null, genericMemberName, genericOverloadIndex);
+            }
+
+            var (memberName, overloadIndex) = SharedParsers.ParseOverloadShorthand(memberSelector);
+            return ([probe.Remainder], probe.SourceName, memberName, overloadIndex);
+        }
+
+        return null;
     }
 
     private static bool ProbeMatchesExplicitSource(

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -572,6 +572,21 @@ public static class SourceCommand
             return null;
 
         var context = new CommandContext(options.Verbose);
+        if (options.MemberName == null)
+        {
+            var memberResolution = await TypeFindIfMissResolver.ResolvePlatformMemberAsync(
+                options.PackagePath,
+                options.IncludeAll,
+                options.NuGetOptions,
+                context.HttpClient,
+                context.Logger);
+
+            if (memberResolution.Status == TypeFindIfMissStatus.Found)
+                return await ExecuteAsync(memberResolution.ApplyTo(options));
+            if (memberResolution.Status == TypeFindIfMissStatus.Ambiguous)
+                return memberResolution.WriteAmbiguousError();
+        }
+
         var resolution = await TypeFindIfMissResolver.ResolvePlatformAsync(
             options.PackagePath,
             options.IncludeAll,

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -98,6 +98,16 @@ internal sealed record TypeMemberFindIfMissResult(
         };
     }
 
+    public SourceOptions ApplyTo(SourceOptions options)
+    {
+        var applied = TypeResolution.ApplyTo(options);
+        return applied with
+        {
+            MemberName = MemberName,
+            OverloadIndex = OverloadIndex
+        };
+    }
+
     public int WriteAmbiguousError() => TypeResolution.WriteAmbiguousError();
 }
 


### PR DESCRIPTION
## Summary
- let source resolve member-like platform inputs through shared type/member find-if-miss
- support implicit source forms such as String.IndexOf, System.String.IndexOf, List<T>.Add, and JsonSerializer.Deserialize<TValue>
- normalize source member selectors passed with -m, including generic method syntax

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- source String.IndexOf --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source System.String.IndexOf --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source JsonSerializer.Deserialize<TValue> --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source List<T>.Add --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source System.Collections.Generic.List<T>.Add --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source JsonSerializer -m Deserialize<TValue> --table --tips q --head 4