### PR TITLE
Generalize ReturnMergePass to fold any common-exit return tail (control-flow step 2)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -196,7 +196,8 @@ through to the exit. This is always possible for a reducible CFG, but in general
 requires **code duplication** (the tail after the merge is duplicated into each
 arm) or an introduced boolean flag — the classic structured-programming cost.
 For a merge that is a short `return` tail this is cheap and clean (it is exactly
-what `ReturnMergePass` already does for comparison trees); for a merge with a
+what `ReturnMergePass` does — for any common-exit return tail since step 2, not
+only comparison trees); for a merge with a
 substantial shared tail it bloats the output and diverges further from the
 oracle.
 
@@ -206,8 +207,8 @@ oracle.
   use the **immediate post-dominator** as the join, lifting the index-range
   restriction. This is the core change and is shared by both targets.
 - When the post-dominator merge is a **short return tail**, eliminate it by
-  inlining (generalize `ReturnMergePass` beyond comparison trees, reusing its
-  gating discipline). This is full structuring for the cheap case.
+  inlining (`ReturnMergePass`, generalized beyond comparison trees in step 2,
+  reusing its gating discipline). This is full structuring for the cheap case.
 - Otherwise, retain the merge as a labelled block and let the arms `goto` it —
   matching the oracle. This is target A, and it is where the all-on-nothing
   relaxation is required.
@@ -293,6 +294,14 @@ only when the post-dominator machinery is proven.
    comparison-tree gate but keeping the scale/duplication guards. Fully
    structures the cheap case; no invariant change. Measure the `--gaps` drop
    and the blast radius.
+   *Status: landed.* The `ComparisonTrees.IsLikely` gate is gone; the fold now
+   fires on any short return tail reached by two or more unconditional
+   predecessors (the two guards make the tail the immediate post-dominator of
+   its arms, so duplicating it reorders nothing). `--gaps` fully-raised rose
+   +48 (39,347 → 39,395); the compile-check defect set is byte-for-byte
+   unchanged vs main (0 regressed, 0 new invalid); `--pass-impact return-merge`
+   covers 261 methods with 0 pass bugs. The plain forward common-exit
+   (`GotoCommonExit`) now folds to nested guards.
 3. **Post-dominator joins in the diamond/guard recursion.** Let `Validate`/
    `BuildRegion` accept a forward branch to the region's immediate
    post-dominator as the join, lifting the `target > stop` bail for that one

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -111,10 +111,11 @@ public class CfgSampleClass
         _ => 0,
     };
 
-    // Explicit gotos to a common exit — the forward-common-merge shape the
-    // structuring pass still leaves flat (only two comparisons, so not a
-    // comparison tree). `result` is assigned on every path before the read, so
-    // the CFG definite-assignment over the goto graph must declare it bare.
+    // Explicit gotos to a common exit — the forward-common-merge shape. The merge
+    // is a short `return result;` tail reached by two unconditional gotos plus a
+    // fallthrough, so the return-merge pass inlines the tail into each arm and the
+    // guard tree above nests cleanly (the step-2 common-exit fold). `result` is
+    // assigned on every path, so the CFG definite-assignment declares it bare.
     public static int GotoCommonExit(int x)
     {
         int result;
@@ -130,6 +131,31 @@ public class CfgSampleClass
         }
         result = 0;
     done:
+        return result;
+    }
+
+    // A forward-common-merge whose merge is NOT a short return tail: it ends in a
+    // guard, so the return-merge pass leaves it (its scale/shape guards reject a
+    // non-return-tail merge) and the index-range structurer still cannot express
+    // the past-region join — the body stays a goto graph. `result` is assigned on
+    // every path before the read, so CFG definite-assignment still declares it bare.
+    public static int GotoCommonExitGuardedMerge(int x)
+    {
+        int result;
+        if (x > 0)
+        {
+            if (x > 100)
+            {
+                result = 2;
+                goto done;
+            }
+            result = 1;
+            goto done;
+        }
+        result = 0;
+    done:
+        if (result > 1)
+            return result + 100;
         return result;
     }
 

--- a/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackGateTests.cs
@@ -25,12 +25,16 @@ public class CompileBackGateTests
     /// ClassifyMode is a sparse switch csc lowers to a comparison tree the
     /// structuring pass does not yet raise, so it round-trips through flat gotos
     /// (tracked under the structuring docket — leaves the set when that lands).
+    /// GotoCommonExit is the step-2 common-exit fold: the decompiler inlines the
+    /// shared return tail into each arm, recompiling to cleaner direct-return IL
+    /// than the original goto-and-merge shape — a benign equivalent restructuring.
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
         "ClassifyMode",
         "DayNumber",
