### PR TITLE
Add CorpusSweepGateTests: the corpus breadth gate

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -67,34 +67,32 @@ slip back. The decompiler unit suite (`ILInspector.Decompiler.Tests`) and the IL
 round-trip sweep (`DotnetInspector.ILRoundtrip.Tests`) gate the importer, the
 passes, and the disassembler.
 
-The corpus rails (`--gaps`, `--compile-check`, `--compile-back` over a real
-assembly, `--pass-impact`) are **developer-driven**, not gates: run them while
-working, read them in review. They are the breadth signal; the fixture gate is
-the depth signal.
+Breadth is gated separately by `CorpusSweepGateTests` (next section), which runs
+the whole CoreLib corpus through the pipeline and asserts health floors. The
+fixture gate is the depth signal; the corpus sweep is the breadth signal. The
+exploratory corpus rails (`--compile-back`/`--compile-check` over a real
+assembly, `--pass-impact`) stay **developer-driven** — run them while working
+and read them in review, but only the sweep's floors block CI.
 
-## The corpus gap, and the plan
+## The corpus breadth gate
 
-The fixture gate is strong but narrow (~80 curated methods). The breadth signals
-are manual. That leaves one gap: **nothing in CI runs the whole CoreLib corpus
-through the pipeline.** The old stack carried a `PlatformAssembly_AllMethods_NoCrashes`
-sweep; it was deleted with that stack and has no replacement yet.
+The fixture gate is strong but narrow (~80 curated methods), and the corpus rails
+above are manual. The breadth net is **`CorpusSweepGateTests`** — the
+new-pipeline analog of the old stack's no-crash sweep, made objective:
 
