### PR TITLE
Centralize well-known attribute names in KnownAttributeNames

### DIFF
--- a/src/ILInspector.Decompiler/ILAstBuilder.cs
+++ b/src/ILInspector.Decompiler/ILAstBuilder.cs
@@ -1118,7 +1118,7 @@ public static class ILAstBuilder
             if (AttributeReader.HasAttribute(
                     reader,
                     parameter.GetCustomAttributes(),
-                    "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
+                    KnownAttributeNames.IsReadOnlyAttribute))
             {
                 modifiers[index] = CallArgumentModifier.In;
             }

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -133,11 +133,11 @@ public static class AssemblyDetailScanner
                         }
                         break;
 
-                    case "System.Runtime.CompilerServices.MemorySafetyRulesAttribute":
+                    case KnownAttributeNames.MemorySafetyRulesAttribute:
                         memorySafetyRulesVersion = TryGetInt32CtorArgument(reader, attr);
                         break;
 
-                    case "System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute":
+                    case KnownAttributeNames.DisableRuntimeMarshallingAttribute:
                         hasDisableRuntimeMarshalling = true;
                         break;
 
@@ -260,16 +260,16 @@ public static class AssemblyDetailScanner
         "System.Reflection.AssemblyConfigurationAttribute" => true,
         "System.Reflection.AssemblyTitleAttribute" => true,
         // Compiler-generated noise
-        "System.Runtime.CompilerServices.CompilationRelaxationsAttribute" => true,
-        "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" => true,
+        KnownAttributeNames.CompilationRelaxationsAttribute => true,
+        KnownAttributeNames.RuntimeCompatibilityAttribute => true,
         "System.Diagnostics.DebuggableAttribute" => true,
-        "System.Runtime.CompilerServices.RefSafetyRulesAttribute" => true,
-        "System.Runtime.CompilerServices.NullablePublicOnlyAttribute" => true,
-        "System.Runtime.CompilerServices.NullableContextAttribute" => true,
-        "System.Runtime.CompilerServices.NullableAttribute" => true,
+        KnownAttributeNames.RefSafetyRulesAttribute => true,
+        KnownAttributeNames.NullablePublicOnlyAttribute => true,
+        KnownAttributeNames.NullableContextAttribute => true,
+        KnownAttributeNames.NullableAttribute => true,
         // Runtime/compiler infrastructure — not developer decisions
-        "System.Runtime.CompilerServices.ExtensionAttribute" => true,
-        "System.Runtime.CompilerServices.SkipLocalsInitAttribute" => true,
+        KnownAttributeNames.ExtensionAttribute => true,
+        KnownAttributeNames.SkipLocalsInitAttribute => true,
         "System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute" => true,
         "System.Reflection.Metadata.MetadataUpdateHandlerAttribute" => true,
         "System.CLSCompliantAttribute" => true,
@@ -467,8 +467,8 @@ public static class AssemblyDetailScanner
                         if (!flags.HasRuntimeAsync && (method.ImplAttributes & AsyncImplFlag) != 0)
                             flags.HasRuntimeAsync = true;
                         else if (!flags.HasStateMachineAsync
-                            && (AttributeReader.HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices.AsyncStateMachineAttribute")
-                                || AttributeReader.HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute")))
+                            && (AttributeReader.HasAttribute(reader, method.GetCustomAttributes(), KnownAttributeNames.AsyncStateMachineAttribute)
+                                || AttributeReader.HasAttribute(reader, method.GetCustomAttributes(), KnownAttributeNames.AsyncIteratorStateMachineAttribute)))
                             flags.HasStateMachineAsync = true;
                     }
                 }

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -9,11 +9,8 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class AttributeReader
 {
-    private const string ExtensionAttributeName = "System.Runtime.CompilerServices.ExtensionAttribute";
     private const string EditorBrowsableAttributeName = "System.ComponentModel.EditorBrowsableAttribute";
     private const string ObsoleteAttributeName = "System.ObsoleteAttribute";
-    private const string RequiredMemberAttributeName = "System.Runtime.CompilerServices.RequiredMemberAttribute";
-    private const string CompilerFeatureRequiredAttributeName = "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute";
     private const string RequiredMembersFeatureName = "RequiredMembers";
     private const string RequiredMembersConstructorObsoleteMessage =
         "Constructors of types with required members are not supported in this version of your compiler.";
@@ -30,7 +27,7 @@ public static class AttributeReader
         {
             var attr = reader.GetCustomAttribute(attrHandle);
             var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
-            if (attrTypeName == ExtensionAttributeName)
+            if (attrTypeName == KnownAttributeNames.ExtensionAttribute)
                 return true;
         }
         return false;
@@ -101,7 +98,7 @@ public static class AttributeReader
     }
 
     public static bool HasRequiredMemberAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
