### PR TITLE
Emit unsafe blocks for requires-unsafe calls and stackalloc under the new memory-safety rules

### DIFF
--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -72,6 +72,33 @@ Two divergences from ILSpy are intentional and argued in [decompiler-taste.md](d
 - **Zero runtime dependencies.** The library depends only on `System.Reflection.Metadata` (via `ILInspector.Metadata`). We borrow the architecture of our neighbors, not their packages — no Roslyn syntax trees, no NRefactory-derived AST. The statement tree is small (roughly a dozen node kinds) and hand-written; ILSpy's generated 60 KB instruction set solves a scale problem we do not have.
 - **Dataflow facts proportionate to the rewrites we do.** Cross-block transforms get only the facts they need (the definite-assignment CFG dataflow behind `--facts`, for instance). We deliberately stop short of SSA and value numbering: ILSpy ships a complete decompiler without them, and a JIT-grade dataflow stack would be infrastructure without a customer here.
 
+## Unsafe contexts under the updated memory-safety rules
+
+A module compiled with the `updated-memory-safety-rules` feature carries a
+module-level `MemorySafetyRulesAttribute`. Under those rules the member `unsafe`
+modifier no longer makes a method body an unsafe context, so `CSharpPrinter`
+emits explicit, minimally scoped `unsafe { }` blocks around the operations that
+still need one. For a legacy module (no attribute) it emits no blocks — the
+member modifier supplies the context. The wrapping is gated on the source
+module's rules, so legacy output is byte-identical.
+
+An operation needs a block when it is:
+
+- a pointer dereference (`*p`) or a function-pointer invocation (`calli`);
+- a call to a *requires-unsafe* member — one stamped with `RequiresUnsafeAttribute`
+  (`System.Diagnostics.CodeAnalysis`), i.e. declared `unsafe`/`extern`, even with
+  no pointer in the call;
+- a call whose callee has a pointer or function-pointer anywhere in its signature
+  (the spec's compat fallback for cross-assembly callees whose attributes can't be
+  read, e.g. `NativeMemory.Free(void*)`);
+- a `stackalloc` converted to a `Span<T>`/`ReadOnlySpan<T>` with no initializer in
+  a `[SkipLocalsInit]` body (the stack space is uninitialized).
+
+Taking an address (`&x`), declaring pointer locals, the `fixed` statement, and
+`sizeof` are safe under the new rules and stay outside the blocks. When the unsafe
+operation initializes a local used later, the declaration is hoisted above the
+block so the variable stays in scope.
+
 ## Inspection and verification
 
 The architecture earns its observability from one property: **every stage boundary is a projectable IR.** A single `IrPasses.RunWithStages` runner captures the typed tree at import and after every pass, and one `StageDump` formatter frames them — exactly JitDump's relationship to GenTree. Every harness mode reads that one capture rather than rebuilding it: `--dump` (the per-pass tree), `--diff` (each pass as a `+`/`-` hunk), `--facts` (the definite-assignment dataflow that decides `= default` elision), `--cfg` (block edges; `--mermaid` renders them), `--remarks` (the IR sites that cap fidelity, each with its `DEC####` code), and `--pass-impact` (the corpus-wide inverse — a pass's blast radius).

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -23,6 +23,14 @@ public static class UnsafeFixtures
         return callback(x);
     }
 
+    // A requires-unsafe member: declared `unsafe` with no pointers. Under legacy
+    // rules calling it needs an unsafe context too — supplied by the caller's
+    // member `unsafe` modifier — so the body printer emits no block. The IL is
+    // identical to the new-rules fixture.
+    public static unsafe int Risky() => 42;
+
+    public static unsafe int CallRisky() => Risky();
+
     // `fixed` is SAFE under the new rules, but the pointer element access
     // `p[i]` inside the loop is not. A minimal-scope emitter must wrap only the
     // unsafe access, not the whole `fixed` statement.

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -1,5 +1,7 @@
 namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 
