### PR TITLE
Render ref-typed locals and slots as valid C# ref assignments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1025,6 +1025,56 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void RefLocal_DeclaredBeforeStore_InitializesToNullRef()
+    {
+        // A ref local whose defining store is not the entry-block first
+        // reference declares up front. A bare `ref int V_0;` is CS8174, so it
+        // spells IL's null-reference zero-init via Unsafe.NullRef<T>().
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var entry = new Block(0);
+        container.Add(entry);
+        entry.Add(new Branch(1));
+        var body = new Block(1);
+        container.Add(body);
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        body.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [])));
+        body.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+        Assert.DoesNotContain("ref int V_0;", output);
+    }
+
+    [Fact]
+    public void RefSlot_DeclaredUpFront_InitializesToNullRef()
+    {
+        // The same null-ref zero-init applies to a ref-typed stack slot whose
+        // store is not its declaring site.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var entry = new Block(0);
+        container.Add(entry);
+        entry.Add(new Branch(1));
+        var body = new Block(1);
+        container.Add(body);
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        body.Add(new StoreStackSlot(0, new Call(getRef, isVirtual: false, [])));
+        body.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int S_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+    }
+
+    [Fact]
     public void Truthiness_UnknownDefinition_DoesNotGuessNull()
     {
         // A bare definition could be a struct or an enum; '!= null' would be

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -999,6 +999,32 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void RefLocal_StoreRendersRefAssignment()
+    {
+        // stloc into a ref-typed local rebinds the reference (it is not a
+        // write-through), so it must spell C#'s ref (re)assignment: `= ref`
+        // on the initial declaration (CS8172) and on any later rebind (CS8173).
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var getA = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        var getB = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "B", refInt, [], HasThis: false);
+        block.Add(new StoreLocal(0, refInt, new Call(getA, isVirtual: false, [])));
+        block.Add(new StoreLocal(0, refInt, new Call(getB, isVirtual: false, [])));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref T.A();", output);
+        Assert.Contains("V_0 = ref T.B();", output);
+        Assert.DoesNotContain("V_0 = T.A();", output);
+    }
+
+    [Fact]
     public void Truthiness_UnknownDefinition_DoesNotGuessNull()
     {
         // A bare definition could be a struct or an enum; '!= null' would be

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1075,6 +1075,32 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void RefConditional_BindsRefToEachArm()
+    {
+        // A ref-typed conditional is a ref ternary: `ref` binds each arm, not
+        // the whole expression. `= ref (cond ? a : b)` would be CS8173.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var ternary = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new LoadArgument(1, "a", refInt),
+            new LoadArgument(2, "b", refInt)) { MergedType = refInt };
+        block.Add(new StoreLocal(0, refInt, ternary));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("flag", boolType), new Parameter("a", refInt), new Parameter("b", refInt)],
+            HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref (flag ? ref a : ref b);", output);
+    }
+
+    [Fact]
     public void Truthiness_UnknownDefinition_DoesNotGuessNull()
     {
         // A bare definition could be a struct or an enum; '!= null' would be

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -654,6 +654,16 @@ public sealed class CSharpPrinter
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
         LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         { ResultType.Kind: TypeRefKind.Pointer } => $"*{Operand(address)}",
+        // A ref-typed conditional is a ref ternary: the `ref` binds each arm
+        // (`cond ? ref a : ref b`), not the expression as a whole — placing it
+        // outside is CS8173 in a `= ref` position. Only when both arms are
+        // themselves references; a conditional typed ref by an upstream merge
+        // but carrying value arms is left to the generic spelling rather than
+        // dereferencing a non-pointer.
+        Conditional { ResultType.Kind: TypeRefKind.ByRef } c
+            when c.WhenTrue.ResultType?.Kind == TypeRefKind.ByRef
+                && c.WhenFalse.ResultType?.Kind == TypeRefKind.ByRef
+            => $"({Condition(c.Condition)} ? ref {Deref(c.WhenTrue)} : ref {Deref(c.WhenFalse)})",
         { ResultType.Kind: TypeRefKind.ByRef } => Operand(address),
         _ => $"*{Operand(address)}",
     };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -172,19 +172,27 @@ public sealed class CSharpPrinter
                 // it relies on IL's zero-initialization of locals (localsinit).
                 // Spell that as `= default` — both faithful and what C#'s
                 // definite-assignment requires (a bare declaration is CS0165 on
