### PR TITLE
Fold the dup-based ++/-- idiom back into the operator at the use site

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -19,10 +19,10 @@ public class CompileBackGateTests
     /// Methods that still recompile to a different opcode stream — the open
     /// decompiler docket. Each is a tracked defect or a benign over-render; the gate
     /// tolerates these but fails if a NEW method joins the set. Shrink this list as
-    /// fixes land. Tracked defects include branch-polarity in the string-switch
-    /// lowering (DayNumber, SmallStringSwitch), and benign codegen choices
-    /// (BothPositive, NeitherOr, ReverseCopy, the volatile field stub in
-    /// ReadVolatileFlag).
+    /// fixes land. Tracked defects include StaleFieldRead (issue #605),
+    /// branch-polarity in the string-switch lowering (DayNumber,
+    /// SmallStringSwitch), and benign codegen choices (BothPositive, NeitherOr,
+    /// the volatile field stub in ReadVolatileFlag).
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
@@ -30,7 +30,6 @@ public class CompileBackGateTests
         "DayNumber",
         "NeitherOr",
         "ReadVolatileFlag",
-        "ReverseCopy",
         "SmallStringSwitch",
     };
 
@@ -41,7 +40,9 @@ public class CompileBackGateTests
     /// qualifying the shadowed this.field load (#607), .ctor must keep lifting
     /// its field initializer ahead of the base call to the field declaration
     /// (#614), StaleFieldRead must keep pinning a field read taken before a
-    /// store to that field (#605), and the return-accumulator elimination must
+    /// store to that field (#605), ReverseCopy must keep folding the dup-based
+    /// ++/-- idiom back into the operator at the use site, and the
+    /// return-accumulator elimination must
     /// keep sinking the result temp out of an EH region or lock (TryFinallyAdd,
     /// TryFinallyTwoReturns, CatchEverything, ClassicLock,
     /// ManualDisposeAsyncInFinally).
@@ -53,6 +54,7 @@ public class CompileBackGateTests
         "Shadowed",
         ".ctor",
         "StaleFieldRead",
+        "ReverseCopy",
         "TryFinallyAdd",
         "TryFinallyTwoReturns",
         "CatchEverything",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1179,6 +1179,22 @@ public class RaisingPassTests
 
 
     [Fact]