+using System.Runtime.InteropServices;
+
 /// <summary>
 /// Legacy-rules unsafe fixtures. Each method uses the member <c>unsafe</c>
 /// modifier, which under pre-memory-safety semantics makes the whole body an
@@ -30,6 +32,11 @@ public static class UnsafeFixtures
     public static unsafe int Risky() => 42;
 
     public static unsafe int CallRisky() => Risky();
+
+    // Compat mode: calling NativeMemory.Free (pointer in signature) needs an
+    // unsafe context, supplied here by the member modifier. IL is identical to
+    // the new-rules fixture.
+    public static unsafe void FreePointer(void* p) => NativeMemory.Free(p);
 
     // `fixed` is SAFE under the new rules, but the pointer element access
     // `p[i]` inside the loop is not. A minimal-scope emitter must wrap only the

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -1,5 +1,6 @@
 namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 /// <summary>
@@ -37,6 +38,22 @@ public static class UnsafeFixtures
     // unsafe context, supplied here by the member modifier. IL is identical to
     // the new-rules fixture.
     public static unsafe void FreePointer(void* p) => NativeMemory.Free(p);
+
+    // stackalloc -> Span is legal in safe C# today, so no member modifier is
+    // needed. The IL (including the cleared localsinit flag from
+    // [SkipLocalsInit]) is identical to the new-rules fixture.
+    [SkipLocalsInit]
+    public static int StackAllocSkipInit(int n)
+    {
+        Span<int> s = stackalloc int[n];
+        return s.Length;
+    }
+
+    public static int StackAllocDefault(int n)
+    {
+        Span<int> s = stackalloc int[n];
+        return s.Length;
+    }
 
     // `fixed` is SAFE under the new rules, but the pointer element access
     // `p[i]` inside the loop is not. A minimal-scope emitter must wrap only the

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -37,6 +37,23 @@ public static class UnsafeFixtures
         }
     }
 
+    // A method declared `unsafe` with NO pointers in its signature is still
+    // *requires-unsafe* under the new rules: the compiler stamps it with
+    // `RequiresUnsafeAttribute`. There is no unsafe operation in its own body,
+    // so it needs no block here.
+    public static unsafe int Risky() => 42;
+
+    // Calling a requires-unsafe member needs an unsafe context even though no
+    // pointer crosses the call boundary. The call — not any intrinsic op — is
+    // what forces the block.
+    public static int CallRisky()
+    {
+        unsafe
+        {
+            return Risky();
+        }
+    }
+
     // `fixed` is safe; only the `p[i]` element access needs a context. The block
     // is scoped to that access inside the loop, not the whole `fixed` statement.
     public static int SumPinned(int[] data)

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -1,5 +1,6 @@
 namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 /// <summary>
@@ -65,6 +66,27 @@ public static class UnsafeFixtures
         {
             NativeMemory.Free(p);
         }
+    }
+
+    // stackalloc -> Span is unsafe ONLY when the member has [SkipLocalsInit]
+    // (the stack space is uninitialized and a Span is a safe wrapper). The
+    // stackalloc expression needs the context; using the span is safe.
+    [SkipLocalsInit]
+    public static int StackAllocSkipInit(int n)
+    {
+        unsafe
+        {
+            Span<int> s = stackalloc int[n];
+            return s.Length;
+        }
+    }
+
+    // Without [SkipLocalsInit] the same stackalloc -> Span is SAFE under the new
+    // rules and needs no unsafe context.
+    public static int StackAllocDefault(int n)
+    {
+        Span<int> s = stackalloc int[n];
+        return s.Length;
     }
 
     // `fixed` is safe; only the `p[i]` element access needs a context. The block

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -1,5 +1,7 @@
 namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 
+using System.Runtime.InteropServices;
+
 /// <summary>
 /// New-rules unsafe fixtures. This assembly is compiled with
 /// <c>/features:updated-memory-safety-rules</c>, so the compiler enforces the
