### PR TITLE
Gate --annotate-check in CI: AnnotateCheckGateTests (annotation breadth gate)

### DIFF
--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -136,7 +136,10 @@ The witnesses:
 | `lifetime.*` | metadata: byref return type, `[IsByRefLike]`, `[UnscopedRef]` |
 
 Run into the harness as an `--annotate-check` mode, this yields per-category
-precision/recall — the analyzer analog of the decompiler's fidelity %.
+precision/recall — the analyzer analog of the decompiler's fidelity %. It is
+held durably by `AnnotateCheckGateTests` (the breadth gate, analog of
+`CompileBackGateTests`), which runs the sweep over the running runtime's CoreLib
+and fails CI on any precision violation or import crash, with a floor on recall.
 
 ### Coupling to IL quality
 

--- a/src/ILInspector.Decompiler.Tests/AnnotateCheckGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotateCheckGateTests.cs
@@ -1,0 +1,67 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The annotation oracle gate (docs/design/hidden-fact-annotations.md): the
+/// breadth signal for the hidden-fact annotations, the analyzer analog of the
+/// <see cref="CompileBackGateTests"/> depth signal. It runs <c>--annotate-check</c>
+/// over the running runtime's CoreLib and grades every annotation's IL offset
+/// against the raw opcode read independently with <c>ILReader</c>:
+/// <list type="bullet">
+/// <item><b>precision == 0 violations</b> — a wrong fact (an <c>alloc.box</c> not
+/// sitting on a <c>box</c>) is always an importer-typing or classifier bug, never
+/// runtime drift, so it is gated absolutely;</item>
+/// <item><b>0 import crashes</b> — pins the exception-safe-by-construction
+/// guarantee across the whole corpus, not just the curated fixtures;</item>
+/// <item><b>recall above a floor</b> — every unambiguous witness opcode
+/// (<c>box</c>/<c>newarr</c>/<c>localloc</c>/<c>calli</c>) should produce its
+/// annotation; a floor (not an exact baseline) tolerates runtime-version drift
+/// while a broad completeness regression still fails it.</item>
+/// </list>
+/// The corpus check guards against a vacuous green: a refactor that silently stops
+/// producing annotations would make a zero-violation assertion meaningless, so the
+/// gate also requires a large checked population.
+/// </summary>
+public class AnnotateCheckGateTests
+{
+    // Measured over net11 CoreLib (41,012 methods): 100% precision (16,857
+    // annotations, 0 violations), 100% recall (5,502 witnesses). The recall floor
+    // sits a couple points below; precision and crashes are absolute.
+    const double RecallFloor = 98.0;
+
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    [Fact]
+    public void CoreLib_AnnotationsAgreeWithRawIL()
+    {
+        var result = AnnotateCheck.Evaluate(CoreLibPath);
+
+        Assert.True(result.Methods > 10_000,
+            $"Expected a large CoreLib corpus; swept only {result.Methods} methods.");
+
+        // Non-vacuous: the sweep must actually grade a broad annotation population,
+        // or a zero-violation result would prove nothing.
+        Assert.True(result.PrecisionChecked > 1_000,
+            $"Expected a broad annotation population to grade; only {result.PrecisionChecked} were checked. "
+                + "A classifier or importer change may have silently stopped producing annotations.");
+
+        Assert.True(result.ImportCrashes == 0,
+            $"The annotation sweep must be exception-safe over the whole corpus, but {result.ImportCrashes} method(s) crashed:\n  "
+                + string.Join("\n  ", result.ImportCrashExamples));
+
+        Assert.True(result.PrecisionViolations == 0,
+            $"Annotation precision must be exact: {result.PrecisionViolations} annotation(s) sit on an IL offset whose raw "
+                + "opcode contradicts the claim — an importer-typing or classifier bug:\n  "
+                + string.Join("\n  ", result.Precision.SelectMany(c => c.Examples)));
+
+        double recallPercent = result.RecallChecked == 0
+            ? 0
+            : 100.0 * (result.RecallChecked - result.RecallViolations) / result.RecallChecked;
+        Assert.True(recallPercent >= RecallFloor,
+            $"Annotation recall {recallPercent:F2}% ({result.RecallChecked - result.RecallViolations}/{result.RecallChecked}) "
+                + $"fell below the {RecallFloor}% floor — a broad completeness regression (an unambiguous witness opcode "
+                + "stopped producing its annotation). If this is an intentional runtime-version shift, re-measure and adjust the floor.\n  "
+                + string.Join("\n  ", result.Recall.SelectMany(c => c.Examples)));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -36,6 +36,8 @@
   <ItemGroup>
     <Compile Include="..\..\tools\DecompilerHarness\CompileBack.cs"
              Link="CompileBack.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AnnotateCheck.cs"
+             Link="AnnotateCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"
              Link="VolatileFieldDetector.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\Gaps.cs"

--- a/tools/DecompilerHarness/AnnotateCheck.cs
+++ b/tools/DecompilerHarness/AnnotateCheck.cs
@@ -79,10 +79,53 @@ static class AnnotateCheck
         public readonly List<string> Examples = [];
     }
 
+    /// <summary>Per-category agreement counts (a descriptor for precision, a witness opcode for recall).</summary>
+    public sealed record CategoryStats(string Id, long Checked, long Violations, IReadOnlyList<string> Examples)
+    {
+        public long Agree => Checked - Violations;
+    }
+
+    /// <summary>
+    /// The structured oracle result, so a CI gate (<c>AnnotateCheckGateTests</c>)
+    /// can assert on it without re-implementing the sweep. <see cref="Run"/> is the
+    /// console wrapper over <see cref="Evaluate(IReadOnlyList{string}, int)"/>.
+    /// </summary>
+    public sealed class AnnotateCheckResult
+    {
+        public long Methods { get; init; }
+        public long ImportCrashes { get; init; }
+        public long NoProvenance { get; init; }
+        public long RecallExcludedPartial { get; init; }
+        public IReadOnlyList<string> ImportCrashExamples { get; init; } = [];
+        public IReadOnlyList<CategoryStats> Precision { get; init; } = [];
+        public IReadOnlyList<CategoryStats> Recall { get; init; } = [];
+
+        public long PrecisionChecked => Precision.Sum(s => s.Checked);
+        public long PrecisionViolations => Precision.Sum(s => s.Violations);
+        public long RecallChecked => Recall.Sum(s => s.Checked);
+        public long RecallViolations => Recall.Sum(s => s.Violations);
+    }
+
+    /// <summary>Convenience overload for a single assembly (used by the gate test).</summary>
+    public static AnnotateCheckResult Evaluate(string assemblyPath, int maxExamples = 10)
+        => Evaluate([assemblyPath], maxExamples);
+
     public static int Run(List<string> assemblies, int maxExamples)
+    {
+        var result = Evaluate(assemblies, maxExamples);
+        Report(result);
+        return result.PrecisionViolations > 0 || result.ImportCrashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Sweeps every method of the given assemblies, grading each annotation's IL
+    /// offset against the raw opcode read independently with <see cref="ILReader"/>.
+    /// </summary>
+    public static AnnotateCheckResult Evaluate(IReadOnlyList<string> assemblies, int maxExamples)
     {
         long methods = 0, importCrashes = 0, noProvenance = 0;
         long recallExcludedPartial = 0;
+        var importCrashExamples = new List<string>();
 
         // Precision tallies are per-descriptor; recall tallies are per-witness-opcode.
         var precision = new Dictionary<string, Tally>();
@@ -125,6 +168,8 @@ static class AnnotateCheck
                     catch (Exception ex)
                     {
                         importCrashes++;
+                        if (importCrashExamples.Count < maxExamples)
+                            importCrashExamples.Add($"{id}: {ex.GetType().Name}: {ex.Message}");
                         Console.Error.WriteLine($"IMPORT CRASH: {id}: {ex.GetType().Name}: {ex.Message}");
                         continue;
                     }
@@ -199,10 +244,21 @@ static class AnnotateCheck
             }
         }
 
-        Report(methods, importCrashes, noProvenance, recallExcludedPartial, precision, recall);
+        static IReadOnlyList<CategoryStats> Snapshot(Dictionary<string, Tally> tallies) =>
+            tallies.OrderBy(p => p.Key)
+                .Select(p => new CategoryStats(p.Key, p.Value.Checked, p.Value.Violations, p.Value.Examples))
+                .ToList();
 
-        long precisionViolations = precision.Values.Sum(t => t.Violations);
-        return precisionViolations > 0 || importCrashes > 0 ? 1 : 0;
+        return new AnnotateCheckResult
+        {
+            Methods = methods,
+            ImportCrashes = importCrashes,
+            NoProvenance = noProvenance,
+            RecallExcludedPartial = recallExcludedPartial,
+            ImportCrashExamples = importCrashExamples,
+            Precision = Snapshot(precision),
+            Recall = Snapshot(recall),
+        };
     }
 
     /// <summary>
