### PR TITLE
Opaque-contract: flag requires-unsafe methods that hide the obligation from their signature

### DIFF
--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -95,3 +95,24 @@ pointerless `unsafe` method's requires-unsafe-ness. Legacy compilation stamps no
 Still future (not built): emit `// SAFETY-TODO` audit comments at introduced
 blocks; emit the tighter `unsafe(expr)` expression form once it lands in a usable
 compiler (tracked: roslyn #84012 / csharplang #10196).
+
+## Opaque-contract classification (analysis surface)
+
+Separate from rendering, the analysis layer flags **opaque-contract** methods:
+a requires-unsafe method (`CallerUnsafeMode != None`) whose signature carries no
+pointer (`OpaqueUnsafe.IsOpaque` / `LibraryBodyIndex.OpaqueUnsafeMethods`). The
+requires-unsafe obligation is then visible only via `RequiresUnsafeAttribute` or
+the `unsafe` modifier — a caller reading the parameter and return types alone sees
+nothing unsafe. This is the new-rules analogue of the pointerless `unsafe` method
+discussed above: under the updated rules the attribute survives, so the fact is
+*recoverable as an annotation* even though the signature hides it.
+
+The classification is **positive and sound** — it states that the contract is
+invisible in the signature, never that the body is safe (a `mode != None`
+pointerless method may still do real unsafe work, e.g. `ContractUnsafe(int[])`
+which hardcodes an element index as an unenforced caller precondition). It joins
+no body evidence; it reads `CallerUnsafeMode` alone. Specimens in
+`UnsafeChainA.LibraryA`: positives `M1`, `HollowUnsafe`, `ContractUnsafe`;
+negatives are the pointer-signature methods (`RealUnsafePointer`,
+`SignatureOnlyUnsafe`, `DelegatedUnsafe`, `EscapingStackPointer`) and the safe
+control (`Safe`).

--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -70,6 +70,14 @@ static int RunUnsafeReport(string[] args)
     foreach (var entry in top)
         Console.WriteLine($"{rank++}. {entry.DirectCallerCount,6} callers  [{entry.Mode}]  {MethodDisplay(entry.Method)}");
 
+    var opaque = index.OpaqueUnsafeMethods();
+    Console.WriteLine();
+    Console.WriteLine($"Opaque-contract methods ({opaque.Length}): requires-unsafe with no pointer in the signature");
+    Console.WriteLine("  (the obligation is visible only via the attribute / unsafe modifier, not the signature)");
+    Console.WriteLine();
+    foreach (var entry in opaque)
+        Console.WriteLine($"  [{entry.Mode}]  {MethodDisplay(entry.Method)}");
+
     return 0;
 }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -167,6 +167,79 @@ public class LibraryBodyIndexTests
     }
 }
 