@@ -51,6 +53,17 @@ public static class UnsafeFixtures
         unsafe
         {
             return Risky();
+        }
+    }
+
+    // Compat mode: NativeMemory.Free has a pointer in its signature, so it is
+    // requires-unsafe even though its attributes can't be read cross-assembly.
+    // The call needs an unsafe context; declaring the pointer parameter does not.
+    public static void FreePointer(void* p)
+    {
+        unsafe
+        {
+            NativeMemory.Free(p);
         }
     }
 

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -119,4 +119,23 @@ public class UnsafeEmitterTests
 
         Assert.DoesNotContain("unsafe", output);
     }
+
+    [Fact]
+    public void NewRulesModule_CompatPointerSignatureCall_WrapsInUnsafeBlock()
+    {
+        // NativeMemory.Free has a pointer in its signature, so under compat mode
+        // it is requires-unsafe even though its attributes are cross-assembly.
+        // The call must be wrapped; the pointer parameter itself is safe.
+        var output = DecompileNew(nameof(NewFixtures.FreePointer));
+
+        Assert.Contains("Free", FirstUnsafeBlockBody(output));
+    }
+
+    [Fact]
+    public void LegacyModule_CompatPointerSignatureCall_EmitsNoUnsafeBlock()
+    {
+        var output = DecompileLegacy(nameof(LegacyFixtures.FreePointer));
+
+        Assert.DoesNotContain("unsafe", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -98,4 +98,25 @@ public class UnsafeEmitterTests
 
         Assert.DoesNotContain("unsafe", output);
     }
+
+    [Fact]
+    public void NewRulesModule_RequiresUnsafeCall_WrapsInUnsafeBlock()
+    {
+        // Risky() has no pointers but is declared `unsafe`, so the compiler
+        // stamps it requires-unsafe. Every call site needs an unsafe context
+        // even though no pointer crosses the boundary.
+        var output = DecompileNew(nameof(NewFixtures.CallRisky));
+
+        Assert.Contains("Risky()", FirstUnsafeBlockBody(output));
+    }
+
+    [Fact]
+    public void LegacyModule_RequiresUnsafeCall_EmitsNoUnsafeBlock()
+    {
+        // A legacy module relies on the member `unsafe` modifier for its body
+        // context, so the call to the unsafe member needs no block here.
+        var output = DecompileLegacy(nameof(LegacyFixtures.CallRisky));
+
+        Assert.DoesNotContain("unsafe", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -138,4 +138,40 @@ public class UnsafeEmitterTests
 
         Assert.DoesNotContain("unsafe", output);
     }
+
+    [Fact]
+    public void NewRulesModule_StackAllocSpanSkipInit_WrapsAndHoistsDeclaration()
+    {
+        // stackalloc -> Span under [SkipLocalsInit] is unsafe. The unsafe op is
+        // the initializer of a local used afterwards, so the declaration must be
+        // hoisted out of the block (declared up front, assigned inside) to keep
+        // the variable in scope.
+        var output = DecompileNew(nameof(NewFixtures.StackAllocSkipInit));
+
+        Assert.Contains("stackalloc", FirstUnsafeBlockBody(output));
+        // The declaration is hoisted above the unsafe block, the use survives.
+        Assert.True(
+            output.IndexOf("Span<int> s", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the span declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("s.Length", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_StackAllocSpanDefault_EmitsNoUnsafeBlock()
+    {
+        // Without [SkipLocalsInit] the same stackalloc -> Span is safe under the
+        // new rules; the pointer in the Span constructor's signature must not
+        // trigger the compat heuristic here.
+        var output = DecompileNew(nameof(NewFixtures.StackAllocDefault));
+
+        Assert.DoesNotContain("unsafe", output);
+    }
+
+    [Fact]
+    public void LegacyModule_StackAllocSpan_EmitsNoUnsafeBlock()
+    {
+        Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocSkipInit)));
+        Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocDefault)));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -25,6 +25,13 @@ public sealed class CSharpPrinter
     readonly bool _newMemorySafetyRules;
 
     /// <summary>
+    /// True when the method body skips locals initialization (<see
+    /// cref="IrFunction.SkipLocalsInit"/>) — the extra condition that makes a
+    /// <c>stackalloc</c>-to-<c>Span</c> conversion unsafe under the new rules.
+    /// </summary>
+    readonly bool _skipLocalsInit;
+
+    /// <summary>
     /// Nesting depth of emitted <c>unsafe { }</c> blocks. Non-zero means the
     /// current statements are already in an unsafe context, so inner operations
     /// are not wrapped again (no redundant nested blocks).
@@ -35,6 +42,7 @@ public sealed class CSharpPrinter
     {
         _function = function;
         _newMemorySafetyRules = function.UsesUpdatedMemorySafetyRules;
+        _skipLocalsInit = function.SkipLocalsInit;
     }
 
     /// <summary>The product path: runs the default raising passes, then prints. <see cref="Print"/> alone renders whatever tree it is given — right for stage dumps, wrong for output paths.</summary>
@@ -825,7 +833,25 @@ public sealed class CSharpPrinter
                 case LoadStackSlot slotLoad: seenSlots.Add(slotLoad.Slot); break;
             }
         }
