### PR TITLE
Mask method access bits with MemberAccessMask before comparing to Public

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -240,6 +240,15 @@ public class ControlFlowGraphTests
 /// </summary>
 public class CfgSampleClass
 {
+    // A non-public overload declared BEFORE the public one of the same name.
+    // With publicOnly resolution, the visibility filter must skip this so the
+    // overload index lands on the public overload below — masking the access
+    // bits correctly (MethodAttributes.Public is the value 6, not a single bit,
+    // so a naive `& Public` test lets internal/protected overloads through).
+    internal static int VisibilityOverload() => 1;
+
+    public static int VisibilityOverload(int ignored) => 2;
+
     public static byte ToByte(int x) => (byte)x;
 
     public static int LengthOf(string s) => s.Length;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -16,6 +16,26 @@ public class IrImporterTests
         => (Block)Assert.Single(function.Body.Children);
 
     [Fact]
+    public void PublicOnlyResolution_SkipsNonPublicSameNameOverload()
+    {
+        // `internal VisibilityOverload()` is declared before the public
+        // `VisibilityOverload(int)`. With publicOnly resolution, overload 0 must
+        // be the PUBLIC method (`return 2;`), not the internal one (`return 1;`).
+        // MethodAttributes.Public is the value 6 within MemberAccessMask, so a
+        // naive `(attrs & Public) == 0` filter lets internal (3) and protected
+        // (4) through and selects the wrong method.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, "VisibilityOverload",
+            overloadIndex: 0, publicOnly: true);
+
+        Assert.NotNull(function);
+        var ret = Assert.IsType<Return>(Assert.Single(SingleBlock(function).Children));
+        var constant = Assert.IsType<Constant>(ret.Value);
+        Assert.Equal(2, constant.Value);
+    }
+
+    [Fact]
     public void Add_BuildsTypedExpressionTree()
     {
         var function = ImportFixture(nameof(CfgSampleClass.Add));

--- a/src/ILInspector.Decompiler/MethodBodyContext.cs
+++ b/src/ILInspector.Decompiler/MethodBodyContext.cs
@@ -261,7 +261,7 @@ public sealed class MethodBodyContext
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != methodName)
                     continue;
-                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
+                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
                     continue;
                 if (matchCount == overloadIndex)
                     return Create(peReader, reader, method, pdbReader, methodHandle);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -98,7 +98,7 @@ public static class IlProjection
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != methodName)
                     continue;
-                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
+                if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
                     continue;
                 if (seen++ != overloadIndex)
                     continue;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -59,7 +59,7 @@ public static class IrImporter
                     var method = reader.GetMethodDefinition(methodHandle);
                     if (reader.GetString(method.Name) != methodName)
                         continue;
-                    if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.Public) == 0)
+                    if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
                         continue;
                     if (seen++ != overloadIndex)
                         continue;

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -235,7 +235,7 @@ public static class AttributeReader
         foreach (var mHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(mHandle);
-            if (publicOnly && (method.Attributes & MethodAttributes.Public) == 0)
+            if (publicOnly && (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
                 continue;
             if (reader.GetString(method.Name) != methodName)
                 continue;

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -59,7 +59,7 @@ public static class ExtensionMethodScanner
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+                if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
                 if ((method.Attributes & MethodAttributes.Static) == 0) continue;
 
                 string methodName = reader.GetString(method.Name);
@@ -173,7 +173,7 @@ public static class ExtensionMethodScanner
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+                if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
                 if ((method.Attributes & MethodAttributes.Static) == 0) continue;
 
                 string methodName = reader.GetString(method.Name);
@@ -332,7 +332,7 @@ public static class ExtensionMethodScanner
                 foreach (var methodHandle in typeDef.GetMethods())
                 {
                     var method = reader.GetMethodDefinition(methodHandle);
-                    if ((method.Attributes & MethodAttributes.Public) == 0) continue;
+                    if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
 
                     string methodName = reader.GetString(method.Name);
                     if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||


### PR DESCRIPTION
## Summary

`MethodAttributes.Public` is the **value 6** within the `MemberAccessMask`
(`0x7`) enum — not a single bit. The filter `(method.Attributes & Public) == 0`
only excludes access `0` (CompilerControlled) and `1` (Private):
`Assembly`(3)`&6=2`, `Family`(4)`&6=4`, `FamORAssem`(5)`&6=4` are all non-zero,
so **internal / protected / protected-internal methods passed as public**.

Impact:
- **Decompiler overload resolution** — when a same-named non-public overload
  precedes the intended public one, the public-only overload index shifts and
  Decompiled Source / Annotated IL / attributes / IL projections can target the
  **wrong method**.
- **Extension-method scanner** — non-public static methods could be reported as
  public extensions.

## Fix

Switch to the mask form already used throughout the metadata layer
(`ApiSurfaceExtractor`, `OpenTelemetryScanner`, `PdbContext`, `ILDisassembler`,
…): `(method.Attributes & MemberAccessMask) != Public`.

Sites: `IrImporter`, `MethodBodyContext`, `IlProjection`, `AttributeReader`,
`ExtensionMethodScanner` (×3).

## Test

A public + internal same-name overload pair (internal declared first) proves
`publicOnly` resolution selects the public method. Verified the test **fails**
against the old mask (`got 1, expected 2`) and passes with the fix.

Decompiler tests 444 → 445; main (1140), metadata (194), analysis (18) suites
green.

Addresses **finding 1 of #623**.