-        => HasAttribute(reader, attributes, RequiredMemberAttributeName);
+        => HasAttribute(reader, attributes, KnownAttributeNames.RequiredMemberAttribute);
 
     private static bool IsCompilerCompatibilityObsolete(
         MetadataReader reader,
@@ -129,7 +126,7 @@ public static class AttributeReader
         {
             var attr = reader.GetCustomAttribute(attrHandle);
             var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
-            if (attrTypeName != CompilerFeatureRequiredAttributeName)
+            if (attrTypeName != KnownAttributeNames.CompilerFeatureRequiredAttribute)
                 continue;
 
             var value = TryGetAttributeDisplayValue(reader, attr);
@@ -256,15 +253,15 @@ public static class AttributeReader
     /// </summary>
     private static bool IsMethodNoiseAttribute(string name) => name switch
     {
-        ExtensionAttributeName => true,
-        "System.Runtime.CompilerServices.NullableContextAttribute" => true,
-        "System.Runtime.CompilerServices.NullableAttribute" => true,
-        "System.Runtime.CompilerServices.CompilerGeneratedAttribute" => true,
-        "System.Runtime.CompilerServices.AsyncStateMachineAttribute" => true,
-        "System.Runtime.CompilerServices.IteratorStateMachineAttribute" => true,
+        KnownAttributeNames.ExtensionAttribute => true,
+        KnownAttributeNames.NullableContextAttribute => true,
+        KnownAttributeNames.NullableAttribute => true,
+        KnownAttributeNames.CompilerGeneratedAttribute => true,
+        KnownAttributeNames.AsyncStateMachineAttribute => true,
+        KnownAttributeNames.IteratorStateMachineAttribute => true,
         "System.Diagnostics.DebuggerStepThroughAttribute" => true,
         "System.Diagnostics.DebuggerHiddenAttribute" => true,
-        "System.Runtime.CompilerServices.MethodImplAttribute" => false, // interesting to see
+        KnownAttributeNames.MethodImplAttribute => false, // interesting to see
         _ => false
     };
 
@@ -394,21 +391,21 @@ public static class AttributeReader
     /// <summary>Attributes the C# compiler re-synthesizes from syntax — emitting them in source is redundant or a duplicate-attribute error.</summary>
     static bool IsReEmittedAttribute(string name) => name switch
     {
-        ExtensionAttributeName => true,
-        "System.Runtime.CompilerServices.CompilerGeneratedAttribute" => true,
-        "System.Runtime.CompilerServices.NullableAttribute" => true,
-        "System.Runtime.CompilerServices.NullableContextAttribute" => true,
-        "System.Runtime.CompilerServices.IsReadOnlyAttribute" => true,
-        "System.Runtime.CompilerServices.IsByRefLikeAttribute" => true,
-        "System.Runtime.CompilerServices.IsUnmanagedAttribute" => true,
-        "System.Runtime.CompilerServices.RefSafetyRulesAttribute" => true,
-        "System.Runtime.CompilerServices.ScopedRefAttribute" => true,
-        "System.Runtime.CompilerServices.NativeIntegerAttribute" => true,
-        "System.Runtime.CompilerServices.DynamicAttribute" => true,
-        "System.Runtime.CompilerServices.TupleElementNamesAttribute" => true,
-        "System.Runtime.CompilerServices.RequiredMemberAttribute" => true,
-        "System.Runtime.CompilerServices.AsyncStateMachineAttribute" => true,
-        "System.Runtime.CompilerServices.IteratorStateMachineAttribute" => true,
+        KnownAttributeNames.ExtensionAttribute => true,
+        KnownAttributeNames.CompilerGeneratedAttribute => true,
+        KnownAttributeNames.NullableAttribute => true,
+        KnownAttributeNames.NullableContextAttribute => true,
+        KnownAttributeNames.IsReadOnlyAttribute => true,
+        KnownAttributeNames.IsByRefLikeAttribute => true,
+        KnownAttributeNames.IsUnmanagedAttribute => true,
+        KnownAttributeNames.RefSafetyRulesAttribute => true,
+        KnownAttributeNames.ScopedRefAttribute => true,
+        KnownAttributeNames.NativeIntegerAttribute => true,
+        KnownAttributeNames.DynamicAttribute => true,
+        KnownAttributeNames.TupleElementNamesAttribute => true,
+        KnownAttributeNames.RequiredMemberAttribute => true,
+        KnownAttributeNames.AsyncStateMachineAttribute => true,
+        KnownAttributeNames.IteratorStateMachineAttribute => true,
         "System.Reflection.DefaultMemberAttribute" => true,
         _ => false,
     };

--- a/src/ILInspector.Metadata/KnownAttributeNames.cs
+++ b/src/ILInspector.Metadata/KnownAttributeNames.cs
@@ -1,0 +1,39 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Full type names of well-known <c>System.Runtime.CompilerServices</c>
+/// attributes the metadata scanners classify (compiler-emitted noise,
+/// re-synthesized attributes, state-machine markers, etc.). Centralized so the
+/// long namespace prefix and exact spelling live in one place instead of being
+/// retyped at each comparison site.
+/// </summary>
+public static class KnownAttributeNames
+{
+    private const string Prefix = "System.Runtime.CompilerServices.";
+
+    public const string AsyncIteratorStateMachineAttribute = Prefix + "AsyncIteratorStateMachineAttribute";
+    public const string AsyncStateMachineAttribute = Prefix + "AsyncStateMachineAttribute";
+    public const string CompilationRelaxationsAttribute = Prefix + "CompilationRelaxationsAttribute";
+    public const string CompilerFeatureRequiredAttribute = Prefix + "CompilerFeatureRequiredAttribute";
+    public const string CompilerGeneratedAttribute = Prefix + "CompilerGeneratedAttribute";
+    public const string DisableRuntimeMarshallingAttribute = Prefix + "DisableRuntimeMarshallingAttribute";
+    public const string DynamicAttribute = Prefix + "DynamicAttribute";
+    public const string ExtensionAttribute = Prefix + "ExtensionAttribute";
+    public const string IsByRefLikeAttribute = Prefix + "IsByRefLikeAttribute";
+    public const string IsReadOnlyAttribute = Prefix + "IsReadOnlyAttribute";
+    public const string IsUnmanagedAttribute = Prefix + "IsUnmanagedAttribute";
+    public const string IteratorStateMachineAttribute = Prefix + "IteratorStateMachineAttribute";
+    public const string MemorySafetyRulesAttribute = Prefix + "MemorySafetyRulesAttribute";
+    public const string MethodImplAttribute = Prefix + "MethodImplAttribute";
+    public const string NativeIntegerAttribute = Prefix + "NativeIntegerAttribute";
+    public const string NullableAttribute = Prefix + "NullableAttribute";
+    public const string NullableContextAttribute = Prefix + "NullableContextAttribute";
+    public const string NullablePublicOnlyAttribute = Prefix + "NullablePublicOnlyAttribute";
+    public const string RefSafetyRulesAttribute = Prefix + "RefSafetyRulesAttribute";
+    public const string RequiredMemberAttribute = Prefix + "RequiredMemberAttribute";
+    public const string RuntimeCompatibilityAttribute = Prefix + "RuntimeCompatibilityAttribute";
+    public const string RuntimeHostConfigurationOptionAttribute = Prefix + "RuntimeHostConfigurationOptionAttribute";
+    public const string ScopedRefAttribute = Prefix + "ScopedRefAttribute";
+    public const string SkipLocalsInitAttribute = Prefix + "SkipLocalsInitAttribute";
+    public const string TupleElementNamesAttribute = Prefix + "TupleElementNamesAttribute";
+}

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -145,8 +145,8 @@ public static class MethodClassificationScanner
             return MethodClassification.RuntimeAsync;
 
         var attributes = method.GetCustomAttributes();
-        if (AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.AsyncStateMachineAttribute")
-            || AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute"))
+        if (AttributeReader.HasAttribute(reader, attributes, KnownAttributeNames.AsyncStateMachineAttribute)
+            || AttributeReader.HasAttribute(reader, attributes, KnownAttributeNames.AsyncIteratorStateMachineAttribute))
             return MethodClassification.StateMachineAsync;
 
         return null;

--- a/src/ILInspector.Metadata/NullabilityReader.cs
+++ b/src/ILInspector.Metadata/NullabilityReader.cs
@@ -8,8 +8,6 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class NullabilityReader
 {
-    private const string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
-    private const string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
 
     /// <summary>
     /// Gets the NullableContextAttribute default byte from custom attributes.
@@ -21,7 +19,7 @@ public static class NullabilityReader
         {
             var attr = reader.GetCustomAttribute(attrHandle);
             var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
-            if (attrTypeName != NullableContextAttributeName) continue;
+            if (attrTypeName != KnownAttributeNames.NullableContextAttribute) continue;
 
             var blob = reader.GetBlobReader(attr.Value);
             if (blob.Length < 3) continue;
@@ -42,7 +40,7 @@ public static class NullabilityReader
         {
             var attr = reader.GetCustomAttribute(attrHandle);
             var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
-            if (attrTypeName != NullableAttributeName) continue;
+            if (attrTypeName != KnownAttributeNames.NullableAttribute) continue;
 
             var blob = reader.GetBlobReader(attr.Value);
             if (blob.Length < 3) return null;

--- a/src/ILInspector.Metadata/SwitchScanner.cs
+++ b/src/ILInspector.Metadata/SwitchScanner.cs
@@ -14,7 +14,7 @@ public static class SwitchScanner
     private const string FeatureSwitchDefinitionAttributeName =
         "System.Diagnostics.CodeAnalysis.FeatureSwitchDefinitionAttribute";
     private const string RuntimeHostConfigurationOptionAttributeName =
-        "System.Runtime.CompilerServices.RuntimeHostConfigurationOptionAttribute";
+        KnownAttributeNames.RuntimeHostConfigurationOptionAttribute;
 
     public static List<SwitchInfo> Scan(PEReader peReader)
     {


### PR DESCRIPTION
## Summary

Consolidation pass: the full type names of well-known
`System.Runtime.CompilerServices` attributes were hardcoded as string
literals all over the metadata scanners and the decompiler. Ten names
were duplicated 2–4× each, with the long `System.Runtime.CompilerServices.`
prefix retyped at every comparison site.

This PR adds `KnownAttributeNames` (a `public const string` per attribute,
namespace prefix factored into one private `Prefix` const) and routes
every site through it:

- `AttributeReader` — three classification switch tables + the private
  alias consts (`ExtensionAttributeName`, `RequiredMemberAttributeName`,
  `CompilerFeatureRequiredAttributeName`) removed
- `AssemblyDetailScanner` — module-attribute noise table + async
  state-machine detection
- `NullabilityReader` — local `NullableAttributeName` /
  `NullableContextAttributeName` aliases removed
- `MethodClassificationScanner` — async state-machine detection
- `SwitchScanner` — host-config attribute const
- `ILInspector.Decompiler/ILAstBuilder` — `IsReadOnlyAttribute` check

## Notes

- The consts are usable directly in the existing switch-arm constant
  patterns, so the classification tables stay readable; only the spelling
  and namespace prefix move to one place.
- One-off literals in other namespaces (`System.Diagnostics.*`,
  `System.Reflection.*`, `System.ObsoleteAttribute`, etc.) were left as
  literals — they are not the duplicated CompilerServices family.

## Tests

- ILInspector.Metadata.Tests: 194 pass
- ILInspector.Decompiler.Tests: 421 pass
- dotnet-inspect.Tests: 1140 pass / 9 skip (ilasm)
