### PR TITLE
Render a value-type this read as `this`, not the CS0193 `*this`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1273,6 +1273,15 @@ public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
 [System.Flags]
 public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
 
+// A value-type instance method whose `this` value is read directly: returning
+// `this` by value compiles to `ldarg.0; ldobj` (a load-indirect of the `this`
+// managed pointer), which must render as `this`, not the CS0193 `*this`.
+public struct CfgSelf
+{
+    public int Value;
+    public CfgSelf Identity() => this;
+}
+
 public sealed class CfgNullableTarget
 {
     public int Value;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2368,6 +2368,20 @@ public class EnumConstantTests
         Assert.Contains("return (CfgPriority)value;", output);
     }
 
+    [Fact]
+    public void ValueTypeThisRead_RendersAsThis()
+    {
+        // `ldarg.0; ldobj` reads the value through the `this` managed pointer;
+        // C#'s `this` already denotes the value, so it renders bare — `*this`
+        // would be CS0193 (`this` is not an unmanaged pointer).
+        using var source = MetadataSource.Open(typeof(CfgSelf).Assembly.Location);
+        string output = new RaisingPassTestsAccessor().Print(
+            typeof(CfgSelf).FullName!, nameof(CfgSelf.Identity), source);
+
+        Assert.Contains("return this;", output);
+        Assert.DoesNotContain("*this", output);
+    }
+
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
     {
         var block = new Block(0);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -657,6 +657,11 @@ public sealed class CSharpPrinter
     /// </summary>
     string Deref(IrExpression address) => address switch
     {
+        // `this` in a value-type instance method is a managed pointer to the
+        // value (IL's `ldarg.0` pushes `T&`), but C#'s `this` already denotes
+        // the value, so reading through it is just `this` — never `*this`,
+        // which is CS0193 (DeclaringType is never an unmanaged pointer).
+        LoadArgument { Index: 0, Name: "this" } => "this",
         LoadLocalAddress a => $"V_{a.Index}",
         LoadArgumentAddress a => a.Name,
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),


### PR DESCRIPTION
## What

`this` in a value-type instance method is a managed pointer to the value (IL's `ldarg.0` pushes `T&`), but the importer types it as the value type itself. So a `ldarg.0; ldind`/`ldobj` lowered to `LoadIndirect(this)` fell through `Deref` to **`*this`** — **CS0193**, since `this` is not an unmanaged pointer. C#'s `this` already denotes the value, so reading through it is just `this`.

## Soundness

Faithful — the managed-pointer dereference is implicit in C#'s `this`, matching how `Deref` already collapses ref locals/args/fields/elements to their place. Keyed on `LoadArgument { Index: 0, Name: "this" }`; `DeclaringType` is never a pointer, so a `this` deref always spells bare. Reference-type `this` (never load-indirected) is unaffected.

## Corpus (`--pipeline next --compile-check`, 38191 Full methods)

| | before | after |
| --- | --- | --- |
| semantic defects | 579 | **441** (−138) |
| CS0193 | 168 | **0** |
| CS0019 | 79 | 79 |
| CS0266 | 232 | 232 |
| Full malformed | 1206 | 1206 |

CS0193 is eliminated entirely; every other code is unchanged. The methods that would surface a latent `bool > uint` (CS0019) after the fix were already failing on CS0193 at baseline, so nothing reshuffles. No regressions. Tests +1 (418 decompiler, 1110 main).
