### PR TITLE
Add harness --dump --facts/--cfg/--diff decompiler introspection modes

### DIFF
--- a/docs/decompiler-pipeline.md
+++ b/docs/decompiler-pipeline.md
@@ -117,6 +117,12 @@ The connection is load-bearing: **the final stage `--dump-stages` shows is exact
 
 In workflow terms they form the quality loop: **`--compile-back` detects at scale** *which* methods regressed (opcode diffs across whole assemblies), and **`--dump-stages` diagnoses one** of them — drilling into the per-pass IR to find which pass introduced the divergence (`--steps`/`--step-limit` narrows to a single rewrite). Detection → diagnosis, both anchored on the same final C#.
 
+Three narrower inspection modes drill past the per-pass tree into the analyses and structure the tree alone does not show:
+
+- **`--facts`** surfaces the printer's definite-assignment dataflow — the per-block `gen` and `in`/`out` sets, computed by the *same* `CSharpPrinter` walk that ships, that decide which locals keep `= default`. It answers "is this `= default` elision sound?" by reading the analysis instead of running a slow `--compile-back` A/B.
+- **`--cfg`** prints the control-flow graph (predecessor/successor edges) of each block container, so a flat goto-residue body's structure is a glance instead of a reconstruction by eye from `Branch IL_xxxx` targets. The edges come from the shared `Cfg.Build` the definite-assignment dataflow also uses, so the view and the analysis cannot disagree.
+- **`--diff`** renders each pass's effect as a unified `+`/`-` hunk over the previous stage (no-change passes collapse), turning "what did this pass do?" into a glance over the same `RunWithStages` capture.
+
 Two notes that save head-scratching:
 
 - **Ref-kind and other call-site defects surface at callers, not at the definition.** Dumping a method's own definition (e.g. `System.AppContext::TryGetSwitch`) can report `fidelity: Full` because its callees are MethodDefs in the same assembly; a `DEC0007` ref-kind loss only appears when you dump a cross-assembly *caller* of that method. Dump the call site, not the target, to reproduce a call-shape defect.

