### PR TITLE
Raise the csc pinned-ref lowering into a C# `fixed` statement (#622 item F)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -48,7 +48,9 @@ public class CompileBackGateTests
     /// prefix, and the return-accumulator elimination must
     /// keep sinking the result temp out of an EH region or lock (TryFinallyAdd,
     /// TryFinallyTwoReturns, CatchEverything, ClassicLock,
-    /// ManualDisposeAsyncInFinally).
+    /// ManualDisposeAsyncInFinally), and SumPinnedArray must keep raising the
+    /// csc pin lowering into a `fixed` statement whose derived pointer recompiles
+    /// opcode-exact (#622 item F).
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -64,6 +66,7 @@ public class CompileBackGateTests
         "CatchEverything",
         "ClassicLock",
         "ManualDisposeAsyncInFinally",
+        "SumPinnedArray",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1149,6 +1149,23 @@ public class CfgSampleClass
         return *(&value);
     }
 
+    // A loop deref keeps the pin alive through csc optimization (a single deref
+    // is elided): the pinned `int&` local survives and the fixed statement is
+    // raised back from the csc pin lowering. Indexing through the fixed pointer
+    // (`p[i]`) keeps the body recompile-exact.
+    public static unsafe int SumPinnedArray(int[] values)
+    {
+        int sum = 0;
+        fixed (int* p = &values[0])
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                sum += *p;
+            }
+        }
+        return sum;
+    }
+
     public static unsafe nuint AddressAsNativeUInt()
     {
         int value = 42;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -273,6 +273,44 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void PinnedLocal_RaisesToFixedStatement()
+    {
+        // The csc pin lowering imports as a `pinned ref` local with a derived
+        // unmanaged pointer (Convert(nuint, LoadLocal pinned)). Rendered
+        // literally that is invalid C# (`pinned ref int V_0 = ref values[0]; ...
+        // (nuint)V_0`) and the top syntactic malformedness driver in CoreLib
+        // (#622 item F). FixedStatementPass raises the single-pinned-local shape
+        // back into a real `fixed (T* p = &place) { ... }` — the pinned local IS
+        // the fixed pointer. The loop deref keeps the pin alive through csc
+        // optimization (a single deref is elided), so the shape survives.
+        var function = ImportFixture(nameof(CfgSampleClass.SumPinnedArray));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<Fixed>());
+        Assert.Contains("fixed (int* ", output);
+        Assert.Contains("= &values[0])", output);
+        Assert.DoesNotContain("pinned", output);
+    }
+
+    [Fact]
+    public void PinnedLocal_DerivedPointerRendersAsPointerCast()
+    {
+        // A pointer derived from the pinned local — IL conv.u over the pinned
+        // load into a pointer slot — must render as a pointer cast `(int*)V`, not
+        // a managed-reference-to-nuint conversion. Both lower to `ldloc; conv.u`,
+        // so the cast keeps the recompiled opcode stream faithful.
+        var function = ImportFixture(nameof(CfgSampleClass.SumPinnedArray));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("(int*)", output);
+        Assert.DoesNotContain("(nuint)", output);
+    }
+
+    [Fact]
     public void CheckedAdd_RendersCheckedExpression()
     {
         // add.ovf carries an overflow check the default (unchecked) C# context

--- a/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
@@ -57,6 +57,7 @@ public class LoweredCompileBackGateTests
         "TryFinallyTwoReturns",
         "CatchEverything",
         "ManualDisposeAsyncInFinally",
+        "SumPinnedArray",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -106,10 +106,15 @@ public sealed class CSharpPrinter
     readonly List<(string Field, string Value)> _fieldInitializers = [];
     readonly HashSet<IrNode> _fieldInitStores = [];
 
+    /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
+    readonly HashSet<int> _fixedLocals = [];
+
     string PrintBody(IrFunction function)
     {
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
+        foreach (var fixedNode in function.Descendants.OfType<Fixed>())
+            _fixedLocals.Add(fixedNode.LocalIndex);
         CollectDeclaringStores(function);
         _readBeforeAssign = ComputeReadBeforeAssign(function);
 
@@ -225,6 +230,10 @@ public sealed class CSharpPrinter
         }
         foreach (int index in locals)
         {
+            // A fixed-statement pinned local is declared by the fixed header
+            // (fixed (T* V = &place)), not up front.
+            if (_fixedLocals.Contains(index))
+                continue;
             bool declaredAtStore = _declaringStores.Any(s =>
                 s is StoreLocal store && store.Index == index
                 || s is InitObject { Address: LoadLocalAddress init } && init.Index == index);
@@ -827,6 +836,17 @@ public sealed class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             return;
         }
+        if (node is Fixed fixedStatement)
+        {
+            sb.Append(pad)
+                .Append("fixed (").Append(TypeText(fixedStatement.ElementType)).Append("* ")
+                .Append(LocalName(fixedStatement.LocalIndex)).Append(" = &")
+                .Append(Deref(fixedStatement.PinSource)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, fixedStatement.Body, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is TryFinally tryFinally)
         {
             sb.Append(pad).AppendLine("try");
@@ -1335,6 +1355,17 @@ public sealed class CSharpPrinter
     /// </summary>
     string CastValue(IrExpression value, TypeRef? target)
     {
+        // A fixed-statement pinned local reads as a pointer (the fixed variable),
+        // so the IL's conv.u/conv.i deriving an unmanaged pointer from it
+        // (Convert over the pinned load) is a pointer reinterpret. Into a pointer
+        // target that is the explicit pointer cast — (uint*)V_0 — not the
+        // managed-reference-to-nuint conversion the conv would otherwise print.
+        if (target is { Kind: TypeRefKind.Pointer }
+            && value is Convert { Operand: LoadLocal pinnedLoad }
+            && _fixedLocals.Contains(pinnedLoad.Index))
+        {
+            return $"({TypeText(target)}){LocalName(pinnedLoad.Index)}";
+        }
         // An integer flowing into an enum-typed position — a comparison kind, a
         // flags value computed at run time — needs an explicit (Enum)x cast: C#
         // converts int→enum implicitly only for the literal 0. The cast is always

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -542,6 +542,15 @@ public sealed class CSharpPrinter
                 case Lock lockNode:
                     CheckReads(lockNode.LockObject, assigned);
                     return Container(lockNode.Body, assigned);
+                // A fixed statement evaluates its pin source, binds the pinned
+                // local in the header, then runs its body in program order. Model
+                // the source read, mark the pinned local assigned, and walk the
+                // body so an inner derived-pointer store counts as an assignment
+                // (otherwise it floods to `= default`, a dead store the IL lacks).
+                case Fixed fixedNode:
+                    CheckReads(fixedNode.PinSource, assigned);
+                    assigned.Add(fixedNode.LocalIndex);
+                    return Container(fixedNode.Body, assigned);
                 // Unmodeled control flow: stop trusting the program order.
                 case Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter:
                     BailAll();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -387,6 +387,43 @@ public sealed class Lock : IrNode
     public override string Describe() => "Lock";
 }
 
+/// <summary>
+/// A raised <c>fixed</c> statement. Produced by <see cref="FixedStatementPass"/>
+/// from the csc pin lowering: a <c>pinned T&amp;</c> local assigned a managed
+/// reference, used to derive an unmanaged pointer inside the pinned region, and
+/// (when the region ends before the method) unpinned by a store of null/zero.
+/// The pinned local becomes the <c>fixed</c> pointer variable
+/// (<c>fixed (T* V = &amp;place) { ... }</c>): its source spelling is
+/// <c>&amp;</c> applied to the reference being pinned (<see cref="PinSource"/>),
+/// and its loads inside the body read as a pointer of type
+/// <see cref="ElementType"/><c>*</c>. <see cref="LocalIndex"/> is the pinned
+/// slot, so the printer can name the variable and skip its up-front declaration.
+/// </summary>
+public sealed class Fixed : IrNode
+{
+    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body)
+    {
+        ElementType = elementType;
+        LocalIndex = localIndex;
+        AddChild(pinSource);
+        AddChild(body);
+    }
+
+    /// <summary>The pointed-to element type — the <c>T</c> in the <c>T*</c> pinned pointer.</summary>
+    public TypeRef ElementType { get; }
+
+    /// <summary>The pinned local slot that becomes the <c>fixed</c> pointer variable.</summary>
+    public int LocalIndex { get; }
+
+    /// <summary>The managed reference being pinned; rendered as <c>&amp;</c> applied to the place it refers to.</summary>
+    public IrExpression PinSource => (IrExpression)Children[0];
+    public BlockContainer Body => (BlockContainer)Children[1];
+
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType];
+
+    public override string Describe() => $"Fixed V_{LocalIndex} ({ElementType.ToDisplayString()}*)";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the csc pin lowering into a <see cref="Fixed"/> statement. C#'s
+/// <c>fixed (T* p = &amp;place) { ... }</c> compiles to a <c>pinned T&amp;</c>
+/// local assigned the managed reference, an unmanaged pointer derived from it
+/// (<c>ldloc; conv.u</c>) inside the pinned region, and — when the region ends
+/// before the method does — a store of zero into the local that unpins it:
+/// <code>
+///   pinned ref char V_0 = ref _firstChar;   // pin
+///   uint* V_3 = (nuint)V_0;                  // derive pointer
+///   ... use V_3 ...
+///   V_0 = (nuint)0;                          // unpin (optional)
+/// </code>
+/// becomes <c>fixed (char* V_0 = &amp;_firstChar) { uint* V_3 = (uint*)V_0; ... }</c>.
+/// Left flat, the pinned local renders as the non-C# <c>pinned ref T</c> with a
+/// managed-reference-to-pointer cast that does not bind — every such method is
+/// syntactically malformed, so it contributes no compile-check/compile-back
+/// signal at all.
+///
+/// <para>Scoped to the well-understood shape: exactly one pinned local, pinning
+/// a managed reference (<c>pinned T&amp;</c>), assigned once in the entry block,
+/// used only to derive pointers (every load feeds a <see cref="Convert"/>), and
+/// either never unpinned (the pin runs to method end — the fixed region is the
+/// whole tail) or unpinned by a single later store in the same block (the fixed
+/// region is the run between them). Anything outside this — multiple pinned
+/// locals, array/string pinning, an escaping or address-taken pinned local, a
+/// reference used before the pin or after the unpin — is left flat. The whole
+/// shape is proven before any node is detached.</para>
+/// </summary>
+public sealed class FixedStatementPass : IIrPass
+{
+    public string Name => "fixed-statement";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Exactly one pinned local, pinning a managed reference. More than one,
+        // or a pinned array/string (a non-byref pinned element), is out of scope.
+        var pinned = Enumerable.Range(0, function.Locals.Length)
+            .Where(i => function.Locals[i].Kind == TypeRefKind.Pinned)
+            .ToList();
+        if (pinned is not [int idx]
+            || function.Locals[idx].ElementType is not { Kind: TypeRefKind.ByRef } byRef)
+        {
+            return;
+        }
+
+        if (function.Body.Blocks.Count == 0)
+            return;
+        var entry = function.Body.Blocks[0];
+
+        // The pinned slot's stores: a single defining store, plus at most one
+        // unpinning store (a store of null/zero that ends the pinned region).
+        var stores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == idx).ToList();
+        if (stores is not [var defStore, ..] || !ReferenceEquals(defStore.Parent, entry))
+            return;
+        if (defStore.Value.ResultType is not { Kind: TypeRefKind.ByRef })
+            return;
+        // Pinning `this` (a value-type receiver's `ldarg.0`) has no `&this`
+        // spelling; leave it flat. A static method's first parameter is also
+        // index 0 but is a normal `&param`, so key on the receiver name.
+        if (defStore.Value is LoadArgument { Index: 0, Name: "this" })
+            return;
+
+        StoreLocal? unpin = null;
+        if (stores.Count == 2 && IsUnpin(stores[1]) && ReferenceEquals(stores[1].Parent, entry))
+            unpin = stores[1];
+        else if (stores.Count != 1)
+            return;
+
+        // Every other reference to the pinned slot must be a load that derives a
+        // pointer (feeds a Convert). An address-of the pinned local, or a load
+        // used some other way, is a shape this rewrite does not model.
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case LoadLocalAddress a when a.Index == idx:
+                    return;
+                case LoadLocal l when l.Index == idx && l.Parent is not Convert:
+                    return;
+            }
+        }
+
+        int d = defStore.ChildIndex;
+        int end = unpin?.ChildIndex ?? entry.Children.Count;
+        if (unpin is not null && end <= d)
+            return;
+        var scope = entry.Children.Skip(d + 1).Take(end - (d + 1)).ToList();
+
+        // The pinned region must lexically contain every pinned-local reference:
+        // each load lives in one of the statements between the pin and the unpin
+        // (or method end). A reference outside that run cannot be brought under
+        // the fixed block without reordering, so the whole shape is rejected.
+        foreach (var node in function.Descendants)
+        {
+            bool refsPin = node is LoadLocal l && l.Index == idx;
+            if (refsPin && !scope.Any(stmt => IsInside(node, stmt)))
+                return;
+        }
+
+        // Shape proven — detach the scope statements into the fixed body, drop
+        // the unpin, and replace the defining store with the fixed statement.
+        var body = new BlockContainer();
+        var bodyBlock = new Block(entry.StartOffset);
+        foreach (var stmt in scope)
+        {
+            stmt.Detach();
+            bodyBlock.Add(stmt);
+        }
+        body.Add(bodyBlock);
+        unpin?.Detach();
+        var pinSource = (IrExpression)defStore.DetachChildren()[0];
+        var fixedNode = new Fixed(byRef.ElementType!, idx, pinSource, body);
+        context.Stepper.StepOver("raise pinned local to fixed statement", defStore);
+        defStore.ReplaceWith(fixedNode);
+    }
+
+    /// <summary>A store that ends the pinned region: null or zero, possibly through a conv to a native pointer.</summary>
+    static bool IsUnpin(StoreLocal store)
+    {
+        var value = store.Value;
+        while (value is Convert convert)
+            value = convert.Operand;
+        return value is Constant { Value: null or 0 or 0L };
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -98,6 +98,12 @@ public static class IrPasses
         // formed; expression inlining leaves these temps standing because it
         // refuses to move a value across a leave/region edge.
         new ReturnSinkingPass(),
+        // Raise the csc pin lowering (a pinned managed-ref local + derived
+        // pointer + optional unpin store) into fixed (T* p = &place) { ... }.
+        // Runs after structuring and the second inlining so the pinned region's
+        // body is fully raised before it is wrapped; left flat the pinned local
+        // renders as the non-C# `pinned ref T` and the method never compiles.
+        new FixedStatementPass(),
         // Raise any static function-pointer load still standing into &Method
         // (it feeds a calli, native callback, or delegate*-typed field — all of
         // which take a function pointer directly).


### PR DESCRIPTION
## What

Raises the csc pin lowering back into a real C# `fixed (T* p = &place) { ... }` statement. This was the **top syntactic malformedness driver in CoreLib** — `pinned ref` (~235 occurrences, #622 item F). A parse failure aborts both compile-check and compile-back for the *whole* method, so fixing the malformed set first unlocks downstream signal.

Before (invalid C#, never compiles):

```csharp
pinned ref char V_0 = ref _firstChar;
uint* V_3 = (nuint)V_0;
... use V_3 ...
V_0 = (nuint)0;
```

After:

```csharp
fixed (char* V_0 = &_firstChar)
{
    uint* V_3 = (uint*)V_0;
    ... use V_3 ...
}
```

The pinned `T&` local **is** the `fixed` pointer variable, so a pointer derived from it (`Convert(nuint, LoadLocal pinned)` into a pointer slot) renders as the pointer cast `(uint*)V_0`. Both spellings lower to `ldloc; conv.u`, so the recompiled opcode stream stays faithful.

## How

- New `Fixed` IR node + `FixedStatementPass`, registered after `ReturnSinkingPass` (so the pinned region's body is fully raised/structured before it is wrapped).
- Printer: declares the pinned local via the `fixed` header (skipped up front), renders the derived-pointer cast, and the definite-assignment walk now models the `Fixed` node so the derived pointer declares **bare** (`int* p;`) instead of `int* p = default;` — the latter is a dead store the IL never had (it leans on `.locals init`) and would break compile-back.

### Soundness

Fires only when the shape is fully proven before any node is detached: exactly one pinned local pinning a managed reference (`pinned T&`); a single defining store in the entry block from a ByRef source (field / element / arg-ref / ref-returning call — **not** `this`); an optional null/zero unpin store; no address-of the pinned local; every load consumed by a `Convert`; and all pinned-local references contained in one contiguous scope run. Anything else — multiple pins, array/string pinning, an escaping or address-taken pinned local — is left flat (a follow-up).

## Results (CoreLib, `--pipeline next`)

- **Compile-check Full malformed: 1206 → 1141 (−65)**, zero regressions. 64 methods fully cleaned; 8 had the `pinned ref` parse error removed, exposing a pre-existing semantic residual (now visible to the compile-check arbiter rather than masked by a parse abort). 0 new CS0165.
- `--pass-impact fixed-statement`: **72/41012** methods rewritten, **0 pass bugs** (no IR invariant violations).
- `SumPinnedArray` fixture recompiles **opcode-exact**; pinned in both `CompileBackGateTests` and `LoweredCompileBackGateTests`.
- **506** decompiler tests green; **1143** product tests green.

## Follow-ups (deferred, out of scope)

- SzArray array/string pinning (has csc length guards): ~32 methods.
- Multi-pinned methods: ~146.
- `src=none` pinned shapes: ~46.
