### PR TITLE
Render function-pointer types as delegate*<...>

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1093,12 +1093,14 @@ public class CfgSampleClass
         }
     }
 
-    // A function-pointer parameter has no slice representation, so its presence
-    // in the signature caps fidelity. Unlike an out-of-slice body opcode it
-    // carries no node-level stop, so the importer must surface a typed
-    // (DEC0005) diagnostic naming the reason — otherwise the method is Partial
-    // with no diagnostic, invisible to the harness roadmap.
+    // A function-pointer parameter is a representable type: delegate*<int, int>
+    // imports at Full fidelity and renders in C# function-pointer syntax (return
+    // type last). It carries no node-level stop.
     public static unsafe void TakesFunctionPointer(delegate*<int, int> callback) { _ = callback; }
+
+    // An unmanaged function-pointer parameter carries a calling convention that
+    // must render as `delegate* unmanaged[Cdecl]<…>`.
+    public static unsafe void TakesUnmanagedFunctionPointer(delegate* unmanaged[Cdecl]<int, void> callback) { _ = callback; }
 
     // An `in` parameter carries modreq(InAttribute) on the byref. The importer
     // sees through the modifier, so the body imports at Full fidelity and the

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -131,7 +131,7 @@ public class IrImporterTests
         block.Add(new Return(null));
         var signature = new MethodSignature(
             TypeRef.CoreLib("System", "Void"),
-            [new Parameter("p", TypeRef.Unsupported("function pointer"))],
+            [new Parameter("p", TypeRef.Unsupported("refanytype"))],
             HasThis: false,
             GenericParameterCount: 0);
         var function = new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
@@ -140,18 +140,33 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void UnsupportedSignatureType_ReportsTypedDiagnostic()
+    public void FunctionPointerSignature_ImportsAtFullFidelity()
     {
-        // A function-pointer parameter sinks fidelity through the signature but
-        // carries no node-level stop, so the importer must surface a DEC0005
-        // diagnostic naming the reason — otherwise it is Partial-with-no-reason,
-        // invisible to the harness roadmap.
+        // A delegate*<int, int> parameter is a representable function-pointer
+        // type, not an unsupported shape: the body imports at Full, emits no
+        // UnsupportedType stop, and the parameter renders in C# function-pointer
+        // syntax (return type last).
         var function = ImportFixture(nameof(CfgSampleClass.TakesFunctionPointer));
 
-        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
-        var diagnostic = Assert.Single(function.Diagnostics);
-        Assert.Equal(DiagnosticIds.UnsupportedType, diagnostic.Id);
-        Assert.Contains("function pointer", diagnostic.Message);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.DoesNotContain(function.Diagnostics, d => d.Id == DiagnosticIds.UnsupportedType);
+        var parameter = Assert.Single(function.Signature.Parameters);
+        Assert.Equal(TypeRefKind.FunctionPointer, parameter.Type.Kind);
+        Assert.Equal("delegate*<int, int>", parameter.Type.ToDisplayString());
+    }
+
+    [Fact]
+    public void UnmanagedFunctionPointerSignature_RendersCallingConvention()
+    {
+        // delegate* unmanaged[Cdecl]<int, void> must surface the calling
+        // convention in the rendered function-pointer syntax.
+        var function = ImportFixture(nameof(CfgSampleClass.TakesUnmanagedFunctionPointer));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.DoesNotContain(function.Diagnostics, d => d.Id == DiagnosticIds.UnsupportedType);
+        var parameter = Assert.Single(function.Signature.Parameters);
+        Assert.Equal(TypeRefKind.FunctionPointer, parameter.Type.Kind);
+        Assert.Equal("delegate* unmanaged[Cdecl]<int, void>", parameter.Type.ToDisplayString());
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -19,6 +19,8 @@ public enum TypeRefKind
     GenericParameter,
     /// <summary>A method generic parameter (<c>T</c> in <c>M&lt;T&gt;()</c>).</summary>
     MethodGenericParameter,
+    /// <summary>A function pointer: <see cref="TypeRef.ElementType"/> is the return type, <see cref="TypeRef.TypeArguments"/> the parameters, rendered <c>delegate*&lt;...&gt;</c>.</summary>
+    FunctionPointer,
     /// <summary>A shape outside the supported core (function pointers, custom modifiers). Carries a reason; lowers fidelity, never lies.</summary>
     Unsupported,
 }
@@ -76,6 +78,9 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// <summary>Why this shape is unsupported; empty for supported shapes.</summary>
     public string UnsupportedReason { get; private init; } = "";
 
+    /// <summary>The C# calling-convention spelling of a function pointer (empty = managed, e.g. <c>unmanaged</c>, <c>unmanaged[Cdecl]</c>); empty otherwise.</summary>
+    public string CallingConvention { get; private init; } = "";
+
     public static TypeRef Definition(string assembly, string ns, string name)
         => new(TypeRefKind.Definition) { Assembly = assembly, Namespace = ns, Name = name };
 
@@ -103,6 +108,10 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     public static TypeRef Unsupported(string reason)
         => new(TypeRefKind.Unsupported) { UnsupportedReason = reason };
+
+    /// <summary>A function pointer over <paramref name="parameters"/> returning <paramref name="returnType"/>; <paramref name="callingConvention"/> is the C# spelling (empty = managed).</summary>
+    public static TypeRef FunctionPointer(TypeRef returnType, ImmutableArray<TypeRef> parameters, string callingConvention)
+        => new(TypeRefKind.FunctionPointer) { ElementType = returnType, TypeArguments = parameters, CallingConvention = callingConvention };
 
     /// <summary>
     /// Substitutes generic parameters with the given arguments (type
