### PR TITLE
Fix StaleFieldRead: spill field reads taken before a store (#605)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -19,10 +19,10 @@ public class CompileBackGateTests
     /// Methods that still recompile to a different opcode stream — the open
     /// decompiler docket. Each is a tracked defect or a benign over-render; the gate
     /// tolerates these but fails if a NEW method joins the set. Shrink this list as
-    /// fixes land. Tracked defects include StaleFieldRead (issue #605),
-    /// branch-polarity in the string-switch lowering (DayNumber,
-    /// SmallStringSwitch), and benign codegen choices (BothPositive, NeitherOr,
-    /// ReverseCopy, the volatile field stub in ReadVolatileFlag).
+    /// fixes land. Tracked defects include branch-polarity in the string-switch
+    /// lowering (DayNumber, SmallStringSwitch), and benign codegen choices
+    /// (BothPositive, NeitherOr, ReverseCopy, the volatile field stub in
+    /// ReadVolatileFlag).
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
@@ -32,7 +32,6 @@ public class CompileBackGateTests
         "ReadVolatileFlag",
         "ReverseCopy",
         "SmallStringSwitch",
-        "StaleFieldRead",
     };
 
     /// <summary>
@@ -41,8 +40,9 @@ public class CompileBackGateTests
     /// must keep dropping the redundant width mask (#606), Shadowed must keep
     /// qualifying the shadowed this.field load (#607), .ctor must keep lifting
     /// its field initializer ahead of the base call to the field declaration
-    /// (#614), and the return-accumulator elimination must keep sinking the
-    /// result temp out of an EH region or lock (TryFinallyAdd,
+    /// (#614), StaleFieldRead must keep pinning a field read taken before a
+    /// store to that field (#605), and the return-accumulator elimination must
+    /// keep sinking the result temp out of an EH region or lock (TryFinallyAdd,
     /// TryFinallyTwoReturns, CatchEverything, ClassicLock,
     /// ManualDisposeAsyncInFinally).
     /// </summary>
@@ -52,6 +52,7 @@ public class CompileBackGateTests
         "UnsignedShift",
         "Shadowed",
         ".ctor",
+        "StaleFieldRead",
         "TryFinallyAdd",
         "TryFinallyTwoReturns",
         "CatchEverything",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -266,6 +266,23 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void StaleFieldRead_PinsFieldReadTakenBeforeStore()
+    {
+        // `int v = h.Value; h.Value = 99; return v + h.Value;` carries the first
+        // h.Value read on the symbolic stack across the store. Without spilling it
+        // the importer re-materialized the load after the store, yielding
+        // `h.Value + h.Value` — a different result (issue #605). The pre-store read
+        // must be pinned to a temp so it keeps its old value.
+        var function = ImportFixture(nameof(CfgSampleClass.StaleFieldRead));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.DoesNotContain("h.Value + h.Value", output);
+        Assert.Contains("= h.Value;", output);
+    }
+
+    [Fact]
     public void DeadDefaultInitializer_DroppedWhenAssignedBeforeUse()
     {
         // A local assigned on every path before it is read — here in each switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -626,14 +626,18 @@ public static class IrImporter
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var value = Pop(stack);
-                    body.Add(new StoreField(field, Pop(stack), value) { IsVolatile = volatilePrefix });
+                    var instance = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreField(field, instance, value) { IsVolatile = volatilePrefix });
                     volatilePrefix = false;
                     break;
                 }
                 case ILOpCode.Stsfld:
                 {
                     var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
-                    body.Add(new StoreField(field, null, Pop(stack)) { IsVolatile = volatilePrefix });
+                    var value = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreField(field, null, value) { IsVolatile = volatilePrefix });
                     volatilePrefix = false;
                     break;
                 }
@@ -684,14 +688,18 @@ public static class IrImporter
                 {
                     var type = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var value = Pop(stack);
-                    body.Add(new StoreIndirect(type, Pop(stack), value) { IsVolatile = volatilePrefix });
+                    var address = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreIndirect(type, address, value) { IsVolatile = volatilePrefix });
                     volatilePrefix = false;
                     break;
                 }
                 case ILOpCode.Initobj:
                 {
                     var type = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
-                    body.Add(new InitObject(type, Pop(stack)));
+                    var address = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new InitObject(type, address));
                     break;
                 }
 
@@ -704,7 +712,9 @@ public static class IrImporter
                 case ILOpCode.Stind_ref or (>= ILOpCode.Stind_i1 and <= ILOpCode.Stind_r8) or ILOpCode.Stind_i:
                 {
                     var value = Pop(stack);
-                    body.Add(new StoreIndirect(IndirectTypeOf(opcode), Pop(stack), value) { IsVolatile = volatilePrefix });
+                    var address = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreIndirect(IndirectTypeOf(opcode), address, value) { IsVolatile = volatilePrefix });
                     volatilePrefix = false;
                     break;
                 }
@@ -727,14 +737,18 @@ public static class IrImporter
                     var elementType = ResolveTypeToken(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
                     var value = Pop(stack);
                     var index = Pop(stack);
-                    body.Add(new StoreElement(elementType, Pop(stack), index, value));
+                    var array = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreElement(elementType, array, index, value));
                     break;
                 }
                 case >= ILOpCode.Stelem_i and <= ILOpCode.Stelem_ref:
                 {
                     var value = Pop(stack);
                     var index = Pop(stack);
-                    body.Add(new StoreElement(ElementTypeOf(opcode), Pop(stack), index, value));
+                    var array = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(new StoreElement(ElementTypeOf(opcode), array, index, value));
                     break;
                 }
 
