### PR TITLE
Structure the comparison tree csc emits for a sparse switch

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -346,6 +346,28 @@ public class CfgSampleClass
         _ => 0,
     };
 
+    // Explicit gotos to a common exit — the forward-common-merge shape the
+    // structuring pass still leaves flat (only two comparisons, so not a
+    // comparison tree). `result` is assigned on every path before the read, so
+    // the CFG definite-assignment over the goto graph must declare it bare.
+    public static int GotoCommonExit(int x)
+    {
+        int result;
+        if (x > 0)
+        {
+            if (x > 100)
+            {
+                result = 2;
+                goto done;
+            }
+            result = 1;
+            goto done;
+        }
+        result = 0;
+    done:
+        return result;
+    }
+
     // A local assigned inside a lock body before the read after it. Modeling the
     // lock as its sequential body (rather than bailing) proves the bare decl.
     public static int LockedAssign(object gate, int x)

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -326,16 +326,32 @@ public class IrImporterTests
     [Fact]
     public void DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath()
     {
-        // ClassifyMode is a sparse switch csc lowers to a comparison tree the
-        // structuring pass cannot raise, so the body stays a flat goto graph.
-        // The old global bail flooded every local to `= default`; CFG
+        // GotoCommonExit's gotos to a shared exit are the forward-common-merge
+        // shape the structuring pass still leaves flat, so the body is a goto
+        // graph. The old global bail flooded every local to `= default`; CFG
         // definite-assignment proves `result` assigned on every path first.
-        var function = ImportFixture(nameof(CfgSampleClass.ClassifyMode));
+        var function = ImportFixture(nameof(CfgSampleClass.GotoCommonExit));
         IrPasses.Run(function);
         var output = CSharpPrinter.PrintRaised(function).Output!;
 
         Assert.Contains("goto ", output);   // guard: the body really did stay flat
         Assert.DoesNotContain("= default", output);
+    }
+
+    [Fact]
+    public void ComparisonTree_StructuresToNestedGuardsWithoutGotos()
+    {
+        // ClassifyMode is a sparse switch csc lowered to a comparison tree, each
+        // arm storing its result and jumping to one ldloc; ret tail. The
+        // return-merge fold turns the arms into straight returns and the guard
+        // inlining nests the comparisons — no surviving goto and no `= default`.
+        var function = ImportFixture(nameof(CfgSampleClass.ClassifyMode));
+        IrPasses.Run(function);
+        var output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.DoesNotContain("goto ", output);
+        Assert.DoesNotContain("= default", output);
+        Assert.Contains("if (", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ComparisonTrees.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ComparisonTrees.cs
@@ -1,0 +1,32 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Recognizes the block container csc emits for a sparse <c>switch</c>: a chain
+/// or tree of constant comparisons on one value, each arm storing its result and
+/// jumping to a shared tail. The return-merge and guard-leaf inlining that raise
+/// it as nested <c>if/else</c> are gated on this so they fire only for genuine
+/// multi-way selection — a two- or three-way ternary stays on the path the
+/// folding/boolean passes already raise cleanly, rather than being duplicated
+/// into guard clauses.
+/// </summary>
+static class ComparisonTrees
+{
+    /// <summary>
+    /// Four distinct constant tests is the floor: enough that the ternary and
+    /// boolean-folding passes will not collapse the selection, so the structuring
+    /// path is the one that produces readable C#. Below it the smaller selection
+    /// shapes (ternaries, short-circuit &amp;&amp;/||) are left untouched.
+    /// </summary>
+    const int MinComparisons = 4;
+
+    public static bool IsLikely(BlockContainer container)
+    {
+        int comparisons = 0;
+        foreach (var block in container.Blocks)
+            if (block.Children.Count > 0
+                && block.Children[^1] is ConditionalBranch { Condition: Comparison comparison }
+                && (comparison.Left is Constant || comparison.Right is Constant))
+                comparisons++;
+        return comparisons >= MinComparisons;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -62,6 +62,10 @@ public static class IrPasses
         // Raise IL jump tables into switch statements; the section bodies are
         // containers the structuring pass then raises.
         new SwitchRaisingPass(),
+        // Inline a shared multi-way return-merge into its arms, so the comparison
+        // tree csc emits for a sparse switch (each arm goto-ing one ldloc; ret
+        // tail) nests as guard clauses instead of staying flat goto soup.
+        new ReturnMergePass(),
         new StructuringPass(),
         // After structuring the finally guard is an IfStatement, so the
         // Monitor lock lowering is matchable as lock (obj) { ... }.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
@@ -1,0 +1,128 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Dissolves a shared return-merge: a short <c>return</c>-only block that two or
+/// more blocks reach by an unconditional <c>goto</c>. csc lowers a <c>switch</c>
+/// (and other multi-way selection) to a comparison tree whose every arm stores
+/// its result and jumps forward to one <c>ldloc; ret</c> tail — a join the
+/// structuring pass cannot nest, because the arms branch past their region to
+/// reach it. Inlining a copy of the tail into each such predecessor (the shape
+/// the prior emitter produced) turns those arms into straight returns, so the
+/// guard tree above them nests cleanly and the definite-assignment walk sees no
+/// surviving goto.
+///
+/// Conservative by construction:
+///   • only short tails (the terminator-inlining budget) are duplicated;
+///   • a merge needs two or more <em>unconditional</em> predecessors — a
+///     two-way <c>if/else</c> join (one goto + one fallthrough) is left to the
+///     structuring pass's diamond form, which already nests it without
+///     duplicating the tail;
+///   • a conditional <c>if (c) goto tail</c> predecessor is left in place for
+///     the structuring pass to raise as a guard.
+/// Runs before structuring.
+/// </summary>
+public sealed class ReturnMergePass : IIrPass
+{
+    public string Name => "return-merge";
+
+    /// <summary>A tail longer than this is not duplicated (keeps the inlining bounded).</summary>
+    const int MaxTailStatements = 3;
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+            Fold(container, context);
+    }
+
+    static void Fold(BlockContainer container, PassContext context)
+    {
+        // Only dissolve merges inside a genuine comparison tree; a two- or
+        // three-way selection's shared return reads better kept (the folding and
+        // boolean passes raise it as a ternary).
+        if (!ComparisonTrees.IsLikely(container))
+            return;
+
+        // Folding one merge can turn its own predecessor (a default arm that
+        // fell into it) into a fresh return tail, so iterate to a fixpoint.
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            var blocks = container.Blocks;
+            for (int m = 0; m < blocks.Count; m++)
+            {
+                var merge = blocks[m];
+                if (!IsShortReturnTail(merge))
+                    continue;
+
+                var branchPreds = new List<Block>();
+                bool hasConditionalOrSwitchPred = false;
+                foreach (var block in blocks)
+                {
+                    if (ReferenceEquals(block, merge) || block.Children.Count == 0)
+                        continue;
+                    switch (block.Children[^1])
+                    {
+                        case Branch b when b.TargetOffset == merge.StartOffset:
+                            branchPreds.Add(block);
+                            break;
+                        case ConditionalBranch c when c.TargetOffset == merge.StartOffset:
+                            hasConditionalOrSwitchPred = true;
+                            break;
+                        case SwitchBranch s when s.TargetOffsets.Contains(merge.StartOffset):
+                            hasConditionalOrSwitchPred = true;
+                            break;
+                    }
+                }
+
+                // A genuine multi-way join, not a two-way diamond.
+                if (branchPreds.Count < 2)
+                    continue;
+
+                var fallthroughPred = m > 0 && FallsThrough(blocks[m - 1]) ? blocks[m - 1] : null;
+                var tail = merge.Children.ToList();   // snapshot before any mutation
+
+                foreach (var pred in branchPreds)
+                {
+                    pred.Children[^1].Detach();   // drop the `goto merge`
+                    foreach (var statement in tail)
+                        pred.Add(statement.Clone());
+                }
+                if (fallthroughPred is not null)
+                    foreach (var statement in tail)
+                        fallthroughPred.Add(statement.Clone());
+
+                context.Stepper.StepOver(
+                    $"inline return-merge IL_{merge.StartOffset:X4} into {branchPreds.Count} arm(s)", merge);
+
+                // Every unconditional and the fallthrough edge now carries the
+                // tail; if no conditional guard still targets the merge, nothing
+                // reaches it (and the block before it now terminates), so drop it.
+                if (!hasConditionalOrSwitchPred)
+                    merge.Detach();
+
+                changed = true;
+                break;   // the block list changed — restart the scan
+            }
+        }
+    }
+
+    /// <summary>A short block whose only control flow is a trailing <see cref="Return"/>.</summary>
+    static bool IsShortReturnTail(Block block)
+    {
+        int count = block.Children.Count;
+        if (count == 0 || count > MaxTailStatements)
+            return false;
+        if (block.Children[^1] is not Return)
+            return false;
+        for (int s = 0; s < count - 1; s++)
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return false;
+        return true;
+    }
+
+    /// <summary>Whether control reaching the end of this block continues into its successor.</summary>
+    static bool FallsThrough(Block block) =>
+        block.Children.Count == 0
+        || block.Children[^1] is not (Return or Throw or Branch or Leave or EndFinally or EndFilter);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -37,6 +37,8 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, int> ConditionalTargetCounts { get; init; }
         public required HashSet<int> DroppableTerminators { get; init; }
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
+        public required HashSet<int> FallenInto { get; init; }
+        public required bool IsComparisonTree { get; init; }
     }
 
     public void Run(IrFunction function, PassContext context)
@@ -93,11 +95,22 @@ public sealed class StructuringPass : IIrPass
         // targets it and the preceding block does not fall into it) becomes
         // dead once its guards inline — drop it from the walk. Snapshot every
         // inlinable terminator's statements now, before BuildRegion mutates.
+        // Blocks the preceding block falls through into — control reaches them
+        // in program order, so they are not isolated guard leaves.
+        var fallenInto = new HashSet<int>();
+        for (int i = 1; i < blocks.Count; i++)
+            if (FallsThrough(blocks[i - 1]))
+                fallenInto.Add(blocks[i].StartOffset);
+
+        // A return guard-leaf is only inlined inside a genuine comparison tree;
+        // small selections keep their ternary/boolean shape.
+        bool isComparisonTree = ComparisonTrees.IsLikely(container);
+
         var droppable = new HashSet<int>();
         var snapshots = new Dictionary<int, IReadOnlyList<IrNode>>();
         for (int i = 0; i < blocks.Count; i++)
         {
-            if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts))
+            if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree))
                 continue;
             snapshots[i] = blocks[i].Children.ToList();
             if (i > 0 && !FallsThrough(blocks[i - 1]))