+        "GotoCommonExit",
         "NeitherOr",
         "SmallStringSwitch",
     };

--- a/src/ILInspector.Decompiler.Tests/GapsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GapsTests.cs
@@ -35,10 +35,21 @@ public class GapsTests
     [Fact]
     public void CommonExitGotos_FlaggedAsStructuringGap()
     {
-        // GotoCommonExit's gotos to a shared exit are the forward-common-merge
-        // shape the structuring pass still leaves flat — a surviving branch.
-        var residual = Gaps.Residual(Raised(nameof(CfgSampleClass.GotoCommonExit)));
+        // GotoCommonExitGuardedMerge's gotos reach a merge that is not a short
+        // return tail (it ends in a guard), so the return-merge pass leaves it and
+        // the index-range structurer still cannot express the past-region join —
+        // a surviving branch the gap docket records.
+        var residual = Gaps.Residual(Raised(nameof(CfgSampleClass.GotoCommonExitGuardedMerge)));
         Assert.NotNull(residual);
         Assert.StartsWith("structuring:", residual);
+    }
+
+    [Fact]
+    public void CommonExitReturnTail_FoldedToFullyStructured()
+    {
+        // GotoCommonExit's shared `return result;` tail is inlined into each arm by
+        // the return-merge pass (the step-2 common-exit fold), so the guard tree
+        // nests cleanly and no residual control flow survives.
+        Assert.Null(Gaps.Residual(Raised(nameof(CfgSampleClass.GotoCommonExit))));
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -406,11 +406,12 @@ public class IrImporterTests
     [Fact]
     public void DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath()
     {
-        // GotoCommonExit's gotos to a shared exit are the forward-common-merge
-        // shape the structuring pass still leaves flat, so the body is a goto
-        // graph. The old global bail flooded every local to `= default`; CFG
-        // definite-assignment proves `result` assigned on every path first.
-        var function = ImportFixture(nameof(CfgSampleClass.GotoCommonExit));
+        // GotoCommonExitGuardedMerge's gotos to a shared guarded exit are a
+        // forward-common-merge the structuring pass leaves flat (the merge is not
+        // a short return tail, so the return-merge pass leaves it too), so the body
+        // is a goto graph. The old global bail flooded every local to `= default`;
+        // CFG definite-assignment proves `result` assigned on every path first.
+        var function = ImportFixture(nameof(CfgSampleClass.GotoCommonExitGuardedMerge));
         IrPasses.Run(function);
         var output = CSharpPrinter.PrintRaised(function).Output!;
 

--- a/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredCompileBackGateTests.cs
@@ -19,8 +19,9 @@ public class LoweredCompileBackGateTests
     /// <summary>
     /// Methods whose lowered C# still recompiles to a different opcode stream — the open
     /// lowered docket. The gate tolerates these but fails if a NEW method joins the set.
-    /// Beyond the shared sugared docket (BothPositive, ClassifyMode, DayNumber, NeitherOr,
-    /// SmallStringSwitch), the lowered view adds ReverseCopy: lowering deliberately skips
+    /// Beyond the shared sugared docket (BothPositive, ClassifyMode, DayNumber,
+    /// GotoCommonExit, NeitherOr, SmallStringSwitch), the lowered view adds ReverseCopy:
+    /// lowering deliberately skips
     /// IncrementDecrementPass, so the dup-based ++/-- idiom round-trips as an explicit temp
     /// rather than the folded operator — a benign by-design divergence for this view.
     /// </summary>
@@ -29,6 +30,7 @@ public class LoweredCompileBackGateTests
         "BothPositive",
         "ClassifyMode",
         "DayNumber",
+        "GotoCommonExit",
         "NeitherOr",
         "ReverseCopy",
         "SmallStringSwitch",

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -17,10 +17,11 @@ public class StructuringDiagnosticsTests
     [Fact]
     public void CommonExitMerge_RecordsForwardBranchBail()
     {
-        // Two nested guards both `goto done` onto a shared exit past the region:
-        // the index-range model cannot express the merge, so the container stays
-        // flat and the sink records exactly why.
-        var diag = RunWithDiagnostics(nameof(CfgSampleClass.GotoCommonExit));
+        // Two nested guards both `goto done` onto a shared exit past the region
+        // whose merge is not a short return tail (it ends in a guard, so the
+        // return-merge pass leaves it): the index-range model cannot express the
+        // merge, so the container stays flat and the sink records exactly why.
+        var diag = RunWithDiagnostics(nameof(CfgSampleClass.GotoCommonExitGuardedMerge));
 
         Assert.Equal(0, diag.Structured);
         Assert.Equal("forward-branch-not-region-exit", Assert.Single(diag.Bails));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
@@ -2,14 +2,21 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// Dissolves a shared return-merge: a short <c>return</c>-only block that two or
-/// more blocks reach by an unconditional <c>goto</c>. csc lowers a <c>switch</c>
-/// (and other multi-way selection) to a comparison tree whose every arm stores
-/// its result and jumps forward to one <c>ldloc; ret</c> tail — a join the
-/// structuring pass cannot nest, because the arms branch past their region to
-/// reach it. Inlining a copy of the tail into each such predecessor (the shape
-/// the prior emitter produced) turns those arms into straight returns, so the
-/// guard tree above them nests cleanly and the definite-assignment walk sees no
-/// surviving goto.
+/// more blocks reach by an unconditional <c>goto</c>. csc lowers many multi-way
+/// selections — a <c>switch</c> comparison tree, but equally a plain forward
+/// common-exit (two nested guards both jumping to one shared <c>ldloc; ret</c>) —
+/// to arms that each store their result and branch forward to a single return
+/// tail, a join the index-range structuring pass cannot nest because the arms
+/// branch past their region to reach it. Inlining a copy of the tail into each
+/// such predecessor (the shape the prior emitter produced) turns those arms into
+/// straight returns, so the guard tree above them nests cleanly and the
+/// definite-assignment walk sees no surviving goto.
+///
+/// The fold is gated structurally rather than by a selection-shape heuristic: a
+/// merge qualifies only when it is a short return tail reached by two or more
+/// <em>unconditional</em> predecessors. Those two guards together make the tail
+/// the immediate post-dominator of its arms, so duplicating it is a pure copy of
+/// a <c>return</c> that reorders nothing.
 ///
 /// Conservative by construction:
 ///   • only short tails (the terminator-inlining budget) are duplicated;
@@ -36,12 +43,6 @@ public sealed class ReturnMergePass : IIrPass
 
     static void Fold(BlockContainer container, PassContext context)
     {
-        // Only dissolve merges inside a genuine comparison tree; a two- or
-        // three-way selection's shared return reads better kept (the folding and
-        // boolean passes raise it as a ternary).
-        if (!ComparisonTrees.IsLikely(container))
-            return;
-
         // Folding one merge can turn its own predecessor (a default arm that
         // fell into it) into a fresh return tail, so iterate to a fixpoint.
         bool changed = true;


### PR DESCRIPTION
## Control-flow structuring track — step 2 (return-tail merges)

Implements step 2 of `docs/design/control-flow-structuring.md`: generalize `ReturnMergePass` beyond comparison trees to fold **any** post-dominator return-tail merge.

### Change
Drop the `ComparisonTrees.IsLikely` gate from `ReturnMergePass`. The fold now fires on any short `return` tail reached by **two or more unconditional predecessors**. Those two guards make the tail the immediate post-dominator of its arms, so inlining a clone into each arm is a pure copy of a `return` that reorders nothing. The scale (`MaxTailStatements=3`) and duplication (`>=2` unconditional preds) guards are kept; a two-way diamond (one goto + one fallthrough) is still left to the structuring pass.

The plain forward common-exit — two nested guards both `goto done` onto one `ldloc; ret` — now folds to nested guard clauses instead of staying flat goto soup.

### Rails (all green)
| Rail | Result |
| --- | --- |
| `--gaps` fully-raised | **+48** (39,347 → 39,395); conditional-branch residual −53 (1,621 → 1,568) |
| `--compile-check` defect-set A/B (`--diff-defects` vs main) | **0 regressed, 0 improved, 0 new invalid** — byte-for-byte unchanged |
| `--pass-impact return-merge` | 261 methods, **0 pass bugs** |
| decompiler test suite | **315 green** (+1) |

The duplicated tail multiplies a few existing CS0266/CS0030 *occurrences* inside methods already in the defect set; no method gains or loses a defect.

### Test changes
- `GotoCommonExit` now folds, so it joins both compile-back dockets — a benign equivalent goto-layout restructuring (cleaner direct-return IL than the original goto-and-merge shape), like `ClassifyMode`/`SmallStringSwitch`. It also gains a positive `--gaps` fully-raised assertion.
- New `GotoCommonExitGuardedMerge` fixture (a common-exit whose merge ends in a guard, so it is *not* a short return tail and is intentionally left flat) preserves the goto-graph coverage for the forward-branch bail sink (`StructuringDiagnosticsTests`) and the CFG definite-assignment-over-goto test (`IrImporterTests`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>