### PR TITLE
Collapse dual-constant guard-returns to the bare condition, not `c && true`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1582,6 +1582,20 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void BooleanFolding_GuardReturn_BothConstantArms_CollapseToCondition()
+    {
+        // if (a > 0) { if (b > 0) return true; } return false; folds the nested
+        // guards to one condition, then the dual-constant return to the bare
+        // condition — not a dead `a > 0 && b > 0 && true` (the true arm is the
+        // result, not an extra && term).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.BothPositive), source);
+
+        Assert.Equal("return a > 0 && b > 0;", output);
+    }
+
+    [Fact]
     public void Structuring_NestedGuards_NestAndDropGotos()
     {
         using var fixtureSource = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -228,7 +228,15 @@ public sealed class BooleanFoldingPass : IIrPass
         var condition = guard.Condition;
         condition.Detach();
         IrExpression folded;
-        if (tailConstant is { } tailBool)
+        if (thenConstant is { } thenBool && tailConstant is { } tailBool2 && thenBool != tailBool2)
+        {
+            // Both arms are opposite bool constants, so the condition itself is
+            // the result: if (c) return true; return false; ≡ return c; and the
+            // dual ≡ return !c;. The generic fold below would append the literal
+            // arm as a dead `c && true` / `!c || false`.
+            folded = thenBool ? condition : Conditions.Negate(condition);
+        }
+        else if (tailConstant is { } tailBool)
         {
             thenValue.Detach();
             // if (c) return A; return true;  ≡ return !c || A;


### PR DESCRIPTION
## What

`FoldGuardReturn` folds `if (c) return A; return B;` into a short-circuit boolean when either arm is a bool constant. When **both** arms are constants it still ran the generic formula, appending the `then` literal as a dead term:

- `BothPositive` (`if (a > 0) { if (b > 0) return true; } return false;`) folded to `return a > 0 && b > 0 && true;`
- the dual `if (c) return false; return true;` to `return !c || false;`

## How

When the two arms are **opposite** bool constants, the condition itself is the result — `if (c) return true; return false;` is `return c;`, and the dual is `return !c;`. Special-case that ahead of the generic fold and reuse the (already detached) condition directly: no extra `&&`/`||` term, and the condition is still evaluated, so the rewrite is sound even when it has side effects.

Equal-constant arms (the dead `if (c) return true; return true;`) fall through to the generic path; they do not arise in compiled code.

## Soundness / scope

This is an output-fidelity fix. `BothPositive` already diverges from its fixture's nested-if-to-literal IL — an intentional, idiomatic boolean-fold over-render (the same policy that renders `IsNullOrEmpty` as `return value is null || value.Length == 0;`). It stays on the compile-back docket as before, but now renders the idiomatic `return a > 0 && b > 0;` instead of the noisy `&& true`.

## Numbers

- Compile-back fixture counts **unchanged**: exact 157, docket 8, recompile-fail 537 (System.Linq unchanged).
- Decompiler tests **440 to 441** (new `BothPositive` fold test).
- Main suite 1140 green.

Found via the #604 `--compile-back` oracle while reviewing the ternary/branch-sense docket.
