### PR TITLE
Move product annotated-IL onto the new decompiler stack

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
@@ -61,4 +61,55 @@ public class IlProjectionTests
         Assert.Contains("// .try", output);
         Assert.Contains("// catch", output);
     }
+
+    [Fact]
+    public void Annotated_EmitsMethodHeader()
+    {
+        // DoWhileSum(int n) with a single int local: the header reports the
+        // parameter, the local, the max stack, and the IL size.
+        var output = Project(nameof(CfgSampleClass.DoWhileSum), IlProjectionDepth.Annotated);
+        Assert.Contains("// Method IL", output);
+        Assert.Contains("//   Parameters: int n", output);
+        Assert.Contains("//   Locals: int ", output);
+        Assert.Contains("//   MaxStack:", output);
+        Assert.Contains("//   IL size:", output);
+    }
+
+    [Fact]
+    public void Annotated_LabelsBlocksWithRanges()
+    {
+        // A loop splits into multiple basic blocks, each labeled with its range.
+        var output = Project(nameof(CfgSampleClass.DoWhileSum), IlProjectionDepth.Annotated);
+        Assert.Matches(@"Block_0: \(IL_[0-9A-F]{4}-IL_[0-9A-F]{4}\)", output);
+        Assert.Contains("Block_1:", output);
+    }
+
+    [Fact]
+    public void Annotated_AnnotatesArgumentAndLocalNames()
+    {
+        var output = Project(nameof(CfgSampleClass.DoWhileSum), IlProjectionDepth.Annotated);
+        Assert.Contains("// arg: n", output);
+        Assert.Contains("// local: s", output);
+    }
+
+    [Fact]
+    public void Annotated_RendersExceptionRegionsAsBracesWithCatchType()
+    {
+        // try { int.Parse(s) } catch (FormatException) { ... } renders as braces
+        // with the catch type, not bare comment markers.
+        var output = Project(nameof(CfgSampleClass.CatchLogs), IlProjectionDepth.Annotated);
+        Assert.Contains(".try {", output);
+        Assert.Contains("catch (FormatException) {", output);
+        Assert.Contains("} // end .try", output);
+    }
+
+    [Fact]
+    public void Annotated_AnnotatesPerInstructionStackTypes()
+    {
+        // ldarg.0 (string s) then call get_Length leaves [int] on the stack.
+        // (The stack annotation follows any variable-name annotation on the line.)
+        var output = Project(nameof(CfgSampleClass.LengthOf), IlProjectionDepth.Annotated);
+        Assert.Contains("[string]", output);
+        Assert.Contains("[int]", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
@@ -104,6 +104,52 @@ public class IlProjectionTests
     }
 
     [Fact]
+    public void Annotated_RendersFilterExpressionAndHandlerAsSeparateBlocks()
+    {
+        // A `catch (Exception e) when (...)` filter: the filter expression and
+        // the handler body are distinct blocks. The filter block opens at the
+        // filter offset, not collapsed onto the handler offset.
+        var output = Project(nameof(CfgSampleClass.FilteredLength), IlProjectionDepth.Annotated);
+        Assert.Contains("filter {", output);
+        Assert.Contains("} // end filter", output);
+        Assert.Contains("handler {", output);
+        // The filter expression (endfilter) sits inside the filter block, above
+        // the handler block — not inside the handler.
+        int filterOpen = output.IndexOf("filter {", StringComparison.Ordinal);
+        int endfilterOp = output.IndexOf("endfilter", StringComparison.Ordinal);
+        int filterClose = output.IndexOf("} // end filter", StringComparison.Ordinal);
+        Assert.True(filterOpen < endfilterOp && endfilterOp < filterClose,
+            "endfilter must render between `filter {` and `} // end filter`");
+    }
+
+    [Fact]
+    public void Annotated_NestsExceptionRegionsWithBalancedBraces()
+    {
+        // try { try {...} catch {...} } finally {...}: the inner and outer try
+        // both start at IL_0000, so both `.try {` must open and every block must
+        // close. Brace markers stay balanced.
+        var output = Project(nameof(CfgSampleClass.NestedExceptionHandlers), IlProjectionDepth.Annotated);
+        Assert.Equal(2, Regex.Matches(output, @"^\s*\.try \{$", RegexOptions.Multiline).Count);
+        Assert.Contains("finally {", output);
+
+        int opens = Regex.Matches(output, @"\{\s*$", RegexOptions.Multiline).Count;
+        int closes = Regex.Matches(output, @"^\s*\}", RegexOptions.Multiline).Count;
+        Assert.Equal(opens, closes);
+    }
+
+    [Fact]
+    public void Annotated_SiblingCatchesShareOneTryBlock()
+    {
+        // try {...} catch (A) {...} catch (B) {...}: two handlers protect one
+        // block, so a single `.try {` / `} // end .try` pair brackets both.
+        var output = Project(nameof(CfgSampleClass.TwoCatches), IlProjectionDepth.Annotated);
+        Assert.Single(Regex.Matches(output, @"^\s*\.try \{$", RegexOptions.Multiline));
+        Assert.Single(Regex.Matches(output, @"^\s*\} // end \.try$", RegexOptions.Multiline));
+        Assert.Contains("catch (FormatException) {", output);
+        Assert.Contains("catch (OverflowException) {", output);
+    }
+
+    [Fact]
     public void Annotated_AnnotatesPerInstructionStackTypes()
     {
         // ldarg.0 (string s) then call get_Length leaves [int] on the stack.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -18,21 +18,29 @@ public enum IlProjectionDepth
 
     /// <summary>Block-structured output with labels, indentation, and exception-region markers.</summary>
     Structured,
+
+    /// <summary>
+    /// Rich annotated view: a method header (parameters, locals, max stack, IL
+    /// size), named blocks with ranges, exception regions rendered as braces
+    /// with catch types, and per-instruction variable names and stack types.
+    /// This is the user-facing annotated-IL view.
+    /// </summary>
+    Annotated,
 }
 
 /// <summary>
-/// Renders ground-truth IL views from the replacement pipeline's materialized
-/// method data (off a <see cref="MetadataSource"/>) — the new-pipeline backing
-/// for the annotated-IL view, replacing the old
-/// <c>MethodBodyContext</c> → <c>MethodAnalysis</c> → <c>AnnotatedILEmitter</c>
-/// contract. Operands are resolved through the importer's own token resolvers,
-/// and block structure reuses the importer's <c>FindLeaders</c>, so the views
-/// share one analysis with the IR import rather than a parallel one.
+/// Renders ground-truth IL views from the pipeline's materialized method data
+/// (off a <see cref="MetadataSource"/>): the backing for the annotated-IL view.
+/// Operands are resolved through the importer's own token resolvers, and block
+/// structure reuses the importer's <c>FindLeaders</c>, so the views share one
+/// analysis with the IR import rather than a parallel one.
 ///
 /// The <see cref="IlProjectionDepth.Typed"/> depth annotates each instruction
 /// with the evaluation-stack types after it, sourced from the importer's own
 /// stack simulation via an optional per-instruction trace — one analysis shared
-/// with the IR import, not a second simulator.
+/// with the IR import, not a second simulator. The
+/// <see cref="IlProjectionDepth.Annotated"/> depth builds on that with a method
+/// header, named blocks, exception-region braces, and variable names.
 ///
 /// Exception-safe by construction: any malformed-metadata read or resolver
 /// failure surfaces as a diagnosed <see cref="DecompilerResult"/>, never a throw.
@@ -56,6 +64,7 @@ public static class IlProjection
         {
             IlProjectionDepth.Structured => RenderStructured(instructions, imported.Body),
             IlProjectionDepth.Typed => RenderTyped(source, imported, scope, instructions),
+            IlProjectionDepth.Annotated => RenderAnnotated(source, imported, scope, instructions),
             _ => RenderRaw(instructions),
         };
     }
