### PR TITLE
Raise the null-conditional lowering to target?.Member

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1175,6 +1175,17 @@ public class CfgSampleClass
         node.Mark();
         return node;
     }
+
+    // A null-conditional property access consumed inline by ?? — the inline use
+    // keeps the value on the stack, so the compiler spills the receiver into a
+    // stack slot, null-tests it, and reloads the spill to read the property on
+    // the non-null path, reusing ONE slot for both the receiver (JoinBase) and
+    // the result (string). NullConditionalPass raises this to node?.Label.
+    public static string NullConditionalProperty(JoinBase node) => node?.Label ?? "none";
+
+    // The call form: node?.Shape() consumed by ??. Same receiver-spill lowering,
+    // raised to a null-conditional invocation node?.Shape().
+    public static string NullConditionalCall(JoinBase node) => node?.Shape() ?? "none";
 }
 
 public interface IJoinShape

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -595,6 +595,37 @@ public class CSharpPrinterTests
     }
 
     [Fact]
+    public void NullConditional_RaisesQuestionDot_AndSoundlyTypesSlot()
+    {
+        // The ?. lowering spills the receiver into a stack slot, null-tests it,
+        // and reloads the spill for the member access — reusing one slot for the
+        // receiver (JoinBase) and the result (string). NullConditionalPass raises
+        // it to node?.Member, so the slot carries only the string result and the
+        // receiver type never declares a slot/local.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+
+        var property = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.NullConditionalProperty));
+        Assert.NotNull(property);
+        var propertyResult = CSharpPrinter.PrintRaised(property);
+        Assert.True(propertyResult.Succeeded);
+        string propertyOutput = propertyResult.Output!.ReplaceLineEndings("\n");
+        Assert.Contains("node?.Label", propertyOutput);
+        // The reused slot must not declare as the receiver type — that is the
+        // unsound slot-conflation the raise removes (config-agnostic spelling).
+        Assert.DoesNotContain("JoinBase S_", propertyOutput);
+        Assert.DoesNotContain("JoinBase V_", propertyOutput);
+
+        var call = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.NullConditionalCall));
+        Assert.NotNull(call);
+        var callResult = CSharpPrinter.PrintRaised(call);
+        Assert.True(callResult.Succeeded);
+        string callOutput = callResult.Output!.ReplaceLineEndings("\n");
+        Assert.Contains("node?.Shape()", callOutput);
+    }
+
+    [Fact]
     public void StraightLine_PrintsCurrentStyle()
     {
         Assert.Equal("return a + b;\n", PrintFixture(nameof(CfgSampleClass.Add)));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -459,6 +459,7 @@ public sealed class CSharpPrinter
         LogicalBinary l => LogicalText(l),
         Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
         Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
+        NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
         Convert v => ConvertText(v),
@@ -613,7 +614,7 @@ public sealed class CSharpPrinter
         string text = Expression(node);
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod;
+            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional;
         return atomic ? text : $"({text})";
     }
 
@@ -846,6 +847,44 @@ public sealed class CSharpPrinter
 
     string Arguments(IEnumerable<IrExpression> arguments)
         => string.Join(", ", arguments.Select(Expression));
+
+    /// <summary>
+    /// <c>target?.Member</c>: the member's receiver child is the target, and the
+    /// member's name/arguments form the suffix after <c>?</c>. Mirrors the
+    /// instance spellings of <see cref="CallText"/>, <see cref="PropertyTarget"/>,
+    /// and <see cref="FieldTarget"/>, minus their receiver — the <c>?.</c> owns it.
+    /// </summary>
+    string NullConditionalText(NullConditional node)
+    {
+        var member = node.Member;
+        var receiver = NullConditionalReceiver(member);
+        return $"{ReceiverText(receiver)}?{NullConditionalSuffix(member)}";
+    }
+
+    static IrExpression NullConditionalReceiver(IrExpression member) => member switch
+    {
+        Call call => call.Arguments[0],
+        LoadProperty property => property.Instance!,
+        LoadField field => field.Instance!,
+        _ => member,
+    };
+
+    string NullConditionalSuffix(IrExpression member) => member switch
+    {
+        LoadField field => $".{field.Field.Name}",
+        LoadProperty property when property.IndexArguments.Count > 0 => $"[{Arguments(property.IndexArguments)}]",
+        LoadProperty property => $".{property.PropertyName}",
+        Call call => NullConditionalCallSuffix(call),
+        _ => $".{member.Describe()}",
+    };
+
+    string NullConditionalCallSuffix(Call call)
+    {
+        string typeArguments = call.Callee.TypeArguments.IsEmpty
+            ? ""
+            : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
+        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1))})";
+    }
 
     string ConvertText(Convert convert)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -437,6 +437,28 @@ public sealed class Coalesce : IrExpression
     public override string Describe() => "Coalesce";
 }
 
