### PR TITLE
Merge join-type slots to the nearest resolved common supertype

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1156,16 +1156,49 @@ public class CfgSampleClass
     // body imports at Full fidelity instead of stopping at a join-type unknown.
     public static string MergedReferenceSlot(bool flag)
         => (flag ? new JoinDerived() : new JoinBase()).Label;
+
+    // An interface stack join: one arm is cast to the interface IJoinShape, the
+    // other is a class that implements it. The slot merges to IJoinShape — an
+    // interface one side resolves to and the other implements — exercising the
+    // interface arm of the merge, distinct from the base-class walk above.
+    public static string MergedInterfaceSlot(bool flag)
+        => (flag ? (IJoinShape)new JoinDerived() : new JoinImpl()).Shape();
+
+    // A ternary whose result is used as a receiver and then returned: the
+    // compiler keeps it on the stack (a dup slot), so the folded ternary types
+    // the declared slot. The arms are JoinDerived and JoinBase; the slot must
+    // declare as the common base JoinBase, not the WhenTrue arm JoinDerived —
+    // guarding Conditional.MergedType against narrowing to one branch.
+    public static JoinBase MergedTernaryDeclaration(bool flag)
+    {
+        JoinBase node = flag ? new JoinDerived() : new JoinBase();
+        node.Mark();
+        return node;
+    }
 }
 
-public class JoinBase
+public interface IJoinShape
+{
+    string Shape();
+}
+
+public class JoinBase : IJoinShape
 {
     public virtual string Label => "base";
+
+    public string Shape() => "shape";
+
+    public void Mark() { }
 }
 
 public sealed class JoinDerived : JoinBase
 {
     public override string Label => "derived";
+}
+
+public sealed class JoinImpl : IJoinShape
+{
+    public string Shape() => "impl";
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -538,6 +538,23 @@ public class JoinTypeConflictTests : IDisposable
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
         function.CheckInvariant();
     }
+
+    [Fact]
+    public void ReferenceJoin_ToImplementedInterface_ImportsAtFullFidelity()
+    {
+        // One ternary arm is cast to IJoinShape; the other implements it. The
+        // merge resolves to IJoinShape — an interface one arm already carries
+        // and the other implements — so the body imports Full with no
+        // join-type diagnostic, exercising the interface arm of the merge.
+        var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        _disposables.Push(source);
+        var function = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.MergedInterfaceSlot))!;
+
+        Assert.DoesNotContain(function.Diagnostics, d => (d.Message ?? "").Contains("(join-type)"));
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        function.CheckInvariant();
+    }
 }
 
 public class CSharpPrinterTests
@@ -550,6 +567,31 @@ public class CSharpPrinterTests
         var result = CSharpPrinter.Print(function);
         Assert.True(result.Succeeded);
         return result.Output!.ReplaceLineEndings("\n");
