### PR TITLE
Diversify unsafe specimens and add lifetime.pointer-return annotation

### DIFF
--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -48,7 +48,7 @@ family is registering one classifier; the core does not change.
 | --- | --- | --- |
 | `Allocation` | `AllocationClassifier` | `alloc.box`, `alloc.array`, `alloc.new`, `alloc.closure`, `alloc.statemachine`, `alloc.delegate`, `alloc.enumerator` |
 | `Unsafety` | `UnsafetyClassifier` | `unsafe.deref`, `unsafe.stackalloc`, `unsafe.calli` |
-| `Lifetime` | `LifetimeClassifier` | `lifetime.ref-return`, `lifetime.stack-bound`, `lifetime.ref-struct-return` |
+| `Lifetime` | `LifetimeClassifier` | `lifetime.ref-return`, `lifetime.stack-bound`, `lifetime.ref-struct-return`, `lifetime.pointer-return` |
 
 ### Surfacing
 

--- a/src/ILInspector.Decompiler.Fixtures.UnsafeChainA/LibraryA.cs
+++ b/src/ILInspector.Decompiler.Fixtures.UnsafeChainA/LibraryA.cs
@@ -1,19 +1,39 @@
 namespace ILInspector.Decompiler.Fixtures.UnsafeChainA;
 
 /// <summary>
-/// Leaf assembly A of the cross-assembly unsafe chain. <see cref="M1"/> is a
-/// pointerless method declared <c>unsafe</c>: under the updated memory-safety
-/// rules the compiler stamps it with <c>RequiresUnsafeAttribute</c> even though
-/// nothing about its signature is unsafe. The attribute is the ONLY signal that
-/// the method is requires-unsafe, and it lives on this MethodDef in A — a caller
-/// in another assembly must resolve A to read it.
+/// Leaf assembly A of the cross-assembly unsafe chain, and the shared
+/// memory-safety specimen library. The module opts into the updated
+/// memory-safety rules (see the csproj), so the compiler stamps every method
+/// declared <c>unsafe</c> with <c>RequiresUnsafeAttribute</c> and treats a
+/// pointer anywhere in a signature as requires-unsafe.
+///
+/// The methods below are deliberately diverse so the fixture serves many
+/// scenarios at once — cross-assembly requires-unsafe rendering, and the
+/// "is this method's unsafety realized in its body?" classification. Each is a
+/// single, clean specimen of one cell in this matrix:
+///
+/// <code>
+/// method               | requires-unsafe via   | body deref? | forwards ptr? | classification
+/// ---------------------+-----------------------+-------------+---------------+-----------------------------
+/// M1                   | `unsafe` modifier     | yes         | no            | real unsafe (cross-asm leaf)
+/// RealUnsafePointer    | pointer signature     | yes         | no            | real unsafe (signature+body)
+/// HollowUnsafe         | `unsafe` modifier     | no          | no            | hollow — removable `unsafe`
+/// SignatureOnlyUnsafe  | pointer signature     | no          | no            | hollow — signature-only
+/// DelegatedUnsafe      | pointer signature     | no          | yes           | delegated — correctly unsafe
+/// Safe                 | (not requires-unsafe) | no          | no            | safe baseline
+/// </code>
 /// </summary>
 public static class LibraryA
 {
-    // Pointerless, declared `unsafe` -> stamped [RequiresUnsafe]. No pointer in
-    // the signature, so a cross-assembly caller cannot infer requires-unsafe
-    // from the MemberRef signature alone; it must read this attribute. The body
-    // does real pointer work so a result genuinely "passes through" unsafe code.
+    // ---- Cross-assembly chain leaf -------------------------------------------
+
+    /// <summary>
+    /// Pointerless method declared <c>unsafe</c> -> stamped <c>[RequiresUnsafe]</c>.
+    /// No pointer in the signature, so a cross-assembly caller cannot infer
+    /// requires-unsafe from the <c>MemberRef</c> alone; it must resolve A and
+    /// read this attribute. The body does real pointer work so a result
+    /// genuinely "passes through" unsafe code (B.M2 -> A.M1, printed by C).
+    /// </summary>
     public static unsafe int M1()
     {
         int value = 41;
@@ -24,4 +44,54 @@ public static class LibraryA
             return *p;
         }
     }
