### PR TITLE
Consolidate compiler-generated type-name check into TypeFilters

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
+using ILInspector.Metadata;
 using NuGet.Versioning;
 
 namespace DotnetInspector.Services;
@@ -984,7 +985,7 @@ public static class PlatformResolver
             return false;
 
         var name = reader.GetString(typeDef.Name);
-        return name.Length > 0 && !name.StartsWith('<') && !name.StartsWith("__", StringComparison.Ordinal);
+        return name.Length > 0 && !TypeFilters.IsCompilerGenerated(name);
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -27,7 +27,7 @@ public static class ApiSurfaceExtractor
             string metadataName = reader.GetString(typeDef.Name);
 
             // Skip compiler-generated types
-            if (metadataName.StartsWith("<") || metadataName.StartsWith("__"))
+            if (TypeFilters.IsCompilerGenerated(metadataName))
                 continue;
 
             // Skip EditorBrowsable(Never) and Obsolete types unless --all

--- a/src/ILInspector.Metadata/AssemblyReader.cs
+++ b/src/ILInspector.Metadata/AssemblyReader.cs
@@ -96,7 +96,7 @@ public static class AssemblyReader
                 if (typeDef.IsPublic)
                 {
                     var name = reader.GetString(typeDef.Name);
-                    if (!name.StartsWith("<") && !name.StartsWith("__"))
+                    if (!TypeFilters.IsCompilerGenerated(name))
                     {
                         count++;
                     }

--- a/src/ILInspector.Metadata/TypeDependencyScanner.cs
+++ b/src/ILInspector.Metadata/TypeDependencyScanner.cs
@@ -66,7 +66,7 @@ public static class TypeDependencyScanner
                             continue;
 
                         var name = mdReader.GetString(typeDef.Name);
-                        if (name.StartsWith("<") || name.StartsWith("__"))
+                        if (TypeFilters.IsCompilerGenerated(name))
                             continue;
 
                         var ns = mdReader.GetString(typeDef.Namespace);

--- a/src/ILInspector.Metadata/TypeFilters.cs
+++ b/src/ILInspector.Metadata/TypeFilters.cs
@@ -1,0 +1,16 @@
+namespace ILInspector.Metadata;
+
+public static class TypeFilters
+{
+    /// <summary>
+    /// True when a metadata type name is compiler-generated, identified by the
+    /// reserved name prefixes the runtime/Roslyn use for synthesized types:
+    /// <c>&lt;</c> (closures, state machines, display classes) and <c>__</c>
+    /// (e.g. <c>__StaticArrayInitTypeSize=...</c>).
+    /// This is the type-name counterpart to
+    /// <see cref="MemberFilters.IsCompilerGenerated"/>, which uses a broader
+    /// rule appropriate for member names.
+    /// </summary>
+    public static bool IsCompilerGenerated(string typeName)
+        => typeName.StartsWith('<') || typeName.StartsWith("__", System.StringComparison.Ordinal);
+}

--- a/src/ILInspector.Metadata/TypeHierarchyScanner.cs
+++ b/src/ILInspector.Metadata/TypeHierarchyScanner.cs
@@ -64,7 +64,7 @@ public static class TypeHierarchyScanner
             string typeName = reader.GetString(typeDef.Name);
 
             // Skip compiler-generated
-            if (typeName.StartsWith("<") || typeName.StartsWith("__"))
+            if (TypeFilters.IsCompilerGenerated(typeName))
                 continue;
 
             // Skip hidden unless requested


### PR DESCRIPTION
## Summary

Another consolidation pass. Five sites independently spelled the
compiler-generated **type-name** idiom:

```
name.StartsWith("<") || name.StartsWith("__")
```

This PR introduces `TypeFilters.IsCompilerGenerated(typeName)` in
`ILInspector.Metadata` and routes all five through it:

- `TypeHierarchyScanner.cs`
- `TypeDependencyScanner.cs`
- `AssemblyReader.cs` (negated)
- `ApiSurfaceExtractor.cs`
- `DotnetInspector.Services/PlatformResolver.cs` (negated)

## Design

`TypeFilters.IsCompilerGenerated` is deliberately kept **distinct** from
the existing `MemberFilters.IsCompilerGenerated`. They now form a
symmetric pair:

- `MemberFilters.IsCompilerGenerated` — member names, broader rule
  (`<`, `__`, `s_`, backing-field/`value__` markers).
- `TypeFilters.IsCompilerGenerated` — type names, narrow `<`-or-`__`
  prefix rule.

Conflating them would over-match type names, so they stay separate.
The helper uses ordinal prefix checks, behavior-equivalent for these
ASCII markers (and preserves PlatformResolver's prior `Ordinal` intent).

Member-name single-`<` checks in `ApiSurfaceExtractor` (methods/fields)
are a different idiom and were left untouched.

## Tests

- ILInspector.Metadata.Tests: 194 pass
- DotnetInspector.Services.Tests: 158 pass
- dotnet-inspect.Tests: 1140 pass / 9 skip (ilasm)