+    }
+
+    [Fact]
+    public void MergedTernary_DeclaresCommonBase_NotWhenTrueArm()
+    {
+        // A folded ternary feeding a declared slot: the arms are JoinDerived
+        // and JoinBase, so the slot must declare as the common base JoinBase.
+        // Without carrying the importer-merged type the ternary would narrow to
+        // the WhenTrue arm (JoinDerived) and assign JoinBase to it — unsound.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.MergedTernaryDeclaration));
+        Assert.NotNull(function);
+        var result = CSharpPrinter.PrintRaised(function);
+        Assert.True(result.Succeeded);
+        string output = result.Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("new JoinDerived()", output);
+        Assert.Contains("new JoinBase()", output);
+        // The slot/local carrying the ternary declares as the common base,
+        // never the WhenTrue arm — config-agnostic (Release spills a stack
+        // slot, Debug keeps a named local).
+        Assert.Matches(@"JoinBase \w+ = flag \?", output);
+        Assert.DoesNotContain("JoinDerived S_", output);
+        Assert.DoesNotContain("JoinDerived V_", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -132,6 +132,8 @@ public sealed class CSharpPrinter
     {
         var locals = new SortedSet<int>();
         var slots = new SortedDictionary<int, TypeRef?>();
+        var slotLoadTypes = new Dictionary<int, TypeRef?>();
+        var slotStoreTypes = new Dictionary<int, TypeRef?>();
         // Catch variables declare in their clause header, not up front.
         var clauseDeclared = function.Descendants.OfType<CatchClause>()
             .Where(clause => clause.VariableIndex is not null)
@@ -144,9 +146,20 @@ public sealed class CSharpPrinter
                 case LoadLocal l: locals.Add(l.Index); break;
                 case StoreLocal s: locals.Add(s.Index); break;
                 case LoadLocalAddress a: locals.Add(a.Index); break;
-                case LoadStackSlot ls: slots.TryAdd(ls.Slot, ls.Type); break;
-                case StoreStackSlot ss: slots.TryAdd(ss.Slot, ss.Value.ResultType); break;
+                // A slot's declared type is the type it is loaded AS — the merged
+                // join type every predecessor's store is assignable to. A store
+                // value can be a subtype at a join (object slot fed a string),
+                // so store types are only a fallback when the slot is never
+                // loaded with a known type.
+                case LoadStackSlot ls: slotLoadTypes.TryAdd(ls.Slot, ls.Type); break;
+                case StoreStackSlot ss: slotStoreTypes.TryAdd(ss.Slot, ss.Value.ResultType); break;
             }
+        }
+        foreach (int slot in slotLoadTypes.Keys.Concat(slotStoreTypes.Keys).Distinct())
+        {
+            slots[slot] = slotLoadTypes.TryGetValue(slot, out var loaded) && loaded is not null
+                ? loaded
+                : slotStoreTypes.TryGetValue(slot, out var stored) ? stored : null;
         }
         foreach (int index in locals)
         {
@@ -187,6 +200,12 @@ public sealed class CSharpPrinter
         var entryStatements = new HashSet<IrNode>(function.Body.Blocks[0].Children);
         var seenLocals = new HashSet<int>();
         var seenSlots = new HashSet<int>();
+        // A slot stored on more than one path is a join slot: it must declare
+        // once, up front, with its merged type — declaring it at one store would
+        // type it from that branch's value and strand the other branch's store.
+        var slotStoreCounts = new Dictionary<int, int>();
+        foreach (var store in function.Descendants.OfType<StoreStackSlot>())
+            slotStoreCounts[store.Slot] = slotStoreCounts.GetValueOrDefault(store.Slot) + 1;
         foreach (var node in function.Descendants)
         {
             switch (node)
@@ -216,7 +235,8 @@ public sealed class CSharpPrinter
                 case LoadLocalAddress address: seenLocals.Add(address.Index); break;
                 case StoreStackSlot slotStore when !seenSlots.Contains(slotStore.Slot):
                     seenSlots.Add(slotStore.Slot);
-                    if (entryStatements.Contains(slotStore) && slotStore.Value.ResultType is not null)
+                    if (entryStatements.Contains(slotStore) && slotStore.Value.ResultType is not null
+                        && slotStoreCounts[slotStore.Slot] == 1)
                         _declaringStores.Add(slotStore);
                     break;
                 case LoadStackSlot slotLoad: seenSlots.Add(slotLoad.Slot); break;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1033,10 +1033,12 @@ public static class IrImporter
             return a;
         if (IsReferenceType(source, a) && IsReferenceType(source, b))
         {
-            if (IsObject(a) || source.IsBaseClassOf(a, b))
-                return a;
-            if (IsObject(b) || source.IsBaseClassOf(b, a))
-                return b;
+            // The nearest common supertype both paths are assignable to — an
+            // implemented interface or a common base class (object only when
+            // both chains genuinely resolve to it). Null leaves the slot
+            // untyped and the method honestly Partial.
+            if (source.MergeReferenceTypes(a, b) is { } merged)
+                return merged;
         }
         var familyA = TypeFamilies.Of(a);
         var familyB = TypeFamilies.Of(b);
@@ -1053,9 +1055,6 @@ public static class IrImporter
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
         return definition is not null && source.ResolveShape(definition) == TypeShape.Reference;
     }
-
-    static bool IsObject(TypeRef type)
-        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
 
     /// <summary>A block whose entry expects stack values is a stack-carrying edge — out of slice, reported honestly via the importer's stop path.</summary>
     sealed class OutOfSliceException(string reason) : Exception(reason);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -450,7 +450,18 @@ public sealed class Conditional : IrExpression
     public IrExpression Condition => (IrExpression)Children[0];
     public IrExpression WhenTrue => (IrExpression)Children[1];
     public IrExpression WhenFalse => (IrExpression)Children[2];
-    public override TypeRef? ResultType => WhenTrue.ResultType ?? WhenFalse.ResultType;
+
+    /// <summary>
+    /// The merged slot type the importer computed for the join the two arms
+    /// feed (a genuine common supertype of both arms). When set it is the
+    /// honest result type — the bare <c>WhenTrue ?? WhenFalse</c> fallback
+    /// would otherwise lie whenever the arms carry unequal reference types
+    /// (e.g. <c>cond ? new DirectoryInfo() : new FileInfo()</c> must type as
+    /// <c>FileSystemInfo</c>, not <c>DirectoryInfo</c>).
+    /// </summary>
+    public TypeRef? MergedType { get; set; }
+
+    public override TypeRef? ResultType => MergedType ?? WhenTrue.ResultType ?? WhenFalse.ResultType;
 
     public override string Describe() => "Conditional";
 }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
@@ -60,6 +61,8 @@ public sealed class MetadataSource : IDisposable
     Dictionary<TypeRef, TypeShape>? _shapes;
     Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? _enumMembers;
     Dictionary<TypeRef, TypeRef?>? _baseTypes;
+    HashSet<TypeRef>? _interfaces;
+    Dictionary<TypeRef, ImmutableArray<TypeRef>>? _interfaceImpls;
 
     /// <summary>
     /// The C# shape of a type defined in THIS assembly — enum, struct, or
@@ -97,6 +100,8 @@ public sealed class MetadataSource : IDisposable
         var shapes = new Dictionary<TypeRef, TypeShape>();
         var enums = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>();
         var bases = new Dictionary<TypeRef, TypeRef?>();
+        var interfaces = new HashSet<TypeRef>();
+        var interfaceImpls = new Dictionary<TypeRef, ImmutableArray<TypeRef>>();
         foreach (var handle in Reader.TypeDefinitions)
         {
             var typeDef = Reader.GetTypeDefinition(handle);
@@ -105,23 +110,60 @@ public sealed class MetadataSource : IDisposable
             var key = TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, handle, 0);
             var shape = ClassifyShape(typeDef);
             shapes[key] = shape;
-            bases[key] = DecodeBaseType(typeDef.BaseType);
+            // The type's own generic parameters scope the base and interface
+            // signatures, so a generic-instance base (List<T>) or interface
+            // (IEqualityComparer<T>) decodes to an open TypeRef carrying T as a
+            // generic parameter — later substituted by the concrete instance.
+            var scope = new GenericScope(GenericParameterNames(typeDef.GetGenericParameters()), []);
+            bases[key] = DecodeBaseType(typeDef.BaseType, scope);
+            if ((typeDef.Attributes & System.Reflection.TypeAttributes.Interface) != 0)
+                interfaces.Add(key);
+            interfaceImpls[key] = DecodeInterfaces(typeDef, scope);
             if (shape == TypeShape.Enum)
                 enums[key] = BuildEnumMembers(typeDef);
         }
         _enumMembers = enums;
         _baseTypes = bases;
