### PR TITLE
Recover enum identity at returns, bitwise ops, and unnamed values

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -402,6 +402,15 @@ public class CfgSampleClass
     // member-map key must reinterpret the uint the same way to name it.
     public static void CallWithTopFlag() => TakesFlags(CfgFlags.Top);
 
+    // Returns an enum the method never loads as a value other than the literal:
+    // the enum is reached only through the return-type signature, so it resolves
+    // (and the ldc.i4.2 names CfgPriority.High) only when the signature is seeded.
+    public static CfgPriority ReturnsHighPriority() => CfgPriority.High;
+
+    // Bitwise mask of an enum: the ldc.i4.2 operand beside the enum value must
+    // retype to CfgPriority, otherwise `p & 2` is CS0019 (enum & int).
+    public static CfgPriority MaskHighPriority(CfgPriority p) => p & CfgPriority.High;
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2030,7 +2030,8 @@ public class TypeShapeTruthinessTests
 /// <summary>
 /// Enum-constant naming: an integer flowing into an enum position retypes to
 /// the enum and prints as EnumType.Member from the resolved same-assembly
-/// member map. Exact matches only; composite/unnamed values stay raw.
+/// member map. A value with no single member casts to the enum rather than
+/// rendering a bare int (which would be CS0266).
 /// </summary>
 public class EnumConstantTests
 {
@@ -2061,7 +2062,7 @@ public class EnumConstantTests
     }
 
     [Fact]
-    public void ExactMember_Names_UnmatchedValue_StaysRaw()
+    public void ExactMember_Names_UnmatchedValue_Casts()
     {
         var enumType = TypeRef.Definition("asm", "NS", "Color");
         var members = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
@@ -2071,16 +2072,46 @@ public class EnumConstantTests
 
         Assert.Equal("Color.Red", PrintEnumConstant(1, enumType, members));
         Assert.Equal("Color.Green", PrintEnumConstant(2, enumType, members));
-        // 3 names no member (would be a composite/cast) — raw, never guessed.
-        Assert.Equal("3", PrintEnumConstant(3, enumType, members));
+        // 3 names no member (a composite flag value); a bare int would be CS0266,
+        // so it casts. Naming flag combinations is a later slice.
+        Assert.Equal("(Color)3", PrintEnumConstant(3, enumType, members));
+        // A negative high-bit value must be parenthesized after the cast (CS0075).
+        Assert.Equal("(Color)(-2147483648)", PrintEnumConstant(int.MinValue, enumType, members));
     }
 
     [Fact]
-    public void EnumWithNoResolvedMembers_StaysRaw()
+    public void EnumWithNoResolvedMembers_Casts()
     {
-        // A cross-assembly enum is absent from the map → raw integer.
+        // A cross-assembly enum absent from the member map still casts (the
+        // value can't be named, but a bare int into the enum is CS0266).
         var enumType = TypeRef.Definition("other", "NS", "Mystery");
-        Assert.Equal("5", PrintEnumConstant(5, enumType, new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()));
+        Assert.Equal("(Mystery)5", PrintEnumConstant(5, enumType, new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()));
+    }
+
+    [Fact]
+    public void EnumReturn_NamesMember_FromSeededSignature()
+    {
+        // The enum is reached only via the return-type signature; the constant
+        // names CfgPriority.High only because ResolveTypeInfo seeds it.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReturnsHighPriority), source);
+
+        Assert.Contains("return CfgPriority.High;", output);
+        Assert.DoesNotContain("return 2;", output);
+    }
+
+    [Fact]
+    public void EnumBitwiseOperand_NamesMember()
+    {
+        // p & CfgPriority.High — the ldc.i4.2 beside the enum retypes, so the
+        // mask is not the CS0019 `p & 2`.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.MaskHighPriority), source);
+
+        Assert.Contains("CfgPriority.High", output);
+        Assert.DoesNotContain("& 2", output);
     }
 
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
@@ -2093,6 +2124,9 @@ public class EnumConstantTests
         var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container)
         {
             EnumMembers = members,
+            // The real pipeline only gives a constant an enum type when that
+            // type resolved as an enum shape; mirror that so the cast path fires.
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
         };
         // Strip the leading "return " and trailing ";" to get the operand text.
         string output = CSharpPrinter.Print(function).Output!.Trim();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -472,6 +472,12 @@ public sealed class CSharpPrinter
         LoadLocal l => $"V_{l.Index}",
         LoadStackSlot s => $"S_{s.Slot}",
         Constant { Value: int } c when EnumMemberName(c) is { } named => named,
