### PR TITLE
Raise Span-over-stackalloc to source-level stackalloc T[n]

### DIFF
--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -99,6 +99,17 @@ Taking an address (`&x`), declaring pointer locals, the `fixed` statement, and
 operation initializes a local used later, the declaration is hoisted above the
 block so the variable stays in scope.
 
+The stackalloc→`Span<T>` case is first raised from the compiler's lowering — a
+`localloc` fed to the `Span<T>(void*, int)` constructor — back into a source-level
+`stackalloc T[n]` by `StackAllocSpanPass`. That raise is mode-independent
+correctness (the lowered ctor shape `new Span<T>(stackalloc byte[...], n)` never
+compiles, in any module); only the `unsafe` wrapping above is gated on the rules.
+The hoisted declaration omits `scoped` — a `scoped` local leaves no IL trace and so
+cannot be recovered (it may produce a CS9081 *warning*, never an error). The
+rationale for replaying only what the binary records — and what a future opt-in
+"simulate" mode would add — is in
+[design/memory-safety-modes.md](design/memory-safety-modes.md).
+
 ## Inspection and verification
 
 The architecture earns its observability from one property: **every stage boundary is a projectable IR.** A single `IrPasses.RunWithStages` runner captures the typed tree at import and after every pass, and one `StageDump` formatter frames them — exactly JitDump's relationship to GenTree. Every harness mode reads that one capture rather than rebuilding it: `--dump` (the per-pass tree), `--diff` (each pass as a `+`/`-` hunk), `--facts` (the definite-assignment dataflow that decides `= default` elision), `--cfg` (block edges; `--mermaid` renders them), `--remarks` (the IR sites that cap fidelity, each with its `DEC####` code), and `--pass-impact` (the corpus-wide inverse — a pass's blast radius).

