### PR TITLE
Pin non-AOT "any" package to net10.0 floor structurally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,10 @@ jobs:
           if-no-files-found: error
 
       - name: Pack any (non-AOT) package
-        run: dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:DefaultTargetFramework=net10.0 -p:OfficialBuild=true
+        # TFM is pinned to net10.0 structurally via Directory.Build.props
+        # (OfficialBuild + non-AOT) so this fallback stays installable on the LTS
+        # runtime even though dev/AOT builds use the latest runtime. See issue #240.
+        run: dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
 
       - name: Upload any package
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,36 @@ jobs:
       
       - name: List packages
         run: ls -la packages/
-      
+
+      # Reach guard (issue #240): the non-AOT "any" fallback must target the LTS
+      # floor so it installs on machines without the latest runtime, and the
+      # pointer must stay TFM-agnostic. Fail the publish before pushing if either
+      # regresses. Kept here (publish-time) to keep PR CI cheap.
+      - name: Validate reach packaging
+        run: |
+          set -euo pipefail
+
+          settings_path() {
+            unzip -l "$1" | grep -oE 'tools/[^[:space:]]*DotnetToolSettings.xml' | head -1
+          }
+
+          any_pkg=$(ls packages/dotnet-inspect.any.*.nupkg)
+          any_path=$(settings_path "$any_pkg")
+          echo "any package:     $any_pkg -> $any_path"
+          case "$any_path" in
+            tools/net10.0/*) echo "OK: any package targets net10.0 (LTS reach floor)";;
+            *) echo "ERROR: any package must target net10.0 for reach, found: $any_path"; exit 1;;
+          esac
+
+          pointer_pkg=$(ls packages/dotnet-inspect.[0-9]*.nupkg)
+          pointer_path=$(settings_path "$pointer_pkg")
+          echo "pointer package: $pointer_pkg -> $pointer_path"
+          case "$pointer_path" in
+            tools/any/any/*) echo "OK: pointer is TFM-agnostic (tools/any/any)";;
+            *) echo "ERROR: pointer must be TFM-agnostic (tools/any/any), found: $pointer_path"; exit 1;;
+          esac
+        shell: bash
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,16 @@
 <Project>
   <PropertyGroup>
+    <!--
+      The official non-AOT "any" fallback package targets the LTS floor (net10.0) so
+      it installs and runs on machines that only have the LTS runtime. Everything else
+      (dev, test, and the RID-specific Native AOT packages) uses the latest runtime so
+      daily development dogfoods it and surfaces runtime bugs early. The "any" package
+      is the only managed-runtime artifact we ship, so it is the only one that needs the
+      conservative floor. Keyed on OfficialBuild + non-AOT (rather than a CLI override)
+      so an accidental `dotnet pack -r any` can't silently ship a net11.0 fallback. See
+      issue #240.
+    -->
+    <DefaultTargetFramework Condition="'$(DefaultTargetFramework)' == '' and '$(OfficialBuild)' == 'true' and '$(PublishAot)' == 'false'">net10.0</DefaultTargetFramework>
     <DefaultTargetFramework Condition="'$(DefaultTargetFramework)' == ''">net$(NETCoreAppMaximumVersion)</DefaultTargetFramework>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>


### PR DESCRIPTION
Keeps daily dev/test and Native AOT on the latest runtime (net11) to dogfood it, while guaranteeing the `any` (CoreCLR fallback) package — the only managed-runtime artifact shipped — stays on the net10.0 LTS floor so it installs on machines without the latest runtime. Closes the regression risk for issue #240.

## Problem

PR #493 flipped the default TFM from a conservative `net10.0` to `net$(NETCoreAppMaximumVersion)` (= net11.0 under the 11.0 SDK). That is correct for dev/AOT (we want to exercise net11), but it left the net10.0 floor for the `any` package living **only** in the CI pack command line (`-p:DefaultTargetFramework=net10.0`). An accidental `dotnet pack -r any -p:PublishAot=false` would inherit net11.0 and silently break LTS-only users — the same class of failure as #240. CI also never exercises the net10 reach path (the `dotnet tool install` smoke test resolves the linux-x64 AOT package), so the regression could ship green.

## Changes

- **`Directory.Build.props`**: pin `net10.0` structurally, keyed on `OfficialBuild=true && PublishAot=false` (the `any` pack). The floor no longer depends on remembering a CLI flag. Dev, test, and Native AOT builds keep using the latest runtime.
- **`ci.yml`**: drop the now-redundant `-p:DefaultTargetFramework=net10.0`; the condition is the single source of truth.
- **`release.yml`**: add a publish-time "Validate reach packaging" guard asserting the `any` package targets `tools/net10.0/…` and the pointer stays TFM-agnostic (`tools/any/any/…`), failing before push. Kept at publish time to keep PR CI cheap.

## Verification

- `dotnet msbuild -getProperty:TargetFramework`: default/AOT/pointer -> `net11.0`, any -> `net10.0`.
- Packed locally: `any` -> `tools/net10.0/any/DotnetToolSettings.xml`, pointer -> `tools/any/any/DotnetToolSettings.xml`.
- Reach guard passes on net10 and fails on a simulated net11 `any` package.
- Default build + full test suite (1145 passed, 9 skipped) unaffected.