### PR TITLE
Re-declare volatile fields in the compile-back skeleton

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -21,15 +21,13 @@ public class CompileBackGateTests
     /// tolerates these but fails if a NEW method joins the set. Shrink this list as
     /// fixes land. Tracked defects include StaleFieldRead (issue #605),
     /// branch-polarity in the string-switch lowering (DayNumber,
-    /// SmallStringSwitch), and benign codegen choices (BothPositive, NeitherOr,
-    /// the volatile field stub in ReadVolatileFlag).
+    /// SmallStringSwitch), and benign codegen choices (BothPositive, NeitherOr).
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
         "DayNumber",
         "NeitherOr",
-        "ReadVolatileFlag",
         "SmallStringSwitch",
     };
 
@@ -41,8 +39,9 @@ public class CompileBackGateTests
     /// its field initializer ahead of the base call to the field declaration
     /// (#614), StaleFieldRead must keep pinning a field read taken before a
     /// store to that field (#605), ReverseCopy must keep folding the dup-based
-    /// ++/-- idiom back into the operator at the use site, and the
-    /// return-accumulator elimination must
+    /// ++/-- idiom back into the operator at the use site, ReadVolatileFlag must
+    /// keep re-declaring the volatile field so the read keeps its volatile.
+    /// prefix, and the return-accumulator elimination must
     /// keep sinking the result temp out of an EH region or lock (TryFinallyAdd,
     /// TryFinallyTwoReturns, CatchEverything, ClassicLock,
     /// ManualDisposeAsyncInFinally).
@@ -55,6 +54,7 @@ public class CompileBackGateTests
         ".ctor",
         "StaleFieldRead",
         "ReverseCopy",
+        "ReadVolatileFlag",
         "TryFinallyAdd",
         "TryFinallyTwoReturns",
         "CatchEverything",

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -34,6 +34,8 @@
   <ItemGroup>
     <Compile Include="..\..\tools\DecompilerHarness\CompileBack.cs"
              Link="CompileBack.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"
+             Link="VolatileFieldDetector.cs" />
   </ItemGroup>
 
 </Project>

--- a/tools/DecompilerHarness/CompileBack.cs
+++ b/tools/DecompilerHarness/CompileBack.cs
@@ -594,7 +594,10 @@ static class CompileBack
         }
         string? initializer = fieldInits.FirstOrDefault(fi => fi.Field == name).Value;
         string suffix = initializer is not null && !isStatic ? $" = {initializer}" : "";
-        sb.AppendLine($"{pad}public {(isStatic ? "static " : "")}{Clean(type)} {Identifier(name)}{suffix};");
+        bool isVolatile = false;
+        try { isVolatile = field.DecodeSignature(VolatileFieldDetector.Instance, null); }
+        catch { /* signature already decoded above; treat as non-volatile */ }
+        sb.AppendLine($"{pad}public {(isStatic ? "static " : "")}{(isVolatile ? "volatile " : "")}{Clean(type)} {Identifier(name)}{suffix};");
     }
 
     static void EmitMethod(MetadataReader reader, TypeDefinitionHandle typeHandle,

--- a/tools/DecompilerHarness/VolatileFieldDetector.cs
+++ b/tools/DecompilerHarness/VolatileFieldDetector.cs
@@ -1,0 +1,42 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Detects whether a field signature carries <c>modreq(IsVolatile)</c> — the
+/// metadata encoding of a <c>volatile</c> field. The compile-back skeleton must
+/// re-declare such fields <c>volatile</c>: a read of a volatile field emits a
+/// <c>volatile.</c> prefix before the <c>ldsfld</c>/<c>ldfld</c>, so a skeleton
+/// that drops the modifier recompiles to a bare load (an opcode diff).
+/// </summary>
+internal sealed class VolatileFieldDetector : ISignatureTypeProvider<bool, object?>
+{
+    public static VolatileFieldDetector Instance { get; } = new();
+
+    public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
+    public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
+
+    public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        return reader.GetString(typeRef.Name) == "IsVolatile"
+            && reader.GetString(typeRef.Namespace) == "System.Runtime.CompilerServices";
+    }
+
+    public bool GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
+        => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+
+    public bool GetSZArrayType(bool elementType) => elementType;
+    public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
+    public bool GetByReferenceType(bool elementType) => elementType;
+    public bool GetPointerType(bool elementType) => elementType;
+    public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
+        => genericType || typeArguments.Any(static t => t);
+    public bool GetGenericMethodParameter(object? context, int index) => false;
+    public bool GetGenericTypeParameter(object? context, int index) => false;
+    public bool GetFunctionPointerType(MethodSignature<bool> signature) => false;
+    public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired)
+        => (isRequired && modifier) || unmodifiedType;
+    public bool GetPinnedType(bool elementType) => elementType;
+}


### PR DESCRIPTION
## Summary

A `volatile` field carries `modreq(IsVolatile)` on its type. The compile-back
skeleton's signature decoder sees through the modifier, so it re-declared the
field as a plain type — and a read of a (now non-volatile) field recompiled
without the `volatile.` prefix:

```
ReadVolatileFlag
  orig : volatile. ldsfld ret
  recmp: ldsfld ret
```

The decompiler itself was correct (`return VolatileFlag;`); the fidelity gap
was purely in the skeleton's field declaration.

## Fix

New `VolatileFieldDetector` — an allocation-free `ISignatureTypeProvider<bool,...>`
modeled on `PointerDetector` — reports whether a field signature carries
`modreq(IsVolatile)`. `EmitField` now emits the `volatile` keyword for such
fields, so the recompiled read keeps its `volatile.` prefix.

## Numbers

- Compile-back fixture: exact **159 → 160**, docket **6 → 5** (`ReadVolatileFlag`
  now opcode-exact), recompile-fail unchanged (**541**).
- Decompiler tests **444** pass; main suite unchanged (1140 pass, 9 skipped).
- `ReadVolatileFlag` pinned exact in `CompileBackGateTests`.

Found via the #604 `--compile-back` oracle.
