### PR TITLE
Fix four soundness findings from the raising-pass review

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -752,7 +752,13 @@ public sealed class CSharpPrinter
             && _function.TypeShapes.GetValueOrDefault(enumTarget) == TypeShape.Enum
             && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
             && TypeFamilies.IsIntegerLike(enumSource))
-            return $"({TypeText(enumTarget)}){Operand(value)}";
+        {
+            // A negative literal must be parenthesized after the cast (CS0075),
+            // as the enum-constant path above (line ~482) already does.
+            bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
+                || value is Constant { Value: long lv } && lv < 0;
+            return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
+        }
         // A constant carries an exact value: C# converts an in-range one to the
         // target type implicitly (render bare), while an out-of-range one — a
         // negative into unsigned, a bitmask wider than the target — does not

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1266,15 +1266,21 @@ public static class IrImporter
     }
 
     /// <summary>
-    /// Recovers each parameter's call-site ref-kind (ref/out/in) from the
-    /// MethodDef parameter rows: a by-ref parameter flagged <c>Out</c> is
-    /// <c>out</c>, one flagged <c>In</c> is <c>in</c>, otherwise plain <c>ref</c>.
-    /// By-value parameters are <see cref="ArgumentRefKind.Value"/>. The result
-    /// aligns 1:1 with <paramref name="parameterTypes"/>.
+    /// Recovers each by-ref parameter's call-site ref-kind (ref/out/in) from the
+    /// MethodDef parameter rows. C# <c>in</c> is marked by
+    /// <c>IsReadOnlyAttribute</c> — NOT the raw <c>In</c> metadata flag, which is
+    /// also a marshalling directive; a true <c>out</c> carries the <c>Out</c> flag
+    /// without <c>In</c> (an <c>[In, Out]</c> by-ref is interop marshalling on a
+    /// <c>ref</c>). By-value parameters are <see cref="ArgumentRefKind.Value"/>.
+    /// The result aligns 1:1 with <paramref name="parameterTypes"/>, or is empty
+    /// when there are no by-ref parameters to spell.
     /// </summary>
     static ImmutableArray<ArgumentRefKind> ReadParameterRefKinds(MetadataReader reader, MethodDefinition method, ImmutableArray<TypeRef> parameterTypes)
     {
-        if (parameterTypes.Length == 0)
+        bool anyByRef = false;
+        foreach (var p in parameterTypes)
+            if (p.Kind == TypeRefKind.ByRef) { anyByRef = true; break; }
+        if (!anyByRef)
             return [];
         var kinds = new ArgumentRefKind[parameterTypes.Length];
         for (int i = 0; i < kinds.Length; i++)
@@ -1285,12 +1291,47 @@ public static class IrImporter
             int index = parameter.SequenceNumber - 1;  // sequence 0 is the return parameter
             if (index < 0 || index >= kinds.Length || parameterTypes[index].Kind != TypeRefKind.ByRef)
                 continue;
-            if ((parameter.Attributes & System.Reflection.ParameterAttributes.Out) != 0)
-                kinds[index] = ArgumentRefKind.Out;
-            else if ((parameter.Attributes & System.Reflection.ParameterAttributes.In) != 0)
-                kinds[index] = ArgumentRefKind.In;
+            kinds[index] = ClassifyByRefParameter(reader, parameter);
         }
         return ImmutableArray.Create(kinds);
+    }
+
+    static ArgumentRefKind ClassifyByRefParameter(MetadataReader reader, System.Reflection.Metadata.Parameter parameter)
+    {
+        if (HasReadOnlyAttribute(reader, parameter.GetCustomAttributes()))
+            return ArgumentRefKind.In;
+        var attributes = parameter.Attributes;
+        if ((attributes & System.Reflection.ParameterAttributes.Out) != 0
+            && (attributes & System.Reflection.ParameterAttributes.In) == 0)
+            return ArgumentRefKind.Out;
+        return ArgumentRefKind.Ref;
+    }
+
+    // Pure-SRM attribute presence check (the decompiler Pipeline stays SRM-only,
+    // so it does not reach into the Metadata AttributeReader).
+    static bool HasReadOnlyAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var handle in attributes)
+            if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
+                is ("System.Runtime.CompilerServices", "IsReadOnlyAttribute"))
+                return true;
+        return false;
+    }
+
+    static (string Namespace, string Name) AttributeTypeName(MetadataReader reader, EntityHandle constructor)
+    {
+        switch (constructor.Kind)
+        {
+            case HandleKind.MemberReference
+                when reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent:
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)parent);
+                return (reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            case HandleKind.MethodDefinition:
+                var declaring = reader.GetTypeDefinition(reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
+                return (reader.GetString(declaring.Namespace), reader.GetString(declaring.Name));
+            default:
+                return ("", "");
+        }
     }
 
     internal static FieldRef ResolveField(MetadataReader reader, EntityHandle handle, GenericScope callerScope)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -18,10 +18,13 @@ public sealed record MethodRef(
 
     /// <summary>
     /// Per-parameter call-site ref-kind (ref/out/in), aligned 1:1 with
-    /// <see cref="ParameterTypes"/>. Populated for same-assembly MethodDefs from
-    /// the parameter In/Out flags; empty when unknown (cross-assembly MemberRefs
-    /// carry no parameter rows), in which case the printer keeps its by-ref
-    /// argument spelling unchanged.
+    /// <see cref="ParameterTypes"/>. Populated for callees resolved as a
+    /// MethodDef, from the parameter rows (IsReadOnlyAttribute / the Out flag);
+    /// empty when the callee resolves as a MemberReference — both cross-assembly
+    /// references AND same-assembly calls on a generic type instance (the parent
+    /// is a TypeSpecification), since a MemberRef carries no parameter rows. When
+    /// empty the printer keeps its by-ref argument spelling unchanged, so an
+    /// out/in parameter on such a call still renders as ref (a known gap).
     /// </summary>
     public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; init; } = [];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -55,6 +55,8 @@ public sealed class BooleanFoldingPass : IIrPass
             var loads = loadsBySlot.GetValueOrDefault(slot) ?? [];
             if (!stores.Any(s => IsZeroOne(s.Value)) && !loads.Any(l => !IsBool(l.Type)))
                 continue;  // nothing left to retype