@@ -1083,6 +1097,75 @@ public static class IrImporter
         => stack.Count > 0
             ? stack.Pop()
             : throw new OutOfSliceException("evaluation stack carries values into this block, outside the slice");
+
+    /// <summary>
+    /// Spills pending stack entries that read mutable state (field/element/
+    /// indirect loads, prior call results) into dup slots before a heap-mutating
+    /// statement is emitted. The symbolic stack carries lazy expression trees, so
+    /// a value read <em>before</em> a store but consumed <em>after</em> it would
+    /// otherwise be re-evaluated against the post-store state — a reordering
+    /// miscompile (issue #605, StaleFieldRead). Materializing the survivor pins
+    /// it to its pre-store value. Stable entries (constants, locals, arguments,
+    /// addresses, and pure compositions of them) are left in place so output
+    /// stays minimal; the inliner re-collapses any single-use temp it can prove
+    /// safe to fold.
+    /// </summary>
+    static void SpillUnstableBeforeSideEffect(Block body, Stack<IrExpression> stack, BuildState state)
+    {
+        if (stack.Count == 0)
+            return;
+
+        var values = stack.Reverse().ToArray(); // bottom-to-top
+        bool anyUnstable = false;
+        foreach (var value in values)
+            if (!IsStableAcrossSideEffect(value)) { anyUnstable = true; break; }
+        if (!anyUnstable)
+            return;
+
+        stack.Clear();
+        foreach (var value in values) // bottom-to-top preserves evaluation order
+        {
+            if (IsStableAcrossSideEffect(value))
+            {
+                stack.Push(value);
+                continue;
+            }
+            int slot = state.NextDupSlot++;
+            body.Add(new StoreStackSlot(slot, value));
+            stack.Push(new LoadStackSlot(slot, value.ResultType));
+        }
+    }
+
+    /// <summary>
+    /// True when re-evaluating <paramref name="expression"/> after an intervening
+    /// heap/static store yields the same value — i.e. it does not read mutable
+    /// heap state and has no side effect. Conservative: anything not on this
+    /// allow-list (field/element/indirect/property loads, calls, allocations) is
+    /// treated as unstable and spilled.
+    /// </summary>
+    static bool IsStableAcrossSideEffect(IrExpression expression)
+    {
+        // A managed pointer or pointer is an address: re-evaluating the address
+        // expression yields the same location even after a store, and routing it
+        // through a value slot would strip the ref-ness a later ref/out argument
+        // needs (CS1620). Treat any byref/pointer-typed value as stable.
+        if (expression.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer })
+            return true;
+
+        return expression switch
+        {
+            Constant or SizeOf or LoadToken or TypeOf => true,
+            LoadArgument or LoadLocal or LoadStackSlot => true,
+            LoadLocalAddress or LoadArgumentAddress => true,
+            LoadFunctionPointer or AddressOfMethod => true,
+            Binary binary => IsStableAcrossSideEffect(binary.Left) && IsStableAcrossSideEffect(binary.Right),
+            Comparison comparison => IsStableAcrossSideEffect(comparison.Left) && IsStableAcrossSideEffect(comparison.Right),
+            Convert convert => IsStableAcrossSideEffect(convert.Operand),
+            Unary unary => IsStableAcrossSideEffect(unary.Operand),
+            LogicalNot logicalNot => IsStableAcrossSideEffect(logicalNot.Operand),
+            _ => false,
+        };
+    }
 
     /// <summary>Records the honest stopping point: spill the pending stack as statements, append the unsupported marker, attach the diagnostic.</summary>
     static void Stop(IrFunction function, Block body, Stack<IrExpression> stack, int offset, string opcode, string reason)


### PR DESCRIPTION
Closes #605.

## The bug

The IL importer (`IrImporter`) models the evaluation stack as a stack of lazy expression trees. When a value is read **before** a heap store but consumed **after** it, the load was left on the symbolic stack and re-materialized against the *post-store* state — a reordering miscompile.

`StaleFieldRead`:
```csharp
int v = h.Value;
h.Value = 99;
return v + h.Value;   // expects old + new
```
decompiled to `return h.Value + h.Value;` — reading the field twice *after* the store, computing a different result (198 instead of old+99). Invisible to the parse/bind (`--compile-check`) and token-similarity rails; only the compile-back oracle (recompile → compare opcodes) catches it.

## The fix

Before emitting a heap-mutating statement (`stfld`/`stsfld`/`stobj`/`stind*`/`initobj`/`stelem*`), spill pending stack entries that read mutable state (field/element/indirect loads, call results) into dup slots, pinning their pre-store value. Output now:
```csharp
int S_0 = h.Value;
h.Value = 99;
return S_0 + h.Value;
```

Kept minimal and safe:
- **Stable** entries (constants, locals, arguments, addresses, and pure compositions of them) are left in place; the inliner re-collapses any single-use temp it can prove safe to fold.
- **Byref/pointer** survivors are never spilled — an address is stable across a store, and routing it through a value slot would strip the `ref`-ness a later `ref`/`out` argument needs (caught a CS1620 on `Interlocked.CompareExchange(ref GetStorageRef(...))` during validation).

## Validation

- Compile-back oracle: `StaleFieldRead` leaves the docket (now opcode-exact); moved from `KnownDiffs` to `PinnedExact`.
- **Zero compile-check regression**: identical per-method defect maps before/after across `System.Linq` (988 methods) and `System.Private.CoreLib` (38,204 methods).
- Full decompiler suite green (443 tests); added importer regression test `StaleFieldRead_PinsFieldReadTakenBeforeStore`.