--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -1,0 +1,74 @@
+# Memory-Safety Rendering Modes (Conservative vs Optimistic)
+
+This note records a decision about how the decompiler renders `unsafe` and related
+constructs in light of .NET's updated memory-safety rules (the redefined `unsafe`
+context, the `MemorySafetyRulesAttribute`, and the per-member `RequiresUnsafeAttribute`).
+See [decompiler.md](../decompiler.md) — "Unsafe contexts under the updated
+memory-safety rules" — for the mechanics this note frames.
+
+## The two takes
+
+There are two coherent ways for the decompiler to treat the new rules:
+
+- **Conservative ("replay").** Reproduce only what the compiler *forced* the source
+  to do. If a binary exists, it already satisfied whatever rules it was compiled
+  under, and the metadata records the proof (a module-level `MemorySafetyRulesAttribute`,
+  a member's `RequiresUnsafeAttribute`). We replay those facts and nothing more.
+- **Optimistic ("simulate").** Show the code as the new rules *would* require, even
+  for input that never had to satisfy them — a migration preview that deliberately
+  overlaps a source fixer.
+
+## Decision
+
+**Conservative is the default and, for now, the only mode.** It is principled and
+self-gating: new-rules behavior keys off the module-level `MemorySafetyRulesAttribute`
+(`IrImporter.ModuleUsesUpdatedMemorySafetyRules`), so a legacy module's output is
+byte-identical to what it was before the feature existed, and a new-rules module
+replays the `unsafe` contexts the compiler demanded. No new surface is needed; it is
+the path Features C (body `unsafe` blocks) and D (signature `unsafe`) already follow.
+
+Optimistic is recorded here as a **future opt-in mode**, not built.
+
+## What forces the split: recoverability
+
+The deciding factor is whether a construct leaves a trace in the binary.
+
+- The `unsafe` *context* is recoverable: the compiler stamps `MemorySafetyRulesAttribute`
+  / `RequiresUnsafeAttribute`, and pointer/`calli`/stackalloc operations are visible in
+  IL. So replaying `unsafe` blocks is faithful.
+- The `scoped` modifier on a **local** is *not* recoverable: it is compile-time-only
+  escape analysis and emits no IL or metadata (only `scoped` *parameters* get
+  `ScopedRefAttribute`). A decompiler reading IL has zero signal that the source said
+  `scoped`.
+
+Therefore synthesizing `scoped` cannot be part of conservative replay — there is no
+fact to replay. Omitting it on a hoisted stack-bound span declaration produces at most
+a **warning** (CS9081, "result of a stackalloc expression … may be exposed outside of
+the containing method"); the output still compiles. Silencing that warning by adding
+`scoped` is a judgment the source author made, not a fact in the binary, so it belongs
+to the optimistic mode.
+
+## Off this axis: stackalloc raising is plain correctness
+
+Raising the compiler's lowering of `Span<T> s = stackalloc T[n]` (a `localloc` fed to
+the `Span<T>(void*, int)` constructor) back into a source-level `stackalloc T[n]` is
+**not** a memory-safety-mode choice. The lowered ctor shape
+(`new Span<T>(stackalloc byte[...], n)`) never compiled in any mode — a `stackalloc`
+in argument position types as `Span<byte>`, not `void*` — so the raise is mode-independent
+fidelity, applied unconditionally by `StackAllocSpanPass`. The unsafe *wrapping* of that
+stackalloc (under `[SkipLocalsInit]`) remains gated on the new rules.
+
+## What an optimistic mode would add (future)
+
+A future opt-in mode (e.g. a `--simulate-new-rules` switch) would intentionally
+fabricate new-rules-conformant source for *any* input, mirroring a source fixer
+(cf. the ILLink `unsafe` evolution codefix, diagnostics IL5005/IL5006):
+
+- synthesize `scoped` on stack-bound ref-struct declarations to silence CS9081;
+- apply `unsafe` contexts to legacy code where the new rules *would* require them;
+- optionally emit `// SAFETY-TODO` audit comments at introduced blocks;
+- (later) emit the tighter `unsafe(expr)` expression form once it lands in a usable
+  compiler (tracked: roslyn #84012 / csharplang #10196).
+
+This mode must stay opt-in and clearly labeled, because it invents source the original
+author may never have written.

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -148,7 +148,11 @@ public class UnsafeEmitterTests
         // the variable in scope.
         var output = DecompileNew(nameof(NewFixtures.StackAllocSkipInit));
 
-        Assert.Contains("stackalloc", FirstUnsafeBlockBody(output));
+        // Raised to the source-level `stackalloc int[n]`, not the lowered
+        // `new Span<int>(stackalloc byte[...], n)` ctor shape (which never compiles).
+        Assert.Contains("stackalloc int[", FirstUnsafeBlockBody(output));
+        Assert.DoesNotContain("new Span", output);
+        Assert.DoesNotContain("stackalloc byte[", output);
         // The declaration is hoisted above the unsafe block, the use survives.
         Assert.True(
             output.IndexOf("Span<int> s", StringComparison.Ordinal)
@@ -166,12 +170,20 @@ public class UnsafeEmitterTests
         var output = DecompileNew(nameof(NewFixtures.StackAllocDefault));
 
         Assert.DoesNotContain("unsafe", output);
+        // Safe case keeps the inline `Span<int> s = stackalloc int[n]` form.
+        Assert.Contains("stackalloc int[", output);
+        Assert.DoesNotContain("new Span", output);
     }
 
     [Fact]
     public void LegacyModule_StackAllocSpan_EmitsNoUnsafeBlock()
     {
-        Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocSkipInit)));
+        // The stackalloc->Span raise is mode-independent correctness (the lowered
+        // ctor shape never compiled), so legacy output raises too — just without
+        // the unsafe wrapping the new rules require.
+        var skipInit = DecompileLegacy(nameof(LegacyFixtures.StackAllocSkipInit));
+        Assert.DoesNotContain("unsafe", skipInit);
+        Assert.Contains("stackalloc int[", skipInit);
         Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocDefault)));
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1071,9 +1071,10 @@ public sealed class CSharpPrinter
     bool IsUnsafeOperation(IrNode node) => node switch
     {
         CallIndirect => true,
-        // A stackalloc-backed Span is governed by the stackalloc rule (unsafe
-        // only under [SkipLocalsInit]), not its constructor's pointer signature.
-        NewObject n when IsStackBoundSpan(n) => _skipLocalsInit,
+        // A stackalloc-backed Span (raised to `stackalloc T[n]` by
+        // StackAllocSpanPass) is governed by the stackalloc rule — unsafe only
+        // under [SkipLocalsInit], where the stack space is uninitialized.
+        StackAllocArray => _skipLocalsInit,
         Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
         NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
         LoadIndirect l => RendersAsPointerDeref(l.Address),
@@ -1081,30 +1082,6 @@ public sealed class CSharpPrinter
         InitObject o => RendersAsPointerDeref(o.Address),
         _ => false,
     };
