### PR TITLE
Normalize constructor and operator member selectors

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -96,20 +96,72 @@ public static class TypeMatcher
     }
 
     /// <summary>
-    /// Normalizes a member selector by removing C# generic method type arguments.
-    /// "Deserialize&lt;TValue&gt;" -> "Deserialize". Malformed/non-generic names pass through unchanged.
+    /// Normalizes a member selector to metadata member names.
+    /// "Deserialize&lt;TValue&gt;" -> "Deserialize", "ctor" -> ".ctor", "operator+" -> "op_Addition".
+    /// Malformed/non-aliased names pass through unchanged.
     /// </summary>
     public static string NormalizeMemberName(string memberName)
     {
+        memberName = memberName.Trim();
         var angleIdx = memberName.IndexOf('<');
-        if (angleIdx <= 0)
+        if (angleIdx > 0)
+        {
+            var closeIdx = memberName.LastIndexOf('>');
+            if (closeIdx > angleIdx && closeIdx == memberName.Length - 1)
+                memberName = memberName[..angleIdx];
+        }
+
+        return NormalizeOperatorOrSpecialMemberName(memberName);
+    }
+
+    private static string NormalizeOperatorOrSpecialMemberName(string memberName)
+    {
+        if (memberName.Equals("ctor", StringComparison.OrdinalIgnoreCase)
+            || memberName.Equals("constructor", StringComparison.OrdinalIgnoreCase))
+            return ".ctor";
+
+        if (memberName.StartsWith("operator", StringComparison.OrdinalIgnoreCase))
+            memberName = memberName["operator".Length..].Trim();
+        else if (memberName.StartsWith("op_", StringComparison.OrdinalIgnoreCase))
             return memberName;
 
-        var closeIdx = memberName.LastIndexOf('>');
-        if (closeIdx <= angleIdx || closeIdx != memberName.Length - 1)
-            return memberName;
-
-        return memberName[..angleIdx];
+        var compact = memberName.Replace(" ", "", StringComparison.Ordinal);
+        return compact.ToLowerInvariant() switch
+        {
+            "implicit" => "op_Implicit",
+            "explicit" => "op_Explicit",
+            "checkedimplicit" => "op_CheckedImplicit",
+            "checkedexplicit" => "op_CheckedExplicit",
+            "+" => "op_Addition",
+            "checked+" => "op_CheckedAddition",
+            "-" => "op_Subtraction",
+            "checked-" => "op_CheckedSubtraction",
+            "*" => "op_Multiply",
+            "checked*" => "op_CheckedMultiply",
+            "/" => "op_Division",
+            "%" => "op_Modulus",
+            "++" => "op_Increment",
+            "checked++" => "op_CheckedIncrement",
+            "--" => "op_Decrement",
+            "checked--" => "op_CheckedDecrement",
+            "==" => "op_Equality",
+            "!=" => "op_Inequality",
+            "<" => "op_LessThan",
+            ">" => "op_GreaterThan",
+            "<=" => "op_LessThanOrEqual",
+            ">=" => "op_GreaterThanOrEqual",
+            "&" => "op_BitwiseAnd",
+            "|" => "op_BitwiseOr",
+            "^" => "op_ExclusiveOr",
+            "~" => "op_OnesComplement",
+            "!" => "op_LogicalNot",
+            "<<" => "op_LeftShift",
+            ">>" => "op_RightShift",
+            ">>>" => "op_UnsignedRightShift",
+            "true" => "op_True",
+            "false" => "op_False",
+            _ => memberName
+        };
     }
 
     private static int CountTypeParameters(ReadOnlySpan<char> typeParams)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -461,6 +461,77 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_ConstructorSelector_NormalizesCtorAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "String.ctor", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(".ctor", output);
+        Assert.Contains("public String(", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_DoubleDotConstructorSelector_NormalizesCtorAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "List<T>..ctor", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(".ctor", output);
+        Assert.Contains("public List(", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_OperatorSelector_NormalizesOperatorAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "DateTime.operator+", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("operator +", output);
+        Assert.Contains("public static System.DateTime operator +", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_ConversionSelector_NormalizesImplicitAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "Decimal.implicit", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("implicit operator", output);
+        Assert.Contains("public static implicit operator System.Decimal", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Type_OperatorMemberFilter_NormalizesOperatorAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "DateTime", "-m", "operator+", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("operator +", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_ConstructorSelector_NormalizesCtorAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "String", "-m", "ctor", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(".ctor", output);
+        Assert.Contains("public String(", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Type_BareSimpleTypeMiss_PrefersPlatformTypeOverSameNamedPackage()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -222,6 +222,13 @@ internal static class TypeFindIfMissResolver
 
         typeQuery = query[..lastDot];
         memberSelector = query[(lastDot + 1)..];
+        if (typeQuery.EndsWith('.', StringComparison.Ordinal) &&
+            memberSelector.Equals("ctor", StringComparison.OrdinalIgnoreCase))
+        {
+            typeQuery = typeQuery.TrimEnd('.');
+            memberSelector = ".ctor";
+        }
+
         return true;
     }
 

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -222,10 +222,10 @@ internal static class TypeFindIfMissResolver
 
         typeQuery = query[..lastDot];
         memberSelector = query[(lastDot + 1)..];
-        if (typeQuery.EndsWith('.', StringComparison.Ordinal) &&
+        if (typeQuery.EndsWith(".", StringComparison.Ordinal) &&
             memberSelector.Equals("ctor", StringComparison.OrdinalIgnoreCase))
         {
-            typeQuery = typeQuery.TrimEnd('.');
+            typeQuery = typeQuery.TrimEnd(['.']);
             memberSelector = ".ctor";
         }
 


### PR DESCRIPTION
## Summary
- normalize constructor aliases like ctor and constructor to .ctor
- normalize user-facing operator selectors like operator+, implicit, explicit, and common operator symbols to metadata names
- support double-dot constructor shorthand such as List<T>..ctor through platform member find-if-miss

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- String.ctor --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- List<T>..ctor --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- DateTime.operator+ --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- Decimal.implicit --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- source DateTime.operator+ --table --tips q --head 4