### PR TITLE
Qualify shadowed instance field loads with this.

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -248,6 +248,19 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Shadowed_QualifiesFieldLoadWhenParameterShadows()
+    {
+        // The parameter _shadowed has the same name as the field, so a bare
+        // _shadowed binds to the parameter. The field load must spell
+        // this._shadowed or the recompiled IL reads the parameter twice.
+        var function = ImportFixture(nameof(CfgSampleClass.Shadowed));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("this._shadowed", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
     public void InParameter_SeesThroughModifier_ImportsAtFull()
     {
         // modreq(InAttribute) on the byref is a declaration-site concern that

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -923,9 +923,33 @@ public sealed class CSharpPrinter
         return instance switch
         {
             null => $"{TypeText(field.DeclaringType)}.{field.Name}",
-            LoadArgument { Index: 0, Name: "this" } => field.Name,
+            // A parameter or local with the same name shadows the field, so the
+            // bare name binds to it, not the field (e.g. int Foo(int _x) =>
+            // this._x + _x). Qualify with this. to reach the field; an
+            // unshadowed instance field stays bare per the taste convention.
+            LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(field.Name) ? $"this.{field.Name}" : field.Name,
             _ => $"{ReceiverText(instance)}.{field.Name}",
         };
+    }
+
+    HashSet<string>? _localScopeNames;
+
+    /// <summary>
+    /// True when an instance-method parameter or local would shadow a field of
+    /// this name, so a bare reference binds to the local rather than the field.
+    /// Locals print as <c>V_n</c>; parameters carry their metadata names.
+    /// </summary>
+    bool IsShadowedByLocal(string fieldName)
+    {
+        if (_localScopeNames is null)
+        {
+            _localScopeNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var parameter in _function.Signature.Parameters)
+                _localScopeNames.Add(parameter.Name);
+            for (int i = 0; i < _function.Locals.Length; i++)
+                _localScopeNames.Add($"V_{i}");
+        }
+        return _localScopeNames.Contains(fieldName);
     }
 
     /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>


### PR DESCRIPTION
## Problem

The decompiler printed an instance field load as the bare field name. When a
parameter or local shadows the field, the bare name binds to the local instead
of the field. The compile-back oracle caught this on the `Shadowed` fixture:

```csharp
int _shadowed = 1;
public int Shadowed(int _shadowed) => this._shadowed + _shadowed;
```

decompiled to `return _shadowed + _shadowed;` — reading the parameter twice and
dropping the `this._shadowed` field load entirely. Invisible to `--compile-check`
and `--grade-source` because the output still parses and binds; only the IL
differs.

## Fix

In `CSharpPrinter.FieldTarget`, render `this.{field}` for a `this`-receiver
instance field load when the field name collides with a parameter or local in
scope; unshadowed fields stay bare per the taste convention. This mirrors the
existing auto-property backing-field branch, which already qualifies with `this.`
for the same shadowing reason.

## Verification

- `--compile-back` on `CfgSampleClass`: opcode-exact goes from 82 to 83; the
  `Shadowed` docket entry is resolved.
- New regression test `IrImporterTests.Shadowed_QualifiesFieldLoadWhenParameterShadows`.
- Full `ILInspector.Decompiler.Tests` suite green (425 passing).

Part of the compile-back oracle docket (#604). Related: #605.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>