-                // any path that reads before assigning). A ref local can't take
-                // `= default`; it needs `= ref …` (a separate slice), so it
-                // stays bare.
+                // any path that reads before assigning). A ref local takes
+                // neither: `= default` is illegal and a bare declaration is
+                // CS8174. IL zero-initializes a managed pointer to a null
+                // reference, whose faithful C# spelling is Unsafe.NullRef<T>().
+                // Fully qualified so the per-member view compiles without a
+                // using; the whole-type hoister shortens it and adds the using.
                 var type = function.Locals[index];
                 yield return type.Kind == TypeRefKind.ByRef
-                    ? $"{TypeText(type)} V_{index};"
+                    ? $"{TypeText(type)} V_{index} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
                     : $"{TypeText(type)} V_{index} = default;";
             }
         }
         foreach (var (slot, type) in slots)
         {
-            if (!_declaringStores.OfType<StoreStackSlot>().Any(s => s.Slot == slot))
-                yield return $"{(type is null ? "var" : TypeText(type))} S_{slot};";
+            if (_declaringStores.OfType<StoreStackSlot>().Any(s => s.Slot == slot))
+                continue;
+            // A ref-typed slot, like a ref-typed local, can't be declared bare
+            // (CS8174); spell IL's null-reference zero-init as Unsafe.NullRef<T>().
+            yield return type is { Kind: TypeRefKind.ByRef }
+                ? $"{TypeText(type)} S_{slot} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
+                : $"{(type is null ? "var" : TypeText(type))} S_{slot};";
         }
     }
 
@@ -418,6 +426,11 @@ public sealed class CSharpPrinter
             ? $"{TypeText(s.Type)} V_{s.Index} = {Expression(s.Value)};"
             : AssignmentText($"V_{s.Index}", s.Value, left => left is LoadLocal load && load.Index == s.Index),
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index),
+        // A ref-typed slot stores by rebinding the reference — C#'s ref
+        // (re)assignment, exactly as for ref locals above.
+        StoreStackSlot { Value.ResultType.Kind: TypeRefKind.ByRef } s => _declaringStores.Contains(s)
+            ? $"{TypeText(s.Value.ResultType!)} S_{s.Slot} = ref {Deref(s.Value)};"
+            : $"S_{s.Slot} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Value.ResultType!)} S_{s.Slot} = {Expression(s.Value)};"
             : AssignmentText($"S_{s.Slot}", s.Value, left => left is LoadStackSlot load && load.Slot == s.Slot),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -406,6 +406,14 @@ public sealed class CSharpPrinter
         ExpressionStatement e => e.Expression is UnsupportedNode u
             ? $"/* {u.Describe()} */"
             : $"{Expression(e.Expression)};",
+        // Storing into a ref-typed local rebinds the reference itself (stloc of
+        // a managed pointer), not a write-through — that is C#'s ref
+        // (re)assignment, which takes `= ref <place>` on both the initial
+        // declaration (CS8172) and any later rebind (CS8173). Deref renders the
+        // address value as the place it refers to.
+        StoreLocal { Type.Kind: TypeRefKind.ByRef } s => _declaringStores.Contains(s)
+            ? $"{TypeText(s.Type)} V_{s.Index} = ref {Deref(s.Value)};"
+            : $"V_{s.Index} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} V_{s.Index} = {Expression(s.Value)};"
             : AssignmentText($"V_{s.Index}", s.Value, left => left is LoadLocal load && load.Index == s.Index),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -656,10 +656,13 @@ public sealed class CSharpPrinter
         { ResultType.Kind: TypeRefKind.Pointer } => $"*{Operand(address)}",
         // A ref-typed conditional is a ref ternary: the `ref` binds each arm
         // (`cond ? ref a : ref b`), not the expression as a whole — placing it
