### PR TITLE
Raise csc inline-array span lowering to a C# 12 collection expression

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -68,6 +68,7 @@ public class CompileBackGateTests
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
         "ConstantUIntSpan",
+        "InlineArraySpan",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowGraphTests.cs
@@ -1231,6 +1231,17 @@ public class CfgSampleClass
     // same field — opcode-exact.
     public static System.ReadOnlySpan<uint> ConstantUIntSpan() => new uint[] { 1, 10, 100, 1000, 10000 };
 
+    static int SumSpan(System.ReadOnlySpan<int> s) => s.Length;
+
+    // A collection expression with NON-constant elements in a ReadOnlySpan<T>
+    // context: csc cannot use an RVA blob (the elements are runtime values), so
+    // it lowers `[a, b]` to a compiler-synthesized inline-array buffer
+    // (`<>y__InlineArray2<int>` / `InlineArray2<int>` on .NET 11+) default-init'd,
+    // each slot stored through <PrivateImplementationDetails>.InlineArrayElementRef,
+    // and exposed via InlineArrayAsReadOnlySpan. InlineArrayCollectionPass raises
+    // it back to `[a, b]`, which csc re-lowers to the same buffer — opcode-exact.
+    public static int InlineArraySpan(int a, int b) => SumSpan([a, b]);
+
     static void Tick() { }
     void Instance() { }
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -332,6 +332,27 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void InlineArraySpan_RaisesToCollectionExpression()
+    {
+        // A collection expression with non-constant elements in a ReadOnlySpan<T>
+        // context lowers to a compiler-synthesized inline-array buffer:
+        // `<>y__InlineArray2<int>` (or `InlineArray2<int>` on .NET 11+) default-
+        // init'd, each slot stored through
+        // <PrivateImplementationDetails>.InlineArrayElementRef, then exposed via
+        // InlineArrayAsReadOnlySpan. Left flat the angle-bracketed buffer/method
+        // names never parse. InlineArrayCollectionPass raises it back to `[a, b]`.
+        var function = ImportFixture(nameof(CfgSampleClass.InlineArraySpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains("[a, b]", output);
+        Assert.DoesNotContain("InlineArray", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+    [Fact]
     public void CheckedAdd_RendersCheckedExpression()
     {
         // add.ovf carries an overflow check the default (unchecked) C# context

--- a/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
@@ -59,6 +59,7 @@ public class LoweredCompileBackGateTests
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
         "ConstantUIntSpan",
+        "InlineArraySpan",
     };
 
     static IReadOnlyList<CompileBack.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1065,6 +1065,7 @@ public sealed class CSharpPrinter
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
+        CollectionExpression c => $"[{string.Join(", ", c.Elements.Select(Expression))}]",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
@@ -1250,7 +1251,7 @@ public sealed class CSharpPrinter
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional
-            or IncrementDecrement or SpanLiteral
+            or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1176,6 +1176,38 @@ public sealed class SpanLiteral : IrExpression
     public override string Describe() => $"SpanLiteral {ElementType.ToDisplayString()}[{Children.Count}]";
 }
 
+/// <summary>
+/// A C# 12 collection expression — <c>[e0, e1, ...]</c> in a
+/// <see cref="System.ReadOnlySpan{T}"/> context — raised from the compiler's
+/// inline-array lowering of a span collection expression with non-constant
+/// elements: a <c>&lt;&gt;y__InlineArrayN&lt;T&gt;</c> temporary default-initialized,
+/// each slot stored through
+/// <c>&lt;PrivateImplementationDetails&gt;.InlineArrayElementRef</c>, then exposed
+/// as a span by <c>&lt;PrivateImplementationDetails&gt;.InlineArrayAsReadOnlySpan</c>.
+/// The elements are the per-slot stored values, in index order. Its result type
+/// is the <c>ReadOnlySpan&lt;T&gt;</c> the AsReadOnlySpan call produced, so
+/// replacing that call leaves the surrounding expression's type unchanged; the
+/// compiler re-lowers <c>[...]</c> to the same inline-array sequence.
+/// </summary>
+public sealed class CollectionExpression : IrExpression
+{
+    public CollectionExpression(TypeRef elementType, TypeRef spanType, IEnumerable<IrExpression> elements)
+    {
+        ElementType = elementType;
+        SpanType = spanType;
+        foreach (var element in elements)
+            AddChild(element);
+    }
+
+    public TypeRef ElementType { get; }
+    public TypeRef SpanType { get; }
+    public IReadOnlyList<IrExpression> Elements => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => SpanType;
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType, SpanType];
+
+    public override string Describe() => $"CollectionExpression {ElementType.ToDisplayString()}[{Children.Count}]";
+}
+
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
 public sealed class LoadToken : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -1,0 +1,137 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the csc inline-array lowering of a span collection expression back into
+/// a C# 12 collection expression — <c>[e0, e1, ...]</c> in a
+/// <see cref="System.ReadOnlySpan{T}"/> context. A collection expression with
+/// non-constant elements targeting a span, e.g.
+/// <c>GetFlattenedIndex([index1, index2])</c>, is lowered to a
+/// compiler-synthesized <c>&lt;&gt;y__InlineArrayN&lt;T&gt;</c> temporary that is
+/// default-initialized, has each slot stored through
+/// <c>&lt;PrivateImplementationDetails&gt;.InlineArrayElementRef&lt;…&gt;(ref tmp, i)</c>,
+/// and is finally exposed as a span by
+/// <c>&lt;PrivateImplementationDetails&gt;.InlineArrayAsReadOnlySpan&lt;…&gt;(tmp, N)</c>
+/// (or <c>InlineArrayAsSpan</c> for a mutable <see cref="System.Span{T}"/> target).
+/// Left flat the angle-bracketed compiler-internal type and method names never
+/// parse — every such method is syntactically malformed.
+///
+/// <para>Scoped to the well-understood shape: the span source is a
+/// <c>&lt;&gt;y__InlineArrayN</c> local (the runtime's own InlineArray structs such
+/// as <c>TwoObjects</c> used by string.Format's params lowering are a distinct
+/// shape and left untouched), default-initialized once, written by exactly N
+/// element stores covering slots 0..N-1, and used by exactly one
+/// AsReadOnlySpan — nothing else references the local. Anything outside this is
+/// left flat. The whole shape is proven before any node is detached.</para>
+/// </summary>
+public sealed class InlineArrayCollectionPass : IIrPass
+{
+    const string PrivateImpl = "<PrivateImplementationDetails>";
+
+    public string Name => "inline-array-collection";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var span in function.Descendants.OfType<Call>().ToList())
+        {
+            if (span.Parent is null)
+                continue; // already rewritten in this pass (a nested match)
+            if (!IsPrivateImpl(span.Callee, "InlineArrayAsReadOnlySpan") && !IsPrivateImpl(span.Callee, "InlineArrayAsSpan"))
+                continue;
+            // Only the compiler-synthesized inline arrays — not the runtime's own
+            // InlineArray structs (TwoObjects/ThreeObjects) behind string.Format.
+            if (span.Callee.TypeArguments is not [var arrayType, var element] || !IsSynthesizedInlineArray(arrayType))
+                continue;
+            if (span.Arguments is not [LoadLocalAddress { Index: var local }, Constant { Value: int count }])
+                continue;
+            if (span.ResultType is not { } spanType)
+                continue;
+
+            // Every reference to the inline-array local: the single init, the N
+            // element stores, and this AsReadOnlySpan. A load of the local by
+            // value, an address taken elsewhere, or a second span use means the
+            // local escapes the shape — leave it flat.
+            var addressRefs = function.Descendants.OfType<LoadLocalAddress>().Where(a => a.Index == local).ToList();
+            if (function.Descendants.OfType<LoadLocal>().Any(l => l.Index == local))
+                continue;
+            if (addressRefs.Count != count + 2)
+                continue;
+
+            var init = FindInit(function, local);
+            if (init is null)
+                continue;
+
+            var stores = CollectElementStores(function, local, count);
+            if (stores is null)
+                continue;
+
+            // Shape proven. Detach each element value (discarding the
+            // ElementRef address subtree), build the collection expression, and
+            // replace the span source; then drop the init and the stores.
+            var elements = stores.Select(s => (IrExpression)s.DetachChildren()[1]).ToList();
+            var collection = new CollectionExpression(element, spanType, elements);
+            context.Stepper.StepOver("raise inline-array lowering to collection expression", span);
+            span.ReplaceWith(collection);
+            init.Detach();
+            foreach (var store in stores)
+                store.Detach();
+        }
+    }
+
+    static bool IsPrivateImpl(MethodRef callee, string name)
+        => callee.Name == name && callee.DeclaringType.Name == PrivateImpl;
+
+    /// <summary>
+    /// True for a compiler-synthesized inline-array buffer — the span source csc
+    /// emits for a collection expression. The name lives on the generic definition
+    /// (the type is a generic instance) and carries an arity backtick. Roslyn spells
+    /// it <c>&lt;&gt;y__InlineArray4`1</c> on older runtimes and <c>InlineArray4`1</c>
+    /// on .NET 11+; both forms are accepted. The runtime's own params buffers
+    /// (<c>TwoObjects</c>/<c>ThreeObjects</c>/<c>EightObjects</c>/<c>ArgumentData</c>)
+    /// do not start with <c>InlineArray</c>, so they stay excluded.
+    /// </summary>
+    static bool IsSynthesizedInlineArray(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        string name = definition?.Name ?? "";
+        if (name.StartsWith("<>y__InlineArray"))
+            return true;
+        return name.StartsWith("InlineArray") && name.Length > "InlineArray".Length && char.IsAsciiDigit(name["InlineArray".Length]);
+    }
+
+    /// <summary>The single <c>initobj</c> that default-initializes the inline-array local; null if absent or not unique.</summary>
+    static InitObject? FindInit(IrFunction function, int local)
+    {
+        var inits = function.Descendants.OfType<InitObject>()
+            .Where(i => i.Address is LoadLocalAddress { } a && a.Index == local)
+            .ToList();
+        return inits.Count == 1 ? inits[0] : null;
+    }
+
+    /// <summary>
+    /// The N element stores for the inline-array local, ordered by slot index, or
+    /// null when they do not cover exactly slots 0..N-1 through
+    /// <c>InlineArrayElementRef(ref local, i)</c> — each a statement directly in a
+    /// block (its own slot, so it can be detached).
+    /// </summary>
+    static List<StoreIndirect>? CollectElementStores(IrFunction function, int local, int count)
+    {
+        var byIndex = new SortedDictionary<int, StoreIndirect>();
+        foreach (var store in function.Descendants.OfType<StoreIndirect>())
+        {
+            if (store.Address is not Call elementRef || !IsPrivateImpl(elementRef.Callee, "InlineArrayElementRef"))
+                continue;
+            if (elementRef.Arguments is not [LoadLocalAddress { Index: var refLocal }, Constant { Value: int slot }] || refLocal != local)
+                continue;
+            if (store.Parent is not Block)
+                return null;
+            if (slot < 0 || slot >= count || byIndex.ContainsKey(slot))
+                return null;
+            byIndex[slot] = store;
+        }
+        if (byIndex.Count != count)
+            return null;
+        return byIndex.Values.ToList();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -111,6 +111,13 @@ public static class IrPasses
         // compiler-internal field name and never compiles. Kept in Lowered
         // (the CreateSpan call has no valid C# spelling).
         new RvaSpanPass(),
+        // Raise the csc inline-array lowering of a span collection expression
+        // (a <>y__InlineArrayN<T> temp written slot-by-slot through
+        // <PrivateImplementationDetails>.InlineArrayElementRef and exposed by
+        // InlineArrayAsReadOnlySpan) back into a C# 12 collection expression
+        // [e0, e1, ...]. Left flat the angle-bracketed compiler-internal names
+        // never parse. Kept in Lowered (no valid C# spelling otherwise).
+        new InlineArrayCollectionPass(),
         // Raise any static function-pointer load still standing into &Method
         // (it feeds a calli, native callback, or delegate*-typed field — all of
         // which take a function pointer directly).


### PR DESCRIPTION
## Summary

Raises the csc inline-array lowering of a span collection expression back into a C# 12 collection expression `[e0, e1, ...]`.

A collection expression with **non-constant** elements in a `ReadOnlySpan<T>` / `Span<T>` context — `SumSpan([a, b])`, `string.Join(", ", [resourceFormat, p1])`, `new ValueListBuilder<Task>([null x8])` — lowers to a compiler-synthesized inline-array buffer:

- `<>y__InlineArrayN<T>` (spelled `InlineArrayN<T>` on .NET 11+) default-initialized,
- each slot stored through `<PrivateImplementationDetails>.InlineArrayElementRef<...>(ref tmp, i)`,
- exposed via `InlineArrayAsReadOnlySpan` (or `InlineArrayAsSpan` for a mutable `Span<T>`).

Left flat, the angle-bracketed compiler-internal buffer/method names never parse — every such method is syntactically malformed (**CS1525**).

## Approach

New `CollectionExpression` IR node + `InlineArrayCollectionPass` (registered in `Default` after `RvaSpanPass`) raise the whole shape back to `[e0, e1, ...]`, which csc re-lowers to the same content-addressed buffer — **opcode-exact**.

### Soundness

The pass proves the entire shape before detaching any node:
- span source is a synthesized inline-array buffer — the runtime's own params buffers (`TwoObjects`/`ThreeObjects`/`EightObjects`/`ArgumentData`) do **not** start with `InlineArray`, so they stay excluded;
- default-initialized exactly once;
- written by exactly N element stores covering slots 0..N-1, each a statement directly under a block;
- used by exactly one span call with no by-value escape of the local.

Anything outside this shape bails flat (no regression). Handles both the older `<>y__InlineArrayN` and the .NET 11+ `InlineArrayN` synthesized-buffer naming.

## Numbers

- Compile-check **Full malformed 1141 -> 1115 (-26)**, **0 regressions**, 0 new CS0165.
- `--pass-impact inline-array-collection`: **26 methods, 0 pass bugs**.
- `InlineArraySpan` fixture **opcode-exact**, pinned in both compile-back gates.
- **508** decompiler tests green (+1).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
