### PR TITLE
Retarget same-width conversions and reinterpret out-of-range constants

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -757,19 +757,51 @@ public class CSharpPrinterTests
     }
 
     [Fact]
-    public void NumericBoundary_Constant_NotCast()
+    public void NumericBoundary_InRangeConstant_RendersBare()
     {
-        // A constant is left uncast: C# converts an in-range constant to the
-        // target type implicitly, and casting an out-of-range one (negative into
-        // unsigned) would be CS0221 — neither wants an inserted (T).
+        // 5 is in uint's range, so C#'s constant-expression conversion applies —
+        // no cast needed.
+        Assert.Equal("return 5;", ReturnConstant(5, "Int32", "UInt32"));
+    }
+
+    [Fact]
+    public void NumericBoundary_OutOfRangeConstant_UncheckedCast()
+    {
+        // -1 is out of uint's range (uint.MaxValue's ldc.i4.m1); a bare literal
+        // is CS0031, so reinterpret the bits with an unchecked cast.
+        Assert.Equal("return unchecked((uint)(-1));", ReturnConstant(-1, "Int32", "UInt32"));
+    }
+
+    [Fact]
+    public void NumericBoundary_SameWidthConv_SingleCast()
+    {
+        // A conv.u2 (→ ushort) feeding a char slot renders as one (char) cast on
+        // the conversion's operand, not the redundant (char)((ushort)x).
+        var arg = new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32"));
+        var conv = new ILInspector.Decompiler.Pipeline.Convert(TypeRef.CoreLib("System", "UInt16"), isChecked: false, isUnsigned: false, arg);
         var container = new BlockContainer();
         var block = new Block(0);
         container.Add(block);
-        block.Add(new Return(new Constant(-1, TypeRef.CoreLib("System", "Int32"))));
-        var signature = new MethodSignature(TypeRef.CoreLib("System", "UInt32"), [], HasThis: false, GenericParameterCount: 0);
-        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        block.Add(new StoreLocal(0, TypeRef.CoreLib("System", "Char"), conv));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("a", TypeRef.CoreLib("System", "Int32"))], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [TypeRef.CoreLib("System", "Char")], container);
 
-        Assert.Equal("return -1;", CSharpPrinter.Print(function).Output!.Trim());
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("char V_0 = (char)a;", output);
+        Assert.DoesNotContain("(ushort)", output);
+    }
+
+    static string ReturnConstant(int value, string constType, string returnType)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new Constant(value, TypeRef.CoreLib("System", constType))));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", returnType), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
     }
 
     static string ReturnOf(string sourceType, string returnType)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -732,16 +732,29 @@ public sealed class CSharpPrinter
         // result type. A merge node (ternary/coalesce) reports a merged type the
         // arms may not actually share, and a stack slot's type is the join of
         // every store — both diverge from the rendered type in slot-confused or
-        // generic bodies, where a keyed cast would be illegal (CS0030). A
-        // constant needs no cast: C# already converts an in-range constant to a
-        // narrower/other numeric type implicitly, and an out-of-range one
-        // (a negative into unsigned) is CS0221 a cast cannot fix — that wants
-        // the value re-spelled in the target type, a separate slice. All such
-        // bodies do not compile worse than before; leave them to render as-is.
-        if (value is Conditional or Coalesce or LoadStackSlot or Constant)
+        // generic bodies, where a keyed cast would be illegal (CS0030). Leave
+        // those to render as-is.
+        if (value is Conditional or Coalesce or LoadStackSlot)
             return Expression(value);
+        // A constant carries an exact value: C# converts an in-range one to the
+        // target type implicitly (render bare), while an out-of-range one — a
+        // negative into unsigned, a bitmask wider than the target — does not
+        // convert bare and is CS0266/CS0221, so reinterpret its bits with an
+        // unchecked cast (uint.MaxValue's `ldc.i4.m1` → unchecked((uint)(-1))).
+        if (value is Constant { Value: int or long } konst && target is { } t && TypeFamilies.IsNumericPrimitive(t))
+        {
+            long literal = konst.Value is int i ? i : (long)konst.Value!;
+            return TypeFamilies.ConstantFits(literal, t)
+                ? Expression(value)
+                : $"unchecked(({TypeText(t)})({Expression(value)}))";
+        }
         if (!TypeFamilies.NeedsNumericCast(EffectiveType(value), target))
             return Expression(value);
+        // A plain conversion to a same-width sibling (conv.u2 → ushort feeding a
+        // char slot) is subsumed by the boundary cast: emit one cast to the
+        // target on the conversion's operand, not (char)((ushort)x).
+        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && TypeFamilies.SameWidth(conv.Target, target))
+            return $"({TypeText(target!)}){Operand(conv.Operand)}";
         return $"({TypeText(target!)}){Operand(value)}";
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -106,10 +106,49 @@ public static class TypeFamilies
     static bool IsBoolean(TypeRef type)
         => type is { Name: "Boolean", Assembly: TypeRef.CoreLibrary, Namespace: "System" };
 