+/// <summary>
+/// A raised null-conditional member access — <c>target?.Member</c>. The single
+/// child is the member access (a <see cref="Call"/>, <see cref="LoadProperty"/>,
+/// or <see cref="LoadField"/>) whose receiver IS the <c>?.</c> target; the
+/// printer prints that receiver, then <c>?</c>, then the member suffix. The
+/// NullConditionalPass raises this only from the <c>recv is not null ? recv.M :
+/// null</c> shape, where the literal-null false arm proves the member result is
+/// a reference type — so the access carries the member's own result type with no
+/// Nullable wrapping, and the lowered receiver spill collapses into the target.
+/// </summary>
+public sealed class NullConditional : IrExpression
+{
+    public NullConditional(IrExpression member) => AddChild(member);
+
+    /// <summary>The member access whose receiver is the <c>?.</c> target.</summary>
+    public IrExpression Member => (IrExpression)Children[0];
+
+    public override TypeRef? ResultType => Member.ResultType;
+
+    public override string Describe() => "NullConditional";
+}
+
 /// <summary>A raised ternary: condition selects between two values (the slot-diamond shape).</summary>
 public sealed class Conditional : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -62,6 +62,11 @@ public static class IrPasses
         new LockSugarPass(),
         new ForLoopPass(),
         new BooleanFoldingPass(),