+
+    // ---- Real unsafe (unsafety realized in the body) -------------------------
+
+    /// <summary>
+    /// Requires-unsafe via its pointer signature AND realizes it: dereferences
+    /// the pointer (an <c>ldind</c> body op). The unambiguous "real unsafe"
+    /// specimen — both the signature and the body are unsafe.
+    /// </summary>
+    public static unsafe int RealUnsafePointer(int* p)
+    {
+        unsafe { return *p + 1; }
+    }
+
+    // ---- Hollow unsafe (caller-unsafe, but no unsafe op in the body) ---------
+
+    /// <summary>
+    /// Declared <c>unsafe</c> — so stamped <c>[RequiresUnsafe]</c>, forcing every
+    /// caller into an unsafe context — yet the body performs no unsafe operation
+    /// and touches no pointer. The <c>unsafe</c> modifier is gratuitous: this is
+    /// the canonical "removable <c>unsafe</c>" specimen.
+    /// </summary>
+    public static unsafe int HollowUnsafe(int x) => x * 2;
+
+    /// <summary>
+    /// Requires-unsafe purely because of the <c>int*</c> in its signature, but
+    /// the body never dereferences it — it only compares the pointer to null.
+    /// "Signature-only" hollow: caller-unsafe, no body deref, no pointer handed
+    /// onward. Distinct from <see cref="HollowUnsafe"/> (hollow via the modifier).
+    /// </summary>
+    public static unsafe bool SignatureOnlyUnsafe(int* p) => p == null;
+
+    /// <summary>
+    /// Requires-unsafe via its pointer signature and never dereferences the
+    /// pointer itself — but forwards it to <see cref="RealUnsafePointer"/>. Its
+    /// unsafety is real, just delegated: the discriminator that separates a
+    /// genuine pass-through from a truly hollow method. A body-op-only scan sees
+    /// no deref here, but the pointer-forwarding call marks it correctly unsafe.
+    /// </summary>
+    public static unsafe int DelegatedUnsafe(int* p)
+    {
+        unsafe { return RealUnsafePointer(p); }
+    }
+
+    // ---- Safe baseline -------------------------------------------------------
+
+    /// <summary>
+    /// No <c>unsafe</c> modifier, no pointer in the signature, no unsafe body op:
+    /// not requires-unsafe at all. The negative control for every specimen above.
+    /// </summary>
+    public static int Safe(int x) => x + 1;
 }

--- a/src/ILInspector.Decompiler.Fixtures.UnsafeChainA/LibraryA.cs
+++ b/src/ILInspector.Decompiler.Fixtures.UnsafeChainA/LibraryA.cs
@@ -15,13 +15,22 @@ namespace ILInspector.Decompiler.Fixtures.UnsafeChainA;
 /// <code>
 /// method               | requires-unsafe via   | body deref? | forwards ptr? | classification
 /// ---------------------+-----------------------+-------------+---------------+-----------------------------
-/// M1                   | `unsafe` modifier     | yes         | no            | real unsafe (cross-asm leaf)
+/// M1                   | `unsafe` modifier     | yes*        | no            | real unsafe (cross-asm leaf)
 /// RealUnsafePointer    | pointer signature     | yes         | no            | real unsafe (signature+body)
+/// ContractUnsafe       | `unsafe` modifier     | yes         | no            | caller contract, safe-looking sig
+/// EscapingStackPointer | pointer signature     | no (escape) | no            | unconditionally unsafe (stack escape)
 /// HollowUnsafe         | `unsafe` modifier     | no          | no            | hollow — removable `unsafe`
 /// SignatureOnlyUnsafe  | pointer signature     | no          | no            | hollow — signature-only
 /// DelegatedUnsafe      | pointer signature     | no          | yes           | delegated — correctly unsafe
 /// Safe                 | (not requires-unsafe) | no          | no            | safe baseline
 /// </code>
