### PR TITLE
Raise reference-type stack joins to a common base (99.49% -> 99.65% Full)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1131,6 +1131,24 @@ public class CfgSampleClass
         byte* buffer = stackalloc byte[n];
         return buffer[0];
     }
+
+    // A reference-type stack join: the ternary's two branches push a derived
+    // and a base instance into one slot that merges to their common base
+    // JoinBase. The importer types the slot JoinBase — an actual ancestor it
+    // resolves by walking the same-assembly base chain, never a guess — so the
+    // body imports at Full fidelity instead of stopping at a join-type unknown.
+    public static string MergedReferenceSlot(bool flag)
+        => (flag ? new JoinDerived() : new JoinBase()).Label;
+}
+
+public class JoinBase
+{
+    public virtual string Label => "base";
+}
+
+public sealed class JoinDerived : JoinBase
+{
+    public override string Label => "derived";
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -441,6 +441,23 @@ public class JoinTypeConflictTests : IDisposable
         Assert.Contains("types disagree", diagnostic.Message);
         function.CheckInvariant();
     }
+
+    [Fact]
+    public void ReferenceJoin_ToCommonBase_ImportsAtFullFidelity()
+    {
+        // Two ternary branches carry JoinDerived and JoinBase into one slot.
+        // The merge resolves to JoinBase — an ancestor of JoinDerived reached
+        // by walking the same-assembly base chain — so the body imports Full
+        // with no join-type diagnostic, unlike the unresolvable conflicts above.
+        var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        _disposables.Push(source);
+        var function = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.MergedReferenceSlot))!;
+
+        Assert.DoesNotContain(function.Diagnostics, d => (d.Message ?? "").Contains("(join-type)"));
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        function.CheckInvariant();
+    }
 }
 
 public class CSharpPrinterTests

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -324,7 +324,7 @@ public static class IrImporter
     /// predecessors of a join store to the same slots. Returns false on a
     /// depth disagreement or a stack-carrying back edge (out of slice).
     /// </summary>
-    static bool PropagateAndSpill(IrFunction function, Block body, Stack<IrExpression> stack, BuildState state, int[] targets, int offset)
+    static bool PropagateAndSpill(MetadataSource source, IrFunction function, Block body, Stack<IrExpression> stack, BuildState state, int[] targets, int offset)
     {
         var values = stack.Reverse().ToArray();
         stack.Clear();
@@ -360,7 +360,7 @@ public static class IrImporter
                     // ECMA stack-type model: bool and int are the same I4
                     // stack entry, float and double the same F entry — the
                     // family-canonical type IS the ground truth there.
-                    var merged = MergeSlotTypes(existing[i]!, types[i]!);
+                    var merged = MergeSlotTypes(existing[i]!, types[i]!, source);
                     if (state.Built.Contains(target))
                     {
                         if (merged is null)
@@ -522,7 +522,7 @@ public static class IrImporter
                         targets.Add(next + raw);
                     var value = Pop(stack);
                     var allSuccessors = targets.Append(end).Distinct().ToArray();
-                    if (!PropagateAndSpill(function, body, stack, state, allSuccessors, offset))
+                    if (!PropagateAndSpill(source, function, body, stack, state, allSuccessors, offset))
                         return false;
                     body.Add(new SwitchBranch(value, targets.MoveToImmutable()));
                     break;
@@ -853,7 +853,7 @@ public static class IrImporter
                 case ILOpCode.Br or ILOpCode.Br_s:
                 {
                     int target = reader.ReadBranchDestination(opcode);
-                    if (!PropagateAndSpill(function, body, stack, state, [target], offset))
+                    if (!PropagateAndSpill(source, function, body, stack, state, [target], offset))
                         return false;
                     body.Add(new Branch(target));
                     break;
@@ -865,7 +865,7 @@ public static class IrImporter
                     if (opcode is ILOpCode.Brfalse or ILOpCode.Brfalse_s)
                         condition = new LogicalNot(condition);
                     int target = reader.ReadBranchDestination(opcode);
-                    if (!PropagateAndSpill(function, body, stack, state, [target, end], offset))
+                    if (!PropagateAndSpill(source, function, body, stack, state, [target, end], offset))
                         return false;
                     body.Add(new ConditionalBranch(condition, target));
                     break;
@@ -877,7 +877,7 @@ public static class IrImporter
                     var right = Pop(stack);
                     var left = Pop(stack);
                     var (kind, isUnsigned) = ComparisonOf(opcode);
-                    if (!PropagateAndSpill(function, body, stack, state, [target, end], offset))
+                    if (!PropagateAndSpill(source, function, body, stack, state, [target, end], offset))
                         return false;
                     body.Add(new ConditionalBranch(new Comparison(kind, isUnsigned, left, right), target));
                     break;
@@ -988,26 +988,52 @@ public static class IrImporter
                     "evaluation stack is not empty at the end of the method");
                 return false;
             }
-            return PropagateAndSpill(function, body, stack, state, [end], end);
+            return PropagateAndSpill(source, function, body, stack, state, [end], end);
         }
         return true;
     }
 
     /// <summary>