+        // Raise the null-conditional lowering (receiver spill + null diamond)
+        // into target?.Member before the second inlining run, so the receiver
+        // spill collapses into the ?. target and the reused slot stops carrying
+        // two unrelated types.
+        new NullConditionalPass(),
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -1,0 +1,136 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the C# null-conditional lowering <c>target?.Member</c> back to a
+/// single <see cref="NullConditional"/> access. The compiler lowers <c>a?.M</c>
+/// to "test the receiver for null; on the non-null path perform the member
+/// access; otherwise yield null", and <see cref="BooleanFoldingPass"/> folds
+/// that diamond into a ternary. Two lowered shapes survive, by whether the
+/// receiver is cheap to re-evaluate:
+/// <list type="number">
+/// <item>
+/// <b>Spilled receiver</b> (a field load, an <c>as</c> result — anything the
+/// compiler will not re-evaluate). The receiver is spilled into a stack slot
+/// and reloaded for the access, reusing ONE slot index for both the receiver (a
+/// reference type) and the member result (often an unrelated type) — an unsound
+/// <c>Full</c> render. The shape is two adjacent stores to the same slot j:
+/// <code>
+///   StoreStackSlot(j, LoadStackSlot(s))                      // spill the receiver
+///   StoreStackSlot(j, Conditional(LoadStackSlot(s),          // s is not null ?
+///                                 member(receiver: LoadStackSlot(j)),  //   recv.Member :
+///                                 Constant null))                       //   null
+/// </code>
+/// Raising drops the spill, moves the real receiver into the access, and leaves
+/// slot j carrying only the member result type — the soundness fix.
+/// </item>
+/// <item>
+/// <b>Re-evaluable receiver</b> (an argument or local). The compiler re-emits
+/// the load instead of spilling, so the receiver appears in both the null test
+/// and the access:
+/// <code>
+///   Conditional(LoadArgument n, member(receiver: LoadArgument n), Constant null)
+/// </code>
+/// No slot is conflated here — the win is idiom only: the ternary becomes
+/// <c>n?.Member</c>, dropping the duplicate load.
+/// </item>
+/// </list>
+/// Both arms require a literal-null false arm, which proves the member result is
+/// a reference type (a value-type <c>?.</c> lowers through <c>Nullable&lt;T&gt;</c>,
+/// never a bare <c>ldnull</c>). Runs to fixpoint so chained accesses raise.
+/// </summary>
+public sealed class NullConditionalPass : IIrPass
+{
+    public string Name => "null-conditional";
+
+    public void Run(IrFunction function)
+    {
+        while (RaiseSpilled(function) || RaiseReevaluable(function))
+        {
+        }
+    }
+
+    /// <summary>Arm 1: the spilled-receiver shape (two adjacent stores to slot j).</summary>
+    static bool RaiseSpilled(IrFunction function)
+    {
+        foreach (var block in function.Descendants.OfType<Block>())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not StoreStackSlot spill || children[i + 1] is not StoreStackSlot result)
+                    continue;
+                if (spill.Slot != result.Slot)
+                    continue;
+                // The spill holds the receiver, loaded from slot s.
+                if (spill.Value is not LoadStackSlot receiverLoad)
+                    continue;
+                if (result.Value is not Conditional conditional || !IsNullConditionalShape(conditional, out var member))
+                    continue;
+                // The null test reads the SAME source slot s, and the member's
+                // receiver is the spill slot j — the two stores tie them together.
+                if (conditional.Condition is not LoadStackSlot conditionLoad || conditionLoad.Slot != receiverLoad.Slot)
+                    continue;
+                if (MemberReceiver(member) is not LoadStackSlot memberReceiver || memberReceiver.Slot != spill.Slot)
+                    continue;
+
+                member.Detach();
+                var receiver = (IrExpression)spill.DetachChildren()[0];
+                member.SetChild(0, receiver);
+                result.SetChild(0, new NullConditional(member));
+                spill.Detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Arm 2: the re-evaluable-receiver shape (argument/local loaded in both test and access).</summary>
+    static bool RaiseReevaluable(IrFunction function)
+    {
+        foreach (var conditional in function.Descendants.OfType<Conditional>())
+        {
+            if (!IsNullConditionalShape(conditional, out var member))
+                continue;
+            if (MemberReceiver(member) is not { } receiver || !SameReevaluableLoad(conditional.Condition, receiver))
+                continue;
+
+            member.Detach();
+            conditional.ReplaceWith(new NullConditional(member));
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// A <c>recv is not null ? member : null</c> ternary whose true arm is an
+    /// instance member access with a reference-typed result (guaranteed by the
+    /// literal-null false arm; a known value family means hand-rolled IL — leave
+    /// it a ternary).
+    /// </summary>
+    static bool IsNullConditionalShape(Conditional conditional, out IrExpression member)
+    {
+        member = conditional.WhenTrue;
+        if (conditional.WhenFalse is not Constant { Value: null })
+            return false;
+        if (MemberReceiver(member) is null)
+            return false;
+        return TypeFamilies.Of(member.ResultType) is not { } family || family == StackFamily.O;
+    }
+
+    /// <summary>The receiver child of an instance member access — always its first child.</summary>
+    static IrNode? MemberReceiver(IrExpression member) => member switch
+    {
+        Call { Callee.HasThis: true } call when call.Children.Count > 0 => call.Children[0],
+        LoadProperty { HasInstance: true } property => property.Instance,
+        LoadField { Instance: not null } field => field.Instance,
+        _ => null,
+    };
+
+    /// <summary>True when both nodes load the same argument or local — a pure re-evaluation the <c>?.</c> can fold.</summary>
+    static bool SameReevaluableLoad(IrNode condition, IrNode receiver) => (condition, receiver) switch
+    {
+        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
+        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
+        _ => false,
+    };
+}


### PR DESCRIPTION
## What

Adds `NullConditionalPass`, which raises the C# null-conditional lowering back to `target?.Member`, and a `NullConditional` IR node + printer rendering.

## Why

The compiler lowers `a?.M` to a null-test diamond around the member access. For a non-trivial receiver (a field load, an `as` result) it **spills the receiver into a stack slot and reloads it** for the access — reusing one slot index for both the receiver (a reference type) and the member result (often an unrelated type). After `BooleanFoldingPass` folds the diamond into a ternary the render is:

```csharp
AsyncLocal<IPrincipal> S_0 = Thread.s_asyncLocalPrincipal;
S_0 = S_0.Value;   // assigns IPrincipal to an AsyncLocal-typed slot — unsound
```

A `Full` render that lies about the slot's type. The old emitter shares this defect, and neither emitter raised `?.`.

## How

`NullConditionalPass` (after `BooleanFoldingPass`, before the second `ExpressionInliningPass`) matches two lowered shapes:

- **Spilled receiver** (two adjacent stores to slot `j`): drop the spill, move the real receiver into the access, leaving slot `j` carrying only the member result type. **This is the soundness fix** — the receiver spill then collapses into the `?.` target via the following inlining pass.
- **Re-evaluable receiver** (an argument or local loaded in both the null test and the access): fold the duplicate load into `n?.Member`. No slot is conflated here — idiom only.

Both arms require a **literal-null false arm**, which proves the member result is a reference type (a value-type `?.` lowers through `Nullable<T>`, never a bare `ldnull`), so the raise never wraps a `Nullable` result. Runs to fixpoint so chained accesses raise.

Results, e.g.:

```csharp
IPrincipal V_0 = Thread.s_asyncLocalPrincipal?.Value;
S_0 = (comparer as NonRandomizedStringEqualityComparer)?.GetUnderlyingEqualityComparer();
```

## Soundness

Removes genuinely **unsound** `Full` renders where one slot held two incompatible types. Inventory stays flat at **99.97%** (these methods were already `Full`) and parity is **essentially unchanged** (`agree` −1, `candidate-worse` unchanged at **1254** — no new regressions). The win is **soundness + idiom**, not inventory movement. Across `System.Private.CoreLib` the pass raises **49 methods (59 accesses)**.

## Tests

- `CSharpPrinterTests.NullConditional_RaisesQuestionDot_AndSoundlyTypesSlot` covers both the property and call forms and asserts the reused slot no longer declares the receiver type.
- Full decompiler suite passes Release + Debug (392 tests; Debug exercises `CheckInvariant` after every pass).
- CLI suite: only the pre-existing version-sensitive `Type_SingleType_NormalVerbosity_StaysShapeAndExpandsOverloads` fails (unrelated).