+    public void IncrementDecrement_DupSlotIdiom_FoldsToOperatorAtUseSite()
+    {
+        // `dst[--j] = src[i++];` lowers to two dup-captured stack slots: one for
+        // the pre-decremented j, one for the pre-increment value of i. The pass
+        // folds each spilled capture back into the ++/-- operator at the use
+        // site, restoring the source spelling (and the dup on recompile).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReverseCopy), source);
+
+        Assert.Contains("dst[--V_1] = src[V_0++];", output);
+        // The dup-capture slots must no longer leak as explicit spill statements.
+        Assert.DoesNotContain("S_", output);
+    }
+
+
+    [Fact]
     public void TypedConstants_BoolReturn_PrintsFalse()
     {
         using var source = MetadataSource.Open(typeof(object).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -835,6 +835,9 @@ public sealed class CSharpPrinter
         NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
+        IncrementDecrement id => id.IsPrefix
+            ? $"{(id.IsIncrement ? "++" : "--")}{Operand(id.Target)}"
+            : $"{Operand(id.Target)}{(id.IsIncrement ? "++" : "--")}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
         CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
@@ -1031,6 +1034,7 @@ public sealed class CSharpPrinter
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional
+            or IncrementDecrement
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -530,6 +530,34 @@ public sealed class Unary : IrExpression
     public override string Describe() => $"Unary.{Kind}";
 }
 
+/// <summary>
+/// A pre/post increment or decrement used as a value: <c>++x</c>, <c>x++</c>,
+/// <c>--x</c>, <c>x--</c>. The compiler lowers these (and compound array
+/// element stores like <c>a[--i] = ...</c>) to a <c>dup</c> that the importer
+/// raises into a single-use stack slot capturing the value beside the matching
+/// local update; <see cref="IncrementDecrementPass"/> folds that idiom back so
+/// the value renders as the operator the source spelled — and recompiles to the
+/// same <c>dup</c> rather than spilling to extra locals.
+/// </summary>
+public sealed class IncrementDecrement : IrExpression
+{
+    public IncrementDecrement(IrExpression target, bool isIncrement, bool isPrefix)
+    {
+        IsIncrement = isIncrement;
+        IsPrefix = isPrefix;
+        AddChild(target);
+    }
+
+    public bool IsIncrement { get; }
+    public bool IsPrefix { get; }
+    /// <summary>The incremented place — a local or argument load.</summary>
+    public IrExpression Target => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Target.ResultType;
+
+    public override string Describe()
+        => $"{(IsPrefix ? "Pre" : "Post")}{(IsIncrement ? "Increment" : "Decrement")}";
+}
+
 /// <summary>A numeric conversion (the conv.* family).</summary>
 public sealed class Convert : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -1,0 +1,177 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds the compiler's <c>dup</c>-based increment/decrement idiom back into the
+/// <c>++x</c>/<c>x++</c>/<c>--x</c>/<c>x--</c> operator the source spelled.
+///
+/// A pre/post increment or decrement used as a value — <c>a[--i] = src[j++];</c>,
+/// <c>return list[index++];</c> — lowers to a <c>dup</c>: the updated (or
+/// pre-update) value is duplicated, one copy stored to the local and the other
+/// consumed in place. The importer raises the <c>dup</c> into a single-use stack
+/// slot, leaving a three-statement shape:
+///
+/// <code>
+/// S = x;      x = S + 1;   ... use S ...   ≡   ... x++ ...   (post-increment)
+/// S = x - 1;  x = S;       ... use S ...   ≡   ... --x ...   (pre-decrement)
+/// </code>
+///
+/// The slot capture and the local update spill the value into two extra locals
+/// on recompile (no <c>dup</c>); folding them into the operator at the use site
+/// restores the <c>dup</c> exactly. The fold only fires when the captured value
+/// is read once downstream and the local is untouched between its update and
+/// that read, so moving the side effect to the use site reorders nothing.
+/// </summary>
+public sealed class IncrementDecrementPass : IIrPass
+{
+    public string Name => "increment-decrement";
+
+    public void Run(IrFunction function)
+    {
+        while (FoldOnce(function))
+        {
+        }
+    }
+
+    static bool FoldOnce(IrFunction function)
+    {
+        foreach (var block in function.Descendants.OfType<Block>())
+        {
+            for (int i = 0; i + 1 < block.Children.Count; i++)
+            {
+                if (TryFold(function, block, i))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    readonly record struct PlaceRef(bool IsLocal, int Index, string Name, TypeRef Type);
+
+    static bool TryFold(IrFunction function, Block block, int i)
+    {
+        if (block.Children[i] is not StoreStackSlot slotStore)
+            return false;
+        var update = block.Children[i + 1];
+        if (PlaceOf(update) is not { } place || StoreValue(update) is not { } updateValue)
+            return false;
+
+        int slot = slotStore.Slot;
+        bool isIncrement;
+        bool isPrefix;
+
+        if (IsPlaceLoad(slotStore.Value, place)
+            && updateValue is Binary { IsChecked: false, Kind: var postKind } post
+            && post.Left is LoadStackSlot postLoad && postLoad.Slot == slot
+            && post.Right is Constant { Value: 1 }
+            && postKind is BinaryKind.Add or BinaryKind.Subtract)
+        {
+            // S = x; x = S ± 1;  →  x++ / x--
+            isPrefix = false;
+            isIncrement = postKind is BinaryKind.Add;
+        }
+        else if (slotStore.Value is Binary { IsChecked: false, Kind: var preKind } pre
+            && IsPlaceLoad(pre.Left, place)
+            && pre.Right is Constant { Value: 1 }
+            && preKind is BinaryKind.Add or BinaryKind.Subtract
+            && updateValue is LoadStackSlot preLoad && preLoad.Slot == slot)
+        {
+            // S = x ± 1; x = S;  →  ++x / --x
+            isPrefix = true;
+            isIncrement = preKind is BinaryKind.Add;
+        }
+        else
+        {
+            return false;
+        }
+
+        // The dup slot must be written once and read exactly twice: the local
+        // update above, plus one downstream consumer.
+        var loads = function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == slot).ToList();
+        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot) != 1)
+            return false;
+        if (loads.Count != 2 || loads.Count(l => IsInside(l, update)) != 1)
+            return false;
+        if (loads.FirstOrDefault(l => !IsInside(l, update)) is not { } useLoad)
+            return false;
+
+        // The consumer must be a later statement in this same block.
+        if (StatementOf(useLoad, block) is not { } useStatement)
+            return false;
+        int useIndex = useStatement.ChildIndex;
+        if (useIndex <= i + 1)
+            return false;
+
+        // Moving the ±1 to the use site is sound only if the place is neither
+        // read nor written between its update and that use — otherwise an
+        // intervening access would observe the pre-fold (already updated) value.
+        for (int k = i + 2; k <= useIndex; k++)
+        {
+            if (ReferencesPlace(block.Children[k], place))
+                return false;
+        }
+
+        useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix));
+        update.Detach();
+        slotStore.Detach();
+        return true;
+    }
+
+    static PlaceRef? PlaceOf(IrNode store) => store switch
+    {
+        StoreLocal s => new PlaceRef(true, s.Index, "", s.Type),
+        StoreArgument s => new PlaceRef(false, s.Index, s.Name, s.Type),
+        _ => null,
+    };
+
+    static IrExpression? StoreValue(IrNode store) => store switch
+    {
+        StoreLocal s => s.Value,
+        StoreArgument s => s.Value,
+        _ => null,
+    };
+
+    static bool IsPlaceLoad(IrExpression expression, PlaceRef place) => place.IsLocal
+        ? expression is LoadLocal local && local.Index == place.Index
+        : expression is LoadArgument argument && argument.Index == place.Index;
+
+    static IrExpression ClonePlace(PlaceRef place) => place.IsLocal
+        ? new LoadLocal(place.Index, place.Type)
+        : new LoadArgument(place.Index, place.Name, place.Type);
+
+    static bool ReferencesPlace(IrNode node, PlaceRef place)
+    {
+        foreach (var current in (IEnumerable<IrNode>)[node, .. node.Descendants])
+        {
+            bool hit = place.IsLocal
+                ? current is LoadLocal { } l && l.Index == place.Index
+                    || current is StoreLocal { } s && s.Index == place.Index
+                    || current is LoadLocalAddress { } a && a.Index == place.Index
+                : current is LoadArgument { } la && la.Index == place.Index
+                    || current is StoreArgument { } sa && sa.Index == place.Index
+                    || current is LoadArgumentAddress { } aa && aa.Index == place.Index;
+            if (hit)
+                return true;
+        }
+        return false;
+    }
+
+    static IrNode? StatementOf(IrNode node, Block block)
+    {
+        for (var current = node; current.Parent is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current.Parent, block))
+                return current;
+        }
+        return null;
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -75,6 +75,11 @@ public static class IrPasses
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // Fold the compiler's dup-based ++/-- idiom (a value-carrying increment
+        // spilled to a single-use slot beside the local update) back into the
+        // operator at the use site, so a[--i] = src[j++] recompiles to the same
+        // dup rather than spilling the captured value to extra locals.
+        new IncrementDecrementPass(),
         // With structuring done, a spilled base/this constructor argument is a
         // folded expression (base(message ?? "default")); collapse it into the
         // chain call so the call lands as the body's first statement and the


