### PR TITLE
Add --annotate-check: the hidden-fact annotation oracle (static IL pair-agreement)

### DIFF
--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -15,6 +15,9 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ILInspector.Decompiler.Tests" />
+    <!-- The diagnostic harness reuses the runtime-ported ILReader to walk raw IL
+         independently of the semantic importer (the annotate-check oracle). -->
+    <InternalsVisibleTo Include="decompiler-harness" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/DecompilerHarness/AnnotateCheck.cs
+++ b/tools/DecompilerHarness/AnnotateCheck.cs
@@ -1,0 +1,273 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Analysis;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// The hidden-fact annotation oracle: static IL pair-agreement at corpus scale.
+/// It is the analyzer analog of <c>--compile-back</c> — where compile-back grades
+/// the decompiler's C# against a recompiled opcode stream, this grades each
+/// <em>annotation</em> against the raw IL opcode it claims to describe.
+///
+/// The witness is read with <see cref="ILReader"/> (the runtime-ported byte
+/// reader ILVerify is built on) directly over the method's IL bytes — not via the
+/// IR importer that produced the annotations. The two paths share only that
+/// externally byte-match-validated reader, never the semantic classification
+/// logic under test, so agreement is genuine evidence.
+///
+/// It measures two directions, the analyzer duals of fidelity and completeness:
+///   * PRECISION — every annotation's offset must carry an opcode consistent with
+///     its claim (an <c>alloc.box</c> sits on a <c>box</c>). A violation is an
+///     importer-typing or classifier bug.
+///   * RECALL — every <em>unambiguous</em> witness opcode must produce an
+///     annotation (a <c>box</c> always yields <c>alloc.box</c>). Ambiguous
+///     witnesses (a <c>newobj</c> may be a struct ctor; a <c>ldind</c> may be a
+///     safe managed-ref deref) are precision-only by nature and excluded from the
+///     recall gate, the documented exceptions the model calls for.
+///
+/// See docs/design/hidden-fact-annotations.md.
+/// </summary>
+static class AnnotateCheck
+{
+    // Precision: the opcode set each descriptor's offset is allowed to carry.
+    static readonly Dictionary<string, ILOpCode[]> Witnesses = new()
+    {
+        ["alloc.box"] = [ILOpCode.Box],
+        ["alloc.array"] = [ILOpCode.Newarr],
+        ["alloc.new"] = [ILOpCode.Newobj],
+        ["alloc.closure"] = [ILOpCode.Newobj],
+        ["alloc.statemachine"] = [ILOpCode.Newobj],
+        ["alloc.delegate"] = [ILOpCode.Newobj],
+        ["alloc.enumerator"] = [ILOpCode.Call, ILOpCode.Callvirt],
+        ["unsafe.stackalloc"] = [ILOpCode.Localloc],
+        ["unsafe.calli"] = [ILOpCode.Calli],
+        ["unsafe.deref"] =
+        [
+            ILOpCode.Ldind_i1, ILOpCode.Ldind_u1, ILOpCode.Ldind_i2, ILOpCode.Ldind_u2,
+            ILOpCode.Ldind_i4, ILOpCode.Ldind_u4, ILOpCode.Ldind_i8, ILOpCode.Ldind_i,
+            ILOpCode.Ldind_r4, ILOpCode.Ldind_r8, ILOpCode.Ldind_ref, ILOpCode.Ldobj,
+            ILOpCode.Stind_ref, ILOpCode.Stind_i1, ILOpCode.Stind_i2, ILOpCode.Stind_i4,
+            ILOpCode.Stind_i8, ILOpCode.Stind_r4, ILOpCode.Stind_r8, ILOpCode.Stind_i,
+            ILOpCode.Stobj,
+        ],
+        ["lifetime.ref-return"] = [ILOpCode.Ret],
+        ["lifetime.ref-struct-return"] = [ILOpCode.Ret],
+        ["lifetime.stack-bound"] = [ILOpCode.Newobj],
+    };
+
+    // Recall is gated only on witnesses that unambiguously imply one annotation.
+    // A box/newarr/localloc/calli has exactly one meaning; a newobj might be a
+    // struct constructor and a ldind/stind might be a safe managed-ref access, so
+    // those stay precision-only (the model's documented exceptions).
+    static readonly Dictionary<ILOpCode, string> RecallWitnesses = new()
+    {
+        [ILOpCode.Box] = "alloc.box",
+        [ILOpCode.Newarr] = "alloc.array",
+        [ILOpCode.Localloc] = "unsafe.stackalloc",
+        [ILOpCode.Calli] = "unsafe.calli",
+    };
+
+    sealed class Tally
+    {
+        public long Checked;
+        public long Violations;
+        public readonly List<string> Examples = [];
+    }
+
+    public static int Run(List<string> assemblies, int maxExamples)
+    {
+        long methods = 0, importCrashes = 0, noProvenance = 0;
+        long recallExcludedPartial = 0;
+
+        // Precision tallies are per-descriptor; recall tallies are per-witness-opcode.
+        var precision = new Dictionary<string, Tally>();
+        var recall = new Dictionary<string, Tally>();
+
+        Tally PrecisionFor(string id) =>
+            precision.TryGetValue(id, out var t) ? t : precision[id] = new Tally();
+        Tally RecallFor(string id) =>
+            recall.TryGetValue(id, out var t) ? t : recall[id] = new Tally();
+
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath);
+            var reader = source.Reader;
+
+            foreach (var typeDefHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeDefHandle);
+                string typeName = reader.GetFullTypeName(typeDef);
+
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var method = reader.GetMethodDefinition(methodHandle);
+                    if (method.RelativeVirtualAddress == 0)
+                        continue;
+
+                    methods++;
+                    string memberName = reader.GetString(method.Name);
+                    string id = $"{typeName}::{memberName}";
+
+                    IrFunction function;
+                    ImmutableArray<byte> il;
+                    try
+                    {
+                        var imported = MethodImporter.Import(source, typeDefHandle, methodHandle);
+                        function = IrImporter.Build(
+                            source, imported, IrImporter.CallerScope(reader, typeDef, method));
+                        il = imported.Body.IL;
+                    }
+                    catch (Exception ex)
+                    {
+                        importCrashes++;
+                        Console.Error.WriteLine($"IMPORT CRASH: {id}: {ex.GetType().Name}: {ex.Message}");
+                        continue;
+                    }
+
+                    var annotations = AnnotationEngine.Default.ClassifyImported(function);
+
+                    // The independent witness: offset -> opcode, read straight from
+                    // the IL bytes with the runtime-ported reader.
+                    var opcodes = DecodeOpcodes(il.AsSpan());
+
+                    // --- PRECISION: each annotation's offset carries a consistent opcode.
+                    foreach (var annotation in annotations)
+                    {
+                        if (annotation.SourceOffset < 0)
+                        {
+                            noProvenance++;
+                            continue;
+                        }
+                        if (!Witnesses.TryGetValue(annotation.Descriptor.Id, out var expected))
+                            continue; // an id with no opcode witness (none today) is not graded here.
+
+                        var tally = PrecisionFor(annotation.Descriptor.Id);
+                        tally.Checked++;
+
+                        bool agrees = opcodes.TryGetValue(annotation.SourceOffset, out var op)
+                            && Array.IndexOf(expected, op) >= 0;
+                        if (!agrees)
+                        {
+                            tally.Violations++;
+                            if (tally.Examples.Count < maxExamples)
+                            {
+                                string found = opcodes.TryGetValue(annotation.SourceOffset, out var actual)
+                                    ? actual.ToString().ToLowerInvariant()
+                                    : "(not an instruction boundary)";
+                                tally.Examples.Add($"{id} @IL_{annotation.SourceOffset:X4}: expected {annotation.Descriptor.Id}, found {found}");
+                            }
+                        }
+                    }
+
+                    // --- RECALL: every unambiguous witness opcode produced an annotation.
+                    // Excluded for partial imports: a stop leaves later opcodes with no
+                    // IR node, a legitimate absence rather than a missed fact.
+                    if (function.Fidelity != DecompilationFidelity.Full)
+                    {
+                        recallExcludedPartial++;
+                        continue;
+                    }
+
+                    var annotatedOffsets = annotations
+                        .Where(a => a.SourceOffset >= 0)
+                        .GroupBy(a => a.SourceOffset)
+                        .ToDictionary(g => g.Key, g => g.Select(a => a.Descriptor.Id).ToArray());
+
+                    foreach (var (offset, op) in opcodes)
+                    {
+                        if (!RecallWitnesses.TryGetValue(op, out var expectedId))
+                            continue;
+
+                        var tally = RecallFor(expectedId);
+                        tally.Checked++;
+
+                        bool covered = annotatedOffsets.TryGetValue(offset, out var ids)
+                            && Array.IndexOf(ids, expectedId) >= 0;
+                        if (!covered)
+                        {
+                            tally.Violations++;
+                            if (tally.Examples.Count < maxExamples)
+                                tally.Examples.Add($"{id} @IL_{offset:X4}: {op.ToString().ToLowerInvariant()} produced no {expectedId}");
+                        }
+                    }
+                }
+            }
+        }
+
+        Report(methods, importCrashes, noProvenance, recallExcludedPartial, precision, recall);
+
+        long precisionViolations = precision.Values.Sum(t => t.Violations);
+        return precisionViolations > 0 || importCrashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Decodes the method body's IL into an offset -> opcode map using the
+    /// runtime-ported <see cref="ILReader"/>. Independent of the IR importer's
+    /// semantic stack modelling — it only walks instruction boundaries.
+    /// </summary>
+    static Dictionary<int, ILOpCode> DecodeOpcodes(ReadOnlySpan<byte> il)
+    {
+        var map = new Dictionary<int, ILOpCode>();
+        var reader = new ILReader(il);
+        while (reader.HasNext)
+        {
+            int offset = reader.Offset;
+            var op = reader.ReadILOpcode();
+            map[offset] = op;
+            if (!reader.TrySkip(op))
+                break; // malformed or unknown operand shape — stop this body.
+        }
+        return map;
+    }
+
+    static void Report(
+        long methods, long importCrashes, long noProvenance, long recallExcludedPartial,
+        Dictionary<string, Tally> precision, Dictionary<string, Tally> recall)
+    {
+        long precisionChecked = precision.Values.Sum(t => t.Checked);
+        long precisionViolations = precision.Values.Sum(t => t.Violations);
+        long recallChecked = recall.Values.Sum(t => t.Checked);
+        long recallViolations = recall.Values.Sum(t => t.Violations);
+
+        Console.WriteLine($"ANNOTATE-CHECK over {methods} methods ({importCrashes} import crashes):");
+        Console.WriteLine();
+        Console.WriteLine($"PRECISION — annotation offset agrees with raw opcode ({precisionChecked} annotations):");
+        Console.WriteLine($"  agree     : {precisionChecked - precisionViolations} ({Percent(precisionChecked - precisionViolations, precisionChecked)})");
+        Console.WriteLine($"  violations: {precisionViolations}");
+        foreach (var (id, tally) in precision.OrderBy(p => p.Key))
+        {
+            if (tally.Checked == 0)
+                continue;
+            Console.WriteLine($"    {id,-26} {tally.Checked - tally.Violations,8}/{tally.Checked,-8} {Percent(tally.Checked - tally.Violations, tally.Checked)}");
+            foreach (var example in tally.Examples)
+                Console.WriteLine($"      ! {example}");
+        }
+        if (noProvenance > 0)
+            Console.WriteLine($"  ({noProvenance} synthetic annotations with no IL provenance — not graded)");
+
+        Console.WriteLine();
+        Console.WriteLine($"RECALL — unambiguous witness opcode produced its annotation ({recallChecked} witnesses, {recallExcludedPartial} partial-import methods excluded):");
+        Console.WriteLine($"  covered   : {recallChecked - recallViolations} ({Percent(recallChecked - recallViolations, recallChecked)})");
+        Console.WriteLine($"  missing   : {recallViolations}");
+        foreach (var (id, tally) in recall.OrderBy(p => p.Key))
+        {
+            if (tally.Checked == 0)
+                continue;
+            Console.WriteLine($"    {id,-26} {tally.Checked - tally.Violations,8}/{tally.Checked,-8} {Percent(tally.Checked - tally.Violations, tally.Checked)}");
+            foreach (var example in tally.Examples)
+                Console.WriteLine($"      ? {example}");
+        }
+        Console.WriteLine();
+        Console.WriteLine("Exit non-zero on any precision violation (a wrong fact) or import crash;");
+        Console.WriteLine("recall misses are reported but not gated — newobj/deref recall is");
+        Console.WriteLine("precision-only by nature (struct ctors, safe managed-ref derefs).");
+    }
+
+    static string Percent(long n, long total)
+        => total == 0 ? "n/a" : $"{100.0 * n / total:F2}%";
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -31,6 +31,7 @@ static class Program
         string? diffDefects = null;
         bool compileBack = false;
         bool gaps = false;
