### PR TITLE
Instrument all IR passes to record Stepper rewrites (#629)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -30,7 +30,7 @@ public class RedundantBranchEliminationPassTests
         // dead branch is dropped (the condition has no side effect to preserve).
         var function = TwoBlocks(new ConditionalBranch(PureCondition(), targetOffset: 8));
 
-        new RedundantBranchEliminationPass().Run(function);
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
 
         Assert.Empty(function.Body.Blocks[0].Children);
     }
@@ -44,7 +44,7 @@ public class RedundantBranchEliminationPassTests
         var call = new Call(new MethodRef(TypeRef.CoreLib("System", "Object"), "Probe", boolType, [], HasThis: false), isVirtual: false, []);
         var function = TwoBlocks(new ConditionalBranch(call, targetOffset: 8));
 
-        new RedundantBranchEliminationPass().Run(function);
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
 
         Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
     }
@@ -55,7 +55,7 @@ public class RedundantBranchEliminationPassTests
         // The pre-existing behavior still holds.
         var function = TwoBlocks(new Branch(8));
 
-        new RedundantBranchEliminationPass().Run(function);
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
 
         Assert.Empty(function.Body.Blocks[0].Children);
     }

--- a/src/ILInspector.Decompiler.Tests/StepperTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StepperTests.cs
@@ -92,18 +92,29 @@ public class StepperTests
     }
 
     [Fact]
-    public void RunWithSteps_StopsAtLimit_LeavingPartialTree()
+    public void RunWithSteps_InstrumentsMultiplePasses()
     {
-        // A run that records at least one step, replayed to stop before step 0,
-        // returns the pre-first-rewrite tree without throwing to the caller.
-        var full = ImportFixture(nameof(CfgSampleClass.Add));
-        var fullStepper = IrPasses.RunWithSteps(full);
-        if (fullStepper.Count == 0)
-            return;  // fixture records no steps; nothing to replay
+        // ReverseCopy exercises structuring plus the ++/-- fold; before the
+        // passes were instrumented only the inliner/structurer recorded steps,
+        // so a method like this reported a single step. Guard that the raising
+        // passes now each record their rewrite.
+        var function = ImportFixture(nameof(CfgSampleClass.ReverseCopy));
 
-        var partial = ImportFixture(nameof(CfgSampleClass.Add));
-        var stepper = IrPasses.RunWithSteps(partial, stepLimit: 0);
+        var stepper = IrPasses.RunWithSteps(function);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
 
-        Assert.Equal(0, stepper.Count);
+        Assert.True(stepper.Count >= 3, $"expected several recorded steps, got {stepper.Count}");
+        Assert.Contains(descriptions, d => d.Contains("structure container", StringComparison.Ordinal));
+        Assert.Contains(descriptions, d => d.Contains("fold dup", StringComparison.Ordinal));
+    }
+
+    static IEnumerable<Step> Flatten(IEnumerable<Step> steps)
+    {
+        foreach (var step in steps)
+        {
+            yield return step;
+            foreach (var child in Flatten(step.Children))
+                yield return child;
+        }
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -19,7 +19,7 @@ public sealed class BooleanFoldingPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (FoldOnce(function) || MaterializeBooleanSlots(function))
+        while (FoldOnce(function, context.Stepper) || MaterializeBooleanSlots(function, context.Stepper))
         {
         }
     }
@@ -33,7 +33,7 @@ public sealed class BooleanFoldingPass : IIrPass
     /// declaring it <c>int</c> (CS0029). The non-constant bool store is the
     /// proof — a genuine integer slot never receives one.
     /// </summary>
