### PR TITLE
Raise calli to a function-pointer invocation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1102,6 +1102,14 @@ public class CfgSampleClass
     // must render as `delegate* unmanaged[Cdecl]<…>`.
     public static unsafe void TakesUnmanagedFunctionPointer(delegate* unmanaged[Cdecl]<int, void> callback) { _ = callback; }
 
+    // Invoking a function pointer compiles to calli: the arguments and the
+    // pointer value are pushed, then the call-site signature drives the call.
+    // Raised to a CallIndirect and rendered as `callback(value)`.
+    public static unsafe int InvokesFunctionPointer(delegate*<int, int> callback, int value) => callback(value);
+
+    // A void-returning function-pointer invocation renders as a statement.
+    public static unsafe void InvokesVoidFunctionPointer(delegate*<int, void> callback, int value) => callback(value);
+
     // An `in` parameter carries modreq(InAttribute) on the byref. The importer
     // sees through the modifier, so the body imports at Full fidelity and the
     // underlying ByRef(int) shape stays intact for the load-indirect unwrap.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -170,6 +170,39 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Calli_RaisesToFunctionPointerInvocation()
+    {
+        // `callback(value)` compiles to calli through a delegate*<int, int>.
+        // The importer consumes the pointer and its argument into a typed
+        // CallIndirect instead of stopping on the opcode. (Roslyn spills the
+        // pointer to a local first, per C# evaluation order, so the rendered
+        // invocation reads through that local.)
+        var function = ImportFixture(nameof(CfgSampleClass.InvokesFunctionPointer));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var call = Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Equal("int", call.ReturnType.ToDisplayString());
+        Assert.Single(call.Arguments);
+        Assert.IsType<LoadLocal>(call.Pointer);
+        Assert.Contains("(value)", CSharpPrinter.Print(function).Output!);
+    }
+
+    [Fact]
+    public void Calli_VoidReturn_RendersAsStatement()
+    {
+        // A void function-pointer invocation has no result on the stack, so it
+        // renders as an expression statement, not a pushed value.
+        var function = ImportFixture(nameof(CfgSampleClass.InvokesVoidFunctionPointer));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var call = Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Equal("void", call.ReturnType.ToDisplayString());
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("(value);", output);
+        Assert.DoesNotContain("return", output);
+    }
+
+    [Fact]
     public void InParameter_SeesThroughModifier_ImportsAtFull()
     {
         // modreq(InAttribute) on the byref is a declaration-site concern that

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -443,6 +443,7 @@ public sealed class CSharpPrinter
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
+        CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
@@ -591,7 +592,7 @@ public sealed class CSharpPrinter
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation;
+            or LoadProperty or TypeOf or DelegateCreation or CallIndirect;
         return atomic ? text : $"({text})";
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -946,6 +946,28 @@ public static class IrImporter
                     break;
                 }
 
+                case ILOpCode.Calli:
+                {
+                    // The operand is a standalone call-site signature: it gives
+                    // the return and parameter types and whether the pointer is
+                    // an instance function pointer. The function-pointer value
+                    // is on top; the arguments are beneath it.
+                    var signature = source.Reader
+                        .GetStandaloneSignature((StandaloneSignatureHandle)MetadataTokens.EntityHandle(reader.ReadILToken()))
+                        .DecodeMethodSignature(TypeRefDecoder.Instance, callerScope);
+                    var pointer = Pop(stack);
+                    int argumentCount = signature.ParameterTypes.Length + (signature.Header.IsInstance ? 1 : 0);
+                    var arguments = new IrExpression[argumentCount];
+                    for (int i = argumentCount - 1; i >= 0; i--)
+                        arguments[i] = Pop(stack);
+                    var callIndirect = new CallIndirect(pointer, arguments, signature.ReturnType, signature.ParameterTypes);
+                    if (signature.ReturnType is { Name: "Void", Namespace: "System" })
+                        body.Add(new ExpressionStatement(callIndirect));
+                    else
+                        stack.Push(callIndirect);
+                    break;
+                }
+
                 case ILOpCode.Localloc:
                 {
                     // localloc's operand is a native-int byte count; C#'s

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -653,6 +653,38 @@ public sealed class Call : IrExpression
         => $"{(IsVirtual ? "CallVirt" : "Call")} {Callee.DeclaringType.ToDisplayString()}.{Callee.Name}";
 }
 
