### PR TITLE
Raise static ldftn to a &Method address-of

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1110,6 +1110,13 @@ public class CfgSampleClass
     // A void-returning function-pointer invocation renders as a statement.
     public static unsafe void InvokesVoidFunctionPointer(delegate*<int, void> callback, int value) => callback(value);
 
+    static unsafe delegate*<int, int> s_functionPointer;
+    static int FunctionPointerTarget(int value) => value;
+
+    // Storing a method address into a delegate*-typed field is a static ldftn
+    // that no delegate constructor consumes; it raises to &Method.
+    public static unsafe void StoresMethodAddress() => s_functionPointer = &FunctionPointerTarget;
+
     // An `in` parameter carries modreq(InAttribute) on the byref. The importer
     // sees through the modifier, so the body imports at Full fidelity and the
     // underlying ByRef(int) shape stays intact for the load-indirect unwrap.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -217,6 +217,24 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Ldftn_StaticMethodAddress_RaisesToAmpersandMethod()
+    {
+        // A static ldftn that feeds a delegate*-typed field store (not a
+        // delegate constructor) survives DelegateConstructionPass and is raised
+        // by MethodAddressPass to AddressOfMethod — C#'s &Method — instead of
+        // stopping as an unspellable function-pointer load.
+        var function = ImportFixture(nameof(CfgSampleClass.StoresMethodAddress));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<LoadFunctionPointer>());
+        var address = Assert.Single(function.Descendants.OfType<AddressOfMethod>());
+        Assert.Equal("FunctionPointerTarget", address.Method.Name);
+        Assert.Equal(TypeRefKind.FunctionPointer, address.ResultType!.Kind);
+        Assert.Contains("&FunctionPointerTarget", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
     public void InParameter_SeesThroughModifier_ImportsAtFull()
     {
         // modreq(InAttribute) on the byref is a declaration-site concern that

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -445,6 +445,7 @@ public sealed class CSharpPrinter
         Call c => CallText(c),
         CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
+        AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
@@ -592,7 +593,7 @@ public sealed class CSharpPrinter
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or CallIndirect;
+            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod;
         return atomic ? text : $"({text})";
     }
 
@@ -752,6 +753,24 @@ public sealed class CSharpPrinter
         if (target is LoadArgument { Index: 0, Name: "this" })
             return name;
         return $"{ReceiverText(target)}.{name}";
+    }
+
+    /// <summary>
+    /// <c>&amp;Method</c> for a static method group. A same-type target — every
+    /// local function, and members of the function's own type — needs no
+    /// qualifier; a cross-type static method is qualified by its declaring type.
+    /// Generic methods carry their type arguments (<c>&amp;Method&lt;int&gt;</c>).
+    /// </summary>
+    string AddressOfMethodText(AddressOfMethod node)
+    {
+        var method = node.Method;
+        string typeArguments = method.TypeArguments.IsEmpty
+            ? ""
+            : $"<{string.Join(", ", method.TypeArguments.Select(TypeText))}>";
+        string name = $"{MethodName(method.Name)}{typeArguments}";
+        return IsCrossType(method.DeclaringType)
+            ? $"&{TypeText(method.DeclaringType)}.{name}"
+            : $"&{name}";
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -734,6 +734,28 @@ public sealed class LoadFunctionPointer : IrExpression
 }
 
 /// <summary>
+/// <c>&amp;Method</c> — the address of a static method as a function pointer.
+/// The renderable form of a static <c>ldftn</c> that did not feed a delegate
+/// constructor: it feeds a <c>calli</c>, a native-callback argument, or a
+/// <c>delegate*</c>-typed field. Raised from a surviving
+/// <see cref="LoadFunctionPointer"/> by <see cref="MethodAddressPass"/>; its
+/// result type is the managed function-pointer type of the method's signature.
+/// </summary>
+public sealed class AddressOfMethod : IrExpression
+{
+    public AddressOfMethod(MethodRef method) => Method = method;
+
+    public MethodRef Method { get; }
+    public override TypeRef? ResultType
+        => TypeRef.FunctionPointer(Method.ReturnType, Method.ParameterTypes, "");
+    public override IEnumerable<TypeRef> DirectTypes
+        => Method.ParameterTypes.Append(Method.DeclaringType).Append(Method.ReturnType).Concat(Method.TypeArguments);
+
+    public override string Describe()
+        => $"AddressOfMethod {Method.DeclaringType.ToDisplayString()}.{Method.Name}";
+}
+
+/// <summary>
 /// A delegate instance from a method group — the inverse of the compiler's
 /// <c>ldftn; newobj DelegateType::.ctor(object, native int)</c> lowering. The
 /// target is the receiver object (a null constant for a static method group).

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -65,6 +65,10 @@ public static class IrPasses
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // Raise any static function-pointer load still standing into &Method
+        // (it feeds a calli, native callback, or delegate*-typed field — all of
+        // which take a function pointer directly).
+        new MethodAddressPass(),
         // Last: any function-pointer load still standing fed something other
         // than a delegate constructor — record the honest residual diagnostic.
         new FunctionPointerDiagnosticsPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
