### PR TITLE
Normalize C# primitive keyword type aliases

### DIFF
--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -81,6 +81,9 @@ public static class TypeMatcher
         if (string.IsNullOrEmpty(typeName))
             return typeName;
 
+        if (PrimitiveTypeNames.TryToClrFullName(typeName.Trim().ToLowerInvariant(), out var primitiveFullName))
+            return primitiveFullName;
+
         var angleIdx = typeName.IndexOf('<');
         if (angleIdx <= 0)
             return typeName;

--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -81,7 +81,9 @@ public static class TypeMatcher
         if (string.IsNullOrEmpty(typeName))
             return typeName;
 
-        if (PrimitiveTypeNames.TryToClrFullName(typeName.Trim().ToLowerInvariant(), out var primitiveFullName))
+        var trimmed = typeName.Trim();
+        if (typeName.Equals(trimmed, StringComparison.Ordinal)
+            && PrimitiveTypeNames.TryToClrFullName(typeName, out var primitiveFullName))
             return primitiveFullName;
 
         var angleIdx = typeName.IndexOf('<');

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -401,6 +401,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_VoidKeyword_UsesPlatformFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "void", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Package 'void'", error);
+    }
+
+    [Fact]
     public async Task Router_FullyQualifiedPlatformMember_UsesPlatformMemberFindIfMiss()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -433,6 +443,54 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("IndexOf", output);
         Assert.Contains("public int IndexOf(char value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_PrimitiveKeywordMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "string.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("IndexOf", output);
+        Assert.Contains("public int IndexOf(char value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_NumericKeywordMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "int.Parse", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Parse", output);
+        Assert.Contains("Return Type", output);
+        Assert.Contains("int", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_BooleanKeywordMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "bool.TryParse", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("TryParse", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Router_ObjectKeywordMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "object.GetType", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("GetType", output);
+        Assert.Contains("System.Type GetType()", output);
         Assert.Empty(error);
     }
 
@@ -552,6 +610,17 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("String.cs#L", output);
         Assert.DoesNotContain("Could not resolve source location", error);
+    }
+
+    [Fact]
+    public async Task Source_PrimitiveKeywordMember_UsesPlatformMemberFindIfMiss()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "source", "string.IndexOf", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("String.cs#L", output);
+        Assert.DoesNotContain("Package 'string.IndexOf' not found", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -115,12 +115,15 @@ internal static class TypeFindIfMissResolver
 {
     public static bool LooksLikeSimpleTypeQuery(string? query)
         => query is { Length: > 0 }
-           && char.IsUpper(query[0])
+           && (char.IsUpper(query[0]) || LooksLikePrimitiveKeyword(query))
            && !query.Contains('*')
            && !query.Contains('?')
            && !query.Contains('@')
            && !query.Contains('/')
            && !query.Contains('\\');
+
+    private static bool LooksLikePrimitiveKeyword(string query) =>
+        PrimitiveTypeNames.TryToClrFullName(query.Trim().ToLowerInvariant(), out _);
 
     public static async Task<TypeFindIfMissResult> ResolvePlatformAsync(
         string? query,
@@ -135,16 +138,17 @@ internal static class TypeFindIfMissResolver
         List<string> tempDirs = [];
         try
         {
+            var normalizedQuery = TypeMatcher.Normalize(query!);
             var findOptions = new FindOptions
             {
-                Pattern = query!,
+                Pattern = normalizedQuery,
                 PlatformFrameworks = CommandLineBuilder.PlatformFrameworkNames,
                 IncludeAll = includeAll,
                 SourceOptions = sourceOptions
             };
             var results = await TypeSearchService.CollectTypesAsync(
                 findOptions,
-                query,
+                normalizedQuery,
                 logger,
                 tempDirs,
                 httpClient);
@@ -165,7 +169,6 @@ internal static class TypeFindIfMissResolver
                 .DistinctBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            var normalizedQuery = TypeMatcher.Normalize(query!);
             var exactDisplayNameMatches = exactMatches
                 .Where(r => string.Equals(TypeMatcher.Normalize(r.Type), normalizedQuery, StringComparison.OrdinalIgnoreCase))
                 .ToList();


### PR DESCRIPTION
## Summary
- normalize C# primitive keyword aliases through PrimitiveTypeNames in TypeMatcher
- allow primitive keywords through platform find-if-miss and search by their CLR names
- cover router/source member-like inputs such as string.IndexOf, int.Parse, bool.TryParse, object.GetType, and source string.IndexOf

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- string.IndexOf --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- int.Parse --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- bool.TryParse --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- object.GetType --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- void --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- source string.IndexOf --table --tips q --head 5
- dotnet run --project src/dotnet-inspect -c Release -- string[] --table --tips q --head 5 (still separate from indexer syntax)