### PR TITLE
Replace the DA-walk's global bail with CFG-based definite assignment

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -22,10 +22,14 @@ public class CompileBackGateTests
     /// fixes land. Tracked defects include StaleFieldRead (issue #605),
     /// branch-polarity in the string-switch lowering (DayNumber,
     /// SmallStringSwitch), and benign codegen choices (BothPositive, NeitherOr).
+    /// ClassifyMode is a sparse switch csc lowers to a comparison tree the
+    /// structuring pass does not yet raise, so it round-trips through flat gotos
+    /// (tracked under the structuring docket — leaves the set when that lands).
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
+        "ClassifyMode",
         "DayNumber",
         "NeitherOr",
         "SmallStringSwitch",

--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -331,6 +331,33 @@ public class CfgSampleClass
 
     public static int PowerOfTwo(int x) => x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 };
 
+    // A switch over sparse masked values csc lowers to a comparison tree (not a
+    // jump table), which the structuring pass leaves as a flat block graph.
+    // `result` is still assigned on every case and the default before the read,
+    // so CFG definite-assignment must prove it bare rather than `= default`.
+    public static int ClassifyMode(int mode) => (mode & 0xF000) switch
+    {
+        0x1000 => 1,
+        0x2000 => 2,
+        0x4000 => 4,
+        0x8000 => 8,
+        0xA000 => 10,
+        0xC000 => 12,
+        _ => 0,
+    };
+
+    // A local assigned inside a lock body before the read after it. Modeling the
+    // lock as its sequential body (rather than bailing) proves the bare decl.
+    public static int LockedAssign(object gate, int x)
+    {
+        int result;
+        lock (gate)
+        {
+            result = x + 1;
+        }
+        return result;
+    }
+
     // --- EH structuring fixtures ---
 
     public static int CatchLogs(string s)

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -324,6 +324,33 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath()
+    {
+        // ClassifyMode is a sparse switch csc lowers to a comparison tree the
+        // structuring pass cannot raise, so the body stays a flat goto graph.
+        // The old global bail flooded every local to `= default`; CFG
+        // definite-assignment proves `result` assigned on every path first.
+        var function = ImportFixture(nameof(CfgSampleClass.ClassifyMode));
+        IrPasses.Run(function);
+        var output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Contains("goto ", output);   // guard: the body really did stay flat
+        Assert.DoesNotContain("= default", output);
+    }
+
+    [Fact]
+    public void DeadDefaultInitializer_DroppedWhenAssignedInsideLock()
+    {
+        // A lock body runs in program order, so a local it assigns before a read
+        // after the lock is definitely assigned — modeling the lock (rather than
+        // bailing on it) declares it bare.
+        var function = ImportFixture(nameof(CfgSampleClass.LockedAssign));
+        IrPasses.Run(function);
+
+        Assert.DoesNotContain("= default", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
     public void DeadDefaultInitializer_KeptWhenAssignmentNotProven()
     {
         // ParseOrZero reaches its local first through a by-ref out-argument,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -294,19 +294,161 @@ public sealed class CSharpPrinter
             return DefiniteFlow.FallThrough;
         }
 
+        // A container whose blocks branch among themselves (or are reached by
+        // goto) cannot be read in program order. Rather than give up on every
+        // local, analyze it as the control-flow graph it is.
+        bool IsFlat(BlockContainer container) =>
+            container.Blocks.Any(b =>
+                _labelTargets.Contains(b.StartOffset)
+                || (b.Children.Count > 0 && b.Children[^1] is Branch or ConditionalBranch or SwitchBranch));
+
         DefiniteFlow Container(BlockContainer container, HashSet<int> assigned)
         {
+            if (IsFlat(container))
+                return CfgContainer(container, assigned);
             foreach (var block in container.Blocks)
             {
-                // A block reachable by goto cannot be analyzed in program order.
-                if (_labelTargets.Contains(block.StartOffset))
-                {
-                    BailAll();
-                    return DefiniteFlow.Bail;
-                }
                 var flow = Sequence(block.Children, assigned);
                 if (flow != DefiniteFlow.FallThrough)
                     return flow;
+            }
+            return DefiniteFlow.FallThrough;
+        }
+
+        // Forward must-dataflow over a goto-connected container: a local is
+        // assigned on entry to a block only if assigned on every predecessor
+        // edge. This is the definite-assignment the C# compiler itself runs, so
+        // a local it proves bare-safe declares bare instead of flooding to
+        // `= default`. Conservative on shapes it cannot model (an EH leave, a
+        // branch out of the container): those still take the global bail.
+        DefiniteFlow CfgContainer(BlockContainer container, HashSet<int> entryAssigned)
+        {
+            var blocks = container.Blocks;
+            int n = blocks.Count;
+            if (n == 0)
+                return DefiniteFlow.FallThrough;
+
+            var offsetToIndex = new Dictionary<int, int>(n);
+            for (int i = 0; i < n; i++)
+                offsetToIndex[blocks[i].StartOffset] = i;
+
+            // Successor edges. An unmodeled terminator (EH leave, or a branch
+            // whose target is outside this container) leaves the graph
+            // incomplete — fall back to the safe bail rather than reason from it.
+            var successors = new List<int>[n];
+            for (int i = 0; i < n; i++)
+            {
+                var succ = new List<int>();
+                switch (blocks[i].Children.Count > 0 ? blocks[i].Children[^1] : null)
+                {
+                    case Branch b:
+                        if (!offsetToIndex.TryGetValue(b.TargetOffset, out int bt)) { BailAll(); return DefiniteFlow.Bail; }
+                        succ.Add(bt);
+                        break;
+                    case ConditionalBranch cb:
+                        if (!offsetToIndex.TryGetValue(cb.TargetOffset, out int ct)) { BailAll(); return DefiniteFlow.Bail; }
+                        succ.Add(ct);
+                        if (i + 1 < n) succ.Add(i + 1);
+                        break;
+                    case SwitchBranch sb:
+                        foreach (var target in sb.TargetOffsets)
+                        {
+                            if (!offsetToIndex.TryGetValue(target, out int st)) { BailAll(); return DefiniteFlow.Bail; }
+                            succ.Add(st);
+                        }
+                        if (i + 1 < n) succ.Add(i + 1);
+                        break;
+                    case Return or Throw:
+                        break;  // no successor
+                    case Leave or EndFinally or EndFilter:
+                        BailAll();
+                        return DefiniteFlow.Bail;  // EH survivor: not modeled
+                    default:
+                        if (i + 1 < n) succ.Add(i + 1);  // falls through to the next block
+                        break;
+                }
+                successors[i] = succ;
+            }
+
+            // gen[i]: locals block i assigns on every path through it (order
+            // within the block does not matter for what holds at its exit).
+            var gen = new HashSet<int>[n];
+            for (int i = 0; i < n; i++)
+            {
+                gen[i] = [];
+                foreach (var child in blocks[i].Children)
+                {
+                    if (child is StoreLocal store)
+                        gen[i].Add(store.Index);
+                    else if (child is InitObject { Address: LoadLocalAddress address })
+                        gen[i].Add(address.Index);
+                }
+            }
+
+            var preds = new List<int>[n];
+            for (int i = 0; i < n; i++)
+                preds[i] = [];
+            for (int i = 0; i < n; i++)
+                foreach (var s in successors[i])
+                    preds[s].Add(i);
+
+            // in[0] is the entry assignments: the external edge always supplies
+            // them, and a local assigned before the container stays assigned
+            // across any back edge. Other blocks start at the universe so the
+            // first intersection narrows down; intersection only shrinks, so the
+            // fixpoint terminates.
+            var inSets = new HashSet<int>[n];
+            inSets[0] = new HashSet<int>(entryAssigned);
+            for (int i = 1; i < n; i++)
+                inSets[i] = new HashSet<int>(Enumerable.Range(0, function.Locals.Length));
+
+            bool changed = true;
+            while (changed)
+            {
+                changed = false;
+                for (int k = 1; k < n; k++)
+                {
+                    if (preds[k].Count == 0)
+                        continue;  // unreachable: leaving it at the universe never narrows a reachable join
+                    HashSet<int>? merged = null;
+                    foreach (var p in preds[k])
+                    {
+                        var outP = new HashSet<int>(inSets[p]);
+                        outP.UnionWith(gen[p]);
+                        if (merged is null)
+                            merged = outP;
+                        else
+                            merged.IntersectWith(outP);
+                    }
+                    if (merged is not null && !merged.SetEquals(inSets[k]))
+                    {
+                        inSets[k] = merged;
+                        changed = true;
+                    }
+                }
+            }
+
+            // With the assignment-on-entry known per block, check reads in
+            // program order within each block.
+            for (int k = 0; k < n; k++)
+            {
+                var running = new HashSet<int>(inSets[k]);
+                foreach (var child in blocks[k].Children)
+                {
+                    switch (child)
+                    {
+                        case StoreLocal store:
+                            CheckReads(store.Value, running);
+                            running.Add(store.Index);
+                            break;
+                        case InitObject { Address: LoadLocalAddress address }:
+                            running.Add(address.Index);
+                            break;
+                        default:
+                            CheckReads(child, running);
+                            break;
+                    }
+                }
             }
             return DefiniteFlow.FallThrough;
         }
@@ -354,8 +496,14 @@ public sealed class CSharpPrinter
                     return DoWhile(loop, assigned);
                 case ForLoop loop:
                     return For(loop, assigned);
+                // A lock runs its body in program order — the monitor
+                // enter/exit around it does not perturb assignment — so model it
+                // as the lock object's read followed by the sequential body.
+                case Lock lockNode:
+                    CheckReads(lockNode.LockObject, assigned);
+                    return Container(lockNode.Body, assigned);
                 // Unmodeled control flow: stop trusting the program order.
-                case Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter or Lock:
+                case Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter:
                     BailAll();
                     return DefiniteFlow.Bail;
                 // Any other node is a straight-line statement (a call, a field or


### PR DESCRIPTION
## What

The printer's read-before-assign analysis decides whether a local declares **bare** (`int V_0;`) or with a dead initializer (`int V_0 = default;`). It walked the structured tree and bailed **globally** — flooding *every* local to `= default` — on any unmodeled control flow: a surviving goto/label, a `lock`, or an EH `leave`. Since the dominant candidate-worse population is methods the structuring pass left partly flat (surviving gotos), this global bail is the source of most of the `= default` noise.

Two changes in `CSharpPrinter.ComputeReadBeforeAssign`:

1. **Model `Lock`** as the lock-object read followed by its sequential body, instead of bailing — the monitor enter/exit doesn't perturb definite assignment.
2. **CFG-based definite assignment for flat containers.** For a goto-connected container, run a forward *must*-dataflow over the block CFG: a local is assigned on entry to a block only if assigned on **every** predecessor edge (`in[k] = ⋂ preds (in[p] ∪ gen[p])`, fixpoint; `in[0]` = entry assignments). This is the analysis the C# compiler itself runs. A local it proves bare-safe declares bare instead of `= default`. Shapes it can't model (an EH `leave`, a branch leaving the container) still take the conservative global bail.

## Impact

On `System.Private.CoreLib` (preview.5), ~**227 spurious `= default` declarations cleaned**, matching the baseline emitter's bare-local idiom:

| First-diff bucket | before | after |
| --- | ---: | ---: |
| `int V_0;` vs `int V_0 = default;` | 261 | 119 |
| `int V_1;` vs `int V_1 = default;` | 121 | 74 |
| `bool V_0;` vs `bool V_0 = default;` | 87 | 49 |

The parity *agree* count is unchanged: the affected methods carry co-occurring cosmetic diffs (namespace qualifiers like `System.BitConverter` vs `BitConverter`) that keep them in "differ", so this is a real but currently agree-invisible quality win — it becomes agree-visible once those cosmetic diffs are resolved.

## Soundness

A bare local that's actually read-before-assign is CS0165. Verified by a `--compile-check` A/B over **3,726** methods (DA-fix vs the same tree with the change reverted):

- **Zero new CS0165.** The one CS0165 in the corpus (`System.String::JoinCore`) is **identical on both sides** — pre-existing in an already-malformed method.
- **Methods-with-defects unchanged: 3726 → 3726.** No valid method became invalid. (One already-malformed method, `MakeFunctionPointer`, shifts one parse-artifact code — still invalid either way.)

## Tests

- `ILInspector.Decompiler.Tests`: **468** green. New: `DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath` (sparse-switch comparison tree → flat goto graph; `result` proven bare) and `DeadDefaultInitializer_DroppedWhenAssignedInsideLock`. `ClassifyMode` joins the compile-back known-diff docket (unstructured comparison tree — leaves the set when structuring lands).
- `dotnet-inspect.Tests`: 1142 green (no member-output drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)