+        // A retyped enum constant with no single named member (a composite flag
+        // value, or one outside the resolved member map) is still that enum — a
+        // bare int is CS0266. Cast it; naming flag combinations is a later slice.
+        // A negative value must be parenthesized after the cast (else CS0075).
+        Constant { Value: int value, Type: { } enumType } when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
+            => $"({TypeText(enumType)}){(value < 0 ? $"({value})" : value.ToString(CultureInfo.InvariantCulture))}",
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -241,6 +241,14 @@ public static class IrImporter
                 Consider(expression.ResultType);
         }
 
+        // The signature's own types are not reached by any node's result type —
+        // a method returning an enum it never loads (return TypeCode.Decimal as
+        // ldc.i4 15) leaves the enum unresolved, so its constant stays a bare
+        // int. Seed return and parameter types directly.
+        Consider(function.Signature.ReturnType);
+        foreach (var parameter in function.Signature.Parameters)
+            Consider(parameter.Type);
+
         if (shapes.Count > 0)
             function.TypeShapes = shapes;
         if (enums is not null)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -48,9 +48,24 @@ public sealed class TypedConstantsPass : IIrPass
                 case StoreIndirect { Value: Constant constant, Type: { } indirectType }:
                     Retype(constant, indirectType, shapes);
                     break;
+                // `flags & 16` is `BindingFlags & int` — CS0019. The bitwise
+                // operators are the enum-flag idiom; an int constant beside an
+                // enum operand carries that enum's identity, so retype it (the
+                // printer then names the member or casts).
+                case Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary:
+                    if (EnumOperandType(binary.Left, shapes) is { } leftEnum && binary.Right is Constant rightConst)
+                        Retype(rightConst, leftEnum, shapes);
+                    else if (EnumOperandType(binary.Right, shapes) is { } rightEnum && binary.Left is Constant leftConst)
+                        Retype(leftConst, rightEnum, shapes);
+                    break;
             }
         }
     }
+
+    static TypeRef? EnumOperandType(IrExpression operand, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => operand is not Constant && operand.ResultType is { } type && shapes.GetValueOrDefault(type) == TypeShape.Enum
+            ? type
+            : null;
 
     static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
     {


### PR DESCRIPTION
Next step in the **validity docket** (`--compile-check`): the enum-flag idiom was rendering as raw integers — invalid C# — in three positions. On `System.Private.CoreLib` (38,350 methods) this takes methods-with-a-real-compiler-error **811 → 774 (−37)**, with **CS0019 238→87** and **CS0266 301→272**.

## What

IL has no enum types on the evaluation stack — everything is `ldc.i4`. Recovering the enum is *raising*, not guessing: the cast is bit-identical, so the value is preserved exactly.

1. **Enum returns** — `ResolveTypeInfo` only reached types through node result types, so a method returning an enum it never loads as a value (e.g. `Decimal.GetTypeCode`'s `ldc.i4.15; ret`) left the enum unresolved and the constant a bare int. Now seeds the signature's return and parameter types → `return TypeCode.Decimal;`.
2. **Bitwise operands** — a `&`/`|`/`^` beside an enum operand is the flag idiom, but the int constant kept its int type (`bindingFlags & 16` = CS0019). `TypedConstantsPass` now retypes the constant operand to the sibling's enum type → `bindingFlags & BindingFlags.Public`. (Only fires when the *non-constant* sibling resolves as an enum.)
3. **Unnamed values** — a retyped enum constant with no single named member (a composite flag value) fell through to a bare int (CS0266). The printer now casts it → `(Color)3`, parenthesizing negatives so a high-bit value (`int.MinValue`) doesn't hit CS0075.

## Soundness

Every retype preserves the value (an enum cast is bit-identical to the underlying int), so this is faithful. Long/byte/ulong-backed enums are unaffected: `Retype` only acts on `int`-valued constants. Bitwise retyping excludes `Constant` siblings, so it never retypes the wrong operand or double-handles. Verified no regressions across the full histogram (CS0075 stays at its pre-existing 3; nothing increased).

> Note: the usual adversarial agent review was unavailable this run (transient API 529s); I performed a manual soundness review covering operand-retyping faithfulness, non-int-backed enums, signature-seeding scope, and negative-value formatting.

## Testing

- `ILInspector.Decompiler.Tests`: 400 pass (4 new/updated enum tests: seeded-signature return, bitwise operand, composite cast, negative parenthesization).
- `dotnet-inspect.Tests`: 1104 pass (verified 2×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)