@@ -112,6 +125,8 @@ public sealed class StructuringPass : IIrPass
             ConditionalTargetCounts = conditionalTargetCounts,
             DroppableTerminators = droppable,
             TerminatorSnapshots = snapshots,
+            FallenInto = fallenInto,
+            IsComparisonTree = isComparisonTree,
         };
 
         if (!Validate(ctx, 0, blocks.Count, joinIndex: blocks.Count, breakTarget: null))
@@ -312,24 +327,42 @@ public sealed class StructuringPass : IIrPass
     }
 
     /// <summary>
-    /// A terminator block worth inlining into its guards: a short
-    /// <c>throw</c>-ending block (<see cref="IsTerminatorBlock"/>) that no
-    /// unconditional goto targets (so inlining erases no needed label) and that
-    /// two or more conditional branches reach — a genuine shared join strict
-    /// nesting cannot express. Restricted to <c>throw</c>: a flat
-    /// <c>if (c) throw;</c> guard clause is the idiomatic shape, whereas a
-    /// shared <c>return</c> join reads better as the standard nested form that
-    /// mirrors the source.
+    /// A terminator block worth inlining into the conditional guard(s) that
+    /// reach it: a short <c>throw</c>/<c>return</c>-ending block
+    /// (<see cref="IsTerminatorBlock"/>) that no unconditional goto targets (so
+    /// inlining erases no needed label). Two cases:
+    ///   • <c>throw</c> — only when two or more conditionals reach it: a genuine
+    ///     shared throw join strict nesting cannot express. A single
+    ///     <c>if (c) throw;</c> already raises cleanly as the standard guard.
+    ///   • <c>return</c> — even a single conditional, raising it as a guard
+    ///     clause (<c>if (c) { …; return x; }</c>). This is the comparison-tree
+    ///     case body the return-merge pass left ending in <c>return</c>: a leaf
+    ///     reached only by its one equality test, jumping past its region to the
+    ///     (now dissolved) tail. Inlining it is what lets the tree nest at all.
     /// </summary>