@@ -135,6 +144,19 @@ public sealed class TypeRef : IEquatable<TypeRef>
                     builder.Add(substituted);
                 }
                 return changed ? GenericInstance(definition, builder.MoveToImmutable()) : this;
+            }
+            case TypeRefKind.FunctionPointer:
+            {
+                var returnType = ElementType!.Instantiate(typeArguments, methodArguments);
+                bool changed = !ReferenceEquals(returnType, ElementType);
+                var builder = ImmutableArray.CreateBuilder<TypeRef>(TypeArguments.Length);
+                foreach (var parameter in TypeArguments)
+                {
+                    var substituted = parameter.Instantiate(typeArguments, methodArguments);
+                    changed |= !ReferenceEquals(substituted, parameter);
+                    builder.Add(substituted);
+                }
+                return changed ? FunctionPointer(returnType, builder.MoveToImmutable(), CallingConvention) : this;
             }
             default:
                 return this;
@@ -179,6 +201,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
             || Rank != other.Rank
             || GenericParameterIndex != other.GenericParameterIndex
             || UnsupportedReason != other.UnsupportedReason
+            || CallingConvention != other.CallingConvention
             || !Equals(ElementType, other.ElementType)
             || TypeArguments.Length != other.TypeArguments.Length)
         {
@@ -205,6 +228,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         hash.Add(Name);
         hash.Add(Rank);
         hash.Add(GenericParameterIndex);
+        hash.Add(CallingConvention);
         hash.Add(ElementType);
         foreach (var arg in TypeArguments)
             hash.Add(arg);
@@ -223,6 +247,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString()}",
         TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter =>
             GenericParameterName.Length > 0 ? GenericParameterName : $"!{GenericParameterIndex}",
+        TypeRefKind.FunctionPointer => RenderFunctionPointer(),
         _ => $"<unsupported: {UnsupportedReason}>",
     };
 
@@ -258,6 +283,18 @@ public sealed class TypeRef : IEquatable<TypeRef>
             return simpleName;
         var ownArguments = TypeArguments.Skip(Math.Max(0, TypeArguments.Length - ownArity));
         return $"{simpleName}<{string.Join(", ", ownArguments.Select(a => a.ToDisplayString()))}>";
+    }
+
+    /// <summary>
+    /// A function pointer in C# spelling: <c>delegate*&lt;p1, …, returnType&gt;</c>,
+    /// the return type last, with the calling-convention keyword (when the
+    /// pointer is unmanaged) between <c>delegate*</c> and the type list.
+    /// </summary>
+    string RenderFunctionPointer()
+    {
+        var parts = TypeArguments.Select(p => p.ToDisplayString()).Append(ElementType!.ToDisplayString());
+        string convention = CallingConvention.Length > 0 ? $" {CallingConvention}" : "";
+        return $"delegate*{convention}<{string.Join(", ", parts)}>";
     }
 
     static string StripArity(string name)

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -102,7 +102,18 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         => TypeRef.MethodGenericParameter(index, NameAt(genericContext.MethodParameters, index));
 
     public TypeRef GetFunctionPointerType(MethodSignature<TypeRef> signature)
-        => TypeRef.Unsupported("function pointer");
+        => TypeRef.FunctionPointer(signature.ReturnType, signature.ParameterTypes, ConventionText(signature.Header.CallingConvention));
+
+    /// <summary>The C# calling-convention spelling for a function pointer: empty for a managed pointer, the <c>unmanaged</c> keyword (with the specific convention in brackets) otherwise.</summary>
+    static string ConventionText(SignatureCallingConvention convention) => convention switch
+    {
+        SignatureCallingConvention.Default => "",
+        SignatureCallingConvention.CDecl => "unmanaged[Cdecl]",
+        SignatureCallingConvention.StdCall => "unmanaged[Stdcall]",
+        SignatureCallingConvention.ThisCall => "unmanaged[Thiscall]",
+        SignatureCallingConvention.FastCall => "unmanaged[Fastcall]",
+        _ => "unmanaged",
+    };
 
     /// <summary>
     /// Custom modifiers are seen through to the unmodified type. The three that


### PR DESCRIPTION
## Summary

Function-pointer signature types previously decoded to `TypeRef.Unsupported("function pointer")`, capping fidelity with a DEC0005 `UnsupportedType` stop (`type function pointer` — 35 methods in CoreLib). They are fully representable in C#, so this renders them as `delegate*<...>`.

- **TypeRef**: add `FunctionPointer` kind, `CallingConvention` field, factory, and `delegate*<p1, …, ret>` rendering (return type last; `unmanaged` / `unmanaged[Cdecl]` prefix). Wired into `Instantiate`/`Equals`/`GetHashCode`.
- **TypeRefDecoder.GetFunctionPointerType** builds the real type and maps the signature calling convention to its C# spelling.

## Soundness

Rendering a previously-`<unsupported>` type as its true `delegate*<...>` spelling is the exact C# for the metadata signature; it only needs an `unsafe` context, consistent with existing `T*` pointer rendering. No node-level stop or body consumer depended on it being `Unsupported`.

## Corpus (`--pipeline next`, CoreLib)

| | Full | % |
|---|---|---|
| before | 40525 | 99.65% |
| after | 40546 | 99.70% |

**+21 Full.** The `type function pointer` bucket (35) is eliminated: 21 → Full, 13 surface a pre-existing `ldftn` stop (function-pointer **invocation** via calli/ldftn — the natural follow-on), 1 → another reason.

## Tests

- Decompiler: 385 pass (added managed `delegate*<int, int>` and `unmanaged[Cdecl]` fixtures + rendering assertions; updated the former unsupported-fp test to assert Full).
- Parity (`--candidate next`): no new candidate-worse regressions.
- CLI: only the known version-sensitive `JsonSerializer` overload-count failure remains (pre-existing on main).