### PR TITLE
Spell scoped on hoisted stackalloc span declarations

### DIFF
--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -105,10 +105,13 @@ The stackalloc→`Span<T>` case is first raised from the compiler's lowering —
 `stackalloc T[n]` by `StackAllocSpanPass`. That raise is mode-independent
 correctness (the lowered ctor shape `new Span<T>(stackalloc byte[...], n)` never
 compiles, in any module); only the `unsafe` wrapping above is gated on the rules.
-The hoisted declaration omits `scoped` — a `scoped` local leaves no IL trace and so
-cannot be recovered (it may produce a CS9081 *warning*, never an error). The
-rationale for replaying only what the binary records — and what the opt-in
-"simulate" mode (`--simulate-new-rules`) adds — is in
+Hoisting the declaration above the block splits it from the `stackalloc`
+assignment, which loses C#'s inline `scoped` inference, so the hoisted
+declaration spells `scoped` explicitly (otherwise CS9081). That is not a
+recovered fact but a provable one: a `stackalloc` result can never escape its
+method, so a `scoped` local holding it is always correct. The rationale for
+replaying only what the binary records — and what the opt-in "simulate" mode
+(`--simulate-new-rules`) adds — is in
 [design/memory-safety-modes.md](design/memory-safety-modes.md).
 
 ## Inspection and verification

--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -42,17 +42,22 @@ The deciding factor is whether a construct leaves a trace in the binary.
 - The `unsafe` *context* is recoverable: the compiler stamps `MemorySafetyRulesAttribute`
   / `RequiresUnsafeAttribute`, and pointer/`calli`/stackalloc operations are visible in
   IL. So replaying `unsafe` blocks is faithful.
-- The `scoped` modifier on a **local** is *not* recoverable: it is compile-time-only
-  escape analysis and emits no IL or metadata (only `scoped` *parameters* get
-  `ScopedRefAttribute`). A decompiler reading IL has zero signal that the source said
-  `scoped`.
+- The `scoped` modifier on a **local** is generally *not* recoverable: it is
+  compile-time-only escape analysis and emits no IL or metadata (only `scoped`
+  *parameters* get `ScopedRefAttribute`). A decompiler reading IL has zero signal
+  that the source said `scoped` on an arbitrary ref-struct local.
 