-    static bool IsSharedTerminator(Block block, HashSet<int> unconditionalTargets, Dictionary<int, int> conditionalTargetCounts) =>
-        IsTerminatorBlock(block)
-        && block.Children[^1] is Throw
-        && !unconditionalTargets.Contains(block.StartOffset)
-        && conditionalTargetCounts.GetValueOrDefault(block.StartOffset) >= 2;
+    static bool IsSharedTerminator(Block block, HashSet<int> unconditionalTargets, Dictionary<int, int> conditionalTargetCounts, HashSet<int> fallenInto, bool isComparisonTree)
+    {
+        if (!IsTerminatorBlock(block) || unconditionalTargets.Contains(block.StartOffset))
+            return false;
+        int conditionalPredecessors = conditionalTargetCounts.GetValueOrDefault(block.StartOffset);
+        return block.Children[^1] switch
+        {
+            Throw => conditionalPredecessors >= 2,
+            // A comparison-tree case body: a return leaf reached only by its
+            // equality test and never by fallthrough, in a container that is a
+            // genuine multi-way tree. Inlining it as a guard clause is what lets
+            // the tree nest. Gated to trees so a small selection's return is left
+            // to the ternary/boolean passes rather than duplicated into guards.
+            Return => isComparisonTree
+                && conditionalPredecessors >= 1
+                && !fallenInto.Contains(block.StartOffset),
+            _ => false,
+        };
+    }
 
     /// <summary>A terminator block that may be inlined into a guard at <paramref name="index"/>.</summary>
     static bool IsInlinableTerminator(Ctx ctx, int index) =>