--- a/src/ILInspector.Decompiler.Tests/CfgTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgTests.cs
@@ -1,0 +1,72 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CfgTests
+{
+    static Block Term(int offset, IrNode terminator)
+    {
+        var block = new Block(offset);
+        block.Add(terminator);
+        return block;
+    }
+
+    [Fact]
+    public void Build_ConditionalBranch_AddsTargetThenFallthrough()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var blocks = new List<Block>
+        {
+            Term(0x00, new ConditionalBranch(
+                new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, i32), new Constant(0, i32)),
+                targetOffset: 0x10)),
+            Term(0x08, new Branch(0x10)),
+            Term(0x10, new Return(null)),
+        };
+
+        var edges = Cfg.Build(blocks);
+
+        // index 0: conditional → target (block index 2) then fall-through (1).
+        Assert.Equal([2, 1], edges[0].Successors);
+        Assert.Empty(edges[0].ExternalTargets);
+        // index 1: unconditional branch to 0x10 (block index 2).
+        Assert.Equal([2], edges[1].Successors);
+        // index 2: return — a method exit, no successor.
+        Assert.Empty(edges[2].Successors);
+        Assert.True(edges[2].ExitsMethod);
+    }
+
+    [Fact]
+    public void Build_FlagsExternalTargetsAndRegionExits()
+    {
+        var blocks = new List<Block>
+        {
+            Term(0x00, new Branch(0xFF)),     // target not in this container
+            Term(0x08, new Leave(0x20)),      // EH survivor
+            Term(0x10, new Return(null)),
+        };
+
+        var edges = Cfg.Build(blocks);
+
+        Assert.Empty(edges[0].Successors);
+        Assert.Equal([0xFF], edges[0].ExternalTargets);
+        Assert.True(edges[1].LeavesRegion);
+        Assert.True(edges[2].ExitsMethod);
+    }
+
+    [Fact]
+    public void Build_NoTerminator_FallsThroughToNext()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var blocks = new List<Block>
+        {
+            Term(0x00, new StoreLocal(0, i32, new Constant(1, i32))),  // no branch: falls through
+            Term(0x08, new Return(null)),
+        };
+
+        var edges = Cfg.Build(blocks);
+
+        Assert.Equal([1], edges[0].Successors);
+        Assert.True(edges[1].ExitsMethod);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DataflowFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DataflowFactsTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class DataflowFactsTests
+{
+    // A diamond: the entry conditionally branches; only the fall-through arm
+    // assigns V_0; both arms join at a block that reads V_0. V_0 is therefore
+    // possibly-read-before-assigned and must keep `= default`. Built flat so the
+    // printer's CFG dataflow (not the structured walk) analyzes it.
+    static IrFunction Diamond()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+
+        var entry = new Block(0x00);
+        entry.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, i32), new Constant(0, i32)),
+            targetOffset: 0x10));
+
+        var assign = new Block(0x08);
+        assign.Add(new StoreLocal(0, i32, new Constant(7, i32)));
+        assign.Add(new Branch(0x14));
+
+        var skip = new Block(0x10);
+        skip.Add(new Branch(0x14));
+
+        var join = new Block(0x14);
+        join.Add(new Return(new LoadLocal(0, i32)));
+
+        container.Add(entry);
+        container.Add(assign);
+        container.Add(skip);
+        container.Add(join);
+
+        var signature = new MethodSignature(i32, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("Diamond", TypeRef.CoreLib("System", "Object"), signature, [i32], container);
+    }
+
+    [Fact]
+    public void CollectDataflowFacts_RecordsTheCfgInOutSets()
+    {
+        var facts = CSharpPrinter.CollectDataflowFacts(Diamond());
+
+        Assert.False(facts.Bailed);
+        Assert.Equal(["V_0"], facts.LocalNames);
+
+        // V_0 is genned on only one arm, so the join drops it: read-before-assign.
+        Assert.Equal([0], facts.ReadBeforeAssign);
+
+        var container = Assert.Single(facts.Containers);
+        Assert.Equal(4, container.Blocks.Count);
+
+        var assign = Assert.Single(container.Blocks, b => b.Offset == 0x08);
+        Assert.Equal([0], assign.Gen);
+        Assert.Empty(assign.In);
+        Assert.Equal([0], assign.Out);
+
+        var join = Assert.Single(container.Blocks, b => b.Offset == 0x14);
+        Assert.Equal([0x08, 0x10], join.Predecessors);
+        // The intersection over predecessors keeps only locals assigned on every
+        // path — V_0 is not — so it is absent from the join's in-set.
+        Assert.Empty(join.In);
+    }
+
+    [Fact]
+    public void CollectDataflowFacts_BareSafeLocalIsNotReadBeforeAssign()
+    {
+        // Same shape, but the read happens after a block that assigns on both
+        // arms: drop the conditional skip's bypass by assigning in it too.
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+
+        var entry = new Block(0x00);
+        entry.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, i32), new Constant(0, i32)),
+            targetOffset: 0x10));
+
+        var assign = new Block(0x08);
+        assign.Add(new StoreLocal(0, i32, new Constant(7, i32)));
+        assign.Add(new Branch(0x14));
+
+        var alsoAssign = new Block(0x10);
+        alsoAssign.Add(new StoreLocal(0, i32, new Constant(9, i32)));
+        alsoAssign.Add(new Branch(0x14));
+
+        var join = new Block(0x14);
+        join.Add(new Return(new LoadLocal(0, i32)));
+
+        container.Add(entry);
+        container.Add(assign);
+        container.Add(alsoAssign);
+        container.Add(join);
+
+        var signature = new MethodSignature(i32, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("BothArms", TypeRef.CoreLib("System", "Object"), signature, [i32], container);
+
+        var facts = CSharpPrinter.CollectDataflowFacts(function);
+
+        Assert.False(facts.Bailed);
+        Assert.Empty(facts.ReadBeforeAssign);
+
+        var join2 = Assert.Single(facts.Containers).Blocks.Single(b => b.Offset == 0x14);
+        Assert.Equal([0], join2.In);  // assigned on every path, so definitely-assigned at the join
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StageDiffTests
+{
+    static PipelineStage Stage(string name, string projection) =>
+        new(name, projection, DecompilationFidelity.Full);
+
+    [Fact]
+    public void FormatDiff_ShowsFirstStageInFull()
+    {
+        var diff = StageDump.FormatDiff([Stage("(import)", "a\nb\nc\n")]);
+
+        Assert.Contains("==== IR (typed tree after import) ====", diff);
+        Assert.Contains("a\nb\nc", diff);
+    }
+
+    [Fact]
+    public void FormatDiff_CollapsesUnchangedStages()
+    {
+        var diff = StageDump.FormatDiff(
+        [
+            Stage("(import)", "a\nb\nc\n"),
+            Stage("identity-convert", "a\nb\nc\n"),
+        ]);
+
+        Assert.Contains("==== IR (after identity-convert) (no change) ====", diff);
+    }
+
+    [Fact]
+    public void FormatDiff_ShowsChangedLinesAsUnifiedHunk()
+    {
+        var diff = StageDump.FormatDiff(
+        [
+            Stage("(import)", "a\nb\nc\n"),
+            Stage("property-sugar", "a\nB\nc\n"),
+        ]);
+
+        // The changed stage is not collapsed, and the delta shows the swapped line.
+        Assert.Contains("==== IR (after property-sugar) ====", diff);
+        Assert.DoesNotContain("(after property-sugar) (no change)", diff);
+        Assert.Contains("- b", diff);
+        Assert.Contains("+ B", diff);
+        // Context line is retained; the far context is elided.
+        Assert.Contains("  a", diff);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Cfg.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Cfg.cs
@@ -1,0 +1,78 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Structural control-flow edges for one container's blocks — computed in a
+/// single place so the printer's definite-assignment dataflow and the
+/// <c>--dump --cfg</c> view can never disagree about successors. Edges follow
+/// the block terminator: a branch/conditional/switch to its target(s) (plus
+/// fall-through for the conditional and switch), nothing for a method exit,
+/// and fall-through to the next block otherwise. Targets outside the container
+/// and EH-survivor terminators are reported as such rather than resolved, so
+/// the dataflow can bail on shapes it does not model while the view still shows
+/// the edges it does.
+/// </summary>
+public static class Cfg
+{
+    /// <summary>
+    /// One block's outgoing edges. <paramref name="Successors"/> are indices
+    /// into the same container; <paramref name="ExternalTargets"/> are branch
+    /// target offsets that do not name a block in this container.
+    /// </summary>
+    public sealed record BlockEdges(
+        IReadOnlyList<int> Successors,
+        IReadOnlyList<int> ExternalTargets,
+        bool ExitsMethod,
+        bool LeavesRegion);
+
+    public static IReadOnlyList<BlockEdges> Build(IReadOnlyList<Block> blocks)
+    {
+        int n = blocks.Count;
+        var offsetToIndex = new Dictionary<int, int>(n);
+        for (int i = 0; i < n; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        var result = new BlockEdges[n];
+        for (int i = 0; i < n; i++)
+        {
+            var successors = new List<int>();
+            var external = new List<int>();
+            bool exits = false, leaves = false;
+
+            void AddTarget(int offset)
+            {
+                if (offsetToIndex.TryGetValue(offset, out int index))
+                    successors.Add(index);
+                else
+                    external.Add(offset);
+            }
+
+            switch (blocks[i].Children.Count > 0 ? blocks[i].Children[^1] : null)
+            {
+                case Branch b:
+                    AddTarget(b.TargetOffset);
+                    break;
+                case ConditionalBranch cb:
+                    AddTarget(cb.TargetOffset);
+                    if (i + 1 < n) successors.Add(i + 1);
+                    break;
+                case SwitchBranch sb:
+                    foreach (var target in sb.TargetOffsets)
+                        AddTarget(target);
+                    if (i + 1 < n) successors.Add(i + 1);
+                    break;
+                case Return or Throw:
+                    exits = true;
+                    break;
+                case Leave or EndFinally or EndFilter:
+                    leaves = true;
+                    break;
+                default:
+                    if (i + 1 < n) successors.Add(i + 1);
+                    break;
+            }
+
+            result[i] = new BlockEdges(successors, external, exits, leaves);
+        }
+        return result;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/DataflowFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/DataflowFacts.cs
@@ -1,0 +1,58 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Optional recorder for the printer's definite-assignment dataflow — the
+/// analysis inside <see cref="CSharpPrinter"/> that decides which locals keep
+/// their <c>= default</c> zero-initializer. The facts (per-block predecessors,
+/// gen, and the <c>in</c>/<c>out</c> sets of the CFG fixpoint) otherwise exist
+/// only as transient sets inside <c>ComputeReadBeforeAssign</c>, so a
+/// soundness question can only be answered by a slow compile-check A/B rather
+/// than by reading the analysis directly.
+///
+/// Like <see cref="Stepper"/>, this is opt-in: the shipped print path passes no
+/// sink and pays nothing. The recorder is filled by the <em>real</em> analysis
+/// (the same walk that produces the output), so what it surfaces is what ships
+/// — never a parallel reimplementation that could drift.
+/// </summary>
+public sealed class DataflowFacts
+{
+    /// <summary>
+    /// One block's definite-assignment facts. Offsets identify blocks; locals
+    /// are slot indices into <see cref="LocalNames"/>.
+    /// </summary>
+    public sealed record BlockFacts(
+        int Offset,
+        IReadOnlyList<int> Predecessors,
+        IReadOnlyList<int> Successors,
+        IReadOnlyList<int> Gen,
+        IReadOnlyList<int> In,
+        IReadOnlyList<int> Out,
+        bool Reachable);
+
+    /// <summary>The per-block facts for one goto-connected container analyzed as a CFG.</summary>
+    public sealed record ContainerFacts(IReadOnlyList<BlockFacts> Blocks);
+
+    readonly List<ContainerFacts> _containers = [];
+
+    /// <summary>Each container the analysis solved as a control-flow graph, in walk order.</summary>
+    public IReadOnlyList<ContainerFacts> Containers => _containers;
+
+    /// <summary>Display names for each local slot, index-aligned (a source name or <c>V_N</c>).</summary>
+    public IReadOnlyList<string> LocalNames { get; set; } = [];
+
+    /// <summary>
+    /// Locals the analysis proved may be read before they are definitely
+    /// assigned — the ones whose declaration keeps <c>= default</c>. The
+    /// complement declares bare.
+    /// </summary>
+    public IReadOnlyList<int> ReadBeforeAssign { get; set; } = [];
+
+    /// <summary>
+    /// True when the analysis hit a shape it does not model (an EH leave, a
+    /// branch leaving the container) and conservatively bailed, marking every
+    /// local read-before-assign.
+    /// </summary>
+    public bool Bailed { get; set; }
+
+    internal void AddContainer(ContainerFacts container) => _containers.Add(container);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -348,47 +348,18 @@ public sealed class CSharpPrinter
             if (n == 0)
                 return DefiniteFlow.FallThrough;
 
-            var offsetToIndex = new Dictionary<int, int>(n);
-            for (int i = 0; i < n; i++)
-                offsetToIndex[blocks[i].StartOffset] = i;
-
             // Successor edges. An unmodeled terminator (EH leave, or a branch
             // whose target is outside this container) leaves the graph
             // incomplete — fall back to the safe bail rather than reason from it.
+            var edges = Cfg.Build(blocks);
+            if (edges.Any(e => e.LeavesRegion || e.ExternalTargets.Count > 0))
+            {
+                BailAll();
+                return DefiniteFlow.Bail;
+            }
             var successors = new List<int>[n];
             for (int i = 0; i < n; i++)
-            {
-                var succ = new List<int>();
-                switch (blocks[i].Children.Count > 0 ? blocks[i].Children[^1] : null)
-                {
-                    case Branch b:
-                        if (!offsetToIndex.TryGetValue(b.TargetOffset, out int bt)) { BailAll(); return DefiniteFlow.Bail; }
-                        succ.Add(bt);
-                        break;
-                    case ConditionalBranch cb:
-                        if (!offsetToIndex.TryGetValue(cb.TargetOffset, out int ct)) { BailAll(); return DefiniteFlow.Bail; }
-                        succ.Add(ct);
-                        if (i + 1 < n) succ.Add(i + 1);
-                        break;
-                    case SwitchBranch sb:
-                        foreach (var target in sb.TargetOffsets)
-                        {
-                            if (!offsetToIndex.TryGetValue(target, out int st)) { BailAll(); return DefiniteFlow.Bail; }
-                            succ.Add(st);
-                        }
-                        if (i + 1 < n) succ.Add(i + 1);
-                        break;
-                    case Return or Throw:
-                        break;  // no successor
-                    case Leave or EndFinally or EndFilter:
-                        BailAll();
-                        return DefiniteFlow.Bail;  // EH survivor: not modeled
-                    default:
-                        if (i + 1 < n) succ.Add(i + 1);  // falls through to the next block
-                        break;
-                }
-                successors[i] = succ;
-            }
+                successors[i] = [.. edges[i].Successors];
 
             // gen[i]: locals block i assigns on every path through it (order
             // within the block does not matter for what holds at its exit).

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -33,6 +33,21 @@ public sealed class CSharpPrinter
         return Print(function);
     }
 
+    /// <summary>
+    /// Runs the print analysis on an already-raised tree purely to capture the
+    /// definite-assignment dataflow facts — the per-block <c>in</c>/<c>out</c>
+    /// sets that decide which locals keep <c>= default</c>. The same walk that
+    /// produces the output fills the sink, so the facts are the shipped
+    /// analysis, not a parallel model. The rendered C# is discarded.
+    /// </summary>
+    public static DataflowFacts CollectDataflowFacts(IrFunction function)
+    {
+        var facts = new DataflowFacts();
+        var printer = new CSharpPrinter(function) { _facts = facts };
+        printer.PrintBody(function);
+        return facts;
+    }
+
     public static DecompilerResult Print(IrFunction function)
     {
         try
@@ -56,6 +71,9 @@ public sealed class CSharpPrinter
 
     /// <summary>Locals that may be read before they are definitely assigned, so their declaration must keep its `= default` zero-initializer (a bare declaration would be CS0165).</summary>
     HashSet<int> _readBeforeAssign = [];
+
+    /// <summary>Optional sink for the definite-assignment dataflow facts; null on the shipped print path (the analysis records nothing then).</summary>
+    DataflowFacts? _facts;
 
     /// <summary>Offsets some surviving goto targets — labels print wherever the block lives, top-level or inside a flat EH body.</summary>
     HashSet<int> _labelTargets = [];
@@ -247,6 +265,8 @@ public sealed class CSharpPrinter
         void BailAll()
         {
             bailed = true;
+            if (_facts is not null)
+                _facts.Bailed = true;
             for (int i = 0; i < function.Locals.Length; i++)
                 readEarly.Add(i);
         }
@@ -430,6 +450,26 @@ public sealed class CSharpPrinter
 
             // With the assignment-on-entry known per block, check reads in
             // program order within each block.
+            if (_facts is not null)
+            {
+                var blockFacts = new List<DataflowFacts.BlockFacts>(n);
+                for (int i = 0; i < n; i++)
+                {
+                    bool reachable = i == 0 || preds[i].Count > 0;
+                    var outI = new HashSet<int>(inSets[i]);
+                    outI.UnionWith(gen[i]);
+                    blockFacts.Add(new DataflowFacts.BlockFacts(
+                        blocks[i].StartOffset,
+                        [.. preds[i].Select(p => blocks[p].StartOffset).Order()],
+                        [.. successors[i].Select(s => blocks[s].StartOffset).Order()],
+                        [.. gen[i].Order()],
+                        reachable ? [.. inSets[i].Order()] : [],
+                        reachable ? [.. outI.Order()] : [],
+                        reachable));
+                }
+                _facts.AddContainer(new DataflowFacts.ContainerFacts(blockFacts));
+            }
+
             for (int k = 0; k < n; k++)
             {
                 var running = new HashSet<int>(inSets[k]);
@@ -652,6 +692,13 @@ public sealed class CSharpPrinter
         }
 
         Container(function.Body, []);
+
+        if (_facts is not null)
+        {
+            _facts.LocalNames = [.. Enumerable.Range(0, function.Locals.Length).Select(LocalName)];
+            _facts.ReadBeforeAssign = [.. readEarly.Order()];
+        }
+
         return readEarly;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -45,6 +45,110 @@ public static class StageDump
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Renders the stage list as a per-pass diff: the first stage in full, then
+    /// for each later stage only the lines that pass changed (a unified-style
+    /// <c>-</c>/<c>+</c> hunk with one line of context). Passes that change
+    /// nothing collapse to a one-line "(no change)" header, so "what did this
+    /// pass do?" is a glance instead of a manual sed between two stage headers
+    /// (issue #633 item 3). Same stage boundaries as <see cref="Format"/>.
+    /// </summary>
+    public static string FormatDiff(IReadOnlyList<PipelineStage> stages)
+    {
+        var sb = new StringBuilder();
+        if (stages.Count == 0)
+            return sb.ToString();
+
+        sb.AppendLine();
+        sb.AppendLine($"==== {Title(stages[0].PassName)} ====");
+        sb.Append(stages[0].Projection);
+
+        for (int i = 1; i < stages.Count; i++)
+        {
+            var hunks = DiffHunks(stages[i - 1].Projection, stages[i].Projection);
+            sb.AppendLine();
+            if (hunks.Count == 0)
+            {
+                sb.AppendLine($"==== {Title(stages[i].PassName)} (no change) ====");
+                continue;
+            }
+            sb.AppendLine($"==== {Title(stages[i].PassName)} ====");
+            foreach (var line in hunks)
+                sb.AppendLine(line);
+        }
+        return sb.ToString();
+    }
+
+    static string[] SplitLines(string text) =>
+        text.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+
+    /// <summary>
+    /// A unified-style line diff condensed to changed hunks with one line of
+    /// surrounding context, hunks separated by an <c>  …</c> elision marker. An
+    /// empty result means the two texts are line-identical. Falls back to a
+    /// coarse summary when the inputs are too large to diff with the quadratic
+    /// LCS (a dev tool on one method rarely hits this).
+    /// </summary>
+    static List<string> DiffHunks(string oldText, string newText)
+    {
+        var a = SplitLines(oldText);
+        var b = SplitLines(newText);
+
+        if ((long)a.Length * b.Length > 4_000_000)
+        {
+            if (oldText == newText)
+                return [];
+            return [$"  (changed; {a.Length} → {b.Length} lines — too large to diff line-by-line)"];
+        }
+
+        // LCS length table, then backtrack into a +/-/context op stream.
+        int n = a.Length, m = b.Length;
+        var lcs = new int[n + 1, m + 1];
+        for (int i = n - 1; i >= 0; i--)
+            for (int j = m - 1; j >= 0; j--)
+                lcs[i, j] = a[i] == b[j] ? lcs[i + 1, j + 1] + 1 : Math.Max(lcs[i + 1, j], lcs[i, j + 1]);
+
+        var ops = new List<(char Kind, string Text)>();
+        int x = 0, y = 0;
+        while (x < n && y < m)
+        {
+            if (a[x] == b[y]) { ops.Add((' ', a[x])); x++; y++; }
+            else if (lcs[x + 1, y] >= lcs[x, y + 1]) { ops.Add(('-', a[x])); x++; }
+            else { ops.Add(('+', b[y])); y++; }
+        }
+        while (x < n) { ops.Add(('-', a[x])); x++; }
+        while (y < m) { ops.Add(('+', b[y])); y++; }
+
+        if (ops.All(o => o.Kind == ' '))
+            return [];
+
+        // Keep changed lines plus one line of context on each side; collapse the
+        // rest, marking each elision with "  …".
+        const int context = 1;
+        var keep = new bool[ops.Count];
+        for (int i = 0; i < ops.Count; i++)
+        {
+            if (ops[i].Kind == ' ')
+                continue;
+            for (int k = Math.Max(0, i - context); k <= Math.Min(ops.Count - 1, i + context); k++)
+                keep[k] = true;
+        }
+
+        var lines = new List<string>();
+        bool elided = false;
+        for (int i = 0; i < ops.Count; i++)
+        {
+            if (!keep[i])
+            {
+                if (!elided) { lines.Add("  …"); elided = true; }
+                continue;
+            }
+            elided = false;
+            lines.Add($"{ops[i].Kind} {ops[i].Text}");
+        }
+        return lines;
+    }
+
     /// <summary>The section header for a stage — "after import" for the importer output, "after {pass}" otherwise.</summary>
     public static string Title(string passName) =>
         passName == IrPasses.ImportStageName

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -51,6 +51,7 @@ static class Program
         int stepLimit = int.MaxValue;
         bool ilView = false;
         bool skipPdb = false;
+        bool facts = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -58,6 +59,7 @@ static class Program
             {
                 case "--dump": dumpMethod = args[++i]; break;
                 case "--steps": steps = true; break;
+                case "--facts": facts = true; break;
                 case "--step-limit": steps = true; stepLimit = int.Parse(args[++i]); break;
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
@@ -104,6 +106,8 @@ static class Program
         {
             if (pipelineExplicit && pipelineName.Equals("current", StringComparison.OrdinalIgnoreCase))
                 return DumpStages(assemblies, dumpMethod);
+            if (facts)
+                return DumpFacts(assemblies, dumpMethod, skipPdb);
             return steps
                 ? DumpSteps(assemblies, dumpMethod, stepLimit, skipPdb)
                 : DumpNext(assemblies, dumpMethod, ilView ? StageDumpView.Full : StageDumpView.IrTree, skipPdb);
@@ -492,6 +496,70 @@ static class Program
     }
 
     /// <summary>
+    /// Surfaces the printer's definite-assignment dataflow facts — the per-block
+    /// predecessors, gen, and the <c>in</c>/<c>out</c> sets of the CFG fixpoint
+    /// that decides which locals keep <c>= default</c>. The same analysis that
+    /// produces the shipped C# fills the sink, so what prints here is the real
+    /// decision, not a re-derivation (issue #633 item 1). The function is raised
+    /// through the canonical pipeline first so the facts match the output.
+    /// </summary>
+    static int DumpFacts(List<string> assemblies, string dumpMethod, bool skipPdb = false)
+    {
+        int separator = dumpMethod.IndexOf("::", StringComparison.Ordinal);
+        if (separator <= 0)
+            return Fail("--dump expects Namespace.Type::Method (metadata type name)");
+        string typeName = dumpMethod[..separator];
+        string methodName = dumpMethod[(separator + 2)..];
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            var function = IrImporter.Import(source, typeName, methodName);
+            if (function is null)
+                continue;
+
+            IrPasses.Run(function);  // raise through the canonical pipeline, as the product does
+            var facts = CSharpPrinter.CollectDataflowFacts(function);
+
+            Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, definite-assignment facts)");
+            Console.WriteLine();
+            Console.WriteLine("==== definite-assignment dataflow ====");
+            Console.WriteLine($"locals: {(facts.LocalNames.Count == 0 ? "(none)" : string.Join(", ", facts.LocalNames))}");
+
+            if (facts.Bailed)
+                Console.WriteLine("result: analysis bailed on an unmodeled shape — every local keeps `= default`");
+            else
+                Console.WriteLine($"result: reads-before-assign = {NameSet(facts.ReadBeforeAssign, facts.LocalNames)}  (these keep `= default`; the rest declare bare)");
+
+            for (int c = 0; c < facts.Containers.Count; c++)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"container #{c} (CFG dataflow):");
+                foreach (var block in facts.Containers[c].Blocks)
+                {
+                    string tag = block.Reachable ? "" : "  [unreachable]";
+                    Console.WriteLine(
+                        $"  IL_{block.Offset:X4}{tag}" +
+                        $"  preds: {OffsetSet(block.Predecessors)}" +
+                        $"  succs: {OffsetSet(block.Successors)}");
+                    Console.WriteLine(
+                        $"           gen: {NameSet(block.Gen, facts.LocalNames)}" +
+                        $"  in: {NameSet(block.In, facts.LocalNames)}" +
+                        $"  out: {NameSet(block.Out, facts.LocalNames)}");
+                }
+            }
+            return 0;
+        }
+        return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
+    }
+
+    static string NameSet(IReadOnlyList<int> indices, IReadOnlyList<string> names) =>
+        indices.Count == 0 ? "{}" : "{" + string.Join(", ", indices.Select(i => i < names.Count ? names[i] : $"V_{i}")) + "}";
+
+    static string OffsetSet(IReadOnlyList<int> offsets) =>
+        offsets.Count == 0 ? "-" : string.Join(", ", offsets.Select(o => $"IL_{o:X4}"));
+
+    /// <summary>
     /// JitDump for the decompiler: every stage of one method's analysis as a
     /// projection of the shared MethodAnalysis — raw IL, typed IL, structured
     /// IL, then C#. The IL projections come from pre-transform stages, so
@@ -743,6 +811,10 @@ static class Program
                                 CSharpEmitter staged view (a known fidelity trap).
           --steps               with --dump: print the per-pass step log
                                 (fine-grained rewrites). Ignored by --pipeline current.
+          --facts               with --dump: print the printer's definite-assignment
+                                dataflow facts — per-block preds/gen and the in/out
+                                sets that decide which locals keep `= default`.
+                                Ignored by --pipeline current.
           --step-limit <N>      with --dump: replay to step N and dump the IR
                                 right before that rewrite. Ignored by --pipeline current.
           --il                  with --dump: prepend the annotated-IL import

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -52,6 +52,7 @@ static class Program
         bool ilView = false;
         bool skipPdb = false;
         bool facts = false;
+        bool cfg = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -60,6 +61,7 @@ static class Program
                 case "--dump": dumpMethod = args[++i]; break;
                 case "--steps": steps = true; break;
                 case "--facts": facts = true; break;
+                case "--cfg": cfg = true; break;
                 case "--step-limit": steps = true; stepLimit = int.Parse(args[++i]); break;
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
@@ -108,6 +110,8 @@ static class Program
                 return DumpStages(assemblies, dumpMethod);
             if (facts)
                 return DumpFacts(assemblies, dumpMethod, skipPdb);
+            if (cfg)
+                return DumpCfg(assemblies, dumpMethod, skipPdb);
             return steps
                 ? DumpSteps(assemblies, dumpMethod, stepLimit, skipPdb)
                 : DumpNext(assemblies, dumpMethod, ilView ? StageDumpView.Full : StageDumpView.IrTree, skipPdb);
@@ -560,6 +564,76 @@ static class Program
         offsets.Count == 0 ? "-" : string.Join(", ", offsets.Select(o => $"IL_{o:X4}"));
 
     /// <summary>
+    /// Renders the control-flow graph of each block container in the raised IR —
+    /// the predecessor/successor edges that otherwise have to be reconstructed
+    /// by eye from <c>Branch IL_xxxx</c> targets across many blocks (issue #633
+    /// item 2). Edges come from the shared <see cref="Cfg.Build"/> the printer's
+    /// definite-assignment dataflow also uses, so the view cannot drift from the
+    /// analysis.
+    /// </summary>
+    static int DumpCfg(List<string> assemblies, string dumpMethod, bool skipPdb = false)
+    {
+        int separator = dumpMethod.IndexOf("::", StringComparison.Ordinal);
+        if (separator <= 0)
+            return Fail("--dump expects Namespace.Type::Method (metadata type name)");
+        string typeName = dumpMethod[..separator];
+        string methodName = dumpMethod[(separator + 2)..];
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            var function = IrImporter.Import(source, typeName, methodName);
+            if (function is null)
+                continue;
+
+            IrPasses.Run(function);  // raise through the canonical pipeline, as the product does
+
+            Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, control-flow graph)");
+
+            var containers = function.Descendants.Prepend(function).OfType<BlockContainer>().ToList();
+            int index = 0;
+            foreach (var container in containers)
+            {
+                var blocks = container.Blocks;
+                if (blocks.Count == 0)
+                    continue;
+                var edges = Cfg.Build(blocks);
+
+                var preds = new List<int>[blocks.Count];
+                for (int i = 0; i < blocks.Count; i++)
+                    preds[i] = [];
+                for (int i = 0; i < blocks.Count; i++)
+                    foreach (int s in edges[i].Successors)
+                        preds[s].Add(i);
+
+                Console.WriteLine();
+                Console.WriteLine($"container #{index++} ({blocks.Count} block{(blocks.Count == 1 ? "" : "s")}):");
+                for (int i = 0; i < blocks.Count; i++)
+                {
+                    var predOffsets = preds[i].Select(p => blocks[p].StartOffset).Order().ToList();
+                    Console.WriteLine($"  IL_{blocks[i].StartOffset:X4}  preds: {OffsetSet(predOffsets),-28}  succs: {Succs(blocks, edges[i])}");
+                }
+            }
+            return 0;
+        }
+        return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
+    }
+
+    static string Succs(IReadOnlyList<Block> blocks, Cfg.BlockEdges edges)
+    {
+        var parts = new List<string>();
+        foreach (int s in edges.Successors)
+            parts.Add($"IL_{blocks[s].StartOffset:X4}");
+        foreach (int t in edges.ExternalTargets)
+            parts.Add($"IL_{t:X4} (external)");
+        if (edges.ExitsMethod)
+            parts.Add("(return)");
+        if (edges.LeavesRegion)
+            parts.Add("(leave region)");
+        return parts.Count == 0 ? "-" : string.Join(", ", parts);
+    }
+
+    /// <summary>
     /// JitDump for the decompiler: every stage of one method's analysis as a
     /// projection of the shared MethodAnalysis — raw IL, typed IL, structured
     /// IL, then C#. The IL projections come from pre-transform stages, so
@@ -815,6 +889,9 @@ static class Program
                                 dataflow facts — per-block preds/gen and the in/out
                                 sets that decide which locals keep `= default`.
                                 Ignored by --pipeline current.
+          --cfg                 with --dump: print the control-flow graph (per-block
+                                predecessor/successor edges) of each block container
+                                in the raised IR. Ignored by --pipeline current.
           --step-limit <N>      with --dump: replay to step N and dump the IR
                                 right before that rewrite. Ignored by --pipeline current.
           --il                  with --dump: prepend the annotated-IL import

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -53,6 +53,7 @@ static class Program
         bool skipPdb = false;
         bool facts = false;
         bool cfg = false;
+        bool diff = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -62,6 +63,7 @@ static class Program
                 case "--steps": steps = true; break;
                 case "--facts": facts = true; break;
                 case "--cfg": cfg = true; break;
+                case "--diff": diff = true; break;
                 case "--step-limit": steps = true; stepLimit = int.Parse(args[++i]); break;
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
@@ -112,6 +114,8 @@ static class Program
                 return DumpFacts(assemblies, dumpMethod, skipPdb);
             if (cfg)
                 return DumpCfg(assemblies, dumpMethod, skipPdb);
+            if (diff)
+                return DumpDiff(assemblies, dumpMethod, skipPdb);
             return steps
                 ? DumpSteps(assemblies, dumpMethod, stepLimit, skipPdb)
                 : DumpNext(assemblies, dumpMethod, ilView ? StageDumpView.Full : StageDumpView.IrTree, skipPdb);
@@ -452,8 +456,33 @@ static class Program
     }
 
     /// <summary>
-    /// Step log for the replacement pipeline: the fine-grained rewrites each
-    /// pass records through the stepper, JitDump's per-rewrite trace. With a
+    /// Per-pass diff of the staged pipeline: each pass's effect shown as a
+    /// unified +/- hunk over the previous stage's IR tree, so "what did this
+    /// pass change?" is a glance instead of a manual sed between two stage
+    /// headers (issue #633 item 3). Same stages and boundaries as the plain
+    /// stage dump — only the rendering condenses to deltas.
+    /// </summary>
+    static int DumpDiff(List<string> assemblies, string dumpMethod, bool skipPdb = false)
+    {
+        int separator = dumpMethod.IndexOf("::", StringComparison.Ordinal);
+        if (separator <= 0)
+            return Fail("--dump expects Namespace.Type::Method (metadata type name)");
+        string typeName = dumpMethod[..separator];
+        string methodName = dumpMethod[(separator + 2)..];
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            var function = IrImporter.Import(source, typeName, methodName);
+            if (function is null)
+                continue;
+
+            Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, per-pass diff)");
+            Console.Write(StageDump.FormatDiff(IrPasses.RunWithStages(function)));
+            return 0;
+        }
+        return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
+    }
     /// step limit, replays to that ordinal and dumps the IR tree right before
     /// the rewrite — "show me the tree just before this went wrong."
     /// </summary>
