### PR TITLE
Add --structuring-bails harness diagnostic (control-flow track, PR 1)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -20,19 +20,23 @@ jump-tables by `SwitchRaisingPass`. Two recent passes closed bounded gaps:
 - **#640** — `ReturnMergePass` + a guard-leaf inlining generalization raise the
   comparison tree csc emits for a sparse `switch`.
 
-What remains is not bounded. Measured on `System.Private.CoreLib` (preview.5),
-the 1,293 candidate-worse methods bucket by the reason `StructuringPass` left
-them flat:
+What remains is not bounded. The bail-reason histogram below is produced by
+`decompiler-harness --structuring-bails` (landed as the first PR of this track),
+which attaches a `StructuringDiagnostics` sink to the pipeline and tallies, per
+block container, why `StructuringPass` left it flat. Measured on the running
+runtime's `System.Private.CoreLib` (net11 preview.5), across 41,012 methods —
+**10,166 containers structured, 1,672 bailed across 1,645 methods**:
 
-| Bail reason | Count | Shape |
+| Bail reason | Containers | Shape |
 | --- | ---: | --- |
-| `cond-target-past-region` | 680 | a conditional branch whose target is past the region |
-| `forward-branch-not-region-exit` | 403 | an unconditional forward goto that is not the region exit |
-| `unconsumed-regions` (EH) | 79 | a try/catch/finally the EH pass left flat |
-| `backward-branch` / `cond-backward-loop` | 111 | an unraised loop |
-| `leave-target-container` / structured-ok | 20 | EH leave survivor, or worse for a non-structuring reason |
+| `cond-target-past-region` | 876 | a conditional branch whose target is past the region |
+| `forward-branch-not-region-exit` | 599 | an unconditional forward goto that is not the region exit |
+| `unconsumed-regions` (EH) | 108 | a try/catch/finally the EH pass left flat |
+| `cond-backward-branch` | 61 | an unraised loop |
+| `leave-target-in-container` | 14 | an EH leave survivor keeps its container flat |
+| `eh-terminator-survivor` | 14 | a `Leave`/`EndFinally`/`EndFilter` terminator |
 
-The top two — **1,083 of 1,293** — are the same shape: **a forward branch to a
+The top two — **1,475 of 1,672** — are the same shape: **a forward branch to a
 common merge/exit that lies past the region**. Representative methods:
 `System.Array::InternalSetValue`, `System.Array::LastIndexOf`,
 `System.Array::Reverse`, `Interop.OSReleaseFile::GetPrettyName`,
@@ -68,14 +72,15 @@ after every step of this plan.
 - **The per-method view** — `decompiler-harness --dump 'Ns.Type::Method'` prints
   every stage; the final stage is `PrintRaised`. Use it to confirm a method
   exhibits (or, after a fix, no longer exhibits) the common-exit `goto`.
