### PR TITLE
Add CommandLineHelpers.CreateVerboseLogger for the verbose stderr logger

### DIFF
--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -156,7 +156,7 @@ public static class InspectionCommandDefinitions
                 {
                     // Platform-preferred routing for System.*/Microsoft.* bare names
                     bool verbose = parseResult.GetValue(opts.Verbose);
-                    Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+                    Action<string>? log = CommandLineHelpers.CreateVerboseLogger(verbose);
                     var (asmPath, _, _, error) = await PlatformResolver.ResolveAssemblyAsync(
                         source, HttpClientFactory.Shared, log,
                         requestedFramework,

--- a/src/dotnet-inspect/CommandLine/Commands/RouterRouteRegistry.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterRouteRegistry.cs
@@ -224,7 +224,7 @@ internal static class RouterRouteRegistry
         RouterOptionsParser.RouterCommandArgs commandArgs)
     {
         bool verbose = route.Options.Verbose;
-        Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+        Action<string>? log = CommandLineHelpers.CreateVerboseLogger(verbose);
         var client = HttpClientFactory.Shared;
 
         var (resolvedPath, _, _, resolvedError) = await PlatformResolver.ResolveAssemblyAsync(

--- a/src/dotnet-inspect/CommandLine/Helpers/CommandLineHelpers.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/CommandLineHelpers.cs
@@ -15,6 +15,14 @@ public static class CommandLineHelpers
         => value != null && int.TryParse(value, out var n) ? n : null;
 
     /// <summary>
+    /// Creates a progress logger that writes to stderr when <paramref name="verbose"/>
+    /// is set, or null otherwise. Centralizes the convention that verbose diagnostic
+    /// output goes to stderr, keeping stdout reserved for machine-readable results.
+    /// </summary>
+    public static Action<string>? CreateVerboseLogger(bool verbose)
+        => verbose ? msg => Console.Error.WriteLine(msg) : null;
+
+    /// <summary>
     /// Resolves a package ID prefix and merges with existing packages.
     /// </summary>
     public static async Task<string[]> MergeWithPrefixPackagesAsync(string[] packages, string? prefix, bool verbose)
@@ -31,7 +39,7 @@ public static class CommandLineHelpers
     /// </summary>
     private static async Task<string[]> ResolvePrefixPackagesAsync(string prefix, bool verbose)
     {
-        Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+        Action<string>? log = CreateVerboseLogger(verbose);
         var client = HttpClientFactory.Shared;
 
         log?.Invoke($"Resolving packages with prefix: {prefix}");

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -358,7 +358,7 @@ public static class SourceResolver
                 if (PlatformResolver.IsPlatformCandidate(bareName))
                 {
                     var client = HttpClientFactory.Shared;
-                    Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
+                    Action<string>? log = CommandLineHelpers.CreateVerboseLogger(verbose);
 
                     // Build framework spec if explicit version given
                     string? frameworkSpec = null;


### PR DESCRIPTION
## Summary

The verbose-logger idiom was copy-pasted verbatim in four places:

```csharp
Action<string>? log = verbose ? msg => Console.Error.WriteLine(msg) : null;
```

- `CommandLine/Helpers/CommandLineHelpers.cs`
- `CommandLine/Commands/RouterRouteRegistry.cs`
- `CommandLine/Commands/InspectionCommandDefinitions.cs`
- `Services/SourceResolver.cs`

This adds `CommandLineHelpers.CreateVerboseLogger(bool verbose)` and
routes all four through it.

## Why it matters beyond DRY

It pins the convention that verbose diagnostics go to **stderr** in a
single place. If one site drifted to `Console.Out`, it would corrupt the
machine-readable stdout that several output modes depend on. Centralizing
the factory removes that drift risk.

All four call sites already see `CommandLineHelpers` (same namespace or an
existing `using`), so no `using` changes were needed.

## Tests

- dotnet-inspect.Tests: 1140 pass / 9 skip (ilasm)
