### PR TITLE
Split attribute decode into MetadataPrimitives, keep rendering in Metadata

### DIFF
--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -163,20 +162,7 @@ public static class AttributeReader
     /// Gets the fully qualified type name of an attribute from its constructor handle.
     /// </summary>
     public static string? GetAttributeTypeName(MetadataReader reader, EntityHandle constructorHandle)
-    {
-        if (constructorHandle.Kind == HandleKind.MemberReference)
-        {
-            var memberRef = reader.GetMemberReference((MemberReferenceHandle)constructorHandle);
-            return TypeResolver.GetTypeName(reader, memberRef.Parent);
-        }
-        else if (constructorHandle.Kind == HandleKind.MethodDefinition)
-        {
-            var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)constructorHandle);
-            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
-            return TypeResolver.GetFullName(reader, typeDef);
-        }
-        return null;
-    }
+        => AttributeDecoder.GetAttributeTypeName(reader, constructorHandle);
 
     /// <summary>
     /// Gets custom attributes for a specific method, identified by type name, method name, and overload index.
@@ -364,29 +350,23 @@ public static class AttributeReader
 
     static string? TryRenderAttribute(MetadataReader reader, CustomAttribute attr)
     {
-        string name = GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);
-        try
-        {
-            var value = attr.DecodeValue(new AttributeArgTypeProvider(reader));
-            var args = new List<string>();
-            foreach (var arg in value.FixedArguments)
-            {
-                if (RenderArgument(arg.Type, arg.Value) is not { } text)
-                    return null;
-                args.Add(text);
-            }
-            foreach (var named in value.NamedArguments)
-            {
-                if (RenderArgument(named.Type, named.Value) is not { } text)
-                    return null;
-                args.Add($"{named.Name} = {text}");
-            }
-            return args.Count == 0 ? name : $"{name}({string.Join(", ", args)})";
-        }
-        catch
-        {
+        if (AttributeDecoder.TryDecode(reader, attr) is not { } value)
             return null;
+        string name = GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);
+        var args = new List<string>();
+        foreach (var arg in value.FixedArguments)
+        {
+            if (RenderArgument(arg.Type, arg.Value) is not { } text)
+                return null;
+            args.Add(text);
         }
+        foreach (var named in value.NamedArguments)
+        {
+            if (RenderArgument(named.Type, named.Value) is not { } text)
+                return null;
+            args.Add($"{named.Name} = {text}");
+        }
+        return args.Count == 0 ? name : $"{name}({string.Join(", ", args)})";
     }
 
     /// <summary>Renders one attribute-argument value, or null when its shape is not faithfully spellable (arrays, unknown).</summary>
@@ -431,77 +411,6 @@ public static class AttributeReader
         "System.Reflection.DefaultMemberAttribute" => true,
         _ => false,
     };