+///
+/// * M1 derefs in source, but its plain pointer local is optimized away in
+/// Release so the body scan records NO realized op (bodyOp=n) — the standing
+/// caution that "no visible unsafe op" must never be read as "safe."
+/// These annotations advertise obligations and surface evidence; none asserts
+/// safety (raw pointers opt out of the ref-safety escape analysis that the
+/// compiler enforces for `Span`/ref structs, so verification is out of scope).
 /// </summary>
 public static class LibraryA
 {
@@ -85,6 +94,75 @@ public static class LibraryA
     public static unsafe int DelegatedUnsafe(int* p)
     {
         unsafe { return RealUnsafePointer(p); }
+    }
+
+    // ---- Caller contract behind a safe-looking signature ---------------------
+
+    /// <summary>
+    /// A SAFE-looking signature (<c>int[]</c>, no pointer) that is nonetheless
+    /// requires-unsafe: the body pins the array (a <c>fixed</c> pinned local),
+    /// advances the pointer by one element with pointer arithmetic, dereferences
+    /// it, and prints the result. Reading element <c>[1]</c> is hardcoded, so the
+    /// method is only memory-safe if the caller passes a two-element (or longer)
+    /// array — an unenforced precondition, i.e. a real CALLER CONTRACT. Because
+    /// of that contract the method carries the <c>unsafe</c> modifier, so the
+    /// compiler stamps <c>RequiresUnsafeAttribute</c> and
+    /// <c>CallerUnsafeMode</c> is <c>Explicit</c>. The <c>int[]</c> signature
+    /// gives a caller no hint; the attribute on the MethodDef is the ONLY signal,
+    /// and a cross-assembly caller can only learn it by resolving A
+    /// (the case <c>MetadataContext</c> serves). Contrast with a truly safe
+    /// encapsulation, which would discharge the obligation internally (bounds
+    /// check, or derive the index from <c>pair.Length</c>) and stay
+    /// <c>CallerUnsafeMode.None</c>. Unlike <see cref="M1"/> the deref also
+    /// survives the body scan: the <c>fixed</c> pinned local is flagged
+    /// unconditionally, opening the indirect-opcode scan.
+    /// </summary>
+    public static unsafe void ContractUnsafe(int[] pair)
+    {
+        // The `unsafe` modifier above is the caller contract (stamps
+        // RequiresUnsafeAttribute); this inner block is the deref *context* that
+        // v2 requires separately.
+        unsafe
+        {
+            fixed (int* p = pair)
+            {
+                int* second = p + 1;
+                System.Console.WriteLine(*second);
+            }
+        }
+    }
+
+    // ---- Unconditionally unsafe: a pointer that escapes its stack frame ------
+
+    /// <summary>
+    /// Returns a pointer into stack memory (<c>stackalloc</c> ⇒ <c>localloc</c>)
+    /// that is reclaimed the instant this method returns: a dangling pointer.
+    /// Unlike <see cref="ContractUnsafe"/>, there is NO caller contract that makes
+    /// the result usable — even a correct caller cannot safely deref it. C#
+    /// compiles this because raw pointers carry no lifetime / ref-safety tracking;
+    /// the unsafe surface is exactly where C#'s static lifetime guarantees are
+    /// switched off. Compare the <c>Span&lt;int&gt;</c> form, which is the SAME
+    /// bug but the compiler REJECTS it via ref-struct ref-safety analysis:
+    /// <code>
+    ///     static Span&lt;int&gt; Escaping() {
+    ///         Span&lt;int&gt; s = stackalloc int[10];
+    ///         return s; // CS8352: may expose referenced variables outside their
+    ///                   // declaration scope — rejected at COMPILE time.
+    ///     }
+    /// </code>
+    /// Two cheap, honest annotations fall out of this specimen, neither of which
+    /// claims "safe": (1) the pointer RETURN type alone signals the caller
+    /// inherits an unverifiable lifetime obligation; (2) <c>localloc</c> in a body
+    /// that returns a pointer signals a probable stack escape. <c>localloc</c> is
+    /// flagged UNGATED, so this is a gate-independent body-op survivor.
+    /// </summary>
+    public static unsafe int* EscapingStackPointer()
+    {
+        unsafe
+        {
+            int* p = stackalloc int[10];
+            return p;
+        }
     }
 
     // ---- Safe baseline -------------------------------------------------------

--- a/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
@@ -43,6 +43,25 @@ public class LifetimeClassifierTests
     }
 
     [Fact]
