### PR TITLE
Qualify nested types in the IR importer (finding 2 of #623)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1293,6 +1293,23 @@ public class CfgSampleClass
         box.Put(in a);
         return value;
     }
+
+    // A nested type whose leaf name (NestedSample) is shared with an unrelated
+    // top-level type below. Its full metadata name is the declaring chain
+    // (CfgSampleClass.NestedSample), not the leaf — the IR importer must
+    // qualify nested types or this body is unreachable (and collides with the
+    // top-level NestedSample on its bare leaf name).
+    public sealed class NestedSample
+    {
+        public static int Triple(int x) => x * 3;
+    }
+}
+
+// A top-level type sharing the nested type's leaf name, to prove the importer
+// keys on the fully-qualified name, not the leaf.
+public sealed class NestedSample
+{
+    public static int Negate(int x) => -x;
 }
 
 public sealed class RefKindBox<T>

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -483,6 +483,31 @@ public class IrImporterTests
         Assert.All(genericCall.Callee.ParameterTypes, p => Assert.False(ContainsGenericParameter(p)));
     }
 
+    [Fact]
+    public void NestedType_ImportsByFullyQualifiedName()
+    {
+        // A nested type's metadata name threads its declaring types
+        // (CfgSampleClass.NestedSample), with a nil namespace and a leaf Name.
+        // The importer must qualify it, or the body is unreachable. The dotted
+        // metadata spelling differs from reflection's `+` separator.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string nestedName = typeof(CfgSampleClass.NestedSample).FullName!.Replace('+', '.');
+
+        var nested = IrImporter.Import(source, nestedName, nameof(CfgSampleClass.NestedSample.Triple));
+        Assert.NotNull(nested);
+        Assert.Equal(DecompilationFidelity.Full, nested.Fidelity);
+
+        // The unrelated top-level type shares the leaf name; keying on the leaf
+        // alone would collide. Each resolves to its own method.
+        var topLevel = IrImporter.Import(source, typeof(NestedSample).FullName!, nameof(NestedSample.Negate));
+        Assert.NotNull(topLevel);
+        Assert.Equal("Triple", nested.Name);
+        Assert.Equal("Negate", topLevel.Name);
+
+        // The bare leaf name must not resolve the nested type.
+        Assert.Null(IrImporter.Import(source, "NestedSample", nameof(CfgSampleClass.NestedSample.Triple)));
+    }
+
     static bool ContainsGenericParameter(TypeRef type)
         => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
             || (type.ElementType is { } element && ContainsGenericParameter(element))

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -88,9 +89,7 @@ public static class IlProjection
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
-            string ns = reader.GetString(typeDef.Namespace);
-            string name = reader.GetString(typeDef.Name);
-            if ((ns.Length == 0 ? name : $"{ns}.{name}") != typeFullName)
+            if (reader.GetFullTypeName(typeDef) != typeFullName)
                 continue;
             int seen = 0;
             foreach (var methodHandle in typeDef.GetMethods())

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -44,9 +45,11 @@ public static class IrImporter
             foreach (var typeDefHandle in reader.TypeDefinitions)
             {
                 var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                string ns = reader.GetString(typeDef.Namespace);
-                string name = reader.GetString(typeDef.Name);
-                if ((ns.Length == 0 ? name : $"{ns}.{name}") != typeFullName)
+                // Nested-aware: a nested type has a nil namespace and a leaf
+                // Name, so the full name must thread its declaring types
+                // (Outer.Inner). The product passes such names; a raw ns+name
+                // would never match and the body would silently disappear.
+                if (reader.GetFullTypeName(typeDef) != typeFullName)
                     continue;
 
                 // Overload indices count name matches at the requested
@@ -87,9 +90,7 @@ public static class IrImporter
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
-            string ns = reader.GetString(typeDef.Namespace);
-            string name = reader.GetString(typeDef.Name);
-            string typeName = ns.Length == 0 ? name : $"{ns}.{name}";
+            string typeName = reader.GetFullTypeName(typeDef);
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -22,7 +23,7 @@ public static class MethodImporter
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
-            if (FullName(reader, typeDef) != typeFullName)
+            if (reader.GetFullTypeName(typeDef) != typeFullName)
                 continue;
 
             // Overload indices count every name match, body or not (parity
@@ -127,12 +128,5 @@ public static class MethodImporter
         foreach (var handle in handles)
             names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
         return names.MoveToImmutable();
-    }
-
-    static string FullName(MetadataReader reader, TypeDefinition typeDef)
-    {
-        string ns = reader.GetString(typeDef.Namespace);
-        string name = reader.GetString(typeDef.Name);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 }


### PR DESCRIPTION
## Summary

Fixes **finding 2 of #623**: the IR "next" pipeline reconstructed type full names as namespace + leaf `Name`, which is wrong for **nested types** (nil namespace, leaf-only `Name`). Three sites — `IrImporter.Import` (single-method lookup), `IrImporter.ImportAssembly` (the sweep), `IlProjection.Locate`, plus a private `MethodImporter.FullName` helper — built `Inner` instead of `Namespace.Outer.Inner`.

## Impact

The product and the rest of the metadata layer key on the nested-aware `reader.GetFullTypeName(typeDef)` (`TypeResolver.GetFullName` threads the declaring-type chain). So:

- **Single-method `Import`** of a nested type by its correct qualified name returned `null` → **decompiled source silently disappeared**.
- **`ImportAssembly`** yielded a bare leaf `TypeName` that both mislabeled the body and **collided** with every other nested type sharing that leaf (`Enumerator`, `Entry`, …).

This affects **13.6% of CoreLib — 5,559 of 41,012 method bodies** live in nested types.

## Fix

Use the same `reader.GetFullTypeName(typeDef)` the legacy path and `StackSimulator`/`MethodBodyContext`/`ILAstBuilder` already use; delete the redundant non-nested `MethodImporter.FullName` helper.

Verified end-to-end with the new `--dump`:

    $ ... --dump 'System.Collections.Generic.List`1.Enumerator::MoveNext'   # nested — now resolves

## Soundness

Non-nested types are unchanged (`GetFullTypeName` reduces to the same `ns+name`); only nested types change, from a wrong/unreachable name to the correct qualified one. The `AttributeTypeName` `(namespace, name)` tuple is intentionally left as-is — attributes are not nested types and it matches well-known attributes only.

## Tests / numbers

- New `NestedType_ImportsByFullyQualifiedName`: imports `CfgSampleClass.NestedSample::Triple` by its dotted nested name (unreachable before), proves an unrelated top-level `NestedSample` with the same leaf resolves independently, and asserts the bare leaf does **not** resolve the nested type.
- Compile-back: **docket 6 → 6 (no method-level regression)**, exact 181 → 183 (two trivial new fixtures match exactly).
- Decompiler 479 → 480; main 1142 (9 skip); metadata 194.
