### PR TITLE
Dereference a pointer address in ldind.ref

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -140,6 +140,20 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void LoadIndirect_RefForm_DereferencesPointerAddress()
+    {
+        // ldind.ref through an unmanaged pointer to a reference type (e.g.
+        // `object*`, expressible only in IL) carries no element-type token, so
+        // the result type comes from the address. A Pointer address must be
+        // dereferenced like a ByRef one — otherwise the result type is null,
+        // capping fidelity silently with no diagnostic.
+        var pointerToObject = TypeRef.Pointer(TypeRef.CoreLib("System", "Object"));
+        var load = new LoadIndirect(null, new LoadArgument(0, "p", pointerToObject));
+
+        Assert.Equal("object", load.ResultType!.ToDisplayString());
+    }
+
+    [Fact]
     public void FunctionPointerSignature_ImportsAtFullFidelity()
     {
         // A delegate*<int, int> parameter is a representable function-pointer

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1171,7 +1171,7 @@ public sealed class LoadIndirect : IrExpression
     public bool IsVolatile { get; init; }
     public IrExpression Address => (IrExpression)Children[0];
     public override TypeRef? ResultType
-        => Type ?? (Address.ResultType is { Kind: TypeRefKind.ByRef } byRef ? byRef.ElementType : null);
+        => Type ?? (Address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null);
     public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
 
     public override string Describe() => $"LoadIndirect {ResultType?.ToDisplayString() ?? "?"}{(IsVolatile ? " volatile" : "")}";


### PR DESCRIPTION
## Summary

For the `.ref` indirect-load forms (`ldind.ref` / `ldobj` of a reference type) the opcode carries no element-type token, so `LoadIndirect.ResultType` takes the element type from the address. It dereferenced only a managed **ByRef** (`T&`), so an unmanaged **Pointer** address (`object*` — expressible only in IL) yielded a `null` result type, which caps fidelity to Partial **silently**: `RecordUnsupportedTypeDiagnostics` skips null types, so these landed in the harness's invisible `(typed)` catch-all (50 in CoreLib).

The fix: treat a `Pointer` address the same as a `ByRef` one and take its element type.

## Soundness

`ldind.ref`/`ldobj` read the referent of the address; for a pointer `E*` the referent is `E`, exactly as for a ref `E&`. This is the type the metadata already states on the address, not an inference. The existing `*p` deref rendering was already correct — only the result type was missing.

## Corpus (`--pipeline next`, CoreLib)

| | Full | % |
|---|---|---|
| before | 40580 | 99.79% |
| after | 40626 | 99.90% |

**+46 Full.** The `(typed)` bucket falls **50 → 4**. The 4 residual are a distinct gap: the address is laundered through a `conv` to `nuint` (an `Unsafe`-style reinterpret), so the element type is genuinely unrecoverable without guessing — left as honest Partial.

### Example (`System.AppContext::OnUnhandledException`)

```csharp
try
{
    AppContext.OnUnhandledException(*pException);
}
catch
{
}
```

## Tests

- Decompiler: 388 pass (added a deterministic unit test building `LoadIndirect(null, object*-address)` and asserting the result type is `object`; `object*` can't be written in C#, so the IR is constructed directly). Green in Debug too (invariant checks).
- Parity (`--candidate next`): no new candidate-worse regressions (real-gap known 1512 → 1466; candidate Partial 264 → 218).
- CLI: only the known version-sensitive `JsonSerializer` overload-count failure remains (pre-existing on main).
