### PR TITLE
Mark RequiresUnsafe members unsafe in the API surface (new rules, feature D)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,26 +184,33 @@ private static bool CheckForUnsafeCode(MetadataReader reader)
 
 #### Method-Level Detection (`--unsafe` filter)
 
-The `--unsafe` filter identifies methods with **pointer types in their signature**:
+The `--unsafe` filter identifies methods that require the caller to enter an
+unsafe context, from two metadata signals:
 
 ```csharp
-private static bool HasUnsafeSignature(string? signature)
-{
-    return signature?.Contains('*') ?? false;
-}
+IsUnsafe = HasUnsafeSignature(signature)               // pointer in signature
+        || AttributeReader.HasRequiresUnsafeAttribute(...); // declared `unsafe`/`extern`
 ```
 
-This detects:
+The signature check (`signature.Contains('*')`) detects:
 
 - Pointer parameters: `void Process(byte* buffer)`
 - Pointer return types: `int* GetPointer()`
 - Function pointers: `delegate*<int, void>`
 
+The attribute check detects members declared `unsafe`/`extern` even when no
+pointer appears in their signature. Under the updated memory-safety rules the
+compiler stamps such members with `RequiresUnsafeAttribute`
+(`System.Diagnostics.CodeAnalysis`); the attribute is only emitted under those
+rules, so the check is self-gating and legacy assemblies are unaffected.
+
 This approach is intentionally **API-focused** - it surfaces methods that require the caller to use an unsafe context. Methods that use unsafe internally but expose a safe API are not included.
 
 #### What's Not Detected
 
-Methods marked with the `unsafe` keyword but without pointers in their signature are not detected. For example:
+For a **legacy** assembly (no `RequiresUnsafeAttribute`), a method declared with
+the `unsafe` keyword but without a pointer in its signature is not detected,
+because there is no metadata trace of the member modifier. For example:
 
 ```csharp
 public unsafe int StackAlloc()
@@ -213,7 +220,9 @@ public unsafe int StackAlloc()
 }
 ```
 
-This method is `unsafe` but has a safe signature (`int StackAlloc()`), so `--unsafe` won't include it.
+This method is `unsafe` but has a safe signature (`int StackAlloc()`), so for a
+legacy assembly `--unsafe` won't include it. Under the updated memory-safety
+rules the same member carries `RequiresUnsafeAttribute` and **is** detected.
 
 #### Fully Accurate Implementation
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -199,7 +199,8 @@ public static class ApiSurfaceExtractor
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     Signature = signature,
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
-                    IsUnsafe = HasUnsafeSignature(signature),
+                    IsUnsafe = HasUnsafeSignature(signature)
+                        || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
                     Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage
