### PR TITLE
Route PlatformResolver's type-visibility check through IsPublic

### DIFF
--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -980,8 +980,7 @@ public static class PlatformResolver
 
     private static bool IsMeaningfulPublicType(MetadataReader reader, TypeDefinition typeDef)
     {
-        var visibility = typeDef.Attributes & TypeAttributes.VisibilityMask;
-        if (visibility is not (TypeAttributes.Public or TypeAttributes.NestedPublic))
+        if (!typeDef.IsPublic)
             return false;
 
         var name = reader.GetString(typeDef.Name);


### PR DESCRIPTION
## Summary

`PlatformResolver.IsMeaningfulPublicType` reimplemented the type
visibility test inline:

```csharp
var visibility = typeDef.Attributes & TypeAttributes.VisibilityMask;
if (visibility is not (TypeAttributes.Public or TypeAttributes.NestedPublic))
    return false;
```

That exact computation is already the `TypeDefinition.IsPublic` extension
in `ILInspector.Metadata`, used by 11+ other sites (ApiSurfaceExtractor,
TypeHierarchyScanner, SourceResolver, etc.). This routes the lone
inliner through it:

```csharp
if (!typeDef.IsPublic)
    return false;
```

Behavior-identical — `reader.GetString` never returns null, so the prior
mask test and `IsPublic` agree. `DotnetInspector.Services` already
imports `ILInspector.Metadata`.

## Tests

- DotnetInspector.Services.Tests: 158 pass
