### PR TITLE
Render call-site ref/out keywords from parameter metadata

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1204,6 +1204,25 @@ public class CfgSampleClass
     // DefaultInterpolatedStringHandler(...)`; left alone it prints as the illegal
     // handler..ctor(...) (CS0201, "not a valid statement").
     public static string InterpolatedStruct(int value) => $"value={value} again={value}";
+
+    // Same-assembly callees with explicit ref-kinds, so the importer can recover
+    // each parameter's keyword from the MethodDef parameter rows.
+    public static void RefHelper(ref int x) => x++;
+
+    public static void OutHelper(out int x) => x = 0;
+
+    public static void InHelper(in int x) { }
+
+    // A caller forwarding a managed pointer to each ref-kind: the call sites must
+    // print `ref`/`out` and leave the `in` argument bare (CS1620/CS1615).
+    public static int RefKindCallSites(int a)
+    {
+        int r = a;
+        RefHelper(ref r);
+        OutHelper(out int o);
+        InHelper(in r);
+        return r + o;
+    }
 }
 
 public interface IJoinShape

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -984,6 +984,25 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void CallSite_RefKinds_PrintRefOutAndBareIn()
+    {
+        // A managed pointer forwarded to a by-ref parameter needs the parameter's
+        // own keyword at the call site: `ref`/`out` are required (CS1620), while
+        // an `in` argument must stay bare (adding `ref` would be CS1615). The
+        // importer recovers each kind from the callee's MethodDef parameter rows.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.RefKindCallSites), source);
+
+        Assert.Contains("RefHelper(ref ", output);
+        Assert.Contains("OutHelper(out ", output);
+        // The `in` argument is passed without a keyword.
+        Assert.Contains("InHelper(", output);
+        Assert.DoesNotContain("InHelper(ref", output);
+        Assert.DoesNotContain("InHelper(out", output);
+    }
+
+
+    [Fact]
     public void TypedConstants_BoolReturn_PrintsFalse()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
 
@@ -392,7 +393,7 @@ public sealed class CSharpPrinter
         var arguments = call.Arguments.Skip(1).ToList();
         if (!isThis && arguments.Count == 0)
             return null;  // implicit base()
-        return $"{(isThis ? "this" : "base")}({Arguments(arguments, callee.ParameterTypes)});";
+        return $"{(isThis ? "this" : "base")}({Arguments(arguments, callee.ParameterTypes, callee.ParameterRefKinds)});";
     }
 
     /// <summary>Baseline-style clause headers: bare <c>catch</c> for object (the catch-all), the variable form when the entry store folded into the clause.</summary>
@@ -497,7 +498,7 @@ public sealed class CSharpPrinter
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
-        NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes)})",
+        NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
@@ -955,10 +956,10 @@ public sealed class CSharpPrinter
             // operator spelling is the faithful inverse.
             if (call.Callee.IsSpecialName && OperatorSpelling(call) is { } op)
                 return op;
-            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes)})";
+            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
         }
         var receiver = arguments[0];
