### PR TITLE
Add lifetime.stack-escape: correlate a pointer return to its stackalloc

### DIFF
--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -48,7 +48,7 @@ family is registering one classifier; the core does not change.
 | --- | --- | --- |
 | `Allocation` | `AllocationClassifier` | `alloc.box`, `alloc.array`, `alloc.new`, `alloc.closure`, `alloc.statemachine`, `alloc.delegate`, `alloc.enumerator` |
 | `Unsafety` | `UnsafetyClassifier` | `unsafe.deref`, `unsafe.stackalloc`, `unsafe.calli` |
-| `Lifetime` | `LifetimeClassifier` | `lifetime.ref-return`, `lifetime.stack-bound`, `lifetime.ref-struct-return`, `lifetime.pointer-return` |
+| `Lifetime` | `LifetimeClassifier` | `lifetime.ref-return`, `lifetime.stack-bound`, `lifetime.ref-struct-return`, `lifetime.pointer-return`, `lifetime.stack-escape` |
 
 ### Surfacing
 

--- a/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
@@ -62,6 +62,24 @@ public class LifetimeClassifierTests
     }
 
     [Fact]
+    public void EscapingStackPointer_IsAStackEscape()
+    {
+        // The strong refinement of pointer-return: the returned pointer is proven
+        // to carry stackalloc memory out of the frame — a dangling pointer.
+        var facts = Classify(nameof(LifetimeSampleClass.EscapingStackPointer));
+        Assert.Contains(facts, f => f.Descriptor.Id == "lifetime.stack-escape");
+    }
+
+    [Fact]
+    public void PassthroughPointer_IsNotAStackEscape()
+    {
+        // Precision: a forwarded pointer is a pointer-return but NOT a stack escape.
+        var facts = Classify(nameof(LifetimeSampleClass.PassthroughPointer));
+        Assert.Contains(facts, f => f.Descriptor.Id == "lifetime.pointer-return");
+        Assert.DoesNotContain(facts, f => f.Descriptor.Id == "lifetime.stack-escape");
+    }
+
+    [Fact]
     public void RefStructParameter_AloneIsNotReported()
     {
         // A Span parameter is visible in the source signature — not a hidden fact.

--- a/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
@@ -36,6 +36,11 @@ public static class LifetimeSampleClass
         return p;
     }
 
+    // Returns a pointer that is NOT stack memory: it forwards the input pointer.
+    // A pointer-return (the caller still inherits a lifetime obligation) but NOT a
+    // stack escape — the precision control for lifetime.stack-escape.
+    public static unsafe int* PassthroughPointer(int* p) => p;
+
     // A plain value method for the negative case.
     public static int Add(int a, int b) => a + b;
 }

--- a/src/ILInspector.Decompiler/Analysis/LifetimeClassifier.cs
+++ b/src/ILInspector.Decompiler/Analysis/LifetimeClassifier.cs
@@ -19,7 +19,9 @@ namespace ILInspector.Decompiler.Analysis;
 /// prove. The raw-pointer return is the dangerous twin of the stack-bound span:
 /// where ref-safety makes a returned <c>Span</c> a compile error (CS8352), a
 /// returned <c>int*</c> opts out of that analysis and compiles silently, so the