-
-    /// <summary>
-    /// A <c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c> constructed directly
-    /// over a <c>stackalloc</c> — the source <c>Span&lt;int&gt; s = stackalloc
-    /// int[n]</c> lowering. Such a conversion is unsafe only under
-    /// <c>[SkipLocalsInit]</c>; otherwise it is safe and must not be wrapped even
-    /// though the Span constructor carries a pointer parameter.
-    /// </summary>
-    static bool IsStackBoundSpan(NewObject newObject)
-    {
-        var declaring = newObject.Constructor.DeclaringType;
-        var (simpleName, ns) = declaring.Kind == TypeRefKind.GenericInstance
-            ? (StripArity(declaring.ElementType?.Name), declaring.ElementType?.Namespace)
-            : (StripArity(declaring.Name), declaring.Namespace);
-        return ns == "System"
-            && simpleName is "Span" or "ReadOnlySpan"
-            && newObject.Descendants.OfType<StackAllocate>().Any();
-
-        static string StripArity(string? name)
-        {
-            int tick = name?.IndexOf('`') ?? -1;
-            return tick < 0 ? name ?? "" : name![..tick];
-        }
-    }
 
     /// <summary>
     /// Compat-mode requires-unsafe heuristic for a callee whose
@@ -1306,6 +1283,7 @@ public sealed class CSharpPrinter
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
         CollectionExpression c => $"[{string.Join(", ", c.Elements.Select(Expression))}]",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
+        StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1165,6 +1165,37 @@ public sealed class StackAllocate : IrExpression
     public override string Describe() => "StackAllocate byte[]";
 }
 
+/// <summary>
+/// A source-level <c>stackalloc T[n]</c> whose result is a
+/// <c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c> (target-typed), raised from the
+/// compiler's lowering of <c>Span&lt;T&gt; s = stackalloc T[n]</c> — a
+/// <c>localloc</c> of <c>n * sizeof(T)</c> bytes fed to the <c>Span&lt;T&gt;(void*,
+/// int)</c> constructor. The lowered ctor shape
+/// (<c>new Span&lt;T&gt;(stackalloc byte[...], n)</c>) does not compile: a
+/// <c>stackalloc</c> in argument position types as <c>Span&lt;byte&gt;</c>, not
+/// <c>void*</c>. The element count is the constructor's <c>length</c> argument; the
+/// byte size carried by the original <see cref="StackAllocate"/> is redundant
+/// (<c>n * sizeof(T)</c>) and dropped.
+/// </summary>
+public sealed class StackAllocArray : IrExpression
+{
+    readonly TypeRef? _resultType;
+
+    public StackAllocArray(TypeRef elementType, IrExpression count, TypeRef? resultType)
+    {
+        ElementType = elementType;
+        _resultType = resultType;
+        AddChild(count);
+    }
+
+    public TypeRef ElementType { get; }
+    public IrExpression Count => (IrExpression)Children[0];
+    public override TypeRef? ResultType => _resultType;
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType];
+
+    public override string Describe() => $"StackAllocArray {ElementType.ToDisplayString()}[]";
+}
+
 /// <summary>The raised typeof(T): GetTypeFromHandle over a type token, folded.</summary>
 public sealed class TypeOf : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -111,6 +111,12 @@ public static class IrPasses
         // compiler-internal field name and never compiles. Kept in Lowered
         // (the CreateSpan call has no valid C# spelling).
         new RvaSpanPass(),
