### PR TITLE
Cast call arguments to their parameter types

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -793,6 +793,45 @@ public class CSharpPrinterTests
         Assert.DoesNotContain("(ushort)", output);
     }
 
+    [Fact]
+    public void CallArgument_NumericMismatch_Casts()
+    {
+        // M(uint) into an int parameter: the argument casts to the parameter
+        // type, the call-site counterpart of the return/store boundary casts.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var callee = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "M",
+            TypeRef.CoreLib("System", "Void"), [intType], HasThis: false);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ExpressionStatement(new Call(callee, isVirtual: false, [new LoadArgument(0, "a", uintType)])));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("a", uintType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("F", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Contains("T.M((int)a);", CSharpPrinter.Print(function).Output!);
+    }
+
+    [Fact]
+    public void ConvertOfOutOfRangeConstant_UsesUnchecked()
+    {
+        // conv.u8 of ldc.i4.m1 (ulong.MaxValue): the plain (ulong)-1 is CS0221,
+        // so the conversion reinterprets the bits with unchecked.
+        var conv = new ILInspector.Decompiler.Pipeline.Convert(
+            TypeRef.CoreLib("System", "UInt64"), isChecked: false, isUnsigned: false,
+            new Constant(-1, TypeRef.CoreLib("System", "Int32")));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(conv));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "UInt64"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return unchecked((ulong)(-1));", CSharpPrinter.Print(function).Output!.Trim());
+    }
+
     static string ReturnConstant(int value, string constType, string returnType)
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -392,7 +392,7 @@ public sealed class CSharpPrinter
         var arguments = call.Arguments.Skip(1).ToList();
         if (!isThis && arguments.Count == 0)
             return null;  // implicit base()
-        return $"{(isThis ? "this" : "base")}({Arguments(arguments)});";
+        return $"{(isThis ? "this" : "base")}({Arguments(arguments, callee.ParameterTypes)});";
     }
 
     /// <summary>Baseline-style clause headers: bare <c>catch</c> for object (the catch-all), the variable form when the entry store folded into the clause.</summary>
@@ -497,7 +497,7 @@ public sealed class CSharpPrinter
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
-        NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments)})",
+        NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
@@ -742,20 +742,32 @@ public sealed class CSharpPrinter
         // convert bare and is CS0266/CS0221, so reinterpret its bits with an
         // unchecked cast (uint.MaxValue's `ldc.i4.m1` → unchecked((uint)(-1))).
         if (value is Constant { Value: int or long } konst && target is { } t && TypeFamilies.IsNumericPrimitive(t))
-        {
-            long literal = konst.Value is int i ? i : (long)konst.Value!;
-            return TypeFamilies.ConstantFits(literal, t)
-                ? Expression(value)
-                : $"unchecked(({TypeText(t)})({Expression(value)}))";
-        }
+            return NumericConstant(konst, t);
         if (!TypeFamilies.NeedsNumericCast(EffectiveType(value), target))
             return Expression(value);
         // A plain conversion to a same-width sibling (conv.u2 → ushort feeding a
         // char slot) is subsumed by the boundary cast: emit one cast to the
-        // target on the conversion's operand, not (char)((ushort)x).
+        // target on the conversion's operand, not (char)((ushort)x). An
+        // out-of-range constant operand still needs the unchecked spelling.
         if (value is Convert { IsChecked: false, IsUnsigned: false } conv && TypeFamilies.SameWidth(conv.Target, target))
-            return $"({TypeText(target!)}){Operand(conv.Operand)}";
+            return conv.Operand is Constant { Value: int or long } convConst
+                ? NumericConstant(convConst, target!)
+                : $"({TypeText(target!)}){Operand(conv.Operand)}";
         return $"({TypeText(target!)}){Operand(value)}";
+    }
+
+    /// <summary>
+    /// An integer constant rendered for a numeric target: bare when in range (C#
+    /// converts it implicitly), reinterpreted with an unchecked cast when out of
+    /// range (a negative into unsigned, a mask wider than the target — CS0031/
+    /// CS0221 as a bare or plain-cast literal).
+    /// </summary>
+    string NumericConstant(Constant konst, TypeRef target)
+    {
+        long literal = konst.Value is int i ? i : (long)konst.Value!;
+        return TypeFamilies.ConstantFits(literal, target)
+            ? Expression(konst)
+            : $"unchecked(({TypeText(target)})({Expression(konst)}))";
     }
 
     /// <summary>
@@ -920,10 +932,10 @@ public sealed class CSharpPrinter
             // operator spelling is the faithful inverse.
             if (call.Callee.IsSpecialName && OperatorSpelling(call) is { } op)
                 return op;