-- **The bail-reason histogram** — the `cond-target-past-region` /
-  `forward-branch-not-region-exit` table above is **not** emitted by the
-  committed harness; the original diagnosis instrumented `StructuringPass.Validate`
-  to tally its early `return false` sites. **The first PR of this track should
-  land that instrumentation as a real harness diagnostic** (e.g.
-  `--structuring-bails`) so the 1,083-method merge docket is reproducible on
-  demand and every subsequent step can show the bucket shrinking, rather than
-  relying on the ad-hoc tally this doc inherited.
+- **The bail-reason histogram** — `decompiler-harness --structuring-bails`
+  attaches a `StructuringDiagnostics` sink to the Default pipeline and tallies,
+  per block container, the `StructuringPass` bail reason (or that it structured).
+  This is the merge-docket lens: the `cond-target-past-region` /
+  `forward-branch-not-region-exit` table above is reproducible on demand, so
+  every subsequent step of this plan can show the bucket shrinking. The counts
+  are **per container** (a method may bail in more than one container), which is
+  why the totals differ from DiffNext's per-method `candidate-worse`. Honors
+  `--cap` to bound a partial sweep.
 
 Two shapes that are **already handled** and are out of scope: short-circuit
 `&&`/`||` guard chains (they nest cleanly today — the `TripleAnd`/`IfAnd`/
@@ -356,24 +361,24 @@ than something to emit speculatively now.
 
 ## Out of scope
 
-- Loops (`backward-branch`/`cond-backward-loop`, 111) — a separate loop-raising
-  effort, not control-flow merging.
-- EH (`unconsumed-regions`, 79) — the EH pass leaving regions flat is a distinct
+- Loops (`cond-backward-branch`, 61) — a separate loop-raising effort, not
+  control-flow merging.
+- EH (`unconsumed-regions`, 108) — the EH pass leaving regions flat is a distinct
   gap; the CFG-DA's `Leave` bail (#631) is the related printer-side residue.
 - Switch jump tables (`SwitchRaisingPass`) and comparison trees (#640) — done.
 
 ## Open questions
 
-- **How much of the 1,083 is fully eliminable (return-tail) vs retained-label?**
+- **How much of the 1,475 is fully eliminable (return-tail) vs retained-label?**
   Step 2 answers it empirically: the return-tail subset's recovery count tells
   us how much value lands before the invariant relaxation is needed. The
-  `--structuring-bails` diagnostic from step 1 makes this a number, not a guess.
+  `--structuring-bails` diagnostic (landed) makes this a number, not a guess.
 - **What is the true structuring-only burndown, separated from the residue?**
   The refreshed `--candidate next` docket (1,217) is dominated by `= default`
   and `pinned` cosmetics, not the merge shape, so the scoreboard alone
-  overstates the structuring gap. Until `--structuring-bails` lands, the merge
-  docket is sized only by the inherited 1,083 tally; the first PR should restate
-  it against current main so this track is measured against its own number.
+  overstates the structuring gap. `--structuring-bails` now sizes the merge
+  docket directly (1,475 containers), so this track is measured against its own
+  number rather than the inherited tally.
 - **Does the oracle's retained-goto shape match what step 4 would emit?** If the
   baseline's label placement differs, recovered methods land in
   `baseline-worse`/`uncertain` rather than `agree` — still a real quality win,

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -1,0 +1,57 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StructuringDiagnosticsTests
+{
+    static StructuringDiagnostics RunWithDiagnostics(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        var diagnostics = new StructuringDiagnostics();
+        IrPasses.Run(function, IrPasses.Default, new PassContext(new Stepper(enabled: false), diagnostics));
+        return diagnostics;
+    }
+
+    [Fact]
+    public void CommonExitMerge_RecordsForwardBranchBail()
+    {
+        // Two nested guards both `goto done` onto a shared exit past the region:
+        // the index-range model cannot express the merge, so the container stays
+        // flat and the sink records exactly why.
+        var diag = RunWithDiagnostics(nameof(CfgSampleClass.GotoCommonExit));
+
+        Assert.Equal(0, diag.Structured);
+        Assert.Equal("forward-branch-not-region-exit", Assert.Single(diag.Bails));
+    }
+
+    [Theory]
+    [InlineData(nameof(CfgSampleClass.TripleAnd))]
+    [InlineData(nameof(CfgSampleClass.IfAnd))]
+    [InlineData(nameof(CfgSampleClass.IfOr))]
+    public void GuardChain_StructuresCleanlyWithNoBail(string methodName)
+    {
+        // &&/|| guard chains are in the slice today: the container structures and
+        // the sink records the success, never a bail.
+        var diag = RunWithDiagnostics(methodName);
+
+        Assert.True(diag.Structured > 0);
+        Assert.Empty(diag.Bails);
+    }
+
+    [Fact]
+    public void NoSink_DefaultRunMatchesSinkRun()
+    {
+        // The sink is optional: a normal run (PassContext.None, null sink) records
+        // nothing and behaves identically — the structuring decision is unchanged.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var withSink = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.GotoCommonExit))!;
+        var withoutSink = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.GotoCommonExit))!;
+
+        IrPasses.Run(withSink, IrPasses.Default, new PassContext(new Stepper(enabled: false), new StructuringDiagnostics()));
+        IrPasses.Run(withoutSink);  // PassContext.None — no sink
+
+        Assert.Equal(IrPrinter.Dump(withoutSink), IrPrinter.Dump(withSink));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/PassContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PassContext.cs
@@ -9,9 +9,20 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public sealed class PassContext
 {
-    public PassContext(Stepper stepper) => Stepper = stepper;
+    public PassContext(Stepper stepper, StructuringDiagnostics? structuringDiagnostics = null)
+    {
+        Stepper = stepper;
+        StructuringDiagnostics = structuringDiagnostics;
+    }
 
     public Stepper Stepper { get; }
+
+    /// <summary>
+    /// Optional sink for <see cref="StructuringPass"/> bail reasons. Null on every
+    /// normal run (the pass records nothing); set only by the <c>--structuring-bails</c>
+    /// diagnostic to make the common-exit docket reproducible.
+    /// </summary>
+    public StructuringDiagnostics? StructuringDiagnostics { get; }
 
     /// <summary>A context with stepping disabled — the default for normal runs and for tests that drive a pass directly.</summary>
     public static PassContext None { get; } = new(new Stepper(enabled: false));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -39,12 +39,30 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
         public required bool IsComparisonTree { get; init; }
+
+        /// <summary>
+        /// First-wins recorder for the deepest direct bail reason, populated only
+        /// when the <c>--structuring-bails</c> diagnostic is active (null on every
+        /// normal run). <see cref="Validate"/> records at each labelled
+        /// <c>return false</c>; recursion propagating that false does not overwrite it.
+        /// </summary>
+        public BailRecorder? Recorder { get; init; }
+    }
+
+    /// <summary>Captures the first (innermost) bail reason for one container; later reasons are ignored.</summary>
+    sealed class BailRecorder
+    {
+        public string? Reason { get; private set; }
+        public void Record(string reason) => Reason ??= reason;
     }
 
     public void Run(IrFunction function, PassContext context)
     {
         if (!function.Regions.IsEmpty)
+        {
+            context.StructuringDiagnostics?.RecordBail("unconsumed-regions");
             return;  // unconsumed regions: the flat form is still the truth
+        }
         // Surviving leaves are the one cross-container goto (an early exit
         // through outer constructs); their target blocks must keep printing
         // a label, so their containers stay flat.
@@ -65,7 +83,10 @@ public sealed class StructuringPass : IIrPass
         if (blocks.Count <= 1)
             return;
         if (leaveTargets.Count > 0 && blocks.Any(b => leaveTargets.Contains(b.StartOffset)))
+        {
+            context.StructuringDiagnostics?.RecordBail("leave-target-in-container");
             return;
+        }
 
         var offsetToIndex = new Dictionary<int, int>();
         for (int i = 0; i < blocks.Count; i++)
@@ -117,6 +138,7 @@ public sealed class StructuringPass : IIrPass
                 droppable.Add(i);
         }
 
+        var recorder = context.StructuringDiagnostics is null ? null : new BailRecorder();
         var ctx = new Ctx
         {
             Blocks = blocks,
@@ -127,10 +149,16 @@ public sealed class StructuringPass : IIrPass
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
             IsComparisonTree = isComparisonTree,
+            Recorder = recorder,
         };
 
         if (!Validate(ctx, 0, blocks.Count, joinIndex: blocks.Count, breakTarget: null))
+        {
+            context.StructuringDiagnostics?.RecordBail(recorder?.Reason ?? "unknown");
             return;
+        }
+
+        context.StructuringDiagnostics?.RecordStructured();
 
         context.Stepper.StepOver(
             $"structure container at IL_{blocks[0].StartOffset:X4} ({blocks.Count} blocks) into nested if/diamond regions",
@@ -171,7 +199,10 @@ public sealed class StructuringPass : IIrPass
             for (int s = 0; s < block.Children.Count - 1; s++)
             {
                 if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                {
+                    ctx.Recorder?.Record("mid-block-control-flow");
                     return false;  // mid-block control flow is outside the slice
+                }
             }
             switch (block.Children[^1])
             {
@@ -184,11 +215,15 @@ public sealed class StructuringPass : IIrPass
                     // Survivors of the EH pass (an early exit through outer
                     // constructs) keep their container flat: structure would
                     // erase the label their goto needs.
+                    ctx.Recorder?.Record("eh-terminator-survivor");
                     return false;
                 case Branch branch:
                 {
                     if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget))
+                    {
+                        ctx.Recorder?.Record("branch-target-external");
                         return false;
+                    }
                     // An unconditional branch to the enclosing loop's exit is a break.
                     if (breakTarget == branchTarget)
                     {
@@ -207,14 +242,20 @@ public sealed class StructuringPass : IIrPass
                     // Otherwise only the region-exit goto is in the slice; it
                     // must be the region's last block.
                     if (branchTarget != joinIndex || i + 1 != stop)
+                    {
+                        ctx.Recorder?.Record("forward-branch-not-region-exit");
                         return false;
+                    }
                     i = stop;
                     break;
                 }
                 case ConditionalBranch conditional:
                 {
                     if (!offsetToIndex.TryGetValue(conditional.TargetOffset, out int target))
+                    {
+                        ctx.Recorder?.Record("cond-target-external");
                         return false;
+                    }
                     // A conditional branch to the loop exit is `if (c) break;`.
                     if (breakTarget == target)
                     {
@@ -230,8 +271,16 @@ public sealed class StructuringPass : IIrPass
                         i++;
                         break;
                     }
-                    if (target <= i || target > stop)
-                        return false;  // backward = loop (later slice); past region = out of slice
+                    if (target <= i)
+                    {
+                        ctx.Recorder?.Record("cond-backward-branch");
+                        return false;  // backward = loop (later slice)
+                    }
+                    if (target > stop)
+                    {
+                        ctx.Recorder?.Record("cond-target-past-region");
+                        return false;  // past region = out of slice (the common-exit merge)
+                    }
                     // Guard: if (c) goto M with M ending this region's view.
                     // Diamond: the fallthrough arm ends with goto M past the
                     // true arm.
@@ -257,7 +306,10 @@ public sealed class StructuringPass : IIrPass
                 default:
                     // A block that falls through to its successor.
                     if (i + 1 >= stop && stop != joinIndex)
+                    {
+                        ctx.Recorder?.Record("fallthrough-past-region");
                         return false;
+                    }
                     i++;
                     break;
             }

--- a/src/ILInspector.Decompiler/Pipeline/StructuringDiagnostics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/StructuringDiagnostics.cs
@@ -1,0 +1,33 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Optional sink that records, per block container, why <see cref="StructuringPass"/>
+/// left it flat (or that it structured cleanly). It exists only to make the
+/// "forward branch to a common exit past the region" docket
+/// (docs/design/control-flow-structuring.md) reproducible on demand: a normal
+/// run leaves <see cref="PassContext.StructuringDiagnostics"/> null and the pass
+/// records nothing, so there is zero behavioral or allocation cost outside the
+/// <c>--structuring-bails</c> diagnostic.
+///
+/// <para>One sink is created per method run; each bailed container contributes
+/// one reason and each structured container increments <see cref="Structured"/>.
+/// The reason is the deepest direct cause: <c>Validate</c> records the first
+/// (innermost) labelled bail it hits, so propagation up the recursion does not
+/// overwrite it.</para>
+/// </summary>
+public sealed class StructuringDiagnostics
+{
+    readonly List<string> _bails = [];
+
+    /// <summary>One reason string per container the pass left flat.</summary>
+    public IReadOnlyList<string> Bails => _bails;
+
+    /// <summary>The number of containers the pass structured into nested if/diamond regions.</summary>
+    public int Structured { get; private set; }
+
+    /// <summary>Record that a container was left flat for the given reason.</summary>
+    public void RecordBail(string reason) => _bails.Add(reason);
+
+    /// <summary>Record that a container structured cleanly.</summary>
+    public void RecordStructured() => Structured++;
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -60,6 +60,7 @@ static class Program
         bool passImpact = false;
         string? passImpactPass = null;
         bool showDiff = false;
+        bool structuringBails = false;
         int cap = int.MaxValue;
 
         for (int i = 0; i < args.Length; i++)
@@ -100,6 +101,7 @@ static class Program
                         passImpactPass = args[++i];
                     break;
                 case "--show-diff": showDiff = true; break;
+                case "--structuring-bails": structuringBails = true; break;
                 case "--cap": cap = int.Parse(args[++i]); break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
@@ -148,6 +150,9 @@ static class Program
 
         if (passImpact)
             return PassImpact(assemblies, passImpactPass, showDiff, cap);
+
+        if (structuringBails)
+            return StructuringBails(assemblies, cap);
 
         if (pipelineName.Equals("next", StringComparison.OrdinalIgnoreCase))
             return SweepNext(assemblies);
@@ -363,6 +368,69 @@ static class Program
             Console.WriteLine();
             Console.WriteLine($"{canonicalPass} changed {matched}/{scope} ({Percent(matched, total)}); {crashes} pass bugs");
         }
+        return crashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Tally why <see cref="StructuringPass"/> leaves block containers flat
+    /// (docs/design/control-flow-structuring.md, first PR of the structuring
+    /// track). Each method runs the Default pipeline with a
+    /// <see cref="StructuringDiagnostics"/> sink attached; the pass records one
+    /// reason per container it bails on and one tick per container it structures.
+    /// The output is a per-container histogram — the reproducible measurement
+    /// behind the "forward branch to a common exit past the region" docket that
+    /// the index-range model cannot express. Behavior is unchanged: the sink only
+    /// observes the bail decisions the pass already makes.
+    /// </summary>
+    static int StructuringBails(List<string> assemblies, int cap)
+    {
+        long total = 0, crashes = 0, structured = 0, bailedContainers = 0, methodsWithBail = 0;
+        var reasons = new Dictionary<string, (long Count, string Example)>(StringComparer.Ordinal);
+        bool capped = false;
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath);
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                if (total >= cap) { capped = true; break; }
+                total++;
+
+                var diagnostics = new StructuringDiagnostics();
+                var context = new PassContext(new Stepper(enabled: false), diagnostics);
+                try
+                {
+                    IrPasses.Run(function, IrPasses.Default, context);
+                }
+                catch (Exception ex)
+                {
+                    crashes++;
+                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                    continue;
+                }
+
+                structured += diagnostics.Structured;
+                if (diagnostics.Bails.Count > 0)
+                    methodsWithBail++;
+                foreach (var reason in diagnostics.Bails)
+                {
+                    bailedContainers++;
+                    var prior = reasons.GetValueOrDefault(reason);
+                    reasons[reason] = (prior.Count + 1,
+                        prior.Example ?? $"{typeName}::{methodName}");
+                }
+            }
+            if (capped) break;
+        }
+
+        string scope = capped ? $"{total} methods (capped)" : $"{total} methods";
+        Console.WriteLine();
+        Console.WriteLine($"structuring bails over {scope} ({crashes} pass bugs):");
+        Console.WriteLine($"  {structured} containers structured; " +
+            $"{bailedContainers} bailed across {methodsWithBail} methods");
+        Console.WriteLine();
+        foreach (var entry in reasons.OrderByDescending(e => e.Value.Count))
+            Console.WriteLine($"  {entry.Value.Count,8}  {entry.Key,-30}  e.g. {entry.Value.Example}");
         return crashes > 0 ? 1 : 0;
     }
 
