### PR TITLE
Lower fidelity for unverifiable by-ref call arguments (DEC0007)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -466,11 +466,20 @@ public class IrImporterTests
     {
         var function = ImportFixture(nameof(CfgSampleClass.ParseOrZero));
 
-        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        // int.TryParse(s, out v) is a cross-assembly MemberRef: it carries no
+        // parameter rows, so the out kind is unknown and the printer spells the
+        // address as `ref` (CS1620 for an out parameter). That unverifiable
+        // spelling lowers fidelity and records DEC0007 rather than claiming Full.
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
         var address = function.Descendants.OfType<LoadLocalAddress>().First();
         Assert.Equal("ref int", address.ResultType?.ToDisplayString());
         var call = function.Descendants.OfType<Call>().First(c => c.Callee.Name == "TryParse");
         Assert.Contains(call.Arguments, a => a is LoadLocalAddress);
+        Assert.True(call.HasUnverifiedByRefArgument);
+
+        // The diagnostics pass annotates the gap with DEC0007.
+        IrPasses.Run(function);
+        Assert.Contains(function.Diagnostics, d => d.Id == DiagnosticIds.UnverifiedByRefArgument);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -67,6 +67,18 @@ public static class DiagnosticIds
     /// pattern is raised away before this is recorded; only the residue remains.
     /// </summary>
     public const string UnsupportedFunctionPointer = "DEC0006";
+
+    /// <summary>
+    /// A by-ref argument rendered against an unknown call-site ref-kind. The
+    /// callee resolved as a MemberReference (a cross-assembly reference, or a
+    /// same-assembly call on a generic type instance), which carries no
+    /// parameter rows, so <c>out</c>/<c>in</c> cannot be distinguished from
+    /// <c>ref</c>. The printer spells the managed-pointer argument with its
+    /// default <c>ref</c> (or none), which is wrong for an <c>out</c>/<c>in</c>
+    /// parameter (CS1620/CS1615) — an unverifiable spelling, so it lowers
+    /// fidelity instead of claiming a faithful render.
+    /// </summary>
+    public const string UnverifiedByRefArgument = "DEC0007";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -35,6 +35,28 @@ public sealed record MethodRef(
     /// local evidence available without assembly resolution.
     /// </summary>
     public bool IsSpecialName { get; init; }
+
+    /// <summary>
+    /// True when a managed-pointer argument is passed to a by-ref parameter of
+    /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
+    /// resolved as a MemberReference (cross-assembly, or a same-assembly call on
+    /// a generic type instance), which carries no parameter rows, so the
+    /// call-site <c>out</c>/<c>in</c>/<c>ref</c> kind is unknown. The printer
+    /// then spells a default keyword it cannot verify (wrong for out/in:
+    /// CS1620/CS1615), so callers lower fidelity rather than claim a faithful
+    /// render. <paramref name="nonReceiverArguments"/> aligns 1:1 with
+    /// <see cref="ParameterTypes"/> (the instance receiver dropped first).
+    /// </summary>
+    public bool HasUnverifiableByRefArgument(IReadOnlyList<IrExpression> nonReceiverArguments)
+    {
+        if (!ParameterRefKinds.IsDefaultOrEmpty)
+            return false;
+        for (int i = 0; i < ParameterTypes.Length && i < nonReceiverArguments.Count; i++)
+            if (ParameterTypes[i].Kind == TypeRefKind.ByRef
+                && nonReceiverArguments[i].ResultType is { Kind: TypeRefKind.ByRef })
+                return true;
+        return false;
+    }
 }
 
 /// <summary>A materialized field reference.</summary>
@@ -112,6 +134,8 @@ public sealed class IrFunction : IrNode
         => Descendants.Prepend(this).Any(n =>
             n is UnsupportedNode
             || n is LoadFunctionPointer
+            || n is Call { HasUnverifiedByRefArgument: true }
+            || n is NewObject { HasUnverifiedByRefArgument: true }
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || n is IrExpression { ResultType: null }
             || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
@@ -728,6 +752,15 @@ public sealed class Call : IrExpression
     public TypeRef? ConstrainedTo { get; init; }
     /// <summary>Arguments including the receiver for instance calls.</summary>
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
+
+    /// <summary>
+    /// A by-ref argument is forwarded against an unknown call-site ref-kind —
+    /// the printer spells a keyword it cannot verify. Lowers fidelity. See
+    /// <see cref="MethodRef.HasUnverifiableByRefArgument"/>.
+    /// </summary>
+    public bool HasUnverifiedByRefArgument
+        => Callee.HasUnverifiableByRefArgument(Callee.HasThis ? [.. Arguments.Skip(1)] : Arguments);
+
     public override TypeRef? ResultType => Callee.ReturnType;
     public override IEnumerable<TypeRef> DirectTypes
         => Callee.ParameterTypes.Concat(Callee.TypeArguments).Append(Callee.DeclaringType).Append(Callee.ReturnType)
@@ -781,6 +814,14 @@ public sealed class NewObject : IrExpression
 
     public MethodRef Constructor { get; }
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
+
+    /// <summary>
+    /// A by-ref constructor argument forwarded against an unknown call-site
+    /// ref-kind. Lowers fidelity. See
+    /// <see cref="MethodRef.HasUnverifiableByRefArgument"/>.
+    /// </summary>
+    public bool HasUnverifiedByRefArgument => Constructor.HasUnverifiableByRefArgument(Arguments);
+
     public override TypeRef? ResultType => Constructor.DeclaringType;
     public override IEnumerable<TypeRef> DirectTypes
         => Constructor.ParameterTypes.Append(Constructor.DeclaringType);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -101,6 +101,7 @@ public static class IrPasses
         // Last: any function-pointer load still standing fed something other
         // than a delegate constructor — record the honest residual diagnostic.
         new FunctionPointerDiagnosticsPass(),
+        new RefKindDiagnosticsPass(),
     ];
 
     public static void Run(IrFunction function) => Run(function, Default);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
@@ -17,7 +17,7 @@ public sealed class RefKindDiagnosticsPass : IIrPass
 {
     public string Name => "ref-kind-diagnostics";
 
-    public void Run(IrFunction function)
+    public void Run(IrFunction function, PassContext context)
     {
         foreach (var node in function.Descendants)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
@@ -1,0 +1,37 @@
+using ILInspector.Decompiler;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Records a <see cref="DiagnosticIds.UnverifiedByRefArgument"/> diagnostic for
+/// every <see cref="Call"/>/<see cref="NewObject"/> that forwards a
+/// managed-pointer argument to a by-ref parameter whose call-site ref-kind is
+/// unknown (the callee resolved as a MemberReference, which carries no
+/// parameter rows). The printer spells a default <c>ref</c> there that it
+/// cannot verify against the real <c>out</c>/<c>in</c>/<c>ref</c> — wrong for
+/// an out/in parameter (CS1620/CS1615). Running last, it keeps these honest,
+/// visible gaps off the silent-Full path: the method is already lowered to
+/// Partial by <see cref="IrFunction.Fidelity"/>, and now says why.
+/// </summary>
+public sealed class RefKindDiagnosticsPass : IIrPass
+{
+    public string Name => "ref-kind-diagnostics";
+
+    public void Run(IrFunction function)
+    {
+        foreach (var node in function.Descendants)
+        {
+            var callee = node switch
+            {
+                Call { HasUnverifiedByRefArgument: true } c => c.Callee,
+                NewObject { HasUnverifiedByRefArgument: true } o => o.Constructor,
+                _ => null,
+            };
+            if (callee is null)
+                continue;
+            function.Diagnostics.Add(new DecompilerDiagnostic(
+                DiagnosticIds.UnverifiedByRefArgument,
+                $"unverified by-ref argument: call-site ref-kind for {callee.DeclaringType.ToDisplayString()}.{callee.Name} is unknown (MemberReference carries no parameter rows)"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Makes the **cross-assembly by-ref ref-kind loss** visible instead of silent (finding 3 of #623).

When a callee resolves as a MemberReference (a cross-assembly reference, or a cross-assembly generic-instance call) it carries no parameter rows, so the call-site `out`/`in`/`ref` kind is unknown. The printer spells a managed-pointer argument with its default `ref` (or bare) — wrong for an `out`/`in` parameter (CS1620/CS1615) — yet the method still claimed `Full` fidelity with **no diagnostic**. Real examples that silently misrendered:

- `AppContext.TryGetSwitch(name, out value)` → `ref value`
- `Vector.Widen(source, out low, out high)` → `ref low, ref high`
- `CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out exists)` → `ref exists`

## Change

- `MethodRef.HasUnverifiableByRefArgument(args)` — a by-ref parameter receives a managed-pointer argument (`ResultType` is ByRef) while `ParameterRefKinds` is empty.
- `Call` / `NewObject` surface it; `IrFunction.Fidelity` lowers to `Partial`; new `RefKindDiagnosticsPass` records **DEC0007** explaining why.

Mirrors the `LoadFunctionPointer` / `FunctionPointerDiagnosticsPass` precedent: a structural tree condition lowers fidelity, a last-running pass annotates it.

## Soundness

Fires only when the kind is genuinely unrecoverable (empty `ParameterRefKinds`) **and** the argument is itself a managed pointer. Same-assembly calls — including generic-instance calls whose kind the importer recovers from the underlying MethodDef — keep populated ref-kinds and stay `Full`. An `in` parameter taking a *value* argument is not a managed-pointer argument, so it is never flagged (already renders correctly).

## Numbers

- Blast radius: **261 methods / 328 call sites** across CoreLib + System.Linq + System.Collections + System.Linq.Expressions + System.Private.Xml (64376 methods, ~0.4%) move `Full → Partial` — all genuine cross-assembly by-ref forwards.
- Output rendering unchanged → compile-back oracle **identical** (fixture exact 174, docket 5, recompile-fail 547).
- Decompiler tests **443 → 445** (strengthened `AddressOf_OutArgument` to assert `Partial` + DEC0007 + `HasUnverifiedByRefArgument` on `int.TryParse(s, out v)`). Main suite unchanged (1140 pass, 9 skip).

Follow-up: actually *recover* the kind (`out` from the `Param.Out` flag, `in` from the signature `modreq` where resolvable) is the larger change; this slice just stops the loss from being silent.