+
+        // Under the updated memory-safety rules a declaring store whose value is
+        // an unsafe operation gets wrapped in an `unsafe { }` block. If the local
+        // is also read elsewhere, an inline `Type v = <unsafe>` declaration would
+        // strand the variable inside that block (out of scope at its uses), so
+        // demote the store: the local declares up front and the wrapped statement
+        // becomes a plain `v = <unsafe>` assignment.
+        if (_newMemorySafetyRules)
+            _declaringStores.RemoveWhere(node =>
+                node is StoreLocal store
+                && HasUnsafeOperation(store.Value)
+                && LocalIsRead(function, store.Index));
     }
+
+    /// <summary>True when the local slot is read (loaded by value or address) anywhere in the body.</summary>
+    static bool LocalIsRead(IrFunction function, int index)
+        => function.Descendants.Any(n =>
+            (n is LoadLocal load && load.Index == index)
+            || (n is LoadLocalAddress address && address.Index == index));
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
@@ -1015,7 +1041,7 @@ public sealed class CSharpPrinter
     /// separate statement sequence the recursion wraps independently, keeping the
     /// block minimal. A simple statement is tested whole.
     /// </summary>
-    static bool NeedsUnsafeContext(IrNode node) => node switch
+    bool NeedsUnsafeContext(IrNode node) => node switch
     {
         ForLoop f => HasUnsafeOperation(f.Initializer) || HasUnsafeOperation(f.Condition) || HasUnsafeOperation(f.Increment),
         WhileLoop w => HasUnsafeOperation(w.Condition),
@@ -1028,22 +1054,26 @@ public sealed class CSharpPrinter
         _ => HasUnsafeOperation(node),
     };
 
-    static bool HasUnsafeOperation(IrNode? node)
+    bool HasUnsafeOperation(IrNode? node)
         => node is not null && (IsUnsafeOperation(node) || node.Descendants.Any(IsUnsafeOperation));
 
     /// <summary>
     /// A single IR operation that requires an unsafe context under the updated
     /// rules: a function-pointer invocation (<c>calli</c>), a read/write through
-    /// an unmanaged pointer, or a call to a <em>requires-unsafe</em> member (one
+    /// an unmanaged pointer, a call to a <em>requires-unsafe</em> member (one
     /// stamped with <c>RequiresUnsafeAttribute</c> — declared <c>unsafe</c>/
