### PR TITLE
Add a scope-uniform attribute API (assembly, module, type, member)

### DIFF
--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -75,8 +75,7 @@ public static class TypeSourceComposer
             // join them so the short attribute names resolve.
             var bodyNamespaces = new SortedSet<string>(StringComparer.Ordinal);
 
-            foreach (var attribute in AttributeReader.RenderAttributes(
-                reader, reader.GetTypeDefinition(typeHandle).GetCustomAttributes(), bodyNamespaces))
+            foreach (var attribute in AttributeReader.RenderAttributes(reader, typeHandle, bodyNamespaces))
                 sb.AppendLine($"[{attribute}]");
 
             sb.AppendLine(TypeDeclaration(type));
@@ -193,7 +192,7 @@ public static class TypeSourceComposer
                 continue;
             }
 
-            foreach (var attribute in AttributeReader.RenderAttributes(reader, field.GetCustomAttributes(), namespaces))
+            foreach (var attribute in AttributeReader.RenderAttributes(reader, fieldHandle, namespaces))
                 sb.AppendLine($"    [{attribute}]");
 
             var decl = new StringBuilder($"    {access} ");

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -290,7 +290,7 @@ public static class AttributeReader
     /// rendered is skipped rather than emitted wrong.
     /// </summary>
     public static List<string> RenderAttributes(
-        MetadataReader reader, CustomAttributeHandleCollection attributes, SortedSet<string> namespaces)
+        MetadataReader reader, CustomAttributeHandleCollection attributes, SortedSet<string>? namespaces = null)
     {
         var result = new List<string>();
         foreach (var attrHandle in attributes)
@@ -303,11 +303,39 @@ public static class AttributeReader
                 continue;
             int lastDot = typeName.LastIndexOf('.');
             if (lastDot > 0)
-                namespaces.Add(typeName[..lastDot]);
+                namespaces?.Add(typeName[..lastDot]);
             result.Add(rendered);
         }
         return result;
     }
+
+    // Scope-uniform entry points: every metadata entity exposes its own
+    // GetCustomAttributes(), so these thin overloads render the attributes of an
+    // assembly, module, type, or member without each caller repeating the
+    // reader.GetX(handle).GetCustomAttributes() dance.
+    public static List<string> RenderAssemblyAttributes(MetadataReader reader, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetAssemblyDefinition().GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderModuleAttributes(MetadataReader reader, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetModuleDefinition().GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, TypeDefinitionHandle type, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetTypeDefinition(type).GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, MethodDefinitionHandle method, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetMethodDefinition(method).GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, FieldDefinitionHandle field, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetFieldDefinition(field).GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, PropertyDefinitionHandle property, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetPropertyDefinition(property).GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, EventDefinitionHandle @event, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetEventDefinition(@event).GetCustomAttributes(), namespaces);
+
+    public static List<string> RenderAttributes(MetadataReader reader, ParameterHandle parameter, SortedSet<string>? namespaces = null)
+        => RenderAttributes(reader, reader.GetParameter(parameter).GetCustomAttributes(), namespaces);
 
     /// <summary>
     /// Renders the attributes on a method, resolved by the same name + public-only
@@ -315,22 +343,21 @@ public static class AttributeReader
     /// pair with the right overload.
     /// </summary>
     public static List<string> RenderMethodAttributes(
-        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly, SortedSet<string> namespaces)
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly, SortedSet<string>? namespaces = null)
     {
         var handle = FindMethodHandleInType(reader, typeHandle, methodName, overloadIndex, publicOnly);
-        return handle.IsNil ? [] : RenderAttributes(reader, reader.GetMethodDefinition(handle).GetCustomAttributes(), namespaces);
+        return handle.IsNil ? [] : RenderAttributes(reader, handle, namespaces);
     }
 
     /// <summary>Renders the attributes on a property, found by name within the type.</summary>
     public static List<string> RenderPropertyAttributes(
-        MetadataReader reader, TypeDefinitionHandle typeHandle, string propertyName, SortedSet<string> namespaces)
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string propertyName, SortedSet<string>? namespaces = null)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         foreach (var propertyHandle in typeDef.GetProperties())
         {
-            var property = reader.GetPropertyDefinition(propertyHandle);
-            if (reader.GetString(property.Name) == propertyName)
-                return RenderAttributes(reader, property.GetCustomAttributes(), namespaces);
+            if (reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name) == propertyName)
+                return RenderAttributes(reader, propertyHandle, namespaces);
         }
         return [];
     }

