### PR TITLE
Normalize indexed this selector spellings

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -120,7 +120,8 @@ public static class TypeMatcher
             || memberName.Equals("constructor", StringComparison.OrdinalIgnoreCase))
             return ".ctor";
 
-        if (memberName.Equals("this[]", StringComparison.OrdinalIgnoreCase)
+        if ((memberName.StartsWith("this[", StringComparison.OrdinalIgnoreCase)
+                && memberName.EndsWith("]", StringComparison.Ordinal))
             || memberName.Equals("this", StringComparison.OrdinalIgnoreCase)
             || memberName.Equals("[]", StringComparison.OrdinalIgnoreCase))
             return "this[]";

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -509,10 +509,45 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_IndexerSelector_NormalizesThisAliasWithIllustrativeArgument()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "String.this[0]", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Chars", output);
+        Assert.Contains("this[int index]", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_GenericIndexerSelector_NormalizesThisAliasWithTypeArgument()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "Dictionary<TKey,TValue>.this[TKey]", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Item", output);
+        Assert.Contains("this[TKey key]", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Source_IndexerSelector_NormalizesThisAlias()
     {
         var (exit, output, error) = await RunAppAsync(
             "source", "String.this[]", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("String.cs#L", output);
+        Assert.DoesNotContain("Could not resolve source location", error);
+    }
+
+    [Fact]
+    public async Task Source_IndexerSelector_NormalizesThisAliasWithIllustrativeArgument()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "String.this[0]", "--table", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("String.cs#L", output);


### PR DESCRIPTION
## Summary
- normalize member selectors like this[0], this[int], and this[TKey] to the existing this[] indexer alias
- add router coverage for String.this[0] and Dictionary<TKey,TValue>.this[TKey]
- add source coverage for String.this[0]

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- String.this[0] --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- List<T>.this[int] --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- Dictionary<TKey,TValue>.this[TKey] --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- source String.this[0] --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- string[] --table --tips q --head 5 (still package/type-shaped, not an indexer alias)