### PR TITLE
Detect unsafe-marking via Roslyn's CallerUnsafeMode model

### DIFF
--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -123,3 +123,44 @@ cleaner for the independence story; resolve it then, not now.
 - Pulling rendering or I/O into the primitives library.
 - Pre-emptive breadth: primitives earn their place from demonstrated
   duplication (the rule of three), not speculation.
+
+## Decision (2026-06): stop after step 3
+
+**Steps 1–3 are complete (#578/#579/#580) and stand. Do not do step 4 (Analysis
+adopts) or step 5 (Pipeline adopts) now.** Keep `Analysis` at zero project
+references; keep the `ILInspector.Metadata` namespace on the moved primitives.
+
+The migration sequence above was written without a real second consumer of
+`Analysis`, so step 4's payoff was a hypothesis. The memory-safety unsafe-mode
+detector (`ILInspector.Analysis.App`, `CallerUnsafeMode` in `LibraryBodyIndex`)
+is now that consumer, and it reads metadata three ways — attribute-by-name,
+signature decode, module-attribute scan — exercising exactly the primitives this
+note is about. It turns the hypothesis into evidence:
+
+- **TypeRef unification is decisively wrong.** The detector's pointer-signature
+  check needs `TypeRefKind.Pointer` — *semantic* structure. `Metadata.TypeResolver`
+  produces display **strings** and cannot answer "is there a pointer in this
+  signature." `Analysis`'s own `TypeRefDecoder → TypeRef` is what makes the check
+  possible. A shared model would have forced `Analysis` to keep its own anyway.
+- **`Analysis`'s independence is load-bearing.** The whole detector shipped
+  SRM-direct with no dependency negotiation. That is the property step 4 spends.
+- **The real duplication is tiny and stable.** `Analysis` hand-rolled
+  `AttributeTypeName` (ctor → declaring-type namespace+name, `MemberReference`
+  vs `MethodDefinition`) — the same SRM walk as
+  `AttributeDecoder.GetAttributeTypeName`, differing only in return shape
+  (`(ns, name)` vs full-name `string?`). It needs **only the name**, not
+  `TryDecode`/`CustomAttributeValue` argument decode. The shareable slice is
+  ~15 lines of mechanical SRM that does not churn.
+
+The trade-off, now concrete: sharing buys deleting ~15 stable lines; it costs
+`Analysis` its first project reference and the zero-dependency independence that
+just paid off. Tolerate the duplication.
+
+**Trip-wire (the only condition to revisit):** if the Decompiler `Pipeline` also
+needs attribute-name reads, that is rule-of-three across projects — at that point
+share `GetAttributeTypeName` *only* (the name walk, never `TryDecode`, never a
+`TypeRef`). Until that third sighting, no action.
+
+Underlying principle: let real consumers *pull* primitives into the shared
+library; do not *push* them in speculatively. The first real pull pulled almost
+nothing — which is the answer.

--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -2,6 +2,11 @@ using System.Reflection;
 
 using ILInspector.Analysis;
 
+// `unsafe <assembly> [count]` — detect requires-unsafe methods under the new
+// memory-safety model (CallerUnsafeMode) and rank them by direct callers.
+if (args.Length > 0 && args[0] == "unsafe")
+    return RunUnsafeReport(args);
+
 var options = Parse(args);
 if (options is null)
     return 1;
@@ -32,6 +37,41 @@ foreach (var diagnostic in index.Diagnostics.Take(options.Limit))
     Console.Error.WriteLine($"diagnostic 0x{diagnostic.MethodToken:X8} {diagnostic.Method}: {diagnostic.Message}");
 
 return 0;
