### PR TITLE
Cast indirect stores to the pointer's element type, not the stind opcode type

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2383,6 +2383,31 @@ public class EnumConstantTests
     }
 
     [Fact]
+    public void IndirectStoreThroughTypedPointer_CastsToPointerElement()
+    {
+        // `*(uint*)p = (int)x` is int->uint (CS0266): a primitive `stind.i4`
+        // carries `int`, but the C# lvalue `*p` is typed by the pointer (uint).
+        // The store must cast to the pointer's element type, not the opcode's —
+        // here a uint value into a uint* needs no cast at all.
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var address = new LoadLocal(0, TypeRef.Pointer(uintType));
+        var value = new LoadLocal(1, uintType);
+        var block = new Block(0);
+        block.Add(new StoreIndirect(intType, address, value));
+        block.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [TypeRef.Pointer(uintType), uintType], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("*V_0 = V_1;", output);
+        Assert.DoesNotContain("(int)", output);
+    }
+
+    [Fact]
     public void NotOverOperatorCall_Parenthesizes()
     {
         // !(a != b) — an operator-spelled call renders as a compound `a != b`,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -444,7 +444,7 @@ public sealed class CSharpPrinter
             s.Field.Type),
         StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual)} = {Expression(s.Value)};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
-        StoreIndirect s => $"{Deref(s.Address)} = {CastValue(s.Value, s.Type)};",
+        StoreIndirect s => $"{Deref(s.Address)} = {CastValue(s.Value, IndirectStoreType(s.Address, s.Type))};",
         // default-initialization of a named place spells through the place,
         // not its address.
         InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
@@ -694,6 +694,29 @@ public sealed class CSharpPrinter
             => $"({Condition(c.Condition)} ? ref {Deref(c.WhenTrue)} : ref {Deref(c.WhenFalse)})",
         { ResultType.Kind: TypeRefKind.ByRef } => Operand(address),
         _ => $"*{Operand(address)}",
+    };
+
+    /// <summary>
+    /// The C# type a store-indirect writes through. A primitive <c>stind</c>
+    /// opcode carries its own signed type (<c>stind.i4</c> → <c>int</c>) which
+    /// can contradict the pointer it writes through: <c>*(uint*)p = (int)x</c>
+    /// is int→uint (CS0266), since the C# lvalue <c>*p</c> is typed by the
+    /// pointer (<c>uint</c>), not the opcode. Prefer the element type rooted in
+    /// the address — the faithful target — falling back to the opcode type when
+    /// the address carries no pointer/managed-ref type (an untyped <c>stind</c>).
+    /// </summary>
+    TypeRef? IndirectStoreType(IrExpression address, TypeRef? opcodeType) => PointeeType(address) ?? opcodeType;
+
+    /// <summary>The element a pointer/managed-ref address points at, seen through the additive pointer arithmetic (<c>p + i</c>) and conversions that an indexed store roots in.</summary>
+    static TypeRef? PointeeType(IrExpression address) => address.ResultType switch
+    {
+        { Kind: TypeRefKind.Pointer or TypeRefKind.ByRef, ElementType: { } element } => element,
+        _ => address switch
+        {
+            Binary { Kind: BinaryKind.Add or BinaryKind.Subtract } b => PointeeType(b.Left) ?? PointeeType(b.Right),
+            Convert c => PointeeType(c.Operand),
+            _ => null,
+        },
     };
 
     /// <summary>


### PR DESCRIPTION
## Summary

A primitive `stind` opcode carries its own signed type — `stind.i4` is `int` —
but the C# lvalue it writes through is typed by the **pointer**, not the opcode.
Storing through a `uint*` rendered:

```csharp
*(V_0 + offset) = (int)V_3;   // int -> uint (CS0266)
```

The store cast targeted the opcode type (`int`) instead of the pointer's element
type (`uint`). The fix targets the element type rooted in the address — seen
through additive pointer arithmetic (`p + i`) and the conversions an indexed
store roots in — and falls back to the opcode type only when the address carries
no pointer/managed-ref type. A `uint` value into a `uint*` then needs no cast:

```csharp
*(V_0 + offset) = V_3;
```

This is the first slice of the conversion (CS0266) family — the typed-pointer
indirect-store mechanism, prominent in `DecCalc` decimal math.

## Soundness

The element type is the faithful C# target (`*p` already denotes a `uint`
place), and a same-family reinterpretation never changes the stored bits. The
opcode type is retained as the fallback, so untyped `stind` stores are
unaffected.

## Corpus (`--pipeline next --compile-check`)

- Semantic-defect methods: **328 → 317 (−11)**
- CS0266 occurrences: 232 → 195 (−37)
- All other codes unchanged; Full malformed flat 1206.
- No method-level regressions.

## Tests

+1 synthetic-IR test (422 total): a `uint` value stored through a `uint*`
renders `*V_0 = V_1;` with no `(int)` cast.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