-            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments)})";
+            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes)})";
         }
         var receiver = arguments[0];
-        string rest = Arguments(arguments.Skip(1));
+        string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes);
         if (call.Callee.Name == ".ctor" && receiver is LoadArgument { Index: 0, Name: "this" })
         {
             // A this-receiver constructor call is C#'s base(...)/this(...).
@@ -943,6 +955,25 @@ public sealed class CSharpPrinter
 
     string Arguments(IEnumerable<IrExpression> arguments)
         => string.Join(", ", arguments.Select(Expression));
+
+    /// <summary>
+    /// Arguments paired positionally with the callee's parameter types, casting
+    /// each to its parameter type where C# needs it (CS0266) — the call-site
+    /// counterpart of the return/store boundary casts. Callers pass arguments
+    /// that already align 1:1 with the parameters (the receiver of an instance
+    /// call is dropped first), so index i maps to parameterTypes[i].
+    /// </summary>
+    string Arguments(IEnumerable<IrExpression> arguments, IReadOnlyList<TypeRef> parameterTypes)
+    {
+        var parts = new List<string>();
+        int i = 0;
+        foreach (var argument in arguments)
+        {
+            parts.Add(i < parameterTypes.Count ? CastValue(argument, parameterTypes[i]) : Expression(argument));
+            i++;
+        }
+        return string.Join(", ", parts);
+    }
 
     /// <summary>
     /// <c>target?.Member</c>: the member's receiver child is the target, and the
@@ -979,11 +1010,21 @@ public sealed class CSharpPrinter
         string typeArguments = call.Callee.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
-        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1))})";
+        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes)})";
     }
 
     string ConvertText(Convert convert)
     {
+        // Converting an out-of-range integer constant (conv.u8 of ldc.i4.m1 for
+        // ulong.MaxValue) is CS0221 as a plain cast; reinterpret its bits with
+        // unchecked, matching the constant handling at value boundaries.
+        if (!convert.IsChecked && convert.Operand is Constant { Value: int or long } c
+            && TypeFamilies.IsNumericPrimitive(convert.Target))
+        {
+            long literal = c.Value is int i ? i : (long)c.Value!;
+            if (!TypeFamilies.ConstantFits(literal, convert.Target))
+                return $"unchecked(({TypeText(convert.Target)})({Expression(convert.Operand)}))";
+        }
         // conv.r.un and conv.ovf.*.un interpret the SOURCE as unsigned —
         // a signed operand needs its unsigned cast or the value is wrong.
         string operand = convert.IsUnsigned ? UnsignedOperand(convert.Operand) : Operand(convert.Operand);


### PR DESCRIPTION
Extends the numeric boundary casts (#570, #571) to the **call site** — the natural follow-up on the `CastValue`/`NeedsNumericCast` foundation.

## What

Each call/constructor argument now casts to its parameter type where C# needs it, paired positionally with the callee's `ParameterTypes` (the receiver of an instance call is dropped first, so argument *i* maps to parameter *i*). Covers method calls, constructors (`NewObject`), and `base`/`this` chains.

```csharp
// before → after
M(uintValue)                      → M((int)uintValue)
new PowerOvfl(429496729, -1717986919, …)  → new PowerOvfl(429496729, unchecked((uint)(-1717986919)), …)
```

## On the metric

An argument type mismatch surfaces as **CS1503**, which `--compile-check` filters as a shell artifact (the shell can't always resolve the real overload), so this does **not** move the tracked CS0266 count. But the product output now compiles where `M(uintValue)` into an `int` parameter was a real CS1503 — a genuine output-quality gain the metric can't see. (Worth recording so the docket isn't misread: the CS0266 residual was *not* call-args, as I'd guessed — it's CS1503-filtered.)

## Constant fixes it surfaced

Folding constants into the call site exposed two places where an out-of-range integer constant rendered as a plain cast (**CS0221**), now both routed through a shared `NumericConstant` helper:
- A conversion node of an out-of-range constant (`conv.u8` of `ldc.i4.m1` for `ulong.MaxValue`) → `ConvertText` spells it `unchecked`.
- A same-width conversion retarget whose operand is an out-of-range constant (a `long -1` feeding a `ulong` parameter, `GetValueOrDefault(unchecked((ulong)(-1)))`).

**CS0221 5→1, methods-with-a-real-error 706→705**, no code regresses.

## Testing

- `ILInspector.Decompiler.Tests`: 408 pass (new: call-argument cast, out-of-range-constant conversion).
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)