### PR TITLE
ci: move Windows/macOS infra from CI to Publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
         with:
           globs: '**/*.md'
 
-  # Build and test on Ubuntu and Windows
+  # Build and test on Ubuntu only. Windows/macOS coverage was moved to the
+  # Publish workflow to cut Actions minutes (those runners bill at higher
+  # multipliers). This trades per-PR cross-platform test coverage for cost.
   test:
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -77,10 +79,6 @@ jobs:
         include:
           - os: ubuntu-26.04
             rid: linux-x64
-          - os: windows-latest
-            rid: win-x64
-          - os: macos-latest
-            rid: osx-arm64
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_INSPECT_TIPS: q
@@ -123,9 +121,9 @@ jobs:
       - name: Run CLI tests
         run: dotnet run --project src/dotnet-inspect.Tests -c Release
 
-      # Decompiler tests run on every OS deliberately: many decompile the
-      # PLATFORM's CoreLib (chain/loop/spill regression tests, emit-all
-      # stress), so each OS contributes a genuinely different IL corpus.
+      # Decompiler tests decompile the platform CoreLib (chain/loop/spill
+      # regression tests, emit-all stress). Cross-platform IL diversity is now
+      # only exercised at Publish time on the Windows/macOS build legs.
       - name: Run decompiler tests
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 
@@ -264,7 +262,9 @@ jobs:
       - name: Uninstall tool
         run: dotnet tool uninstall --global dotnet-inspect
 
-  # Build RID-specific Native AOT packages (cross-platform)
+  # Build RID-specific Native AOT packages built on Linux runners. The
+  # win-x64, win-arm64, and osx-arm64 AOT packages are built in the Publish
+  # workflow instead, so Windows/macOS runners are only used at release time.
   pack-rid:
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -272,14 +272,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rid: win-x64
-            os: windows-latest
-          - rid: win-arm64
-            os: windows-latest
           - rid: linux-arm64
             os: ubuntu-26.04-arm
-          - rid: osx-arm64
-            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,62 @@ permissions:
   id-token: write
 
 jobs:
+  # Resolve the exact commit the CI run was built from so the Windows/macOS
+  # packages we build here match the Linux packages produced by that run.
+  resolve:
+    runs-on: ubuntu-26.04
+    if: github.event.inputs.confirm == 'publish'
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - name: Resolve CI run commit
+        id: sha
+        run: |
+          SHA=$(gh run view ${{ github.event.inputs.run_id }} \
+            --repo ${{ github.repository }} --json headSha -q .headSha)
+          echo "Resolved CI run ${{ github.event.inputs.run_id }} -> $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build the RID-specific Native AOT packages that used to be built in CI.
+  # These run only at publish time to keep Windows/macOS off the per-PR path.
+  build-native:
+    needs: resolve
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            os: windows-latest
+          - rid: win-arm64
+            os: windows-latest
+          - rid: osx-arm64
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Pack RID-specific package
+        run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
+
+      - name: Upload RID package
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-${{ matrix.rid }}
+          path: artifacts/package/release/*.nupkg
+          if-no-files-found: error
+
   publish:
+    needs: [resolve, build-native]
     runs-on: ubuntu-26.04
     if: github.event.inputs.confirm == 'publish'
     environment: nuget
@@ -24,8 +79,10 @@ jobs:
     
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
       
-      - name: Download all packages from CI run
+      - name: Download Linux/any/pointer packages from CI run
         uses: actions/download-artifact@v8
         with:
           path: packages
@@ -33,6 +90,13 @@ jobs:
           merge-multiple: true
           run-id: ${{ github.event.inputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Windows/macOS packages built in this run
+        uses: actions/download-artifact@v8
+        with:
+          path: packages
+          pattern: package-*
+          merge-multiple: true
       
       - name: List packages
         run: ls -la packages/


### PR DESCRIPTION
## Why

Actions minutes are getting expensive. Windows (2x) and macOS (10x) runners bill at higher multipliers, and running them on every PR/push is the bulk of the cost. We accept reduced per-PR coverage to make CI faster and cheaper.

## What changed

**`ci.yml`** — Windows/macOS runners removed from the per-PR path:

- `test` matrix is now Linux-only (`ubuntu-26.04` / `linux-x64`).
- `pack-rid` matrix is now `linux-arm64` only.
- A CI run now produces 4 packages: pointer, any, linux-x64, linux-arm64.

**`release.yml`** — Windows/macOS infra moved here, used only at publish:

- New `resolve` job pins the CI run's exact commit (`gh run view ... headSha`) so the native packages built here match the Linux packages from that run.
- New `build-native` matrix job builds `win-x64`, `win-arm64`, `osx-arm64` AOT packages (checked out at the pinned SHA) and uploads them as artifacts.
- `publish` downloads the Linux/any/pointer packages from the CI run **and** the Windows/macOS packages built in this run, then pushes all 7 as before. Both checkouts use the pinned SHA, keeping the version tag consistent.

## Tradeoff / risk

No per-PR Windows or macOS **build or test** coverage. Cross-platform regressions (including the platform-CoreLib IL diversity the decompiler tests relied on) now surface at publish time, build-only. This is an intentional cost-for-coverage trade.

## Net effect

Every PR/push burns only Linux minutes. The expensive runners are used solely when publishing.
