### PR TITLE
Accept a diamond false-arm early exit to the region merge (step 3)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -307,6 +307,33 @@ only when the post-dominator machinery is proven.
    post-dominator as the join, lifting the `target > stop` bail for that one
    target. Still all-or-nothing; recovers the cases where the merge is reachable
    by fallthrough after nesting.
+
+   *Status: merge-exit slice landed.* `Validate`/`BuildRegion` now accept a
+   conditional branch whose target is the region's tracked join (`joinIndex`)
+   even when `joinIndex > stop` — a diamond false arm that early-exits straight
+   to the merge. Because `joinIndex >= stop` always holds, this can never
+   intercept a `target < stop` case, so it cannot reshape any container that
+   already structured (zero blast radius). Result: `--gaps` fully raised
+   39,395 → 39,418 (+23); `cond-target-past-region` 879 → 851; defect diff vs
+   the step-2 baseline 0 regressed, 2 methods improved (malformed → valid);
+   `--pass-impact structuring` 0 pass bugs; 317 decompiler tests green
+   (`DiamondArmEarlyExitGuardedMerge` fixture pins the recovery — it bails
+   without the slice, structures with it).
+
+   *Finding — the residual is two distinct mechanisms, not more post-dominator
+   joins.* The remaining `cond-target-past-region` (851) splits by block count:
+   198 ≤6 blocks, 224 of 7–12, 423 of >12. The small/medium bulk is the
+   `||`/`&&`-guard-chain-ending-in-throw shape (`if (A) goto THROW; if (B) goto
+   MERGE; THROW: throw; MERGE: return`, e.g. `System.Range::GetOffsetAndLength`,
+   `System.Enum::ValidateRuntimeType`). Post-dominators are **degenerate** here:
+   because `throw` is a parallel method exit, every block's immediate
+   post-dominator collapses to the virtual exit, so the CFG cannot name the
+   success-MERGE as a join. These need a distinct boolean-combining mechanism
+   (combine guards across a shared throw terminator into `if (A || !B) throw;`),
+   closer to the existing `&&`/`||` guard handling than to post-dominator joins.
+   The >12-block tail is the large shared-merge DAG that step 4 (retained merge
+   label) targets. So the "full post-dominator join" idea recovers exactly the
+   merge-exit slice above; the bulk is deferred to those two follow-ups.
 4. **Partial structuring with a retained merge label (the invariant relaxation).**
    Allow a structured container to keep one labelled post-dominator block that
    the arms `goto`, matching the oracle for tails that cannot be eliminated.

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -159,6 +159,32 @@ public class CfgSampleClass
         return result;
     }
 
+    // A diamond whose false arm carries an internal guard that branches straight
+    // to the shared merge — `if (y > 0) goto done;` from inside the false arm,
+    // the merge lying past the false arm's lexical boundary. The merge ends in a
+    // guard (not a short return tail), so the return-merge pass leaves it and the
+    // join survives as a real block. The index-range model bailed here
+    // (cond-target-past-region: the false-arm conditional's target is the region
+    // join, which is > the arm's stop); the merge-exit recovery (step 3) raises
+    // it, because the target is the region's tracked join. `r` is assigned on
+    // every path before the read.
+    public static int DiamondArmEarlyExitGuardedMerge(int x, int y)
+    {
+        int r = 0;
+        if (x > 0)
+            goto trueArm;
+        if (y > 0)
+            goto done;
+        r = 1;
+        goto done;
+    trueArm:
+        r = 2;
+    done:
+        if (r > 1)
+            return r + 100;
+        return r;
+    }
+
     // A local assigned inside a lock body before the read after it. Modeling the
     // lock as its sequential body (rather than bailing) proves the bare decl.
     public static int LockedAssign(object gate, int x)

--- a/src/ILInspector.Decompiler.Tests/GapsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GapsTests.cs
@@ -52,4 +52,16 @@ public class GapsTests
         // nests cleanly and no residual control flow survives.
         Assert.Null(Gaps.Residual(Raised(nameof(CfgSampleClass.GotoCommonExit))));
     }