+        // Raise the csc lowering of `Span<T> s = stackalloc T[n]` (a localloc fed
+        // to the Span<T>(void*, int) ctor) back into `stackalloc T[n]`. Left flat
+        // it renders `new Span<T>(stackalloc byte[...], n)`, which never compiles
+        // (a stackalloc in argument position is a Span<byte>, not void*). Kept in
+        // Lowered (the ctor shape has no valid C# spelling).
+        new StackAllocSpanPass(),
         // Raise the csc inline-array lowering of a span collection expression
         // (a <>y__InlineArrayN<T> temp written slot-by-slot through
         // <PrivateImplementationDetails>.InlineArrayElementRef and exposed by

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's lowering of <c>Span&lt;T&gt; s = stackalloc T[n]</c> back
+/// into a source-level <c>stackalloc T[n]</c>. The source form lowers to a
+/// <c>localloc</c> of <c>n * sizeof(T)</c> bytes fed to the <c>Span&lt;T&gt;(void*,
+/// int)</c> constructor, which left flat renders as
+/// <c>new Span&lt;T&gt;(stackalloc byte[...], n)</c> — and that does not compile:
+/// a <c>stackalloc</c> in argument position types as <c>Span&lt;byte&gt;</c>, not
+/// <c>void*</c>, and the byte-count expression carries a <c>nuint</c> that will not
+/// implicitly convert to <c>int</c>. Rewriting to <c>stackalloc T[n]</c> (target-typed
+/// to the span) round-trips to the same lowering.
+///
+/// <para>The element type is the span's type argument; the element count is the
+/// constructor's <c>length</c> argument (the byte size on the inner
+/// <see cref="StackAllocate"/> is the redundant <c>n * sizeof(T)</c> and is dropped).
+/// This raise is independent of the memory-safety rules — the lowered shape never
+/// compiled — so the pass runs unconditionally. Whether the result needs an
+/// <c>unsafe</c> context (only under <c>[SkipLocalsInit]</c>, per the stackalloc
+/// rule) is decided later by the printer.</para>
+/// </summary>
+public sealed class StackAllocSpanPass : IIrPass
+{
+    public string Name => "stackalloc-span";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
+        {
+            var declaring = newObject.Constructor.DeclaringType;
+            if (declaring.Kind != TypeRefKind.GenericInstance
+                || declaring.ElementType is not { Namespace: "System" } definition
+                || StripArity(definition.Name) is not ("Span" or "ReadOnlySpan")
+                || declaring.TypeArguments is not [var element])
+                continue;
+
+            // Span<T>(void* pointer, int length): the pointer is the stackalloc,
+            // the length is the logical element count.
+            if (newObject.Arguments is not [{ } pointer, var count]
+                || !(pointer is StackAllocate || pointer.Descendants.OfType<StackAllocate>().Any()))
+                continue;
+
+            count.Detach();
+            var raised = new StackAllocArray(element, count, newObject.ResultType);
+            raised.InheritSourceOffset(newObject);
+            context.Stepper.StepOver("raise Span-over-stackalloc to stackalloc T[n]", newObject);
+            newObject.ReplaceWith(raised);
+        }
+    }
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a pre-existing decompiler fidelity gap: `Span<T> s = stackalloc T[n]` was rendered as the compiler's **lowered** shape `new Span<T>(stackalloc byte[...], n)`, which **never compiles** in any module — a `stackalloc` in argument position types as `Span<byte>`, not `void*` (CS1503), and the byte-count expression carries a `nuint` that won't implicitly convert to `int` (CS0266).

A new `StackAllocSpanPass` raises that pattern back to a source-level `stackalloc T[n]` (target-typed to the span), via a `StackAllocArray` IR node + printer support. Raw `byte*` stackalloc (`StackAllocate`) is untouched.

### Conservative vs optimistic decision (documented)

This work also nailed down the **memory-safety rendering model**:

- **Conservative ("replay")** is the default and only mode: reproduce only what the binary records, self-gated on the module-level `MemorySafetyRulesAttribute`. Legacy output stays byte-identical.
- **Optimistic ("simulate")** — synthesize `scoped`, apply `unsafe` to legacy code, emit `unsafe(expr)` — is recorded as a **future opt-in**, deliberately overlapping a source fixer (cf. ILLink IL5005/IL5006).

The split is forced by **recoverability**: the `unsafe` context is recoverable from metadata/IL, but `scoped` on a *local* leaves no trace (only `scoped` parameters get `ScopedRefAttribute`). So the hoisted declaration omits `scoped` (at most a CS9081 *warning*, never an error). The stackalloc raise here is **off this axis** — plain correctness, applied unconditionally; only the unsafe *wrapping* under `[SkipLocalsInit]` stays gated on the new rules.

New design note: `docs/design/memory-safety-modes.md`, cross-linked from `docs/decompiler.md`.

## Verification

Decompiled output, now compiling under the nightly new-rules SDK (`11.0.100-preview.6`):

```csharp
// StackAllocSkipInit ([SkipLocalsInit]) — Build succeeded (warning CS9081, expected)
Span<int> s;
int V_1 = n;
unsafe { s = stackalloc int[V_1]; }
return s.Length;

// StackAllocDefault — clean
Span<int> s = stackalloc int[V_1];
return s.Length;
```

- Decompiler tests: **317 pass** (strengthened `UnsafeEmitterTests` to assert the raised `stackalloc int[` form and forbid `new Span` / `stackalloc byte[`).
- `--compile-back` corpus (`ILInspector.Decompiler.Tests.dll`): **709 rendered / 696 Full / 8 opcode diffs** — identical to baseline (stashed-changes comparison), i.e. **zero regression**.
- Main project builds clean, 0 warnings.

## Follow-ups (tracked, not in this PR)

- `scoped` synthesis + `unsafe(expr)` emission → future optimistic mode (roslyn #84012 / csharplang #10196).