@@ -892,6 +921,9 @@ static class Program
           --cfg                 with --dump: print the control-flow graph (per-block
                                 predecessor/successor edges) of each block container
                                 in the raised IR. Ignored by --pipeline current.
+          --diff                with --dump: print each pass's effect as a unified
+                                +/- diff over the previous stage's IR tree. Ignored
+                                by --pipeline current.
           --step-limit <N>      with --dump: replay to step N and dump the IR
                                 right before that rewrite. Ignored by --pipeline current.
           --il                  with --dump: prepend the annotated-IL import

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -31,7 +31,7 @@ The similarity is a coarse token-bag measure and is deliberately understood to b
 
 *The CI gate.* The console mode above is for exploration; the durable regression guard is `CompileBackGateTests` in `ILInspector.Decompiler.Tests`, which calls the same machinery through `CompileBack.Evaluate` (the non-printing, structured-result entry point) over `CfgSampleClass`. It fails CI when a method newly recompiles to a different opcode stream (a regression beyond the documented `KnownDiffs` docket) and when a previously-fixed method (`PinnedExact`) regresses. Shrink `KnownDiffs` as you fix docket entries; add the fixed method to `PinnedExact` to pin the fix.
 
-**Stage dump** (`--dump 'Type::Method'`): JitDump for the decompiler — prints every stage of one method's analysis as projections of the shared `MethodAnalysis`: raw IL, typed IL (per-instruction stack states), structured IL (blocks and exception regions), then C#. The IL projections come from pre-transform stages, so the output is exactly what each pipeline layer saw.
+**Stage dump** (`--dump 'Type::Method'`): JitDump for the decompiler — prints every stage of one method's analysis as projections of the shared `MethodAnalysis`: raw IL, typed IL (per-instruction stack states), structured IL (blocks and exception regions), then C#. The IL projections come from pre-transform stages, so the output is exactly what each pipeline layer saw. Add a sub-mode to narrow what `--dump` shows: `--steps`/`--step-limit` (per-pass fine-grained rewrites), `--facts` (the printer's definite-assignment `gen`/`in`/`out` sets that decide which locals keep `= default`), `--cfg` (per-block predecessor/successor edges), or `--diff` (each pass's effect as a unified `+`/`-` hunk over the previous stage).
 
 ## Usage
 
@@ -66,6 +66,14 @@ CB_TYPE=CfgSampleClass CB_DUMP=1 dotnet run --project tools/DecompilerHarness -c
 # Stage-by-stage dump of one method (metadata type name)
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --dump 'System.Collections.Generic.Stack`1::Push'
+
+# Introspect one method: definite-assignment facts, the CFG, or per-pass deltas
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --dump 'DecCalc::Div128By96' --facts
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --dump 'DecCalc::Div128By96' --cfg
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --dump 'DecCalc::Div128By96' --diff
 ```
 
 Inputs are assembly paths or directories (non-managed files are skipped). Methods slower than 2s are listed in the report; true hangs stall the sweep visibly rather than being misreported by a nested-task timeout (CI applies job-level timeouts).


### PR DESCRIPTION
Implements the three printer-stage introspection gaps from #633 — field feedback from using the stage-dump infra in anger. Each mode is opt-in and behavior-neutral on the shipped path; the dump still terminates on the real `PrintRaised` and the stage list is unchanged.

## Item 1 — definite-assignment dataflow facts (`--dump --facts`)

Adds a `DataflowFacts` sink (opt-in, like `Stepper`) that is filled by the **real** `ComputeReadBeforeAssign`/`CfgContainer` walk rather than a reimplementation, so the reported facts are exactly the shipped analysis. New `CSharpPrinter.CollectDataflowFacts` entrypoint drives it. Surfaces, per block: predecessors, successors, gen set, in/out sets, reachability, plus the locals kept `= default` because they're read-before-assign.

Demo (`DecCalc::Div128By96`): `V_4` is reported read-before-assign directly from the `in`/`out` sets — no 6-minute compile-check round-trip needed to see why the `= default` was kept.

## Item 2 — CFG/edge view (`--dump --cfg`)

Extracts a shared `Cfg.Build` edge builder and refactors the DA analysis to call it, so the `--cfg` view and the analyzer can't drift. Per-block `preds:`/`succs:` with external-target / exits-method / leaves-region flags. The DA refactor preserves the original bail semantics and is verified behavior-identical.

## Item 3 — per-pass stage diff (`--dump --diff`)

Adds `StageDump.FormatDiff`: first stage in full, then unified `+`/`-` hunks per adjacent pass (context=1, no-change passes collapse to a header), with an LCS size guard that falls back to a coarse line-count summary. Reuses the existing `RunWithStages` capture so stage boundaries match the plain dump.

Demo (`DecCalc::Div128By96`): the diff shows `property-sugar` → `LoadProperty` and the do-while loop being raised, at a glance.

## Tests & docs

- 479 decompiler tests green. New: `DataflowFactsTests` (hand-built diamond CFG), `CfgTests`, `StageDiffTests`.
- Documented the three modes in `docs/decompiler-pipeline.md` and the harness README; markdownlint clean.

Closes #633