@@ -109,7 +118,7 @@ public static class IlProjection
         throw new InvalidOperationException($"{typeFullName}::{methodName} not found");
     }
 
-    readonly record struct Instr(int Offset, string Name, string Operand);
+    readonly record struct Instr(int Offset, ILOpCode Op, string Name, string Operand);
 
     static List<Instr> Decode(MetadataReader reader, GenericScope scope, ReadOnlySpan<byte> il)
     {
@@ -121,7 +130,7 @@ public static class IlProjection
             int b = il[pos++];
             var op = b == 0xFE ? (ILOpCode)(0xFE00 | il[pos++]) : (ILOpCode)b;
             string name = op.ToString().ToLowerInvariant().Replace('_', '.');
-            result.Add(new Instr(offset, name, ReadOperand(reader, scope, il, op, ref pos)));
+            result.Add(new Instr(offset, op, name, ReadOperand(reader, scope, il, op, ref pos)));
         }
         return result;
     }
@@ -280,4 +289,180 @@ public static class IlProjection
     }
 
     static string Format(Instr i) => $"IL_{i.Offset:X4}: {i.Name}{(i.Operand.Length > 0 ? " " + i.Operand : "")}";
+
+    // --- Annotated view (header + named blocks + exception braces + variable
+    // names + per-instruction stack types) ---
+
+    static string RenderAnnotated(MetadataSource source, ImportedMethod imported, GenericScope scope, List<Instr> instructions)
+    {
+        var body = imported.Body;
+        var stackByOffset = StackTypesByOffset(source, imported, scope);
+
+        // Block leaders → ordinal index, plus the byte range of each block (to
+        // the next leader, or to end of IL) for the `Block_N: (range)` label.
+        var leaders = IrImporter.FindLeaders([.. body.IL], body.Handlers).ToList();
+        var blockIndex = new Dictionary<int, int>();
+        var blockEnd = new Dictionary<int, int>();
+        for (int b = 0; b < leaders.Count; b++)
+        {
+            blockIndex[leaders[b]] = b;
+            int next = b + 1 < leaders.Count ? leaders[b + 1] : body.IL.Length;
+            blockEnd[leaders[b]] = next - 1;
+        }
+
+        BuildRegionMarkers(body.Handlers, out var regionStarts, out var regionEnds);
+
+        var sb = new StringBuilder();
+        AnnotatedHeader(sb, imported);
+
+        int indent = 1;
+        foreach (var i in instructions)
+        {
+            if (regionEnds.TryGetValue(i.Offset, out var endMarker))
+            {
+                indent--;
+                WriteIndent(sb, indent);
+                sb.AppendLine(endMarker);
+            }
+            if (regionStarts.TryGetValue(i.Offset, out var startMarker))
+            {
+                WriteIndent(sb, indent);
+                sb.AppendLine(startMarker);
+                indent++;
+            }
+            if (blockIndex.TryGetValue(i.Offset, out int index))
+            {
+                if (i.Offset > 0) sb.AppendLine();
+                WriteIndent(sb, indent);
+                sb.AppendLine($"Block_{index}: (IL_{i.Offset:X4}-IL_{blockEnd[i.Offset]:X4})");
+            }
+
+            WriteIndent(sb, indent + 1);
+            sb.Append($"IL_{i.Offset:X4}: {i.Name,-12}");
+            if (i.Operand.Length > 0)
+                sb.Append(' ').Append(i.Operand);
+
+            List<string> annotations = [];
+            if (VariableAnnotation(imported, i) is { } variable)
+                annotations.Add(variable);
+            if (stackByOffset.TryGetValue(i.Offset, out var stack))
+                annotations.Add($"[{string.Join(", ", stack.Select(t => t?.ToDisplayString() ?? "?"))}]");
+            if (annotations.Count > 0)
+                sb.Append("  // ").Append(string.Join("; ", annotations));
+
+            sb.AppendLine();
+        }
+
+        while (indent > 1)
+        {
+            indent--;
+            WriteIndent(sb, indent);
+            sb.AppendLine("}");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Per-instruction post-opcode evaluation-stack types, from the importer's own simulation via the trace hook.</summary>
+    static Dictionary<int, ImmutableArray<TypeRef?>> StackTypesByOffset(MetadataSource source, ImportedMethod imported, GenericScope scope)
+    {
+        var trace = new List<IlTracePoint>();
+        IrImporter.Build(source, imported, scope, trace);
+        var byOffset = new Dictionary<int, ImmutableArray<TypeRef?>>();
+        foreach (var point in trace)
+            byOffset[point.Offset] = point.StackTypes;
+        return byOffset;
+    }
+
+    static void AnnotatedHeader(StringBuilder sb, ImportedMethod imported)
+    {
+        var body = imported.Body;
+        sb.AppendLine("// Method IL");
+        if (imported.Signature.Parameters.Length > 0)
+            sb.AppendLine($"//   Parameters: {string.Join(", ", imported.Signature.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))}");
+        if (body.Locals.Length > 0)
+            sb.AppendLine($"//   Locals: {string.Join(", ", body.Locals.Select((t, i) => $"{t.ToDisplayString()} {LocalName(body, i)}"))}");
+        sb.AppendLine($"//   MaxStack: {body.MaxStack}");
+        sb.AppendLine($"//   IL size: {body.IL.Length} bytes");
+        sb.AppendLine();
+    }
+
+    static string LocalName(MethodBody body, int index) =>
+        index < body.LocalNames.Length && !string.IsNullOrWhiteSpace(body.LocalNames[index])
+            ? body.LocalNames[index]!
+            : $"V_{index}";
+
+    /// <summary>Builds `.try {`/`catch (Type) {`/`finally {` start markers and their matching `}` end markers, keyed by IL offset.</summary>
+    static void BuildRegionMarkers(ImmutableArray<HandlerRegion> handlers, out Dictionary<int, string> starts, out Dictionary<int, string> ends)
+    {
+        starts = [];
+        ends = [];
+        foreach (var region in handlers)
+        {
+            if (!starts.ContainsKey(region.TryOffset))
+                starts[region.TryOffset] = ".try {";
+
+            string handlerLabel = region.Kind switch
+            {
+                HandlerKind.Catch => $"catch ({region.CatchType?.ToDisplayString() ?? "?"}) {{",
+                HandlerKind.Filter => "filter {",
+                HandlerKind.Finally => "finally {",
+                HandlerKind.Fault => "fault {",
+                _ => $"{region.Kind} {{",
+            };
+
+            int tryEnd = region.TryOffset + region.TryLength;
+            if (!ends.ContainsKey(tryEnd))
+                ends[tryEnd] = "} // end .try";
+
+            starts[region.HandlerOffset] = handlerLabel;
+            ends[region.HandlerOffset + region.HandlerLength] = $"}} // end {region.Kind.ToString().ToLowerInvariant()}";
+        }
+    }
+
+    /// <summary>Resolves a load/store of an argument or local to a `arg: name`/`local: name` annotation, or null when the instruction is neither or the name is unavailable.</summary>
+    static string? VariableAnnotation(ImportedMethod imported, Instr i)
+    {
+        switch (i.Op)
+        {
+            case ILOpCode.Ldarg_0: return ArgName(imported.Signature, 0);
+            case ILOpCode.Ldarg_1: return ArgName(imported.Signature, 1);
+            case ILOpCode.Ldarg_2: return ArgName(imported.Signature, 2);
+            case ILOpCode.Ldarg_3: return ArgName(imported.Signature, 3);
+            case ILOpCode.Ldloc_0: case ILOpCode.Stloc_0: return LocalRef(imported.Body, 0);
+            case ILOpCode.Ldloc_1: case ILOpCode.Stloc_1: return LocalRef(imported.Body, 1);
+            case ILOpCode.Ldloc_2: case ILOpCode.Stloc_2: return LocalRef(imported.Body, 2);
+            case ILOpCode.Ldloc_3: case ILOpCode.Stloc_3: return LocalRef(imported.Body, 3);
+            case ILOpCode.Ldarg: case ILOpCode.Ldarg_s: case ILOpCode.Ldarga: case ILOpCode.Ldarga_s:
+            case ILOpCode.Starg: case ILOpCode.Starg_s:
+                return int.TryParse(i.Operand, out int a) ? ArgName(imported.Signature, a) : null;
+            case ILOpCode.Ldloc: case ILOpCode.Ldloc_s: case ILOpCode.Ldloca: case ILOpCode.Ldloca_s:
+            case ILOpCode.Stloc: case ILOpCode.Stloc_s:
+                return int.TryParse(i.Operand, out int l) ? LocalRef(imported.Body, l) : null;
+            default: return null;
+        }
+    }
+
+    static string? ArgName(MethodSignature signature, int index)
+    {
+        if (signature.HasThis)
+        {
+            if (index == 0)
+                return "arg: this";
+            index--;
+        }
+        return index >= 0 && index < signature.Parameters.Length
+            ? $"arg: {signature.Parameters[index].Name}"
+            : null;
+    }
+
+    static string? LocalRef(MethodBody body, int index) =>
+        index < body.LocalNames.Length && !string.IsNullOrWhiteSpace(body.LocalNames[index])
+            ? $"local: {body.LocalNames[index]}"
+            : null;
+
+    static void WriteIndent(StringBuilder sb, int indent)
+    {
+        for (int i = 0; i < indent; i++)
+            sb.Append("    ");
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -318,18 +318,22 @@ public static class IlProjection
         int indent = 1;
         foreach (var i in instructions)
         {
-            if (regionEnds.TryGetValue(i.Offset, out var endMarker))
-            {
-                indent--;
-                WriteIndent(sb, indent);
-                sb.AppendLine(endMarker);
-            }
-            if (regionStarts.TryGetValue(i.Offset, out var startMarker))
-            {
-                WriteIndent(sb, indent);
-                sb.AppendLine(startMarker);
-                indent++;
-            }
+            // Ends close innermost-first, then starts open outermost-first, so
+            // brace/indent stays balanced when regions nest or share an offset.
+            if (regionEnds.TryGetValue(i.Offset, out var endMarkers))
+                foreach (var endMarker in endMarkers)
+                {
+                    if (indent > 1) indent--;
+                    WriteIndent(sb, indent);
+                    sb.AppendLine(endMarker);
+                }
+            if (regionStarts.TryGetValue(i.Offset, out var startMarkers))
+                foreach (var startMarker in startMarkers)
+                {
+                    WriteIndent(sb, indent);
+                    sb.AppendLine(startMarker);
+                    indent++;
+                }
             if (blockIndex.TryGetValue(i.Offset, out int index))
             {
                 if (i.Offset > 0) sb.AppendLine();
@@ -391,32 +395,66 @@ public static class IlProjection
             ? body.LocalNames[index]!
             : $"V_{index}";
 
-    /// <summary>Builds `.try {`/`catch (Type) {`/`finally {` start markers and their matching `}` end markers, keyed by IL offset.</summary>
-    static void BuildRegionMarkers(ImmutableArray<HandlerRegion> handlers, out Dictionary<int, string> starts, out Dictionary<int, string> ends)
+    /// <summary>
+    /// Builds the brace markers for every exception region, keyed by IL offset.
+    /// Each offset can carry several markers (nested or adjacent regions sharing
+    /// a boundary), pre-ordered so that a single forward pass stays balanced:
+    /// end markers run innermost-first (smallest enclosing extent first) and
+    /// start markers outermost-first. Filter clauses render as a `filter` block
+    /// (the filter expression, <c>[FilterOffset, HandlerOffset)</c>) followed by
+    /// a `handler` block (the handler body), rather than collapsing both onto the
+    /// handler offset.
+    /// </summary>
+    static void BuildRegionMarkers(ImmutableArray<HandlerRegion> handlers, out Dictionary<int, List<string>> starts, out Dictionary<int, List<string>> ends)
     {
-        starts = [];
-        ends = [];
+        // Each marker carries the enclosing region's extent (try start → handler
+        // end) as the nesting key; larger extent = more enclosing.
+        var startMarkers = new List<(int Offset, int Extent, string Text)>();
+        var endMarkers = new List<(int Offset, int Extent, string Text)>();
+        var protectedBlocks = new HashSet<(int Offset, int Length)>();
+
         foreach (var region in handlers)
         {
-            if (!starts.ContainsKey(region.TryOffset))
-                starts[region.TryOffset] = ".try {";
-
-            string handlerLabel = region.Kind switch
-            {
-                HandlerKind.Catch => $"catch ({region.CatchType?.ToDisplayString() ?? "?"}) {{",
-                HandlerKind.Filter => "filter {",
-                HandlerKind.Finally => "finally {",
-                HandlerKind.Fault => "fault {",
-                _ => $"{region.Kind} {{",
-            };
-
             int tryEnd = region.TryOffset + region.TryLength;
-            if (!ends.ContainsKey(tryEnd))
-                ends[tryEnd] = "} // end .try";
+            int handlerEnd = region.HandlerOffset + region.HandlerLength;
+            int extent = handlerEnd - region.TryOffset;
 
-            starts[region.HandlerOffset] = handlerLabel;
-            ends[region.HandlerOffset + region.HandlerLength] = $"}} // end {region.Kind.ToString().ToLowerInvariant()}";
+            // Sibling handlers (e.g. multiple catches) protect an identical
+            // block, so its `.try` open/close emits once; a nested try sharing
+            // only the start offset has a different length and stays distinct.
+            if (protectedBlocks.Add((region.TryOffset, region.TryLength)))
+            {
+                startMarkers.Add((region.TryOffset, extent, ".try {"));
+                endMarkers.Add((tryEnd, extent, "} // end .try"));
+            }
+
+            if (region.Kind == HandlerKind.Filter)
+            {
+                startMarkers.Add((region.FilterOffset, extent, "filter {"));
+                endMarkers.Add((region.HandlerOffset, extent, "} // end filter"));
+                startMarkers.Add((region.HandlerOffset, extent, "handler {"));
+                endMarkers.Add((handlerEnd, extent, "} // end handler"));
+            }
+            else
+            {
+                string label = region.Kind switch
+                {
+                    HandlerKind.Catch => $"catch ({region.CatchType?.ToDisplayString() ?? "?"}) {{",
+                    HandlerKind.Finally => "finally {",
+                    HandlerKind.Fault => "fault {",
+                    _ => $"{region.Kind} {{",
+                };
+                startMarkers.Add((region.HandlerOffset, extent, label));
+                endMarkers.Add((handlerEnd, extent, $"}} // end {region.Kind.ToString().ToLowerInvariant()}"));
+            }
         }
+
+        starts = startMarkers
+            .GroupBy(m => m.Offset)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(m => m.Extent).Select(m => m.Text).ToList());
+        ends = endMarkers
+            .GroupBy(m => m.Offset)
+            .ToDictionary(g => g.Key, g => g.OrderBy(m => m.Extent).Select(m => m.Text).ToList());
     }
 
     /// <summary>Resolves a load/store of an argument or local to a `arg: name`/`local: name` annotation, or null when the instruction is neither or the name is unavailable.</summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1640,6 +1640,31 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectedOverload_SelectAnnotatedIL_RendersRichAnnotatedView()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToElement" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "IL (Annotated)" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## IL (Annotated)", output);
+        // The annotated view leads with a method header and renders named blocks
+        // with byte ranges — the rich view, not a bare instruction list.
+        Assert.Contains("// Method IL", output);
+        Assert.Contains("//   MaxStack:", output);
+        Assert.Contains("//   IL size:", output);
+        Assert.Matches(@"Block_0: \(IL_[0-9A-Fa-f]{4}-IL_[0-9A-Fa-f]{4}\)", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_NormalShowsLocalImplementationSections()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -53,10 +53,9 @@ internal static class MemberCodeProvider
 
         var reader = peReader.GetMetadataReader();
 
-        // Decompiled source is produced by the replacement pipeline; the old
-        // emitter is retired from the product path (demoted to the harness's
-        // differential oracle). The source owns its own readers for the call.
-        // A malformed-metadata failure opening it degrades decompiled source to
+        // All decompiler-backed sections (decompiled source, annotated IL, IR
+        // stages) read through one MetadataSource that owns its own readers.
+        // A malformed-metadata failure opening it degrades those sections to
         // empty — the IL/attribute sections still render — instead of throwing.
         using var pipelineSource = OpenPipelineSource(request, dllPath, pdbPath);
 
@@ -86,34 +85,17 @@ internal static class MemberCodeProvider
                     attributes = found.Select(a => (a.Name, a.Value)).ToList();
             }
 
-            // Annotated IL still uses the method-body context (it is immutable),
-            // so the PDB is opened and the method body decoded once for it.
-            Decompiler.MethodBodyContext? context = null;
-            Decompiler.DecompilerResult? contextFailure = null;
-            if (request.AnnotatedIL)
-            {
-                try
-                {
-                    context = Decompiler.MethodBodyContext.Create(
-                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly, externalPdbPath: pdbPath);
-                }
-                catch (Exception ex)
-                {
-                    contextFailure = Decompiler.DecompilerResult.Failure(
-                        Decompiler.DiagnosticIds.ContextUnavailable,
-                        $"method body context unavailable: {ex.GetType().Name}: {ex.Message}");
-                }
-            }
+            // Method generic parameter names, read straight from metadata, feed
+            // the decompiled-source declaration formatter. Sourced here (not from
+            // a decompiler pass) so it is available whenever a method body is
+            // shown, independent of which sections were requested.
+            var methodGenericParameters = MethodGenericParameterNames(
+                reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
 
-            // Annotated IL keeps the old pipeline's analysis for now (a lower
-            // -level diagnostic view, not the decompiled source users read).
-            var analysis = context != null ? Decompiler.MethodAnalysis.Create(context) : null;
-
-            // Decompiled source through the replacement pipeline: import the
-            // method to typed IR, run the raising passes, and print. A null
-            // function means the member has no IL body (abstract/extern) —
-            // nothing to show, not an error. PrintRaised never throws; an
-            // import or pass failure surfaces as an honest diagnostic.
+            // Decompiled source: import the method to typed IR, run the raising
+            // passes, and print. A null function means the member has no IL body
+            // (abstract/extern) — nothing to show, not an error. PrintRaised
+            // never throws; an import or pass failure surfaces as a diagnostic.
             string? loweredBody = null, loweredDiagnostic = null;
             if (request.DecompiledSource && pipelineSource is not null)
             {
@@ -151,19 +133,24 @@ internal static class MemberCodeProvider
             }
 
             string? annotatedText = null, annotatedDiagnostic = null;
-            if (request.AnnotatedIL && (analysis != null || contextFailure != null))
+            if (request.AnnotatedIL)
             {
-                var result = contextFailure ?? Decompiler.AnnotatedILEmitter.Decompile(
-                    analysis!, Decompiler.ILAnnotationDepth.Structured);
+                var result = pipelineSource is null
+                    ? Decompiler.DecompilerResult.Failure(
+                        Decompiler.DiagnosticIds.ContextUnavailable,
+                        "method body source unavailable")
+                    : Decompiler.Pipeline.IlProjection.Project(
+                        pipelineSource, lookupType, method.Name,
+                        Decompiler.Pipeline.IlProjectionDepth.Annotated, lookupOverloadIndex, publicOnly);
                 if (result.Output is { } annotated)
                     annotatedText = annotated.TrimEnd();
                 else
                     annotatedDiagnostic = DiagnosticComment(result);
             }
 
-            // Per-pass IR pipeline dump (JitDump-style). Shares the replacement
-            // pipeline's MetadataSource with decompiled source, so it is opened
-            // when either section is requested.
+            // Per-pass IR pipeline dump (JitDump-style). Shares the decompiler's
+            // MetadataSource with decompiled source, so it is opened when either
+            // section is requested.
             string? stagesText = null, stagesDiagnostic = null;
             if (request.Stages && pipelineSource is not null)
             {
@@ -179,7 +166,7 @@ internal static class MemberCodeProvider
             results.Add((method, new Item(
                 loweredBody,
                 loweredDiagnostic,
-                context?.GenericContext?.MethodParameters,
+                methodGenericParameters,
                 ilText,
                 ilDiagnostic,
                 annotatedText,
@@ -197,16 +184,48 @@ internal static class MemberCodeProvider
         => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
 
     /// <summary>
-    /// Opens the replacement pipeline's reader for decompiled source, or null
-    /// when not requested or when the assembly cannot be opened (malformed
-    /// metadata that nonetheless passed the first PE read). Failing to a null
-    /// source keeps the no-crash invariant: decompiled source degrades to empty
-    /// while the IL and attribute sections, which use the already-open reader,
-    /// still render.
+    /// Resolves the selected method overload's generic parameter names directly
+    /// from metadata (e.g. <c>["T", "TResult"]</c>), or null when the method is
+    /// non-generic or not found. Mirrors the overload-selection walk the IL and
+    /// annotated-IL sections use, so the same method is named.
+    /// </summary>
+    static IReadOnlyList<string>? MethodGenericParameterNames(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        int matchCount = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+            if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
+                continue;
+            if (matchCount != overloadIndex)
+            {
+                matchCount++;
+                continue;
+            }
+            var handles = method.GetGenericParameters();
+            if (handles.Count == 0)
+                return null;
+            return handles.Select(reader.GetGenericParameterName).ToList();
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Opens the decompiler's reader for the code sections that need it
+    /// (decompiled source, annotated IL, IR stages), or null when none are
+    /// requested or when the assembly cannot be opened (malformed metadata
+    /// that nonetheless passed the first PE read). Failing to a null source
+    /// keeps the no-crash invariant: those sections degrade to empty while the
+    /// IL and attribute sections, which use the already-open reader, still
+    /// render.
     /// </summary>
     static Decompiler.Pipeline.MetadataSource? OpenPipelineSource(Request request, string dllPath, string? pdbPath)
     {
-        if (!request.DecompiledSource && !request.Stages)
+        if (!request.DecompiledSource && !request.Stages && !request.AnnotatedIL)
             return null;
         try
         {


### PR DESCRIPTION
## What

The annotated-IL section was the last product consumer of the old decompiler stack (`MethodBodyContext` → `MethodAnalysis` → `AnnotatedILEmitter`). This moves it to the new pipeline, so the **product runs entirely on one stack**. The old stack stays in the harness as a differential oracle.

## Changes

- **New `IlProjectionDepth.Annotated`** — a rich IL view sourced from the importer's materialized method data and its own stack-simulation trace:
  - Method header: parameters, locals, max stack, IL size
  - Named blocks with byte ranges (`Block_0: (IL_0000-IL_000F)`)
  - Exception regions as `.try { … } catch (Type) { … } finally { … }` braces with catch types
  - Per-instruction variable names (`// arg: x`, `// local: s`) and evaluation-stack types
  - The existing `Structured` depth (pinned by `IlProjectionTests` and harness stage dumps) is left untouched.
- **`MemberCodeProvider`** now points the annotated-IL section at the new depth and drops its `MethodBodyContext`/`MethodAnalysis` plumbing.
- **Generic-parameter fix** — method generic-parameter names are now read straight from metadata, fixing a latent coupling where they only populated when annotated IL was *also* requested (so decompiled-source declarations could silently lose them).
- **Tests** — `IlProjection` annotated-view tests plus a product annotated-IL regression test.

## Note

Type operands render with the new stack's short display names (e.g. `int::Parse`, `JsonTypeInfo<TValue>`) — a deliberate change from the old emitter's fully-qualified names, for consistency with the rest of the new pipeline's output.

## Verification

- `ILInspector.Decompiler.Tests`: 495 passed
- `dotnet-inspect.Tests`: 1143 passed (9 skipped)
- Product is free of old-stack references (`AnnotatedILEmitter`/`MethodBodyContext`/`MethodAnalysis`/`CSharpEmitter`); confirmed end-to-end on `JsonSerializer.SerializeToElement`.