-Therefore synthesizing `scoped` cannot be part of conservative replay — there is no
-fact to replay. Omitting it on a hoisted stack-bound span declaration produces at most
-a **warning** (CS9081, "result of a stackalloc expression … may be exposed outside of
-the containing method"); the output still compiles. Silencing that warning by adding
-`scoped` is a judgment the source author made, not a fact in the binary, so it belongs
-to the optimistic mode.
+The one exception is a local initialized by a `stackalloc`. A `stackalloc` result
+is *inherently* scoped — the language guarantees it can never escape its method —
+so a `scoped` local holding one is a **derivable fact**, not a source author's
+judgment, even though the keyword itself left no trace. It surfaces only because
+hoisting splits the declaration from the assignment (`scoped Span<int> s; …; s =
+stackalloc int[n];`): the inline form (`Span<int> s = stackalloc int[n]`) infers
+`scoped` on its own, and the split would otherwise lose it and warn CS9081
+("result of a stackalloc expression … may be exposed outside of the containing
+method"). So the printer spells `scoped` on exactly that hoisted-stackalloc case
+as plain conservative correctness; recovering `scoped` for any *other* ref-struct
+local would be a guess and stays out of scope.
 
 ## Off this axis: stackalloc raising is plain correctness
 
@@ -87,7 +92,6 @@ pointerless `unsafe` method's requires-unsafe-ness. Legacy compilation stamps no
 `RequiresUnsafeAttribute` and the call carries no pointer, so the fact was erased
 — there is nothing to replay or recover. This is the principled limit of the mode.
 
-Still future (not built): synthesize `scoped` on stack-bound ref-struct
-declarations to silence CS9081; emit `// SAFETY-TODO` audit comments at introduced
+Still future (not built): emit `// SAFETY-TODO` audit comments at introduced
 blocks; emit the tighter `unsafe(expr)` expression form once it lands in a usable
 compiler (tracked: roslyn #84012 / csharplang #10196).

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -1,5 +1,12 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
@@ -274,5 +281,98 @@ public class UnsafeEmitterTests
 
         var optimistic = DecompileSimulate(typeof(ChainC).Assembly.Location, typeof(ChainC).FullName!, nameof(ChainC.CallChain));
         Assert.Contains("M1()", FirstUnsafeBlockBody(optimistic));
+    }
+
+    // ---- Recompile rail: the new-rules output is valid, warning-free C# ----
+    //
+    // The fidelity/compile-back rails recompile *without* the
+    // updated-memory-safety-rules feature, so they can never surface CS9081 on a
+    // hoisted stackalloc declaration that dropped `scoped`. These tests close that
+    // gap: they recompile the actual decompiled new-rules output and fail if it
+    // warns. CS9081 ("a stackalloc result may be exposed outside the method") is a
+    // ref-safety diagnostic independent of the new-rules feature, so the pinned
+    // Roslyn package surfaces it today; enabling the feature flag below is a no-op
+    // now but turns this into a full new-rules semantic check once the package
+    // advances to a compiler that implements the rules.
+
+    [Fact]
+    public void NewRulesModule_StackAllocSkipInit_RecompilesScopedWithoutWarning()
+    {
+        var body = DecompileNew(nameof(NewFixtures.StackAllocSkipInit));
+        // The hoisted span needs `scoped`; without it the recompile warns CS9081.
+        Assert.Contains("scoped Span<int> s", body);
+
+        var diagnostics = Recompile("[SkipLocalsInit] static int M(int n)", body);
+        AssertNoWarningsOrErrors(diagnostics, body);
+    }
+
+    [Fact]
+    public void OptimisticMode_LegacyStackAllocSkipInit_RecompilesScopedWithoutWarning()
+    {
+        // Simulate forces the same hoist on legacy input, so the scoped guard must
+        // hold there too.
+        var body = DecompileLegacySimulate(nameof(LegacyFixtures.StackAllocSkipInit));
+        Assert.Contains("scoped Span<int> s", body);
+
+        var diagnostics = Recompile("[SkipLocalsInit] static int M(int n)", body);
+        AssertNoWarningsOrErrors(diagnostics, body);
+    }
+
+    /// <summary>
+    /// Recompile a decompiled method body inside a minimal non-<c>unsafe</c>
+    /// method shell (so the output's explicit <c>unsafe { }</c> blocks are
+    /// actually required, not masked by an outer modifier) with no warning
+    /// suppression, so a CS9081 (or any other) warning is observable.
+    /// </summary>
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            using System;
+            using System.Runtime.CompilerServices;
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview)
+            .WithFeatures([new KeyValuePair<string, string>("updated-memory-safety-rules", "true")]);
+        var tree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static void AssertNoWarningsOrErrors(ImmutableArray<Diagnostic> diagnostics, string body)
+    {
+        var relevant = diagnostics
+            .Where(d => d.Severity >= DiagnosticSeverity.Warning)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToList();
+        Assert.True(
+            relevant.Count == 0,
+            "decompiled new-rules output must recompile clean, got:\n  "
+                + string.Join("\n  ", relevant) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var trustedPlatformAssemblies =
+            (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+                .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (var path in trustedPlatformAssemblies)
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { /* skip an unreadable TPA entry */ }
+        }
+        return references.ToImmutable();
     }
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -191,6 +191,11 @@ public class UnsafeEmitterTests
                 < output.IndexOf("unsafe", StringComparison.Ordinal),
             "the span declaration must be hoisted above the unsafe block:\n" + output);
         Assert.Contains("s.Length", output);
+        // Splitting the declaration from the stackalloc assignment loses the
+        // inline `scoped` inference, so the hoisted declaration must spell
+        // `scoped` to stay clean (otherwise CS9081). A stackalloc result is
+        // always scoped, so this is mode-independent correctness, not a guess.
+        Assert.Contains("scoped Span<int> s", output);
     }
 
     [Fact]
@@ -216,6 +221,9 @@ public class UnsafeEmitterTests
         var skipInit = DecompileLegacy(nameof(LegacyFixtures.StackAllocSkipInit));
         Assert.DoesNotContain("unsafe", skipInit);
         Assert.Contains("stackalloc int[", skipInit);
+        // Legacy keeps the inline `Span<int> s = stackalloc int[n]` form, which
+        // infers `scoped` on its own — no split declaration, so no `scoped`.
+        Assert.DoesNotContain("scoped", skipInit);
         Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocDefault)));
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -172,6 +172,9 @@ public sealed class CSharpPrinter
     /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
     readonly HashSet<int> _fixedLocals = [];
 
+    /// <summary>Ref-struct locals whose hoisted declaration must spell <c>scoped</c>: a <c>stackalloc</c>-initialized span whose declaration was split from its assignment (out of the unsafe block) would otherwise warn CS9081. A stackalloc result is always scoped, so this is faithful, not a guess.</summary>
+    readonly HashSet<int> _scopedLocals = [];
+
     /// <summary>Optional sink mapping each printed top-level statement node to its 0-based start line in the output; null on the shipped print path. Drives line-anchored overlays (annotated views) without the printer knowing what they are.</summary>
     Dictionary<IrNode, int>? _statementLines;
 
