### PR TITLE
Co-locate IL string escaping in ILStringEscaper (ForDisplay / ForIlasm)

### DIFF
--- a/src/ILInspector.Metadata/CanonicalIL.cs
+++ b/src/ILInspector.Metadata/CanonicalIL.cs
@@ -98,35 +98,12 @@ public static class CanonicalIL
         try
         {
             var handle = MetadataTokens.UserStringHandle(token);
-            return $"\"{EscapeString(reader.GetUserString(handle))}\"";
+            return $"\"{ILStringEscaper.ForIlasm(reader.GetUserString(handle))}\"";
         }
         catch
         {
             return $"0x{token:X8}";
         }
-    }
-
-    /// <summary>
-    /// Escapes a string for an ilasm QSTRING literal: standard backslash escapes
-    /// plus octal escapes for remaining control characters.
-    /// </summary>
-    public static string EscapeString(string value)
-    {
-        var sb = new System.Text.StringBuilder(value.Length);
-        foreach (char c in value)
-        {
-            switch (c)
-            {
-                case '\\': sb.Append("\\\\"); break;
-                case '"': sb.Append("\\\""); break;
-                case '\n': sb.Append("\\n"); break;
-                case '\r': sb.Append("\\r"); break;
-                case '\t': sb.Append("\\t"); break;
-                case < ' ' or '\x7f': sb.Append('\\').Append(Convert.ToString(c, 8).PadLeft(3, '0')); break;
-                default: sb.Append(c); break;
-            }
-        }
-        return sb.ToString();
     }
 
     public static string ResolveType(MetadataReader reader, int token)

--- a/src/ILInspector.Metadata/ILStringEscaper.cs
+++ b/src/ILInspector.Metadata/ILStringEscaper.cs
@@ -1,0 +1,54 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Escapes IL <c>ldstr</c> user-string operands into quoted string literals.
+/// Both methods consume the same input (a raw <c>#US</c>-heap string that may
+/// contain arbitrary control characters); they differ only in their output
+/// contract:
+/// <list type="bullet">
+/// <item><see cref="ForDisplay"/> — human-readable rendering; escapes the common
+/// backslash sequences and leaves other control characters as-is.</item>
+/// <item><see cref="ForIlasm"/> — round-trippable ilasm QSTRING literal; also
+/// octal-escapes remaining control characters so ilasm can reassemble it.</item>
+/// </list>
+/// Used respectively by <see cref="ILTokenResolver"/> and <see cref="CanonicalIL"/>.
+/// </summary>
+public static class ILStringEscaper
+{
+    /// <summary>
+    /// Escapes a user string for human-readable display: standard backslash
+    /// escapes only (<c>\ " \n \r \t</c>), leaving other control characters raw.
+    /// </summary>
+    public static string ForDisplay(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r")
+            .Replace("\t", "\\t");
+    }
+
+    /// <summary>
+    /// Escapes a user string for a round-trippable ilasm QSTRING literal: standard
+    /// backslash escapes plus octal escapes for remaining control characters.
+    /// </summary>
+    public static string ForIlasm(string value)
+    {
+        var sb = new System.Text.StringBuilder(value.Length);
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case < ' ' or '\x7f': sb.Append('\\').Append(Convert.ToString(c, 8).PadLeft(3, '0')); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/ILInspector.Metadata/ILTokenResolver.cs
+++ b/src/ILInspector.Metadata/ILTokenResolver.cs
@@ -21,7 +21,7 @@ public static class ILTokenResolver
         try
         {
             var handle = MetadataTokens.UserStringHandle(token);
-            return $"\"{EscapeString(reader.GetUserString(handle))}\"";
+            return $"\"{ILStringEscaper.ForDisplay(reader.GetUserString(handle))}\"";
         }
         catch
         {
@@ -99,16 +99,6 @@ public static class ILTokenResolver
         {
             return $"0x{token:X8}";
         }
-    }
-
-    public static string EscapeString(string value)
-    {
-        return value
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"")
-            .Replace("\n", "\\n")
-            .Replace("\r", "\\r")
-            .Replace("\t", "\\t");
     }
 
     static string FormatMethodDef(MetadataReader reader, MethodDefinitionHandle handle)


### PR DESCRIPTION
## Summary

`ILTokenResolver` and `CanonicalIL` each defined a `public static string EscapeString(string)` — same name, but **behaviorally different**:

- `ILTokenResolver` (human display): escapes only `\ " \n \r \t`
- `CanonicalIL` (ilasm QSTRING): the same **plus** octal-escapes control characters so the literal round-trips through ilasm

Both consume the **same** input — a raw `#US`-heap user string (an `ldstr` operand) that may contain control characters. The divergence is an *output-contract* difference, not an input one. Having two identically-named methods hidden in separate classes obscured that contrast (they're selected at a single switch in `ILDisassembler`: `canonical ? CanonicalIL.ResolveString(...) : ILTokenResolver.ResolveString(...)`).

This co-locates both into a single `ILStringEscaper` class with intuitively contrasting names that document the shared input and differing contracts:

- `ILStringEscaper.ForDisplay` — human-readable
- `ILStringEscaper.ForIlasm` — round-trippable ilasm QSTRING

`ILTokenResolver` and `CanonicalIL` now delegate to the shared helpers. No behavior change.

## Testing

- `ILInspector.Metadata.Tests`: 194 pass
- `ILInspector.Decompiler.Tests`: 421 pass
- `DotnetInspector.ILRoundtrip.Tests`: 20 pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