+
+    [Fact]
+    public void DiamondArmEarlyExitToJoin_RecoveredByMergeExit()
+    {
+        // DiamondArmEarlyExitGuardedMerge's false arm branches straight to the
+        // region join (`if (y > 0) goto done;`). The merge ends in a guard, so the
+        // return-merge pass leaves the join as a real block past the arm's lexical
+        // stop. The index-range model bailed (cond-target-past-region); the step-3
+        // merge-exit recovery raises it because the target is the tracked join, so
+        // no residual control flow survives.
+        Assert.Null(Gaps.Residual(Raised(nameof(CfgSampleClass.DiamondArmEarlyExitGuardedMerge))));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -276,6 +276,21 @@ public sealed class StructuringPass : IIrPass
                         ctx.Recorder?.Record("cond-backward-branch");
                         return false;  // backward = loop (later slice)
                     }
+                    // A conditional that jumps to this region's own merge — its
+                    // post-dominator, tracked as joinIndex — is an early exit to
+                    // the join: `if (c) goto JOIN` selects the merge, the
+                    // fallthrough body runs otherwise. This is the diamond/guard
+                    // false arm reaching the common exit past its lexical
+                    // boundary (joinIndex >= stop), the shape the index-range
+                    // model could not name. Raise it as a guard over the rest of
+                    // the region; the merge stays reached by fallthrough.
+                    if (target == joinIndex)
+                    {
+                        if (!Validate(ctx, i + 1, stop, joinIndex, breakTarget))
+                            return false;
+                        i = stop;
+                        break;
+                    }
                     if (target > stop)
                     {
                         ctx.Recorder?.Record("cond-target-past-region");
@@ -495,6 +510,17 @@ public sealed class StructuringPass : IIrPass
                             guardArm.Add(statement.Clone());
                         result.Add(new IfStatement(condition, guardArm, null));
                         i++;
+                        break;
+                    }
+                    // A conditional jumping to this region's merge (joinIndex) is
+                    // an early exit to the join: raise it as a guard over the rest
+                    // of the region, the negated condition selecting the
+                    // fallthrough body (mirrors Validate's merge-exit recovery).
+                    if (target == joinIndex)
+                    {
+                        var exitArm = BuildRegion(ctx, i + 1, stop, joinIndex, breakTarget);
+                        result.Add(new IfStatement(Negate(condition), exitArm, null));
+                        i = stop;
                         break;
                     }
                     int falseStart = i + 1;


### PR DESCRIPTION
## Summary

Step 3 of the control-flow structuring track (`docs/design/control-flow-structuring.md`): the **merge-exit slice** of the post-dominator-join work.

The index-range structurer bailed (`cond-target-past-region`) whenever a conditional inside a diamond/guard false arm branched straight to the region's common merge — its post-dominator, tracked as `joinIndex` — when that merge lay past the arm's lexical `stop`. The `[start, stop)` model could not name a join past its own boundary, so the whole container stayed a goto graph.

`Validate`/`BuildRegion` now accept a conditional whose target is the region's tracked `joinIndex` even when `joinIndex > stop`: it's an early exit to the join (`if (c) goto MERGE` selects the merge, the fallthrough body runs otherwise), raised as a guard over the rest of the region with the merge still reached by fallthrough.

**Zero blast radius:** because `joinIndex >= stop` always holds, `target == joinIndex` can never intercept a `target < stop` case, so this cannot reshape any container that already structured. The only new behavior is the diamond false-arm early-exit-to-merge that previously bailed.

## Rails (CoreLib sweep, net11 preview.5)

- `--gaps` fully raised **39,395 → 39,418 (+23)**; `cond-target-past-region` 879 → 851
- `--compile-check --diff-defects` (vs step-2 baseline): **0 regressed, 2 methods improved** (malformed → valid)
- `--pass-impact structuring`: 9,243 methods touched, **0 pass bugs**
- **317** decompiler tests green (+1)

New `DiamondArmEarlyExitGuardedMerge` fixture pins the recovery — verified it bails without the slice and structures with it.

## Roadmap finding

The doc records that the residual `cond-target-past-region` (851) is **two distinct mechanisms, not more post-dominator joins**: the small/medium bulk (198 ≤6-block + 224 of 7–12) is the `||`/`&&`-guard-to-throw shape, where post-dominators are degenerate (`throw` is a parallel exit, so the CFG cannot name the success merge) — that needs a boolean-combining pass. The >12-block tail (423) is the shared-merge DAG that step 4's retained merge label targets.