@@ -225,41 +281,39 @@ static class AnnotateCheck
         return map;
     }
 
-    static void Report(
-        long methods, long importCrashes, long noProvenance, long recallExcludedPartial,
-        Dictionary<string, Tally> precision, Dictionary<string, Tally> recall)
+    static void Report(AnnotateCheckResult result)
     {
-        long precisionChecked = precision.Values.Sum(t => t.Checked);
-        long precisionViolations = precision.Values.Sum(t => t.Violations);
-        long recallChecked = recall.Values.Sum(t => t.Checked);
-        long recallViolations = recall.Values.Sum(t => t.Violations);
+        long precisionChecked = result.PrecisionChecked;
+        long precisionViolations = result.PrecisionViolations;
+        long recallChecked = result.RecallChecked;
+        long recallViolations = result.RecallViolations;
 
-        Console.WriteLine($"ANNOTATE-CHECK over {methods} methods ({importCrashes} import crashes):");
+        Console.WriteLine($"ANNOTATE-CHECK over {result.Methods} methods ({result.ImportCrashes} import crashes):");
         Console.WriteLine();
         Console.WriteLine($"PRECISION — annotation offset agrees with raw opcode ({precisionChecked} annotations):");
         Console.WriteLine($"  agree     : {precisionChecked - precisionViolations} ({Percent(precisionChecked - precisionViolations, precisionChecked)})");
         Console.WriteLine($"  violations: {precisionViolations}");
-        foreach (var (id, tally) in precision.OrderBy(p => p.Key))
+        foreach (var stats in result.Precision)
         {
-            if (tally.Checked == 0)
+            if (stats.Checked == 0)
                 continue;
-            Console.WriteLine($"    {id,-26} {tally.Checked - tally.Violations,8}/{tally.Checked,-8} {Percent(tally.Checked - tally.Violations, tally.Checked)}");
-            foreach (var example in tally.Examples)
+            Console.WriteLine($"    {stats.Id,-26} {stats.Agree,8}/{stats.Checked,-8} {Percent(stats.Agree, stats.Checked)}");
+            foreach (var example in stats.Examples)
                 Console.WriteLine($"      ! {example}");
         }
-        if (noProvenance > 0)
-            Console.WriteLine($"  ({noProvenance} synthetic annotations with no IL provenance — not graded)");
+        if (result.NoProvenance > 0)
+            Console.WriteLine($"  ({result.NoProvenance} synthetic annotations with no IL provenance — not graded)");
 
         Console.WriteLine();
-        Console.WriteLine($"RECALL — unambiguous witness opcode produced its annotation ({recallChecked} witnesses, {recallExcludedPartial} partial-import methods excluded):");
+        Console.WriteLine($"RECALL — unambiguous witness opcode produced its annotation ({recallChecked} witnesses, {result.RecallExcludedPartial} partial-import methods excluded):");
         Console.WriteLine($"  covered   : {recallChecked - recallViolations} ({Percent(recallChecked - recallViolations, recallChecked)})");
         Console.WriteLine($"  missing   : {recallViolations}");
-        foreach (var (id, tally) in recall.OrderBy(p => p.Key))
+        foreach (var stats in result.Recall)
         {
-            if (tally.Checked == 0)
+            if (stats.Checked == 0)
                 continue;
-            Console.WriteLine($"    {id,-26} {tally.Checked - tally.Violations,8}/{tally.Checked,-8} {Percent(tally.Checked - tally.Violations, tally.Checked)}");
-            foreach (var example in tally.Examples)
+            Console.WriteLine($"    {stats.Id,-26} {stats.Agree,8}/{stats.Checked,-8} {Percent(stats.Agree, stats.Checked)}");
+            foreach (var example in stats.Examples)
                 Console.WriteLine($"      ? {example}");
         }
         Console.WriteLine();

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -30,6 +30,8 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 *When to use it.* Run after any change to the classifiers (`AllocationClassifier`/`UnsafetyClassifier`/`LifetimeClassifier`), or to the importer's typing/metadata layer the classifiers read (value-type hints, signature decoding). A precision drop on a category points straight at the bug. Over .NET 11 preview CoreLib it currently reads **100% precision** (all 13 descriptors) and **100% recall** (the four gated witnesses).
 
+*The CI gate.* The console mode above is for exploration; the durable regression guard is `AnnotateCheckGateTests` in `ILInspector.Decompiler.Tests`, which calls the same machinery through `AnnotateCheck.Evaluate` (the non-printing, structured-result entry point) over the running runtime's CoreLib. It is the breadth gate (analog of `CompileBackGateTests`, the fixture depth gate): it fails CI on any precision violation (a wrong fact, always a bug — never runtime drift, so gated absolutely) or import crash, holds recall above a floor, and asserts a large checked population so a refactor that silently stops producing annotations cannot pass vacuously.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

Promotes the `--annotate-check` annotation oracle (#663) from a manual harness run to a **durable CI gate**: `AnnotateCheckGateTests`, the breadth gate for hidden-fact annotations — the analyzer analog of `CompileBackGateTests` (the fixture depth gate) and a sibling to `CorpusSweepGateTests`.

## What changed

- **Refactor `AnnotateCheck`** to split the sweep from the console report. A new structured `AnnotateCheck.Evaluate(assembly)` returns per-category precision/recall stats, import-crash counts, and examples; `Run` is now the printing wrapper over it. (Same `Run`-over-`Evaluate` shape `CompileBack` already uses.)
- **`AnnotateCheckGateTests`** links the one harness source file in (the established pattern — no project reference on the Exe) and runs the sweep over the running runtime's CoreLib.

## What it asserts

- **precision == 0 violations** — a wrong fact (an `alloc.box` not sitting on a `box`) is always an importer-typing or classifier bug, never runtime drift, so it is gated **absolutely**.
- **0 import crashes** — pins exception-safe-by-construction across the whole corpus, not just curated fixtures.
- **recall ≥ a floor (98%)** — a broad completeness regression fails, while a floor (not an exact baseline) tolerates runtime-version drift. Mirrors `CorpusSweepGateTests` floor philosophy.
- **a large checked population (>1000 annotations)** — guards against a vacuous green: a refactor that silently stops producing annotations cannot pass.

## Validation

- Non-vacuous proof: perturbing one witness (`alloc.box` → `Newarr`) fails the gate with **4273** precision violations and sample diffs; reverted.
- Full decompiler suite green (**315** tests). `Evaluate` refactor leaves the CLI behavior identical (100% precision / 100% recall, exit 0 over CoreLib).

## Docs

Gate documented in the harness README and `docs/design/hidden-fact-annotations.md`.

## Follow-ups (unchanged)

- `newobj`/`deref` recall via value-type / pointer resolution (the documented cross-assembly value-type gap).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
