### PR TITLE
Consolidate simple-name and attribute-name extraction in TypeMatcher

### DIFF
--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -75,7 +75,7 @@ public static class AssemblyDetailScanner
                     continue;
                 }
 
-                string shortName = GetShortAttributeName(name);
+                string shortName = TypeMatcher.GetShortAttributeName(name);
                 string? value = TryGetAttributeDisplayValue(reader, attr);
                 results.Add(new AssemblyAttributeInfo(shortName, target, value));
             }
@@ -275,17 +275,6 @@ public static class AssemblyDetailScanner
         "System.CLSCompliantAttribute" => true,
         _ => false
     };
-
-    private static string GetShortAttributeName(string fullName)
-    {
-        // Remove "Attribute" suffix and namespace
-        var name = fullName;
-        if (name.EndsWith("Attribute", StringComparison.Ordinal))
-            name = name[..^9];
-
-        var lastDot = name.LastIndexOf('.');
-        return lastDot >= 0 ? name[(lastDot + 1)..] : name;
-    }
 
     private static string? TryGetAttributeDisplayValue(MetadataReader reader, CustomAttribute attr)
     {

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -208,7 +208,7 @@ public static class AttributeReader
             if (attrTypeName == null || IsMethodNoiseAttribute(attrTypeName))
                 continue;
 
-            var shortName = GetShortAttributeName(attrTypeName);
+            var shortName = TypeMatcher.GetShortAttributeName(attrTypeName);
             var value = TryGetAttributeDisplayValue(reader, attr);
             results.Add((shortName, value));
         }
@@ -267,15 +267,6 @@ public static class AttributeReader
         "System.Runtime.CompilerServices.MethodImplAttribute" => false, // interesting to see
         _ => false
     };
-
-    private static string GetShortAttributeName(string fullName)
-    {
-        var name = fullName;
-        if (name.EndsWith("Attribute", StringComparison.Ordinal))
-            name = name[..^9];
-        var lastDot = name.LastIndexOf('.');
-        return lastDot >= 0 ? name[(lastDot + 1)..] : name;
-    }
 
     /// <summary>
     /// Renders the source attributes on an entity as their bracket contents
