### PR TITLE
Scrub retired-oracle jargon from the test infra (rename step 1)

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -87,7 +87,7 @@ new-pipeline analog of the old stack's no-crash sweep, made objective:
   the by-construction safety), and `Full`-fidelity % and fully-raised % above
   ratchets a couple points below the measured numbers. Floors tolerate minor
   runtime-version drift and need no per-method baseline file — which is why this
-  beats both a fuzzy text-agreement oracle and a brittle exact-baseline net.
+  beats both fuzzy text agreement and a brittle exact-baseline net.
 
 So a crash, or a broad fidelity/raising drop, fails CI, using only the
 self-contained signals. When the structuring work raises the true numbers, the

--- a/src/ILInspector.Decompiler.Tests/AnnotateCheckGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotateCheckGateTests.cs
@@ -3,7 +3,7 @@ using ILInspector.DecompilerHarness;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// The annotation oracle gate (docs/design/hidden-fact-annotations.md): the
+/// The annotation check gate (docs/design/hidden-fact-annotations.md): the
 /// breadth signal for the hidden-fact annotations, the analyzer analog of the
 /// <see cref="CompileBackGateTests"/> depth signal. It runs <c>--annotate-check</c>
 /// over the running runtime's CoreLib and grades every annotation's IL offset

--- a/tools/DecompilerHarness/AnnotateCheck.cs
+++ b/tools/DecompilerHarness/AnnotateCheck.cs
@@ -10,7 +10,7 @@ using ILInspector.Metadata;
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// The hidden-fact annotation oracle: static IL pair-agreement at corpus scale.
+/// The hidden-fact annotation check: static IL pair-agreement at corpus scale.
 /// It is the analyzer analog of <c>--compile-back</c> — where compile-back grades
 /// the decompiler's C# against a recompiled opcode stream, this grades each
 /// <em>annotation</em> against the raw IL opcode it claims to describe.
@@ -101,7 +101,7 @@ static class AnnotateCheck
     }
 
     /// <summary>
-    /// The structured oracle result, so a CI gate (<c>AnnotateCheckGateTests</c>)
+    /// The structured check result, so a CI gate (<c>AnnotateCheckGateTests</c>)
     /// can assert on it without re-implementing the sweep. <see cref="Run"/> is the
     /// console wrapper over <see cref="Evaluate(IReadOnlyList{string}, int)"/>.
     /// </summary>

--- a/tools/DecompilerHarness/CompileBack.cs
+++ b/tools/DecompilerHarness/CompileBack.cs
@@ -14,12 +14,12 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// The semantic-fidelity anchor (the validity anchor is <see cref="CompileChecker"/>;
-/// the completeness anchor is <c>--gaps</c>).
+/// The semantic-fidelity check (validity is <see cref="CompileChecker"/>;
+/// completeness is the <c>--gaps</c> floor).
 /// It closes the loop named in docs/decompiler.md: decompile → recompile →
 /// compare IL. A decompiled body that compiles and reads plausibly but recompiles
 /// to a different opcode stream changed the program — the worst failure class
-/// (docs/decompiler-taste.md), invisible to compile-check and source-grade.
+/// (docs/decompiler-taste.md), invisible to the validity check.
 ///
 /// Unlike <see cref="CompileChecker"/>'s per-method <c>__Shell</c> — which cannot
 /// see the declaring type's fields, so any <c>this.field</c> reference fails to

--- a/tools/DecompilerHarness/CompileChecker.cs
+++ b/tools/DecompilerHarness/CompileChecker.cs
@@ -8,10 +8,10 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// The validity anchor (the source-grade is the quality anchor; the diff is the
-/// agreement anchor). It compiles every decompiled body to turn "valid C# by
-/// construction" — which the pipeline guarantees only for crashes and
-/// silent-wrong, NOT for the rendered text — into a measured number.
+/// The validity check (the fidelity check is <see cref="CompileBack"/>;
+/// completeness is the <c>--gaps</c> floor). It compiles every decompiled body
+/// to turn "valid C# by construction" — which the pipeline guarantees only for
+/// crashes and silent-wrong, NOT for the rendered text — into a measured number.
 ///
 /// Each body is wrapped in a method shell carrying its real signature (return
 /// type, generic parameters, parameters) so locals, parameters, and type

--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -14,11 +14,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/ILInspector.Decompiler/ILInspector.Decompiler.csproj" />
-    <!-- Source-grade mode: PDB acquisition + SourceLink resolution. -->
+    <!-- ILReader: the byte-match-validated IL reader the fidelity and annotation checks read the witness IL with. -->
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
-    <ProjectReference Include="../../src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
-    <ProjectReference Include="../../src/DotnetInspector.Core/DotnetInspector.Core.csproj" />
-    <!-- Compile-check mode: parse and bind the decompiled C# to measure validity. -->
+    <!-- Validity check: parse and bind the decompiled C# to measure validity. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 

--- a/tools/DecompilerHarness/Gaps.cs
+++ b/tools/DecompilerHarness/Gaps.cs
@@ -11,7 +11,7 @@ namespace ILInspector.DecompilerHarness;
 /// the structuring passes could not consume, or an EH <see cref="Leave"/> — is a
 /// surviving <c>goto</c>, and an <see cref="UnsupportedNode"/> is an import-side
 /// fidelity gap. It reads only the candidate's own raised tree, so it is a