-        string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes);
+        string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
         if (call.Callee.Name == ".ctor" && receiver is LoadArgument { Index: 0, Name: "this" })
         {
             // A this-receiver constructor call is C#'s base(...)/this(...).
@@ -986,17 +987,59 @@ public sealed class CSharpPrinter
     /// that already align 1:1 with the parameters (the receiver of an instance
     /// call is dropped first), so index i maps to parameterTypes[i].
     /// </summary>
-    string Arguments(IEnumerable<IrExpression> arguments, IReadOnlyList<TypeRef> parameterTypes)
+    string Arguments(IEnumerable<IrExpression> arguments, IReadOnlyList<TypeRef> parameterTypes, ImmutableArray<ArgumentRefKind> refKinds)
     {
         var parts = new List<string>();
         int i = 0;
         foreach (var argument in arguments)
         {
-            parts.Add(i < parameterTypes.Count ? CastValue(argument, parameterTypes[i]) : Expression(argument));
+            var parameter = i < parameterTypes.Count ? parameterTypes[i] : null;
+            var refKind = i < refKinds.Length ? refKinds[i] : ArgumentRefKind.Value;
+            parts.Add(RefArgument(argument, parameter, refKind)
+                ?? (parameter is not null ? CastValue(argument, parameter) : Expression(argument)));
             i++;
         }
         return string.Join(", ", parts);
     }
+
+    /// <summary>
+    /// Spells a by-ref argument with the keyword its parameter demands:
+    /// <c>out</c>, <c>in</c> (no keyword — the readonly ref is implicit), or
+    /// <c>ref</c>. A managed pointer forwarded to a <c>ref</c>/<c>out</c>
+    /// parameter needs the keyword at the call site (CS1620); spelling it on an
+    /// <c>in</c> parameter is the inverse error (CS1615), so the address-of
+    /// node's own <c>ref</c> is dropped there. Null when the kind is unknown (a
+    /// cross-assembly MemberRef carries no parameter rows) or the argument is not
+    /// a simple place — both leave the existing spelling untouched.
+    /// </summary>
+    string? RefArgument(IrExpression argument, TypeRef? parameter, ArgumentRefKind refKind)
+    {
+        if (parameter is not { Kind: TypeRefKind.ByRef } || refKind == ArgumentRefKind.Value)
+            return null;
+        if (ArgumentPlace(argument) is not { } place)
+            return null;
+        return refKind switch
+        {
+            ArgumentRefKind.Out => $"out {place}",
+            ArgumentRefKind.In => place,
+            _ => $"ref {place}",
+        };
+    }
+
+    /// <summary>
+    /// The bare place of a by-ref argument — without any <c>ref</c> the keyword
+    /// renderer adds itself. Address-of nodes read back as their place; a by-ref
+    /// value (ref local/parameter, ref-returning call) already renders as a bare
+    /// place. Null for forms that are not a single place (a ref ternary binds
+    /// <c>ref</c> per arm), leaving them to the default spelling.
+    /// </summary>
+    string? ArgumentPlace(IrExpression argument) => argument switch
+    {
+        LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress => Deref(argument),
+        Unbox u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
+        LoadLocal or LoadArgument or LoadIndirect or Call or CallIndirect => Expression(argument),
+        _ => null,
+    };
 
     /// <summary>
     /// <c>target?.Member</c>: the member's receiver child is the target, and the
@@ -1033,7 +1076,7 @@ public sealed class CSharpPrinter
         string typeArguments = call.Callee.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
-        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes)})";
+        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
     }
 
     string ConvertText(Convert convert)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1217,6 +1217,7 @@ public static class IrImporter
                 return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
+                    ParameterRefKinds = ReadParameterRefKinds(reader, method, signature.ParameterTypes),
                 };
             }
             case HandleKind.MemberReference:
@@ -1262,6 +1263,34 @@ public static class IrImporter
             default:
                 return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
         }
+    }
+
+    /// <summary>
+    /// Recovers each parameter's call-site ref-kind (ref/out/in) from the
+    /// MethodDef parameter rows: a by-ref parameter flagged <c>Out</c> is
+    /// <c>out</c>, one flagged <c>In</c> is <c>in</c>, otherwise plain <c>ref</c>.
+    /// By-value parameters are <see cref="ArgumentRefKind.Value"/>. The result
+    /// aligns 1:1 with <paramref name="parameterTypes"/>.
+    /// </summary>
+    static ImmutableArray<ArgumentRefKind> ReadParameterRefKinds(MetadataReader reader, MethodDefinition method, ImmutableArray<TypeRef> parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+            return [];
+        var kinds = new ArgumentRefKind[parameterTypes.Length];
+        for (int i = 0; i < kinds.Length; i++)
+            kinds[i] = parameterTypes[i].Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value;
+        foreach (var handle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(handle);
+            int index = parameter.SequenceNumber - 1;  // sequence 0 is the return parameter
+            if (index < 0 || index >= kinds.Length || parameterTypes[index].Kind != TypeRefKind.ByRef)
+                continue;
+            if ((parameter.Attributes & System.Reflection.ParameterAttributes.Out) != 0)
+                kinds[index] = ArgumentRefKind.Out;
+            else if ((parameter.Attributes & System.Reflection.ParameterAttributes.In) != 0)
+                kinds[index] = ArgumentRefKind.In;
+        }
+        return ImmutableArray.Create(kinds);
     }
 
     internal static FieldRef ResolveField(MetadataReader reader, EntityHandle handle, GenericScope callerScope)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2,6 +2,9 @@ using System.Collections.Immutable;
 
 namespace ILInspector.Decompiler.Pipeline;
 