+
+static int RunUnsafeReport(string[] args)
+{
+    string assemblyPath = args.Length > 1 ? args[1] : Assembly.GetExecutingAssembly().Location;
+    int count = 6;
+    if (args.Length > 2 && (!int.TryParse(args[2], out count) || count <= 0))
+    {
+        Console.Error.WriteLine("Error: count must be a positive integer.");
+        return 1;
+    }
+    if (!File.Exists(assemblyPath))
+    {
+        Console.Error.WriteLine($"Error: assembly not found: {assemblyPath}");
+        return 1;
+    }
+
+    var index = LibraryBodyIndex.Open(assemblyPath);
+    var modes = index.UnsafeModes;
+    var top = index.TopUnsafeLeverage(count);
+
+    Console.WriteLine($"Assembly: {assemblyPath}");
+    Console.WriteLine($"Module opted into updated memory-safety rules: {index.MemorySafetyRulesEnabled}");
+    Console.WriteLine($"Methods: {modes.Total:N0}");
+    Console.WriteLine($"  None     (no requires-unsafe):              {modes.None:N0}");
+    Console.WriteLine($"  Implicit (requires-unsafe, module not opted in): {modes.Implicit:N0}");
+    Console.WriteLine($"  Explicit (requires-unsafe, module opted in):     {modes.Explicit:N0}");
+    Console.WriteLine();
+    Console.WriteLine($"Top {top.Length} requires-unsafe methods by direct callers (with an IL body):");
+    Console.WriteLine();
+    int rank = 1;
+    foreach (var entry in top)
+        Console.WriteLine($"{rank++}. {entry.DirectCallerCount,6} callers  [{entry.Mode}]  {MethodDisplay(entry.Method)}");
+
+    return 0;
+}
 
 static AppOptions? Parse(string[] args)
 {

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -124,6 +124,47 @@ public class LibraryBodyIndexTests
             && evidence.Member.Name == "Add"
             && evidence is { Reason: "Unsafe API member", Kind: "api" });
     }
+
+    [Fact]
+    public void CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn()
+    {
+        // This test assembly carries no MemorySafetyRulesAttribute, so a pointer
+        // signature lands in the legacy Implicit bucket (Roslyn's CallerUnsafeMode).
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        Assert.False(index.MemorySafetyRulesEnabled);
+        Assert.Equal(0, index.UnsafeModes.Explicit);
+
+        var pointerRead = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead)));
+        Assert.Equal(CallerUnsafeMode.Implicit, pointerRead.CallerUnsafeMode);
+    }
+
+    [Fact]
+    public void CallerUnsafeMode_CallingUnsafeApiIsNotRequiresUnsafe()
+    {
+        // The authoritative model is RequiresUnsafeAttribute || pointer signature.
+        // Calling an unsafe API does not itself make a method requires-unsafe —
+        // that is the heuristic's domain, deliberately excluded from the model.
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        var callsUnsafeAs = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)));
+        Assert.Equal(CallerUnsafeMode.None, callsUnsafeAs.CallerUnsafeMode);
+    }
+
+    [Fact]
+    public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()
+    {
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        var top = index.TopUnsafeLeverage(count: 100);
+
+        Assert.Contains(top, e =>
+            e.Method.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead)
+            && e.Mode == CallerUnsafeMode.Implicit);
+        Assert.DoesNotContain(top, e => e.Method.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs));
+    }
 }
 
 public class CallTreeTests

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -15,13 +15,17 @@ public sealed class LibraryBodyIndex
         ImmutableArray<MethodIdentity> methods,
         ImmutableArray<DirectCall> directCalls,
         ImmutableArray<UnsafeEvidence> unsafeEvidence,
-        ImmutableArray<AnalysisDiagnostic> diagnostics)
+        ImmutableArray<AnalysisDiagnostic> diagnostics,
+        bool memorySafetyRulesEnabled,
+        UnsafeModeBreakdown unsafeModes)
     {
         Path = path;
         Methods = methods;
         DirectCalls = directCalls;
         UnsafeEvidence = unsafeEvidence;
         Diagnostics = diagnostics;
+        MemorySafetyRulesEnabled = memorySafetyRulesEnabled;
+        UnsafeModes = unsafeModes;
     }
 
     public string Path { get; }