-    /// <c>extern</c> — whose call site needs a context even with no pointer in
-    /// the call). Dereferencing a managed reference (<c>ByRef</c>) is safe and
-    /// excluded. Creating pointers, the <c>fixed</c> statement, and <c>sizeof</c>
-    /// are safe under the new rules and are not listed here.
+    /// <c>extern</c> — or, by the compat heuristic, one with a pointer in its
+    /// signature), or a <c>stackalloc</c> converted to a <c>Span</c> with no
+    /// initializer in a <c>[SkipLocalsInit]</c> body. Dereferencing a managed
+    /// reference (<c>ByRef</c>) is safe and excluded. Creating pointers, the
+    /// <c>fixed</c> statement, and <c>sizeof</c> are safe under the new rules.
     /// </summary>
-    static bool IsUnsafeOperation(IrNode node) => node switch
+    bool IsUnsafeOperation(IrNode node) => node switch
     {
         CallIndirect => true,
+        // A stackalloc-backed Span is governed by the stackalloc rule (unsafe
+        // only under [SkipLocalsInit]), not its constructor's pointer signature.
+        NewObject n when IsStackBoundSpan(n) => _skipLocalsInit,
         Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
         NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
         LoadIndirect l => RendersAsPointerDeref(l.Address),
@@ -1051,6 +1081,30 @@ public sealed class CSharpPrinter
         InitObject o => RendersAsPointerDeref(o.Address),
         _ => false,
     };
+
+    /// <summary>
+    /// A <c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c> constructed directly
+    /// over a <c>stackalloc</c> — the source <c>Span&lt;int&gt; s = stackalloc
+    /// int[n]</c> lowering. Such a conversion is unsafe only under
+    /// <c>[SkipLocalsInit]</c>; otherwise it is safe and must not be wrapped even
+    /// though the Span constructor carries a pointer parameter.
+    /// </summary>
+    static bool IsStackBoundSpan(NewObject newObject)
+    {
+        var declaring = newObject.Constructor.DeclaringType;
+        var (simpleName, ns) = declaring.Kind == TypeRefKind.GenericInstance
+            ? (StripArity(declaring.ElementType?.Name), declaring.ElementType?.Namespace)
+            : (StripArity(declaring.Name), declaring.Namespace);
+        return ns == "System"
+            && simpleName is "Span" or "ReadOnlySpan"
+            && newObject.Descendants.OfType<StackAllocate>().Any();
+
+        static string StripArity(string? name)
+        {
+            int tick = name?.IndexOf('`') ?? -1;
+            return tick < 0 ? name ?? "" : name![..tick];
+        }
+    }
 
     /// <summary>
     /// Compat-mode requires-unsafe heuristic for a callee whose

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1033,15 +1033,19 @@ public sealed class CSharpPrinter
 
     /// <summary>
     /// A single IR operation that requires an unsafe context under the updated
