### PR TITLE
Fold an OR-guard chain whose root carries the method prologue

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -334,6 +334,26 @@ only when the post-dominator machinery is proven.
    The >12-block tail is the large shared-merge DAG that step 4 (retained merge
    label) targets. So the "full post-dominator join" idea recovers exactly the
    merge-exit slice above; the bulk is deferred to those two follow-ups.
+
+   *Status: throw-guard combine landed.* The `||`/`&&`-guard-to-throw bulk is
+   recovered by extending `OrChainGuardPass` rather than the structurer:
+   `csc` lowers `if (A || B) Throw();` to a short-circuit guard run where the
+   first guard block also carries the method's unconditional prologue (the code
+   computing the operands) ahead of its branch. The original pass required
+   *every* guard, including the root, to be a pure single-condition block, so
+   any method whose prologue shared the first guard's block (e.g.
+   `System.Range::GetOffsetAndLength`) was rejected and stayed flat. The pass
+   now accepts a root that ends in its guard conditional but carries leading
+   straight-line statements (only the root — inner guards run conditionally, so
+   their statements cannot be hoisted out of short-circuit order), keeping that
+   prologue in the folded block. Result: `--gaps` fully raised 39,418 → 39,772
+   (+354); `structuring: conditional-branch` 1,545 → 1,191; defect diff vs the
+   step-3 baseline 0 regressed, 5 methods improved (malformed → valid);
+   `--pass-impact or-chain-guard` 1,177 methods, 0 pass bugs; 318 decompiler
+   tests green (`OrChainGuard_RootCarriesSetupStatements` pins it — fails
+   without the change). `Range::GetOffsetAndLength` now raises to the exact
+   source `if ((uint)end > (uint)length || (uint)start > (uint)end)
+   ThrowArgumentOutOfRangeException();`.
 4. **Partial structuring with a retained merge label (the invariant relaxation).**
    Allow a structured container to keep one labelled post-dominator block that
    the arms `goto`, matching the oracle for tails that cannot be eliminated.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2007,6 +2007,52 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void OrChainGuard_RootCarriesSetupStatements()