@@ -29,6 +33,16 @@ public sealed class LibraryBodyIndex
     public ImmutableArray<DirectCall> DirectCalls { get; }
     public ImmutableArray<UnsafeEvidence> UnsafeEvidence { get; }
     public ImmutableArray<AnalysisDiagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Whether the module opted into the updated memory-safety rules via
+    /// <c>MemorySafetyRulesAttribute</c> (Roslyn's <c>UseUpdatedMemorySafetyRules</c>).
+    /// When false, every requires-unsafe member is <see cref="CallerUnsafeMode.Implicit"/>.
+    /// </summary>
+    public bool MemorySafetyRulesEnabled { get; }
+
+    /// <summary>Per-<see cref="CallerUnsafeMode"/> method counts across the whole assembly.</summary>
+    public UnsafeModeBreakdown UnsafeModes { get; }
 
     public static LibraryBodyIndex Open(string path)
     {
@@ -39,11 +53,21 @@ public sealed class LibraryBodyIndex
         var reader = peReader.GetMetadataReader();
         var builder = new IndexBuilder(path, reader, peReader);
         var index = builder.Build();
-        return new LibraryBodyIndex(path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics);
+        return new LibraryBodyIndex(
+            path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
+            builder.MemorySafetyRulesEnabled, index.UnsafeModes);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
         => [.. DirectCalls.Where(call => pattern.Matches(call.Callee))];
+
+    /// <summary>
+    /// The most-leveraged requires-unsafe methods, ranked by distinct direct
+    /// callers — the highest-value targets for `unsafe` marking, since marking
+    /// them propagates the requirement to the most callers.
+    /// </summary>
+    public ImmutableArray<UnsafeMethodLeverage> TopUnsafeLeverage(int count = 6)
+        => UnsafeLeverage.Top(DirectCalls, Methods, count);
 
     /// <summary>
     /// Builds a bounded outbound (callee) call tree rooted at the method identified by
@@ -132,6 +156,7 @@ public sealed class LibraryBodyIndex
         readonly PEReader _peReader;
         readonly string _assemblyName;
         readonly Guid _mvid;
+        readonly bool _memorySafetyRulesEnabled;
 
         public IndexBuilder(string path, MetadataReader reader, PEReader peReader)
         {
@@ -140,14 +165,30 @@ public sealed class LibraryBodyIndex
             _peReader = peReader;
             _assemblyName = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : System.IO.Path.GetFileNameWithoutExtension(path);
             _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+            _memorySafetyRulesEnabled = DetectMemorySafetyRules();
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics) Build()
+        // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
+        // when MemorySafetyRulesAttribute is applied (emitted [module:], like
+        // RefSafetyRulesAttribute). Check the module and assembly scopes.
+        public bool MemorySafetyRulesEnabled => _memorySafetyRulesEnabled;
+
+        bool DetectMemorySafetyRules()
+        {
+            const string ns = "System.Runtime.CompilerServices";
+            if (HasAttributeNamed(_reader.GetModuleDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns))
+                return true;
+            return _reader.IsAssembly
+                && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
+        }
+
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, UnsafeModeBreakdown UnsafeModes) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
             var unsafeEvidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
             var diagnostics = ImmutableArray.CreateBuilder<AnalysisDiagnostic>();
+            int none = 0, impl = 0, expl = 0;
 
             foreach (var typeHandle in _reader.TypeDefinitions)
             {
@@ -159,6 +200,14 @@ public sealed class LibraryBodyIndex
                         var methodDef = _reader.GetMethodDefinition(methodHandle);
                         var scope = CreateScope(typeDef, methodDef);
                         var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
+                        // Tally the unsafe mode for every method, including bodiless
+                        // extern/abstract members (P/Invokes are a major source).
+                        switch (caller.CallerUnsafeMode)
+                        {
+                            case CallerUnsafeMode.Explicit: expl++; break;
+                            case CallerUnsafeMode.Implicit: impl++; break;
+                            default: none++; break;
+                        }
                         bool hasUnsafeApiMember = AddUnsafeApiMemberEvidence(caller, unsafeEvidence);
                         bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, unsafeEvidence);
                         if (methodDef.RelativeVirtualAddress == 0)