@@ -883,7 +884,10 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
-    /// Checks if a method signature contains unsafe constructs (pointers).
+    /// Checks if a method signature contains unsafe constructs (pointers). This
+    /// catches members whose signature renders a pointer; members declared
+    /// <c>unsafe</c> with no pointer in the signature are detected separately via
+    /// <see cref="AttributeReader.HasRequiresUnsafeAttribute"/>.
     /// </summary>
     private static bool HasUnsafeSignature(string? signature)
     {

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -100,6 +100,15 @@ public static class AttributeReader
     public static bool HasRequiredMemberAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => HasAttribute(reader, attributes, KnownAttributeNames.RequiredMemberAttribute);
 
+    /// <summary>
+    /// Checks whether the member carries <c>RequiresUnsafeAttribute</c> — the
+    /// metadata form of the <c>unsafe</c>/<c>extern</c> modifier stamped under the
+    /// updated memory-safety rules. Tolerates the two namespace spellings.
+    /// </summary>
+    public static bool HasRequiresUnsafeAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+        => HasAttribute(reader, attributes, KnownAttributeNames.RequiresUnsafeAttribute)
+        || HasAttribute(reader, attributes, KnownAttributeNames.RequiresUnsafeAttributeCompilerServices);
+
     private static bool IsCompilerCompatibilityObsolete(
         MetadataReader reader,
         CustomAttributeHandleCollection attributes,

--- a/src/ILInspector.Metadata/KnownAttributeNames.cs
+++ b/src/ILInspector.Metadata/KnownAttributeNames.cs
@@ -31,6 +31,14 @@ public static class KnownAttributeNames
     public const string NullablePublicOnlyAttribute = Prefix + "NullablePublicOnlyAttribute";
     public const string RefSafetyRulesAttribute = Prefix + "RefSafetyRulesAttribute";
     public const string RequiredMemberAttribute = Prefix + "RequiredMemberAttribute";
+
+    // RequiresUnsafeAttribute is emitted in System.Diagnostics.CodeAnalysis (the
+    // metadata form of the member `unsafe`/`extern` modifier under the updated
+    // memory-safety rules). Early design notes placed it in
+    // System.Runtime.CompilerServices, so the legacy spelling is tolerated too.
+    public const string RequiresUnsafeAttribute = "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute";
+    public const string RequiresUnsafeAttributeCompilerServices = Prefix + "RequiresUnsafeAttribute";
+
     public const string RuntimeCompatibilityAttribute = Prefix + "RuntimeCompatibilityAttribute";
     public const string RuntimeHostConfigurationOptionAttribute = Prefix + "RuntimeHostConfigurationOptionAttribute";
     public const string ScopedRefAttribute = Prefix + "ScopedRefAttribute";

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// The API surface <c>unsafe</c> modifier under the updated memory-safety rules.
+/// A member declared <c>unsafe</c>/<c>extern</c> is stamped with
+/// <c>RequiresUnsafeAttribute</c> even when no pointer appears in its signature,
+/// so the extractor must treat that attribute — not just a textual <c>*</c> in
+/// the signature — as evidence of an unsafe member. The fixtures live in the
+/// new-rules assembly (compiled with <c>updated-memory-safety-rules</c>).
+/// </summary>
+public sealed class ApiSurfaceUnsafeTests
+{
+    private static ApiMember Method(string name)
+    {
+        // ApiSurfaceExtractor materializes the surface into lists, so the reader
+        // can be disposed once Extract returns. typeof(...).Name is the simple
+        // type name ("UnsafeFixtures"); nameof on the using-alias would yield the
+        // alias identifier instead.
+        using var stream = File.OpenRead(typeof(NewFixtures).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        return surface.Types.First(t => t.Name == typeof(NewFixtures).Name)
+            .Members.First(m => m.Name == name && m.Kind == "method");
+    }
+
+    [Fact]
+    public void RequiresUnsafeMember_WithoutPointerInSignature_IsUnsafe()
+    {
+        // `public static unsafe int Risky() => 42;` — declared unsafe, no pointer
+        // in the signature, so the only evidence is RequiresUnsafeAttribute.
+        Assert.True(Method(nameof(NewFixtures.Risky)).IsUnsafe);
+    }
+
+    [Fact]
+    public void PointerSignatureMember_IsUnsafe()
+    {
+        // `void* p` parameter — caught by the signature pointer check.
+        Assert.True(Method(nameof(NewFixtures.FreePointer)).IsUnsafe);
+    }
+
+    [Fact]
+    public void SafeMember_IsNotUnsafe()
+    {
+        // No pointer and not declared unsafe at the member level.
+        Assert.False(Method(nameof(NewFixtures.StackAllocDefault)).IsUnsafe);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
+++ b/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
@@ -20,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <!-- New-rules unsafe fixture: a member declared `unsafe` with no pointer in
+         its signature is stamped [RequiresUnsafeAttribute]; used to verify the
+         API surface marks it unsafe. -->
+    <ProjectReference Include="../../src/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Follow-up to #661 (the body-emitter side of the updated memory-safety rules).
This is **Feature D** — the signature/API-surface side: render the `unsafe`
modifier for members the compiler marks `RequiresUnsafe`.

Under the updated memory-safety rules the compiler stamps a member declared
`unsafe`/`extern` with `RequiresUnsafeAttribute` (`System.Diagnostics.CodeAnalysis`)
even when no pointer appears in its signature. `ApiSurfaceExtractor` only inferred
`IsUnsafe` from a textual `*` in the rendered signature, so a member like
`public static unsafe int Risky() => 42;` was rendered **without** the `unsafe`
modifier and excluded from `--unsafe`/audit filtering.

## Change

- **KnownAttributeNames** — add `RequiresUnsafeAttribute` (and the legacy
  `System.Runtime.CompilerServices` spelling, tolerated for namespace churn).
- **AttributeReader** — add `HasRequiresUnsafeAttribute`.
- **ApiSurfaceExtractor** — OR the attribute check into `IsUnsafe`. The attribute
  is only emitted under the new rules, so the check is **self-gating**: legacy
  assemblies are byte-for-byte unaffected.

End-to-end, `member UnsafeFixtures` now renders `public static unsafe int Risky()`
(previously no modifier); `CallRisky` (an `unsafe`-block body, not a member-level
`unsafe`) correctly stays safe.

## Tests

- New `ApiSurfaceUnsafeTests` against the new-rules fixture assembly: `Risky`
  (RequiresUnsafe, no pointer) → unsafe; `FreePointer` (pointer signature) →
  unsafe; `StackAllocDefault` (safe) → not unsafe. TDD: red witnessed on `Risky`
  before the fix.
- Suites green: Metadata **197**, dotnet-inspect.Tests **1145** (9 skipped),
  Analysis **18**.

## Docs

- `docs/architecture.md` — the `--unsafe` detection section now documents the
  attribute signal; the "not detected" limitation is scoped to legacy assemblies.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