@@ -362,7 +353,7 @@ public static class AttributeReader
     {
         if (AttributeDecoder.TryDecode(reader, attr) is not { } value)
             return null;
-        string name = GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);
+        string name = TypeMatcher.GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);
         var args = new List<string>();
         foreach (var arg in value.FixedArguments)
         {

--- a/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -227,7 +227,7 @@ public static class EcosystemIntegrationScanner
         if (!IsConfigurationType(typeName))
             return false;
 
-        var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+        var simpleName = TypeMatcher.GetSimpleName(typeName);
         if (simpleName.EndsWith("ConfigurationProvider", StringComparison.Ordinal))
             kind = "Provider";
         else if (simpleName.EndsWith("ConfigurationSource", StringComparison.Ordinal))
@@ -260,7 +260,7 @@ public static class EcosystemIntegrationScanner
         if (!IsAspNetCoreType(typeName))
             return false;
 
-        var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+        var simpleName = TypeMatcher.GetSimpleName(typeName);
         if (simpleName.EndsWith("Options", StringComparison.Ordinal)
             || simpleName.EndsWith("Settings", StringComparison.Ordinal))
         {
@@ -291,7 +291,7 @@ public static class EcosystemIntegrationScanner
         if (!IsAuthenticationType(typeName))
             return false;
 
-        var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+        var simpleName = TypeMatcher.GetSimpleName(typeName);
         if (simpleName.EndsWith("Options", StringComparison.Ordinal)
             || simpleName.EndsWith("Events", StringComparison.Ordinal)
             || simpleName.EndsWith("Defaults", StringComparison.Ordinal)
@@ -356,7 +356,7 @@ public static class EcosystemIntegrationScanner
         if (!IsOpenApiType(typeName))
             return false;
 
-        var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+        var simpleName = TypeMatcher.GetSimpleName(typeName);
         if (simpleName.EndsWith("Options", StringComparison.Ordinal)
             || simpleName.EndsWith("Settings", StringComparison.Ordinal))
         {
@@ -437,7 +437,7 @@ public static class EcosystemIntegrationScanner
 
         if (typeName.EndsWith("Resource", StringComparison.Ordinal))
         {
-            var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+            var simpleName = TypeMatcher.GetSimpleName(typeName);
             kind = simpleName is ['I', >= 'A' and <= 'Z', ..]
                 ? "Resource Interface"
                 : "Resource";

--- a/src/ILInspector.Metadata/IntegrationOpportunityScanner.cs
+++ b/src/ILInspector.Metadata/IntegrationOpportunityScanner.cs
@@ -26,7 +26,7 @@ public static class IntegrationOpportunityScanner
                 continue;
 
             var typeName = reader.GetFullTypeName(typeDefinition);
-            var simpleName = typeName[(typeName.LastIndexOf('.') + 1)..];
+            var simpleName = TypeMatcher.GetSimpleName(typeName);
 
             AddAuthDomainGaps(gaps, existingIntegrations, typeName, simpleName);
             AddCloudClientGaps(gaps, existingIntegrations, typeName, simpleName);
@@ -198,7 +198,7 @@ public static class IntegrationOpportunityScanner
 
     private static int GetEvidenceRank(string evidence)
     {
-        var simpleName = evidence[(evidence.LastIndexOf('.') + 1)..];
+        var simpleName = TypeMatcher.GetSimpleName(evidence);
         return simpleName switch
         {
             "CognitoUser" => 0,

--- a/src/ILInspector.Metadata/SourceLinkService.cs
+++ b/src/ILInspector.Metadata/SourceLinkService.cs
@@ -239,7 +239,7 @@ public class SourceLinkService : IDisposable
             if (filePathsForType.Count > 0)
             {
                 // Use short name (without namespace) for lookup convenience
-                var shortName = typeName.Contains('.') ? typeName[(typeName.LastIndexOf('.') + 1)..] : typeName;
+                var shortName = TypeMatcher.GetSimpleName(typeName);
                 
                 // Store under both full and short name
                 var paths = filePathsForType.Order().ToArray();

--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -232,6 +232,19 @@ public static class TypeMatcher
     }
 
     /// <summary>
+    /// Extracts a display-friendly attribute name by stripping a trailing
+    /// "Attribute" suffix and the namespace.
+    /// "System.ObsoleteAttribute" → "Obsolete"
+    /// </summary>
+    public static string GetShortAttributeName(string fullName)
+    {
+        var name = fullName.EndsWith("Attribute", StringComparison.Ordinal)
+            ? fullName[..^9]
+            : fullName;
+        return GetSimpleName(name);
+    }
+
+    /// <summary>
     /// Extracts the namespace from a full type name.
     /// "System.Collections.Generic.List`1" → "System.Collections.Generic"
     /// </summary>

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -323,8 +323,7 @@ public static class MemberCommand
                     : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
                     : "";
 
-                var simpleName = apiType.FullName.Contains('.')
-                    ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
+                var simpleName = TypeMatcher.GetSimpleName(apiType.FullName);
 
                 var overloadGroups = apiType.Members
                     .Where(ApiMemberSectionDescriptors.IsMethodLike)

--- a/src/dotnet-inspect/Commands/SourceCommand.cs
+++ b/src/dotnet-inspect/Commands/SourceCommand.cs
@@ -250,8 +250,7 @@ public static class SourceCommand
             var exampleType = typeList.FirstOrDefault(t => rows.Any(r => r.Type == t.FullName && r.Url != null));
             if (exampleType != null)
             {
-                var simpleName = exampleType.FullName.Contains('.')
-                    ? exampleType.FullName[(exampleType.FullName.LastIndexOf('.') + 1)..] : exampleType.FullName;
+                var simpleName = TypeMatcher.GetSimpleName(exampleType.FullName);
                 var sourceFlag = !string.IsNullOrEmpty(options.PlatformAssembly) ? $"--platform {options.PlatformAssembly}"
                     : !string.IsNullOrEmpty(options.PackagePath) ? $"--package {packageName ?? options.PackagePath}"
                     : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
@@ -452,8 +451,7 @@ public static class SourceCommand
                     : !string.IsNullOrEmpty(options.PackagePath) ? $"{packageName ?? options.PackagePath}"
                     : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
                     : "";
-                var simpleName = apiType.FullName.Contains('.')
-                    ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
+                var simpleName = TypeMatcher.GetSimpleName(apiType.FullName);
 
                 Console.Error.WriteLine($"No source URLs found for '{matchedTypeName}'.");
                 Console.Error.WriteLine("The PDB may not contain SourceLink document mappings.");

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -119,8 +119,7 @@ public static class TypeCommand
 
                     if (exampleType != null)
                     {
-                        var simpleName = exampleType.FullName.Contains('.')
-                            ? exampleType.FullName[(exampleType.FullName.LastIndexOf('.') + 1)..] : exampleType.FullName;
+                        var simpleName = TypeMatcher.GetSimpleName(exampleType.FullName);
 
                         List<Tip> tips =
                         [
@@ -264,8 +263,7 @@ public static class TypeCommand
                             : !string.IsNullOrEmpty(options.AssemblyPath) ? $"--library {options.AssemblyPath}"
                             : "";
 
-                        var simpleName = apiType.FullName.Contains('.')
-                            ? apiType.FullName[(apiType.FullName.LastIndexOf('.') + 1)..] : apiType.FullName;
+                        var simpleName = TypeMatcher.GetSimpleName(apiType.FullName);
 
                         var overloadGroups = apiType.Members
                             .Where(ApiMemberSectionDescriptors.IsMethodLike)


### PR DESCRIPTION
## Summary

Follow-up consolidation (no behavior change). Two duplicated string primitives are unified onto the existing `TypeMatcher` helpers in `ILInspector.Metadata`:

### 1. Simple-name extraction → `TypeMatcher.GetSimpleName`

`TypeMatcher.GetSimpleName(fullName)` (strip namespace) already existed, but the same logic was re-implemented inline at **13 call sites**:

- `EcosystemIntegrationScanner` ×5, `IntegrationOpportunityScanner` ×2, `SourceLinkService` ×1
- `TypeCommand` ×2, `SourceCommand` ×2, `MemberCommand` ×1

Behavior-preserving: `x.Contains('.') ? x[(x.LastIndexOf('.')+1)..] : x` is exactly `GetSimpleName`'s guarded logic.

### 2. Short attribute name → `TypeMatcher.GetShortAttributeName`

The private `GetShortAttributeName` method (strip `"Attribute"` suffix + namespace) was duplicated **verbatim** in `AttributeReader` and `AssemblyDetailScanner`. Promoted a single public `TypeMatcher.GetShortAttributeName` (implemented via `GetSimpleName`) and routed both callers to it.

## Testing

- `dotnet-inspect.Tests`: 1140 pass / 9 skip (ilasm-gated)
- `ILInspector.Metadata.Tests`: 194 pass

Net −12 lines across 9 files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
