### PR TITLE
Add per-method defect-diff to the compile-check harness

### DIFF
--- a/tools/DecompilerHarness/CompileChecker.cs
+++ b/tools/DecompilerHarness/CompileChecker.cs
@@ -124,6 +124,11 @@ static class CompileChecker
                         .Where(d => !BindingNoise.Contains(d.Id))
                         .Where(d => !IsShellArtifact(d))
                         .ToList();
+                    // Record EVERY bound method (clean ones with no codes), so the
+                    // diff can restrict to methods checked in BOTH runs — a method
+                    // skipped by the cap in one run must not masquerade as "clean".
+                    if (methodDefects is not null)
+                        Record(methodDefects, $"{typeName}::{methodName}", defects.Select(d => d.Id));
                     if (defects.Count > 0)
                     {
                         semDefect++;
@@ -131,8 +136,6 @@ static class CompileChecker
                             defectCodes[d.Id] = defectCodes.GetValueOrDefault(d.Id) + 1;
                         if (defectExamples.Count < maxExamples)
                             defectExamples.Add($"{typeName}::{methodName}\n    {defects[0].Id}: {defects[0].GetMessage()}");
-                        if (methodDefects is not null)
-                            Record(methodDefects, $"{typeName}::{methodName}", defects.Select(d => d.Id));
                     }
                 }
             }
@@ -183,10 +186,16 @@ static class CompileChecker
 
         var gained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);  // code -> methods
         var lost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
-        foreach (var method in current.Keys.Union(baseline.Keys))
+        // Only methods checked in BOTH runs are comparable; a method present in one
+        // file only was skipped by the cap there, and including it would invent a
+        // spurious regression/improvement (the cap-boundary artifact).
+        var comparable = current.Keys.Intersect(baseline.Keys).ToList();
+        int onlyCurrent = current.Count - comparable.Count;
+        int onlyBaseline = baseline.Count - comparable.Count;
+        foreach (var method in comparable)
         {
-            var now = current.GetValueOrDefault(method) ?? [];
-            var was = baseline.GetValueOrDefault(method) ?? [];
+            var now = current[method];
+            var was = baseline[method];
             foreach (var code in now.Except(was))
                 (gained.TryGetValue(code, out var g) ? g : gained[code] = []).Add(method);
             foreach (var code in was.Except(now))
@@ -194,7 +203,7 @@ static class CompileChecker
         }
 
         Console.WriteLine();
-        Console.WriteLine($"DEFECT DIFF vs {baselinePath}");
+        Console.WriteLine($"DEFECT DIFF vs {baselinePath} ({comparable.Count} methods checked in both; {onlyCurrent} only-current, {onlyBaseline} only-baseline excluded)");
         PrintDiffSide("REGRESSED (method gained the code)", gained);
         PrintDiffSide("IMPROVED (method lost the code)", lost);
     }

--- a/tools/DecompilerHarness/CompileChecker.cs
+++ b/tools/DecompilerHarness/CompileChecker.cs
@@ -45,8 +45,14 @@ static class CompileChecker
         "CS1929", "CS0428", "CS1955",
     ];
 
-    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, string? emitDefectsPath = null, string? diffDefectsPath = null)
     {
+        // When emitting or diffing, record the error-code set per Full method so a
+        // before/after run can be compared method-by-method (which methods gained
+        // or lost a given code) — the differential a raw aggregate count hides.
+        var methodDefects = emitDefectsPath is not null || diffDefectsPath is not null
+            ? new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal)
+            : null;
         var references = RuntimeReferences();
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
@@ -99,6 +105,11 @@ static class CompileChecker
                                 : "CS0201 (illegal statement): " + illegal[0].ToString().Trim();
                             malformedExamples.Add($"{typeName}::{methodName}\n    {reason}");
                         }
+                        if (full && methodDefects is not null)
+                        {
+                            var codes = syntaxErrors.Select(e => e.Id);
+                            Record(methodDefects, $"{typeName}::{methodName}", illegal.Count > 0 ? codes.Append("CS0201") : codes);
+                        }
                         continue;
                     }
 
@@ -120,6 +131,8 @@ static class CompileChecker
                             defectCodes[d.Id] = defectCodes.GetValueOrDefault(d.Id) + 1;
                         if (defectExamples.Count < maxExamples)
                             defectExamples.Add($"{typeName}::{methodName}\n    {defects[0].Id}: {defects[0].GetMessage()}");
+                        if (methodDefects is not null)
+                            Record(methodDefects, $"{typeName}::{methodName}", defects.Select(d => d.Id));
                     }
                 }
             }
@@ -127,7 +140,80 @@ static class CompileChecker
 
         Report(total, fullTotal, partialTotal, fullMalformed, partialMalformed,
             semChecked, semDefect, defectCodes, malformedExamples, defectExamples);
+
+        if (methodDefects is not null && emitDefectsPath is not null)
+            EmitDefects(emitDefectsPath, methodDefects);
+        if (methodDefects is not null && diffDefectsPath is not null)
+            DiffDefects(diffDefectsPath, methodDefects);
         return 0;
