### PR TITLE
Move the TypeResolver + SignatureDecoder cluster to MetadataPrimitives

### DIFF
--- a/src/ILInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/ILInspector.Metadata/MetadataReaderExtensions.cs
@@ -18,25 +18,13 @@ public static class MetadataReaderExtensions
         /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeDefinition"/>.
         /// </summary>
         public string GetFullTypeName(TypeDefinition typeDef)
-        {
-            var declaringType = typeDef.GetDeclaringType();
-            if (!declaringType.IsNil)
-                return $"{reader.GetFullTypeName(reader.GetTypeDefinition(declaringType))}.{reader.GetString(typeDef.Name)}";
-
-            string ns = reader.GetString(typeDef.Namespace);
-            string name = reader.GetString(typeDef.Name);
-            return TypeResolver.GetFullName(ns, name);
-        }
+            => TypeResolver.GetFullName(reader, typeDef);
 
         /// <summary>
         /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeReference"/>.
         /// </summary>
         public string GetFullTypeName(TypeReference typeRef)
-        {
-            string ns = reader.GetString(typeRef.Namespace);
-            string name = reader.GetString(typeRef.Name);
-            return TypeResolver.GetFullName(ns, name);
-        }
+            => TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
 
         /// <summary>
         /// Gets the fully qualified name (Namespace.Name) of an <see cref="ExportedType"/>.

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -38,15 +38,12 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     };
 
     public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-    {
-        var typeDef = reader.GetTypeDefinition(handle);
-        return reader.GetFullTypeName(typeDef);
-    }
+        => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle));
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
     {
         var typeRef = reader.GetTypeReference(handle);
-        return reader.GetFullTypeName(typeRef);
+        return TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
     }
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -31,17 +31,14 @@ public static class TypeResolver
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
     {
         var typeRef = reader.GetTypeReference(handle);
-        return reader.GetFullTypeName(typeRef);
+        return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
     }
 
     /// <summary>
     /// Gets the type name from a TypeDefinition handle.
     /// </summary>
     public static string GetTypeNameFromDefinition(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var typeDef = reader.GetTypeDefinition(handle);
-        return reader.GetFullTypeName(typeDef);
-    }
+        => GetFullName(reader, reader.GetTypeDefinition(handle));
 
     /// <summary>
     /// Gets the type name from a TypeSpecification handle (generic instantiations).
@@ -53,11 +50,15 @@ public static class TypeResolver
     }
 
     /// <summary>
-    /// Gets the full name of a type definition (Namespace.Name).
+    /// Gets the full name of a type definition (Namespace.Name), qualifying a
+    /// nested type through its declaring type (Outer.Inner).
     /// </summary>
     public static string GetFullName(MetadataReader reader, TypeDefinition typeDef)
     {
-        return reader.GetFullTypeName(typeDef);
+        var declaringType = typeDef.GetDeclaringType();
+        if (!declaringType.IsNil)
+            return $"{GetFullName(reader, reader.GetTypeDefinition(declaringType))}.{reader.GetString(typeDef.Name)}";
+        return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
     }
 
     /// <summary>


### PR DESCRIPTION
Step 2 of the shared-primitives migration ([design note](../blob/main/docs/metadata-primitives.md); seed was #578).

## What

`TypeResolver` and `SignatureDecoder` are the mutually-recursive heart of name resolution — `TypeResolver` decodes type specifications through `SignatureDecoder`, which resolves type names back through `TypeResolver` — so they move **together**, joining `GenericContext` in the SRM-only `ILInspector.MetadataPrimitives` library.

## The cross-boundary cycle, resolved

Their one non-SRM dependency was the `GetFullTypeName` extension (in `Metadata`'s `MetadataReaderExtensions`), which *itself* called `TypeResolver.GetFullName` — a cycle across the layer boundary. Fixed by making `TypeResolver` own the canonical nested-aware full-name logic (pure SRM: walk the declaring type, else `Namespace.Name`); `SignatureDecoder` and the `GetFullTypeName` extension now **delegate** to it. The extension stays in `Metadata` for its 21 call sites — there's just one implementation now, in the primitives library.

## Zero churn

The moved types keep the `ILInspector.Metadata` namespace, so all consumers resolve them **transitively** through their existing `Metadata` reference. `Metadata`, `Decompiler`, the CLI, and the harness all build unchanged; `Analysis` is untouched (it has its own resolver — adopting the shared one is step 4).

## Testing

Builds: `Metadata`, `Decompiler`, `dotnet-inspect`, `DecompilerHarness`, `Analysis` all succeed. Tests: `Metadata` 144, `Decompiler` 411, `dotnet-inspect` 1104 — all green.

Remaining migration steps: (3) split the attribute primitive (decode → lib, render stays), (4) Analysis adopts + drops its duplicate resolver, (5) Pipeline likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)