### PR TITLE
Materialize boolean stack slots fed by int literals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1205,6 +1205,18 @@ public class CfgSampleClass
     // handler..ctor(...) (CS0201, "not a valid statement").
     public static string InterpolatedStruct(int value) => $"value={value} again={value}";
 
+    // Candidates for the boolean-materialization pass: a select/diamond that
+    // stores a literal 0/1 beside a genuine bool into a synthetic stack slot.
+    // A select that puts a bool literal beside a genuine bool expression; the
+    // compiler emits the literal as `0`, which the boolean-materialization pass
+    // recovers as `false` so the slot declares bool, not int (CS0029).
+    public static bool SelectBoolReturn(object gate, int x)
+    {
+        bool result = x > 0 ? false : x.GetHashCode() > 0;
+        System.GC.KeepAlive(gate);
+        return result;
+    }
+
     // Same-assembly callees with explicit ref-kinds, so the importer can recover
     // each parameter's keyword from the MethodDef parameter rows.
     public static void RefHelper(ref int x) => x++;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1001,6 +1001,35 @@ public class RaisingPassTests
         Assert.DoesNotContain("InHelper(out", output);
     }
 
+    [Fact]
+    public void BooleanMaterialization_SelectWithIntLiteral_DeclaresBoolSlot()
+    {
+        // `cond ? false : boolExpr` lowers to a select whose false arm is the
+        // literal 0; the pass recovers it as `false` and types the slot bool, so
+        // the bool-returning method no longer returns an int slot (CS0029).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.SelectBoolReturn), source);
+
+        Assert.Contains("bool S_0", output);
+        Assert.DoesNotContain("int S_0", output);
+        Assert.Contains(": false", output);
+        Assert.DoesNotContain(": 0", output);
+    }
+
+    [Fact]
+    public void BooleanMaterialization_MultiStoreSlotDiamond_DeclaresBoolSlot()
+    {
+        // A bool computed across an if/else diamond spills to a stack slot whose
+        // else arm stores the literal 0; the pass retypes the constant store and
+        // the slot's loads to bool (the multi-store counterpart of the select).
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        string output = PrintWithPasses("System.RuntimeType", "get_IsActualEnum", source);
+
+        Assert.Contains("bool S_0", output);
+        Assert.DoesNotContain("int S_0", output);
+        Assert.Contains("S_0 = false;", output);
+    }
+
 
     [Fact]
     public void TypedConstants_BoolReturn_PrintsFalse()

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -19,10 +19,58 @@ public sealed class BooleanFoldingPass : IIrPass
 
     public void Run(IrFunction function)
     {
-        while (FoldOnce(function))
+        while (FoldOnce(function) || MaterializeBooleanSlots(function))
         {
         }
     }
+
+    /// <summary>
+    /// Retypes a stack slot to <c>bool</c> when its stores prove it holds a
+    /// boolean: at least one store is a non-constant bool expression and every
+    /// other store is a bool or an <c>int</c> literal 0/1 (IL's spelling of
+    /// false/true). The 0/1 constant stores become bool literals and the slot's
+    /// loads retype, so a bool-returning method that returns the slot stops
+    /// declaring it <c>int</c> (CS0029). The non-constant bool store is the
+    /// proof — a genuine integer slot never receives one.
+    /// </summary>
+    static bool MaterializeBooleanSlots(IrFunction function)
+    {
+        var storesBySlot = new Dictionary<int, List<StoreStackSlot>>();
+        var loadsBySlot = new Dictionary<int, List<LoadStackSlot>>();
+        foreach (var node in function.Descendants)
+        {
+            if (node is StoreStackSlot store)
+                (storesBySlot.TryGetValue(store.Slot, out var list) ? list : storesBySlot[store.Slot] = []).Add(store);
+            else if (node is LoadStackSlot load)
+                (loadsBySlot.TryGetValue(load.Slot, out var list) ? list : loadsBySlot[load.Slot] = []).Add(load);
+        }
+
+        bool changed = false;
+        foreach (var (slot, stores) in storesBySlot)
+        {
+            bool evidence = stores.Any(s => s.Value is not Constant && IsBool(s.Value.ResultType));
+            bool consistent = stores.All(s => IsZeroOne(s.Value) || IsBool(s.Value.ResultType));
+            if (!evidence || !consistent)
+                continue;
+            var loads = loadsBySlot.GetValueOrDefault(slot) ?? [];
+            if (!stores.Any(s => IsZeroOne(s.Value)) && !loads.Any(l => !IsBool(l.Type)))
+                continue;  // nothing left to retype
+
+            var boolType = TypeRef.CoreLib("System", "Boolean");
+            foreach (var store in stores)
+                if (store.Value is Constant { Value: int value })
+                    store.Value.ReplaceWith(new Constant(value == 1, boolType));
+            foreach (var load in loads)
+                if (!IsBool(load.Type))
+                    load.ReplaceWith(new LoadStackSlot(slot, boolType));
+            changed = true;
+        }
+        return changed;
+    }
+
+    static bool IsZeroOne(IrExpression expression) => expression is Constant { Value: int value } && value is 0 or 1;
+
+    static bool IsBool(TypeRef? type) => type is { Namespace: "System", Name: "Boolean" };
 
     static bool FoldOnce(IrFunction function)
     {
@@ -35,12 +83,36 @@ public sealed class BooleanFoldingPass : IIrPass
                 IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement)
                     || FoldSlotDiamond(function, statement) || FoldCoalesce(statement),
                 Comparison comparison => FoldBoolConstantComparison(comparison),