+/// <summary>How a by-reference argument must be spelled at a C# call site — recovered from the callee's parameter metadata.</summary>
+public enum ArgumentRefKind { Value, Ref, Out, In }
+
 /// <summary>A materialized method reference — callee identity with symbolic types, no metadata handles.</summary>
 public sealed record MethodRef(
     TypeRef DeclaringType,
@@ -12,6 +15,15 @@ public sealed record MethodRef(
 {
     /// <summary>Generic method type arguments (MethodSpec instantiations); empty for non-generic callees.</summary>
     public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
+
+    /// <summary>
+    /// Per-parameter call-site ref-kind (ref/out/in), aligned 1:1 with
+    /// <see cref="ParameterTypes"/>. Populated for same-assembly MethodDefs from
+    /// the parameter In/Out flags; empty when unknown (cross-assembly MemberRefs
+    /// carry no parameter rows), in which case the printer keeps its by-ref
+    /// argument spelling unchanged.
+    /// </summary>
+    public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; init; } = [];
 
     /// <summary>
     /// Metadata SpecialName evidence (accessors, operators). Exact for

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1661,10 +1661,11 @@ public class CommandExecutionTests
         Assert.Contains("## IL", output);
         Assert.Contains("## IL (Annotated)", output);
         Assert.DoesNotContain("## Original Source", output);
-        // The replacement pipeline renders the generic WriteNode<TValue> call
-        // with the explicit type argument and a ref-passed operand (the old
-        // emitter wrote the bare WriteNode(in value) form).
-        Assert.Contains("WriteNode<TValue>(ref value", output);
+        // WriteNode<TValue>'s first parameter is `in TValue`; the call site
+        // passes it without a keyword (an explicit `ref` here is CS1615). The
+        // operand renders bare, not as the old `ref value` spelling.
+        Assert.Contains("WriteNode<TValue>(value", output);
+        Assert.DoesNotContain("WriteNode<TValue>(ref value", output);
         Assert.DoesNotContain("ref ref", output);
     }
 


### PR DESCRIPTION
## What

Render the `ref`/`out` keyword (and the bare `in` argument) at C# call sites, recovered from the callee's parameter metadata.

A managed pointer forwarded into a by-ref parameter rendered as a bare place, so the call was missing the keyword C# requires (**CS1620**, "must be passed with the 'ref'/'out' keyword"). The printer had address-of nodes self-spell `ref` unconditionally — correct for `ref`/`out` parameters, but wrong for `in`, where an explicit `ref` is **CS1615**.

## How

- `IrImporter.ReadParameterRefKinds` recovers each parameter's call-site kind from the MethodDef parameter rows' In/Out flags (`in` is otherwise unrecoverable — the decoder discards the `in` modreq). Result aligns 1:1 with `ParameterTypes` and rides on a new `MethodRef.ParameterRefKinds`.
- `CSharpPrinter` spells each by-ref argument by kind: `out place`, bare `place` for `in`, `ref place` otherwise — applied uniformly to address-of nodes, by-ref values (ref locals/params, ref-returning calls), and unbox operands.
- Cross-assembly MemberRefs carry no parameter rows, so their ref-kinds stay empty and the printer keeps the prior spelling unchanged. No assembly resolution, no fidelity risk.

## Soundness

Ref-kinds come straight from metadata, never inferred. When a kind is unknown the output is byte-for-byte identical to before, so the change can only correct by-ref spellings, never invent them.

## Corpus

Harness `--pipeline next --compile-check` over 38191 Full methods:

| metric | before | after |
| --- | --- | --- |
| semantic defects (methods) | 683 | **594** (−89) |
| CS1620 (missing ref/out) | 182 | **6** |
| CS1615 (ref on in-param), methods | 7 | **6** (fixes `String::ReplaceCore`) |
| Full malformed | 1206 | 1206 |

No method-level regressions: the only new per-occurrence codes (CS1605 etc.) land in methods already in the defect set (e.g. `Decimal::.ctor`, already CS0193/CS0201).

## Tests

- `+1` in `ILInspector.Decompiler.Tests` (413 → 414): a same-assembly caller forwarding a pointer to `ref`/`out`/`in` helpers asserts the keywords appear and the `in` argument is bare.
- Updated `JsonSerializer.SerializeToNode`'s expectation: its `in TValue` operand now renders bare; the prior `ref value` was the CS1615-invalid spelling this change corrects.
- Full suite green: `dotnet-inspect.Tests` 1104 passed (9 skipped).
