### PR TITLE
Filter CS1729 (non-public ctor) as compile-check binding noise

### DIFF
--- a/tools/DecompilerHarness/CompileChecker.cs
+++ b/tools/DecompilerHarness/CompileChecker.cs
@@ -37,12 +37,19 @@ static class CompileChecker
     // constrained-generic family; CS0165 use-before-assignment; CS0136/CS0128
     // duplicate locals; CS0193 deref of non-pointer; CS1656/CS0131 bad assign)
     // are deliberately KEPT.
+    //
+    // CS1729 ("'T' does not contain a constructor that takes N arguments") is the
+    // constructor analog of CS1501 (the method-arity/visibility code already
+    // filtered above): a faithful `new T(args)` against a non-public ctor — every
+    // case is an internal/private runtime ctor (Half, DateOnly, RuntimeTypeHandle,
+    // ...) that binds inside its own assembly but is invisible through the public
+    // reference surface the shell compiles against.
     static readonly HashSet<string> BindingNoise =
     [
         "CS0103", "CS0117", "CS1061", "CS0246", "CS0234", "CS0122",
         "CS0119", "CS1955", "CS0021", "CS0070", "CS0118", "CS1501",
         "CS1502", "CS1503", "CS7036", "CS1929", "CS1928", "CS0411",
-        "CS1929", "CS0428", "CS1955",
+        "CS1929", "CS0428", "CS1955", "CS1729",
     ];
 
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)


### PR DESCRIPTION
## Summary

The compile-check harness wraps every rendered body in a synthetic `__Shell`
class and binds it against the **public** runtime reference assemblies. Any
reference to a non-public member of the real declaring type (or its
dependencies) therefore fails to bind — a shell artifact, not a decompiler
defect. The `BindingNoise` filter already drops that entire family: CS0122
(inaccessible), CS1061 (missing member), CS1501/CS7036 (method arity), etc.

**CS1729** ("'T' does not contain a constructor that takes N arguments") is the
constructor analog of the already-filtered **CS1501**. Every case in the corpus
is a faithful `new T(args)` against an **internal/private** runtime constructor:

| Type | Count | Type | Count |
|------|------:|------|------:|
| `Half` | 20 | `BFloat16` | 2 |
| `RuntimeTypeHandle` | 13 | `CharEnumerator` | 2 |
| `DateOnly` | 10 | `ModuleHandle` | 2 |
| others (`StringRuneEnumerator`, `GCMemoryInfo`, `AppDomain`, `RuntimeMethodHandle`, `RuntimeFieldHandle`, `AppDomainSetup`) | 5 | | |

`new Half(bits)` binds fine **inside** SPC; only the isolated recompile against
the public surface rejects it. No faithful rendering change can fix it, so it
belongs with the other visibility codes.

## Effect

- **No decompiler behavior changes** — harness filter only.
- Semantic-defect methods: **382 → 328 (−54)** — the methods whose *only* error was CS1729.
- CS1729 occurrences: 66 → 0 (filtered).
- Full malformed: flat 1206. All other codes unchanged.

## Note on CS0175 (not included)

CS0175 ("base not valid") was considered alongside this, but it is **not** pure
shell noise: the emitter renders a constructor's chain call as a `base(args);`
*body statement* (CSharpPrinter.cs:386 — "the current emitter's placement, not a
header initializer"), which is invalid C# in any context. The faithful fix is to
hoist it to a `: base(args)` header — a coordinated emitter + harness change —
so it is deliberately left for a separate effort.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