+    public void PointerReturn_IsReported()
+    {
+        // The dangerous twin of the stack-bound span: a returned raw pointer opts
+        // out of ref-safety, so the caller inherits an unverifiable lifetime
+        // obligation. Detail is the pointed-to type.
+        var facts = Classify(nameof(LifetimeSampleClass.EscapingStackPointer));
+        Assert.Contains(facts, f => f.Descriptor.Id == "lifetime.pointer-return" && f.Detail == "int");
+    }
+
+    [Fact]
+    public void PointerReturn_LandsOnTheReturnStatement()
+    {
+        var source = MetadataSource.Open(typeof(LifetimeSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(LifetimeSampleClass).FullName!, nameof(LifetimeSampleClass.EscapingStackPointer))!;
+        var fact = new LifetimeClassifier().Classify(function).Single(f => f.Descriptor.Id == "lifetime.pointer-return");
+        Assert.IsType<Return>(fact.Node);
+    }
+
+    [Fact]
     public void RefStructParameter_AloneIsNotReported()
     {
         // A Span parameter is visible in the source signature — not a hidden fact.

--- a/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
@@ -26,6 +26,16 @@ public static class LifetimeSampleClass
     // Returns a span borrowing from the input span.
     public static ReadOnlySpan<char> Tail(ReadOnlySpan<char> s) => s.Slice(1);
 
+    // Returns a raw pointer into stackalloc memory reclaimed on return: a dangling
+    // pointer. The dangerous twin of StackSpanSum — the compiler rejects the
+    // Span<int> form (CS8352) but raw pointers opt out of ref-safety, so this
+    // compiles silently and the caller inherits an unverifiable lifetime obligation.
+    public static unsafe int* EscapingStackPointer()
+    {
+        int* p = stackalloc int[4];
+        return p;
+    }
+
     // A plain value method for the negative case.
     public static int Add(int a, int b) => a + b;
 }

--- a/src/ILInspector.Decompiler/Analysis/LifetimeClassifier.cs
+++ b/src/ILInspector.Decompiler/Analysis/LifetimeClassifier.cs
@@ -14,14 +14,19 @@ namespace ILInspector.Decompiler.Analysis;
 /// see).
 ///
 /// Precision over recall: it reports only facts it can decide structurally — a
-/// by-ref return, a stackalloc-backed span, a ref-struct return — and stays
-/// silent on the heuristic borrow relationships it cannot prove.
+/// by-ref return, a stackalloc-backed span, a ref-struct return, a raw-pointer
+/// return — and stays silent on the heuristic borrow relationships it cannot
+/// prove. The raw-pointer return is the dangerous twin of the stack-bound span:
+/// where ref-safety makes a returned <c>Span</c> a compile error (CS8352), a
+/// returned <c>int*</c> opts out of that analysis and compiles silently, so the
+/// caller inherits a lifetime obligation nothing checks.
 /// </summary>
 public sealed class LifetimeClassifier : IHiddenFactClassifier
 {
     static readonly AnnotationDescriptor RefReturn = new("lifetime.ref-return", AnnotationCategory.Lifetime, "returns a reference borrowing from an input or field");
     static readonly AnnotationDescriptor StackBound = new("lifetime.stack-bound", AnnotationCategory.Lifetime, "span backed by stack memory — cannot escape the frame");
     static readonly AnnotationDescriptor RefStructReturn = new("lifetime.ref-struct-return", AnnotationCategory.Lifetime, "returns a ref struct — lifetime-constrained, cannot be boxed or stored on the heap");
+    static readonly AnnotationDescriptor PointerReturn = new("lifetime.pointer-return", AnnotationCategory.Lifetime, "returns an unmanaged pointer — the caller inherits an unverifiable lifetime obligation");
 
     public AnnotationCategory Category => AnnotationCategory.Lifetime;
 
@@ -34,8 +39,10 @@ public sealed class LifetimeClassifier : IHiddenFactClassifier
         var returnType = function.Signature.ReturnType;
         var returnFact = returnType.Kind == TypeRefKind.ByRef
             ? RefReturn
-            : IsRefStruct(returnType) ? RefStructReturn : null;
-        string? returnDetail = returnType.Kind == TypeRefKind.ByRef
+            : returnType.Kind == TypeRefKind.Pointer
+                ? PointerReturn
+                : IsRefStruct(returnType) ? RefStructReturn : null;
+        string? returnDetail = returnType.Kind is TypeRefKind.ByRef or TypeRefKind.Pointer
             ? returnType.ElementType?.ToDisplayString()
             : returnType.ToDisplayString();
 

--- a/tools/DecompilerHarness/AnnotationCheck.cs
+++ b/tools/DecompilerHarness/AnnotationCheck.cs
@@ -58,6 +58,7 @@ static class AnnotationCheck
         ],
         ["lifetime.ref-return"] = [ILOpCode.Ret],
         ["lifetime.ref-struct-return"] = [ILOpCode.Ret],
+        ["lifetime.pointer-return"] = [ILOpCode.Ret],
         ["lifetime.stack-bound"] = [ILOpCode.Newobj],
     };
 


