### PR TITLE
Fold default onto a shared terminator case in switch raising

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -19,6 +19,11 @@ jump-tables by `SwitchRaisingPass`. Two recent passes closed bounded gaps:
   surviving goto no longer floods every local to `= default`.
 - **#640** — `ReturnMergePass` + a guard-leaf inlining generalization raise the
   comparison tree csc emits for a sparse `switch`.
+- **switch terminator sections** — `SwitchRaisingPass` folds the `default:` label
+  onto a shared case section when the default jumps into a case body that
+  returns/throws (`case N: default: throw;`). Recovers the `Enum::GetNamesNoCopy`
+  family — every out-of-range table index and the default share one terminator
+  block. +16 fully-raised; 11 `System.Enum` methods went malformed → valid.
 
 What remains is not bounded. The stop-reason histogram below is produced by
 `decompiler-harness --structuring-stops` (landed as the first PR of this track),

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2227,6 +2227,44 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void JumpTable_DefaultSharesTerminatorCase_FoldsDefaultOntoCase()
+    {
+        // switch (x) goto [IL_0008, IL_000C, IL_000C]; default IL_0004 is a bare
+        // `goto IL_000C` into a case body that throws. The shared throw is both a
+        // direct case target (label 1 and 2) and the default's destination, so the
+        // `default:` label folds onto that case section (`case 1: case 2: default:
+        // throw;`) — one block backs one section, no duplication. This is the
+        // System.Enum::GetNamesNoCopy shape. Without the fold the switch stays flat.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new SwitchBranch(new LoadArgument(0, "x", intType), [8, 12, 12]));
+        var dispatch = new Block(4);
+        dispatch.Add(new Branch(12));
+        var case0 = new Block(8);
+        case0.Add(new Return(new Constant(10, intType)));
+        var sharedThrow = new Block(12);
+        sharedThrow.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        foreach (var block in (Block[])[head, dispatch, case0, sharedThrow])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("switch (x)", output);
+        Assert.Contains("case 1:", output);
+        Assert.Contains("case 2:", output);
+        Assert.Contains("default:", output);
+        Assert.Contains("throw", output);
+        Assert.Contains("return 10;", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
     public void TopTestedLoopWithBreak_RaisesBreak()
     {
         // A forward exit out of a top-tested (while/for) loop body raises to a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -982,11 +982,10 @@ public sealed class CSharpPrinter
             string labelPad = pad + "    ";
             foreach (var section in switchNode.Sections)
             {
+                foreach (int label in section.Labels)
+                    sb.Append(labelPad).Append("case ").Append(label).AppendLine(":");
                 if (section.IsDefault)
                     sb.Append(labelPad).AppendLine("default:");
-                else
-                    foreach (int label in section.Labels)
-                        sb.Append(labelPad).Append("case ").Append(label).AppendLine(":");
                 AppendContainer(sb, section.Body, indent + 2);
             }
             sb.Append(pad).AppendLine("}");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -17,11 +17,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// case target, and the default, is one block with no interior control flow
 /// that ends in a terminator, a branch to the shared join, or a fall-through
 /// into the join. The default may instead be a bare dispatch jumping once to
-/// its body. The blocks the sections occupy must form the contiguous span
-/// immediately after the switch, reach nothing else, and be entered only
-/// through the table — otherwise the switch is left flat. Each section exits
-/// through <c>break;</c> (its join branch, or an appended one for a
-/// fall-through); the bodies are containers the structuring pass then raises.
+/// its body — or, when it jumps into a case body that returns/throws, the
+/// <c>default:</c> label folds onto that shared case section (<c>case N:
+/// default: throw;</c>), so one block still backs one section. The blocks the
+/// sections occupy must form the contiguous span immediately after the switch,
+/// reach nothing else, and be entered only through the table — otherwise the
+/// switch is left flat. Each section exits through <c>break;</c> (its join
+/// branch, or an appended one for a fall-through); the bodies are containers the
+/// structuring pass then raises.
 /// </summary>
 public sealed class SwitchRaisingPass : IIrPass
 {
@@ -92,10 +95,26 @@ public sealed class SwitchRaisingPass : IIrPass
         }
 
         // The default: a bare dispatch to a separate body laid out after the
-        // cases, a bare jump to the join (omitted), or an inline section.
+        // cases, a bare jump to the join (omitted), an inline section, or — when
+        // it routes into a case body that terminates — a `default:` label folded
+        // onto that shared case section.
         int? defaultBody;
+        int? defaultSharesTarget = null;
         var dispatch = blocks[defaultIndex];
-        if (dispatch.Children is [Branch bare]
+        if (dispatch.Children is [Branch sharedDefault]
+            && offsetToIndex.TryGetValue(sharedDefault.TargetOffset, out int sharedTarget)
+            && caseTargets.Contains(sharedTarget)
+            && Classify(blocks[sharedTarget], offsetToIndex) is (SectionKind.Terminates, _))
+        {
+            // The default jumps to a case body that returns/throws. C# folds the
+            // `default:` label onto that case's section (`case N: default: throw;`):
+            // one block still backs one section — no duplication, no join. The
+            // dispatch block is consumed, like an omitted-default jump.
+            owned.Add(defaultIndex);
+            defaultBody = null;
+            defaultSharesTarget = sharedTarget;
+        }
+        else if (dispatch.Children is [Branch bare]
             && offsetToIndex.TryGetValue(bare.TargetOffset, out int bareTarget)
             && bareTarget > s
             && (join is null || bareTarget != join)
@@ -168,7 +187,7 @@ public sealed class SwitchRaisingPass : IIrPass
         if (!OnlyReachedByTable(blocks, owned, s, leaveTargets))
             return false;
 
-        Build(container, s, sw, caseTargets, owned, defaultBody, join, regionEnd, stepper);
+        Build(container, s, sw, caseTargets, owned, defaultBody, defaultSharesTarget, join, regionEnd, stepper);
         return true;
     }
 
@@ -216,7 +235,7 @@ public sealed class SwitchRaisingPass : IIrPass
 
     static void Build(
         BlockContainer container, int s, SwitchBranch sw, int[] caseTargets,
-        HashSet<int> owned, int? defaultBody, int? join, int regionEnd, Stepper stepper)
+        HashSet<int> owned, int? defaultBody, int? defaultSharesTarget, int? join, int regionEnd, Stepper stepper)
     {
         var all = container.Blocks.ToList();
         int? joinOffset = join is { } j ? all[j].StartOffset : null;
@@ -231,7 +250,7 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var sections = new List<SwitchSection>();
         foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
-            sections.Add(new SwitchSection([.. labels], isDefault: false, SectionBody(all[target], joinOffset)));
+            sections.Add(new SwitchSection([.. labels], isDefault: target == defaultSharesTarget, SectionBody(all[target], joinOffset)));
         if (defaultBody is { } db)
             sections.Add(new SwitchSection([], isDefault: true, SectionBody(all[db], joinOffset)));
 


### PR DESCRIPTION
## Summary

`SwitchRaisingPass` left a jump table flat when its `default` jumped into a case body that returns/throws — the `System.Enum::GetNamesNoCopy` family, where every out-of-range table index **and** the default share one `throw` block. The default's `goto throw` was misclassified as establishing a *join*, and that join was an owned (case-target) block, so `Raise` bailed at the join-not-owned check.

This recognizes the shape directly: when the default dispatch is a bare branch to a case target that **terminates** (return/throw), fold the `default:` label onto that shared case section — `case N: default: throw;` — rather than treating it as a join or duplicating the terminator. One block still backs one section. The printer now emits a section's case labels **and** its `default:` keyword when it carries both (previously `IsDefault` suppressed the labels).

Example (`System.Enum::HasFlag`):

```csharp
switch (InternalGetCorElementType() - 2)
{
    case 0: case 2: case 3:
        ...
    case 12: case 13: ... case 21:
    default:
        return false;
}
```

## Rails

- **Fully raised:** 39,775 → 39,791 (**+16**)
- **Validity:** 0 new parse-malformed; **11 `System.Enum` methods went malformed → valid**. The `--validity-check` diff shows only 2 *latent semantic* codes surfaced by now-parseable output (`Enum::Format` CS0308 generic-method resolution, `Convert::ChangeType` CS0266) — pre-existing printer issues, no new invalid syntax.
- **`--pass-impact switch`:** 116 methods, **0 pass bugs**
- **Tests:** 322 decompiler tests green; the #640 compile-back canary stays clean. New synthetic regression test (`JumpTable_DefaultSharesTerminatorCase_FoldsDefaultOntoCase`) verified to fail without the change.

## Soundness

A `default:` that jumps to a case body which `return`s/`throw`s executes identical code to that case. Folding the label is behaviorally exact and needs no duplication — the section keeps its explicit case labels (IL-faithful) plus `default:`. csc re-lowers `case N: default: throw;` to the same jump table.