-    /// rules: a function-pointer invocation (<c>calli</c>) or a read/write
-    /// through an unmanaged pointer. Dereferencing a managed reference
-    /// (<c>ByRef</c>) is safe and excluded. Creating pointers, the <c>fixed</c>
-    /// statement, and <c>sizeof</c> are safe under the new rules and are not
-    /// listed here.
+    /// rules: a function-pointer invocation (<c>calli</c>), a read/write through
+    /// an unmanaged pointer, or a call to a <em>requires-unsafe</em> member (one
+    /// stamped with <c>RequiresUnsafeAttribute</c> — declared <c>unsafe</c>/
+    /// <c>extern</c> — whose call site needs a context even with no pointer in
+    /// the call). Dereferencing a managed reference (<c>ByRef</c>) is safe and
+    /// excluded. Creating pointers, the <c>fixed</c> statement, and <c>sizeof</c>
+    /// are safe under the new rules and are not listed here.
     /// </summary>
     static bool IsUnsafeOperation(IrNode node) => node switch
     {
         CallIndirect => true,
+        Call c => c.Callee.RequiresUnsafe,
+        NewObject n => n.Constructor.RequiresUnsafe,
         LoadIndirect l => RendersAsPointerDeref(l.Address),
         StoreIndirect s => RendersAsPointerDeref(s.Address),
         InitObject o => RendersAsPointerDeref(o.Address),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1044,13 +1044,31 @@ public sealed class CSharpPrinter
     static bool IsUnsafeOperation(IrNode node) => node switch
     {
         CallIndirect => true,
-        Call c => c.Callee.RequiresUnsafe,
-        NewObject n => n.Constructor.RequiresUnsafe,
+        Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
+        NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
         LoadIndirect l => RendersAsPointerDeref(l.Address),
         StoreIndirect s => RendersAsPointerDeref(s.Address),
         InitObject o => RendersAsPointerDeref(o.Address),
         _ => false,
     };
+
+    /// <summary>
+    /// Compat-mode requires-unsafe heuristic for a callee whose
+    /// <c>RequiresUnsafeAttribute</c> can't be read (a cross-assembly
+    /// MemberRef): the member is requires-unsafe if a pointer or function-pointer
+    /// type appears anywhere among its parameter or return types — possibly
+    /// nested in a non-pointer type such as <c>int*[]</c>. Mirrors the spec's
+    /// compat fallback, which keeps such calls unsafe during the migration window
+    /// even for callers that haven't opted into the new rules.
+    /// </summary>
+    static bool SignatureRequiresUnsafe(MethodRef callee)
+        => ContainsPointer(callee.ReturnType) || callee.ParameterTypes.Any(ContainsPointer);
+
+    static bool ContainsPointer(TypeRef? type)
+        => type is not null
+            && (type.Kind is TypeRefKind.Pointer or TypeRefKind.FunctionPointer
+                || ContainsPointer(type.ElementType)
+                || type.TypeArguments.Any(ContainsPointer));
 
     /// <summary>
     /// Whether <see cref="Deref"/> renders this load/store-indirect address with

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -144,6 +144,7 @@ public static class IrImporter
             Regions = method.Body.Handlers,
             LocalNames = method.Body.LocalNames,
             UsesUpdatedMemorySafetyRules = ModuleUsesUpdatedMemorySafetyRules(source.Reader),
+            SkipLocalsInit = method.Body.SkipLocalsInit,
         };
         var span = method.Body.IL.AsSpan();
         var leaders = FindLeaders(span, method.Body.Handlers);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1352,6 +1352,7 @@ public static class IrImporter
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
                     ParameterRefKinds = ReadParameterRefKinds(reader, method, signature.ParameterTypes),
+                    RequiresUnsafe = HasRequiresUnsafeAttribute(reader, method),
                 };
             }
             case HandleKind.MemberReference:
@@ -1526,6 +1527,18 @@ public static class IrImporter
         foreach (var handle in reader.GetModuleDefinition().GetCustomAttributes())
             if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
                 is ("System.Runtime.CompilerServices", "MemorySafetyRulesAttribute"))
+                return true;
+        return false;
+    }
+
+    // A member declared `unsafe`/`extern` under the updated memory-safety rules
+    // is stamped with RequiresUnsafeAttribute (no IL difference otherwise), which
+    // is what makes its every call site require an unsafe context.
+    static bool HasRequiresUnsafeAttribute(MetadataReader reader, MethodDefinition method)
+    {
+        foreach (var handle in method.GetCustomAttributes())
+            if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
+                is ("System.Diagnostics.CodeAnalysis", "RequiresUnsafeAttribute"))
                 return true;
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -112,6 +112,16 @@ public sealed class IrFunction : IrNode
     public bool UsesUpdatedMemorySafetyRules { get; set; }
 
     /// <summary>
+    /// True when the method body's locals are not zero-initialized — the
+    /// effective result of <c>[SkipLocalsInit]</c> (applied at the member, type,
+    /// or module level), observed as a cleared <c>.locals init</c> flag. Under
+    /// the updated memory-safety rules a <c>stackalloc</c> converted to a
+    /// <c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c> with no initializer is
+    /// unsafe only in such a body, because the stack space is then uninitialized.
+    /// </summary>
+    public bool SkipLocalsInit { get; set; }
+
+    /// <summary>
     /// Exception regions over the flat block container, by IL offset. The
     /// importer keeps blocks flat (region boundaries are block leaders);
     /// the EH structuring pass consumes these into <see cref="TryCatch"/>/

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -29,6 +29,17 @@ public sealed record MethodRef(
     public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; init; } = [];
 
     /// <summary>