-        // outside is CS8173 in a `= ref` position. Only when both arms are
-        // themselves references; a conditional typed ref by an upstream merge
-        // but carrying value arms is left to the generic spelling rather than
-        // dereferencing a non-pointer.
+        // outside is CS8173 in a `= ref` position. This spelling applies only
+        // when both arms are themselves references. A conditional typed ref by
+        // an upstream merge that carries a non-reference arm is an inexpressible
+        // merge — no valid `= ref` form exists for it — so it falls to the
+        // generic spelling as a best effort, not a correctness guarantee. Only
+        // BooleanFoldingPass.FoldSlotDiamond produces these, and an asymmetric
+        // ref/value slot merge is not seen in non-synthetic IL.
         Conditional { ResultType.Kind: TypeRefKind.ByRef } c
             when c.WhenTrue.ResultType?.Kind == TypeRefKind.ByRef
                 && c.WhenFalse.ResultType?.Kind == TypeRefKind.ByRef

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -219,8 +219,15 @@ public class MemberOptionsParserTests
         var parseResult = root.Parse(["member", "JsonSerializer", "--package", "System.Text.Json", "--json", "--tsv"]);
         Assert.Empty(parseResult.Errors);
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs));
+        // The rejection path writes to Console.Error before cancelling; run it
+        // under ConsoleCapture so that write lands on a live, semaphore-owned
+        // writer instead of one a parallel capture test may have disposed.
+        await ConsoleCapture.RunAsync(async () =>
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs));
+            return 0;
+        });
     }
 
     [Fact]
@@ -230,8 +237,14 @@ public class MemberOptionsParserTests
         var parseResult = root.Parse(["member", "JsonSerializer", "--package", "System.Text.Json", "--json", "--jsonl"]);
         Assert.Empty(parseResult.Errors);
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs));
+        // See ExplicitPackage_WithJsonAndTsv_IsRejected: capture the console so
+        // the rejection's Console.Error write cannot hit a disposed writer.
+        await ConsoleCapture.RunAsync(async () =>
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs));
+            return 0;
+        });
     }
 
     [Fact]


### PR DESCRIPTION
Drives down the **validity docket** (the `--compile-check` anchor) for the ref-typed-local/slot families. On `System.Private.CoreLib` (38,350 methods) this takes methods-with-a-real-compiler-error from **838 → 811 (−27)** with no regressions.

## What

A ref-typed local or stack slot is a managed pointer. CIL `stloc` into one *rebinds the reference* (write-through is `stind`/`StoreIndirect`, a separate node), and C# spells that with `= ref`. The printer was rendering these as plain value assignments and bare declarations, producing invalid C#.

1. **`= ref` for ref-local/slot stores** — a `StoreLocal`/`StoreStackSlot` whose declared type is `ByRef` now renders `= ref <place>` (via `Deref`) on both the declaration and any later rebind. Clears **CS8172 23→2**.
2. **Null-ref init for up-front ref declarations** — a ref local/slot declared before its defining store can't be bare (CS8174). IL `localsinit` zero-initializes a managed pointer to a *null reference*, whose faithful C# is `ref T V = ref Unsafe.NullRef<T>();`. Fully qualified so the per-member view compiles standalone; the whole-type hoister shortens it and adds the `using`. Clears **CS8174 114→0** and the residual **CS0165 4→0**.
3. **Ref ternary** — `Deref` of a ByRef-typed conditional binds `ref` to each arm (`cond ? ref a : ref b`) when both arms are references, instead of the invalid `= ref (cond ? a : b)` (CS8173). Fixes genuine ref-ternaries (e.g. `BigInteger.Add`, `IndexOfAnyCore`).

## Notes

- The CS8173 aggregate is largely unchanged because that compile-checked population is dominated by harder shapes (ref-arg passing CS1620, constrained generic methods) that entangle the ref site; this PR removes the pure-ternary contribution and 5 parse failures.
- **Known limitation** (documented in a code comment): an *asymmetric* ByRef conditional (one reference arm, one value arm) has no valid `= ref` spelling — it is an inexpressible upstream merge produced only by `FoldSlotDiamond` and not seen in non-synthetic IL. The right fix is upstream typing, not the printer.
- Includes a **test-isolation fix**: the printer change shifted `dotnet-inspect.Tests` parallel timing, surfacing the documented process-global `Console.SetError` race in two `MemberOptionsParserTests` rejection tests. They now run under `ConsoleCapture` so the product's legitimate `Console.Error` write lands on a live writer.

## Testing

- `ILInspector.Decompiler.Tests`: 398 pass (4 new synthetic tests for the ref-local/slot/ternary rendering).
- `dotnet-inspect.Tests`: 1104 pass (verified green 3× for determinism after the isolation fix).
- Reviewed adversarially; core soundness (ByRef `stloc` always rebinds; `NullRef` faithful; `ElementType` is a hard invariant) confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)