### PR TITLE
Parenthesize operator-spelled calls as compound operands

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2382,6 +2382,31 @@ public class EnumConstantTests
         Assert.DoesNotContain("*this", output);
     }
 
+    [Fact]
+    public void NotOverOperatorCall_Parenthesizes()
+    {
+        // !(a != b) — an operator-spelled call renders as a compound `a != b`,
+        // so the enclosing `!` must parenthesize it; a bare `!a != b` binds as
+        // `(!a) != b` (CS0023). The C# compiler folds this source form, so the
+        // node is built directly.
+        var type = TypeRef.CoreLib("System", "Type");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var callee = new MethodRef(type, "op_Inequality", boolType, [type, type], HasThis: false) { IsSpecialName = true };
+        var inequality = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", type), new LoadArgument(1, "b", type)]);
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(inequality)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("!(a != b)", output);
+        Assert.DoesNotContain("!a != b", output);
+    }
+
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
     {
         var block = new Block(0);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -641,9 +641,15 @@ public sealed class CSharpPrinter
     string Operand(IrExpression node)
     {
         string text = Expression(node);
+        // A Call is an atom only when it spells as a method invocation; an
+        // operator-spelled call (op_Inequality → `a != b`, op_UnaryNegation →
+        // `-x`) renders as a compound expression, so it must parenthesize like
+        // any other binary/unary — otherwise an enclosing `!`/`-`/binary
+        // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
-            or Call or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional;
+            or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
+            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional
+            || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }
 
@@ -809,6 +815,9 @@ public sealed class CSharpPrinter
         _ => false,
     };
 
+    /// <summary>True when a non-instance call renders as a C# operator (`a != b`, `-x`) rather than a method invocation — the compound form that must parenthesize as an operand.</summary>
+    bool IsOperatorCall(Call call) => !call.Callee.HasThis && call.Callee.IsSpecialName && OperatorSpelling(call) is not null;
+
     /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
     string? OperatorSpelling(Call call)
     {
@@ -970,8 +979,8 @@ public sealed class CSharpPrinter
         {
             // C# compiles user-defined operators TO these calls; the
             // operator spelling is the faithful inverse.
-            if (call.Callee.IsSpecialName && OperatorSpelling(call) is { } op)
-                return op;
+            if (IsOperatorCall(call))
+                return OperatorSpelling(call)!;
             return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
         }
         var receiver = arguments[0];


### PR DESCRIPTION
## What

`Operand()` treated every `Call` as an atom, but a call that renders as a C# operator (`op_Inequality` → `a != b`, `op_UnaryNegation` → `-x`) is a **compound** expression. Left bare under an enclosing `!`/unary/binary, it misbinds to the call's first operand: `!(a != b)` rendered **`!a != b`**, which C# parses as `(!a) != b` → **CS0023** ("operator '!' cannot be applied to operand of type 'T'" — the left operand's type, which is why the bucket reads `!Type`, `!Half`, `!string`, …).

## How

A new `IsOperatorCall` helper captures the exact operator-rendering condition (non-instance + special-name + has an operator spelling), now shared by `CallText` (which already chose the operator form) and `Operand` (which now parenthesizes it). Adding parens is always legal and never a value change.

## Corpus (`--pipeline next --compile-check`, 38191 Full methods)

| | before | after |
| --- | --- | --- |
| semantic defects | 441 | **408** (−33) |
| CS0023 | 129 | **10** |
| Full malformed | 1206 | 1206 |
| CS0019 | 79 | 82 (+3) |

The CS0019 +3 is two methods (`MemberInfoCache.PopulateProperties`, `DefaultBinder.CanChangePrimitive`) that were **already failing on CS0023 at baseline**; fixing the `!` unmasks a latent deeper bool/enum operator mismatch. No new failing methods, no method-level regression. Tests +1 (419 decompiler, 1188 main).
