### PR TITLE
Add Pipeline.PostDominators (control-flow track, step 1)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -2,8 +2,8 @@
 
 This document scopes the next major investment in the decompiler's control-flow
 recovery. It is the design artifact behind the "non-tree forward-conditional"
-work: the diagnosis that the remaining candidate-worse gap is dominated by one
-structural shape the current `StructuringPass` cannot express, and a plan to
+work: the diagnosis that the remaining real-gap docket (`--gaps`) is dominated by
+one structural shape the current `StructuringPass` cannot express, and a plan to
 close it without destabilizing the pass.
 
 Read [decompiler.md](../decompiler.md) first for the pipeline
@@ -258,6 +258,15 @@ only when the post-dominator machinery is proven.
    already introduced). No behavior change; pure analysis with unit tests on
    synthetic CFGs.
 
+   *Status: landed.* `Pipeline.PostDominators` (`PostDominators.Of`) computes
+   immediate post-dominators over `Cfg.BlockEdges` via the Cooper–Harvey–Kennedy
+   fixpoint on the reverse CFG, with a single virtual exit that every method exit,
+   external target, and EH survivor flows to. `ImmediatePostDominator` returns a
+   block index, `VirtualExit`, or `None` (a block that cannot reach the exit —
+   never throws); `PostDominates(p, b)` walks the ipostdom chain. Gated by
+   `PostDominatorsTests` on the four synthetic shapes below; nothing consumes it
+   yet.
+
    *Concrete first-PR shape.* The infrastructure to build on already exists, and
    the new code is its dual: `ILInspector.Decompiler.Pipeline.Cfg.Build(IReadOnlyList<Block>)`
    returns per-block `BlockEdges(Successors, ExternalTargets, ExitsMethod,
@@ -282,8 +291,8 @@ only when the post-dominator machinery is proven.
 2. **Return-tail merges, non-tree.** Generalize `ReturnMergePass` to fold a
    post-dominator merge that is a short `return` tail, dropping the
    comparison-tree gate but keeping the scale/duplication guards. Fully
-   structures the cheap case; no invariant change. Measure the candidate-worse
-   drop and the blast radius.
+   structures the cheap case; no invariant change. Measure the `--gaps` drop
+   and the blast radius.
 3. **Post-dominator joins in the diamond/guard recursion.** Let `Validate`/
    `BuildRegion` accept a forward branch to the region's immediate
    post-dominator as the join, lifting the `target > stop` bail for that one

--- a/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
@@ -1,0 +1,136 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class PostDominatorsTests
+{
+    static readonly TypeRef I32 = TypeRef.CoreLib("System", "Int32");
+
+    static Block Term(int offset, IrNode terminator)
+    {
+        var block = new Block(offset);
+        block.Add(terminator);
+        return block;
+    }
+
+    // A conditional whose taken edge is `targetOffset` and whose fall-through is
+    // the next block. The condition content is irrelevant to post-dominance.
+    static ConditionalBranch Cond(int targetOffset) =>
+        new(new Comparison(ComparisonKind.Equal, isUnsigned: false,
+            new Constant(1, I32), new Constant(0, I32)), targetOffset);
+
+    [Fact]
+    public void Diamond_BothArmsPostDominatedByMerge()
+    {
+        // B0: if (c) goto B2;   B1: goto B3;   B2: <fallthrough>;   B3: return
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(3)),
+            Term(2, new StoreLocal(0, I32, new Constant(7, I32))),  // falls through to B3
+            Term(3, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        Assert.Equal(3, pdom.ImmediatePostDominator(0));  // the merge post-dominates the split
+        Assert.Equal(3, pdom.ImmediatePostDominator(1));
+        Assert.Equal(3, pdom.ImmediatePostDominator(2));
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(3));
+    }
+
+    [Fact]
+    public void NestedDiamond_SingleGlobalMerge_IsPostDominatorOfOuterSplit()
+    {
+        // The InternalSetValue shape: nested diamonds whose every arm branches to
+        // one common exit past every enclosing region. ipostdom of the outer split
+        // is that exit — the join the index-range model cannot name.
+        //
+        // B0: if (c0) goto B4;   // outer split
+        // B1: if (c1) goto B3;   // nested split (value-is-null arm)
+        // B2: goto B5;           // arm → common exit
+        // B3: goto B5;           // arm → common exit
+        // B4: goto B5;           // outer arm → common exit
+        // B5: return             // the common exit / post-dominator
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(4)),
+            Term(1, Cond(3)),
+            Term(2, new Branch(5)),
+            Term(3, new Branch(5)),
+            Term(4, new Branch(5)),
+            Term(5, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        Assert.Equal(5, pdom.ImmediatePostDominator(0));  // the acceptance bar
+        Assert.Equal(5, pdom.ImmediatePostDominator(1));
+        Assert.Equal(5, pdom.ImmediatePostDominator(2));
+        Assert.Equal(5, pdom.ImmediatePostDominator(3));
+        Assert.Equal(5, pdom.ImmediatePostDominator(4));
+        Assert.True(pdom.PostDominates(postDominator: 5, block: 0));
+        Assert.False(pdom.PostDominates(postDominator: 1, block: 0));  // nested split does not post-dominate the outer
+    }
+
+    [Fact]
+    public void EarlyReturnArm_HasNoCommonRealMerge_FallsToVirtualExit()
+    {
+        // Both arms exit the method directly, so the only shared post-dominator is
+        // the method exit, not any real block.
+        // B0: if (c) goto B2;   B1: return;   B2: return
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Return(null)),
+            Term(2, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(0));
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(1));
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(2));
+    }
+
+    [Fact]
+    public void BlockThatCannotReachExit_HasNoPostDominator_NeverThrows()
+    {
+        // B1 self-loops with no exit, so it cannot reach the method exit and has no
+        // defined post-dominator. The analysis must report None, not throw, and
+        // still resolve the reachable arm.
+        // B0: if (c) goto B2;   B1: goto B1 (endless);   B2: return
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(1)),
+            Term(2, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        Assert.Equal(PostDominators.None, pdom.ImmediatePostDominator(1));
+        Assert.Equal(2, pdom.ImmediatePostDominator(0));   // the only exit path is through B2
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(2));
+        Assert.False(pdom.PostDominates(postDominator: 0, block: 1));  // unreachable-to-exit: defined as false
+    }
+
+    [Fact]
+    public void GuardChain_EachBlockPostDominatesItself()
+    {
+        // A straight guard chain: every block falls through to the next. Each
+        // block trivially post-dominates itself.
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(2)),
+            Term(2, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        Assert.True(pdom.PostDominates(postDominator: 0, block: 0));
+        Assert.True(pdom.PostDominates(postDominator: 2, block: 1));
+        Assert.True(pdom.PostDominates(postDominator: 2, block: 0));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
@@ -116,6 +116,32 @@ public class PostDominatorsTests
     }
 
     [Fact]
+    public void LoopWithExit_HeaderPostDominatesBody_ExitPostDominatesHeader()
+    {
+        // A while loop: a cyclic CFG with one exit edge — the shape the
+        // structuring consumers (steps 2-3) actually run on. CHK resolves it
+        // through the fixpoint despite the back-edge.
+        // B0: if (c) goto B2;   // header: exit to B2, else fall into body B1
+        // B1: goto B0;          // body back-edge to the header
+        // B2: return            // loop exit
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(0)),
+            Term(2, new Return(null)),
+        };
+
+        var pdom = PostDominators.Of(blocks);
+
+        // The body's only path to the exit is back through the header, then B2.
+        Assert.Equal(0, pdom.ImmediatePostDominator(1));
+        Assert.Equal(2, pdom.ImmediatePostDominator(0));
+        Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(2));
+        Assert.True(pdom.PostDominates(postDominator: 0, block: 1));   // header post-dominates body
+        Assert.True(pdom.PostDominates(postDominator: 2, block: 1));   // exit block post-dominates body (1 → 0 → 2)
+    }
+
+    [Fact]
     public void GuardChain_EachBlockPostDominatesItself()
     {
         // A straight guard chain: every block falls through to the next. Each

--- a/src/ILInspector.Decompiler/Pipeline/PostDominators.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PostDominators.cs
@@ -1,0 +1,184 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Immediate post-dominators over one container's block CFG — the dual of a
+/// dominator tree, and the graph property the structuring redesign needs to name
+/// a common-exit merge the index-range model cannot
+/// (docs/design/control-flow-structuring.md, step 1). Block <c>m</c>
+/// post-dominates block <c>n</c> when every path from <c>n</c> to the method exit
+/// passes through <c>m</c>; the <em>immediate</em> post-dominator is the closest
+/// such block.
+///
+/// <para>It reuses <see cref="Cfg.BlockEdges"/> — the same successor model the
+/// printer's definite-assignment dataflow and <c>--dump --cfg</c> consume — so a
+/// post-dominator computed here can never disagree with them about edges. Every
+/// method-exit terminator (<c>return</c>/<c>throw</c>), every external branch
+/// target, and every EH-survivor (<c>leave</c>/<c>endfinally</c>/<c>endfilter</c>)
+/// is treated as flowing to a single virtual exit, so the analysis is rooted even
+/// when a container has several real exits. Immediate post-dominators come from
+/// the Cooper–Harvey–Kennedy iterative fixpoint ("A Simple, Fast Dominance
+/// Algorithm") run on the reverse CFG.</para>
+///
+/// <para>This is pure analysis: nothing consumes it yet. A block that cannot
+/// reach the exit (an endless loop with no way out) has <see cref="None"/> as its
+/// immediate post-dominator rather than throwing.</para>
+/// </summary>
+public sealed class PostDominators
+{
+    /// <summary>The immediate post-dominator is the method exit (no real block post-dominates the query).</summary>
+    public const int VirtualExit = -1;
+
+    /// <summary>No post-dominator: the block cannot reach the exit, so the relation is undefined.</summary>
+    public const int None = -2;
+
+    readonly int[] _idom;       // index by block; value is a block index, or _exit, or undefined
+    readonly int _exit;         // the virtual-exit node id (== block count)
+    readonly int _undefined;    // sentinel for "not yet / not computable" (== block count + 1)
+
+    PostDominators(int[] idom, int exit, int undefined)
+    {
+        _idom = idom;
+        _exit = exit;
+        _undefined = undefined;
+    }
+
+    /// <summary>The number of real blocks the analysis covers.</summary>
+    public int Count => _exit;
+
+    /// <summary>
+    /// The immediate post-dominator of <paramref name="block"/>: a block index, or
+    /// <see cref="VirtualExit"/> when the closest post-dominator is the method exit,
+    /// or <see cref="None"/> when the block cannot reach the exit.
+    /// </summary>
+    public int ImmediatePostDominator(int block)
+    {
+        int idom = _idom[block];
+        if (idom == _undefined)
+            return None;
+        return idom == _exit ? VirtualExit : idom;
+    }
+
+    /// <summary>
+    /// True when <paramref name="postDominator"/> post-dominates
+    /// <paramref name="block"/> (walking the immediate-post-dominator chain from
+    /// <paramref name="block"/> reaches it before the exit). A block post-dominates
+    /// itself.
+    /// </summary>
+    public bool PostDominates(int postDominator, int block)
+    {
+        for (int cursor = block; cursor != _exit && cursor != _undefined; cursor = _idom[cursor])
+        {
+            if (cursor == postDominator)
+                return true;
+        }
+        return false;
+    }
+
+    public static PostDominators Of(IReadOnlyList<Block> blocks) => Of(Cfg.Build(blocks));
+
+    public static PostDominators Of(IReadOnlyList<Cfg.BlockEdges> edges)
+    {
+        int n = edges.Count;
+        int exit = n;             // the virtual exit shares the index space after the blocks
+        int undefined = n + 1;
+        int nodes = n + 1;        // blocks plus the virtual exit
+
+        // Forward successors including the virtual exit for any block that reaches
+        // a method exit, an external target, or an EH survivor. Reverse-graph
+        // predecessors of a node are exactly these forward successors.
+        var forwardSuccessors = new List<int>[nodes];
+        for (int i = 0; i < nodes; i++)
+            forwardSuccessors[i] = [];
+        for (int i = 0; i < n; i++)
+        {
+            forwardSuccessors[i].AddRange(edges[i].Successors);
+            if (edges[i].ExitsMethod || edges[i].ExternalTargets.Count > 0 || edges[i].LeavesRegion)
+                forwardSuccessors[i].Add(exit);
+        }
+
+        // Reverse-graph successors (forward predecessors): used to walk the reverse
+        // CFG outward from the exit when numbering nodes in postorder.
+        var reverseSuccessors = new List<int>[nodes];
+        for (int i = 0; i < nodes; i++)
+            reverseSuccessors[i] = [];
+        for (int from = 0; from < nodes; from++)
+            foreach (int to in forwardSuccessors[from])
+                reverseSuccessors[to].Add(from);
+
+        // Postorder of the reverse CFG rooted at the exit. The exit is visited
+        // first, so it finishes last and holds the highest number — the property
+        // the Cooper–Harvey–Kennedy "finger" intersection relies on. Nodes that
+        // cannot reach the exit are never numbered (postorder stays -1).
+        var postorder = new int[nodes];
+        Array.Fill(postorder, -1);
+        var order = new List<int>(nodes);
+        var visited = new bool[nodes];
+        var stack = new Stack<(int Node, int Next)>();
+        stack.Push((exit, 0));
+        visited[exit] = true;
+        while (stack.Count > 0)
+        {
+            var (node, next) = stack.Pop();
+            if (next < reverseSuccessors[node].Count)
+            {
+                stack.Push((node, next + 1));
+                int child = reverseSuccessors[node][next];
+                if (!visited[child])
+                {
+                    visited[child] = true;
+                    stack.Push((child, 0));
+                }
+            }
+            else
+            {
+                postorder[node] = order.Count;
+                order.Add(node);
+            }
+        }
+
+        var idom = new int[nodes];
+        Array.Fill(idom, undefined);
+        idom[exit] = exit;
+
+        // Reverse postorder, excluding the exit root.
+        var reversePostorder = new List<int>(order.Count);
+        for (int i = order.Count - 1; i >= 0; i--)
+            if (order[i] != exit)
+                reversePostorder.Add(order[i]);
+
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (int b in reversePostorder)
+            {
+                int newIdom = undefined;
+                foreach (int p in forwardSuccessors[b])   // reverse-graph predecessors of b
+                {
+                    if (idom[p] == undefined)
+                        continue;
+                    newIdom = newIdom == undefined ? p : Intersect(p, newIdom, idom, postorder);
+                }
+                if (newIdom != undefined && idom[b] != newIdom)
+                {
+                    idom[b] = newIdom;
+                    changed = true;
+                }
+            }
+        }
+
+        return new PostDominators(idom, exit, undefined);
+    }
+
+    static int Intersect(int a, int b, int[] idom, int[] postorder)
+    {
+        while (a != b)
+        {
+            while (postorder[a] < postorder[b])
+                a = idom[a];
+            while (postorder[b] < postorder[a])
+                b = idom[b];
+        }
+        return a;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/PostDominators.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PostDominators.cs
@@ -63,6 +63,12 @@ public sealed class PostDominators
     /// <paramref name="block"/> (walking the immediate-post-dominator chain from
     /// <paramref name="block"/> reaches it before the exit). A block post-dominates
     /// itself.
+    ///
+    /// <para><paramref name="postDominator"/> must be a real block index: the chain
+    /// only ever holds real blocks, so the <see cref="VirtualExit"/> and
+    /// <see cref="None"/> sentinels always return false. A caller asking "does the
+    /// method exit post-dominate b?" (always true) or handling an unreachable block
+    /// must branch on those sentinels itself before calling this.</para>
     /// </summary>
     public bool PostDominates(int postDominator, int block)
     {


### PR DESCRIPTION
Step 1 of the control-flow structuring track (docs/design/control-flow-structuring.md): the post-dominator analysis the redesign needs to name a common-exit merge the index-range model cannot express.

## What

`PostDominators.Of` computes immediate post-dominators over the existing `Cfg.BlockEdges` successor model — the same edges the printer's definite-assignment dataflow and `--dump --cfg` consume, so a post-dominator built here can never disagree with them about successors. It:

- adds a **single virtual exit** that every method exit (`return`/`throw`), external branch target, and EH survivor (`leave`/`endfinally`/`endfilter`) flows to, so the analysis is rooted even when a container has several real exits;
- reverses the CFG and runs the **Cooper–Harvey–Kennedy** iterative fixpoint ("A Simple, Fast Dominance Algorithm") to get each block's immediate post-dominator.

API:
- `ImmediatePostDominator(block)` → a block index, `VirtualExit` (closest post-dominator is the method exit), or `None` (block cannot reach the exit — an endless loop). **Never throws.**
- `PostDominates(p, b)` walks the ipostdom chain.

## Soundness

Pure analysis — **nothing consumes it yet**, so there is no behavior change. Gated by `PostDominatorsTests` over the four synthetic shapes the doc specifies:

1. a simple diamond (both arms post-dominated by the merge);
2. the nested `InternalSetValue` diamond with one global merge — **ipostdom of the outer split is the common exit** (the acceptance bar, the join the index-range model cannot name today);
3. an early-return arm with no common real merge → falls to `VirtualExit`;
4. a no-exit self-loop → reports `None` without throwing.

**306 decompiler tests green** (5 new). Also reconciles two lingering "candidate-worse" phrases in the design doc onto the surviving `--gaps` lens, and marks step 1 landed.

Next: step 2 (return-tail merges) and step 3 (post-dominator joins in the diamond/guard recursion) consume this.