+            if (!loads.All(load => ConsumerAcceptsBool(function, load)))
+                continue;  // a load is consumed as a non-bool; the slot is reused, not purely boolean
 
             var boolType = TypeRef.CoreLib("System", "Boolean");
             foreach (var store in stores)
@@ -72,6 +74,48 @@ public sealed class BooleanFoldingPass : IIrPass
 
     static bool IsBool(TypeRef? type) => type is { Namespace: "System", Name: "Boolean" };
 
+    /// <summary>
+    /// Whether the value produced by <paramref name="node"/> is consumed where a
+    /// <c>bool</c> is valid. Retyping a value to bool is sound only when it is
+    /// boolean at every USE, not just where it is produced: edge slots are
+    /// position-indexed by stack depth, so one slot number can span disjoint live
+    /// ranges, and a stores-only (or arms-only) check can retype a value that
+    /// another range consumes as an integer — a silent overload miscompile
+    /// (<c>f(1)</c> becomes <c>f(true)</c>) or CS0019/CS0029. Unrecognized
+    /// consumers are treated as non-bool (bail), keeping the pass conservative.
+    /// </summary>
+    static bool ConsumerAcceptsBool(IrFunction function, IrExpression node) => ConsumerAcceptsBool(function, node, []);
+
+    static bool ConsumerAcceptsBool(IrFunction function, IrExpression node, HashSet<int> visitedSlots) => node.Parent switch
+    {
+        null => true,
+        Return => IsBool(function.Signature.ReturnType),
+        LogicalBinary or LogicalNot or Coalesce => true,
+        Conditional conditional => ReferenceEquals(conditional.Condition, node) || IsBool(conditional.ResultType),
+        Comparison comparison => comparison.Kind is ComparisonKind.Equal or ComparisonKind.NotEqual,
+        Call call => ParameterAcceptsBool(call.Callee.ParameterTypes, call.Callee.HasThis ? node.ChildIndex - 1 : node.ChildIndex),
+        NewObject newObject => ParameterAcceptsBool(newObject.Constructor.ParameterTypes, node.ChildIndex),
+        StoreLocal store => ReferenceEquals(store.Value, node) && IsBool(store.Type),
+        StoreArgument store => ReferenceEquals(store.Value, node) && IsBool(store.Type),
+        StoreField store => ReferenceEquals(store.Value, node) && IsBool(store.Field.Type),
+        // A value stored into a slot is boolean only if every load of that slot
+        // is itself consumed as a bool (the slot carries it onward).
+        StoreStackSlot store => SlotLoadsAcceptBool(function, store.Slot, visitedSlots),
+        _ => false,
+    };
+
+    static bool SlotLoadsAcceptBool(IrFunction function, int slot, HashSet<int> visitedSlots)
+    {
+        if (!visitedSlots.Add(slot))
+            return false;  // a slot-copy cycle — bail rather than assume boolean
+        return function.Descendants.OfType<LoadStackSlot>()
+            .Where(load => load.Slot == slot)
+            .All(load => ConsumerAcceptsBool(function, load, visitedSlots));
+    }
+
+    static bool ParameterAcceptsBool(IReadOnlyList<TypeRef> parameterTypes, int index)
+        => index >= 0 && index < parameterTypes.Count && IsBool(parameterTypes[index]);
+
     static bool FoldOnce(IrFunction function)
     {
         foreach (var node in function.Descendants.ToList())
@@ -83,7 +127,7 @@ public sealed class BooleanFoldingPass : IIrPass
                 IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement)
                     || FoldSlotDiamond(function, statement) || FoldCoalesce(statement),
                 Comparison comparison => FoldBoolConstantComparison(comparison),