-    static bool IsNumericPrimitive(TypeRef type)
+    public static bool IsNumericPrimitive(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
             && type.Name is "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
                 or "Int64" or "UInt64" or "IntPtr" or "UIntPtr" or "Char" or "Single" or "Double";
+
+    /// <summary>Byte width of a fixed-width integer primitive; null for the platform-sized (nint/nuint) and float types.</summary>
+    static int? Width(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+        ? type.Name switch
+        {
+            "SByte" or "Byte" => 1,
+            "Int16" or "UInt16" or "Char" => 2,
+            "Int32" or "UInt32" => 4,
+            "Int64" or "UInt64" => 8,
+            _ => null,
+        }
+        : null;
+
+    /// <summary>True when two fixed-width integer primitives occupy the same byte width (ushort/char, int/uint) — a same-width cast subsumes any inner conversion to the sibling.</summary>
+    public static bool SameWidth(TypeRef? a, TypeRef? b) => Width(a) is { } wa && wa == Width(b);
+
+    /// <summary>
+    /// True when an integer constant is in <paramref name="target"/>'s range, so
+    /// C# converts it implicitly (a constant-expression conversion) and no cast
+    /// is needed. A value outside the range — a negative into unsigned, a bitmask
+    /// wider than the target — does not convert bare and needs an unchecked cast.
+    /// </summary>
+    public static bool ConstantFits(long value, TypeRef target) => target switch
+    {
+        { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } => target.Name switch
+        {
+            "SByte" => value is >= sbyte.MinValue and <= sbyte.MaxValue,
+            "Byte" => value is >= byte.MinValue and <= byte.MaxValue,
+            "Int16" => value is >= short.MinValue and <= short.MaxValue,
+            "UInt16" or "Char" => value is >= ushort.MinValue and <= ushort.MaxValue,
+            "Int32" => value is >= int.MinValue and <= int.MaxValue,
+            "UInt32" => value is >= uint.MinValue and <= uint.MaxValue,
+            "Int64" or "IntPtr" => true,
+            "UInt64" or "UIntPtr" => value >= 0,
+            "Single" or "Double" => true,
+            _ => false,
+        },
+        _ => false,
+    };
 
     /// <summary>C#'s implicit numeric conversions within a stack family — the widenings that need no cast.</summary>
     static bool IsImplicitlyConvertible(string source, string target) => (source, target) switch


### PR DESCRIPTION
Two refinements to the numeric-boundary casts (#570), both lifted from how the **old emitter** handles these same integer-typing difficulties (its `PreferredUInt16Type` and `unchecked((ulong)…)` recipes).

## #1 — Same-width conversion retarget (readability)

A plain conversion to a same-width sibling — `conv.u2` (→ `ushort`) feeding a `char` slot — is subsumed by the boundary cast. The printer now emits a single cast to the target on the conversion's operand:

```diff
-V_2 = (char)((ushort)(value | 32));
+V_2 = (char)(value | 32);
```

matching the old emitter's context-aware target choice. The inner conversion and the outer cast truncate to the same width, so dropping the inner one is faithful.

## #2 — Out-of-range constant reinterpretation (validity)

A constant at a numeric boundary now reinterprets when it's out of the target's range. In-range constants still render bare (C#'s constant-expression conversion handles them), but one outside the range — `uint.MaxValue`'s `ldc.i4.m1`, a 64-bit mask into `ulong` — is **CS0031** bare, so it's spelled with an unchecked cast:

```csharp
return unchecked((uint)(-1));   // UInt32.MaxValue
V_1 = unchecked((uint)(-2147483648));   // DecCalc.VarDecFromR4
```

Faithful: the unchecked cast reinterprets exactly the bits the IL constant carries.

## Impact

On `System.Private.CoreLib`: **CS0031 4→2**, and dozens of generic-interface and already-broken bodies (`UInt32.MaxValue`, `DecCalc.VarDecFromR4`, `Number.TryNumberToDecimal`, …) now render valid C# where they printed a bare out-of-range literal. No diagnostic code regresses. The headline metric barely moves because most affected bodies are explicit-interface impls excluded from the compile-check (their names contain `<`) — but the output quality gain is real and matches the prime directive (output a Roslyn/JIT engineer recognizes).

## Testing

- `ILInspector.Decompiler.Tests`: 406 pass (new tests: in-range constant bare, out-of-range unchecked cast, same-width conv single cast).
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)