-    static bool MaterializeBooleanSlots(IrFunction function)
+    static bool MaterializeBooleanSlots(IrFunction function, Stepper stepper)
     {
         var storesBySlot = new Dictionary<int, List<StoreStackSlot>>();
         var loadsBySlot = new Dictionary<int, List<LoadStackSlot>>();
@@ -59,6 +59,7 @@ public sealed class BooleanFoldingPass : IIrPass
                 continue;  // a load is consumed as a non-bool; the slot is reused, not purely boolean
 
             var boolType = TypeRef.CoreLib("System", "Boolean");
+            stepper.StepOver($"retype stack slot {slot} to bool", stores[0]);
             foreach (var store in stores)
                 if (store.Value is Constant { Value: int value })
                     store.Value.ReplaceWith(new Constant(value == 1, boolType));
@@ -116,7 +117,7 @@ public sealed class BooleanFoldingPass : IIrPass
     static bool ParameterAcceptsBool(IReadOnlyList<TypeRef> parameterTypes, int index)
         => index >= 0 && index < parameterTypes.Count && IsBool(parameterTypes[index]);
 
-    static bool FoldOnce(IrFunction function)
+    static bool FoldOnce(IrFunction function, Stepper stepper)
     {
         foreach (var node in function.Descendants.ToList())
         {
@@ -124,10 +125,10 @@ public sealed class BooleanFoldingPass : IIrPass
                 continue;
             bool folded = node switch
             {
-                IfStatement statement => FoldNestedGuard(statement) || FoldGuardReturn(statement)
-                    || FoldSlotDiamond(function, statement) || FoldCoalesce(statement),
-                Comparison comparison => FoldBoolConstantComparison(comparison),
-                Conditional conditional => MaterializeBoolConditional(function, conditional),
+                IfStatement statement => FoldNestedGuard(statement, stepper) || FoldGuardReturn(statement, stepper)
+                    || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(statement, stepper),
+                Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
+                Conditional conditional => MaterializeBoolConditional(function, conditional, stepper),
                 _ => false,
             };
             if (folded)
@@ -145,7 +146,7 @@ public sealed class BooleanFoldingPass : IIrPass
     /// bool-returning method returns the slot). The non-constant bool arm is the
     /// proof: a real integer select never pairs with one.
     /// </summary>
-    static bool MaterializeBoolConditional(IrFunction function, Conditional conditional)
+    static bool MaterializeBoolConditional(IrFunction function, Conditional conditional, Stepper stepper)
     {
         var constant = (conditional.WhenTrue as Constant) ?? (conditional.WhenFalse as Constant);
         var other = conditional.WhenTrue is Constant ? conditional.WhenFalse : conditional.WhenTrue;
@@ -160,13 +161,14 @@ public sealed class BooleanFoldingPass : IIrPass
         if (!ConsumerAcceptsBool(function, conditional))
             return false;
         var boolType = TypeRef.CoreLib("System", "Boolean");
+        stepper.StepOver("materialize bool ternary constant arm", conditional);
         constant.ReplaceWith(new Constant(value == 1, boolType));
         conditional.MergedType = boolType;
         return true;
     }
 
     /// <summary>X == false → !X (via the type-aware duals), X == true → X, and the != duals — the ceq-with-zero value form of boolean tests.</summary>
-    static bool FoldBoolConstantComparison(Comparison comparison)
+    static bool FoldBoolConstantComparison(Comparison comparison, Stepper stepper)
     {
         if (comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
             return false;
@@ -178,12 +180,13 @@ public sealed class BooleanFoldingPass : IIrPass
         var operand = comparison.Left;
         comparison.DetachChildren();
         bool keepIdentity = constant == (comparison.Kind == ComparisonKind.Equal);
+        stepper.StepOver($"fold X == {constant.ToString().ToLowerInvariant()} to boolean test", comparison);
         comparison.ReplaceWith(keepIdentity ? operand : Conditions.Negate(operand));
         return true;
     }
 
     /// <summary>if (a) { if (b) { T } } → if (a &amp;&amp; b) { T }</summary>
-    static bool FoldNestedGuard(IfStatement outer)
+    static bool FoldNestedGuard(IfStatement outer, Stepper stepper)
     {
         if (outer.HasElse || outer.Then.Children.Count != 1
             || outer.Then.Children[0] is not IfStatement { HasElse: false } inner)
@@ -193,6 +196,7 @@ public sealed class BooleanFoldingPass : IIrPass
         var outerCondition = outer.Condition;
         outerCondition.Detach();
         var innerParts = inner.DetachChildren();  // [condition, then]
+        stepper.StepOver("fold nested if guards into &&", outer);
         outer.ReplaceWith(new IfStatement(
             new LogicalBinary(LogicalKind.And, outerCondition, (IrExpression)innerParts[0]),
             (Block)innerParts[1],
@@ -201,7 +205,7 @@ public sealed class BooleanFoldingPass : IIrPass
     }
 
     /// <summary>if (c) return A; return B; → short-circuit when either side is a bool constant.</summary>
-    static bool FoldGuardReturn(IfStatement guard)
+    static bool FoldGuardReturn(IfStatement guard, Stepper stepper)
     {
         if (guard.HasElse || guard.Parent is not Block container)
             return false;
@@ -256,6 +260,7 @@ public sealed class BooleanFoldingPass : IIrPass
         }
 
         tailReturn.Detach();
+        stepper.StepOver("fold guarded return into short-circuit", guard);
         guard.ReplaceWith(new Return(folded));
         return true;
     }
@@ -265,7 +270,7 @@ public sealed class BooleanFoldingPass : IIrPass
     /// null-coalescing lowering. X must be a plain load matching the tested
     /// operand exactly; both stores must target the same place.
     /// </summary>
-    static bool FoldCoalesce(IfStatement guard)
+    static bool FoldCoalesce(IfStatement guard, Stepper stepper)
     {
         if (guard.HasElse || guard.Parent is not Block container || guard.ChildIndex == 0)
             return false;
@@ -302,6 +307,7 @@ public sealed class BooleanFoldingPass : IIrPass
         var fallback = inner.DetachChildren()[0];
         var coalesce = new Coalesce((IrExpression)first, (IrExpression)fallback);
         guard.Detach();
+        stepper.StepOver("fold null check into ?? coalesce", previous);
         switch (previous)
         {
             case StoreStackSlot slot:
@@ -323,7 +329,7 @@ public sealed class BooleanFoldingPass : IIrPass
     };
 
     /// <summary>if (c) { S = A } else { S = B } → S = c ? A : B;</summary>
-    static bool FoldSlotDiamond(IrFunction function, IfStatement diamond)
+    static bool FoldSlotDiamond(IrFunction function, IfStatement diamond, Stepper stepper)
     {
         if (diamond.Else is not { Children.Count: 1 } elseArm
             || diamond.Then.Children.Count != 1
@@ -349,6 +355,7 @@ public sealed class BooleanFoldingPass : IIrPass
         var mergedType = function.Descendants
             .OfType<LoadStackSlot>()
             .FirstOrDefault(load => load.Slot == thenStore.Slot && load.Type is not null)?.Type;
+        stepper.StepOver("fold store diamond into ternary", diamond);
         diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
         return true;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
@@ -42,7 +42,7 @@ public sealed class ConstructorChainArgumentPass : IIrPass
         // preceding the call. Each inline detaches its store, so the call's
         // predecessor shifts down and the next iteration re-checks it.
         while (statement.ChildIndex > 0
-            && TryInlineSpill(block.Children[statement.ChildIndex - 1], call, usage))
+            && TryInlineSpill(block.Children[statement.ChildIndex - 1], call, usage, context.Stepper))
         {
         }
     }
@@ -66,7 +66,7 @@ public sealed class ConstructorChainArgumentPass : IIrPass
     /// with its address never taken. Returns false (and changes nothing) for
     /// anything else.
     /// </summary>
-    static bool TryInlineSpill(IrNode previous, Call call, Dictionary<(bool IsSlot, int Index), Place> usage)
+    static bool TryInlineSpill(IrNode previous, Call call, Dictionary<(bool IsSlot, int Index), Place> usage, Stepper stepper)
     {
         (bool IsSlot, int Index)? key = previous switch
         {
@@ -89,6 +89,7 @@ public sealed class ConstructorChainArgumentPass : IIrPass
 
         var value = (IrExpression)previous.DetachChildren()[0];
         previous.Detach();
+        stepper.StepOver("inline spilled base/this constructor argument", call);
         load.ReplaceWith(value);
         return true;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
@@ -36,6 +36,7 @@ public sealed class ConstructorChainPass : IIrPass
                 continue;
 
             var thisArgument = new LoadArgument(0, "this", function.DeclaringType);
+            context.Stepper.StepOver($"canonicalize {call.Callee.DeclaringType.Name}..ctor receiver to this", call);
             receiver.ReplaceWith(thisArgument);
             // The spill's sole load is gone; drop the store so it does not
             // print as a dead `T S_0 = this;` declaration.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DelegateConstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DelegateConstructionPass.cs
@@ -26,6 +26,7 @@ public sealed class DelegateConstructionPass : IIrPass
             var children = newObject.DetachChildren().Cast<IrExpression>().ToList();
             var target = children[0];
             var pointer = (LoadFunctionPointer)children[1];
+            context.Stepper.StepOver($"raise method group to {newObject.Constructor.DeclaringType.Name} delegate creation", newObject);
             newObject.ReplaceWith(new DelegateCreation(
                 newObject.Constructor.DeclaringType, pointer.Method, pointer.IsVirtual, target));
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
@@ -23,12 +23,12 @@ public sealed class DoWhileLoopPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (TransformOne(function))
+        while (TransformOne(function, context.Stepper))
         {
         }
     }
 
-    static bool TransformOne(IrFunction function)
+    static bool TransformOne(IrFunction function, Stepper stepper)
     {
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
@@ -55,7 +55,7 @@ public sealed class DoWhileLoopPass : IIrPass
             if (best is { } loop
                 && Validate(blocks, offsetToIndex, loop.Header, loop.Bottom, loop.Edge))
             {
-                Wrap(container, loop.Header, loop.Bottom, loop.Edge);
+                Wrap(container, loop.Header, loop.Bottom, loop.Edge, stepper);
                 return true;
             }
         }
@@ -116,7 +116,7 @@ public sealed class DoWhileLoopPass : IIrPass
         _ => [],
     };
 
-    static void Wrap(BlockContainer container, int header, int bottom, ConditionalBranch backEdge)
+    static void Wrap(BlockContainer container, int header, int bottom, ConditionalBranch backEdge, Stepper stepper)
     {
         var blocks = container.Blocks;
         var condition = (IrExpression)backEdge.DetachChildren()[0];
@@ -166,6 +166,7 @@ public sealed class DoWhileLoopPass : IIrPass
         for (int i = bottom + 1; i < blocks.Count; i++)
             rebuilt.Add(blocks[i]);
 
+        stepper.StepOver("raise back-edge loop to do-while", container);
         container.ReplaceWith(rebuilt);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -59,6 +59,7 @@ public sealed class EhStructuringPass : IIrPass
         var rebuilt = BuildContainer(blocks, 0, blocks.Count, forest.Roots, offsetToIndex, continuations);
         TrimTailLeaves(rebuilt, continuations);
         InlineReturnLeaves(rebuilt);
+        context.Stepper.StepOver("raise exception regions into try/catch/finally", function.Body);
         function.Body.ReplaceWith(rebuilt);
         function.Regions = [];
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
@@ -34,6 +34,7 @@ public sealed class ForLoopPass : IIrPass
             increment.Detach();
             var parts = loop.DetachChildren();  // [condition, body]
             initializer.Detach();               // reindexes the loop's slot
+            context.Stepper.StepOver("raise while loop to for loop", loop);
             loop.ReplaceWith(new ForLoop(initializer, (IrExpression)parts[0], increment, (Block)parts[1]));
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
@@ -19,6 +19,7 @@ public sealed class FunctionPointerDiagnosticsPass : IIrPass
         foreach (var pointer in function.Descendants.OfType<LoadFunctionPointer>())
         {
             // The second whitespace token (ldftn:) is the harness roadmap bucket.
+            context.Stepper.StepOver($"diagnose residual function pointer to {pointer.Method.DeclaringType.ToDisplayString()}.{pointer.Method.Name}", pointer);
             function.Diagnostics.Add(new DecompilerDiagnostic(
                 DiagnosticIds.UnsupportedFunctionPointer,
                 $"function-pointer ldftn: {pointer.Method.DeclaringType.ToDisplayString()}.{pointer.Method.Name} is not a delegate construction"));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
@@ -32,6 +32,7 @@ public sealed class IdentityConvertPass : IIrPass
             if (operandType is not null && operandType.Equals(convert.Target))
             {
                 var operand = (IrExpression)convert.DetachChildren()[0];
+                context.Stepper.StepOver($"drop identity conversion to {convert.Target.Name}", convert);
                 convert.ReplaceWith(operand);
             }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -27,18 +27,18 @@ public sealed class IncrementDecrementPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (FoldOnce(function))
+        while (FoldOnce(function, context.Stepper))
         {
         }
     }
 
-    static bool FoldOnce(IrFunction function)
+    static bool FoldOnce(IrFunction function, Stepper stepper)
     {
         foreach (var block in function.Descendants.OfType<Block>())
         {
             for (int i = 0; i + 1 < block.Children.Count; i++)
             {
-                if (TryFold(function, block, i))
+                if (TryFold(function, block, i, stepper))
                     return true;
             }
         }
@@ -47,7 +47,7 @@ public sealed class IncrementDecrementPass : IIrPass
 
     readonly record struct PlaceRef(bool IsLocal, int Index, string Name, TypeRef Type);
 
-    static bool TryFold(IrFunction function, Block block, int i)
+    static bool TryFold(IrFunction function, Block block, int i, Stepper stepper)
     {
         if (block.Children[i] is not StoreStackSlot slotStore)
             return false;
@@ -110,6 +110,7 @@ public sealed class IncrementDecrementPass : IIrPass
                 return false;
         }
 
+        stepper.StepOver($"fold dup {(isIncrement ? "++" : "--")} idiom into operator", useLoad);
         useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix));
         update.Detach();
         slotStore.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -20,7 +20,7 @@ public sealed class LockSugarPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (TransformOne(function))
+        while (TransformOne(function, context.Stepper))
         {
         }
     }
@@ -32,7 +32,7 @@ public sealed class LockSugarPass : IIrPass
         ExpressionStatement EnterStatement,
         IrExpression LockObject);
 
-    static bool TransformOne(IrFunction function)
+    static bool TransformOne(IrFunction function, Stepper stepper)
     {
         foreach (var block in function.Descendants.OfType<Block>().ToList())
         {
@@ -63,6 +63,7 @@ public sealed class LockSugarPass : IIrPass
                 var body = match.TryFinally.TryBody;
                 body.Detach();                          // reparent the try body into the lock
                 var lockNode = new Lock(lockObject, body);
+                stepper.StepOver("raise Monitor enter/exit to lock", match.TryFinally);
                 match.TryFinally.ReplaceWith(lockNode); // slot i+2 → Lock
                 match.StoreTaken.Detach();              // drop synthetic locals (high index first)
                 match.StoreObject.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
@@ -20,6 +20,7 @@ public sealed class MethodAddressPass : IIrPass
         {
             if (pointer.Parent is null || pointer.IsVirtual)
                 continue;
+            context.Stepper.StepOver($"raise ldftn to &{pointer.Method.Name}", pointer);
             pointer.ReplaceWith(new AddressOfMethod(pointer.Method));
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -44,13 +44,13 @@ public sealed class NullConditionalPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (RaiseSpilled(function) || RaiseReevaluable(function))
+        while (RaiseSpilled(function, context.Stepper) || RaiseReevaluable(function, context.Stepper))
         {
         }
     }
 
     /// <summary>Arm 1: the spilled-receiver shape (two adjacent stores to slot j).</summary>
-    static bool RaiseSpilled(IrFunction function)
+    static bool RaiseSpilled(IrFunction function, Stepper stepper)
     {
         foreach (var block in function.Descendants.OfType<Block>())
         {
@@ -76,6 +76,7 @@ public sealed class NullConditionalPass : IIrPass
                 member.Detach();
                 var receiver = (IrExpression)spill.DetachChildren()[0];
                 member.SetChild(0, receiver);
+                stepper.StepOver("raise spilled null-check diamond to ?.", result);
                 result.SetChild(0, new NullConditional(member));
                 spill.Detach();
                 return true;
@@ -85,7 +86,7 @@ public sealed class NullConditionalPass : IIrPass
     }
 
     /// <summary>Arm 2: the re-evaluable-receiver shape (argument/local loaded in both test and access).</summary>
-    static bool RaiseReevaluable(IrFunction function)
+    static bool RaiseReevaluable(IrFunction function, Stepper stepper)
     {
         foreach (var conditional in function.Descendants.OfType<Conditional>())
         {
@@ -95,6 +96,7 @@ public sealed class NullConditionalPass : IIrPass
                 continue;
 
             member.Detach();
+            stepper.StepOver("raise re-evaluable null-check diamond to ?.", conditional);
             conditional.ReplaceWith(new NullConditional(member));
             return true;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
@@ -36,12 +36,12 @@ public sealed class OrChainGuardPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (FoldOne(function))
+        while (FoldOne(function, context.Stepper))
         {
         }
     }
 
-    static bool FoldOne(IrFunction function)
+    static bool FoldOne(IrFunction function, Stepper stepper)
     {
         // A surviving leave (an early exit out of an EH region) may target a
         // block this fold would drop or re-parent — including from another
@@ -53,13 +53,13 @@ public sealed class OrChainGuardPass : IIrPass
             .ToHashSet();
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
-            if (TryFold(container, leaveTargets))
+            if (TryFold(container, leaveTargets, stepper))
                 return true;
         }
         return false;
     }
 
-    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets)
+    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
         var offsetToIndex = new Dictionary<int, int>();
@@ -71,7 +71,7 @@ public sealed class OrChainGuardPass : IIrPass
             if (Chain(blocks, offsetToIndex, p) is { } chain
                 && NoExternalEntry(blocks, p, chain.JoinIndex, leaveTargets))
             {
-                Fold(container, p, chain.SkipGuard, chain.JoinOffset);
+                Fold(container, p, chain.SkipGuard, chain.JoinOffset, stepper);
                 return true;
             }
         }
@@ -159,7 +159,7 @@ public sealed class OrChainGuardPass : IIrPass
         _ => [],
     };
 
-    static void Fold(BlockContainer container, int p, int skipGuard, int joinOffset)
+    static void Fold(BlockContainer container, int p, int skipGuard, int joinOffset, Stepper stepper)
     {
         var blocks = container.Blocks.ToList();
 
@@ -193,6 +193,7 @@ public sealed class OrChainGuardPass : IIrPass
         rebuilt.Add(folded);
         for (int idx = skipGuard + 1; idx < blocks.Count; idx++)
             rebuilt.Add(blocks[idx]);
+        stepper.StepOver("fold short-circuit OR guard chain", container);
         container.ReplaceWith(rebuilt);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -23,6 +23,7 @@ public sealed class PropertySugarPass : IIrPass
                     var children = call.DetachChildren().Cast<IrExpression>().ToList();
                     var instance = call.Callee.HasThis ? children[0] : null;
                     var indexArguments = children.Skip(call.Callee.HasThis ? 1 : 0).ToList();
+                    context.Stepper.StepOver($"raise {call.Callee.Name} call to property load", call);
                     call.ReplaceWith(new LoadProperty(call.Callee, instance, indexArguments) { IsVirtual = call.IsVirtual });
                     break;
                 }
@@ -33,6 +34,7 @@ public sealed class PropertySugarPass : IIrPass
                     int skip = call.Callee.HasThis ? 1 : 0;
                     var value = children[^1];
                     var indexArguments = children.Skip(skip).Take(children.Count - skip - 1).ToList();
+                    context.Stepper.StepOver($"raise {call.Callee.Name} call to property store", statement);
                     statement.ReplaceWith(new StoreProperty(call.Callee, instance, indexArguments, value) { IsVirtual = call.IsVirtual });
                     break;
                 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
@@ -28,10 +28,12 @@ public sealed class RedundantBranchEliminationPass : IIrPass
             switch (blocks[i].Children[^1])
             {
                 case Branch branch when branch.TargetOffset == nextOffset:
+                    context.Stepper.StepOver("remove redundant branch to the following block", branch);
                     branch.Detach();
                     break;
                 case ConditionalBranch conditional
                     when conditional.TargetOffset == nextOffset && IsSideEffectFree(conditional.Condition):
+                    context.Stepper.StepOver("remove redundant conditional branch to the following block", conditional);
                     conditional.Detach();
                     break;
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RefKindDiagnosticsPass.cs
@@ -29,6 +29,7 @@ public sealed class RefKindDiagnosticsPass : IIrPass
             };
             if (callee is null)
                 continue;
+            context.Stepper.StepOver($"diagnose unverified by-ref argument to {callee.DeclaringType.ToDisplayString()}.{callee.Name}", node);
             function.Diagnostics.Add(new DecompilerDiagnostic(
                 DiagnosticIds.UnverifiedByRefArgument,
                 $"unverified by-ref argument: call-site ref-kind for {callee.DeclaringType.ToDisplayString()}.{callee.Name} is unknown (MemberReference carries no parameter rows)"));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
@@ -36,12 +36,12 @@ public sealed class ReturnSinkingPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (SinkOnce(function))
+        while (SinkOnce(function, context.Stepper))
         {
         }
     }
 
-    static bool SinkOnce(IrFunction function)
+    static bool SinkOnce(IrFunction function, Stepper stepper)
     {
         var stores = new Dictionary<int, List<StoreLocal>>();
         var returnLoads = new Dictionary<int, List<Return>>();
@@ -78,7 +78,7 @@ public sealed class ReturnSinkingPass : IIrPass
                 continue;
             if (TryPlan(index, indexStores, returns) is { } plan)
             {
-                Apply(plan);
+                Apply(plan, stepper);
                 return true;
             }
         }
@@ -127,12 +127,13 @@ public sealed class ReturnSinkingPass : IIrPass
         return new Plan(folds, returns);
     }
 
-    static void Apply(Plan plan)
+    static void Apply(Plan plan, Stepper stepper)
     {
         foreach (var (store, brk) in plan.Folds)
         {
             var value = (IrExpression)store.DetachChildren()[0];
             brk?.Detach();
+            stepper.StepOver("sink return-accumulator store into return", store);
             store.ReplaceWith(new Return(value));
         }
         foreach (var ret in plan.Returns)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
@@ -35,6 +35,7 @@ public sealed class StructConstructorPass : IIrPass
             var children = call.DetachChildren().Cast<IrExpression>().ToList();
             var receiver = children[0];
             var value = new NewObject(call.Callee, children.Skip(1));
+            context.Stepper.StepOver($"raise in-place {call.Callee.DeclaringType.Name}..ctor to assignment", statement);
             statement.ReplaceWith(Assign(receiver, value));
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -31,12 +31,12 @@ public sealed class SwitchRaisingPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (FoldOne(function))
+        while (FoldOne(function, context.Stepper))
         {
         }
     }
 
-    static bool FoldOne(IrFunction function)
+    static bool FoldOne(IrFunction function, Stepper stepper)
     {
         var leaveTargets = function.Descendants.OfType<Leave>()
             .Select(leave => leave.TargetOffset)
@@ -46,14 +46,14 @@ public sealed class SwitchRaisingPass : IIrPass
             var blocks = container.Blocks;
             for (int s = 0; s < blocks.Count; s++)
             {
-                if (blocks[s].Children is [.., SwitchBranch sw] && Raise(container, s, sw, leaveTargets))
+                if (blocks[s].Children is [.., SwitchBranch sw] && Raise(container, s, sw, leaveTargets, stepper))
                     return true;
             }
         }
         return false;
     }
 
-    static bool Raise(BlockContainer container, int s, SwitchBranch sw, HashSet<int> leaveTargets)
+    static bool Raise(BlockContainer container, int s, SwitchBranch sw, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
         var offsetToIndex = new Dictionary<int, int>();
@@ -168,7 +168,7 @@ public sealed class SwitchRaisingPass : IIrPass
         if (!OnlyReachedByTable(blocks, owned, s, leaveTargets))
             return false;
 
-        Build(container, s, sw, caseTargets, owned, defaultBody, join, regionEnd);
+        Build(container, s, sw, caseTargets, owned, defaultBody, join, regionEnd, stepper);
         return true;
     }
 
@@ -216,7 +216,7 @@ public sealed class SwitchRaisingPass : IIrPass
 
     static void Build(
         BlockContainer container, int s, SwitchBranch sw, int[] caseTargets,
-        HashSet<int> owned, int? defaultBody, int? join, int regionEnd)
+        HashSet<int> owned, int? defaultBody, int? join, int regionEnd, Stepper stepper)
     {
         var all = container.Blocks.ToList();
         int? joinOffset = join is { } j ? all[j].StartOffset : null;
@@ -245,6 +245,7 @@ public sealed class SwitchRaisingPass : IIrPass
             rebuilt.Add(all[idx]);
         for (int idx = regionEnd; idx < all.Count; idx++)
             rebuilt.Add(all[idx]);
+        stepper.StepOver("raise IL jump table to switch", container);
         container.ReplaceWith(rebuilt);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
@@ -19,6 +19,7 @@ public sealed class TypeOfFoldingPass : IIrPass
                 && call.Children.Count == 1
                 && call.Children[0] is LoadToken { Kind: RuntimeTokenKind.Type, Type: { } type })
             {
+                context.Stepper.StepOver($"fold GetTypeFromHandle to typeof({type.Name})", call);
                 call.ReplaceWith(new TypeOf(type));
             }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -13,40 +13,41 @@ public sealed class TypedConstantsPass : IIrPass
     public void Run(IrFunction function, PassContext context)
     {
         var shapes = function.TypeShapes;
+        var stepper = context.Stepper;
         foreach (var node in function.Descendants.ToList())
         {
             switch (node)
             {
                 case Return { Value: Constant constant }:
-                    Retype(constant, function.Signature.ReturnType, shapes);
+                    Retype(constant, function.Signature.ReturnType, shapes, stepper);
                     break;
                 case StoreLocal { Value: Constant constant } store:
-                    Retype(constant, store.Type, shapes);
+                    Retype(constant, store.Type, shapes, stepper);
                     break;
                 case StoreArgument { Value: Constant constant } store:
-                    Retype(constant, store.Type, shapes);
+                    Retype(constant, store.Type, shapes, stepper);
                     break;
                 case StoreField { Value: Constant constant } store:
-                    Retype(constant, store.Field.Type, shapes);
+                    Retype(constant, store.Field.Type, shapes, stepper);
                     break;
                 case Call call:
-                    RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, shapes);
+                    RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, shapes, stepper);
                     break;
                 case NewObject ctor:
-                    RetypeArguments(ctor.Constructor, ctor.Arguments, 0, shapes);
+                    RetypeArguments(ctor.Constructor, ctor.Arguments, 0, shapes, stepper);
                     break;
                 case Comparison { Left: { } left, Right: Constant constant }
                     when left is not Constant && left.ResultType is { } leftType:
-                    Retype(constant, leftType, shapes);
+                    Retype(constant, leftType, shapes, stepper);
                     break;
                 case Box { Operand: Constant constant } box:
-                    Retype(constant, box.Type, shapes);
+                    Retype(constant, box.Type, shapes, stepper);
                     break;
                 case StoreElement { Value: Constant constant, ElementType: { } elementType }:
-                    Retype(constant, elementType, shapes);
+                    Retype(constant, elementType, shapes, stepper);
                     break;
                 case StoreIndirect { Value: Constant constant, Type: { } indirectType }:
-                    Retype(constant, indirectType, shapes);
+                    Retype(constant, indirectType, shapes, stepper);
                     break;
                 // `flags & 16` is `BindingFlags & int` — CS0019. The bitwise
                 // operators are the enum-flag idiom; an int constant beside an
@@ -54,9 +55,9 @@ public sealed class TypedConstantsPass : IIrPass
                 // printer then names the member or casts).
                 case Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary:
                     if (EnumOperandType(binary.Left, shapes) is { } leftEnum && binary.Right is Constant rightConst)
-                        Retype(rightConst, leftEnum, shapes);
+                        Retype(rightConst, leftEnum, shapes, stepper);
                     else if (EnumOperandType(binary.Right, shapes) is { } rightEnum && binary.Left is Constant leftConst)
-                        Retype(leftConst, rightEnum, shapes);
+                        Retype(leftConst, rightEnum, shapes, stepper);
                     break;
             }
         }