+        _interfaces = interfaces;
+        _interfaceImpls = interfaceImpls;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
     }
 
+    ImmutableArray<string> GenericParameterNames(GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(Reader.GetString(Reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    /// <summary>The interfaces a definition directly implements, decoded with the type's own generic scope (open — concrete instances substitute later).</summary>
+    ImmutableArray<TypeRef> DecodeInterfaces(TypeDefinition typeDef, GenericScope scope)
+    {
+        var impls = typeDef.GetInterfaceImplementations();
+        if (impls.Count == 0)
+            return [];
+        var builder = ImmutableArray.CreateBuilder<TypeRef>(impls.Count);
+        foreach (var implHandle in impls)
+        {
+            var iface = Reader.GetInterfaceImplementation(implHandle).Interface;
+            if (DecodeBaseType(iface, scope) is { } decoded)
+                builder.Add(decoded);
+        }
+        return builder.ToImmutable();
+    }
+
     /// <summary>
-    /// The base type of a same-assembly definition, decoded to the same
-    /// nested-aware <see cref="TypeRef"/> the IR carries. A definition or
-    /// reference base resolves; a generic-instance base (TypeSpecification)
-    /// returns null — walking it needs a generic context this map does not
-    /// hold. Object's nil base also returns null, ending the chain.
+    /// The base type (or an interface) of a same-assembly definition, decoded
+    /// to the same nested-aware <see cref="TypeRef"/> the IR carries. A
+    /// definition, reference, or generic-instance (TypeSpecification) base
+    /// resolves — the spec is decoded under <paramref name="scope"/>, so a base
+    /// like <c>Bar&lt;T&gt;</c> keeps the type's own parameter as an open
+    /// generic parameter. Object's nil base returns null, ending the chain.
     /// </summary>
-    TypeRef? DecodeBaseType(EntityHandle baseHandle)
+    TypeRef? DecodeBaseType(EntityHandle baseHandle, GenericScope scope)
     {
         if (baseHandle.IsNil)
             return null;
@@ -129,6 +171,7 @@ public sealed class MetadataSource : IDisposable
         {
             HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, (TypeDefinitionHandle)baseHandle, 0),
             HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(Reader, (TypeReferenceHandle)baseHandle, 0),
+            HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(Reader, scope, (TypeSpecificationHandle)baseHandle, 0),
             _ => null,
         };
     }
@@ -141,28 +184,103 @@ public sealed class MetadataSource : IDisposable
     /// </summary>
     internal TypeRef? ResolveBaseType(TypeRef type)
     {
-        if (type.Kind != TypeRefKind.Definition)
-            return null;
         EnsureTypeMaps();
-        return _baseTypes!.GetValueOrDefault(type);
+        switch (type.Kind)
+        {
+            case TypeRefKind.Definition:
+                return _baseTypes!.GetValueOrDefault(type);
+            case TypeRefKind.GenericInstance when type.ElementType is { } definition:
+                // The base of List<int> is the base of List<T> with T := int.
+                // The stored base is open (carries List's own parameters), so
+                // substitute the instance's arguments to close it.
+                return _baseTypes!.GetValueOrDefault(definition)?.Instantiate(type.TypeArguments, []);
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>True when <paramref name="type"/> is <c>System.Object</c>.</summary>
+    static bool IsObject(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
+
+    /// <summary>True when <paramref name="type"/> (or the definition it instantiates) is an interface.</summary>
+    internal bool IsInterface(TypeRef type)
+    {
+        EnsureTypeMaps();
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && _interfaces!.Contains(definition);
+    }
+
+    /// <summary>True when <paramref name="type"/> implements <paramref name="iface"/> (matched structurally after substitution, so generic arguments must agree).</summary>
+    internal bool Implements(TypeRef type, TypeRef iface)
+    {
+        foreach (var implemented in InterfacesOf(type))
+        {
+            if (implemented.Equals(iface))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>Every interface <paramref name="type"/> implements — its own, its base classes', and those interfaces' bases — fully instantiated.</summary>
+    IEnumerable<TypeRef> InterfacesOf(TypeRef type)
+    {
+        EnsureTypeMaps();
+        var seen = new HashSet<TypeRef>();
+        var pending = new Stack<TypeRef>();
+        for (var current = type; current is not null; current = ResolveBaseType(current))
+            pending.Push(current);
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            var definition = current.Kind == TypeRefKind.GenericInstance ? current.ElementType : current;
+            if (definition is null || !_interfaceImpls!.TryGetValue(definition, out var impls))
+                continue;
+            var arguments = current.Kind == TypeRefKind.GenericInstance ? current.TypeArguments : [];
+            foreach (var open in impls)
+            {
+                var iface = open.Instantiate(arguments, []);
+                if (seen.Add(iface))
+                {
+                    yield return iface;
+                    pending.Push(iface);   // an interface's own base interfaces
+                }
+            }
+        }
     }
 
     /// <summary>
-    /// True when <paramref name="ancestor"/> is a (strict) base class of
-    /// <paramref name="derived"/>, found by walking the same-assembly base
-    /// chain. The walk stops at the first base it cannot resolve — a cross
-    /// -assembly or generic-instance link — and never guesses past it.
+    /// The nearest common supertype of two reference types, both assignable to
+    /// it without a cast — an interface one side implements, else the nearest
+    /// common base class. Returns <c>object</c> only when both base chains
+    /// genuinely resolve to it; null when a chain stops at an unresolvable
+    /// (cross-assembly) link before a common ancestor, so the merge never
+    /// guesses a supertype the IL did not prove.
     /// </summary>
-    internal bool IsBaseClassOf(TypeRef ancestor, TypeRef derived)
+    internal TypeRef? MergeReferenceTypes(TypeRef a, TypeRef b)
     {
-        var current = ResolveBaseType(derived);
-        for (int depth = 0; depth < 64 && current is not null; depth++)
+        if (a.Equals(b))
+            return a;
+        // object is the supertype of every reference type, including interfaces
+        // (whose nil base class the base-walk below cannot climb to it).
+        if (IsObject(a))
+            return a;
+        if (IsObject(b))
+            return b;
+        if (IsInterface(a) && Implements(b, a))
+            return a;
+        if (IsInterface(b) && Implements(a, b))
+            return b;
+        var ancestorsA = new HashSet<TypeRef>();
+        for (var current = a; current is not null && ancestorsA.Count < 64; current = ResolveBaseType(current))
+            ancestorsA.Add(current);
+        var fromB = b;
+        for (int depth = 0; fromB is not null && depth < 64; depth++, fromB = ResolveBaseType(fromB))
         {
-            if (current.Equals(ancestor))
-                return true;
-            current = ResolveBaseType(current);
+            if (ancestorsA.Contains(fromB))
+                return fromB;
         }
-        return false;
+        return null;
     }
 
     Dictionary<long, string> BuildEnumMembers(TypeDefinition enumType)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -33,7 +33,7 @@ public sealed class BooleanFoldingPass : IIrPass
             bool folded = node switch
             {
                 IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement)
-                    || FoldSlotDiamond(statement) || FoldCoalesce(statement),
+                    || FoldSlotDiamond(function, statement) || FoldCoalesce(statement),
                 Comparison comparison => FoldBoolConstantComparison(comparison),
                 _ => false,
             };
@@ -193,7 +193,7 @@ public sealed class BooleanFoldingPass : IIrPass
     };
 
     /// <summary>if (c) { S = A } else { S = B } → S = c ? A : B;</summary>
-    static bool FoldSlotDiamond(IfStatement diamond)
+    static bool FoldSlotDiamond(IrFunction function, IfStatement diamond)
     {
         if (diamond.Else is not { Children.Count: 1 } elseArm
             || diamond.Then.Children.Count != 1
@@ -213,7 +213,13 @@ public sealed class BooleanFoldingPass : IIrPass
             condition = (IrExpression)doubleNegative.DetachChildren()[0];
             (whenTrue, whenFalse) = (whenFalse, whenTrue);
         }
-        diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse)));
+        // The importer merged this slot to the genuine common supertype of the
+        // arms; carry it so the ternary types honestly when the arms differ
+        // (the bare WhenTrue fallback would otherwise narrow the result).
+        var mergedType = function.Descendants
+            .OfType<LoadStackSlot>()
+            .FirstOrDefault(load => load.Slot == thenStore.Slot && load.Type is not null)?.Type;
+        diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
         return true;
     }
 }