-
-    /// <summary>Type provider for attribute-blob decoding: primitives render as C# keywords, everything else as its full name (enums and typeof targets).</summary>
-    sealed class AttributeArgTypeProvider(MetadataReader reader) : ICustomAttributeTypeProvider<string>
-    {
-        public string GetPrimitiveType(PrimitiveTypeCode code) => code switch
-        {
-            PrimitiveTypeCode.Boolean => "bool",
-            PrimitiveTypeCode.Char => "char",
-            PrimitiveTypeCode.SByte => "sbyte",
-            PrimitiveTypeCode.Byte => "byte",
-            PrimitiveTypeCode.Int16 => "short",
-            PrimitiveTypeCode.UInt16 => "ushort",
-            PrimitiveTypeCode.Int32 => "int",
-            PrimitiveTypeCode.UInt32 => "uint",
-            PrimitiveTypeCode.Int64 => "long",
-            PrimitiveTypeCode.UInt64 => "ulong",
-            PrimitiveTypeCode.Single => "float",
-            PrimitiveTypeCode.Double => "double",
-            PrimitiveTypeCode.String => "string",
-            _ => "object",
-        };
-
-        public string GetSystemType() => "System.Type";
-        public bool IsSystemType(string type) => type == "System.Type";
-        public string GetSZArrayType(string elementType) => elementType + "[]";
-        public string GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle handle, byte rawTypeKind)
-            => TypeResolver.GetFullName(r, r.GetTypeDefinition(handle));
-        public string GetTypeFromReference(MetadataReader r, TypeReferenceHandle handle, byte rawTypeKind)
-            => TypeResolver.GetTypeName(r, handle) ?? "object";
-        public string GetTypeFromSerializedName(string name)
-        {
-            int comma = name.IndexOf(',');
-            return comma >= 0 ? name[..comma] : name;
-        }
-
-        public PrimitiveTypeCode GetUnderlyingEnumType(string type)
-        {
-            foreach (var handle in reader.TypeDefinitions)
-            {
-                var def = reader.GetTypeDefinition(handle);
-                if (TypeResolver.GetFullName(reader, def) != type)
-                    continue;
-                foreach (var fieldHandle in def.GetFields())
-                {
-                    var field = reader.GetFieldDefinition(fieldHandle);
-                    if ((field.Attributes & FieldAttributes.Static) == 0)
-                        return field.DecodeSignature(new PrimitiveCodeProvider(), null);
-                }
-            }
-            return PrimitiveTypeCode.Int32;
-        }
-    }
-
-    /// <summary>Minimal signature provider that reports an enum's underlying primitive type code.</summary>
-    sealed class PrimitiveCodeProvider : ISignatureTypeProvider<PrimitiveTypeCode, object?>
-    {
-        public PrimitiveTypeCode GetPrimitiveType(PrimitiveTypeCode code) => code;
-        public PrimitiveTypeCode GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle h, byte k) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetTypeFromReference(MetadataReader r, TypeReferenceHandle h, byte k) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetSZArrayType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetArrayType(PrimitiveTypeCode e, ArrayShape s) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetByReferenceType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetPointerType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetGenericInstantiation(PrimitiveTypeCode g, ImmutableArray<PrimitiveTypeCode> a) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetGenericMethodParameter(object? ctx, int i) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetGenericTypeParameter(object? ctx, int i) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetModifiedType(PrimitiveTypeCode m, PrimitiveTypeCode u, bool r) => u;
-        public PrimitiveTypeCode GetPinnedType(PrimitiveTypeCode e) => e;
-        public PrimitiveTypeCode GetFunctionPointerType(MethodSignature<PrimitiveTypeCode> s) => PrimitiveTypeCode.Int32;
-        public PrimitiveTypeCode GetTypeFromSpecification(MetadataReader r, object? ctx, TypeSpecificationHandle h, byte k) => PrimitiveTypeCode.Int32;
-    }
 
     private static string? TryGetAttributeDisplayValue(MetadataReader reader, CustomAttribute attr)
     {

--- a/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The SRM-only decode half of custom-attribute reading: resolves an
+/// attribute's type name and decodes its constructor blob to typed argument
+/// values. Rendering those values to C# (or any other surface) is the caller's
+/// concern — this layer is shared by anything that needs attribute data.
+/// </summary>
+public static class AttributeDecoder
+{
+    /// <summary>
+    /// The fully qualified type name of an attribute, from its constructor handle.
+    /// </summary>
+    public static string? GetAttributeTypeName(MetadataReader reader, EntityHandle constructorHandle)
+    {
+        if (constructorHandle.Kind == HandleKind.MemberReference)
+        {
+            var memberRef = reader.GetMemberReference((MemberReferenceHandle)constructorHandle);
+            return TypeResolver.GetTypeName(reader, memberRef.Parent);
+        }
+        if (constructorHandle.Kind == HandleKind.MethodDefinition)
+        {
+            var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)constructorHandle);
+            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
+            return TypeResolver.GetFullName(reader, typeDef);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Decodes an attribute's fixed and named arguments to typed values, or null
+    /// when the blob cannot be decoded. Argument <c>Type</c> strings are C#
+    /// keywords for primitives, <c>System.Type</c> for typeof targets, and the
+    /// full type name otherwise (enums, etc.).
+    /// </summary>
+    public static CustomAttributeValue<string>? TryDecode(MetadataReader reader, CustomAttribute attribute)
+    {
+        try
+        {
+            return attribute.DecodeValue(new ArgTypeProvider(reader));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Type provider for attribute-blob decoding: primitives as C# keywords, everything else as its full name (enums and typeof targets).</summary>
+    sealed class ArgTypeProvider(MetadataReader reader) : ICustomAttributeTypeProvider<string>
+    {
+        public string GetPrimitiveType(PrimitiveTypeCode code) => code switch
+        {
+            PrimitiveTypeCode.Boolean => "bool",
+            PrimitiveTypeCode.Char => "char",
+            PrimitiveTypeCode.SByte => "sbyte",
+            PrimitiveTypeCode.Byte => "byte",
+            PrimitiveTypeCode.Int16 => "short",
+            PrimitiveTypeCode.UInt16 => "ushort",
+            PrimitiveTypeCode.Int32 => "int",
+            PrimitiveTypeCode.UInt32 => "uint",
+            PrimitiveTypeCode.Int64 => "long",
+            PrimitiveTypeCode.UInt64 => "ulong",
+            PrimitiveTypeCode.Single => "float",
+            PrimitiveTypeCode.Double => "double",
+            PrimitiveTypeCode.String => "string",
+            _ => "object",
+        };
+
+        public string GetSystemType() => "System.Type";
+        public bool IsSystemType(string type) => type == "System.Type";
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+        public string GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle handle, byte rawTypeKind)
+            => TypeResolver.GetFullName(r, r.GetTypeDefinition(handle));
+        public string GetTypeFromReference(MetadataReader r, TypeReferenceHandle handle, byte rawTypeKind)
+            => TypeResolver.GetTypeName(r, handle) ?? "object";
+        public string GetTypeFromSerializedName(string name)
+        {
+            int comma = name.IndexOf(',');
+            return comma >= 0 ? name[..comma] : name;
+        }
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(string type)
+        {
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var def = reader.GetTypeDefinition(handle);
+                if (TypeResolver.GetFullName(reader, def) != type)
+                    continue;
+                foreach (var fieldHandle in def.GetFields())
+                {
+                    var field = reader.GetFieldDefinition(fieldHandle);
+                    if ((field.Attributes & FieldAttributes.Static) == 0)
+                        return field.DecodeSignature(new PrimitiveCodeProvider(), null);
+                }
+            }
+            return PrimitiveTypeCode.Int32;
+        }
+    }
+
+    /// <summary>Minimal signature provider that reports an enum's underlying primitive type code.</summary>
+    sealed class PrimitiveCodeProvider : ISignatureTypeProvider<PrimitiveTypeCode, object?>
+    {
+        public PrimitiveTypeCode GetPrimitiveType(PrimitiveTypeCode code) => code;
+        public PrimitiveTypeCode GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle h, byte k) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetTypeFromReference(MetadataReader r, TypeReferenceHandle h, byte k) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetSZArrayType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetArrayType(PrimitiveTypeCode e, ArrayShape s) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetByReferenceType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetPointerType(PrimitiveTypeCode e) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetGenericInstantiation(PrimitiveTypeCode g, ImmutableArray<PrimitiveTypeCode> a) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetGenericMethodParameter(object? ctx, int i) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetGenericTypeParameter(object? ctx, int i) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetModifiedType(PrimitiveTypeCode m, PrimitiveTypeCode u, bool r) => u;
+        public PrimitiveTypeCode GetPinnedType(PrimitiveTypeCode e) => e;
+        public PrimitiveTypeCode GetFunctionPointerType(MethodSignature<PrimitiveTypeCode> s) => PrimitiveTypeCode.Int32;
+        public PrimitiveTypeCode GetTypeFromSpecification(MetadataReader r, object? ctx, TypeSpecificationHandle h, byte k) => PrimitiveTypeCode.Int32;
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
@@ -42,4 +42,23 @@ public class AttributeReaderTests
 
         Assert.NotNull(rendered);
     }
+
+    [Fact]
+    public void AttributeDecoder_ResolvesNameAndDecodesArgument()
+    {
+        // The shared decode primitive: CoreLib is [assembly: CLSCompliant(true)].
+        using var pe = OpenCoreLib();
+        var reader = pe.GetMetadataReader();
+        foreach (var handle in reader.GetAssemblyDefinition().GetCustomAttributes())
+        {
+            var attr = reader.GetCustomAttribute(handle);
+            if (AttributeDecoder.GetAttributeTypeName(reader, attr.Constructor) != "System.CLSCompliantAttribute")
+                continue;
+            var value = AttributeDecoder.TryDecode(reader, attr);
+            Assert.NotNull(value);
+            Assert.Equal(true, value!.Value.FixedArguments[0].Value);
+            return;
+        }
+        Assert.Fail("CLSCompliant attribute not found on CoreLib");
+    }
 }