@@ -321,11 +324,12 @@ public sealed class CSharpPrinter
                 // Fully qualified so the per-member view compiles without a
                 // using; the whole-type hoister shortens it and adds the using.
                 var type = function.Locals[index];
+                string scoped = _scopedLocals.Contains(index) ? "scoped " : "";
                 yield return type.Kind == TypeRefKind.ByRef
                     ? $"{TypeText(type)} {LocalName(index)} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
                     : _readBeforeAssign.Contains(index)
-                        ? $"{TypeText(type)} {LocalName(index)} = default;"
-                        : $"{TypeText(type)} {LocalName(index)};";
+                        ? $"{scoped}{TypeText(type)} {LocalName(index)} = default;"
+                        : $"{scoped}{TypeText(type)} {LocalName(index)};";
             }
         }
         foreach (var (slot, type) in slots)
@@ -841,10 +845,20 @@ public sealed class CSharpPrinter
         // demote the store: the local declares up front and the wrapped statement
         // becomes a plain `v = <unsafe>` assignment.
         if (_newMemorySafetyRules)
-            _declaringStores.RemoveWhere(node =>
-                node is StoreLocal store
-                && HasUnsafeOperation(store.Value)
-                && LocalIsRead(function, store.Index));
+        {
+            foreach (var store in _declaringStores.OfType<StoreLocal>().ToList())
+            {
+                if (!HasUnsafeOperation(store.Value) || !LocalIsRead(function, store.Index))
+                    continue;
+                _declaringStores.Remove(store);
+                // A stackalloc-initialized span loses its inline `scoped`
+                // inference when split from its declaration, so the hoisted
+                // declaration must restore it (else CS9081). A stackalloc result
+                // can never escape, so `scoped` is always correct here.
+                if (store.Value is StackAllocArray)
+                    _scopedLocals.Add(store.Index);
+            }
+        }
     }
 
     /// <summary>True when the local slot is read (loaded by value or address) anywhere in the body.</summary>


### PR DESCRIPTION
## Summary

Closes the last polish item from the unsafe / updated-memory-safety-rules work: the hoisted `stackalloc`-span declaration now spells `scoped`, eliminating a CS9081 warning in decompiled output.

Under the new rules, a `stackalloc`→`Span<T>` under `[SkipLocalsInit]` is wrapped in an `unsafe { }` block. When the span is read afterwards, its declaration is hoisted above the block (declared up front, assigned inside). That split loses C#'s inline `scoped` inference, so the output warned:

```text
CS9081: A result of a stackalloc expression of type 'Span<int>' in this context
        may be exposed outside of the containing method
```

Before / after (new-rules module):

```diff
-Span<int> s;
+scoped Span<int> s;

 int V_1 = n;
 unsafe
 {
     s = stackalloc int[V_1];
 }
 return s.Length;
```

## Why this is conservative-mode correctness, not a guess

`scoped` on an arbitrary ref-struct local is generally unrecoverable (compile-time-only, no IL/metadata trace). But a `stackalloc` result is **inherently** scoped — the language guarantees it can never escape its method — so `scoped` on a local holding one is a *derivable fact*. It only surfaces because the hoist splits the declaration from the assignment; spelling `scoped` restores exactly what the inline form (`Span<int> s = stackalloc int[n]`) would have inferred. The change is gated on the demoted declaring store's value being a `StackAllocArray`, so no other ref-struct local is touched.

## Changes

- `CSharpPrinter`: new `_scopedLocals` set; populated in `CollectDeclaringStores` when a hoisted (demoted) declaring store's value is a `StackAllocArray`; consumed in `CollectDeclarations` to prefix `scoped`.
- Docs: corrected `docs/decompiler.md` and `docs/design/memory-safety-modes.md` (previously stated the hoist omits `scoped` / that `scoped` is future optimistic-only work) to reflect that the stackalloc case is recoverable conservative correctness.
- Tests: extended the stackalloc unsafe-emitter tests to assert `scoped` appears (new rules) and is absent (legacy inline form).

## Verification

- Nightly SDK `11.0.100-preview.6` with new rules enforced: the `scoped` form builds with **0 warnings**; the unscoped form warns **CS9081**.
- **327 decompiler tests green** (`dotnet run --project src/ILInspector.Decompiler.Tests -c Release`), including the fidelity gates.
- Conservative legacy output unchanged (inline `Span<int> s = stackalloc int[n]`, no `scoped`); simulate mode hoists + scopes consistently.
- markdownlint clean.