### PR DESCRIPTION
## What

At an IL control-flow join, two predecessors push related-but-unequal reference types into one stack slot. The old merge only walked base classes and refused interfaces and generic-instance bases, so 26 collisions across 19 methods returned `null` — silent `Partial` fidelity and a `(join-type)` diagnostic (the top of the slice roadmap).

This merges to a genuine **resolved common supertype** both values are implicitly assignable to (no synthesized cast):

- **Rule 1** — an interface one side implements (instantiated, structurally matched, so generic arguments must agree).
- **Rule 2** — the nearest common base class, ascending; `object` only when both chains genuinely reach it.
- A chain that stops at an unresolvable cross-assembly link before a common ancestor **stays `Partial`** — never a guess.

## How

- **`MetadataSource`** — build interface + interface-impl maps; decode `TypeSpecification` bases under the type's own generic scope; `ResolveBaseType` handles `GenericInstance` via the element base + `Instantiate`; add `IsInterface`, `Implements`/`InterfacesOf`, and `MergeReferenceTypes`.
- **`IrImporter.MergeSlotTypes`** delegates reference merging to it.
- **`CSharpPrinter`** — declare a slot from its merged *load* type (the type it is loaded as), not the first store's subtype; a multi-store join slot declares once up front so neither branch is stranded.
- **`Conditional`** carries the importer-merged slot type (`MergedType`), set by `BooleanFoldingPass` when it folds a slot diamond, so a ternary with divergent arms types as their common supertype instead of narrowing to the `WhenTrue` arm — e.g. `cond ? new DirectoryInfo() : new FileInfo()` now types `FileSystemInfo`, not `DirectoryInfo` (`FileSystemInfo.Create`).

## Soundness

Every merge result is a supertype both values are implicitly assignable to, so the merge assignments and the folded ternary need **no synthesized cast**. An unresolved chain stays `Partial` rather than guess a supertype the IL did not prove.

## Numbers

- Inventory (`--pipeline next`): **99.94% → 99.97% Full** (40641 → 40655, **+14**); join-type bucket **19 → 5** (the remaining 5 are value-type/pointer — a different stack family the old emitter also fakes).
- Parity (`--candidate next`): candidate-`Partial` **218 → 200**.
- Decompiler tests pass **Release + Debug** (391, **+3**: interface merge, base merge already present, and a ternary-supertype rendering guard).

## Tests

- `ReferenceJoin_ToImplementedInterface_ImportsAtFullFidelity` — interface arm of the merge.
- `MergedTernary_DeclaresCommonBase_NotWhenTrueArm` — folded ternary declares the common base, not the `WhenTrue` arm (verified to fail without the `Conditional.MergedType` fix).

Pre-existing unrelated failure on `main`: `dotnet-inspect.Tests` → `Type_SingleType_NormalVerbosity_StaysShapeAndExpandsOverloads` (version-sensitive `JsonSerializer` overload count).