+/// <summary>
+/// <c>calli</c>: an indirect call through a function-pointer value. The
+/// pointer (a <c>delegate*&lt;...&gt;</c>-typed expression) is the first child;
+/// the arguments follow. The standalone call-site signature supplies the
+/// return and parameter types, so the node is self-describing without the
+/// pointer's own type. Renders as a C# function-pointer invocation
+/// <c>pointer(args)</c>.
+/// </summary>
+public sealed class CallIndirect : IrExpression
+{
+    public CallIndirect(IrExpression pointer, IEnumerable<IrExpression> arguments, TypeRef returnType, ImmutableArray<TypeRef> parameterTypes)
+    {
+        AddChild(pointer);
+        foreach (var argument in arguments)
+            AddChild(argument);
+        ReturnType = returnType;
+        ParameterTypes = parameterTypes;
+    }
+
+    public TypeRef ReturnType { get; }
+    public ImmutableArray<TypeRef> ParameterTypes { get; }
+
+    /// <summary>The function-pointer value being invoked.</summary>
+    public IrExpression Pointer => (IrExpression)Children[0];
+    /// <summary>Call arguments (the function pointer's own parameters, receiver included when the signature carries one).</summary>
+    public IReadOnlyList<IrExpression> Arguments => Children.Skip(1).Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => ReturnType;
+    public override IEnumerable<TypeRef> DirectTypes => ParameterTypes.Append(ReturnType);
+
+    public override string Describe() => $"CallIndirect {ReturnType.ToDisplayString()}";
+}
+
 /// <summary>Object construction: <c>newobj</c> with the constructor's MethodRef (receiver excluded from arguments).</summary>
 public sealed class NewObject : IrExpression
 {


### PR DESCRIPTION
## Summary

The `calli` opcode fell through to the default arm and stopped the import (`opcode is outside the slice` — 38 methods in CoreLib), spilling the pushed function pointer and arguments as orphaned statements. With function-pointer **types** now modeled (`delegate*<...>`, #553), the invocation is expressible — so this raises it.

- **IrNodes**: add `CallIndirect` — the pointer expression plus arguments, carrying the standalone call-site signature's return and parameter types.
- **IrImporter**: decode the `calli` standalone signature, pop the pointer (top of stack) then its arguments, and build `CallIndirect`; void returns render as a statement, others push a value.
- **CSharpPrinter**: render `pointer(args)` (the pointer parenthesized when compound), and treat the invocation as atomic.

## Soundness

`CallIndirect` consumes exactly the pointer and the signature-driven argument count (`ParameterTypes.Length`, plus a receiver when the signature is instance), matching IL stack discipline — no mis-pop. `pointer(args)` is the exact C# spelling of a function-pointer call; the pointer carries its `delegate*<...>` type. A `calli` still fed by a bare `ldftn` keeps that node, so it stays honestly Partial (DEC0006).

## Corpus (`--pipeline next`, CoreLib)

| | Full | % |
|---|---|---|
| before | 40546 | 99.70% |
| after | 40580 | 99.79% |

**+34 Full.** The `calli` bucket (38) is eliminated; the 4 remainder surface a second unsupported-type reason (benign).

### Example (`System.ComAwareWeakReference::PossiblyComWrappersObject`)

```csharp
return ComAwareWeakReference.s_possiblyComObjectCallback != ((nuint)0)
    && ComAwareWeakReference.s_possiblyComObjectCallback(target);
```

## Tests

- Decompiler: 387 pass (added managed `int`-returning and `void`-returning function-pointer-invocation fixtures + structure/rendering assertions). Green in Debug too (invariant checks).
- Parity (`--candidate next`): no new candidate-worse regressions (real-gap known 1546 → 1512).
- CLI: only the known version-sensitive `JsonSerializer` overload-count failure remains (pre-existing on main).
