### PR TITLE
Make pointer package TFM-agnostic (tools/any/any)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,12 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Pack pointer package
-        run: dotnet pack src/dotnet-inspect -c Release -p:OfficialBuild=true
+        # SelfContained=true forces the pack TFM segment to 'any', so the pointer
+        # manifest lands at tools/any/any/DotnetToolSettings.xml instead of
+        # tools/netX.0/any/. This makes the pointer TFM-agnostic: any SDK that
+        # understands RID-specific tools can read it, regardless of TFM. The
+        # pointer carries no implementation, so SelfContained pulls in no runtime.
+        run: dotnet pack src/dotnet-inspect -c Release -p:SelfContained=true -p:OfficialBuild=true
 
       - name: Upload pointer package
         uses: actions/upload-artifact@v7

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.10.7</VersionPrefix>
+    <VersionPrefix>0.11.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## What

Pack the pointer package with `-p:SelfContained=true` so its manifest lands at `tools/any/any/DotnetToolSettings.xml` instead of `tools/netX.0/any/`.

## Why

The pointer package is currently TFM-gated: its `DotnetToolSettings.xml` sits under `tools/{tfm}/any/`, where `{tfm}` is the build SDK's target framework (e.g. `net11.0`). An SDK older than that TFM can't read the pointer at all and fails with the misleading:

```
The settings file in the tool's NuGet package is invalid:
Settings file 'DotnetToolSettings.xml' was not found in the package.
```

`SelfContained=true` flips the pack TFM segment to `any` (via `_ToolPackShortTargetFrameworkName` in `Microsoft.NET.PackTool.targets`), making the pointer **TFM-agnostic** — any SDK that understands RID-specific tools can read it regardless of its own TFM.

## Details

- The pointer carries no implementation, so `SelfContained` pulls in **no runtime** — the package stays manifest-only.
- The full `RuntimeIdentifierPackages` list (win-x64/win-arm64/linux-x64/linux-arm64/osx-arm64 + `any`) is preserved.
- The `any` fallback package is already packed at `net10.0`, so the chain is broadly compatible after this change.

## Verification

Built locally and confirmed the manifest moved from `tools/net11.0/any/` to `tools/any/any/` with the RID list intact. Install-tested both shapes against a **.NET 10 SDK**:

| Pointer | `any` package | .NET 10 SDK |
|---|---|---|
| `tools/any/any/` | `tools/net10.0/any/` | ✅ installs |
| `tools/any/any/` | `tools/net11.0/any/` | ❌ fails (leaf TFM gate) |

The first row is this PR's shape. (The second row shows the remaining gate is the *leaf* package's TFM, which is why the `any` fallback is pinned to `net10.0`.
EOF
)