### PR TITLE
Render a value-type isinst as `obj is T`, not the CS0077 `obj as T`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2407,6 +2407,59 @@ public class EnumConstantTests
         Assert.DoesNotContain("!a != b", output);
     }
 
+    [Fact]
+    public void IsInstanceValueType_RendersAsIs()
+    {
+        // `isinst <valuetype>` is `obj is T`, not `obj as T`: `as` on a
+        // non-nullable value type is CS0077. Built directly so the rendering
+        // is tested independent of csc codegen.
+        var objType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var block = new Block(0);
+        block.Add(new Return(new IsInstance(byteType, new LoadArgument(0, "obj", objType))));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [objType], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [byteType] = TypeShape.ValueType },
+        };
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("obj is byte", output);
+        Assert.DoesNotContain(" as byte", output);
+    }
+
+    [Fact]
+    public void IsInstanceValueType_AsCondition_NoIntCompare()
+    {
+        // A value-type `isinst` used as a branch test is already boolean
+        // (`obj is byte`); wrapping it in `!= 0` would be `bool != int`
+        // (CS0019), so the condition must render bare.
+        var objType = TypeRef.CoreLib("System", "Object");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var then = new Block(0);
+        then.Add(new Return(new Constant(1, intType)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(new IsInstance(byteType, new LoadArgument(0, "obj", objType)), then, null));
+        entry.Add(new Return(new Constant(0, intType)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var signature = new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [objType], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [byteType] = TypeShape.ValueType },
+        };
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("obj is byte", output);
+        Assert.DoesNotContain("!= 0", output);
+    }
+
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
     {
         var block = new Block(0);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -504,7 +504,7 @@ public sealed class CSharpPrinter
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         Box b => Expression(b.Operand),
-        IsInstance i => $"{Operand(i.Operand)} as {TypeText(i.Type)}",
+        IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
         UnboxAny u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
@@ -605,6 +605,12 @@ public sealed class CSharpPrinter
     /// </summary>
     (string Direct, string Inverted)? Truthiness(IrExpression operand)
     {
+        // A value-type `isinst` already renders as the boolean `obj is T`, so it
+        // is its own truth value — wrapping it in `!= 0` would be `bool != int`
+        // (CS0019). The inverse spells the negated pattern.
+        if (operand is IsInstance ii && IsValueTypeTarget(ii.Type))
+            return ($"{Operand(operand)}", $"!({Operand(operand)})");
+
         var type = operand.ResultType;
         if (type is null || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
             return null;
@@ -817,6 +823,17 @@ public sealed class CSharpPrinter
 
     /// <summary>True when a non-instance call renders as a C# operator (`a != b`, `-x`) rather than a method invocation — the compound form that must parenthesize as an operand.</summary>
     bool IsOperatorCall(Call call) => !call.Callee.HasThis && call.Callee.IsSpecialName && OperatorSpelling(call) is not null;
+
+    /// <summary>
+    /// True when <paramref name="type"/> is a value type, so an <c>isinst</c>
+    /// type-test must spell <c>obj is T</c> — <c>obj as T</c> is CS0077 on a
+    /// non-nullable value type. Primitives are value types intrinsically;
+    /// other definitions resolve through the shape map (enums included).
+    /// </summary>
+    bool IsValueTypeTarget(TypeRef type)
+        => TypeFamilies.IsNumericPrimitive(type)
+            || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
+            || _function.TypeShapes.GetValueOrDefault(type) is TypeShape.ValueType or TypeShape.Enum;
 
     /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
     string? OperatorSpelling(Call call)


### PR DESCRIPTION
## Summary

IL `isinst <valuetype>` lowered to `obj as T`, but `as` on a non-nullable
value type is **CS0077**. The faithful C# spelling is the boolean type-test
`obj is T`. The printer now renders `IsInstance` with `is` when the target is
a value type (numeric primitive, `Boolean`, or a `ValueType`/`Enum` shape),
and `as` otherwise.

Because `obj is T` is already boolean, a value-type `isinst` used as a branch
condition must render bare. The prior int-truthiness path wrapped it in `!= 0`
(`(obj is byte) != 0`), which is `bool != int` (**CS0019**). `Truthiness` now
returns the bare pattern for a value-type `isinst` (negation spells `!(...)`).

e.g. `System.Byte::Equals` now renders:

```csharp
return (obj is byte) && (this) == ((byte)obj);
```

## Soundness

`is`/`as` are not interchangeable — `as` requires a nullable result type, so
the prior spelling only ever bound (correctly) for reference targets. Switching
value-type targets to `is` is the IL-faithful and only-bindable form; the
boolean result is unchanged.

## Corpus (`--pipeline next --compile-check`)

- Semantic binding: **408 → 382 (−26)**
- CS0077: **27 → 1**
- CS0023: 10 → 6 (bonus — value-type test parenthesization)
- CS0019: **flat at 82** (the `Truthiness` fix cleared the unmasked `!= 0`
  tests — no reshuffle)
- Full malformed: **flat 1206**
- No method-level regressions.

## Tests

+2 synthetic-IR tests (421 total): value-type `isinst` renders `is`/no `as`;
value-type `isinst` as a condition renders bare/no `!= 0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