-    /// Merges two slot types per the ECMA stack-type model: equal types keep;
-    /// same stack family yields the family-canonical type (the stack really
-    /// does carry an int32 where bool and int join); cross-family yields null.
+    /// Merges two slot types per the ECMA stack-type model. Equal types keep.
+    /// Two reference types prefer the precise common base — whichever operand
+    /// is a base class of the other (object is the universal base of every
+    /// reference type) — the verifier's merge when one operand is an ancestor;
+    /// it never invents a common ancestor, so the slot type is one a path
+    /// already carried and every use still typechecks. Otherwise the stack
+    /// families decide: bool and int are the same I4 entry, float and double
+    /// the same F entry, and two reference values the same O entry (object) —
+    /// the family-canonical type is the ground truth there. Anything else is
+    /// null — an honest "unknown" rather than a guess.
     /// </summary>
-    static TypeRef? MergeSlotTypes(TypeRef a, TypeRef b)
+    static TypeRef? MergeSlotTypes(TypeRef a, TypeRef b, MetadataSource source)
     {
         if (Equals(a, b))
             return a;
+        if (IsReferenceType(source, a) && IsReferenceType(source, b))
+        {
+            if (IsObject(a) || source.IsBaseClassOf(a, b))
+                return a;
+            if (IsObject(b) || source.IsBaseClassOf(b, a))
+                return b;
+        }
         var familyA = TypeFamilies.Of(a);
         var familyB = TypeFamilies.Of(b);
-        if (familyA != familyB || familyA is null)
-            return null;
-        return TypeFamilies.Canonical(familyA.Value);
+        if (familyA is not null && familyB is not null && familyA == familyB)
+            return TypeFamilies.Canonical(familyA.Value);
+        return null;
     }
+
+    /// <summary>A reference type: object, string, an array, or a definition (or generic instantiation of one) the source resolves to a reference shape.</summary>
+    static bool IsReferenceType(MetadataSource source, TypeRef type)
+    {
+        if (TypeFamilies.Of(type) == StackFamily.O)
+            return true;
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && source.ResolveShape(definition) == TypeShape.Reference;
+    }
+
+    static bool IsObject(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
 
     /// <summary>A block whose entry expects stack values is a stack-carrying edge — out of slice, reported honestly via the importer's stop path.</summary>
     sealed class OutOfSliceException(string reason) : Exception(reason);

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -59,6 +59,7 @@ public sealed class MetadataSource : IDisposable
 
     Dictionary<TypeRef, TypeShape>? _shapes;
     Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? _enumMembers;
+    Dictionary<TypeRef, TypeRef?>? _baseTypes;
 
     /// <summary>
     /// The C# shape of a type defined in THIS assembly — enum, struct, or
@@ -95,6 +96,7 @@ public sealed class MetadataSource : IDisposable
             return;
         var shapes = new Dictionary<TypeRef, TypeShape>();
         var enums = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>();
+        var bases = new Dictionary<TypeRef, TypeRef?>();
         foreach (var handle in Reader.TypeDefinitions)
         {
             var typeDef = Reader.GetTypeDefinition(handle);
@@ -103,11 +105,64 @@ public sealed class MetadataSource : IDisposable
             var key = TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, handle, 0);
             var shape = ClassifyShape(typeDef);
             shapes[key] = shape;
+            bases[key] = DecodeBaseType(typeDef.BaseType);
             if (shape == TypeShape.Enum)
                 enums[key] = BuildEnumMembers(typeDef);
         }
         _enumMembers = enums;