-        IsSharedTerminator(ctx.Blocks[index], ctx.UnconditionalTargets, ctx.ConditionalTargetCounts);
+        IsSharedTerminator(ctx.Blocks[index], ctx.UnconditionalTargets, ctx.ConditionalTargetCounts, ctx.FallenInto, ctx.IsComparisonTree);
 
     /// <summary>Whether control reaching the end of this block continues into its successor (vs. returning, throwing, or branching away).</summary>
     static bool FallsThrough(Block block) =>


### PR DESCRIPTION
## What

A sparse `switch` (and other multi-way selection on non-contiguous values) lowers to a **tree of constant comparisons** whose every arm stores its result and jumps forward to one shared `ldloc; ret` tail. The structuring pass left the whole method flat — the arms branch *past their region* to reach the tail — so it rendered as goto soup plus a `= default` flood (the dominant half of the candidate-worse "cond-target-past-region" docket).

Two coupled changes raise it as nested `if/else`, the shape the baseline emitter produced:

1. **`ReturnMergePass`** (new, runs before structuring) — inlines a short shared return-merge into its unconditional/fallthrough predecessors, so the arms become straight `return`s and the tail dissolves. Iterates to a fixpoint (a folded default arm becomes a fresh tail).
2. **`StructuringPass`** — generalizes terminator-guard inlining from `throw`-only to also inline a **return guard-leaf**: a case body now ending in `return`, reached only by its one equality test and never by fallthrough. Inlining it as `if (c) { …; return x; }` is what lets the tree nest.

Both are gated by **`ComparisonTrees.IsLikely`** — a container needs ≥4 constant-comparison branches to qualify — so a two/three-way ternary or short-circuit `&&`/`||` keeps the shape the folding/boolean passes already raise cleanly (avoiding tail duplication). The return-leaf inlining additionally requires a single conditional predecessor and not-fallen-into, so a genuinely shared return stays shared.

## Result

`SafeFileHandle.MapUnixFileTypeToFileType` before: flat, ~20 `goto`s, every local `= default`. After:

```csharp
int V_1 = status.Mode & 61440;
if (V_1 <= 16384)
{
    if (V_1 == 4096) { return FileHandleType.Pipe; }
    if (V_1 == 8192) { return FileHandleType.CharacterDevice; }
    if (V_1 == 16384) { return FileHandleType.Directory; }
    return FileHandleType.Unknown;
}
if (V_1 <= 32768) { … }
…
```

No goto, no `= default`, and the result temp is gone (returns enum values directly — cleaner than the oracle).

On `System.Private.CoreLib` (preview.5): **candidate-worse 1331 → 1293** (agree +13, the rest move to cleaner-than-baseline). Conservative by design — the ≥4 threshold leaves the non-tree forward-conditional shapes (short-circuit chains, mixed conditions) in the bucket for follow-up; this PR banks the clean comparison-tree wins with zero regressions.

## Soundness

A mis-structure would produce invalid C# (or wrong IL). Verified by:
- **compile-check A/B over 3,729 methods**: the defect set is **byte-for-byte identical** to main — zero validity regressions.
- **compile-back gates** (`CompileBackGateTests` + `LoweredCompileBackGateTests`): green — the recovered fixtures recompile correctly; the comparison-tree gate keeps every ternary/boolean fixture (`Pick`, `Ternary`, `IfAnd`, `Classify`, …) on its existing clean path.

## Tests

`ILInspector.Decompiler.Tests`: **491** green. New: `ComparisonTree_StructuresToNestedGuardsWithoutGotos` (the recovery) and `GotoCommonExit` fixture (repoints the CFG-DA test at a shape still left flat, since `ClassifyMode` now structures). `dotnet-inspect.Tests`: 1142 green (no member-output drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)