### PR TITLE
Insert explicit (Enum)x casts at non-constant int->enum boundaries

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -411,6 +411,11 @@ public class CfgSampleClass
     // retype to CfgPriority, otherwise `p & 2` is CS0019 (enum & int).
     public static CfgPriority MaskHighPriority(CfgPriority p) => p & CfgPriority.High;
 
+    // A non-constant int converted to an enum: IL carries an enum as its
+    // underlying int with no conv, so the printer must re-insert the explicit
+    // (CfgPriority)value cast — C# converts int->enum implicitly only for 0.
+    public static CfgPriority ToPriority(int value) => (CfgPriority)value;
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2355,6 +2355,19 @@ public class EnumConstantTests
         Assert.DoesNotContain("& 2", output);
     }
 
+    [Fact]
+    public void NonConstantIntToEnum_InsertsCast()
+    {
+        // (CfgPriority)value — a non-constant int into an enum-typed position has
+        // no IL conv to lean on, so the printer must spell the explicit cast;
+        // a bare `return value;` is CS0266 (int is not implicitly an enum).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ToPriority), source);
+
+        Assert.Contains("return (CfgPriority)value;", output);
+    }
+
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
     {
         var block = new Block(0);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -737,6 +737,17 @@ public sealed class CSharpPrinter
         // those to render as-is.
         if (value is Conditional or Coalesce or LoadStackSlot)
             return Expression(value);
+        // An integer flowing into an enum-typed position — a comparison kind, a
+        // flags value computed at run time — needs an explicit (Enum)x cast: C#
+        // converts int→enum implicitly only for the literal 0. The cast is always
+        // legal off any integer and is faithful, since IL carries an enum as its
+        // underlying integer (TypedConstantsPass already retypes the constant
+        // operands, so only the genuinely non-constant boundaries reach here).
+        if (target is { } enumTarget
+            && _function.TypeShapes.GetValueOrDefault(enumTarget) == TypeShape.Enum
+            && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
+            && TypeFamilies.IsIntegerLike(enumSource))
+            return $"({TypeText(enumTarget)}){Operand(value)}";
         // A constant carries an exact value: C# converts an in-range one to the
         // target type implicitly (render bare), while an out-of-range one — a
         // negative into unsigned, a bitmask wider than the target — does not

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -111,6 +111,10 @@ public static class TypeFamilies
             && type.Name is "SByte" or "Byte" or "Int16" or "UInt16" or "Int32" or "UInt32"
                 or "Int64" or "UInt64" or "IntPtr" or "UIntPtr" or "Char" or "Single" or "Double";
 
+    /// <summary>An integer-family primitive — the values that can carry an enum's underlying representation, so an explicit cast to the enum is faithful (floats excluded).</summary>
+    public static bool IsIntegerLike(TypeRef type)
+        => IsNumericPrimitive(type) && type.Name is not ("Single" or "Double");
+
     /// <summary>Byte width of a fixed-width integer primitive; null for the platform-sized (nint/nuint) and float types.</summary>
     static int? Width(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
         ? type.Name switch


### PR DESCRIPTION
## What

`CastValue` rendered an integer flowing into an enum-typed position bare, which is **CS0266** — C# converts `int`→`enum` implicitly only for the literal `0`. A non-constant comparison kind or a flags value computed at run time has no IL `conv` to lean on (IL carries an enum as its underlying integer), so the printer must re-insert the explicit `(Enum)x` cast. `TypedConstantsPass` already retypes the *constant* operands, so only the genuinely non-constant boundaries reach this branch.

## Soundness

The cast is always legal off any integer and faithful to the IL — a pure reinterpretation of the underlying representation, never a value change. Scoped to **direct integer values**: stack-slot/merge sources stay bare, since a slot's declared type can diverge from a single load's type, where a keyed cast would risk CS0030. Enum detection reuses `_function.TypeShapes`.

## Corpus (`--pipeline next --compile-check`, 38191 Full methods)

| | before | after |
| --- | --- | --- |
| semantic defects | 582 | **579** (−3) |
| CS0266 (occurrences) | 236 | **232** (−4) |
| CS0029 | 181 | 181 |
| CS0030 | 96 | 96 |
| Full malformed | 1206 | 1206 |

Only the targeted code drops; every other code is unchanged. No regressions. Tests +1 (417 decompiler, 1110 main).