+public class OpaqueUnsafeTests
+{
+    static MethodIdentity Method(string name, CallerUnsafeMode mode, TypeRef returnType, params TypeRef[] parameterTypes)
+        => new(
+            AssemblyName: "Fixture",
+            ModuleVersionId: Guid.Empty,
+            DeclaringType: TypeRef.Definition("Fixture", "Ns", "Holder"),
+            Name: name,
+            ParameterTypes: [.. parameterTypes],
+            ReturnType: returnType,
+            MetadataToken: name.GetHashCode(),
+            IsStatic: true,
+            CallerUnsafeMode: mode);
+
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void IsOpaque_RequiresUnsafeWithNoPointerSignature_IsOpaque()
+    {
+        // unsafe modifier / RequiresUnsafeAttribute on a pointerless signature:
+        // the obligation is invisible to a caller reading parameter/return types.
+        var contract = Method("ContractUnsafe", CallerUnsafeMode.Explicit, Int, TypeRef.SzArray(Int));
+        Assert.True(OpaqueUnsafe.IsOpaque(contract));
+    }
+
+    [Fact]
+    public void IsOpaque_PointerSignature_IsNotOpaque()
+    {
+        // The pointer is visible in the signature, so the unsafety is not hidden.
+        var pointerParam = Method("TakesPointer", CallerUnsafeMode.Implicit, Int, TypeRef.Pointer(Int));
+        var pointerReturn = Method("ReturnsPointer", CallerUnsafeMode.Explicit, TypeRef.Pointer(Int), Int);
+        Assert.False(OpaqueUnsafe.IsOpaque(pointerParam));
+        Assert.False(OpaqueUnsafe.IsOpaque(pointerReturn));
+    }
+
+    [Fact]
+    public void IsOpaque_NotRequiresUnsafe_IsNotOpaque()
+    {
+        var safe = Method("Safe", CallerUnsafeMode.None, Int, Int);
+        Assert.False(OpaqueUnsafe.IsOpaque(safe));
+    }
+
+    [Fact]
+    public void Collect_SelectsOnlyOpaqueMethods_OrderedByToken()
+    {
+        var methods = ImmutableArray.Create(
+            Method("Safe", CallerUnsafeMode.None, Int, Int),
+            Method("TakesPointer", CallerUnsafeMode.Implicit, Int, TypeRef.Pointer(Int)),
+            Method("Contract", CallerUnsafeMode.Explicit, Int, TypeRef.SzArray(Int)),
+            Method("Hollow", CallerUnsafeMode.Explicit, Int));
+
+        var opaque = OpaqueUnsafe.Collect(methods);
+
+        Assert.Equal(["Contract", "Hollow"], opaque.Select(o => o.Method.Name).Order());
+        Assert.All(opaque, o => Assert.NotEqual(CallerUnsafeMode.None, o.Mode));
+    }
+
+    [Fact]
+    public void OpaqueUnsafeMethods_PointerSignatureFixtureIsNotOpaque()
+    {
+        // The in-test fixture assembly is not opted into the updated memory-safety
+        // rules, so its only requires-unsafe methods carry a pointer signature —
+        // none should be reported as opaque.
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        var opaque = index.OpaqueUnsafeMethods();
+
+        Assert.DoesNotContain(opaque, o => o.Method.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead));
+        Assert.All(opaque, o => Assert.False(
+            o.Method.ParameterTypes.Any(t => t.ContainsPointer()) || o.Method.ReturnType.ContainsPointer()));
+    }
+}
+
 public class CallTreeTests
 {
     static readonly LibraryBodyIndex Index = LibraryBodyIndex.Open(typeof(CallTreeFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -70,6 +70,14 @@ public sealed class LibraryBodyIndex
         => UnsafeLeverage.Top(DirectCalls, Methods, count);
 
     /// <summary>
+    /// Requires-unsafe methods whose signature carries no pointer — the unsafe
+    /// obligation is visible only via the attribute / <c>unsafe</c> modifier,
+    /// hidden from a caller reading the parameter and return types.
+    /// </summary>
+    public ImmutableArray<OpaqueUnsafeMethod> OpaqueUnsafeMethods()
+        => OpaqueUnsafe.Collect(Methods);
+
+    /// <summary>
     /// Builds a bounded outbound (callee) call tree rooted at the method identified by
     /// <paramref name="rootMethodToken"/>. Expansion stays within this assembly: callees that
     /// resolve to another assembly are recorded as <see cref="CallTreeStatus.External"/> leaves.
@@ -261,27 +269,12 @@ public sealed class LibraryBodyIndex
             bool requiresUnsafe =
                 HasRequiresUnsafe(methodDef.GetCustomAttributes())
                 || HasRequiresUnsafe(_reader.GetTypeDefinition(typeHandle).GetCustomAttributes())
-                || parameterTypes.Any(ContainsPointer)
-                || ContainsPointer(returnType);
+                || parameterTypes.Any(type => type.ContainsPointer())
+                || returnType.ContainsPointer();
 
             if (!requiresUnsafe)
                 return CallerUnsafeMode.None;
             return _memorySafetyRulesEnabled ? CallerUnsafeMode.Explicit : CallerUnsafeMode.Implicit;
-        }
-
-        // A pointer or function pointer anywhere in a type drives implicit
-        // requires-unsafe. (Pinned is a local modifier, not a signature pointer,
-        // so it is deliberately excluded — matching Roslyn's signature check.)
-        static bool ContainsPointer(TypeRef type)
-        {
-            if (type.Kind == TypeRefKind.Pointer)
-                return true;
-            if (type.Kind == TypeRefKind.Unsupported
-                && type.UnsupportedReason.Contains("function pointer", StringComparison.OrdinalIgnoreCase))
-                return true;
-            if (type.ElementType is not null && ContainsPointer(type.ElementType))
-                return true;
-            return type.TypeArguments.Any(ContainsPointer);
         }
 
         // Read attributes straight from SRM — a simple has-attribute check needs

--- a/src/ILInspector.Analysis/OpaqueUnsafe.cs
+++ b/src/ILInspector.Analysis/OpaqueUnsafe.cs
@@ -1,0 +1,45 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// A requires-unsafe method whose signature carries no pointer — the unsafety is
+/// hidden from the caller's signature view. The only structural signal is the
+/// attribute (<c>RequiresUnsafeAttribute</c> or the <c>unsafe</c> modifier), so a
+/// caller reading the parameter and return types alone sees nothing unsafe.
+/// </summary>
+public sealed record OpaqueUnsafeMethod(
+    MethodIdentity Method,
+    CallerUnsafeMode Mode);
+
+public static class OpaqueUnsafe
+{
+    /// <summary>
+    /// Whether <paramref name="method"/> hides its requires-unsafe obligation from
+    /// its signature: it requires unsafe (<see cref="CallerUnsafeMode"/> is not
+    /// <see cref="CallerUnsafeMode.None"/>) yet no parameter or return type
+    /// contains a pointer. The obligation therefore comes from the attribute or
+    /// <c>unsafe</c> modifier, not a visible pointer.
+    /// </summary>
+    /// <remarks>
+    /// This is a positive, sound structural claim — it never asserts the body is
+    /// safe, only that the requires-unsafe contract is invisible in the signature.
+    /// </remarks>
+    public static bool IsOpaque(MethodIdentity method)
+        => method.CallerUnsafeMode != CallerUnsafeMode.None
+            && !method.ParameterTypes.Any(type => type.ContainsPointer())
+            && !method.ReturnType.ContainsPointer();
+
+    /// <summary>
+    /// Every requires-unsafe method whose signature hides the obligation, ordered
+    /// by metadata token. Pure over the index's array so it is testable without a
+    /// real assembly.
+    /// </summary>
+    public static ImmutableArray<OpaqueUnsafeMethod> Collect(ImmutableArray<MethodIdentity> methods)
+        => methods
+            .Where(IsOpaque)
+            .OrderBy(method => method.MetadataToken)
+            .Select(method => new OpaqueUnsafeMethod(method, method.CallerUnsafeMode))
+            .ToImmutableArray();
+}

--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace ILInspector.Analysis;
 
@@ -121,6 +123,25 @@ public sealed class TypeRef : IEquatable<TypeRef>
     };
 
     public override string ToString() => ToDisplayString();
+
+    /// <summary>
+    /// Whether a pointer or function pointer appears anywhere in this type. This
+    /// is the signature-level test that drives the legacy implicit notion of
+    /// requires-unsafe (a pointer in a parameter/return type is visible at the
+    /// call site). Pinned is a local-only modifier, not a signature pointer, so
+    /// it is deliberately excluded — matching Roslyn's signature check.
+    /// </summary>
+    public bool ContainsPointer()
+    {
+        if (Kind == TypeRefKind.Pointer)
+            return true;
+        if (Kind == TypeRefKind.Unsupported
+            && UnsupportedReason.Contains("function pointer", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (ElementType is not null && ElementType.ContainsPointer())
+            return true;
+        return TypeArguments.Any(argument => argument.ContainsPointer());
+    }
 
     public bool Equals(TypeRef? other)
     {


### PR DESCRIPTION
## Opaque-contract: hidden requires-unsafe

A requires-unsafe method whose **signature carries no pointer** hides its
obligation from the caller's signature view. The only structural signal is the
attribute (`RequiresUnsafeAttribute`) or the `unsafe` modifier — a caller
reading the parameter and return types alone sees nothing unsafe.

This is the third unsafe-annotation in the thread (after `lifetime.pointer-return`
#685 and `lifetime.stack-escape` #686), and the first **signature×attribute join**
fact, so it lives on the **`ILInspector.Analysis` surface** (alongside
`CallerUnsafeMode` / `UnsafeLeverage`), not the decompiler IR Facts table — it has
no IR-node anchor and reads `CallerUnsafeMode` alone.

### What's here

- **`TypeRef.ContainsPointer()`** — lifts the signature pointer-recursion predicate
  out of `LibraryBodyIndex` into one shared, reusable place; the requires-unsafe
  mode computation now consumes it (single source of truth).
- **`OpaqueUnsafe.IsOpaque` / `Collect`** — pure over `MethodIdentity`
  (`CallerUnsafeMode != None` and no pointer in any parameter or return type),
  mirroring `UnsafeLeverage`; surfaced via `LibraryBodyIndex.OpaqueUnsafeMethods()`.
- **Analysis.App** unsafe report lists the opaque-contract methods.
- **Docs**: `docs/design/memory-safety-modes.md` gains an opaque-contract section.

### Positive and sound

The claim states only that the contract is **invisible in the signature**, never
that the body is safe — a pointerless `mode != None` method may still do real
unsafe work (e.g. `ContractUnsafe(int[])` hardcodes an element index as an
unenforced caller precondition). Consistent with the thread's design principle:
honest structural signals, never a verification verdict.

### Verification

- 23/23 `ILInspector.Analysis.Tests` (5 new: pure predicate, ordered collect,
  integration negative over the in-test pointer-signature fixture).
- End-to-end on `UnsafeChainA`: positives **M1, HollowUnsafe, ContractUnsafe**;
  excluded — the pointer-signature methods (RealUnsafePointer, SignatureOnlyUnsafe,
  DelegatedUnsafe, EscapingStackPointer) and the safe control (Safe).
- Product builds clean; markdownlint clean.