+    /// The callee is <em>requires-unsafe</em>: under the updated memory-safety
+    /// rules a member declared <c>unsafe</c>/<c>extern</c> is stamped with
+    /// <c>RequiresUnsafeAttribute</c>, and every call site needs an unsafe
+    /// context even when no pointer crosses the call boundary. Recovered from
+    /// the callee MethodDef's attributes; false for cross-assembly MemberRefs
+    /// (whose attributes aren't readable) — the printer's signature-pointer
+    /// heuristic covers the compat-mode cross-assembly case instead.
+    /// </summary>
+    public bool RequiresUnsafe { get; init; }
+
+    /// <summary>
     /// Metadata SpecialName evidence (accessors, operators). Exact for
     /// same-assembly MethodDefs; cross-assembly MemberRefs carry no flags,
     /// so the resolver falls back to accessor-shape naming — the strongest

--- a/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
@@ -23,7 +23,8 @@ public sealed record MethodBody(
     int MaxStack,
     ImmutableArray<TypeRef> Locals,
     ImmutableArray<string?> LocalNames,
-    ImmutableArray<HandlerRegion> Handlers);
+    ImmutableArray<HandlerRegion> Handlers,
+    bool SkipLocalsInit = false);
 
 /// <summary>A parameter: name plus symbolic type.</summary>
 public sealed record Parameter(string Name, TypeRef Type);

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -107,7 +107,8 @@ public static class MethodImporter
             body.MaxStack,
             locals,
             LocalNames: source.LocalNames(methodHandle, locals.Length),
-            handlers.MoveToImmutable());
+            handlers.MoveToImmutable(),
+            SkipLocalsInit: !body.LocalVariablesInitialized);
 
         return new ImportedMethod(declaringType, reader.GetString(method.Name), signature, methodBody);
     }


### PR DESCRIPTION
## Summary

Builds on the new-rules unsafe body emitter (#653) so the decompiler's C# output
recompiles under .NET's updated memory-safety rules, where the member `unsafe`
modifier no longer introduces a body unsafe context. Adds three body-printer
features, each developed TDD (paired Legacy/New fixtures + failing test first,
then implement to green):

- **A — requires-unsafe calls.** Calls/`new` of members stamped
  `[RequiresUnsafeAttribute]` (namespace `System.Diagnostics.CodeAnalysis`) are
  wrapped in `unsafe { }`. `MethodRef.RequiresUnsafe` is stamped in the importer.
- **B — compat-mode pointer-signature calls.** A callee whose param/return types
  contain a pointer/function-pointer anywhere (nested OK) is treated as
  requires-unsafe under compat mode.
- **C — stackalloc→Span under `[SkipLocalsInit]`.** `stackalloc`→`Span`/
  `ReadOnlySpan` with no initializer is unsafe only when `[SkipLocalsInit]`
  applies (uses the localsinit flag as ground truth); otherwise safe despite the
  lowered `Span(void*,int)` ctor. Includes a general declaration-hoisting fix so
  wrapping a declaring store in `unsafe { }` doesn't strand the local out of scope.

All wrapping is gated on the caller module opting into the new rules, so legacy
output stays byte-identical (the #653 compile-back gate stays green).

## Tests

- 8 new tests in `UnsafeEmitterTests` (A:2, B:2, C:4). Decompiler suite: **307 green**.
- Metadata 194, dotnet-inspect.Tests 1145 (9 skipped) — all green.

## Follow-up (deferred)

- **Feature D** — signature-level `unsafe` modifier from `RequiresUnsafeAttribute`
  (vs `signature.Contains('*')`) lives in the API-surface subsystem
  (`ApiSurfaceExtractor`/`ApiOutputFormatter`/`--audit`); split into a separate PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
