### PR TITLE
Insert explicit numeric casts at typed boundaries (CS0266)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -719,6 +719,73 @@ public class CSharpPrinterTests
     }
 
     [Fact]
+    public void NumericBoundary_SameFamilySignChange_Casts()
+    {
+        // A uint value returned from an int-returning method needs (int): same
+        // 4-byte stack family, but not implicitly convertible (CS0266).
+        Assert.Equal("return (int)a;",
+            ReturnOf("UInt32", "Int32"));
+        // long into ulong return — same I8 family, sign change.
+        Assert.Equal("return (ulong)a;",
+            ReturnOf("Int64", "UInt64"));
+    }
+
+    [Fact]
+    public void NumericBoundary_ImplicitWidening_NoCast()
+    {
+        // byte → int and ushort → int are implicit C# conversions; no cast.
+        Assert.Equal("return a;", ReturnOf("Byte", "Int32"));
+        Assert.Equal("return a;", ReturnOf("UInt16", "Int32"));
+    }
+
+    [Fact]
+    public void NumericBoundary_StoreNarrowsToSlotType_Casts()
+    {
+        // A ushort value stored into a char local — both 2-byte, ushort→char is
+        // not implicit, so the declaring store casts to the slot type.
+        var arg = new LoadArgument(0, "a", TypeRef.CoreLib("System", "UInt16"));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreLocal(0, TypeRef.CoreLib("System", "Char"), arg));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("a", TypeRef.CoreLib("System", "UInt16"))], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [TypeRef.CoreLib("System", "Char")], container);
+
+        Assert.Contains("char V_0 = (char)a;", CSharpPrinter.Print(function).Output!);
+    }
+
+    [Fact]
+    public void NumericBoundary_Constant_NotCast()
+    {
+        // A constant is left uncast: C# converts an in-range constant to the
+        // target type implicitly, and casting an out-of-range one (negative into
+        // unsigned) would be CS0221 — neither wants an inserted (T).
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new Constant(-1, TypeRef.CoreLib("System", "Int32"))));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "UInt32"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return -1;", CSharpPrinter.Print(function).Output!.Trim());
+    }
+
+    static string ReturnOf(string sourceType, string returnType)
+    {
+        var arg = new LoadArgument(0, "a", TypeRef.CoreLib("System", sourceType));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(arg));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", returnType),
+            [new Parameter("a", TypeRef.CoreLib("System", sourceType))], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    [Fact]
     public void Constructor_ImplicitBaseCall_IsSuppressed()
     {
         // A no-argument base-constructor call is implicit in C#; only the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -423,9 +423,9 @@ public sealed class CSharpPrinter
             ? $"{TypeText(s.Type)} V_{s.Index} = ref {Deref(s.Value)};"
             : $"V_{s.Index} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
-            ? $"{TypeText(s.Type)} V_{s.Index} = {Expression(s.Value)};"
-            : AssignmentText($"V_{s.Index}", s.Value, left => left is LoadLocal load && load.Index == s.Index),
-        StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index),
+            ? $"{TypeText(s.Type)} V_{s.Index} = {CastValue(s.Value, s.Type)};"
+            : AssignmentText($"V_{s.Index}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
+        StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
         StoreStackSlot { Value.ResultType.Kind: TypeRefKind.ByRef } s => _declaringStores.Contains(s)
@@ -439,10 +439,11 @@ public sealed class CSharpPrinter
             left => left is LoadField load
                 && load.Field.Name == s.Field.Name
                 && Equals(load.Field.DeclaringType, s.Field.DeclaringType)
-                && SamePlace(load.Instance, s.Instance)),
+                && SamePlace(load.Instance, s.Instance),
+            s.Field.Type),
         StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual)} = {Expression(s.Value)};",
-        StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {Expression(s.Value)};",
-        StoreIndirect s => $"{Deref(s.Address)} = {Expression(s.Value)};",
+        StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
+        StoreIndirect s => $"{Deref(s.Address)} = {CastValue(s.Value, s.Type)};",
         // default-initialization of a named place spells through the place,
         // not its address.
         InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
@@ -451,7 +452,7 @@ public sealed class CSharpPrinter
         InitObject { Address: LoadArgumentAddress argument } => $"{argument.Name} = default;",
         InitObject { Address: LoadFieldAddress field } o2 => $"{FieldTarget(field.Field, field.Instance)} = default;",
         InitObject o => $"{Deref(o.Address)} = default({TypeText(o.Type)});",
