### PR TITLE
Emit custom attributes on methods and properties

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DecompilerResultTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerResultTests.cs
@@ -163,6 +163,23 @@ public class TypeSourceComposerTests
         Assert.Contains("[Flags]", listing);
         Assert.Contains("enum AttributeTargets", listing);
     }
+
+    [Fact]
+    public void Compose_Method_EmitsAttribute()
+    {
+        // Buffer.MemoryCopy carries [CLSCompliant(false)]; the method-level
+        // attribute renders above the signature with its bool argument.
+        string dll = typeof(object).Assembly.Location;
+        Metadata.ApiType type;
+        using (var stream = File.OpenRead(dll))
+        using (var peReader = new PEReader(stream))
+            type = Metadata.ApiSurfaceExtractor.Extract(peReader).Types.Single(t => t.FullName == "System.Buffer");
+
+        string? listing = TypeSourceComposer.Compose(type, dll, pdbPath: null);
+
+        Assert.NotNull(listing);
+        Assert.Contains("[CLSCompliant(false)]", listing);
+    }
 }
 
 public class MethodAnalysisTests : IDisposable

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -90,7 +90,7 @@ public static class TypeSourceComposer
             else
             {
                 ComposeFields(sb, reader, typeHandle, bodyNamespaces, ref any);
-                ComposeMembers(sb, type, pipelineSource, bodyNamespaces, ref any);
+                ComposeMembers(sb, type, pipelineSource, reader, typeHandle, bodyNamespaces, ref any);
             }
 
             sb.AppendLine("}");
@@ -218,6 +218,7 @@ public static class TypeSourceComposer
 
     static void ComposeMembers(
         StringBuilder sb, ApiType type, Pipeline.MetadataSource pipelineSource,
+        MetadataReader reader, TypeDefinitionHandle typeHandle,
         SortedSet<string> bodyNamespaces, ref bool any)
     {
         // Per-name running overload index — the same positional pairing the
@@ -244,6 +245,11 @@ public static class TypeSourceComposer
                     if (!first) sb.AppendLine();
                     first = false;
                     any = true;
+
+                    bool publicOnly = member.Kind != "explicit-interface-implementation";
+                    foreach (var attribute in AttributeReader.RenderMethodAttributes(
+                        reader, typeHandle, member.Name, index, publicOnly, bodyNamespaces))
+                        sb.AppendLine($"    [{attribute}]");
 
                     string? constructorChain = null;
                     string? body = member.IsAbstract
@@ -305,6 +311,9 @@ public static class TypeSourceComposer
                     if (!first) sb.AppendLine();
                     first = false;
                     any = true;
+                    foreach (var attribute in AttributeReader.RenderPropertyAttributes(
+                        reader, typeHandle, member.Name, bodyNamespaces))
+                        sb.AppendLine($"    [{attribute}]");
                     ComposeProperty(sb, pipelineSource, type.FullName, member, bodyNamespaces);
                     break;
                 }

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -309,6 +309,32 @@ public static class AttributeReader
         return result;
     }
 
+    /// <summary>
+    /// Renders the attributes on a method, resolved by the same name + public-only
+    /// overload counting the decompiler uses to select the body, so the attributes
+    /// pair with the right overload.
+    /// </summary>
+    public static List<string> RenderMethodAttributes(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly, SortedSet<string> namespaces)
+    {
+        var handle = FindMethodHandleInType(reader, typeHandle, methodName, overloadIndex, publicOnly);
+        return handle.IsNil ? [] : RenderAttributes(reader, reader.GetMethodDefinition(handle).GetCustomAttributes(), namespaces);
+    }
+
+    /// <summary>Renders the attributes on a property, found by name within the type.</summary>
+    public static List<string> RenderPropertyAttributes(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string propertyName, SortedSet<string> namespaces)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            if (reader.GetString(property.Name) == propertyName)
+                return RenderAttributes(reader, property.GetCustomAttributes(), namespaces);
+        }
+        return [];
+    }
+
     static string? TryRenderAttribute(MetadataReader reader, CustomAttribute attr)
     {
         string name = GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);


### PR DESCRIPTION
Completes the custom-attribute story — #575 did types and fields; this does the declaration scopes that needed the member's metadata handle.

## What

`ComposeMembers` now receives the `MetadataReader` and type handle, and:
- resolves each **method's** handle by the *same name + public-only overload counting* the decompiler uses to select the body (`FindMethodHandleInType` matches the importer's counting), so attributes pair with the right overload
- resolves each **property's** handle by name

then renders the attributes above the member, their namespaces joining the using set.

```csharp
[Obsolete("gone")]      public void Old() { }
[Conditional("DEBUG")]  public void Trace() { }   // + using System.Diagnostics;
[CLSCompliant(false)]   public static void MemoryCopy(...)
[Obsolete]              public int Legacy { get; set; }
```

## Scope note

Pseudo-custom attributes stored as **metadata flags** rather than in the custom-attribute table — `[MethodImpl]` (method `ImplAttributes`), `[DllImport]` (P/Invoke maps), `[MarshalAs]` — are a distinct mechanism and remain a follow-up. (Surfaced cleanly while testing: `[MethodImpl(AggressiveInlining)]` doesn't appear via `GetCustomAttributes`.)

Like #575, attributes are a fidelity gain, not a validity one — self round-trip unchanged at 37/159, no regression.

## Testing

- `ILInspector.Decompiler.Tests`: 411 pass (new `Compose_Method_EmitsAttribute` on `Buffer.MemoryCopy`'s `[CLSCompliant(false)]`).
- `ILInspector.Metadata.Tests`: 141 pass.
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)