-The plan of record is a **corpus-sweep ratchet test** — the new-pipeline analog
-of the deleted sweep, made objective:
-
-- Run every method of the running runtime's CoreLib through `IrImporter →
-  IrPasses → CSharpPrinter` (the SDK pins the version, so the corpus is stable).
-- Assert **floors, not exact baselines**: zero pass-bugs / exceptions (pins the
-  by-construction safety), and `Full`-fidelity % and fully-raised % above a
-  ratchet a couple points below today's numbers. Floors tolerate minor version
-  drift and need no per-method baseline file to maintain — which is why this
+- It runs every method of the running runtime's CoreLib through `IrImporter →
+  IrPasses` and the fidelity/gap classification (the SDK pins the version, so the
+  corpus is stable). Cheap — no recompile.
+- It asserts **floors, not exact baselines**: zero pass-bugs / exceptions (pins
+  the by-construction safety), and `Full`-fidelity % and fully-raised % above
+  ratchets a couple points below the measured numbers. Floors tolerate minor
+  runtime-version drift and need no per-method baseline file — which is why this
   beats both a fuzzy text-agreement oracle and a brittle exact-baseline net.
-- Cheap: import + passes + the `--gaps` / fidelity classification, no recompile.
 
-It restores the broad regression net (a crash or a broad fidelity/raising drop
-fails CI) using only the self-contained signals we already have. Beyond it,
-deepening *fidelity* coverage means growing the compile-back fixture corpus, not
-widening the sweep.
+So a crash, or a broad fidelity/raising drop, fails CI, using only the
+self-contained signals. When the structuring work raises the true numbers, the
+floors ratchet up to lock the gain in. Beyond breadth, deepening *fidelity*
+coverage means growing the compile-back fixture corpus, not widening the sweep.
 
 ## The quality loop: detect, then diagnose
 

--- a/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
@@ -1,0 +1,91 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The corpus-sweep ratchet gate (docs/decompiler-quality.md): runs every method
+/// of the running runtime's CoreLib through <c>IrImporter → IrPasses →</c> the
+/// fidelity/gap classification, and asserts <b>health floors</b>. It is the
+/// new-pipeline analog of the corpus no-crash sweep the old stack carried, made
+/// objective:
+/// <list type="bullet">
+/// <item>zero pass-bugs — pins the "exception-safe by construction" guarantee
+/// across the whole corpus, not just the curated fixtures;</item>
+/// <item><c>Full</c>-fidelity % above a floor — a broad import/print regression
+/// drops it;</item>
+/// <item>fully-raised % above a floor — a broad structuring regression drops it.</item>
+/// </list>
+/// Floors, not exact baselines: they tolerate minor runtime-version drift and
+/// need no per-method baseline file. They sit a couple points below the measured
+/// numbers, so normal drift never flakes CI but a real regression fails it. When
+/// the structuring work raises the true numbers, ratchet the floors up to lock
+/// the gain in. The fixture compile-back gate (<see cref="CompileBackGateTests"/>)
+/// remains the depth signal; this is the breadth signal.
+/// </summary>
+public class CorpusSweepGateTests
+{
+    // Measured over net11 CoreLib (41,159 methods): 0 pass-bugs, 99.97% Full,
+    // 95.75% fully raised. Floors sit a couple points below.
+    const double FullFidelityFloor = 99.0;
+    const double FullyRaisedFloor = 94.0;
+
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    [Fact]
+    public void CoreLibSweep_MeetsHealthFloors()
+    {
+        long total = 0, full = 0, fullyRaised = 0;
+        var passBugs = new List<string>();
+
+        using (var source = MetadataSource.Open(CoreLibPath))
+        {
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                total++;
+                try
+                {
+                    IrPasses.Run(function);
+                }
+                catch (Exception ex)
+                {
+                    if (passBugs.Count < 20)
+                        passBugs.Add($"{typeName}::{methodName} — {ex.GetType().Name}: {ex.Message}");
+                    continue;
+                }
+
+                // An importer crash surfaces as a DEC0001 diagnostic, not an
+                // exception (ImportAssembly is exception-safe) — count it as a
+                // pass-bug too, since it is the same by-construction violation.
+                if (function.Diagnostics.FirstOrDefault().Id == DiagnosticIds.InternalError)
+                {
+                    if (passBugs.Count < 20)
+                        passBugs.Add($"{typeName}::{methodName} — importer bug: {function.Diagnostics.First().Message}");
+                    continue;
+                }
+
+                if (function.Fidelity == DecompilationFidelity.Full)
+                    full++;
+                if (Gaps.Residual(function) is null)
+                    fullyRaised++;
+            }
+        }
+
+        Assert.True(total > 10_000, $"Expected a large CoreLib corpus; swept only {total} methods.");
+
+        Assert.True(passBugs.Count == 0,
+            $"Pipeline must be exception-safe by construction over the whole corpus, but {passBugs.Count} method(s) failed:\n  "
+                + string.Join("\n  ", passBugs));
+
+        double fullPercent = 100.0 * full / total;
+        Assert.True(fullPercent >= FullFidelityFloor,
+            $"Full-fidelity rate {fullPercent:F2}% ({full}/{total}) fell below the {FullFidelityFloor}% floor — a broad import/print regression. "
+                + "If this is an intentional runtime-version shift, re-measure and adjust the floor.");
+
+        double raisedPercent = 100.0 * fullyRaised / total;
+        Assert.True(raisedPercent >= FullyRaisedFloor,
+            $"Fully-raised rate {raisedPercent:F2}% ({fullyRaised}/{total}) fell below the {FullyRaisedFloor}% floor — a broad structuring regression. "
+                + "If this is an intentional runtime-version shift, re-measure and adjust the floor.");
+    }
+}


### PR DESCRIPTION
Closes the one open thread from the quality-docs work (#658): there was no corpus-wide CI gate over the decompiler. The old stack carried a `PlatformAssembly_AllMethods_NoCrashes` sweep that was deleted with it (#656), and nothing replaced it — the fixture compile-back gate is strong but narrow (~80 methods), and the corpus rails (`--gaps`/`--compile-check`) were manual. This is the corpus-sweep ratchet `docs/decompiler-quality.md` committed to.

## What it does

`CorpusSweepGateTests` sweeps **every method of the running runtime's CoreLib** (~41k) through `IrImporter → IrPasses` and the fidelity/gap classification, and asserts **health floors**, not exact baselines:

| Floor | Measured (net11 CoreLib) | Gate |
|---|---|---|
| pass-bugs / exceptions | 0 | must be 0 |
| `Full`-fidelity % | 99.97% | ≥ 99.0% |
| fully-raised % (`Gaps.Residual == null`) | 95.75% | ≥ 94.0% |

It reuses the exact classification the harness sweep and `--gaps` use (`IrImporter.ImportAssembly`, `IrPasses.Run`, `DiagnosticIds.InternalError`, `Gaps.Residual`), so the gate and the developer tools can't disagree.

## Why floors, not baselines

Floors sit a couple points below the measured numbers, so minor runtime-version drift never flakes CI but a broad import/print or structuring regression fails it. There's no per-method baseline file to maintain. When the structuring work raises the true numbers, ratchet the floors up to lock the gain in. This is why a floor gate beats both the retired text-agreement oracle (fuzzy) and an exact-baseline net (brittle).

Cheap: import + passes + classification, no recompile (~4s for the whole corpus).

## Verification
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **301 passed** (300 + this gate).
- `markdownlint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)