-        Return { Value: { } value } => $"return {Expression(value)};",
+        Return { Value: { } value } => $"return {CastValue(value, _function.Signature.ReturnType)};",
         Return => "return;",
         // The rethrow: the raw caught value thrown back is C#'s bare throw.
         Throw { Value: CaughtException } => "throw;",
@@ -704,16 +705,58 @@ public sealed class CSharpPrinter
     /// an unchecked binary whose left operand reads the assignment target,
     /// the runtime style is x++/x-- for ±1 and x op= rest otherwise.
     /// </summary>
-    string AssignmentText(string target, IrExpression value, Func<IrExpression, bool> readsTarget)
+    string AssignmentText(string target, IrExpression value, Func<IrExpression, bool> readsTarget, TypeRef? targetType = null)
     {
         if (value is Binary { IsChecked: false } binary && readsTarget(binary.Left))
         {
+            // A compound assignment only forms when the value reads the target
+            // in same-type arithmetic, so the result already matches the target
+            // — no conversion is involved on this path.
             if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
                 return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
             return $"{target} {BinaryOperator(binary)}= {Operand(binary.Right)};";
         }
-        return $"{target} = {Expression(value)};";
+        return $"{target} = {CastValue(value, targetType)};";
     }
+
+    /// <summary>
+    /// Renders <paramref name="value"/> for a position typed <paramref name="target"/>,
+    /// inserting the explicit numeric cast C# requires when the value's type
+    /// would not implicitly convert (the missing-cast case behind CS0266). The
+    /// cast reinterprets bits the evaluation stack already carries (same family),
+    /// so it is faithful to the IL — see <see cref="TypeFamilies.NeedsNumericCast"/>.
+    /// </summary>
+    string CastValue(IrExpression value, TypeRef? target)
+    {
+        // Cast only off a value whose rendered C# type reliably equals its IR
+        // result type. A merge node (ternary/coalesce) reports a merged type the
+        // arms may not actually share, and a stack slot's type is the join of
+        // every store — both diverge from the rendered type in slot-confused or
+        // generic bodies, where a keyed cast would be illegal (CS0030). A
+        // constant needs no cast: C# already converts an in-range constant to a
+        // narrower/other numeric type implicitly, and an out-of-range one
+        // (a negative into unsigned) is CS0221 a cast cannot fix — that wants
+        // the value re-spelled in the target type, a separate slice. All such
+        // bodies do not compile worse than before; leave them to render as-is.
+        if (value is Conditional or Coalesce or LoadStackSlot or Constant)
+            return Expression(value);
+        if (!TypeFamilies.NeedsNumericCast(EffectiveType(value), target))
+            return Expression(value);
+        return $"({TypeText(target!)}){Operand(value)}";
+    }
+
+    /// <summary>
+    /// The C# type the rendered expression actually has. For an unsigned
+    /// div/rem/shr the printer casts the operands to their unsigned type, so the
+    /// rendered result is unsigned even though the node's ECMA binary-promotion
+    /// ResultType keeps the signed operand type; reflect that so a boundary into
+    /// the matching unsigned type does not redundantly re-cast.
+    /// </summary>
+    static TypeRef? EffectiveType(IrExpression value)
+        => value is Binary { IsUnsigned: true, Kind: BinaryKind.Divide or BinaryKind.Remainder or BinaryKind.ShiftRight }
+            && TypeFamilies.UnsignedCounterpart(value.ResultType) is { } unsigned
+            ? unsigned
+            : value.ResultType;
 
     /// <summary>Structural same-place check for compound-assignment receivers; conservative (this/locals/arguments/static only).</summary>
     static bool SamePlace(IrExpression? a, IrExpression? b) => (a, b) switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -81,6 +81,58 @@ public static class TypeFamilies
     };
 
     /// <summary>
