### PR TITLE
Fix SourceLink Availability test flakiness and misleading Signals wording (#675)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3884,8 +3884,12 @@ public class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_ExplicitSourceLinkAudit_IncludesSourceLinkAuditSection()
     {
+        // Target a platform assembly with known SourceLink data so the audit deterministically
+        // renders. The local test assembly's SourceLink presence is environment-dependent
+        // (SDK 8+ auto-enables SourceLink only when building inside a git repo), so it cannot
+        // reliably exercise the section (#675).
         var (exit, output, error) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Signals,SourceLink Availability,SourceLink Missing Files");
+            "library", "System.Text.Json", "-S", "Signals,SourceLink Availability,SourceLink Missing Files");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Signals", output);

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -675,6 +675,24 @@ public class OutputFormatterTests
         Assert.Contains("| CR/LF Mismatch | 2 normalized |", output);
     }
 
+    [Fact]
+    public void SingleAudit_Signals_AbsentSourceLink_DoesNotClaimSourceLinkFound()
+    {
+        // A PDB is present but carries no SourceLink data. The SourceLink signal must report
+        // "Not found" without claiming SourceLink data was found in the PDB (#675).
+        var inspection = CreateTestAudit("Test.dll", "net9.0");
+        inspection.HasSourceLink = false;
+        inspection.PdbLocation = "standalone";
+        inspection.SourceLinkUnavailableReason = "PDB checked; no SourceLink data";
+
+        AuditSignalBuilder.PopulateLibraryAudit(typeof(OutputFormatterTests).Assembly.Location, inspection, new VerboseLogger(false));
+
+        var sourceLink = Assert.Single(inspection.AuditSignals!, s => s.Signal == "SourceLink");
+        Assert.Equal("Not found", sourceLink.Value);
+        Assert.DoesNotContain("SourceLink data found", sourceLink.Evidence);
+        Assert.Contains("no SourceLink data", sourceLink.Evidence);
+    }
+
     private static LibraryInspection CreateTestAudit(string fileName, string? tfm)
     {
         return new LibraryInspection

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -576,19 +576,19 @@ internal static class AuditSignalBuilder
     {
         if (inspection.HasSourceLink)
         {
-            return ("Present", FormatPdbEvidence(inspection));
+            return ("Present", FormatPdbEvidence(inspection, hasSourceLink: true));
         }
 
         if (!string.IsNullOrWhiteSpace(inspection.SourceLinkUnavailableReason))
         {
             if (inspection.SourceLinkUnavailableReason == "PDB checked; no SourceLink data")
-                return ("Not found", FormatPdbEvidence(inspection));
+                return ("Not found", FormatPdbEvidence(inspection, hasSourceLink: false));
 
             return ("Not found", inspection.SourceLinkUnavailableReason);
         }
 
         if (!string.IsNullOrWhiteSpace(inspection.PdbFormat) || !string.IsNullOrWhiteSpace(inspection.PdbLocation))
-            return ("Not found", FormatPdbEvidence(inspection));
+            return ("Not found", FormatPdbEvidence(inspection, hasSourceLink: false));
 
         return ("Not checked", "PDB not checked");
     }
@@ -607,7 +607,7 @@ internal static class AuditSignalBuilder
         return ("Not checked", "SourceLink availability not selected");
     }
 
-    private static string FormatPdbEvidence(LibraryInspection inspection)
+    private static string FormatPdbEvidence(LibraryInspection inspection, bool hasSourceLink)
     {
         var source = !string.IsNullOrWhiteSpace(inspection.SymbolServer)
             ? inspection.SymbolServer
@@ -615,7 +615,9 @@ internal static class AuditSignalBuilder
                 ? inspection.PdbLocation.ToLowerInvariant()
                 : "unknown";
 
-        return $"SourceLink data found in PDB from {source}";
+        return hasSourceLink
+            ? $"SourceLink data found in PDB from {source}"
+            : $"PDB found from {source}; no SourceLink data";
     }
 
     private static string FormatBool(bool value) => value ? "Yes" : "No";


### PR DESCRIPTION
Fixes #675.

## Problem

`LibraryCommand_ExplicitSourceLinkAudit_IncludesSourceLinkAuditSection` targeted the local `dotnet-inspect.Tests.dll`. That assembly's SourceLink presence is **environment-dependent**: SDK 8+ auto-enables SourceLink only when building inside a git repo, so the section rendered on some builds (mine: 47/47 files) but not others (the build in the issue). When SourceLink is absent, `SourceLink Availability.CanRender(...)` stays false and the section silently vanishes, failing the test.

The issue also flagged misleading Signals wording: the `SourceLink` row could read `Not found` while its evidence claimed `SourceLink data found in PDB from standalone`.

## Changes

- **Test determinism:** retarget the test to the platform assembly `System.Text.Json`, which deterministically carries SourceLink data (consistent with the existing platform-targeting Signals tests). The section now reliably renders.
- **Wording fix:** `FormatPdbEvidence` now takes `hasSourceLink`. In the absent case the evidence reads `PDB found from <src>; no SourceLink data` instead of falsely claiming SourceLink data was found. The package-level evidence path (gated on `SourceLinkAvailable > 0`) is unchanged.
- **Coverage:** added `SingleAudit_Signals_AbsentSourceLink_DoesNotClaimSourceLinkFound`.

## Verification

- Full `dotnet-inspect.Tests` suite: 1146 passed, 9 skipped (ilasm/ildasm), 0 failed.
- Repro against `System.Text.Json` renders `## SourceLink Availability` with `Source Files` populated.