+                Conditional conditional => MaterializeBoolConditional(conditional),
                 _ => false,
             };
             if (folded)
                 return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// <c>cond ? 0 : boolExpr</c> → <c>cond ? false : boolExpr</c>. IL has no
+    /// bool constant (ldc.i4 serves bools too), so a select that sets a literal
+    /// 0/1 beside a genuine bool arm is a boolean expression. Retyping the
+    /// constant — and the conditional's merged result — recovers it; the slot
+    /// then declares as <c>bool</c>, not <c>int</c> (the source of CS0029 when a
+    /// bool-returning method returns the slot). The non-constant bool arm is the
+    /// proof: a real integer select never pairs with one.
+    /// </summary>
+    static bool MaterializeBoolConditional(Conditional conditional)
+    {
+        var constant = (conditional.WhenTrue as Constant) ?? (conditional.WhenFalse as Constant);
+        var other = conditional.WhenTrue is Constant ? conditional.WhenFalse : conditional.WhenTrue;
+        if (constant is not { Value: int value } || value is not (0 or 1))
+            return false;
+        if (other is Constant || other.ResultType is not { Namespace: "System", Name: "Boolean" })
+            return false;
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        constant.ReplaceWith(new Constant(value == 1, boolType));
+        conditional.MergedType = boolType;
+        return true;
     }
 
     /// <summary>X == false → !X (via the type-aware duals), X == true → X, and the != duals — the ceq-with-zero value form of boolean tests.</summary>


### PR DESCRIPTION
## What

Recover the `bool` type of a value that the compiler computed into a synthetic stack slot beside a literal `0`/`1`. IL has no bool constant (`ldc.i4.0/1` serves false/true), so such a slot declares as `int`, and a bool-returning method that returns it fails to bind — **CS0029**, "cannot implicitly convert type 'int' to 'bool'".

## How

`BooleanFoldingPass` now retypes boolean slots in two shapes:

- **Select:** `cond ? 0 : boolExpr` → `cond ? false : boolExpr`. The literal arm becomes a bool and the conditional's merged result types `bool`.
- **Multi-store diamond:** `if (c) { S = boolExpr } else { S = 0 }` → the `0` store becomes `false` and the slot's loads retype to `bool`.

Both require a **non-constant bool store** as proof the slot is boolean (a genuine integer slot never receives one) and every other store to be a bool or an int literal `0`/`1`. This is the same "a `0` in a bool position IS `false`" principle `TypedConstantsPass` already applies to direct constants — lifted to constants buried in selects and slot joins.

## Soundness

The bool-typed store is metadata evidence, never inference. Without it the slot is left untouched, so the pass can only recover a boolean spelling that was always there — it can never invent one.

## Corpus

Harness `--pipeline next --compile-check` over 38191 Full methods:

| metric | before | after |
| --- | --- | --- |
| semantic defects (methods) | 594 | **582** (−12) |
| CS0029 occurrences | 197 | **181** |
| Full malformed | 1206 | 1206 |

Every other defect code is unchanged — only CS0029 moved — so there are no method-level regressions.

## Example

`System.RuntimeType.IsActualValueType`:

```diff
-int S_0 = V_0.IsTypeDesc ? 0 : V_0.AsMethodTable().IsValueType;
+bool S_0 = V_0.IsTypeDesc ? false : V_0.AsMethodTable().IsValueType;
 return S_0;
```

## Tests

`+2` in `ILInspector.Decompiler.Tests` (414 → 416): a self-contained select sample and the corelib multi-store diamond (`RuntimeType.get_IsActualEnum`) assert the slot declares `bool` and the literal renders `false`. Full suite green (`dotnet-inspect.Tests` 1104 passed, 9 skipped).