+        bool annotateCheck = false;
         bool steps = false;
         int stepLimit = int.MaxValue;
         bool ilView = false;
@@ -69,6 +70,7 @@ static class Program
                 case "--diff-defects": diffDefects = args[++i]; break;
                 case "--compile-back": compileBack = true; break;
                 case "--gaps": gaps = true; break;
+                case "--annotate-check": annotateCheck = true; break;
                 case "--pass-impact":
                     passImpact = true;
                     // Optional pass name: consume the next token only when it is
@@ -98,6 +100,9 @@ static class Program
 
         if (gaps)
             return GapScan(assemblies, maxExamples);
+
+        if (annotateCheck)
+            return AnnotateCheck.Run(assemblies, maxExamples);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -851,6 +856,15 @@ static class Program
                                 raised tree still holds unstructured control flow
                                 (a surviving goto) or an unsupported node, bucketed
                                 by residual kind. The completeness burn-down signal.
+          --annotate-check      hidden-fact annotation oracle — the analyzer analog
+                                of --compile-back. Cross-checks each allocation/
+                                unsafety/lifetime annotation against the raw IL
+                                opcode at its offset (read independently with the
+                                runtime-ported ILReader): PRECISION (every
+                                annotation sits on a consistent opcode) and RECALL
+                                (every unambiguous witness opcode — box/newarr/
+                                localloc/calli — produced its annotation). Exits
+                                non-zero on any precision violation.
           --pass-impact [pass]  blast-radius sweep — the inverse of --dump --diff.
                                 With no pass: histogram of how many corpus methods
                                 each pass changes. With a pass name (e.g.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -26,6 +26,10 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 *When to use it.* Track the structuring burn-down with `--gaps`. Over CoreLib it currently reads ~96% fully raised, the residual dominated by `structuring: conditional-branch` (the forward-branch-to-common-exit work).
 
+**Annotate-check** (`--annotate-check`): the hidden-fact annotation oracle — the analyzer analog of `--compile-back`. Where compile-back grades the decompiler's *C#* against a recompiled opcode stream, this grades each *annotation* (the allocation/unsafety/lifetime facts from [docs/design/hidden-fact-annotations.md](../../docs/design/hidden-fact-annotations.md)) against the raw IL opcode it claims to describe. The witness is read with the runtime-ported `ILReader` directly over the method's IL bytes — **not** via the IR importer that produced the annotations — so the two paths share only that externally byte-match-validated reader, never the semantic classification logic under test. It measures two directions: **precision** (every annotation's offset carries a consistent opcode — an `alloc.box` sits on a `box`; a violation is an importer-typing or classifier bug) and **recall** (every *unambiguous* witness opcode produced its annotation — a `box`/`newarr`/`localloc`/`calli` always yields its fact). Ambiguous witnesses are precision-only by nature and excluded from the recall gate: a `newobj` may be a struct constructor (no allocation), a `ldind`/`stind` may be a safe managed-`ref` access — the model's documented exceptions. Recall also excludes partial-import methods, where a stop legitimately leaves later opcodes with no IR node. Exits nonzero on any precision violation (a wrong fact) or import crash.
+
+*When to use it.* Run after any change to the classifiers (`AllocationClassifier`/`UnsafetyClassifier`/`LifetimeClassifier`), or to the importer's typing/metadata layer the classifiers read (value-type hints, signature decoding). A precision drop on a category points straight at the bug. Over .NET 11 preview CoreLib it currently reads **100% precision** (all 13 descriptors) and **100% recall** (the four gated witnesses).
+
 ## Usage
 
 ```bash
@@ -82,10 +86,14 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
 # Self-contained gap scoreboard (the completeness burn-down signal)
 dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/System.Private.CoreLib.dll --gaps
+
+# Hidden-fact annotation oracle: precision + recall of the annotations vs raw IL
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --annotate-check
 ```
 
 Inputs are assembly paths or directories (non-managed files are skipped).
 
 ## Baseline
 
-Over .NET 11 preview 5 `System.Private.CoreLib` (~41k methods): the inventory imports at high `Full` fidelity, and `--gaps` reads ~96% fully raised — the residual is the structuring burn-down docket.
+Over .NET 11 preview 5 `System.Private.CoreLib` (~41k methods): the inventory imports at high `Full` fidelity, `--gaps` reads ~96% fully raised — the residual is the structuring burn-down docket — and `--annotate-check` reads 100% precision and 100% recall over ~16.9k annotations.


### PR DESCRIPTION
## Summary

Adds `--annotate-check` to the decompiler harness: the **hidden-fact annotation oracle**, the static-only IL pair-agreement validation the new [hidden-fact-annotations design doc](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/hidden-fact-annotations.md) lays out. It is the analyzer analog of `--compile-back`.

## What it does

Where `--compile-back` grades the decompiler's *C#* against a recompiled opcode stream, `--annotate-check` grades each *annotation* (allocation / unsafety / lifetime) against the raw IL opcode at its offset. Two directions:

- **Precision** — every annotation's offset carries a consistent opcode (an `alloc.box` sits on a `box`). A violation is an importer-typing or classifier bug.
- **Recall** — every *unambiguous* witness opcode (`box`/`newarr`/`localloc`/`calli`) produced its annotation. Ambiguous witnesses (a `newobj` may be a struct ctor; a `ldind`/`stind` may be a safe managed-`ref` access) are precision-only by nature and excluded from the recall gate — the model's documented exceptions. Partial-import methods are excluded from recall too (a stop legitimately leaves later opcodes with no IR node).

## Independence

The witness is read with the runtime-ported `ILReader` (the byte reader ILVerify is built on) **directly over the method's IL bytes**, not via the IR importer that produced the annotations. The two paths share only that externally byte-match-validated reader, never the semantic classification logic under test — so agreement is genuine evidence. The harness is granted `InternalsVisibleTo` to reuse `ILReader`.

## Result

Over .NET 11 preview CoreLib (~41k methods):

- **100% precision** across all 13 descriptors (16,857 annotations)
- **100% recall** on the 4 gated witnesses (5,502)
- 0 import crashes; exits nonzero on any precision violation.

Verified the violation path is live (perturbing one witness drops that category to 0% with sample diffs, then reverted). Decompiler suite green (301).

## Not in scope (follow-ups)

- Wiring `--annotate-check` into a blocking CI gate test (the analog of `CompileBackGateTests`).
- `newobj`/`deref` recall via value-type / pointer resolution (the documented cross-assembly value-type gap).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