@@ -67,16 +68,16 @@ public sealed class TypedConstantsPass : IIrPass
             ? type
             : null;
 
-    static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+    static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {
         for (int i = 0; i < callee.ParameterTypes.Length && i + receiverOffset < arguments.Count; i++)
         {
             if (arguments[i + receiverOffset] is Constant constant)
-                Retype(constant, callee.ParameterTypes[i], shapes);
+                Retype(constant, callee.ParameterTypes[i], shapes, stepper);
         }
     }
 
-    static void Retype(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+    static void Retype(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {
         if (constant.Value is not int value)
             return;
@@ -85,9 +86,11 @@ public sealed class TypedConstantsPass : IIrPass
             switch (target.Name)
             {
                 case "Boolean" when value is 0 or 1:
+                    stepper.StepOver($"retype constant {value} to bool", constant);
                     constant.ReplaceWith(new Constant(value == 1, target));
                     return;
                 case "Char" when value >= char.MinValue && value <= char.MaxValue:
+                    stepper.StepOver($"retype constant {value} to char", constant);
                     constant.ReplaceWith(new Constant((char)value, target));
                     return;
             }
@@ -97,6 +100,9 @@ public sealed class TypedConstantsPass : IIrPass
         // the printer names it from the resolved member map. The value is kept
         // (still an int); only the constant's type changes.
         if (shapes.GetValueOrDefault(target) == TypeShape.Enum)
+        {
+            stepper.StepOver($"retype constant {value} to enum {target.Name}", constant);
             constant.ReplaceWith(new Constant(value, target));
+        }
     }
 }


### PR DESCRIPTION
Closes #629 (item 1).

## Problem

`--steps` / `--step-limit` are meant to be a fine-grained sub-pass tracer
for the decompiler, but only `ExpressionInliningPass` and
`StructuringPass` ever called into the `Stepper`. Every other raising
pass mutated the IR tree silently, so for most methods `--steps`
reported a single recorded step and `--step-limit` had almost nothing to
replay.

## Change

Instrument the remaining ~22 passes to call
`context.Stepper.StepOver(description, nearNode)` immediately **before**
each rewrite (recording-before-mutation is what makes `--step-limit N`
leave the tree in the pre-rewrite state). Where the mutation happens in a
static helper rather than `Run`, the `Stepper`/`PassContext` is threaded
through.

Passes instrumented: IdentityConvert, RedundantBranchElimination,
ConstructorChain, StructConstructor, PropertySugar, TypeOfFolding,
DelegateConstruction, MethodAddress, RefKindDiagnostics,
FunctionPointerDiagnostics, EhStructuring, ForLoop, DoWhileLoop,
OrChainGuard, SwitchRaising, LockSugar, NullConditional,
IncrementDecrement, ConstructorChainArgument, ReturnSinking,
TypedConstants, BooleanFolding.

## Behavior-neutral

Every `StepOver`/`StepInto` is a no-op when the stepper is disabled
(`PassContext.None`), which is the case on all normal product runs and on
`--dump-stages`. Only `RunWithSteps` enables it. Confirmed by 466 green
decompiler tests.

## Demo

`ReverseCopy --steps` now records **3** steps (structure container, fold
dup `++`, fold dup `--`) where it previously recorded **1**;
`--step-limit 1` correctly stops before the first fold.

Adds `StepperTests.RunWithSteps_InstrumentsMultiplePasses` as a
regression guard.