### PR DESCRIPTION
## Summary

Two threads in the memory-safety / unsafe-code line of work:

1. **Expand the `UnsafeChainA` specimen library** so it spans the full hazard matrix (eight specimens), giving every present and future unsafe annotation a single, clean test oracle.
2. **Ship the first new annotation** that falls out of that work: `lifetime.pointer-return`.

## Fixture diversity (`UnsafeChainA/LibraryA.cs`)

Each method is one clean cell of the requires-unsafe × realized-body-op matrix:

| specimen | mode | body op | role |
| --- | --- | --- | --- |
| `Safe` | None | n | negative control |
| `M1` | Explicit | n | recall-gap false-hollow (deref optimized invisible) |
| `HollowUnsafe` | Explicit | n | genuinely hollow (removable `unsafe`) |
| `SignatureOnlyUnsafe` | Explicit | n | pointer sig, null-check only |
| `DelegatedUnsafe` | Explicit | n | forwards a pointer (transitive) |
| `RealUnsafePointer` | Explicit | Y | pointer sig + deref |
| `ContractUnsafe` | Explicit | Y | safe-looking `int[]` sig, caller contract |
| `EscapingStackPointer` | Explicit | Y | unconditionally unsafe stack escape |

Two of these are new in this PR:

- **`ContractUnsafe(int[] pair)`** — a safe-looking `int[]` signature that is nonetheless requires-unsafe: it pins the array, advances the pointer one element, and derefs, so it is only memory-safe when the caller passes a >=2-element array — an unenforced **caller contract**. Carries the `unsafe` modifier so the attribute (the only signal to a cross-assembly caller) is present.
- **`EscapingStackPointer()`** — returns a pointer into `stackalloc` memory reclaimed on return, a dangling pointer with no caller contract that can rescue it. C# compiles this silently because raw pointers opt out of the ref-safety escape analysis that rejects the equivalent `Span<int>` form (CS8352).

## New annotation: `lifetime.pointer-return`

A raw-pointer return surfaced as a `Lifetime` hidden-fact annotation — the structural dual of `lifetime.stack-bound`. Where ref-safety makes a returned `Span<T>` a compile error (CS8352), a returned `int*` opts out of that analysis and compiles silently, so the caller inherits a lifetime obligation nothing checks.

Positive-only and descriptive, in line with the annotation contract: it states the obligation exists, never that any use is safe. `LifetimeClassifier` emits it for any `TypeRefKind.Pointer` return, riding the `Return` node (anchored on `return p;` / the `ret`), with the pointed-to type as detail. The annotate-check oracle gets the `ret` anchor row, and `LifetimeSampleClass` gains the `EscapingStackPointer` sample plus precision/anchor tests.

## Verification

- 9/9 `LifetimeClassifierTests`, 329/329 full decompiler suite.
- 17/17 `UnsafeEmitterTests`; the cross-assembly chain still prints `84`.
- `--annotation-check` reports 100% precision, `lifetime.pointer-return` agreeing with the `ret` opcode.
- End-to-end: the `Facts` section renders `lifetime.pointer-return` on `EscapingStackPointer`.