+        _baseTypes = bases;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
+    }
+
+    /// <summary>
+    /// The base type of a same-assembly definition, decoded to the same
+    /// nested-aware <see cref="TypeRef"/> the IR carries. A definition or
+    /// reference base resolves; a generic-instance base (TypeSpecification)
+    /// returns null — walking it needs a generic context this map does not
+    /// hold. Object's nil base also returns null, ending the chain.
+    /// </summary>
+    TypeRef? DecodeBaseType(EntityHandle baseHandle)
+    {
+        if (baseHandle.IsNil)
+            return null;
+        return baseHandle.Kind switch
+        {
+            HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, (TypeDefinitionHandle)baseHandle, 0),
+            HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(Reader, (TypeReferenceHandle)baseHandle, 0),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// The base type of a same-assembly definition, or null for a cross
+    /// -assembly type, a non-definition, or a generic-instance base. Built
+    /// once with the shape map; the same-assembly chain covers the whole
+    /// single-assembly sweep.
+    /// </summary>
+    internal TypeRef? ResolveBaseType(TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.Definition)
+            return null;
+        EnsureTypeMaps();
+        return _baseTypes!.GetValueOrDefault(type);
+    }
+
+    /// <summary>
+    /// True when <paramref name="ancestor"/> is a (strict) base class of
+    /// <paramref name="derived"/>, found by walking the same-assembly base
+    /// chain. The walk stops at the first base it cannot resolve — a cross
+    /// -assembly or generic-instance link — and never guesses past it.
+    /// </summary>
+    internal bool IsBaseClassOf(TypeRef ancestor, TypeRef derived)
+    {
+        var current = ResolveBaseType(derived);
+        for (int depth = 0; depth < 64 && current is not null; depth++)
+        {
+            if (current.Equals(ancestor))
+                return true;
+            current = ResolveBaseType(current);
+        }
+        return false;
     }
 
     Dictionary<long, string> BuildEnumMembers(TypeDefinition enumType)


### PR DESCRIPTION
## What

A stack slot fed by two reference types from different paths stopped the new IR importer at a join-type *unknown* (Partial) — the largest post-pass bucket at **86 methods**. The ECMA verifier merges such a slot to a common base; this resolves that base **soundly** when one operand is an actual ancestor of the other, never by inventing one.

## How

- **`MetadataSource`** gains a same-assembly base-type map (built alongside the shape map) plus `ResolveBaseType` and `IsBaseClassOf`, which walks the base chain and stops at the first link it cannot resolve (cross-assembly or generic-instance base).
- **`MergeSlotTypes`** threads the `MetadataSource` through `PropagateAndSpill` and, for two reference types, returns whichever is a base class of the other — with `object` treated as the universal base of every reference type, including generic-instance references such as `Dictionary<,>`.
- The prior family-canonical merge (two `O`-family values to `object`) is preserved as the fallthrough, so **nothing that imported Full before regresses**.

## Soundness

- **Precondition:** applies only at a verified stack join of two reference types; non-reference and cross-family pairs keep their prior result.
- **Semantics:** the merged type is always one a path already carried (an actual ancestor), so every slot use typechecks at that type and the rendered locals are valid C#. Member dispatch is unaffected — calls render from their IL tokens, not from the slot declared type.
- **Failure isolation:** an unresolvable join (interface merge, generic covariance, or a cousin whose only common base is a non-object class) returns `null` exactly as before, staying an honest Partial.

## Corpus (.NET 11 CoreLib, 40,667 method bodies)

| Metric | Before | After |
| --- | --- | --- |
| Full | 40,460 (99.49%) | 40,525 (99.65%) |
| `(join-type)` bucket | 86 | 21 |
| importer bugs | 0 | 0 |

Remaining `(join-type)` stops are interface merges, generic covariance, and nearest-common-ancestor cousins — all deferred deliberately.

## Tests

- New fixture `CfgSampleClass.MergedReferenceSlot` with same-assembly `JoinBase`/`JoinDerived` types, exercised by `ReferenceJoin_ToCommonBase_ImportsAtFullFidelity`.
- All 384 decompiler tests pass; CLI suite clean except the known version-sensitive `JsonSerializer` "107 overloads" failure (fails identically on `main`).