--- a/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// The scope-uniform attribute API: assembly, module, type, and member
+/// attributes all render through the same core, exercised here against CoreLib.
+/// </summary>
+public class AttributeReaderTests
+{
+    static PEReader OpenCoreLib() => new(File.OpenRead(typeof(object).Assembly.Location));
+
+    [Fact]
+    public void RenderAssemblyAttributes_IncludesClsCompliant()
+    {
+        using var pe = OpenCoreLib();
+        var rendered = AttributeReader.RenderAssemblyAttributes(pe.GetMetadataReader());
+
+        // CoreLib is marked [assembly: CLSCompliant(true)].
+        Assert.Contains("CLSCompliant(true)", rendered);
+    }
+
+    [Fact]
+    public void RenderAttributes_ByTypeHandle_FindsFlagsEnum()
+    {
+        using var pe = OpenCoreLib();
+        var reader = pe.GetMetadataReader();
+        var handle = reader.TypeDefinitions.Single(h =>
+            TypeResolver.GetFullName(reader, reader.GetTypeDefinition(h)) == "System.AttributeTargets");
+
+        Assert.Contains("Flags", AttributeReader.RenderAttributes(reader, handle));
+    }
+
+    [Fact]
+    public void RenderAttributes_NoNamespaceSet_DoesNotThrow()
+    {
+        // The namespace accumulator is optional — callers that only want the
+        // rendered text omit it.
+        using var pe = OpenCoreLib();
+        var rendered = AttributeReader.RenderModuleAttributes(pe.GetMetadataReader());
+
+        Assert.NotNull(rendered);
+    }
+}


### PR DESCRIPTION
Generalizes the attribute renderer so **any** metadata scope renders through one entry point, per the request for a uniform "get the attributes for an assembly/module/type/member" API.

## What

The core already rendered a `CustomAttributeHandleCollection`. Since every metadata entity exposes its own `GetCustomAttributes()`, thin overloads now cover all scopes without callers repeating `reader.GetX(handle).GetCustomAttributes()`:

- `RenderAssemblyAttributes(reader, ns?)`, `RenderModuleAttributes(reader, ns?)`
- `RenderAttributes(reader, <handle>, ns?)` overloaded for `TypeDefinitionHandle`, `MethodDefinitionHandle`, `FieldDefinitionHandle`, `PropertyDefinitionHandle`, `EventDefinitionHandle`, `ParameterHandle`

The **namespace accumulator is now optional** — a caller that only wants the rendered text (not the using-hoisting the composer needs) just omits it. The by-name method/property helpers and the composer's type/field call sites route through the new handle overloads, so there's one rendering path.

Verified across scopes on CoreLib:
```
[assembly] CLSCompliant(true), RuntimeCompatibility(WrapNonExceptionThrows = true),
           AssemblyMetadata("Serviceable", "True"), ComVisible(false), …
[module]   SkipLocalsInit, …
[type]     Flags (AttributeTargets), …
```

## Context

This is the reusable surface for callers beyond the composer — an assembly-info view, or the `ILInspector.Analysis` layer were it to take the dependency (today it's SRM-direct with no `ILInspector.Metadata` reference, so it would call `GetCustomAttributes()` itself or add the ref; this API is what it'd consume either way).

## Testing

- `ILInspector.Metadata.Tests`: 144 pass (new `AttributeReaderTests` — assembly, type-handle, optional-namespace).
- `ILInspector.Decompiler.Tests`: 411 pass.
- `dotnet-inspect.Tests`: 1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)