### PR DESCRIPTION
Step 3 of the shared-primitives migration ([design note](../blob/main/docs/metadata-primitives.md); #578 seeded `GenericContext`, #579 moved the `TypeResolver`/`SignatureDecoder` cluster).

## The decode/render split

- **Decode → `MetadataPrimitives`.** A new `AttributeDecoder` owns the SRM-only half: resolving an attribute's type name (`GetAttributeTypeName`) and decoding its constructor blob to typed argument values (`TryDecode`), plus the `ICustomAttributeTypeProvider` / enum-underlying providers that drive it.
- **Render stays in `Metadata.AttributeReader`.** Turning those typed values into C# (`Flags`, `Obsolete("msg")`, `(LayoutKind)0`), the re-emitted-attribute noise policy, and the scope overloads (#577) stay put. `AttributeReader` now calls `AttributeDecoder.TryDecode` and renders the result.

This is the split that lets a future **data** consumer (the analysis layer, step 4) read attribute data without pulling in C# rendering — exactly the distinction from the earlier discussion (decode is reusable; rendering is decompiler-flavored).

## Churn

`AttributeReader.GetAttributeTypeName` stays as a forwarder so its three other Metadata callers (`AssemblyInspector`, `NullabilityReader`, `SwitchScanner`) are unchanged. `AttributeDecoder` keeps the `ILInspector.Metadata` namespace, so the move is reference-only.

## Testing

Builds: primitives, Metadata, Decompiler, CLI all succeed. Tests: Metadata **145** (new `AttributeDecoder_ResolvesNameAndDecodesArgument`), Decompiler 411, dotnet-inspect 1104 — all green.

Remaining: (4) Analysis adopts the lib + drops its duplicate resolver (and the namespace decision lands), (5) the Decompiler `Pipeline` likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)