-/// caller inherits a lifetime obligation nothing checks.
+/// caller inherits a lifetime obligation nothing checks. When that returned
+/// pointer is proven to carry stackalloc memory, the stronger
+/// <c>lifetime.stack-escape</c> fact rides alongside it — a dangling pointer.
 /// </summary>
 public sealed class LifetimeClassifier : IHiddenFactClassifier
 {
@@ -27,6 +29,7 @@ public sealed class LifetimeClassifier : IHiddenFactClassifier
     static readonly AnnotationDescriptor StackBound = new("lifetime.stack-bound", AnnotationCategory.Lifetime, "span backed by stack memory — cannot escape the frame");
     static readonly AnnotationDescriptor RefStructReturn = new("lifetime.ref-struct-return", AnnotationCategory.Lifetime, "returns a ref struct — lifetime-constrained, cannot be boxed or stored on the heap");
     static readonly AnnotationDescriptor PointerReturn = new("lifetime.pointer-return", AnnotationCategory.Lifetime, "returns an unmanaged pointer — the caller inherits an unverifiable lifetime obligation");
+    static readonly AnnotationDescriptor StackEscape = new("lifetime.stack-escape", AnnotationCategory.Lifetime, "returns a pointer into stack memory reclaimed on return — a dangling pointer");
 
     public AnnotationCategory Category => AnnotationCategory.Lifetime;
 
@@ -46,6 +49,10 @@ public sealed class LifetimeClassifier : IHiddenFactClassifier
             ? returnType.ElementType?.ToDisplayString()
             : returnType.ToDisplayString();
 
+        // Locals whose value is a stackalloc, so a returned pointer reading one can
+        // be proven to carry stack memory out of the frame.
+        var stackLocals = CollectStackLocals(function);
+
         foreach (var node in function.Descendants)
         {
             switch (node)
@@ -54,6 +61,12 @@ public sealed class LifetimeClassifier : IHiddenFactClassifier
                 // they land on `return ref a[0];` in C# and the `ret` in IL.
                 case Return { Children.Count: > 0 } ret when returnFact is not null:
                     annotations.Add(Make(returnFact, ret, returnDetail));
+                    // The strong refinement: a pointer return whose value is proven
+                    // to be stackalloc memory is a dangling pointer. Emitted in
+                    // addition to pointer-return — the broad obligation plus the
+                    // specific hazard.
+                    if (returnFact == PointerReturn && ret.Value is not null && ReturnsStackMemory(ret.Value, stackLocals))
+                        annotations.Add(Make(StackEscape, ret, returnDetail));
                     break;
 
                 // A Span/ReadOnlySpan constructed over a stackalloc: the source
@@ -67,6 +80,36 @@ public sealed class LifetimeClassifier : IHiddenFactClassifier
 
         return annotations;
     }
+
+    /// <summary>Locals assigned a <c>stackalloc</c> result.</summary>
+    static HashSet<int> CollectStackLocals(IrFunction function)
+    {
+        var stackLocals = new HashSet<int>();
+        foreach (var node in function.Descendants)
+            if (node is StoreLocal store && IsStackAlloc(Unwrap(store.Value)))
+                stackLocals.Add(store.Index);
+        return stackLocals;
+    }
+
+    /// <summary>
+    /// True when a returned value carries stack memory — a <c>stackalloc</c>
+    /// returned directly, or a load of a local holding one. Structural and precise;
+    /// it does not chase the value through arithmetic or calls.
+    /// </summary>
+    static bool ReturnsStackMemory(IrExpression value, HashSet<int> stackLocals)
+        => Unwrap(value) switch
+        {
+            var expr when IsStackAlloc(expr) => true,
+            LoadLocal load => stackLocals.Contains(load.Index),
+            _ => false,
+        };
+
+    static bool IsStackAlloc(IrExpression expr) => expr is StackAllocate or StackAllocArray;
+
+    /// <summary>Strips reinterpreting <see cref="Convert"/> casts (e.g. a lowered
+    /// <c>byte*</c> scratch reinterpreted as <c>int*</c>) to reach the underlying value.</summary>
+    static IrExpression Unwrap(IrExpression expr)
+        => expr is Pipeline.Convert convert ? Unwrap(convert.Operand) : expr;
 
     static Annotation Make(AnnotationDescriptor descriptor, IrNode node, string? detail)
         => new(descriptor, node.SourceOffset, detail, AnnotationConditionality.Always, node);

--- a/tools/DecompilerHarness/AnnotationCheck.cs
+++ b/tools/DecompilerHarness/AnnotationCheck.cs
@@ -59,6 +59,7 @@ static class AnnotationCheck
         ["lifetime.ref-return"] = [ILOpCode.Ret],
         ["lifetime.ref-struct-return"] = [ILOpCode.Ret],
         ["lifetime.pointer-return"] = [ILOpCode.Ret],
+        ["lifetime.stack-escape"] = [ILOpCode.Ret],
         ["lifetime.stack-bound"] = [ILOpCode.Newobj],
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #685. Adds a second Lifetime hidden-fact annotation, `lifetime.stack-escape`, the strong refinement of `lifetime.pointer-return`.

- `lifetime.pointer-return` (from #685) states the **broad obligation**: a returned raw pointer the caller cannot lifetime-check.
- `lifetime.stack-escape` states the **specific hazard**: the returned pointer is proven to carry `stackalloc` memory, so it is a **dangling pointer** — stack memory reclaimed the instant the method returns.

The two ride the same return site additively — the broad net plus the red alert. Today `EscapingStackPointer` emits `unsafe.stackalloc` and `lifetime.pointer-return` as two co-located but uncorrelated facts; this PR proves the correlation and turns it into one definitive claim.

## Detection (precision over recall)

Structural and precise: the returned value, after stripping reinterpreting `Convert` casts, is either a `stackalloc` returned directly or a load of a local assigned a `stackalloc`. It does **not** chase the value through arithmetic or calls, so a forwarded or computed pointer stays `pointer-return` only.

## Relationship to #684

This completes the stackalloc/escape duality:

| origin | ref-safety | tooling response |
| --- | --- | --- |
| stackalloc-backed `Span` | on — escape is CS8352 | #684: recover `scoped` (the guarantee exists) |
| stackalloc-backed pointer return | off — compiles silently | this PR: flag `lifetime.stack-escape` (the obligation is unchecked) |

Recover the guarantee where it exists; surface the obligation where it does not.

## Verification

- 11/11 `LifetimeClassifierTests`, 335/335 full decompiler suite.
- `--annotation-check` 100% precision, `lifetime.stack-escape` 1/1 on the `ret`.
- End-to-end: the `Facts` section renders `unsafe.stackalloc` + `lifetime.pointer-return` + `lifetime.stack-escape` on `EscapingStackPointer`.
