### PR TITLE
Eliminate dead conditional branches to the fallthrough block

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -1,0 +1,62 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class RedundantBranchEliminationPassTests
+{
+    static IrFunction TwoBlocks(IrNode block0Terminator)
+    {
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        var b1 = new Block(8);
+        container.Add(b0);
+        container.Add(b1);
+        b0.Add(block0Terminator);   // targets IL_0008 — the immediately following block
+        b1.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+    }
+
+    static Comparison PureCondition()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        return new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, i32), new Constant(0, i32));
+    }
+
+    [Fact]
+    public void RemovesConditionalBranchToFallthrough_WhenConditionIsSideEffectFree()
+    {
+        // `if (1 == 0) goto IL_0008; IL_0008:` — both arms reach IL_0008, so the
+        // dead branch is dropped (the condition has no side effect to preserve).
+        var function = TwoBlocks(new ConditionalBranch(PureCondition(), targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function);
+
+        Assert.Empty(function.Body.Blocks[0].Children);
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionHasSideEffect()
+    {
+        // The branch is still dead, but evaluating a call condition is observable,
+        // so the conservative pass leaves it in place rather than elide the call.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var call = new Call(new MethodRef(TypeRef.CoreLib("System", "Object"), "Probe", boolType, [], HasThis: false), isVirtual: false, []);
+        var function = TwoBlocks(new ConditionalBranch(call, targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function);
+
+        Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
+    }
+
+    [Fact]
+    public void RemovesUnconditionalBranchToFallthrough()
+    {
+        // The pre-existing behavior still holds.
+        var function = TwoBlocks(new Branch(8));
+
+        new RedundantBranchEliminationPass().Run(function);
+
+        Assert.Empty(function.Body.Blocks[0].Children);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
@@ -1,10 +1,17 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Removes branches to the immediately following block — fallthrough does
-/// the same thing, and Debug-config epilogues (store; br L; L: load; ret)
-/// leave these everywhere. Runs before expression inlining so the
-/// store/load pair becomes a plain fallthrough edge it can see.
+/// Removes branches to the immediately following block — fallthrough does the
+/// same thing. Two shapes:
+///   • an unconditional <see cref="Branch"/> to the next block (Debug-config
+///     epilogues — <c>store; br L; L: load; ret</c> — leave these everywhere);
+///   • a <see cref="ConditionalBranch"/> to the next block — both arms reach the
+///     same place, so the branch is dead (<c>if (c) goto IL_x; IL_x:</c>). When
+///     the condition is side-effect-free it is dropped entirely; a condition that
+///     could have side effects is left in place (evaluating it still matters).
+/// Runs before structuring and expression inlining, so this surviving-goto
+/// residue — which would otherwise make the printer's definite-assignment walk
+/// bail and <c>= default</c> every local — is gone before those passes see it.
 /// </summary>
 public sealed class RedundantBranchEliminationPass : IIrPass
 {
@@ -15,12 +22,29 @@ public sealed class RedundantBranchEliminationPass : IIrPass
         var blocks = function.Body.Blocks;
         for (int i = 0; i < blocks.Count - 1; i++)
         {
-            if (blocks[i].Children.Count > 0
-                && blocks[i].Children[^1] is Branch branch
-                && branch.TargetOffset == blocks[i + 1].StartOffset)
+            if (blocks[i].Children.Count == 0)
+                continue;
+            int nextOffset = blocks[i + 1].StartOffset;
+            switch (blocks[i].Children[^1])
             {
-                branch.Detach();
+                case Branch branch when branch.TargetOffset == nextOffset:
+                    branch.Detach();
+                    break;
+                case ConditionalBranch conditional
+                    when conditional.TargetOffset == nextOffset && IsSideEffectFree(conditional.Condition):
+                    conditional.Detach();
+                    break;
             }
         }
     }
+
+    /// <summary>
+    /// Whether evaluating the expression has no observable effect, so dropping it
+    /// is sound. Conservative: any call-like node (or an unsupported one) is
+    /// assumed to have side effects, leaving its branch in place rather than risk
+    /// eliding an effect.
+    /// </summary>
+    static bool IsSideEffectFree(IrExpression condition)
+        => condition.Descendants.Prepend(condition).All(node => node is not
+            (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode));
 }


### PR DESCRIPTION
## What

Extends `RedundantBranchEliminationPass` to drop a `ConditionalBranch` whose target is the immediately following block. Both arms reach the same place, so the branch is dead — `if (c) goto IL_x; IL_x:`. This is the conditional analog of the pass's existing unconditional fallthrough-branch removal.

- **Side-effect-free condition** → branch removed entirely.
- **Condition that could have side effects** (any `Call`/`CallIndirect`/`NewObject`/`DelegateCreation`/`UnsupportedNode`) → left in place, so the observable evaluation is preserved.

Runs before structuring and expression inlining, as the unconditional case already does, so the residue can't make the printer's definite-assignment walk bail and `= default` every local.

## Impact (measured, honest)

On `System.Private.CoreLib` (preview.5) via `DecompilerHarness --candidate next`:

- Agreement **40.44% → 40.47%** (+13 fully-cleaned methods).
- candidate-worse docket **unchanged at 1,331**.

The measurement revised my own leverage estimate downward: the candidate-worse gap is dominated by *diamond* gotos (`if (c) goto A; goto B;`) and merge-point gotos, **not** the fallthrough shape this pass removes. So this is a correct, no-regression completeness fix — the natural conditional sibling of an existing pass — but the bulk of the structuring gap lives elsewhere (diamond raising + the DA-walk's global bail). Those are the higher-leverage follow-ups.

## Tests

`RedundantBranchEliminationPassTests` (3 cases): removes pure-condition fallthrough, keeps side-effecting-condition fallthrough, preserves the pre-existing unconditional behavior. Full suite: 447 pass, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)