+    /// True when a value of <paramref name="source"/> needs an explicit C# cast
+    /// to flow into a <paramref name="target"/> position — the missing-cast case
+    /// behind CS0266. Restricted to numeric primitives of the SAME stack family
+    /// (int↔uint, ushort↔char, long↔ulong, nint↔nuint, int→byte, …): there the
+    /// cast is a pure reinterpretation of bits the evaluation stack already
+    /// carries, so it is faithful to the IL, never a value change. Cross-family
+    /// narrowing (long→int) is excluded — that always carries an explicit IL
+    /// <c>conv</c> already, so it never reaches here as a bare mismatch. Boolean
+    /// is excluded: it shares the I4 family but `(int)b` is not even legal C#.
+    /// </summary>
+    public static bool NeedsNumericCast(TypeRef? source, TypeRef? target)
+    {
+        if (source is null || target is null || source.Equals(target))
+            return false;
+        if (IsBoolean(source) || IsBoolean(target) || !IsNumericPrimitive(source) || !IsNumericPrimitive(target))
+            return false;
+        var family = Of(source);
+        if (family is null || family != Of(target))
+            return false;   // same stack family only — guarantees a faithful reinterpretation
+        return !IsImplicitlyConvertible(source.Name, target.Name);
+    }
+
+    static bool IsBoolean(TypeRef type)
+        => type is { Name: "Boolean", Assembly: TypeRef.CoreLibrary, Namespace: "System" };
+
+    static bool IsNumericPrimitive(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && type.Name is "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
+                or "Int64" or "UInt64" or "IntPtr" or "UIntPtr" or "Char" or "Single" or "Double";
+
+    /// <summary>C#'s implicit numeric conversions within a stack family — the widenings that need no cast.</summary>
+    static bool IsImplicitlyConvertible(string source, string target) => (source, target) switch
+    {
+        ("SByte", "Int16" or "Int32") => true,
+        ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32") => true,
+        ("Int16", "Int32") => true,
+        ("UInt16", "Int32" or "UInt32") => true,
+        ("Char", "UInt16" or "Int32" or "UInt32") => true,
+        ("Single", "Double") => true,
+        _ => false,
+    };
+
+    /// <summary>The unsigned-counterpart TypeRef of a signed integer type; null when already unsigned, float, or unknown.</summary>
+    public static TypeRef? UnsignedCounterpart(TypeRef? type) => UnsignedCastKeyword(type) switch
+    {
+        "uint" => TypeRef.CoreLib("System", "UInt32"),
+        "ulong" => TypeRef.CoreLib("System", "UInt64"),
+        "nuint" => TypeRef.CoreLib("System", "UIntPtr"),
+        _ => null,
+    };
+
+    /// <summary>
     /// The C# cast keyword that reinterprets a signed-integer type as its
     /// unsigned counterpart; null when the type is already unsigned, float
     /// (.un means unordered there), or unknown.


### PR DESCRIPTION
Continues the conversion docket (`--compile-check`): the integer width/sign family. On `System.Private.CoreLib` (38,350 methods) this takes **CS0266 272 → 229** and methods-with-a-real-compiler-error **734 → 706**, with no diagnostic code regressing.

## What

IL's evaluation stack is type-blind — a `uint` flows where an `int` is expected, a `ushort` into a `char` slot — with no `conv` opcode because the bits already sit in the right-sized stack slot. C# requires an explicit cast, so the printer was emitting non-compiling code (CS0266).

At each typed boundary — `return`, store-to-local/field/element/indirect — the printer now inserts `(T)` when the value's type and the target are numeric primitives of the **same stack family** that C# would not implicitly convert (`int↔uint`, `ushort↔char`, `long↔ulong`, `nint↔nuint`, `int→byte`, …). In the default unchecked context, `(byte)`/`(short)`/`(float)` truncate or round exactly as the IL store to that width does, so the cast is **faithful** — never a value change.

## Faithfulness guards

Casts fire only off a value whose rendered C# type reliably equals its IR result type:
- **Boolean** excluded (shares the I4 family, but `(int)b` isn't legal C#).
- **Unsigned div/rem/shr** already renders its operands cast to unsigned, so its effective type is unsigned despite ECMA promotion keeping the signed operand type — no redundant re-cast.
- **Merge nodes** (ternary/coalesce) and **stack slots** report a joined type the rendered expression may not share (slot-confused or generic bodies, which don't compile regardless) — left as-is.
- **Constants** left as-is: C# converts an in-range constant implicitly, and casting an out-of-range one (a negative into unsigned) is CS0221 a cast can't fix — re-spelling the value in the target type is a later slice.

## No regression — by construction

If a method compiled without a cast, every boundary was already implicitly convertible, so `NeedsNumericCast` never fires and nothing is inserted. **No valid method can be made invalid**, and the casts are bit-faithful, so there is no silent-wrong risk.

## Review

Adversarially reviewed. The review confirmed no silent semantic divergence and no valid→broken regression, and caught an earlier iteration that cast negative constants into `(uint)(-1)` (CS0221) with a test asserting that non-compiling output — fixed by excluding constants here (the realization that C# already handles in-range constant conversion implicitly).

## Testing

- `ILInspector.Decompiler.Tests`: 404 pass (new tests: same-family sign change casts, implicit-widening no-cast, store-to-slot-type cast, constant-not-cast).
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)