+    }
+
+    static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
+    {
+        if (!map.TryGetValue(method, out var set))
+            map[method] = set = new SortedSet<string>(StringComparer.Ordinal);
+        set.UnionWith(codes);
+    }
+
+    /// <summary>Writes one line per defective Full method: <c>Type::Method\tcode,code,…</c>.</summary>
+    static void EmitDefects(string path, Dictionary<string, SortedSet<string>> map)
+    {
+        using var writer = new StreamWriter(path);
+        foreach (var (method, codes) in map.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            writer.WriteLine($"{method}\t{string.Join(",", codes)}");
+        Console.WriteLine();
+        Console.WriteLine($"Wrote per-method defects for {map.Count} methods to {path}");
+    }
+
+    /// <summary>
+    /// Compares the current per-method defect map against a previously emitted
+    /// baseline and prints, per code, the methods that GAINED it (regressions) and
+    /// LOST it (improvements) — the differential a raw count cannot show.
+    /// </summary>
+    static void DiffDefects(string baselinePath, Dictionary<string, SortedSet<string>> current)
+    {
+        var baseline = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+        foreach (var line in File.ReadLines(baselinePath))
+        {
+            int tab = line.IndexOf('\t');
+            if (tab < 0)
+                continue;
+            baseline[line[..tab]] = new SortedSet<string>(line[(tab + 1)..].Split(',', StringSplitOptions.RemoveEmptyEntries), StringComparer.Ordinal);
+        }
+
+        var gained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);  // code -> methods
+        var lost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var method in current.Keys.Union(baseline.Keys))
+        {
+            var now = current.GetValueOrDefault(method) ?? [];
+            var was = baseline.GetValueOrDefault(method) ?? [];
+            foreach (var code in now.Except(was))
+                (gained.TryGetValue(code, out var g) ? g : gained[code] = []).Add(method);
+            foreach (var code in was.Except(now))
+                (lost.TryGetValue(code, out var l) ? l : lost[code] = []).Add(method);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"DEFECT DIFF vs {baselinePath}");
+        PrintDiffSide("REGRESSED (method gained the code)", gained);
+        PrintDiffSide("IMPROVED (method lost the code)", lost);
+    }
+
+    static void PrintDiffSide(string title, SortedDictionary<string, List<string>> byCode)
+    {
+        Console.WriteLine();
+        Console.WriteLine(title + ":");
+        if (byCode.Count == 0)
+        {
+            Console.WriteLine("  (none)");
+            return;
+        }
+        foreach (var (code, methods) in byCode.OrderByDescending(kv => kv.Value.Count))
+        {
+            Console.WriteLine($"  {code}: {methods.Count}");
+            foreach (var method in methods.OrderBy(m => m, StringComparer.Ordinal))
+                Console.WriteLine($"      {method}");
+        }
     }
 
     static void Report(

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -43,6 +43,8 @@ static class Program
         int gradeCap = 1500;
         bool compileCheck = false;
         int compileCap = 4000;
+        string? emitDefects = null;
+        string? diffDefects = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -59,6 +61,8 @@ static class Program
                 case "--grade-cap": gradeCap = int.Parse(args[++i]); break;
                 case "--compile-check": compileCheck = true; break;
                 case "--compile-cap": compileCap = int.Parse(args[++i]); break;
+                case "--emit-defects": emitDefects = args[++i]; break;
+                case "--diff-defects": diffDefects = args[++i]; break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
             }
@@ -71,8 +75,8 @@ static class Program
         if (gradeSource)
             return SourceGrader.Run(assemblies, gradeCap, maxExamples);
 
-        if (compileCheck)
-            return CompileChecker.Run(assemblies, compileCap, maxExamples);
+        if (compileCheck || emitDefects is not null || diffDefects is not null)
+            return CompileChecker.Run(assemblies, compileCap, maxExamples, emitDefects, diffDefects);
 
         if (candidateName?.Equals("next", StringComparison.OrdinalIgnoreCase) == true)
             return DiffNext(assemblies, maxExamples, reportPath);
@@ -670,6 +674,8 @@ static class Program
           --grade-cap <n>       cap graded methods (default 1500)
           --compile-check       compile every decompiled body; report invalid C#
           --compile-cap <n>     cap semantically-bound methods (default 4000)
+          --emit-defects <f>    with --compile-check, write per-method defect codes to <f>
+          --diff-defects <f>    with --compile-check, diff per-method defects against baseline <f>
         """);
 }
 


### PR DESCRIPTION
## What

Two flags on the `DecompilerHarness` `--compile-check` mode that turn its aggregate defect counts into a **method-level differential** — the signal needed to tell whether a raising-pass change actually regressed anything, which a raw count hides.

- **`--emit-defects <file>`** — writes one line per checked Full method: `Type::Method` + its error codes (CS####,…). Clean methods are recorded too (empty code list).
- **`--diff-defects <file>`** — runs the current pipeline and compares against a previously emitted baseline, printing per code the methods that **gained** it (regressions) and **lost** it (improvements).

## Why

Aggregate compile-check counts can't distinguish a real regression from a method shifting in or out of the `--compile-cap` bound set between two runs. The diff records **every** checked method and compares only over the **intersection** of methods checked in both runs, so a cap-skipped method can't masquerade as a phantom regression. It prints the excluded-method counts so the diff is trustworthy.

## Usage

```bash
# baseline (e.g. on main)
dotnet run --project tools/DecompilerHarness -c Release -- \
  --pipeline next --compile-check --compile-cap 4000 --emit-defects /tmp/base.tsv

# after a change — shows exactly which methods regressed/improved, per code
dotnet run --project tools/DecompilerHarness -c Release -- \
  --pipeline next --compile-check --compile-cap 4000 --diff-defects /tmp/base.tsv
```

Example output:

```
DEFECT DIFF vs /tmp/base.tsv (3726 methods checked in both; 0 only-current, 0 only-baseline excluded)
REGRESSED (method gained the code):
  CS1615: 4
      System.Array::Fill
      ...
IMPROVED (method lost the code):
  CS1620: 2
      ...
```

This already paid for itself isolating a generic-instance ref-kind change down to six specific methods. Harness-only; no product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)