@@ -1,0 +1,26 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a surviving static <see cref="LoadFunctionPointer"/> (a
+/// non-virtual <c>ldftn</c>) into <see cref="AddressOfMethod"/> — C#'s
+/// <c>&amp;Method</c>. These are the function-pointer loads the
+/// <see cref="DelegateConstructionPass"/> did not consume: they feed a
+/// <c>calli</c>, a native-callback argument, or a <c>delegate*</c>-typed field,
+/// all of which take a function pointer directly. Runs just before
+/// <see cref="FunctionPointerDiagnosticsPass"/> so only the unspellable residue
+/// (a virtual <c>ldvirtftn</c>, which needs an instance) reaches the diagnostic.
+/// </summary>
+public sealed class MethodAddressPass : IIrPass
+{
+    public string Name => "method-address";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var pointer in function.Descendants.OfType<LoadFunctionPointer>().ToList())
+        {
+            if (pointer.Parent is null || pointer.IsVirtual)
+                continue;
+            pointer.ReplaceWith(new AddressOfMethod(pointer.Method));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A static `ldftn` that does not feed a delegate constructor is C#'s `&Method`: it feeds a `calli`, a native-callback argument, or a `delegate*`-typed field, all of which take a function pointer directly. Previously these survived as raw `LoadFunctionPointer` nodes and capped the method at Partial fidelity.

This adds an `AddressOfMethod` IR node and a `MethodAddressPass` that raises the `LoadFunctionPointer` residue left by `DelegateConstructionPass`. The pass runs just before `FunctionPointerDiagnosticsPass`, so only the unspellable virtual `ldvirtftn` residue (which needs an instance) still reaches the diagnostic.

The printer renders `&Method` bare for same-type and local-function targets and `&Type.Method` cross-type, including generic type arguments — e.g. `Sys.GetAllMountPoints(&AddMountPoint, ...)`, `V_0.callback = &Callback;`, `_pfnAllocator = &ReturnNull;`.

## Soundness

A static `ldftn` is exactly `&Method` in C#. The `AddressOfMethod` node carries the method's managed function-pointer type (`delegate*<params, ret>`, supported since #553) as its result type, so its own types are fully spellable and it reaches Full fidelity honestly. Virtual `ldvirtftn` is left untouched and stays Partial with a diagnostic — it needs an instance and has no bare address-of spelling.

## Corpus (CoreLib, inventory)

| | Full | % |
|---|---|---|
| Before | 40626 | 99.90% |
| After | 40641 | 99.94% |

+15 Full. The `ldftn` bucket is eliminated; all 28 CoreLib `LoadFunctionPointer` survivors are raised (zero virtual). The `(join-type)` bucket incidentally drops 21 → 19.

## Tests

- `ILInspector.Decompiler.Tests`: 389 pass (Release and Debug; Debug runs the post-pass invariant checker).
- New `StoresMethodAddress` fixture + `Ldftn_StaticMethodAddress_RaisesToAmpersandMethod` test (asserts Full, zero `LoadFunctionPointer`, single `AddressOfMethod`, renders `&FunctionPointerTarget`).
- Parity (`--candidate next`): candidate-worse unchanged at 1248 — no new regressions.

> Note: the harness parity path gates on **pre-pass** fidelity, so pass-only raising like this does not move its `candidatePartial`/diff buckets; the meaningful signal is the inventory (`--pipeline next`) above plus candidate-worse holding steady.