-                Conditional conditional => MaterializeBoolConditional(conditional),
+                Conditional conditional => MaterializeBoolConditional(function, conditional),
                 _ => false,
             };
             if (folded)
@@ -101,13 +145,19 @@ public sealed class BooleanFoldingPass : IIrPass
     /// bool-returning method returns the slot). The non-constant bool arm is the
     /// proof: a real integer select never pairs with one.
     /// </summary>
-    static bool MaterializeBoolConditional(Conditional conditional)
+    static bool MaterializeBoolConditional(IrFunction function, Conditional conditional)
     {
         var constant = (conditional.WhenTrue as Constant) ?? (conditional.WhenFalse as Constant);
         var other = conditional.WhenTrue is Constant ? conditional.WhenFalse : conditional.WhenTrue;
         if (constant is not { Value: int value } || value is not (0 or 1))
             return false;
         if (other is Constant || other.ResultType is not { Namespace: "System", Name: "Boolean" })
+            return false;
+        // Only recover the bool spelling when the ternary's result is consumed as
+        // a bool; otherwise retyping it (and its merged type) would push a bool
+        // into a position a later pass treats as int — no TypedConstantsPass runs
+        // after boolean-folding to reconcile it (CS0029/CS0266).
+        if (!ConsumerAcceptsBool(function, conditional))
             return false;
         var boolType = TypeRef.CoreLib("System", "Boolean");
         constant.ReplaceWith(new Constant(value == 1, boolType));


### PR DESCRIPTION
Adversarial review of the recent raising-pass set (#581/#583/#585/#586/#587) surfaced six confirmed defects. This PR fixes the four with clean, self-contained solutions; the remaining two (#3, #6) need larger changes and are noted below.

## Fixes

### #1 + #5 — bool retype ignored load use-context (silent miscompile)
`BooleanFoldingPass` proved a stack slot boolean from its **stores only**, then retyped every load. Edge slots are position-indexed by stack depth, so one slot number can span disjoint live ranges; a stores-only check could retype a load another range consumes as an integer — a **silent overload miscompile** (`f(1)` rendered `f(true)`) or CS0019/CS0029. The `cond ? 0 : boolExpr` conditional case had the same gap (no `TypedConstantsPass` runs after to reconcile).

Gate the retype on every **use** sitting where a bool is valid: a bool-returning return, a logical operator, a bool-typed parameter/field/local/slot, or an equality test. Unrecognized consumers are treated as non-bool, keeping the pass conservative (strictly more so — it cannot introduce new compile errors).

### #2 — ref-kind read from raw In/Out flags instead of IsReadOnlyAttribute
`ReadParameterRefKinds` derived C# `in`/`out` from `ParameterAttributes.In`/`Out`. But `in` is marked by `IsReadOnlyAttribute` (the trusted old `ILAstBuilder` pipeline already does this), and the raw In/Out flags are also **interop marshalling directives** on parameters that are semantically `ref`. So `[In] ref` was mis-rendered `in` (risking CS8331) and `[In, Out] ref` as `out`.

Now: `IsReadOnlyAttribute` → in; `Out`-without-`In` → out; else ref — via a pure-SRM attribute check (the Pipeline stays Metadata-free). Also early-outs before allocating when the callee has no by-ref parameters.

### #4 — negative enum constant not parenthesized (CS0075)
The non-constant int→enum cast emitted `({Enum}){Operand(value)}`; a negative constant yields `(MyEnum)-1` → CS0075. Parenthesize negatives, exactly as the enum-constant path already does.

## Validation

`--pipeline next --compile-check` over **38,337 Full methods**:
- **Full-malformed steady at 1257** before and after every change — no method-level regression.
- CS0029 (187), CS0019 (80), CS0266 (231) unchanged: #1/#5 lose no benefit; the cases they block were silent (compiled, but wrong) and thus invisible to compile-check — which is exactly the class closed.
- #2 is a fidelity fix (corrected keyword semantics matching the trusted old pipeline), largely invisible to compile-check since the affected calls compiled with the wrong keyword.
- #4 is preventive: corelib's current CS0075 occurrences come from elsewhere, but the verifier confirmed the enum-cast branch is reachable.

Tests: **ILInspector.Decompiler.Tests 418/418, dotnet-inspect.Tests 1140/1140** (no golden lowered-C# changes).

## Deferred (separate follow-ups, not band-aided here)

- **#3** — `out`/`in` dropped on same-assembly **generic-instance** calls (callee resolves as a MemberReference with a TypeSpec parent, carrying no parameter rows). The real fix needs SRM MemberRef→MethodDef resolution by signature; this PR corrects the inaccurate doc comment and leaves the resolver to a focused change. Small footprint (CS1620 = 6).
- **#6** — `out`/`ref` over an `unbox` has no valid inline C# spelling (needs a temporary or an honest `Partial` fidelity drop). Current output is keyword-correct-but-invalid and already counted as a malformed defect, so it is not silently wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)