### PR TITLE
Handle indexer and ctor overload selectors

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -120,6 +120,11 @@ public static class TypeMatcher
             || memberName.Equals("constructor", StringComparison.OrdinalIgnoreCase))
             return ".ctor";
 
+        if (memberName.Equals("this[]", StringComparison.OrdinalIgnoreCase)
+            || memberName.Equals("this", StringComparison.OrdinalIgnoreCase)
+            || memberName.Equals("[]", StringComparison.OrdinalIgnoreCase))
+            return "this[]";
+
         if (memberName.StartsWith("operator", StringComparison.OrdinalIgnoreCase))
             memberName = memberName["operator".Length..].Trim();
         else if (memberName.StartsWith("op_", StringComparison.OrdinalIgnoreCase))
@@ -380,11 +385,20 @@ public static class TypeMatcher
             }
             else
             {
-                if (string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase))
+                if (MatchesMemberName(name, pattern))
                     return true;
             }
         }
         return false;
+    }
+
+    public static bool MatchesMemberName(string name, string pattern)
+    {
+        if (pattern.Equals("this[]", StringComparison.OrdinalIgnoreCase))
+            return name.Equals("Item", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("Chars", StringComparison.OrdinalIgnoreCase);
+
+        return string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -465,7 +479,7 @@ public static class TypeMatcher
             filterList.Any(f =>
                 (f.Contains('*') || f.Contains('?'))
                     ? MatchesGlob(name, f)
-                    : string.Equals(name, f, StringComparison.OrdinalIgnoreCase)))
+                    : MatchesMemberName(name, f)))
             .ToList();
 
         if (matched.Count > 0)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -485,6 +485,30 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_DoubleDotConstructorSelector_PreservesOverloadIndex()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "List<T>..ctor:3", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(".ctor", output);
+        Assert.Contains("(int)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_IndexerSelector_NormalizesThisAlias()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "String.this[]", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Chars", output);
+        Assert.Contains("this[int index]", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Router_OperatorSelector_NormalizesOperatorAlias()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
@@ -70,7 +70,7 @@ internal static class ApiTypeLookupService
             bool isGlob = filter.Contains('*') || filter.Contains('?');
             bool anyMatch = isGlob
                 ? memberNames.Any(n => TypeMatcher.MatchesGlob(n, filter))
-                : memberNames.Any(n => string.Equals(n, filter, StringComparison.OrdinalIgnoreCase));
+                : memberNames.Any(n => TypeMatcher.MatchesMemberName(n, filter));
 
             if (!anyMatch)
                 missedFilters.Add(filter);

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -222,11 +222,11 @@ internal static class TypeFindIfMissResolver
 
         typeQuery = query[..lastDot];
         memberSelector = query[(lastDot + 1)..];
+        var (memberName, _) = ParseOverloadShorthand(memberSelector);
         if (typeQuery.EndsWith(".", StringComparison.Ordinal) &&
-            memberSelector.Equals("ctor", StringComparison.OrdinalIgnoreCase))
+            memberName.Equals(".ctor", StringComparison.OrdinalIgnoreCase))
         {
             typeQuery = typeQuery.TrimEnd(['.']);
-            memberSelector = ".ctor";
         }
 
         return true;


### PR DESCRIPTION
## Summary
- normalize indexer aliases such as this[] to indexer-like member names (Item/Chars)
- use the same member alias matching in member-filter validation and rendering
- preserve overload indexes for double-dot constructor shorthand such as List<T>..ctor:3

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- String.this[] --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- List<T>..ctor:3 --table --tips q --head 4
- dotnet run --project src/dotnet-inspect -c Release -- String.Lenght --table --tips q --head 4 (expected member-miss with suggestion)
- dotnet run --project src/dotnet-inspect -c Release -- DateTime.operator++ --table --tips q --head 4 (expected member-miss)