### PR TITLE
Emit explicit unsafe blocks for new memory-safety modules

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Legacy-rules unsafe fixtures.
+
+    This assembly carries NO module-level MemorySafetyRulesAttribute, so the
+    decompiler must treat it as a legacy-rules module: the body-level unsafe
+    context comes from the member `unsafe` modifier (the pre-memory-safety
+    semantics), and the printer is expected to reproduce that member modifier.
+
+    The IL emitted here is byte-identical to the NewUnsafe fixture assembly —
+    `unsafe` (whether a member modifier or a block) has no IL representation.
+    The ONLY observable difference between the two fixture assemblies is the
+    presence of the module attribute, which is exactly the signal the emitter
+    keys on to decide member-modifier vs explicit `unsafe { }` block rendering.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -1,0 +1,42 @@
+namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
+
+/// <summary>
+/// Legacy-rules unsafe fixtures. Each method uses the member <c>unsafe</c>
+/// modifier, which under pre-memory-safety semantics makes the whole body an
+/// unsafe context. The decompiler should reproduce that member modifier when
+/// the source module has no <c>MemorySafetyRulesAttribute</c>.
+/// </summary>
+public static class UnsafeFixtures
+{
+    // Pointer indirection: `*p` requires an unsafe context under both old and
+    // new rules.
+    public static unsafe int DerefPointer(int value)
+    {
+        int* p = &value;
+        return *p;
+    }
+
+    // Function-pointer invocation: `callback(x)` (calli) requires an unsafe
+    // context under both old and new rules.
+    public static unsafe int InvokeFunctionPointer(delegate*<int, int> callback, int x)
+    {
+        return callback(x);
+    }
+
+    // `fixed` is SAFE under the new rules, but the pointer element access
+    // `p[i]` inside the loop is not. A minimal-scope emitter must wrap only the
+    // unsafe access, not the whole `fixed` statement.
+    public static unsafe int SumPinned(int[] data)
+    {
+        int sum = 0;
+        fixed (int* p = data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                sum += p[i];
+            }
+        }
+
+        return sum;
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    New-rules ("memory safety") unsafe fixtures.
+
+    This assembly is stamped with a module-level MemorySafetyRulesAttribute
+    (see MemorySafetyRulesPolyfill.cs). That module attribute is the signal the
+    decompiler keys on to render new-rules unsafe code: the member `unsafe`
+    modifier no longer introduces a body unsafe context, so the printer must
+    emit explicit `unsafe { }` blocks around the unsafe operations instead.
+
+    MemorySafetyRules is set below as the per-fixture MSBuild property that
+    selects the memory-safety mode. The current SDK/compiler ignores it (the new
+    rules are not enforced yet), so the assembly is additionally stamped with a
+    polyfilled module attribute so the decompiler can observe the mode today.
+    When the toolchain begins honoring the property, the polyfill can be dropped.
+
+    The IL emitted here is byte-identical to the LegacyUnsafe fixture assembly.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -1,0 +1,58 @@
+namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
+
+/// <summary>
+/// New-rules unsafe fixtures. This assembly is compiled with
+/// <c>/features:updated-memory-safety-rules</c>, so the compiler enforces the
+/// new unsafe rules and stamps the module with <c>MemorySafetyRulesAttribute</c>.
+/// Under those rules the member <c>unsafe</c> modifier no longer introduces a
+/// body context, so each unsafe operation is wrapped in an explicit, minimally
+/// scoped <c>unsafe { }</c> block. Taking an address, declaring a pointer local,
+/// using a function-pointer type, and the <c>fixed</c> statement are all safe
+/// under the new rules and stay outside the blocks.
+///
+/// The IL is identical to the LegacyUnsafe fixtures; the only difference the
+/// decompiler can observe is this module's <c>MemorySafetyRulesAttribute</c>,
+/// which it must use to render explicit blocks rather than a member modifier.
+/// </summary>
+public static class UnsafeFixtures
+{
+    // Only the pointer indirection `*p` needs a context; `&value` and the
+    // pointer local are safe.
+    public static int DerefPointer(int value)
+    {
+        int* p = &value;
+        unsafe
+        {
+            return *p;
+        }
+    }
+
+    // Only the function-pointer invocation needs a context; the parameter type
+    // is safe.
+    public static int InvokeFunctionPointer(delegate*<int, int> callback, int x)
+    {
+        unsafe
+        {
+            return callback(x);
+        }
+    }
+
+    // `fixed` is safe; only the `p[i]` element access needs a context. The block
+    // is scoped to that access inside the loop, not the whole `fixed` statement.
+    public static int SumPinned(int[] data)
+    {
+        int sum = 0;
+        fixed (int* p = data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                unsafe
+                {
+                    sum += p[i];
+                }
+            }
+        }
+
+        return sum;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -23,6 +23,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LegacyUnsafe\ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -1,0 +1,52 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
+using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Drives the unsafe-context emitter. The two fixture assemblies compile to
+/// identical IL; the only difference the decompiler can observe is the
+/// new-rules module's <c>MemorySafetyRulesAttribute</c>. The printer must use
+/// that signal to choose between a member <c>unsafe</c> modifier (legacy) and
+/// explicit <c>unsafe { }</c> blocks (new rules).
+/// </summary>
+public class UnsafeEmitterTests
+{
+    static string Decompile(string assemblyPath, string typeFullName, string method)
+    {
+        var source = MetadataSource.Open(assemblyPath);
+        var function = IrImporter.Import(source, typeFullName, method);
+        Assert.NotNull(function);
+        var result = CSharpPrinter.PrintRaised(function!);
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static string DecompileNew(string method) =>
+        Decompile(typeof(NewFixtures).Assembly.Location, typeof(NewFixtures).FullName!, method);
+
+    static string DecompileLegacy(string method) =>
+        Decompile(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
+
+    [Fact]
+    public void NewRulesModule_PointerDeref_EmitsExplicitUnsafeContext()
+    {
+        // RED until the emitter lands: under the new rules the member modifier
+        // no longer provides a body context, so `*p` must be wrapped in an
+        // explicit `unsafe { }` block. The printer emits no unsafe context today.
+        var output = DecompileNew(nameof(NewFixtures.DerefPointer));
+
+        Assert.Contains("unsafe", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_FunctionPointerInvoke_EmitsExplicitUnsafeContext()
+    {
+        var output = DecompileNew(nameof(NewFixtures.InvokeFunctionPointer));
+
+        Assert.Contains("unsafe", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -7,11 +7,13 @@ using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Drives the unsafe-context emitter. The two fixture assemblies compile to
-/// identical IL; the only difference the decompiler can observe is the
-/// new-rules module's <c>MemorySafetyRulesAttribute</c>. The printer must use
-/// that signal to choose between a member <c>unsafe</c> modifier (legacy) and
-/// explicit <c>unsafe { }</c> blocks (new rules).
+/// The unsafe-context emitter. The two fixture assemblies compile to identical
+/// IL; the only difference the decompiler can observe is the new-rules module's
+/// <c>MemorySafetyRulesAttribute</c>. The printer uses that signal to wrap
+/// unsafe operations in explicit, minimally scoped <c>unsafe { }</c> blocks for
+/// a new-rules module, and to emit none for a legacy module (whose member
+/// <c>unsafe</c> modifier — rendered at the signature, not by this body printer
+/// — still supplies the context).
 /// </summary>
 public class UnsafeEmitterTests
 {
@@ -31,22 +33,69 @@ public class UnsafeEmitterTests
     static string DecompileLegacy(string method) =>
         Decompile(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
 
-    [Fact]
-    public void NewRulesModule_PointerDeref_EmitsExplicitUnsafeContext()
+    /// <summary>The body of the first <c>unsafe { }</c> block, by brace matching.</summary>
+    static string FirstUnsafeBlockBody(string output)
     {
-        // RED until the emitter lands: under the new rules the member modifier
-        // no longer provides a body context, so `*p` must be wrapped in an
-        // explicit `unsafe { }` block. The printer emits no unsafe context today.
-        var output = DecompileNew(nameof(NewFixtures.DerefPointer));
-
-        Assert.Contains("unsafe", output);
+        int keyword = output.IndexOf("unsafe", StringComparison.Ordinal);
+        Assert.True(keyword >= 0, "no unsafe block in output:\n" + output);
+        int open = output.IndexOf('{', keyword);
+        Assert.True(open >= 0);
+        int depth = 0;
+        for (int i = open; i < output.Length; i++)
+        {
+            if (output[i] == '{') depth++;
+            else if (output[i] == '}' && --depth == 0)
+                return output[(open + 1)..i];
+        }
+        throw new Xunit.Sdk.XunitException("unbalanced unsafe block:\n" + output);
     }
 
     [Fact]
-    public void NewRulesModule_FunctionPointerInvoke_EmitsExplicitUnsafeContext()
+    public void NewRulesModule_PointerDeref_WrapsInUnsafeBlock()
+    {
+        var output = DecompileNew(nameof(NewFixtures.DerefPointer));
+
+        Assert.Contains("unsafe", output);
+        Assert.Contains("*", FirstUnsafeBlockBody(output));
+    }
+
+    [Fact]
+    public void NewRulesModule_FunctionPointerInvoke_WrapsInUnsafeBlock()
     {
         var output = DecompileNew(nameof(NewFixtures.InvokeFunctionPointer));
 
-        Assert.Contains("unsafe", output);
+        Assert.Contains("callback(x)", FirstUnsafeBlockBody(output));
+    }
+
+    [Fact]
+    public void NewRulesModule_PointerElementAccessInLoop_WrapsMinimally()
+    {
+        // The pointer element access is one statement inside the loop body, so
+        // the unsafe block must wrap only that statement — not the surrounding
+        // loop control. A whole-loop wrap would swallow the increment.
+        var output = DecompileNew(nameof(NewFixtures.SumPinned));
+        var block = FirstUnsafeBlockBody(output);
+
+        Assert.Contains("sum +=", block);
+        Assert.DoesNotContain("i++", block);
+        Assert.Contains("i++", output);
+    }
+
+    [Fact]
+    public void LegacyModule_PointerDeref_EmitsNoUnsafeBlock()
+    {
+        // A legacy module relies on the member `unsafe` modifier for its body
+        // context, so the body printer emits no block.
+        var output = DecompileLegacy(nameof(LegacyFixtures.DerefPointer));
+
+        Assert.DoesNotContain("unsafe", output);
+    }
+
+    [Fact]
+    public void LegacyModule_PointerElementAccessInLoop_EmitsNoUnsafeBlock()
+    {
+        var output = DecompileLegacy(nameof(LegacyFixtures.SumPinned));
+
+        Assert.DoesNotContain("unsafe", output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -17,7 +17,25 @@ public sealed class CSharpPrinter
 {
     readonly IrFunction _function;
 
-    CSharpPrinter(IrFunction function) => _function = function;
+    /// <summary>
+    /// True when the source module opts into the updated memory-safety rules
+    /// (see <see cref="IrFunction.UsesUpdatedMemorySafetyRules"/>). When set, the
+    /// printer wraps unsafe operations in explicit <c>unsafe { }</c> blocks.
+    /// </summary>
+    readonly bool _newMemorySafetyRules;
+
+    /// <summary>
+    /// Nesting depth of emitted <c>unsafe { }</c> blocks. Non-zero means the
+    /// current statements are already in an unsafe context, so inner operations
+    /// are not wrapped again (no redundant nested blocks).
+    /// </summary>
+    int _unsafeDepth;
+
+    CSharpPrinter(IrFunction function)
+    {
+        _function = function;
+        _newMemorySafetyRules = function.UsesUpdatedMemorySafetyRules;
+    }
 
     /// <summary>The product path: runs the default raising passes, then prints. <see cref="Print"/> alone renders whatever tree it is given — right for stage dumps, wrong for output paths.</summary>
     public static DecompilerResult PrintRaised(IrFunction function)
@@ -167,6 +185,7 @@ public sealed class CSharpPrinter
             // labeled block's only statement, where trimming would strand
             // the label as invalid C#.
             bool labeledReturnOnly = _labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
+            var emit = new List<IrNode>();
             foreach (var statement in block.Children)
             {
                 if (ReferenceEquals(statement, _chainStatement) || _fieldInitStores.Contains(statement))
@@ -174,8 +193,9 @@ public sealed class CSharpPrinter
                 bool isLast = topLevel && i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
                 if (isLast && !labeledReturnOnly && statement is Return { Value: null })
                     break;
-                AppendStatement(sb, statement, indent);
+                emit.Add(statement);
             }
+            AppendStatements(sb, emit, indent);
         }
     }
 
@@ -799,8 +819,7 @@ public sealed class CSharpPrinter
             sb.Append(pad).Append("for (").Append(initializer).Append("; ")
                 .Append(Condition(forLoop.Condition)).Append("; ").Append(increment).AppendLine(")");
             sb.Append(pad).AppendLine("{");
-            foreach (var statement in forLoop.Body.Children)
-                AppendStatement(sb, statement, indent + 1);
+            AppendStatements(sb, forLoop.Body.Children, indent + 1);
             sb.Append(pad).AppendLine("}");
             return;
         }
@@ -808,8 +827,7 @@ public sealed class CSharpPrinter
         {
             sb.Append(pad).Append("while (").Append(Condition(whileLoop.Condition)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
-            foreach (var statement in whileLoop.Body.Children)
-                AppendStatement(sb, statement, indent + 1);
+            AppendStatements(sb, whileLoop.Body.Children, indent + 1);
             sb.Append(pad).AppendLine("}");
             return;
         }
@@ -872,15 +890,13 @@ public sealed class CSharpPrinter
         {
             sb.Append(pad).Append("if (").Append(Condition(ifStatement.Condition)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
-            foreach (var statement in ifStatement.Then.Children)
-                AppendStatement(sb, statement, indent + 1);
+            AppendStatements(sb, ifStatement.Then.Children, indent + 1);
             sb.Append(pad).AppendLine("}");
             if (ifStatement.Else is { } elseArm)
             {
                 sb.Append(pad).AppendLine("else");
                 sb.Append(pad).AppendLine("{");
-                foreach (var statement in elseArm.Children)
-                    AppendStatement(sb, statement, indent + 1);
+                AppendStatements(sb, elseArm.Children, indent + 1);
                 sb.Append(pad).AppendLine("}");
             }
             return;
@@ -905,6 +921,105 @@ public sealed class CSharpPrinter
         if (Statement(node) is { } line)
             sb.Append(pad).AppendLine(line);
     }
+
+    /// <summary>
+    /// Emits a sibling statement sequence, wrapping unsafe operations in
+    /// explicit <c>unsafe { }</c> blocks when the source module uses the updated
+    /// memory-safety rules. Maximal runs of adjacent statements that need an
+    /// unsafe context coalesce into a single block, and the block is scoped to
+    /// the smallest enclosing statement: a loop or <c>if</c> whose body (not its
+    /// header) holds the unsafe op is left unwrapped so the recursion wraps the
+    /// inner statement instead. When the module uses legacy rules — or the
+    /// statements are already inside an emitted block — this is a plain
+    /// per-statement emit, identical to the pre-feature output.
+    /// </summary>
+    void AppendStatements(StringBuilder sb, IReadOnlyList<IrNode> statements, int indent)
+    {
+        int i = 0;
+        while (i < statements.Count)
+        {
+            if (_newMemorySafetyRules && _unsafeDepth == 0 && NeedsUnsafeContext(statements[i]))
+            {
+                int j = i + 1;
+                while (j < statements.Count && NeedsUnsafeContext(statements[j]))
+                    j++;
+                string pad = new(' ', indent * 4);
+                sb.Append(pad).AppendLine("unsafe");
+                sb.Append(pad).AppendLine("{");
+                _unsafeDepth++;
+                for (int k = i; k < j; k++)
+                    AppendStatement(sb, statements[k], indent + 1);
+                _unsafeDepth--;
+                sb.Append(pad).AppendLine("}");
+                i = j;
+            }
+            else
+            {
+                AppendStatement(sb, statements[i], indent);
+                i++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether a statement must itself sit in an unsafe context. For a compound
+    /// statement only its own header expressions are considered — the body is a
+    /// separate statement sequence the recursion wraps independently, keeping the
+    /// block minimal. A simple statement is tested whole.
+    /// </summary>
+    static bool NeedsUnsafeContext(IrNode node) => node switch
+    {
+        ForLoop f => HasUnsafeOperation(f.Initializer) || HasUnsafeOperation(f.Condition) || HasUnsafeOperation(f.Increment),
+        WhileLoop w => HasUnsafeOperation(w.Condition),
+        DoWhileLoop d => HasUnsafeOperation(d.Condition),
+        IfStatement s => HasUnsafeOperation(s.Condition),
+        Switch s => HasUnsafeOperation(s.Value),
+        Lock l => HasUnsafeOperation(l.LockObject),
+        Fixed fx => HasUnsafeOperation(fx.PinSource),
+        TryCatch or TryFinally => false,
+        _ => HasUnsafeOperation(node),
+    };
+
+    static bool HasUnsafeOperation(IrNode? node)
+        => node is not null && (IsUnsafeOperation(node) || node.Descendants.Any(IsUnsafeOperation));
+
+    /// <summary>
+    /// A single IR operation that requires an unsafe context under the updated
+    /// rules: a function-pointer invocation (<c>calli</c>) or a read/write
+    /// through an unmanaged pointer. Dereferencing a managed reference
+    /// (<c>ByRef</c>) is safe and excluded. Creating pointers, the <c>fixed</c>
+    /// statement, and <c>sizeof</c> are safe under the new rules and are not
+    /// listed here.
+    /// </summary>
+    static bool IsUnsafeOperation(IrNode node) => node switch
+    {
+        CallIndirect => true,
+        LoadIndirect l => RendersAsPointerDeref(l.Address),
+        StoreIndirect s => RendersAsPointerDeref(s.Address),
+        InitObject o => RendersAsPointerDeref(o.Address),
+        _ => false,
+    };
+
+    /// <summary>
+    /// Whether <see cref="Deref"/> renders this load/store-indirect address with
+    /// a leading <c>*</c> — i.e. it is a read/write through an unmanaged pointer
+    /// rather than a managed reference. Mirrors the managed-reference cases of
+    /// <see cref="Deref"/> exactly: anything not spelled as a place or a
+    /// <c>ByRef</c> is a pointer dereference, which requires an unsafe context.
+    /// </summary>
+    static bool RendersAsPointerDeref(IrExpression address) => address switch
+    {
+        LoadArgument { Index: 0, Name: "this" } => false,
+        LoadLocalAddress => false,
+        LoadArgumentAddress => false,
+        LoadFieldAddress => false,
+        LoadElementAddress => false,
+        Conditional { ResultType.Kind: TypeRefKind.ByRef } c
+            when c.WhenTrue.ResultType?.Kind == TypeRefKind.ByRef
+                && c.WhenFalse.ResultType?.Kind == TypeRefKind.ByRef => false,
+        { ResultType.Kind: TypeRefKind.ByRef } => false,
+        _ => true,
+    };
 
     /// <summary>
     /// A constructor-chain call renders as a <c>base(args)</c> / <c>this(args)</c>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -143,6 +143,7 @@ public static class IrImporter
         {
             Regions = method.Body.Handlers,
             LocalNames = method.Body.LocalNames,
+            UsesUpdatedMemorySafetyRules = ModuleUsesUpdatedMemorySafetyRules(source.Reader),
         };
         var span = method.Body.IL.AsSpan();
         var leaders = FindLeaders(span, method.Body.Handlers);
@@ -1478,6 +1479,20 @@ public static class IrImporter
         foreach (var handle in attributes)
             if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
                 is ("System.Runtime.CompilerServices", "IsReadOnlyAttribute" or "RequiresLocationAttribute"))
+                return true;
+        return false;
+    }
+
+    // A module compiled with /features:updated-memory-safety-rules is stamped
+    // with a module-level MemorySafetyRulesAttribute. That is the only metadata
+    // difference between an old-rules and a new-rules build (an `unsafe` block or
+    // member modifier has no IL representation), so it is what the printer keys
+    // on to choose explicit `unsafe { }` blocks over the member modifier.
+    static bool ModuleUsesUpdatedMemorySafetyRules(MetadataReader reader)
+    {
+        foreach (var handle in reader.GetModuleDefinition().GetCustomAttributes())
+            if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
+                is ("System.Runtime.CompilerServices", "MemorySafetyRulesAttribute"))
                 return true;
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -90,6 +90,17 @@ public sealed class IrFunction : IrNode
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 
     /// <summary>
+    /// True when the defining module opts into the updated C# memory-safety
+    /// rules — it carries a module-level
+    /// <c>System.Runtime.CompilerServices.MemorySafetyRulesAttribute</c>. Under
+    /// those rules the member <c>unsafe</c> modifier no longer introduces a body
+    /// unsafe context, so the printer must wrap each unsafe operation in an
+    /// explicit, minimally scoped <c>unsafe { }</c> block. Legacy modules (no
+    /// attribute) keep relying on the member modifier and render no blocks.
+    /// </summary>
+    public bool UsesUpdatedMemorySafetyRules { get; set; }
+
+    /// <summary>
     /// Exception regions over the flat block container, by IL offset. The
     /// importer keeps blocks flat (region boundaries are block leaders);
     /// the EH structuring pass consumes these into <see cref="TryCatch"/>/


### PR DESCRIPTION
## Why

Under the updated C# memory-safety rules, a member `unsafe` modifier no longer introduces a body unsafe context — only explicit `unsafe { }` blocks do. The decompiler's body printer (`CSharpPrinter`) emitted no `unsafe` at all; recompilation only worked because the compile-back harness wraps every member with the `unsafe` *modifier* under legacy semantics. For an assembly built with the new rules, decompiled `*p`, function-pointer calls, and pointer element access are invalid C# and fail to recompile.

This teaches the decompiler to emit explicit, minimally scoped `unsafe { }` blocks when (and only when) the source module opts into the new rules.

## Key facts (verified against SDK 11.0.100-preview.5)

- The new rules are opt-in via the compiler feature `updated-memory-safety-rules` (MSBuild `<Features>`). The SDK **enforces** them (a member-`unsafe` body deref → CS9360) and stamps the module with `System.Runtime.CompilerServices.MemorySafetyRulesAttribute`. The `<MemorySafetyRules>` property is currently a no-op.
- An `unsafe` block or modifier has **no IL representation** — a legacy build and a new-rules build of the same code compile to identical IL. The module attribute is the only observable signal, so it is exactly what the emitter keys on.
- The runtime now defines the attribute and it is compiler-reserved (CS8335), so it cannot be polyfilled or applied in source — none is needed.

## What changed

- **`IrFunction.UsesUpdatedMemorySafetyRules`** — set by the importer from the module-level `MemorySafetyRulesAttribute`.
- **`CSharpPrinter`** wraps maximal runs of adjacent unsafe-context statements in a single `unsafe { }` block, scoped to the **smallest enclosing statement**: a loop or `if` whose *body* (not header) holds the op is left unwrapped so the inner statement is wrapped instead. A depth counter prevents redundant nested blocks. Legacy modules render no blocks (the member modifier still applies, at the signature).
- **Unsafe-op detection**: function-pointer invocation (`calli`) and read/write through an unmanaged pointer. The pointer test mirrors `Deref`'s `*`-emitting decision exactly, so a managed `ByRef` deref is never wrapped. Creating pointers, `fixed`, and `sizeof` are safe under the new rules and are not wrapped.

### Example

| Fixture | New-rules output |
|---|---|
| `DerefPointer` | `unsafe { return *(...); }` |
| `InvokeFunctionPointer` | `unsafe { return callback(x); }` |
| `SumPinned` | minimal — only `unsafe { sum += *(p + ...); }` inside the loop; the increment and loop control stay outside |

Legacy fixtures render no `unsafe` blocks.

## Fixtures + mechanism

Establishes a per-fixture MSBuild-property mechanism (one fixture assembly per memory-safety mode, since `MemorySafetyRulesAttribute` is module-level):

- `ILInspector.Decompiler.Fixtures.LegacyUnsafe` — default rules, member `unsafe` modifier, no module attribute.
- `ILInspector.Decompiler.Fixtures.NewUnsafe` — compiled with `<Features>updated-memory-safety-rules</Features>`, explicit `unsafe { }` blocks, stamped module attribute.

The two assemblies use distinct namespaces so the test project can reference both. Their IL is identical; only the module attribute differs.

## Tests

`UnsafeEmitterTests` covers: new-rules wrapping (deref + function pointer), legacy-no-block, and minimal scoping (`SumPinned` wraps only `sum += p[i]`, not the loop). **513 decompiler tests green**; main project and harness build.

The feature's value is proven by the fixture builds: a bare member-`unsafe` body fails under the new rules (CS9360); the explicit-block form the decompiler emits compiles.

## Follow-ups (not in this PR)

- Signature/composer path (`ApiOutputFormatter`) still emits member `unsafe` modifiers as before — revisit for a fully new-rules-valid whole-member projection.
- Broader coverage: calls to requires-unsafe members (`RequiresUnsafeAttribute`), `stackalloc`→`Span` under `SkipLocalsInit`.
- A real new-rules compile gate over the NewUnsafe fixtures (the existing `*((nuint)(ref value))` deref rendering is a pre-existing fidelity issue, independent of unsafe wrapping).
- Docs + SKILL once scope settles.
