### PR TITLE
Structure shared-throw guards with a fallen-into single conditional (step 4)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -360,6 +360,43 @@ only when the post-dominator machinery is proven.
    This is the largest and riskiest step; it lands last, behind the proven
    machinery and the full rail suite.
 
+   *Status: shared-terminator merge slice landed (partial).* The first slice of
+   step 4 relaxes the all-or-nothing invariant for one safe case: a shared
+   **terminator** (a short `throw`/`return` block) reached past its region can be
+   duplicated into the guards that branch to it, since `IsTerminatorBlock`
+   guarantees no control flow to preserve, so duplication is always
+   semantics-preserving. `IsSharedTerminator`'s `throw` arm now also fires when a
+   throw block has **one** conditional predecessor *and is fallen into* — the
+   `if (A || B) throw;` shape whose inner guard carries a prologue, which
+   `OrChainGuardPass` (needs pure inner guards) cannot flatten (e.g.
+   `DateTime`'s tick-range checks). Result: `--gaps` fully raised 39,772 →
+   39,775 (+3); defect diff vs the step-3 baseline 0 regressed, 2 methods
+   improved (`ArgumentOutOfRangeException::ThrowEqual`/`ThrowNotEqual`);
+   `--pass-impact structuring` 0 pass bugs; 319 decompiler tests green
+   (`SharedThrow_SingleGuardFallenInto_InlinesAsGuardClauses` pins it — fails
+   without the change). `IsSharedTerminator` also now excludes any terminator
+   carrying a base/this constructor-chain call (it must stay the body's first
+   statement for the `: base(...)` lift; duplicating it would strand a bare chain
+   call, CS0175).
+
+   *Finding — the acyclic residual splits three ways, and the return-tail merge
+   is NOT a terminator-duplication win.* Of the ~1,208 `conditional-branch`
+   residuals, **691 contain loop back-edges (out of scope for step 4)**; the
+   ~517 acyclic split into (a) shared **terminator** merges — `throw` (recovered
+   above) and `return`; and (b) shared **non-terminator** merges (e.g.
+   `HashCode::Combine`, where the merge is a computation block with a successor)
+   that genuinely need the retained-merge-label relaxation and cannot be
+   recovered by duplication. The shared **return**-tail merge looked like a quick
+   +67, but a `return` block with ≥2 conditional predecessors is *also exactly*
+   the false-exit of an `&&`/`||` short-circuit guard chain (`if (a > 0 && b > 0)
+   return X; return Y;` lowers to two conditionals both targeting `return Y`).
+   Duplicating that shared return into each guard splits the chain before it can
+   combine into a single `if (a && b)`, changing the recompiled opcodes — the
+   #640 compile-back canary (`IfAnd`/`MixedAndOr`/`TripleAnd`). So the genuine
+   return-tail merge (e.g. `String::Trim`) is deferred to a follow-up that first
+   teaches the guard combiner to defer to it; it is **not** a terminator-rule
+   win.
+
 Steps 1–3 are sound extensions that keep the safety guarantee; step 4 is the one
 that changes it, and is gated on the prior steps demonstrating the
 post-dominator model is correct in practice.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2102,6 +2102,62 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void SharedThrow_SingleGuardFallenInto_InlinesAsGuardClauses()
+    {
+        // The OR-to-throw shape whose throw block has ONE conditional predecessor
+        // but is also fallen into — the CheckTicksRange / `if (A || B) throw;`
+        // case where the inner guard carries a prologue, so OrChainGuardPass
+        // (which needs pure inner guards) cannot flatten it. Built directly so the
+        // test is independent of csc codegen:
+        //   if (a < 0) goto IL_000C;     // → throw  (one conditional predecessor)
+        //   V_0 = 7;                     // inner-guard prologue
+        //   if (b > 100) goto IL_0010;   // → return; falls through to the throw
+        //   IL_000C: throw null;         // fallen into AND one conditional pred
+        //   IL_0010: return a;
+        // The structurer inlines a copy of the throw into the a-guard clause and
+        // keeps the fallthrough copy as the b-guard (negated, since the taken
+        // branch returns) — no goto, the return survives. Without the
+        // one-conditional-plus-fallen relaxation this throw (one conditional
+        // predecessor, below the >= 2 bar) is left as goto-soup.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 12));
+        var b1 = new Block(4);
+        b1.Add(new StoreLocal(0, intType, new Constant(7, intType)));
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, B(), new Constant(100, intType)), 16));
+        var consequence = new Block(12);
+        consequence.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        var ret = new Block(16);
+        ret.Add(new Return(A()));
+        foreach (var block in (Block[])[b0, b1, consequence, ret])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal("""
+            if (a < 0)
+            {
+                throw null;
+            }
+            int V_0 = 7;
+            if (b <= 100)
+            {
+                throw null;
+            }
+            return a;
+            """.ReplaceLineEndings("\n"), output);
+    }
+
+    [Fact]
     public void Clone_DeepCopiesSubtree_AndIsIndependent()
     {
         // Clone produces a detached, structurally identical deep copy: distinct

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -411,10 +411,36 @@ public sealed class StructuringPass : IIrPass
     {
         if (!IsTerminatorBlock(block) || unconditionalTargets.Contains(block.StartOffset))
             return false;
+        // A base/this constructor-chain call must stay the body's first statement
+        // for the `: base(...)` lift to fire; inlining (which duplicates/nests the
+        // block) would strand it as a body statement (CS0175). Leave such a
+        // terminator to the standard nested form.
+        if (ContainsConstructorChainCall(block))
+            return false;
         int conditionalPredecessors = conditionalTargetCounts.GetValueOrDefault(block.StartOffset);
         return block.Children[^1] switch
         {
-            Throw => conditionalPredecessors >= 2,
+            // A shared throw join that strict nesting cannot express. Two forms:
+            //   • two or more conditionals reach it — a genuine multi-goto join.
+            //   • one conditional reaches it AND it is also fallen into — the
+            //     `if (A || B) throw;` shape whose inner guard carries a prologue
+            //     (so OrChainGuardPass, which needs pure inner guards, cannot
+            //     flatten it): `if (A) goto T; <setup>; if (B') goto J; T: throw;`.
+            //     Inlining duplicates the throw into the A-guard clause (always
+            //     sound for a terminator) and the fallthrough copy stays. A clean
+            //     standalone `if (c) throw;` is never fallen into, so it keeps its
+            //     standard-guard raising untouched.
+            Throw => conditionalPredecessors >= 2
+                || (conditionalPredecessors >= 1 && fallenInto.Contains(block.StartOffset)),
+            // A shared return-tail merge is NOT inlined here: a return block with
+            // two or more conditional predecessors is also exactly the false-exit
+            // of an `&&`/`||` short-circuit guard chain (`if (a > 0 && b > 0)
+            // return X; return Y;` lowers to two conditionals both targeting the
+            // `return Y` block). Inlining the shared return into each guard splits
+            // the chain before it can combine into a single `if (a && b)`,
+            // changing the recompiled opcodes (the #640 compile-back canary). A
+            // genuine shared return-tail merge (String::Trim) needs the combiner
+            // to defer to it first — a separate slice, not this terminator rule.
             // A comparison-tree case body: a return leaf reached only by its
             // equality test and never by fallthrough, in a container that is a
             // genuine multi-way tree. Inlining it as a guard clause is what lets
@@ -425,6 +451,26 @@ public sealed class StructuringPass : IIrPass
                 && !fallenInto.Contains(block.StartOffset),
             _ => false,
         };
+    }
+
+    /// <summary>
+    /// Whether the block contains a base/this constructor-chain call
+    /// (<c>Call .ctor</c> on the under-construction <c>this</c>). Such a call
+    /// must remain the constructor body's first statement for the later
+    /// <c>: base(...)</c>/<c>: this(...)</c> lift; duplicating or nesting it
+    /// would leave an invalid bare chain call (CS0175).
+    /// </summary>
+    static bool ContainsConstructorChainCall(Block block)
+    {
+        foreach (var node in block.Descendants)
+        {
+            if (node is Call { Callee: { Name: ".ctor", HasThis: true } } call
+                && call.Arguments is [LoadArgument { Index: 0 }, ..])
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>A terminator block that may be inlined into a guard at <paramref name="index"/>.</summary>


### PR DESCRIPTION
First slice of **step 4** (partial structuring with a retained merge label) from `docs/design/control-flow-structuring.md`. Relaxes the all-or-nothing invariant for the one provably-safe case: a shared **terminator** block.

## What changed

`IsSharedTerminator`'s `throw` arm now also fires when a throw block has **one** conditional predecessor *and is fallen into* — the `if (A || B) throw;` shape whose inner guard carries a prologue (the operand-computing code), which `OrChainGuardPass` (needs pure inner guards) cannot flatten. Duplicating a terminator into the guards that branch to it is always semantics-preserving (`IsTerminatorBlock` guarantees no control flow to preserve), so this stays sound.

Also: exclude any terminator carrying a base/this constructor-chain call from inlining — it must stay the constructor body's first statement for the `: base(...)` lift, and duplicating it would strand a bare chain call (CS0175).

## Rails

- `--gaps` fully raised **39,772 → 39,775 (+3)**
- defect diff vs step-3 baseline: **0 regressed, 2 improved** (`ArgumentOutOfRangeException::ThrowEqual`/`ThrowNotEqual`)
- `--pass-impact structuring`: **0 pass bugs**
- **319** decompiler tests green; `SharedThrow_SingleGuardFallenInto_InlinesAsGuardClauses` pins the recovery (fails without the change)
- compile-back gates clean (`IfAnd`/`MixedAndOr`/`TripleAnd` docket unchanged)

## Finding (in the design doc): the return-tail merge is NOT a terminator-duplication win

A `return` block with ≥2 conditional predecessors is *also exactly* the false-exit of an `&&`/`||` short-circuit guard chain (`if (a > 0 && b > 0) return X; return Y;` lowers to two conditionals both targeting `return Y`). Duplicating that shared return into each guard splits the chain before it can combine into a single `if (a && b)`, changing the recompiled opcodes — the #640 compile-back canary. So the genuine return-tail merge (`String::Trim`) is **deferred** to a follow-up that first teaches the guard combiner to defer to it.

The acyclic residual splits into shared-**terminator** merges (throw recovered here, return deferred) and shared **non-terminator** merges (`HashCode::Combine`, needing the genuine retained-merge-label relaxation). 691 of the conditional-branch residuals are loops (out of scope for step 4).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>