@@ -1190,8 +1258,12 @@ static class Program
                                 changed. Add --show-diff for each method's hunk.
           --show-diff           with --pass-impact <pass>: print the per-pass diff
                                 hunk under each changed method.
-          --cap <n>             with --pass-impact: stop after n methods (default:
-                                unlimited). Bounds a full-CoreLib stage sweep.
+          --structuring-bails   tally why StructuringPass leaves containers flat:
+                                a per-container histogram of bail reasons (the
+                                common-exit merge docket). Honors --cap.
+          --cap <n>             with --pass-impact/--structuring-bails: stop after
+                                n methods (default: unlimited). Bounds a full-CoreLib
+                                stage sweep.
         """);
 }
 


### PR DESCRIPTION
First PR of the control-flow structuring track (docs/design/control-flow-structuring.md). Lands the bail-reason diagnostic the design doc calls for, so the merge docket becomes a reproducible number every subsequent step can measure against.

## What

- **`StructuringDiagnostics` sink**, threaded through the existing `PassContext` seam (the type's own doc comment names it the diagnostics seam). Null on every normal run, so zero behavior or allocation cost.
- **`StructuringPass`** labels each direct `return false` in `Validate` (plus the top-level `Run`/`Structure` guards) with a reason code, recording the *first/innermost* cause per container; recursive propagation never overwrites it. The compound `target <= i || target > stop` bail is split into two `if`s so the backward-loop and common-exit-merge causes count separately — control flow is identical.
- **`decompiler-harness --structuring-bails`**: runs the Default pipeline per method with the sink attached and prints a per-container histogram of bail reasons (honors `--cap`).

## Measurement (net11 CoreLib, 41,012 methods)

```
10,166 containers structured; 1,672 bailed across 1,645 methods

     876  cond-target-past-region
     599  forward-branch-not-region-exit
     108  unconsumed-regions
      61  cond-backward-branch
      14  leave-target-in-container
      14  eh-terminator-survivor
```

`cond-target-past-region` + `forward-branch-not-region-exit` = **1,475** — the forward-branch-to-common-exit shape the index-range model cannot express, exactly as the doc predicted. Counts are per container (a method may bail in more than one), so they differ from DiffNext's per-method `candidate-worse`.

## Soundness

The diagnostic only *observes* the bail decisions the pass already makes; the sink is null in production. Behavior is byte-identical: **513 decompiler tests green** (5 new — common-exit bail, guard-chain success, and a no-sink/sink output-equality check), **0 pass bugs** over the full sweep.
