### PR TITLE
Raise RVA constant-span lowering to a `new T[] { ... }` array literal

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -67,6 +67,7 @@ public class CompileBackGateTests
         "ClassicLock",
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
+        "ConstantUIntSpan",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1223,6 +1223,14 @@ public class CfgSampleClass
 
     public static int ReadVolatileFlag() => VolatileFlag;
 
+    // A constant array initializer in a ReadOnlySpan<T> context: csc lowers
+    // `new uint[] { ... }` to a content-addressed <PrivateImplementationDetails>
+    // field whose RVA maps the little-endian element bytes, loaded through
+    // RuntimeHelpers.CreateSpan<uint>(ldtoken field). RvaSpanPass decodes the
+    // blob and raises it back to the array literal, which csc re-lowers to the
+    // same field — opcode-exact.
+    public static System.ReadOnlySpan<uint> ConstantUIntSpan() => new uint[] { 1, 10, 100, 1000, 10000 };
+
     static void Tick() { }
     void Instance() { }
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -311,6 +311,27 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void ConstantSpan_RaisesToArrayLiteral()
+    {
+        // A constant array initializer in a ReadOnlySpan<T> context lowers to
+        // RuntimeHelpers.CreateSpan<uint>(ldtoken <PrivateImplementationDetails>.blob).
+        // Left flat the ldtoken of a compiler-internal field name renders as an
+        // unspellable comment, dropping the call's only argument. RvaSpanPass
+        // decodes the field's mapped RVA bytes and raises the call back to the
+        // `new uint[] { ... }` literal csc re-lowers to the same content-addressed
+        // field — opcode-exact.
+        var function = ImportFixture(nameof(CfgSampleClass.ConstantUIntSpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains("new uint[] { 1, 10, 100, 1000, 10000 }", output);
+        Assert.DoesNotContain("CreateSpan", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+    [Fact]
     public void CheckedAdd_RendersCheckedExpression()
     {
         // add.ovf carries an overflow check the default (unchecked) C# context

--- a/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
@@ -58,6 +58,7 @@ public class LoweredCompileBackGateTests
         "CatchEverything",
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
+        "ConstantUIntSpan",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1064,6 +1064,7 @@ public sealed class CSharpPrinter
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
+        SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
@@ -1249,7 +1250,7 @@ public sealed class CSharpPrinter
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional
-            or IncrementDecrement
+            or IncrementDecrement or SpanLiteral
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -846,7 +846,10 @@ public static class IrImporter
                         case HandleKind.FieldDefinition:
                         {
                             var field = ResolveField(source.Reader, handle, callerScope);
-                            stack.Push(new LoadToken(RuntimeTokenKind.Field, null, $"{field.DeclaringType.ToDisplayString()}.{field.Name}"));
+                            stack.Push(new LoadToken(RuntimeTokenKind.Field, null, $"{field.DeclaringType.ToDisplayString()}.{field.Name}")
+                            {
+                                FieldRvaData = TryReadFieldRvaData(source, (FieldDefinitionHandle)handle),
+                            });
                             break;
                         }
                         case HandleKind.MemberReference:
@@ -1520,6 +1523,35 @@ public static class IrImporter
         }
     }
 
+    /// <summary>
+    /// The mapped initial-value bytes of a field with an RVA — a
+    /// <c>&lt;PrivateImplementationDetails&gt;</c> constant-data field a constant
+    /// array/span initializer points at — or null when the field has no RVA. The
+    /// length is the field's value-type size (the synthesized
+    /// <c>__StaticArrayInitTypeSize=N</c> struct).
+    /// </summary>
+    static byte[]? TryReadFieldRvaData(MetadataSource source, FieldDefinitionHandle handle)
+    {
+        var field = source.Reader.GetFieldDefinition(handle);
+        int rva = field.GetRelativeVirtualAddress();
+        if (rva == 0)
+            return null;
+        int size = field.DecodeSignature(FieldDataSizeProvider.Instance, null);
+        if (size <= 0)
+            return null;
+        try
+        {
+            var block = source.Pe.GetSectionData(rva);
+            if (block.Length < size)
+                return null;
+            return block.GetContent(0, size).ToArray();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     internal static TypeRef ResolveTypeToken(MetadataReader reader, EntityHandle handle, GenericScope callerScope) => handle.Kind switch
     {
         HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
@@ -1587,4 +1619,39 @@ public static class IrPrinter
         foreach (var child in node.Children)
             Append(sb, child, indent + 1);
     }
+}
+
+/// <summary>
+/// Decodes a field signature to the byte size of its type — for an RVA constant
+/// field that is the synthesized <c>__StaticArrayInitTypeSize=N</c> value type,
+/// whose explicit <see cref="TypeLayout.Size"/> is the mapped blob length.
+/// Only the size is needed, so every constructed form passes its element size
+/// through and unknowns yield 0 (the caller then skips the field).
+/// </summary>
+sealed class FieldDataSizeProvider : ISignatureTypeProvider<int, object?>
+{
+    public static readonly FieldDataSizeProvider Instance = new();
+
+    public int GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        => reader.GetTypeDefinition(handle).GetLayout().Size;
+    public int GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => 0;
+    public int GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => 0;
+    public int GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+    {
+        PrimitiveTypeCode.Boolean or PrimitiveTypeCode.SByte or PrimitiveTypeCode.Byte => 1,
+        PrimitiveTypeCode.Int16 or PrimitiveTypeCode.UInt16 or PrimitiveTypeCode.Char => 2,
+        PrimitiveTypeCode.Int32 or PrimitiveTypeCode.UInt32 or PrimitiveTypeCode.Single => 4,
+        PrimitiveTypeCode.Int64 or PrimitiveTypeCode.UInt64 or PrimitiveTypeCode.Double => 8,
+        _ => 0,
+    };
+    public int GetSZArrayType(int elementType) => 0;
+    public int GetArrayType(int elementType, ArrayShape shape) => 0;
+    public int GetByReferenceType(int elementType) => 0;
+    public int GetPointerType(int elementType) => 0;
+    public int GetGenericInstantiation(int genericType, ImmutableArray<int> typeArguments) => 0;
+    public int GetGenericMethodParameter(object? genericContext, int index) => 0;
+    public int GetGenericTypeParameter(object? genericContext, int index) => 0;
+    public int GetModifiedType(int modifier, int unmodifiedType, bool isRequired) => unmodifiedType;
+    public int GetPinnedType(int elementType) => elementType;
+    public int GetFunctionPointerType(MethodSignature<int> signature) => 0;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1147,6 +1147,35 @@ public sealed class TypeOf : IrExpression
 
 public enum RuntimeTokenKind { Type, Method, Field }
 
+/// <summary>
+/// A constant span literal — <c>new T[] { c0, c1, ... }</c> in a
+/// <see cref="System.ReadOnlySpan{T}"/> context — raised from the compiler's
+/// <c>RuntimeHelpers.CreateSpan&lt;T&gt;(ldtoken &lt;PrivateImplementationDetails&gt;.field)</c>
+/// lowering of a constant array initializer. The element constants are decoded
+/// from the field's mapped RVA blob. Its result type is the
+/// <c>ReadOnlySpan&lt;T&gt;</c> the CreateSpan call produced, so replacing the
+/// call leaves the surrounding expression's type unchanged; the printer spells
+/// it as the array literal that the compiler re-lowers to the same blob.
+/// </summary>
+public sealed class SpanLiteral : IrExpression
+{
+    public SpanLiteral(TypeRef elementType, TypeRef spanType, IEnumerable<IrExpression> elements)
+    {
+        ElementType = elementType;
+        SpanType = spanType;
+        foreach (var element in elements)
+            AddChild(element);
+    }
+
+    public TypeRef ElementType { get; }
+    public TypeRef SpanType { get; }
+    public IReadOnlyList<IrExpression> Elements => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => SpanType;
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType, SpanType];
+
+    public override string Describe() => $"SpanLiteral {ElementType.ToDisplayString()}[{Children.Count}]";
+}
+
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
 public sealed class LoadToken : IrExpression
 {
@@ -1162,6 +1191,16 @@ public sealed class LoadToken : IrExpression
     /// <summary>The token's type when it is a type token; null for method/field tokens.</summary>
     public TypeRef? Type { get; }
     public string Display { get; }
+
+    /// <summary>
+    /// For an <c>ldtoken</c> of a field with mapped RVA data — the
+    /// <c>&lt;PrivateImplementationDetails&gt;</c> blob a constant array/span
+    /// initializer points at — the raw little-endian bytes. Lets the span-literal
+    /// raising reconstruct <c>new T[] { ... }</c> from a
+    /// <c>RuntimeHelpers.CreateSpan&lt;T&gt;</c> call. Null for every other token.
+    /// </summary>
+    public byte[]? FieldRvaData { get; init; }
+
     public override TypeRef? ResultType => TypeRef.CoreLib("System", Kind switch
     {
         RuntimeTokenKind.Type => "RuntimeTypeHandle",

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -104,6 +104,13 @@ public static class IrPasses
         // body is fully raised before it is wrapped; left flat the pinned local
         // renders as the non-C# `pinned ref T` and the method never compiles.
         new FixedStatementPass(),
+        // Raise the csc constant-array/span initializer lowering
+        // (RuntimeHelpers.CreateSpan<T>(ldtoken <PrivateImplementationDetails>.blob))
+        // back into a new T[] { ... } span literal, decoding the field's mapped
+        // RVA bytes. Left flat it renders the unspellable ldtoken of a
+        // compiler-internal field name and never compiles. Kept in Lowered
+        // (the CreateSpan call has no valid C# spelling).
+        new RvaSpanPass(),
         // Raise any static function-pointer load still standing into &Method
         // (it feeds a calli, native callback, or delegate*-typed field — all of
         // which take a function pointer directly).

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's constant-span lowering back into a <see cref="SpanLiteral"/>
+/// — a <c>new T[] { ... }</c> array literal in a <see cref="System.ReadOnlySpan{T}"/>
+/// context. A constant array/span initializer like
+/// <c>static ReadOnlySpan&lt;uint&gt; Powers => new uint[] { 1, 10, 100, ... };</c>
+/// is lowered by Roslyn to a <c>&lt;PrivateImplementationDetails&gt;</c> field whose
+/// RVA maps the raw little-endian element bytes, loaded through
+/// <c>RuntimeHelpers.CreateSpan&lt;T&gt;(ldtoken field)</c>. Left as-is that renders
+/// as <c>RuntimeHelpers.CreateSpan&lt;uint&gt;(/* LoadToken Field ... */)</c> — the
+/// unspellable <c>ldtoken</c> of a compiler-internal field name with angle brackets,
+/// which never parses.
+///
+/// <para>The pass decodes the field's mapped RVA blob (captured on the
+/// <see cref="LoadToken"/> at import) as the call's element type and rebuilds the
+/// element constants. The compiler re-lowers the reconstructed array literal to the
+/// same content-addressed blob, so the round-trip is opcode-exact. Scoped to the
+/// primitive element types whose bytes decode unambiguously; any other element type
+/// (an enum, a struct) is left untouched.</para>
+/// </summary>
+public sealed class RvaSpanPass : IIrPass
+{
+    public string Name => "rva-span";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            if (call.Callee is not { Name: "CreateSpan", DeclaringType.Namespace: "System.Runtime.CompilerServices", DeclaringType.Name: "RuntimeHelpers" })
+                continue;
+            if (call.Arguments is not [LoadToken { Kind: RuntimeTokenKind.Field, FieldRvaData: { } data }])
+                continue;
+            if (call.Callee.TypeArguments is not [var element])
+                continue;
+            if (call.ResultType is not { } spanType)
+                continue;
+
+            var elements = DecodeElements(element, data);
+            if (elements is null)
+                continue;
+
+            var literal = new SpanLiteral(element, spanType, elements);
+            context.Stepper.StepOver("raise CreateSpan RVA blob to span literal", call);
+            call.ReplaceWith(literal);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the little-endian RVA bytes as an array of the element type, or null
+    /// when the element type is not a fixed-size primitive (the bytes carry no
+    /// unambiguous reading without resolving an enum's underlying type or a struct's
+    /// layout).
+    /// </summary>
+    static List<IrExpression>? DecodeElements(TypeRef element, byte[] data)
+    {
+        if (element.Kind != TypeRefKind.Definition || element.Namespace != "System")
+            return null;
+
+        int width = element.Name switch
+        {
+            "Boolean" or "SByte" or "Byte" => 1,
+            "Int16" or "UInt16" or "Char" => 2,
+            "Int32" or "UInt32" or "Single" => 4,
+            "Int64" or "UInt64" or "Double" => 8,
+            _ => 0,
+        };
+        if (width == 0 || data.Length % width != 0)
+            return null;
+
+        var span = data.AsSpan();
+        var result = new List<IrExpression>(data.Length / width);
+        for (int offset = 0; offset < data.Length; offset += width)
+        {
+            var chunk = span.Slice(offset, width);
+            object value = element.Name switch
+            {
+                "Boolean" => chunk[0] != 0,
+                "SByte" => (sbyte)chunk[0],
+                "Byte" => chunk[0],
+                "Int16" => BitConverter.ToInt16(chunk),
+                "UInt16" => BitConverter.ToUInt16(chunk),
+                "Char" => (char)BitConverter.ToUInt16(chunk),
+                "Int32" => BitConverter.ToInt32(chunk),
+                "UInt32" => BitConverter.ToUInt32(chunk),
+                "Single" => BitConverter.ToSingle(chunk),
+                "Int64" => BitConverter.ToInt64(chunk),
+                "UInt64" => BitConverter.ToUInt64(chunk),
+                "Double" => BitConverter.ToDouble(chunk),
+                _ => throw new InvalidOperationException(),
+            };
+            result.Add(new Constant(value, element));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

Raises the csc constant-array/span-initializer lowering back into a real C# array literal. A constant initializer in a `ReadOnlySpan<T>` context:

```csharp
static ReadOnlySpan<uint> UInt32Powers10 => new uint[] { 1, 10, 100, 1000, ... };
```

is lowered by csc to a content-addressed `<PrivateImplementationDetails>` field whose RVA maps the raw little-endian element bytes, loaded through `RuntimeHelpers.CreateSpan<T>(ldtoken field)`. Left flat, the importer renders the `ldtoken` of a compiler-internal field name as an unspellable comment — **dropping the call's only argument**, so the output silently loses the data:

```csharp
return RuntimeHelpers.CreateSpan<uint>(/* LoadToken Field <PrivateImplementationDetails>.A516EE... */);
```

Now:

```csharp
return new uint[] { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
```

## How

- **`LoadToken.FieldRvaData`** — capture the field's mapped RVA bytes at import. Blob length comes from the synthesized `__StaticArrayInitTypeSize=N` struct's explicit layout size, read via a small `ISignatureTypeProvider` (`FieldDataSizeProvider`).
- **`SpanLiteral` IR node** — `new T[] { ... }` whose `ResultType` is the `ReadOnlySpan<T>` the `CreateSpan` call produced, so replacing the call leaves the surrounding expression's type unchanged.
- **`RvaSpanPass`** — match `RuntimeHelpers.CreateSpan<T>(LoadToken{Field, FieldRvaData})`, decode the blob little-endian per element type, and replace with a `SpanLiteral`. Decodes the fixed-size primitives (bool/sbyte/byte/short/ushort/char/int/uint/long/ulong/float/double); any other element type (enum, struct) is left untouched. Registered in both `Default` and `Lowered` (the `CreateSpan` call has no valid C# spelling).
- **Printer** — renders `new T[] { e0, e1, ... }` as an atomic/primary operand.

## Soundness

csc re-lowers `new T[] { constants }` in a `ReadOnlySpan<T>` context back to a `CreateSpan<T>(ldtoken <PrivateImplementationDetails>.SHA)` against a field whose name is the content hash of the blob — identical bytes implies identical field implies **opcode-exact**. The new `ConstantUIntSpan` fixture is pinned in both compile-back gates (raised + lowered).

## Measurement

- `--pass-impact rva-span`: **61 methods changed, 0 pass bugs**.
- Compile-check numbers flat (1141 malformed / 270 semantic). These methods were never in the defect buckets: the elided-argument `CreateSpan()` render's only error (CS1501/CS7036 missing arg) is filtered as binding noise, so the harness scored the broken output as "clean". The real win is correctness — a dropped argument becomes a faithful, recompilable, opcode-exact literal.
- 507 decompiler tests green (+1).

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)