### PR DESCRIPTION
## Summary

Folds the compiler's `dup`-based increment/decrement idiom back into the
`++x`/`x++`/`--x`/`x--` operator the source spelled, so a value-carrying
increment recompiles to the same `dup` rather than spilling to extra locals.

The `ReverseCopy` fixture — `dst[--j] = src[i++];` — now decompiles to exactly
that and is opcode-exact under `--compile-back`.

## Mechanism

A pre/post increment used as a value lowers to a `dup`: the updated (or
pre-update) value is duplicated, one copy stored to the local and the other
consumed in place. The importer raises the `dup` into a single-use stack slot,
leaving a three-statement shape the printer rendered literally:

```
S = x;      x = S + 1;   ... use S ...     (post-increment)
S = x - 1;  x = S;       ... use S ...     (pre-decrement)
```

New `IncrementDecrement` IR node + `IncrementDecrementPass` recognize that shape
and fold it into the operator at the use site.

## Soundness

The fold fires only when:

- the dup slot is written once and read exactly twice (the local update plus one
  downstream consumer in the same block), and
- the place is neither read nor written between its update and that consumer.

The increment already executes at the local-update statement in the IR; folding
*moves* the side effect to the use site, which is sound precisely when nothing
in between observes the place. Conservative: only int `± 1` matches; anything
unmodeled bails (no fold).

## Numbers

- Compile-back fixture: exact **157 → 158**, docket **8 → 7** (`ReverseCopy` now
  opcode-exact), recompile-fail unchanged (**539**); recompile-fail-by-code
  identical (no new failures).
- Decompiler tests **441 → 443**; main suite unchanged (1140 pass, 9 skipped).
- `ReverseCopy` pinned exact in `CompileBackGateTests`.

Found via the #604 `--compile-back` oracle.