@@ -181,7 +230,8 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable());
+            return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
+                new UnsafeModeBreakdown(none, impl, expl));
         }
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
@@ -196,7 +246,78 @@ public sealed class LibraryBodyIndex
                 signature.ParameterTypes,
                 signature.ReturnType,
                 MetadataTokens.GetToken(methodHandle),
-                (methodDef.Attributes & MethodAttributes.Static) != 0);
+                (methodDef.Attributes & MethodAttributes.Static) != 0,
+                ComputeCallerUnsafeMode(typeHandle, methodDef, signature.ParameterTypes, signature.ReturnType));
+        }
+
+        // Mirrors Roslyn's PEMethodSymbol.CallerUnsafeMode: a member "requires
+        // unsafe" when it carries RequiresUnsafeAttribute (the metadata form of
+        // the `unsafe` modifier) or has a pointer/function pointer in its
+        // signature; the mode is then gated on the module opting into the rules.
+        CallerUnsafeMode ComputeCallerUnsafeMode(
+            TypeDefinitionHandle typeHandle, MethodDefinition methodDef,
+            ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
+        {
+            bool requiresUnsafe =
+                HasRequiresUnsafe(methodDef.GetCustomAttributes())
+                || HasRequiresUnsafe(_reader.GetTypeDefinition(typeHandle).GetCustomAttributes())
+                || parameterTypes.Any(ContainsPointer)
+                || ContainsPointer(returnType);
+
+            if (!requiresUnsafe)
+                return CallerUnsafeMode.None;
+            return _memorySafetyRulesEnabled ? CallerUnsafeMode.Explicit : CallerUnsafeMode.Implicit;
+        }
+
+        // A pointer or function pointer anywhere in a type drives implicit
+        // requires-unsafe. (Pinned is a local modifier, not a signature pointer,
+        // so it is deliberately excluded — matching Roslyn's signature check.)
+        static bool ContainsPointer(TypeRef type)
+        {
+            if (type.Kind == TypeRefKind.Pointer)
+                return true;
+            if (type.Kind == TypeRefKind.Unsupported
+                && type.UnsupportedReason.Contains("function pointer", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (type.ElementType is not null && ContainsPointer(type.ElementType))
+                return true;
+            return type.TypeArguments.Any(ContainsPointer);
+        }
+
+        // Read attributes straight from SRM — a simple has-attribute check needs
+        // no shared decode/render machinery, so Analysis stays independent.
+        bool HasRequiresUnsafe(CustomAttributeHandleCollection attributes)
+            // Match the distinctive simple name: the implemented attribute is in
+            // System.Diagnostics.CodeAnalysis, while the design doc says
+            // System.Runtime.CompilerServices — tolerate the namespace churn.
+            => HasAttributeNamed(attributes, "RequiresUnsafeAttribute",
+                "System.Diagnostics.CodeAnalysis", "System.Runtime.CompilerServices");
+
+        bool HasAttributeNamed(CustomAttributeHandleCollection attributes, string simpleName, params string[] namespaces)
+        {
+            foreach (var handle in attributes)
+            {
+                var (ns, name) = AttributeTypeName(_reader.GetCustomAttribute(handle).Constructor);
+                if (name == simpleName && (namespaces.Length == 0 || Array.IndexOf(namespaces, ns) >= 0))
+                    return true;
+            }
+            return false;
+        }
+
+        (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
+        {
+            if (constructor.Kind == HandleKind.MemberReference
+                && _reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent)
+            {
+                var typeRef = _reader.GetTypeReference((TypeReferenceHandle)parent);
+                return (_reader.GetString(typeRef.Namespace), _reader.GetString(typeRef.Name));
+            }
+            if (constructor.Kind == HandleKind.MethodDefinition)
+            {
+                var declType = _reader.GetTypeDefinition(_reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
+                return (_reader.GetString(declType.Namespace), _reader.GetString(declType.Name));
+            }
+            return ("", "");
         }
 
         bool AddUnsafeApiMemberEvidence(MethodIdentity method, ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence)

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -20,6 +20,45 @@ public enum CallKind
     CallIndirect,
 }
 
+/// <summary>
+/// A member's safety under the updated memory-safety rules, mirroring Roslyn's
+/// <c>CallerUnsafeMode</c> (see <c>PEMethodSymbol.CallerUnsafeMode</c>). A member
+/// "requires unsafe" when it carries <c>RequiresUnsafeAttribute</c> or has a
+/// pointer / function pointer in its signature; the distinction below is then
+/// gated on whether the containing module opted into the updated rules via
+/// <c>MemorySafetyRulesAttribute</c>.
+/// </summary>
+public enum CallerUnsafeMode
+{
+    /// <summary>Not considered unsafe under the updated rules.</summary>
+    None,
+
+    /// <summary>
+    /// Requires unsafe, but the module has not opted into the updated rules — the
+    /// legacy implicit notion (e.g. an existing pointer-signature API).
+    /// </summary>
+    Implicit,
+
+    /// <summary>
+    /// Requires unsafe in a module that opted into the updated rules — the
+    /// authoritative mark (the <c>unsafe</c>/<c>extern</c> modifier).
+    /// </summary>
+    Explicit,
+}
+
+/// <summary>
+/// How many methods in an assembly fall into each <see cref="CallerUnsafeMode"/>,
+/// counted across every method (including bodiless extern/abstract members), not
+/// just those with an IL body.
+/// </summary>
+public sealed record UnsafeModeBreakdown(int None, int Implicit, int Explicit)
+{
+    public int Total => None + Implicit + Explicit;
+
+    /// <summary>Methods that require unsafe (implicitly or explicitly).</summary>
+    public int Unsafe => Implicit + Explicit;
+}
+
 public sealed record MethodIdentity(
     string AssemblyName,
     Guid ModuleVersionId,
@@ -28,7 +67,8 @@ public sealed record MethodIdentity(
     ImmutableArray<TypeRef> ParameterTypes,
     TypeRef ReturnType,
     int MetadataToken,
-    bool IsStatic);
+    bool IsStatic,
+    CallerUnsafeMode CallerUnsafeMode = CallerUnsafeMode.None);
 
 public sealed record MemberRef(
     TypeRef DeclaringType,

--- a/src/ILInspector.Analysis/UnsafeLeverage.cs
+++ b/src/ILInspector.Analysis/UnsafeLeverage.cs
@@ -1,0 +1,45 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// A requires-unsafe method (per <see cref="CallerUnsafeMode"/>) ranked by how
+/// many other methods call it directly. Marking these first propagates the
+/// <c>unsafe</c> requirement to the most callers.
+/// </summary>
+public sealed record UnsafeMethodLeverage(
+    MethodIdentity Method,
+    int DirectCallerCount,
+    CallerUnsafeMode Mode);
+
+public static class UnsafeLeverage
+{
+    /// <summary>
+    /// The <paramref name="count"/> most-leveraged requires-unsafe methods,
+    /// ranked by distinct direct callers. Pure over the index's arrays so it is
+    /// testable without a real assembly.
+    /// </summary>
+    public static ImmutableArray<UnsafeMethodLeverage> Top(
+        ImmutableArray<DirectCall> directCalls,
+        ImmutableArray<MethodIdentity> methods,
+        int count)
+    {
+        // Distinct direct callers per callee, keyed by the referenced token. An
+        // intra-assembly call to a method definition references that method's
+        // own token, so this matches a method's MetadataToken to its callers.
+        var callersByToken = directCalls
+            .GroupBy(call => call.OperandToken)
+            .ToDictionary(group => group.Key, group => group.Select(c => c.Caller.MetadataToken).Distinct().Count());
+
+        return methods
+            .Where(method => method.CallerUnsafeMode != CallerUnsafeMode.None)
+            .Select(method => new UnsafeMethodLeverage(
+                method,
+                callersByToken.GetValueOrDefault(method.MetadataToken),
+                method.CallerUnsafeMode))
+            .OrderByDescending(entry => entry.DirectCallerCount)
+            .ThenBy(entry => entry.Method.MetadataToken)
+            .Take(count)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## What

Adds authoritative unsafe-method detection to `ILInspector.Analysis`, mirroring Roslyn's `PEMethodSymbol.CallerUnsafeMode` instead of heuristics. A member **requires unsafe** when it carries `RequiresUnsafeAttribute` **or** has a pointer / function-pointer in its signature; the mode is then gated on whether the module opted into the updated rules via `MemorySafetyRulesAttribute`:

```
requiresUnsafe = RequiresUnsafeAttribute || pointer-in-signature
mode = !requiresUnsafe       -> None
       module opted in        -> Explicit
       else                   -> Implicit
```

This is single-assembly and deliberately heuristic-free — the source-of-truth attribute names and rules were taken from the merged Roslyn "Unsafe evolution" feature (`System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute`, `System.Runtime.CompilerServices.MemorySafetyRulesAttribute`).

## Changes

- `MethodIdentity.CallerUnsafeMode` (`None`/`Implicit`/`Explicit`) replaces the prior `RequiresUnsafe` bool.
- `LibraryBodyIndex` exposes `MemorySafetyRulesEnabled` (Roslyn's `UseUpdatedMemorySafetyRules`) and an `UnsafeModes` breakdown counted across **all** methods, including bodiless extern/abstract members.
- `UnsafeLeverage` now ranks the model's requires-unsafe set by distinct direct callers (no longer the `UnsafeEvidence` heuristic; that pre-existing feature is untouched).
- The app's `unsafe <assembly> [count]` report prints the module opt-in flag, the `None`/`Implicit`/`Explicit` breakdown, and the top methods by callers.

## Result on preview.5 `System.Private.CoreLib`

```
Module opted into updated memory-safety rules: False
Methods: 43,268
  None     (no requires-unsafe):              40,229
  Implicit (requires-unsafe, module not opted in): 3,039
  Explicit (requires-unsafe, module opted in):     0
```

Top methods are all genuine pointer-signature members (`RuntimeHelpers.GetMethodTable`, `ArgumentNullException.ThrowIfNull(void*, ...)`, `NativeMemory.Clear(void*, nuint)`, ...) — no heuristic noise. This confirms the scheme's attribute types ship in preview.5 but **no marks are applied yet**. The detector shifts to reporting `Explicit` with **zero code change** once an assembly opts in and applies marks — which was the design goal: parallel to the real compiler model, easy to shift later.

## Layering decision (docs)

This detector is the first real **second consumer** of `ILInspector.Analysis`, so it also settles the paused `MetadataPrimitives` migration. `docs/metadata-primitives.md` gains a dated **Decision** section: stop after step 3 (#578/#579/#580). Evidence:

- **TypeRef unification is wrong** — the pointer-signature check needs semantic `TypeRefKind.Pointer`; `Metadata.TypeResolver` only produces display strings.
- **Analysis's zero-project-ref independence is load-bearing** — the whole detector shipped SRM-direct.
- The only real duplication (attribute-name resolution vs `AttributeDecoder.GetAttributeTypeName`) is ~15 stable lines, not worth a project reference. Trip-wire to revisit: only if the Decompiler `Pipeline` also needs attribute-name reads.

## Tests

3 new cases lock the model boundary (pointer-sig → `Implicit`; `CallsUnsafeAs` → `None`, since calling an unsafe API is not itself requires-unsafe under the model; leverage ranks the model's set). `ILInspector.Analysis.Tests`: 18/18 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)