### PR TITLE
compile-check: import internal members to avoid false ref/out defects

### DIFF
--- a/tools/DecompilerHarness/CompileChecker.cs
+++ b/tools/DecompilerHarness/CompileChecker.cs
@@ -65,7 +65,17 @@ static class CompileChecker
         var compileOptions = new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
             nullableContextOptions: NullableContextOptions.Disable)
-            .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>());
+            .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
+            // Import internal members of the referenced runtime assemblies. When a
+            // decompiled body legitimately calls an INTERNAL overload of the target
+            // assembly (e.g. the internal `Span<T>(ref T, int)` ctor), the external
+            // shell cannot access it; without the internal members imported, Roslyn
+            // never sees the intended overload and mis-binds to a public sibling,
+            // reporting a misleading CS1615/CS1620 (wrong ref/out keyword). Imported,
+            // it recognizes the intended-but-inaccessible member and reports CS0122
+            // instead — already filtered as visibility noise. The recovered keyword
+            // is correct; the diagnostic was an artifact of the external shell.
+            .WithMetadataImportOptions(MetadataImportOptions.Internal);
 
         int total = 0, fullTotal = 0, partialTotal = 0;
         int fullMalformed = 0, partialMalformed = 0;


### PR DESCRIPTION
## Problem

`--compile-check` compiles each decompiled body in a synthetic shell assembly against the runtime assemblies. As an *external* assembly, it cannot access their `internal` members. So when a decompiled body legitimately calls an internal overload of the target assembly — e.g. the **internal** `Span<T>(ref T reference, int length)` constructor that `Array.Fill`/`Span` code uses — Roslyn never sees the intended overload, mis-binds to a public sibling (`Span(void*, int)`), and reports a misleading **CS1615** ("argument may not be passed with the 'ref' keyword").

The decompiled `ref` is **correct** (it matches the real corelib source); the diagnostic is an artifact of the external shell. These show up as false "claimed-good-but-isn't" defects.

## Fix

Set `MetadataImportOptions.Internal` on the check compilation. Roslyn then imports the internal members, recognizes the intended-but-inaccessible overload as the best match, and reports **CS0122** (inaccessible) instead — which is already in the binding-visibility noise filter. The genuine ref/out defect signal on *public* APIs is unaffected (still CS1615/CS1620).

## Validation

Against the generic-instance ref-kind recovery work (which makes these `ref` arguments appear), the four spurious CS1615 — `Array.Fill`, `Array.Sort`, `Array.UnsafeArrayAsSpan`, `String.JoinCore` — drop to **zero**, with no real defects hidden (confirmed via `--diff-defects`: `REGRESSED: (none)`). Harness-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)