### PR TITLE
Bump System.CommandLine 2.0.5 -> 3.0.0-preview.5 (drop-in)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />
     <PackageVersion Include="SourceLinkFetch" Version="0.1.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
+    <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Updates `System.CommandLine` from `2.0.5` to `3.0.0-preview.5.26302.115`.

## Why it's safe
The 2.x -> 3.x major bump is **additive-only** at the public API surface — zero breaking changes. New opt-in members in 3.0:

- `Argument<T>.CaptureRemainingTokens`
- `Option<T>` / `Argument<T>` `.AcceptOnlyFromAmong(StringComparer, params string[])` (case-insensitive overload)
- `RootCommand.HelpName`

## Validation
- Build: **0 warnings, 0 errors**.
- `dotnet-inspect.Tests`: **1142 passed, 0 failed** (9 skipped — unrelated ildasm tooling).
- No code changes required; one-line version bump in `Directory.Packages.props`.

## Note
3.0 has no stable GA yet; this pins the latest 3.x preview. One consumer-visible packaging shift: 3.0 drops the in-box `net8.0` lib (ships `net10.0` + `netstandard2.0`), so net8/net9 apps would bind the `netstandard2.0` assembly. dotnet-inspect targets net11.0, so it gets the `net10.0` assembly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
