### PR TITLE
Drop the redundant width mask on a shift count

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -463,6 +463,12 @@ public class CfgSampleClass
 
     public static int UnsignedShift(int x, int n) => x >>> n;
 
+    public static int SignedShift(int x, int n) => x >> n;
+
+    public static int LeftShift(int x, int n) => x << n;
+
+    public static long LongLeftShift(long x, int n) => x << n;
+
     public static uint UnsignedDivide(uint a, uint b) => a / b;
 
     public static bool ULongGe(ulong a, ulong b) => a >= b;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -235,6 +235,24 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Shift_DropsRedundantWidthMask()
+    {
+        // C# masks a shift count by the operand width (int -> & 31, long -> & 63)
+        // and bakes that mask into the IL; rendering it explicitly would double-
+        // mask on recompile. The count must read back bare so the opcode stream
+        // stays faithful.
+        foreach (var name in new[] { nameof(CfgSampleClass.UnsignedShift), nameof(CfgSampleClass.LongLeftShift) })
+        {
+            var function = ImportFixture(name);
+            IrPasses.Run(function);
+            string output = CSharpPrinter.PrintRaised(function).Output!;
+
+            Assert.DoesNotContain("& 31", output);
+            Assert.DoesNotContain("& 63", output);
+        }
+    }
+
+    [Fact]
     public void CheckedAdd_RendersCheckedExpression()
     {
         // add.ovf carries an overflow check the default (unchecked) C# context

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -531,7 +531,10 @@ public sealed class CSharpPrinter
         bool castBoth = binary.IsUnsigned && binary.Kind is BinaryKind.Divide or BinaryKind.Remainder;
         bool castLeft = castBoth || (binary.IsUnsigned && binary.Kind is BinaryKind.ShiftRight);
         string left = castLeft ? UnsignedOperand(binary.Left) : Operand(binary.Left);
-        string right = castBoth ? UnsignedOperand(binary.Right) : Operand(binary.Right);
+        bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
+        string right = isShift ? ShiftCount(binary)
+            : castBoth ? UnsignedOperand(binary.Right)
+            : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
         // add.ovf/sub.ovf/mul.ovf (and their .un forms) carry an overflow check
         // the default (unchecked) C# context would drop — spell it explicitly so
@@ -539,6 +542,30 @@ public sealed class CSharpPrinter
         // re-wraps redundantly but emits the same opcode stream.
         return binary.IsChecked ? $"checked({text})" : text;
     }
+
+    /// <summary>
+    /// Renders a shift's count operand, stripping a redundant width mask. C#
+    /// masks a shift count by the left operand's width — int/uint by 31, long/
+    /// ulong by 63 — and the compiler bakes that mask into the IL. Reading it
+    /// back and spelling it explicitly (<c>n &amp; 31</c>) would double-mask on
+    /// recompile, since the compiler re-applies its own mask. Dropping a count
+    /// mask that exactly matches the implicit width mask keeps the opcode stream
+    /// faithful (and the masks are idempotent, so the value is unchanged).
+    /// </summary>
+    string ShiftCount(Binary shift)
+    {
+        if (shift.Right is Binary { Kind: BinaryKind.And, Right: Constant { Value: int mask } } masked
+            && ShiftWidthMask(EffectiveType(shift.Left)) is { } width && mask == width)
+            return Operand(masked.Left);
+        return Operand(shift.Right);
+    }
+
+    static int? ShiftWidthMask(TypeRef? leftOperand) => TypeFamilies.Of(leftOperand) switch
+    {
+        StackFamily.I4 => 31,
+        StackFamily.I8 => 63,
+        _ => null,
+    };
 
     string ComparisonText(Comparison comparison)
         => ComparisonText(comparison.Kind, comparison.IsUnsigned, comparison.Left, comparison.Right);


### PR DESCRIPTION
Found by the new `--compile-back` oracle (#604).

C# masks a shift count by the left operand's width — int/uint by 31, long/ulong by 63 — and the compiler bakes that mask into the IL (`ldc.i4.s 31; and; shr`). The printer read it back and spelled it explicitly, so a plain `x >>> n` decompiled to `(int)((uint)x >> (n & 31))`. On recompile the compiler re-applies its own width mask over the explicit one, emitting a **second** `and`:

```
orig : ldarg ldarg ldc.i4 and shr.un
recmp: ldarg ldarg ldc.i4 and ldc.i4 and shr.un
```

This strips a shift count's `& K` when K is exactly the implicit width mask for the left operand (31 for a 32-bit operand, 63 for 64-bit). The masks are idempotent so the value is unchanged; the result is both opcode-faithful and cleaner source. Native-int operands have no spec'd mask and are left alone.

**Soundness:** faithful. `n & 31` and the compiler's own `& 31` are the same operation; emitting the count bare lets the compiler re-insert the one mask the original carried, reproducing the exact opcode stream.

**Fixtures:** add `SignedShift` / `LeftShift` / `LongLeftShift` alongside `UnsignedShift` to cover both directions and both masks; all four are now compile-back opcode-exact (fixture corpus exact 128 → 132, docket 22 → 21).

**Measurements:** compile-check arbiter unchanged (semantic 312, Full malformed 1206 — no regression). Tests +1 (425, incl. `Shift_DropsRedundantWidthMask`).