-/// self-contained burn-down signal — a measure of completeness, not correctness.
+/// self-contained completeness signal — it measures completeness, not correctness.
 /// </summary>
 public static class Gaps
 {
@@ -19,7 +19,7 @@ public static class Gaps
     /// The most-actionable residual-control-flow kind in a raised function, or
     /// null when it is fully raised (no residual node). Structuring residue ranks
     /// ahead of EH and the unsupported-node residue, since structuring is the
-    /// burn-down target. Run the passes before calling — this reads the finished tree.
+    /// completeness target. Run the passes before calling — this reads the finished tree.
     /// </summary>
     public static string? Residual(IrFunction function)
     {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -13,7 +13,7 @@ namespace ILInspector.DecompilerHarness;
 /// <summary>
 /// Diagnostic harness for the decompiler pipeline — the asmdiffs analog from
 /// docs/decompiler.md. It inventories health (fidelity, stop reasons)
-/// across whole assemblies, scores the real-gap burn-down (<c>--gaps</c>),
+/// across whole assemblies, measures real-gap completeness (<c>--gaps</c>),
 /// validates output (<c>--compile-check</c>, <c>--compile-back</c>), and dumps a
 /// single method through every pipeline stage (<c>--dump</c> and friends).
 /// </summary>
@@ -134,7 +134,7 @@ static class Program
     }
 
     /// <summary>
-    /// The self-contained real-gap scoreboard. It inspects only the raised tree:
+    /// The self-contained real-gap view. It inspects only the raised tree:
     /// a method is a gap if it still carries unstructured control flow (a
     /// surviving <c>goto</c>: a
     /// <see cref="Branch"/>/<see cref="ConditionalBranch"/>/<see cref="SwitchBranch"/>
@@ -189,7 +189,7 @@ static class Program
         Console.WriteLine($"GAPS over {total} methods ({crashes} pass bugs):");
         Console.WriteLine($"  fully raised : {clean} ({Percent(clean, total)}) — no residual control flow, Full fidelity");
         long gapTotal = total - clean - crashes;
-        Console.WriteLine($"  real gaps    : {gapTotal} ({Percent(gapTotal, total)}) — the self-contained burn-down docket");
+        Console.WriteLine($"  real gaps    : {gapTotal} ({Percent(gapTotal, total)}) — the self-contained completeness docket");
         Console.WriteLine("By residual kind (most-actionable bucket per method):");
         foreach (var b in buckets.OrderByDescending(b => b.Value.Count))
             Console.WriteLine($"  {b.Value.Count,8}  {b.Key,-34}  e.g. {string.Join(" | ", b.Value.Examples.Take(3))}");
@@ -852,11 +852,11 @@ static class Program
           --emit-defects <f>    with --compile-check, write per-method defect codes to <f>
           --diff-defects <f>    with --compile-check, diff per-method defects against baseline <f>
           --compile-back        decompile, recompile in-context, and compare IL opcodes (semantic fidelity)
-          --gaps                self-contained real-gap scoreboard — methods whose
+          --gaps                self-contained real-gap view — methods whose
                                 raised tree still holds unstructured control flow
                                 (a surviving goto) or an unsupported node, bucketed
-                                by residual kind. The completeness burn-down signal.
-          --annotate-check      hidden-fact annotation oracle — the analyzer analog
+                                by residual kind. The completeness signal.
+          --annotate-check      hidden-fact annotation check — the analyzer analog
                                 of --compile-back. Cross-checks each allocation/
                                 unsafety/lifetime annotation against the raw IL
                                 opcode at its offset (read independently with the


### PR DESCRIPTION
Step 1 of the test-infra naming cleanup ([gist](https://gist.github.com/richlander/5b0eb57a1c68ccdbc89decb141ab0d62), rev 4). Pure subtraction, no scheme sign-off needed: remove references to retired tools and collapse the organic synonyms for "a check." **No symbol or flag renames** — those are steps 2–3. Landing this first shrinks the later rename diffs so they read as mechanical.

## What changed

- **Dead retired-tool references removed.** `CompileChecker` and `CompileBack` headers still cited the retired `--grade-source` ("source-grade") and DiffNext ("the diff is the agreement anchor") oracles — gone since #657.
- **Check-synonyms collapsed** to the kept vocabulary (check / view / floor / completeness): `anchor` (used as "a check"), `scoreboard`, `burn-down`.
- **`oracle`-as-check flipped to `check`** where the code called a *check* an "oracle" (`AnnotateCheck`'s self-description, the `--help` text). Kept: the reference-role `oracle` (the IL a check compares against, with its own design doc) and the domain terms `witness` / `agreement` / `AnnotationAnchor` — these name genuinely different things, not the retired synonym.
- **Two dead project references dropped** (`DotnetInspector.Packages`, `DotnetInspector.Core`) — remnants of the retired source-grade mode with zero usages; the build confirms they were dead. Relabeled the `ILInspector.Metadata` reference for its real current use (`ILReader`, which the fidelity and annotation checks read the witness IL with).

## Scope notes (for the reviewers)

- Two refinements found vs. the gist's scrub guidance: `anchor` is **hand-filtered**, not mechanical (`AnnotationAnchor` is a domain keeper), and the csproj `Metadata` ref the stale comment guarded is actually **live** (ILReader), not dead.
- The synonym→vocabulary work here is comments/help/one doc line only. The full role taxonomy in the docs (`decompiler-inspection-oracle.md`, etc.) is the later doc-reconciliation pass, not this PR.

## Verification
- `dotnet build tools/DecompilerHarness -c Release` — clean (verifies the dropped refs were dead).
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **321 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)