### PR TITLE
Add decompiler-quality.md; focus the decompiler doc set

### DIFF
--- a/docs/decompiler-pipeline.md
+++ b/docs/decompiler-pipeline.md
@@ -1,6 +1,6 @@
 # Decompiler Pipeline Design
 
-This document describes the architecture of `ILInspector.Decompiler`. The companion [decompiler-taste.md](decompiler-taste.md) governs *what* the decompiler renders; this document governs *how the pipeline decides it*.
+This document describes the architecture of `ILInspector.Decompiler` — *how the pipeline decides* its output. Three companion docs cover the rest: [decompiler-ir.md](decompiler-ir.md) is the focused reference for the IR and importer contracts this doc builds on, [decompiler-taste.md](decompiler-taste.md) governs *what* the decompiler renders, and [decompiler-quality.md](decompiler-quality.md) is *how we know the output is right*.
 
 ## Design goal: recognizability
 
@@ -31,24 +31,34 @@ Decompilation is this pipeline run in reverse. Where Roslyn *lowers* C# construc
 
 ## Architecture
 
-```text
-PE/metadata
-  → MetadataSource              (PE + metadata + optional PDB lifetime; SRM-only)
-  → IrImporter.Import           (raw IL → typed IR tree, with symbolic type identity)
-  → IrPasses.Default            (ordered raising passes — one named class, one job;
-                                 CheckInvariant after each in debug builds)
-  → CSharpPrinter.PrintRaised   (runs the passes, then prints the raised tree;
-                                 taste-doc spelling policy lives here)
+```mermaid
+flowchart LR
+    PE[PE / metadata] --> MS[MetadataSource]
+    MS --> IM[IrImporter.Import]
+    IM --> IR[(typed IR tree)]
+    IR --> PASS[IrPasses.Default]
+    PASS -->|raised tree| PR[CSharpPrinter.PrintRaised]
+    PR --> CS[C# source]
+
+    MCP[MemberCodeProvider] -.->|member| MS
+    TSC[TypeSourceComposer] -.->|whole-type| MS
 ```
 
-The product reaches it through `MemberCodeProvider` (member level) and `TypeSourceComposer` (whole-type). `IrImporter.Import` and `CSharpPrinter.PrintRaised` are both exception-safe by construction: a one-method bug surfaces as a diagnostic comment and a lowered fidelity level, never a crash or silently-wrong output.
+| Stage | Role |
+| --- | --- |
+| `MetadataSource` | PE + metadata + optional PDB lifetime; SRM-only ([decompiler-ir.md](decompiler-ir.md) defines the contract) |
+| `IrImporter.Import` | raw IL → typed IR tree, with symbolic type identity (`TypeRef`) |
+| `IrPasses.Default` | ordered raising passes — one named class, one job; `CheckInvariant` after each in debug builds |
+| `CSharpPrinter.PrintRaised` | runs the passes, then prints the raised tree; taste-doc spelling policy lives here |
+
+The IR and importer contracts are specified in [decompiler-ir.md](decompiler-ir.md); this doc treats them as given and describes how the stages compose. The product reaches the pipeline through `MemberCodeProvider` (member level) and `TypeSourceComposer` (whole-type). `IrImporter.Import` and `CSharpPrinter.PrintRaised` are both exception-safe by construction: a one-method bug surfaces as a diagnostic comment and a lowered fidelity level, never a crash or silently-wrong output (see [decompiler-quality.md](decompiler-quality.md) for what that floor guarantees).
 
 Key properties:
 
 - **The statement tree is the library's product, not the string.** Alternate front ends (IDE hovers, web viewers, diff tools) consume the tree and apply their own formatting and spans; our printer is merely the first front end. Taste splits across two homes: **raising policy** — which patterns the passes recover (`lock`, `using`, switch expressions vs. goto; the taste doc's three-class rule) — lives in the pipeline and shapes the tree itself, while **spelling policy** (qualification, parenthesization, formatting) lives in the printer and is the part alternate front ends may replace.
 - **Whole-type composition lives in the library.** `TypeSourceComposer` (in `ILInspector.Decompiler`) gives any front end per-type listings, using-hoisting, and forwarder-following without rebuilding them.
 - **Naming is a final pass over fully-determined scopes**, as in ILSpy's `AssignVariableNames`. PDB local scopes are its natural input. The two remaining corpus gaps (synthesized names for `S_N`/`V_N`, multi-scope declaration placement) are this pass, not emitter features.
-- **Every stage boundary is a projectable IR.** One `IrPasses.RunWithStages` runner captures the typed IR tree at import and after every pass, and one `StageDump` formatter frames them — exactly JitDump's relationship to GenTree — so `--dump`, `--diff`, `--facts`, and `--pass-impact` all read one capture rather than each rebuilding it. The default projection is the typed IR tree (`IrPrinter`); the annotated-IL import views (raw/typed/structured, from `IlProjection`) prepend as an opt-in (`--il`).
+- **Every stage boundary is a projectable IR.** The default projection is the typed IR tree (`IrPrinter`); the annotated-IL import views (raw/typed/structured, from `IlProjection`) prepend as an opt-in (`--il`). The inspection and verification modes this capture powers are described under *Inspection and verification* below.
 - **Results carry diagnostics, with concrete fidelity levels.** The library returns a result with output, diagnostics, and a fidelity level — never a silent `catch { }` in the library or its hosts. The levels are ordered and concrete, because the product routes on them: `Full` (every construct raised; representable C#), `Partial` (C# containing explicit unrepresentable nodes), `StructuredOnly` (structured control flow over low-level expressions), `IlOnly` (no C# rendering; IL projections still available), `Failed`. IL that has no C# spelling is modeled explicitly in the tree, not forced into plausible text — output degrades honestly, with the reason attached.
 - **Diagnostics get stable IDs from the first PR.** They drive fallback routing and CI triage, so they are machine-readable Roslyn-style identifiers (`DEC0001`-form) with the prose message alongside — never bare strings.
 - **Type identity is symbolic inside the pipeline.** Handles and signatures (byref, pinned, generic, function pointer, token identity) stay typed (`TypeRef`) through the tree; strings appear only at the printer.
@@ -62,34 +72,13 @@ Two divergences from ILSpy are intentional and argued in [decompiler-taste.md](d
 - **Zero runtime dependencies.** The library depends only on `System.Reflection.Metadata` (via `ILInspector.Metadata`). We borrow the architecture of our neighbors, not their packages — no Roslyn syntax trees, no NRefactory-derived AST. The statement tree is small (roughly a dozen node kinds) and hand-written; ILSpy's generated 60 KB instruction set solves a scale problem we do not have.
 - **Dataflow facts proportionate to the rewrites we do.** Cross-block transforms get only the facts they need (the definite-assignment CFG dataflow behind `--facts`, for instance). We deliberately stop short of SSA and value numbering: ILSpy ships a complete decompiler without them, and a JIT-grade dataflow stack would be infrastructure without a customer here.
 
-## Inspection and verification: `--dump-stages` and `--compile-back`
+## Inspection and verification
 
-These two harness modes are the two ends of the same pipeline, and they are designed to meet at a single artifact: the shipped product C#.
+The architecture earns its observability from one property: **every stage boundary is a projectable IR.** A single `IrPasses.RunWithStages` runner captures the typed tree at import and after every pass, and one `StageDump` formatter frames them — exactly JitDump's relationship to GenTree. Every harness mode reads that one capture rather than rebuilding it: `--dump` (the per-pass tree), `--diff` (each pass as a `+`/`-` hunk), `--facts` (the definite-assignment dataflow that decides `= default` elision), `--cfg` (block edges; `--mermaid` renders them), `--remarks` (the IR sites that cap fidelity, each with its `DEC####` code), and `--pass-impact` (the corpus-wide inverse — a pass's blast radius).
 
-Both run the identical decompile front end — `IrImporter.Import` → the canonical `IrPasses` list → `CSharpPrinter`. The only difference is what each does with the result:
+The dump terminates on `CSharpPrinter.Print` of the fully-raised function, **byte-identical to the product's `PrintRaised`**. That is load-bearing: the final stage you inspect is exactly the artifact the verification rails grade, so there is no drift between observation and measurement. `--lowered` selects a lower render altitude — the `IrPasses.Lowered` list, the pipeline minus the cosmetic statement-sugar passes (`ForLoopPass`, `IncrementDecrementPass`, `LockSugarPass`) — still valid, recompilable C#, and earns the same rails.
 
-- **`--dump-stages` is white-box observability.** It answers *how* a method became this C#: `IrPasses.RunWithStages` captures the typed IR after import and after every pass, and the dump frames them in order, terminating on `CSharpPrinter.Print` of the fully-raised function. That final stage is byte-identical to `CSharpPrinter.PrintRaised` — i.e. it is exactly the C# the product emits, not an intermediate view (`PipelineStages.cs`). It is JitDump for the decompiler.
-- **`--compile-back` is a black-box oracle.** It answers *whether* that same C# is semantically faithful: it takes `PrintRaised`'s output, recompiles it inside a reconstructed whole-type skeleton, and compares the canonical IL opcode stream against the original. A body that compiles and reads plausibly but recompiles to a different opcode stream changed the program — the failure class invisible to compile-check and source-grade.
-
-The connection is load-bearing: **the final stage `--dump-stages` shows is exactly the artifact `--compile-back` grades.** Terminating the stage dump on the product renderer is what guarantees no drift between what you inspect and what is measured.
-
-In workflow terms they form the quality loop: **`--compile-back` detects at scale** *which* methods regressed (opcode diffs across whole assemblies), and **`--dump-stages` diagnoses one** of them — drilling into the per-pass IR to find which pass introduced the divergence (`--steps`/`--step-limit` narrows to a single rewrite). Detection → diagnosis, both anchored on the same final C#.
-
-Four narrower inspection modes drill past the per-pass tree into the analyses and structure the tree alone does not show:
-
-- **`--facts`** surfaces the printer's definite-assignment dataflow — the per-block `gen` and `in`/`out` sets, computed by the *same* `CSharpPrinter` walk that ships, that decide which locals keep `= default`. It answers "is this `= default` elision sound?" by reading the analysis instead of running a slow `--compile-back` A/B.
-- **`--cfg`** prints the control-flow graph (predecessor/successor edges) of each block container, so a flat goto-residue body's structure is a glance instead of a reconstruction by eye from `Branch IL_xxxx` targets. The edges come from the shared `Cfg.Build` the definite-assignment dataflow also uses, so the view and the analysis cannot disagree. Add **`--mermaid`** to render the graph as a mermaid `flowchart` (GitHub renders it inline) instead of the textual edge listing.
-- **`--diff`** renders each pass's effect as a unified `+`/`-` hunk over the previous stage (no-change passes collapse), turning "what did this pass do?" into a glance over the same `RunWithStages` capture.
-- **`--remarks`** lists every IR site that caps the method below `Full` fidelity, each paired with its stable `DEC####` code, block offset, and reason — the optimization-remarks analog (LLVM `-Rpass` / opt-viewer). The same predicate that computes `IrFunction.Fidelity` produces the list, so a remark exists for exactly the nodes that lower the score; fidelity is computed from the final tree (never asserted by a pass), so a remark names the IR site and cause, not a pass.
-
-Where `--diff` is per-method, **`--pass-impact`** is its corpus-wide inverse — blast radius. `--diff` answers "for this method, what did each pass do"; `--pass-impact` answers "for this pass, which methods does it change" across a whole assembly. With no pass named it prints a histogram (each pass and the count of methods it altered — the roadmap for which passes carry the load); with a pass name it lists every method that pass changed, optionally with each method's hunk (`--show-diff`). It runs over the same `RunWithStages` capture (a method counts for a pass when any stage of that pass differs from the stage before it, surfaced by the shared `StageDump.PassesThatChanged`/`FormatPassDiff` helpers), and `--cap N` bounds the sweep the way the compile rails do. Use it to scope a pass change before touching it ("how many methods will this pass edit affect, and which") and to validate one after ("the count moved exactly where expected").
-
-Orthogonal to those projections, **`--lowered`** selects a different *render altitude* for the C# itself. The shipped (sugared) output runs the full `IrPasses.Default` pipeline; the lowered view runs `IrPasses.Lowered`, the same pipeline minus the three cosmetic statement-sugar passes (`ForLoopPass`, `IncrementDecrementPass`, `LockSugarPass`), so loops stay `while`, `++`/`--` stay explicit temps, and `lock` stays an explicit `Monitor.Enter`/`Exit` with a `try`/`finally`. It is the decompiler's SharpLab "lowered C#": a lower-level-but-still-valid spelling, never invalid code. The cut is deliberately the largest de-sugaring that stays recompilable — dropping `PropertySugarPass` would emit `get_X()`/`set_X()` (CS0571) and dropping `DelegateConstructionPass` would leave an unspellable `ldftn`, so both stay in. Because the view is still valid C#, it earns the same two quality rails as the sugared view: `--compile-check --lowered` measures its compile rate and `--compile-back --lowered` roundtrips it through the compiler and compares opcode streams (gated by `LoweredCompileBackGateTests`, the lowered twin of `CompileBackGateTests`).
-
-Two notes that save head-scratching:
-
-- **Ref-kind and other call-site defects surface at callers, not at the definition.** Dumping a method's own definition (e.g. `System.AppContext::TryGetSwitch`) can report `fidelity: Full` because its callees are MethodDefs in the same assembly; a `DEC0007` ref-kind loss only appears when you dump a cross-assembly *caller* of that method. Dump the call site, not the target, to reproduce a call-shape defect.
-- **`--skip-pdb` does not affect fidelity.** Local names are cosmetic — they never change emitted IL — so `--compile-back` is unaffected by whether names were recovered. `--skip-pdb` only changes the *spelling* in a dump (`V_n` vs `i`/`j`), for deterministic, symbol-independent reading.
+How those rails (`--compile-back`, `--gaps`, `--compile-check`) prove correctness, what gates CI, and the detect-then-diagnose loop they form are the subject of [decompiler-quality.md](decompiler-quality.md). The harness reference ([tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md)) is the invocation guide for every mode named here.
 
 ## Conventions for pipeline code
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -1,0 +1,152 @@
+# Decompiler Quality
+
+How `ILInspector.Decompiler` stays correct, and how it stays correct as the
+raising passes evolve. The companion docs split the concern: [decompiler-pipeline.md](decompiler-pipeline.md)
+is the architecture (*how* output is produced), [decompiler-taste.md](decompiler-taste.md)
+is *what* to render. This doc is the goal — *how we know the output is right*.
+Tool invocation lives in the harness reference ([tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md));
+here we describe the strategy those tools serve.
+
+## Correct by construction
+
+The pipeline's floor is set in its shape, before any test runs:
+
+- **No crash, no silent wrong output.** `IrImporter.Import` and
+  `CSharpPrinter.PrintRaised` are exception-safe by construction. A one-method
+  bug surfaces as a diagnostic comment and a lowered fidelity level, never a
+  process crash or plausible-but-wrong text.
+- **Honest degradation.** IL with no C# spelling becomes an explicit
+  `UnsupportedNode` rendered as a visible `/* … */` comment, and the result's
+  fidelity level drops accordingly (`Full` → `Partial` → `StructuredOnly` →
+  `IlOnly` → `Failed`). Output never pretends to be more faithful than it is.
+- **Machine-readable diagnostics.** Every degradation carries a stable
+  Roslyn-style `DEC####` code with prose alongside, so CI triage and fallback
+  routing read identifiers, not strings.
+
+Everything below verifies that the output *above* the floor — the `Full`-fidelity
+C# we claim is faithful — actually is.
+
+## The three rails
+
+Correctness is anchored by construction plus weight of evidence — "pounds of
+IL" — rather than per-expression semantic re-resolution. Three independent rails
+measure three different questions; a method can pass one and fail another, so
+they are not redundant:
+
+| Rail | Question | Proves | Blind to |
+| --- | --- | --- | --- |
+| `--compile-back` | *Does it still mean the same thing?* | Semantic **fidelity**: decompile → recompile → compare the canonical opcode stream | Methods it cannot recompile (reported separately, not as diffs) |
+| `--gaps` | *Is the tree fully raised?* | **Completeness**: a method is a gap iff its raised tree still holds unstructured control flow or an `UnsupportedNode` | Whether a fully-raised method is *correct* — only that it is structured |
+| `--compile-check` | *Does it even compile?* | **Validity**: the rendered C# parses, is statement-legal, and binds | Whether valid C# is *faithful* (compile-back's job) |
+
+The deepest is **compile-back**: a body that compiles and reads plausibly but
+recompiles to a different opcode stream changed the program — the worst failure
+class, invisible to every rail that never runs the output back through a
+compiler. The supporting evidence:
+
+- **The IL round-trip oracle.** Our disassembly reassembles (vendored managed
+  ILAssembler, native `ilasm`) to byte-identical IL — the ground truth
+  compile-back grades against.
+- **Fixtures in both configurations.** Purpose-built methods whose *compilation*
+  produces the IL shape under test, run in Debug *and* Release (the compiler
+  emits structurally different IL per configuration; CI runs both).
+- **Corpus sweeps.** Emit-all stress over each platform's CoreLib (three OSes in
+  CI = three corpora). `--gaps` and `--compile-check` measure the sweep two
+  ways; any unexpected delta on a decompiler change is a finding.
+
+## What gates CI
+
+The durable, blocking guard is the **fixture compile-back gate**:
+`CompileBackGateTests` (and its lowered twin `LoweredCompileBackGateTests`)
+decompile every method of `CfgSampleClass`, recompile each inside a reconstructed
+type skeleton, and fail CI when a method newly recompiles to a different opcode
+stream — a regression beyond the documented `KnownDiffs` docket — or when a
+`PinnedExact` method (a previously-fixed one) regresses. Shrinking `KnownDiffs`
+and growing `PinnedExact` is how fidelity progress ratchets forward and cannot
+slip back. The decompiler unit suite (`ILInspector.Decompiler.Tests`) and the IL
+round-trip sweep (`DotnetInspector.ILRoundtrip.Tests`) gate the importer, the
+passes, and the disassembler.
+
+The corpus rails (`--gaps`, `--compile-check`, `--compile-back` over a real
+assembly, `--pass-impact`) are **developer-driven**, not gates: run them while
+working, read them in review. They are the breadth signal; the fixture gate is
+the depth signal.
+
+## The corpus gap, and the plan
+
+The fixture gate is strong but narrow (~80 curated methods). The breadth signals
+are manual. That leaves one gap: **nothing in CI runs the whole CoreLib corpus
+through the pipeline.** The old stack carried a `PlatformAssembly_AllMethods_NoCrashes`
+sweep; it was deleted with that stack and has no replacement yet.
+
+The plan of record is a **corpus-sweep ratchet test** — the new-pipeline analog
+of the deleted sweep, made objective:
+
+- Run every method of the running runtime's CoreLib through `IrImporter →
+  IrPasses → CSharpPrinter` (the SDK pins the version, so the corpus is stable).
+- Assert **floors, not exact baselines**: zero pass-bugs / exceptions (pins the
+  by-construction safety), and `Full`-fidelity % and fully-raised % above a
+  ratchet a couple points below today's numbers. Floors tolerate minor version
+  drift and need no per-method baseline file to maintain — which is why this
+  beats both a fuzzy text-agreement oracle and a brittle exact-baseline net.
+- Cheap: import + passes + the `--gaps` / fidelity classification, no recompile.
+
+It restores the broad regression net (a crash or a broad fidelity/raising drop
+fails CI) using only the self-contained signals we already have. Beyond it,
+deepening *fidelity* coverage means growing the compile-back fixture corpus, not
+widening the sweep.
+
+## The quality loop: detect, then diagnose
+
+The harness modes pair into a loop, both ends anchored on the **same final C#**
+the product emits:
+
+- **Detect at scale.** `--compile-back` finds *which* methods regressed (opcode
+  diffs across an assembly); `--gaps` finds which lost completeness;
+  `--pass-impact` shows a pass's blast radius before and after a change.
+- **Diagnose one.** `--dump` (with `--diff`, `--facts`, `--cfg`, `--remarks`)
+  drills into the per-pass IR of a single method to find which pass introduced
+  the divergence; `--steps` / `--step-limit` narrows to a single rewrite.
+
+The connection is load-bearing: the final stage `--dump` shows is byte-identical
+to what `--compile-back` grades, so there is no drift between what you inspect
+and what is measured.
+
+Two gotchas that save head-scratching when diagnosing:
+
+- **Call-site defects surface at callers, not at the definition.** Dumping a
+  method's own definition (e.g. `System.AppContext::TryGetSwitch`) can report
+  `fidelity: Full` because its callees are MethodDefs in the same assembly; a
+  `DEC0007` ref-kind loss only appears when you dump a cross-assembly *caller*.
+  Dump the call site, not the target, to reproduce a call-shape defect.
+- **`--skip-pdb` does not affect fidelity.** Local names are cosmetic — they
+  never change emitted IL — so `--compile-back` is unaffected by whether names
+  were recovered. `--skip-pdb` only changes the *spelling* in a dump (`V_n` vs
+  `i`/`j`), for deterministic, symbol-independent reading.
+
+## Soundness checklist for IR-mutating passes
+
+Reviews of the raising passes converge on three recurring questions; an author
+who answers them before requesting review collapses the serial round-trips. Any
+pass that detaches, replaces, or rewrites IR nodes states its answers in the PR
+(a short "Soundness" note), and the review verifies them rather than
+rediscovering them:
+
+1. **Prove preconditions whole-function, not locally.** A rewrite that removes a
+   node's defining store (or any binding) must prove the affected locals, slots,
+   and stack positions are referenced *only* by the nodes it consumes — scanned
+   across the whole function, not just the matched neighbourhood. Hand-written or
+   obfuscated IL can wear the shape without being the pattern.
+2. **Preserve semantics exactly.** A conversion, comparison, or identity match
+   keeps checked/unsigned/overflow behaviour and produces valid C# (no CS-error
+   spellings). Match metadata members on assembly identity and exact signature,
+   not just namespace/name and call-site argument shapes.
+3. **Isolate per-item failure.** A sweep over many methods (or assemblies) guards
+   each item so one malformed input yields a diagnostic, not a lost batch;
+   results that escape their source hold no live readers.
+
+A proposed change should arrive with: the IL shape it targets, the argument for
+its class under the taste doc's three-class rule, a fixture covering both
+configurations, and a `--pass-impact` blast-radius read showing exactly the
+intended changes across the corpus. The default first reviewer is the author —
+run the high-effort self-review over the branch before opening the PR.

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -51,38 +51,11 @@ Conflicts between class 1 and class 2 are rare by construction — most fixer su
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.
 
-## Verification philosophy
+## Verification and soundness
 
-Correctness is anchored by construction plus weight of evidence — "pounds of IL" — rather than per-expression semantic re-resolution:
-
-- **The IL round-trip oracle**: our disassembly reassembles (vendored managed ILAssembler, native ilasm) to byte-identical IL.
-- **Fixtures**: purpose-built methods whose *compilation* produces the IL shape under test, run in both Debug and Release (the compiler emits structurally different IL per configuration; CI runs both).
-- **Compile-back**: the semantic-fidelity oracle — decompile → recompile → compare the canonical opcode stream. A body that reads plausibly but recompiles to a different opcode stream changed the program; that is the worst failure class, invisible to every rail that never runs the output back through a compiler.
-- **Corpus sweeps**: emit-all stress over each platform's CoreLib (three OSes in CI = three different corpora). The `--gaps` completeness scoreboard and the `--compile-check` validity pass measure the sweep two ways — any unexpected delta on a decompiler change is a finding.
-
-A proposed rendering change should arrive with: the IL shape it targets, the argument for its class under the three-class rule, a fixture covering both configurations, and a `--pass-impact` blast-radius read showing exactly the intended changes across the corpus.
-
-## Soundness checklist for IR-mutating passes
-
-Reviews of the raising passes have converged on three recurring questions; an
-author who answers them before requesting review collapses the serial
-round-trips. Any pass that detaches, replaces, or rewrites IR nodes states its
-answers in the PR (a short "Soundness" note), and the review verifies them
-rather than rediscovering them:
-
-1. **Prove preconditions whole-function, not locally.** A rewrite that removes
-   a node's defining store (or any binding) must prove the affected locals,
-   slots, and stack positions are referenced *only* by the nodes it consumes —
-   scanned across the whole function, not just the matched neighbourhood.
-   Hand-written or obfuscated IL can wear the shape without being the pattern.
-2. **Preserve semantics exactly.** A conversion, comparison, or identity match
-   keeps checked/unsigned/overflow behaviour and produces valid C# (no CS-error
-   spellings). Match metadata members on assembly identity and exact signature,
-   not just namespace/name and call-site argument shapes.
-3. **Isolate per-item failure.** A sweep over many methods (or assemblies)
-   guards each item so one malformed input yields a diagnostic, not a lost
-   batch; results that escape their source hold no live readers.
-
-The default first reviewer is the author: run the high-effort self-review over
-the branch before opening the PR, so the first external pass starts from a
-clean sheet instead of round one.
+How these rendering choices are held correct — the three verification rails, the
+fixture gate, and the soundness checklist every IR-mutating pass answers — lives
+in [decompiler-quality.md](decompiler-quality.md). A proposed rendering change
+should arrive with its evidence per that doc: the IL shape it targets, the
+argument for its class under the three-class rule above, a fixture covering both
+configurations, and a `--pass-impact` blast-radius read.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -1,6 +1,6 @@
 # Decompiler Harness
 
-The diagnostic harness from [docs/decompiler-pipeline.md](../../docs/decompiler-pipeline.md) — the asmdiffs analog for the decompiler. It inventories the pipeline's health, scores the real-gap burn-down, validates output two ways, and dumps a single method through every pipeline stage.
+The diagnostic harness from [docs/decompiler-pipeline.md](../../docs/decompiler-pipeline.md) — the asmdiffs analog for the decompiler. It inventories the pipeline's health, scores the real-gap burn-down, validates output two ways, and dumps a single method through every pipeline stage. This is the invocation reference for the modes; the strategy they serve — which rail proves what, what gates CI, the corpus-sweep plan — is [docs/decompiler-quality.md](../../docs/decompiler-quality.md).
 
 ## Modes
 


### PR DESCRIPTION
Follow-up to the old-pipeline scrub (#657). Splits the decompiler docs into a focused set with one home per concern — engineering-oriented docs for the architecture, goal-oriented docs for the rendering taste and quality strategy — and removes the duplication that had the verification story scattered across three files.

## The doc set, after this PR

| Doc | Role |
|---|---|
| `decompiler-pipeline.md` | **Architecture** — how output is produced (prose + diagram) |
| `decompiler-ir.md` | **IR reference** — the IR and importer contracts (focused, terse) |
| `decompiler-taste.md` | **Goal: rendering** — what to emit (three-class rule, style oracle) |
| `decompiler-quality.md` | **Goal: correctness** — how we know it's right *(new)* |

`decompiler-pipeline.md` is the hub and links the other three; `decompiler-ir.md` stays a standalone semi-terse reference, complementing the more prose, diagram-led architecture doc.

## What changed

**New `decompiler-quality.md`** — the quality strategy as the plan of record:
- **Correct by construction** — the no-crash / honest-degradation / stable-diagnostics floor.
- **The three rails** — `--compile-back` (fidelity), `--gaps` (completeness), `--compile-check` (validity), each with what it proves *and what it is blind to*.
- **What gates CI** — the fixture compile-back gate (`CompileBackGateTests` + lowered twin) is the durable gold standard; the corpus rails are developer-driven.
- **The corpus gap and the plan** — nothing in CI runs the whole corpus through the new pipeline (the old `PlatformAssembly_AllMethods_NoCrashes` sweep was deleted with the old stack). The plan of record is a corpus-sweep ratchet test: no-crash + fidelity/raising floors, robust to version drift, no per-method baseline.
- **The quality loop** — detect at scale (compile-back/gaps/pass-impact) → diagnose one (dump/diff/facts/cfg/remarks), plus the IR-mutating-pass soundness checklist.

**`decompiler-pipeline.md`** — more prose + diagram-led: a mermaid pipeline flowchart and a stage table replace the ASCII block; the long per-mode verification walkthrough collapses to its architectural core (every stage projects; the dump's final stage is byte-identical to what the rails grade) and backrefs the quality doc and the harness README.

**`decompiler-taste.md`** — now purely about rendering; its verification philosophy and the soundness checklist moved to the quality doc, leaving a short pointer.

**Harness README** — backrefs the quality doc as the strategy its modes serve.

## Follow-up

The corpus-sweep ratchet test that `decompiler-quality.md` commits to is not in this PR (docs only). It's the natural next step — a small CI test, floors measured from a current sweep.

## Verification
- `markdownlint` — clean on all changed files.
- Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)