### PR TITLE
Recover auto-properties from backing-field access

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -794,6 +794,30 @@ public class CSharpPrinterTests
     }
 
     [Fact]
+    public void BackingField_RendersAsProperty()
+    {
+        // An auto-property backing field <Count>k__BackingField has no spellable
+        // C# name; a store/load on `this` renders as this.Count (the property),
+        // which also disambiguates a constructor parameter that shadows it.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var declType = TypeRef.CoreLib("Synthetic", "T");
+        var backing = new FieldRef(declType, "<Count>k__BackingField", intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreField(backing, new LoadArgument(0, "this", declType), new LoadArgument(1, "Count", intType)));
+        block.Add(new Return(new LoadField(backing, new LoadArgument(0, "this", declType))));
+        var signature = new MethodSignature(intType,
+            [new Parameter("Count", intType)], HasThis: true, GenericParameterCount: 0);
+        var function = new IrFunction("M", declType, signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("this.Count = Count;", output);
+        Assert.Contains("return this.Count;", output);
+        Assert.DoesNotContain("k__BackingField", output);
+    }
+
+    [Fact]
     public void CallArgument_NumericMismatch_Casts()
     {
         // M(uint) into an int parameter: the argument casts to the parameter

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -826,12 +826,35 @@ public sealed class CSharpPrinter
         return null;
     }
 
-    string FieldTarget(FieldRef field, IrExpression? instance) => instance switch
+    string FieldTarget(FieldRef field, IrExpression? instance)
     {
-        null => $"{TypeText(field.DeclaringType)}.{field.Name}",
-        LoadArgument { Index: 0, Name: "this" } => field.Name,
-        _ => $"{ReceiverText(instance)}.{field.Name}",
-    };
+        // An auto-property backing field, <Prop>k__BackingField, has no spellable
+        // C# name; render it as the property it backs. `this.` qualifies the
+        // instance form so a constructor assignment whose parameter shadows the
+        // property still binds to it (and is legal even for a get-only property).
+        if (BackingFieldProperty(field.Name) is { } property)
+            return instance switch
+            {
+                null => $"{TypeText(field.DeclaringType)}.{property}",
+                LoadArgument { Index: 0, Name: "this" } => $"this.{property}",
+                _ => $"{ReceiverText(instance)}.{property}",
+            };
+        return instance switch
+        {
+            null => $"{TypeText(field.DeclaringType)}.{field.Name}",
+            LoadArgument { Index: 0, Name: "this" } => field.Name,
+            _ => $"{ReceiverText(instance)}.{field.Name}",
+        };
+    }
+
+    /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>
+    static string? BackingFieldProperty(string fieldName)
+    {
+        const string suffix = ">k__BackingField";
+        return fieldName.Length > suffix.Length + 1 && fieldName[0] == '<' && fieldName.EndsWith(suffix, StringComparison.Ordinal)
+            ? fieldName[1..^suffix.Length]
+            : null;
+    }
 
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -389,6 +389,12 @@ public static class TypeSourceComposer
         sb.AppendLine("    }");
     }
 
+    /// <summary>An accessor that just passes through the auto-property backing field — `return this.Name;` or `this.Name = value;`.</summary>
+    static bool IsTrivialAutoAccessor(string keyword, string? body, string name)
+        => keyword == "get"
+            ? body?.Trim() == $"return this.{name};"
+            : body?.Trim() == $"this.{name} = value;";
+
     static void ComposeProperty(
         StringBuilder sb, Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member,
         SortedSet<string> bodyNamespaces)
@@ -422,6 +428,16 @@ public static class TypeSourceComposer
         if (accessors.Count == 0 || member.IsAbstract || accessors.All(a => a.Body is null))
         {
             sb.AppendLine($"    {signature}");
+            return;
+        }
+
+        // Auto-property: every accessor is the compiler's trivial backing-field
+        // passthrough (the body printer de-mangled <Name>k__BackingField to
+        // this.Name). Render `{ get; set; }` with no bodies — decompiling them
+        // would recurse (a getter that returns the property itself).
+        if (accessors.All(a => IsTrivialAutoAccessor(a.Keyword, a.Body, member.Name)))
+        {
+            sb.AppendLine($"    {head} {{ {string.Join(" ", accessors.Select(a => $"{a.Keyword};"))} }}");
             return;
         }
 


### PR DESCRIPTION
First fix driven by the **compile→decompile→compile round-trip** (see context below). An auto-property compiles to a `<Name>k__BackingField` field plus trivial accessors; the body printer was rendering every access with the raw metadata name — `<Id>k__BackingField = Id;` — which isn't a spellable C# identifier (CS1525), the single biggest blocker to recompiling a decompiled type.

## What

Render backing-field access as the property it backs:
- store/load on `this` → `this.Name` (the `this.` disambiguates a constructor parameter that shadows the property, and is legal even for a get-only auto-property)
- static → `Type.Name`; load through another receiver → `receiver.Name`

The composer then recognizes the now-trivial `this.Name` accessor bodies and renders the property as `{ get; set; }` with **no** bodies — decompiling them would recurse into a getter that returns the property itself.

```csharp
// DecompilerDiagnostic, before → after
<Id>k__BackingField = Id;                          this.Id = Id;
return EqualityComparer<string>.Default            return EqualityComparer<string>.Default
  .GetHashCode(<Id>k__BackingField) ...              .GetHashCode(this.Id) ...
// property now: public string Id { get; }
```

## Round-trip context

I prototyped a per-type **compile→decompile→compile** validity check (compile a fixture, decompile each type whole, recompile against the original assembly for its dependencies). On our **own** `ILInspector.Decompiler.dll`: this fix takes the clean-round-trip count from **30→37 of 159 types**. Backing fields were the top blocker but not the only one — the round-trip surfaces a whole-type-composer docket (abstract/interface member signatures CS0534/CS0549, residual generic-name CS1525, dropped custom attributes) invisible to the per-method `--compile-check`. Those are follow-ups.

## Testing

- `ILInspector.Decompiler.Tests`: 409 pass (new `BackingField_RendersAsProperty`).
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)