+    {
+        // The CoreLib Range.GetOffsetAndLength shape: the first guard block also
+        // holds the method's unconditional prologue (computing the operands) just
+        // ahead of its branch, so it is not a pure single-condition block. The
+        // fold still combines the chain into one || guard, keeping that prologue
+        // in place. Built directly so the test is independent of csc codegen:
+        //   IL_0000: V_0 = a + b;             // prologue, then:
+        //            if (a < 0)  goto IL_000C;   // → throw
+        //   IL_0004: if (b < 0)  goto IL_000C;   // → throw
+        //   IL_0008: if (a <= b) goto IL_0010;   // → skip (return)
+        //   IL_000C: throw null;
+        //   IL_0010: return V_0;
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new StoreLocal(0, intType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, A(), B())));
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 12));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, B(), new Constant(0, intType)), 12));
+        var b2 = new Block(8);
+        b2.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThanOrEqual, false, A(), B()), 16));
+        var consequence = new Block(12);
+        consequence.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        var join = new Block(16);
+        join.Add(new Return(new LoadLocal(0, intType)));
+        foreach (var block in (Block[])[b0, b1, b2, consequence, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        // The prologue survives, the chain folds into one || guard, no goto left.
+        Assert.Contains("= a + b", output);
+        Assert.Contains("if (a < 0 || b < 0 || a > b)", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
     public void SharedThrowGuards_InlineAsGuardClauses()
     {
         // Two guards branch to one shared throw block — the shape that breaks

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
@@ -87,7 +87,7 @@ public sealed class OrChainGuardPass : IIrPass
     static (int SkipGuard, int JoinIndex, int JoinOffset)? Chain(
         IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
     {
-        if (ConditionTarget(blocks[p]) is not { } firstTarget
+        if (ConditionTargetAtEnd(blocks[p]) is not { } firstTarget
             || !offsetToIndex.TryGetValue(firstTarget, out int consequence))
         {
             return null;
@@ -121,6 +121,26 @@ public sealed class OrChainGuardPass : IIrPass
     /// <summary>The single branch target of a pure one-statement condition block, or null.</summary>
     static int? ConditionTarget(Block block)
         => block.Children is [ConditionalBranch conditional] ? conditional.TargetOffset : null;
+
+    /// <summary>
+    /// The branch target of a block whose last statement is a conditional branch
+    /// and whose earlier statements are all straight-line (no control flow), or
+    /// null. The chain root may carry such setup — the method's unconditional
+    /// prologue that computes the guard operands — ahead of its branch; only the
+    /// root qualifies, since inner guards run conditionally (their leading
+    /// statements would move out of short-circuit order if folded).
+    /// </summary>
+    static int? ConditionTargetAtEnd(Block block)
+    {
+        if (block.Children.Count == 0 || block.Children[^1] is not ConditionalBranch conditional)
+            return null;
+        for (int s = 0; s < block.Children.Count - 1; s++)
+        {
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return null;
+        }
+        return conditional.TargetOffset;
+    }
 
     /// <summary>
     /// No block outside the chain-and-consequence span may branch into the
@@ -165,11 +185,13 @@ public sealed class OrChainGuardPass : IIrPass
 
         // Build the throw condition in evaluation order: each guard before the
         // skip contributes its condition; the skip guard contributes the
-        // negation of its own (its taken path skips the consequence).
+        // negation of its own (its taken path skips the consequence). The guard
+        // conditional is always the block's last statement — the root may carry
+        // leading setup statements ahead of it.
         IrExpression? throwCondition = null;
         for (int j = p; j <= skipGuard; j++)
         {
-            var conditional = (ConditionalBranch)blocks[j].Children[0];
+            var conditional = (ConditionalBranch)blocks[j].Children[^1];
             var condition = (IrExpression)conditional.DetachChildren()[0];
             if (j == skipGuard)
                 condition = Conditions.Negate(condition);
@@ -178,10 +200,15 @@ public sealed class OrChainGuardPass : IIrPass
                 : new LogicalBinary(LogicalKind.Or, throwCondition, condition);
         }
 
-        // The folded guard branches to the join when the throw condition is
-        // false; the structuring pass negates !throwCondition back to the
-        // clean `if (throwCondition) { consequence }`.
+        // The folded guard keeps the root block's leading statements (the
+        // unconditional prologue, everything before its trailing conditional)
+        // and branches to the join when the throw condition is false; the
+        // structuring pass negates !throwCondition back to the clean
+        // `if (throwCondition) { consequence }`.
         var folded = new Block(blocks[p].StartOffset);
+        var rootChildren = blocks[p].DetachChildren();
+        for (int k = 0; k < rootChildren.Count - 1; k++)
+            folded.Add(rootChildren[k]);
         folded.Add(new ConditionalBranch(new LogicalNot(throwCondition!), joinOffset));
 
         foreach (var block in blocks)


### PR DESCRIPTION
## Summary

Recovers the `||`/`&&`-guard-to-throw bulk that the step-3 finding flagged as the next focused mechanism — by extending `OrChainGuardPass`, not the structurer.

`csc` lowers `if (A || B) Throw();` to a short-circuit guard run where the **first** guard block also holds the method's unconditional prologue (the code computing the guard operands) just ahead of its branch. The pass required *every* guard, including the root, to be a pure single-condition block, so any method whose prologue shared the first guard's block — e.g. `System.Range::GetOffsetAndLength`, where the block computes `start`/`end` before testing them — was rejected and stayed a flat goto graph.

These are exactly the shapes the step-3 finding identified as needing a **boolean combine** rather than a structurer join: post-dominators are degenerate for them (the throw is a parallel method exit, so the CFG cannot name the success merge).

## The change

Accept a chain root that ends in its guard conditional but carries leading straight-line statements, keeping that prologue in the folded block. **Only the root qualifies** — inner guards run conditionally, so their leading statements cannot be hoisted out of short-circuit order. The combined condition reads each guard from its block's last statement and preserves evaluation order exactly.

## Rails (CoreLib sweep, net11 preview.5)

- `--gaps` fully raised **39,418 → 39,772 (+354)**; `structuring: conditional-branch` 1,545 → 1,191
- `--compile-check --diff-defects` (vs step-3 baseline): **0 regressed, 5 methods improved** (malformed → valid)
- `--pass-impact or-chain-guard`: 1,177 methods, **0 pass bugs**
- **318** decompiler tests green (+1)

New synthetic `OrChainGuard_RootCarriesSetupStatements` pins the recovery — it fails without the change.

`Range::GetOffsetAndLength` now raises to the exact source:

```csharp
if ((uint)end > (uint)length || (uint)start > (uint)end)
    ThrowArgumentOutOfRangeException();
```
