### PR TITLE
Cast a ternary of int arms into an enum local

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2383,6 +2383,36 @@ public class EnumConstantTests
     }
 
     [Fact]
+    public void TernaryIntoEnum_CastsWholeTernary()
+    {
+        // `StringComparison V_0 = flag ? 1 : 0;` is int->enum (CS0266). A ternary
+        // of integer arms into an enum local must take the enum cast on the whole
+        // merge — `(MyEnum)(flag ? 1 : 0)` — even though CastValue otherwise
+        // leaves merge nodes uncast (the bail's CS0030 risk is type-parameter-only,
+        // not a concrete enum).
+        var enumType = TypeRef.Definition("asm", "NS", "MyEnum");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var ternary = new Conditional(new LoadArgument(0, "flag", boolType),
+            new Constant(1, intType), new Constant(0, intType));
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, enumType, ternary));
+        block.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [enumType], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+        };
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains(")(flag ? 1 : 0)", output);
+        Assert.DoesNotContain("= flag ? 1 : 0;", output);
+    }
+
+    [Fact]
     public void IndirectStoreThroughTypedPointer_CastsToPointerElement()
     {
         // `*(uint*)p = (int)x` is int->uint (CS0266): a primitive `stind.i4`

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -769,20 +769,16 @@ public sealed class CSharpPrinter
     /// </summary>
     string CastValue(IrExpression value, TypeRef? target)
     {
-        // Cast only off a value whose rendered C# type reliably equals its IR
-        // result type. A merge node (ternary/coalesce) reports a merged type the
-        // arms may not actually share, and a stack slot's type is the join of
-        // every store — both diverge from the rendered type in slot-confused or
-        // generic bodies, where a keyed cast would be illegal (CS0030). Leave
-        // those to render as-is.
-        if (value is Conditional or Coalesce or LoadStackSlot)
-            return Expression(value);
         // An integer flowing into an enum-typed position — a comparison kind, a
         // flags value computed at run time — needs an explicit (Enum)x cast: C#
         // converts int→enum implicitly only for the literal 0. The cast is always
         // legal off any integer and is faithful, since IL carries an enum as its
         // underlying integer (TypedConstantsPass already retypes the constant
         // operands, so only the genuinely non-constant boundaries reach here).
+        // This runs before the merge-node bail below: a ternary of integer arms
+        // into an enum (`flag ? 1 : 0`) is a real CS0266, and the cast wraps the
+        // whole merge — `(StringComparison)(flag ? 1 : 0)` — which is legal off a
+        // concrete enum target (the bail's CS0030 risk is type-parameter-only).
         if (target is { } enumTarget
             && _function.TypeShapes.GetValueOrDefault(enumTarget) == TypeShape.Enum
             && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
@@ -794,6 +790,14 @@ public sealed class CSharpPrinter
                 || value is Constant { Value: long lv } && lv < 0;
             return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
         }
+        // Cast only off a value whose rendered C# type reliably equals its IR
+        // result type. A merge node (ternary/coalesce) reports a merged type the
+        // arms may not actually share, and a stack slot's type is the join of
+        // every store — both diverge from the rendered type in slot-confused or
+        // generic bodies, where a keyed cast would be illegal (CS0030). Leave
+        // those to render as-is (the enum cast above is the one safe exception).
+        if (value is Conditional or Coalesce or LoadStackSlot)
+            return Expression(value);
         // A constant carries an exact value: C# converts an in-range one to the
         // target type implicitly (render bare), while an out-of-range one — a
         // negative into unsigned, a bitmask wider than the target — does not


### PR DESCRIPTION
A non-constant int flowing into an enum-typed position needs an explicit `(Enum)x` cast — C# converts int→enum implicitly only for the literal `0`. The enum-cast branch in `CastValue` already handled direct integer values, but it sat *after* the merge-node bail that returns `Conditional`/`Coalesce`/`LoadStackSlot` uncast, so `StringComparison V_0 = ignoreCase ? 1 : 0;` (CS0266) never reached it.

This moves the enum branch above the bail. Wrapping the whole merge — `(StringComparison)(ignoreCase ? 1 : 0)` — is legal off a concrete enum target, so the bail's CS0030 (cast-to-type-parameter) concern does not apply; the bail still guards every non-enum merge case.

**Soundness:** faithful. IL carries an enum as its underlying integer; the cast only re-states a conversion the runtime performs implicitly at the store. No value reinterpretation. Scoped to a concrete enum target (`TypeShape.Enum`), so never emitted against a type parameter.

**Corpus** (`--pipeline next --compile-check`): semantic-defect methods 317 → 312 (−5); CS0266 195 → 190; every other code flat; Full malformed flat 1206. No method-level regressions. Tests +1 (423).
