### PR TITLE
Raise in-place struct .ctor calls to new T(args)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1195,6 +1195,15 @@ public class CfgSampleClass
     // The call form: node?.Shape() consumed by ??. Same receiver-spill lowering,
     // raised to a null-conditional invocation node?.Shape().
     public static string NullConditionalCall(JoinBase node) => node?.Shape() ?? "none";
+
+    // An interpolated string lowers to an in-place DefaultInterpolatedStringHandler
+    // construction: `ldloca handler; call DefaultInterpolatedStringHandler::.ctor(
+    // literalLength, formattedCount)`. The handler is a ref struct, so the compiler
+    // always initializes it in place rather than via a copied temporary.
+    // StructConstructorPass raises that call back to `handler = new
+    // DefaultInterpolatedStringHandler(...)`; left alone it prints as the illegal
+    // handler..ctor(...) (CS0201, "not a valid statement").
+    public static string InterpolatedStruct(int value) => $"value={value} again={value}";
 }
 
 public interface IJoinShape

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -953,6 +953,37 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void StructConstructor_InPlaceCtor_PrintsNewObject()
+    {
+        // The in-place struct .ctor (ldloca; call S::.ctor) must print as an
+        // assignment of a fresh value, never the illegal handler..ctor(...).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.InterpolatedStruct), source);
+
+        Assert.Contains("new DefaultInterpolatedStringHandler(", output);
+        Assert.DoesNotContain("..ctor", output);
+    }
+
+    [Fact]
+    public void StructConstructor_RaisesToNewObject_AtFullFidelity()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.InterpolatedStruct));
+        Assert.NotNull(function);
+        IrPasses.Run(function);
+
+        // No struct .ctor call survives on a storage-location address...
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name == ".ctor" && c.Arguments is [LoadLocalAddress, ..]);
+        // ...the handler construction became a NewObject node.
+        Assert.Contains(
+            function.Descendants.OfType<NewObject>(),
+            n => n.Constructor.DeclaringType.Name == "DefaultInterpolatedStringHandler");
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
     public void TypedConstants_BoolReturn_PrintsFalse()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -39,6 +39,11 @@ public static class IrPasses
         // Canonicalize spilled-this constructor receivers before sugar so the
         // base(...)/this(...) call is in its final shape for the printer.
         new ConstructorChainPass(),
+        // Raise in-place struct .ctor calls (ldloca; call S::.ctor(args)) back
+        // to `s = new S(args)`; left as-is they print as the illegal s..ctor(...)
+        // (CS0201). Runs after the constructor-chain canonicalization so the
+        // this/base receiver is already off the table.
+        new StructConstructorPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
@@ -1,0 +1,64 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises an in-place struct constructor call to a whole-value assignment:
+/// <c>ldloca s; call S::.ctor(args)</c> is the C# compiler's lowering of
+/// <c>s = new S(args)</c> when <c>s</c> is a local, by-ref argument, or field of
+/// struct type (the JIT initializes the struct in place rather than copying a
+/// temporary). The IL spelling prints as the illegal <c>s..ctor(args);</c>
+/// (CS0201, "is not a valid statement"), so this pass rewrites it back into the
+/// <see cref="NewObject"/> assignment the printer already renders as
+/// <c>s = new S(args);</c>.
+///
+/// The constructor fully owns the receiver address — it is the call's receiver
+/// and nothing else in the tree — so replacing the in-place init with a
+/// whole-value assignment is observationally identical. The this/base
+/// constructor-chain case (receiver is <c>this</c>) is left to
+/// <see cref="ConstructorChainPass"/> and the printer's base(...)/this(...)
+/// spelling; this pass only matches the address of a nameable storage location.
+/// </summary>
+public sealed class StructConstructorPass : IIrPass
+{
+    public string Name => "struct-constructor";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var statement in function.Descendants.OfType<ExpressionStatement>().ToList())
+        {
+            if (statement.Parent is null)
+                continue;  // detached by an earlier rewrite in this walk
+            if (statement.Expression is not Call { Callee: { Name: ".ctor", HasThis: true } } call)
+                continue;
+            if (call.Arguments.Count == 0 || !IsRaisableTarget(call.Arguments[0]))
+                continue;
+
+            var children = call.DetachChildren().Cast<IrExpression>().ToList();
+            var receiver = children[0];
+            var value = new NewObject(call.Callee, children.Skip(1));
+            statement.ReplaceWith(Assign(receiver, value));
+        }
+    }
+
+    // Only the address of a nameable storage location is a safe target: the
+    // address is a leaf load (local/argument) or a field load whose own
+    // receiver travels with it, so the rewrite stays a local tree edit.
+    static bool IsRaisableTarget(IrExpression receiver)
+        => receiver is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress;
+
+    static IrNode Assign(IrExpression receiver, NewObject value) => receiver switch
+    {
+        LoadLocalAddress local => new StoreLocal(local.Index, local.Type, value),
+        LoadArgumentAddress argument => new StoreArgument(argument.Index, argument.Name, argument.Type, value),
+        LoadFieldAddress field => new StoreField(field.Field, DetachInstance(field), value),
+        _ => throw new InvalidOperationException($"Unexpected struct-ctor target {receiver.Describe()}."),
+    };
+
+    // The field address has already left the call tree; lift its own receiver
+    // out so the new StoreField can adopt it without a double parent.
+    static IrExpression? DetachInstance(LoadFieldAddress field)
+    {
+        var instance = field.Instance;
+        instance?.Detach();
+        return instance;
+    }
+}


### PR DESCRIPTION
## What

The C# compiler lowers `s = new S(args)` to `ldloca s; call S::.ctor(args)` when `s` is a local, by-ref argument, or field of struct type — ref structs (`DefaultInterpolatedStringHandler`), `[LibraryImport]` marshalling stubs, etc. always initialize in place. The decompiler printed that call literally as the illegal `s..ctor(args);` (**CS0201**, "not a valid statement"), so methods claiming `Full` fidelity would not even parse.

`StructConstructorPass` detects an `ExpressionStatement` holding a `.ctor` call whose receiver is the address of a nameable storage location (`LoadLocalAddress`/`LoadArgumentAddress`/`LoadFieldAddress`) and rewrites it to the whole-value assignment the printer already renders as `s = new S(args);`. No printer changes.

### Before / after

Before: `V_0..ctor(36, 3);` (CS0201). After: `DefaultInterpolatedStringHandler V_0 = new DefaultInterpolatedStringHandler(36, 3);`

## Soundness

Only a `.ctor` call with `HasThis` whose first argument is a storage-location address is raised. The constructor is the address's sole consumer, and every such form has an exact `NewObject`-assignment inverse, so nothing is lost or invented. The this/base constructor-chain case is untouched (owned by `ConstructorChainPass`).

## Corpus (corelib, `--pipeline next --compile-check`)

| Metric | Before | After |
|---|---|---|
| Full malformed (claim Full, won't parse) | 1445 (3.78%) | **1206 (3.16%)** — −239 |
| Semantic binding defects | 689 (17.23%) | 683 (17.07%) — no regression |

The remaining malformed set is now dominated by **CS1002 `pinned ref`** locals (the `fixed`-statement gap), the natural next slice.

## Tests

Two new tests (interpolated string -> in-place handler ctor): one printer-level and one IR-level (no `.ctor` on `LoadLocalAddress` survives; a `NewObject` appears; Full fidelity). Full suites green: decompiler 413, dotnet-inspect 1104 (9 ildasm skips).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
