### PR TITLE
Hollow-unsafe: flag requires-unsafe methods with no directly-visible body op

### DIFF
--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -116,3 +116,33 @@ no body evidence; it reads `CallerUnsafeMode` alone. Specimens in
 negatives are the pointer-signature methods (`RealUnsafePointer`,
 `SignatureOnlyUnsafe`, `DelegatedUnsafe`, `EscapingStackPointer`) and the safe
 control (`Safe`).
+
+## Hollow-unsafe classification (analysis surface)
+
+The dual axis to opaque-contract is **hollow-unsafe**: a requires-unsafe method
+(`CallerUnsafeMode != None`) whose body shows no directly-visible unsafe operation
+(`HollowUnsafe.IsHollow` / `LibraryBodyIndex.HollowUnsafeMethods`). A *realized*
+unsafe operation (a pointer dereference, `calli`, `localloc`/`cpblk`/`initblk`, or
+a call into the unsafe surface) is anchored to an IL offset in `UnsafeEvidence`;
+structural evidence (a pointer in the signature, a pointer/pinned local) is not.
+The IL offset is the discriminator — a method is hollow when none of its evidence
+carries one.
+
+Unlike opaque-contract, this is an **absence** claim, so it is deliberately
+caveated: it states only that no unsafe operation is *directly visible* in the
+scanned body — never that the method is safe or that its `unsafe` is removable.
+A pointer local can be optimized away in Release, erasing the IL trace of a real
+dereference: the `M1` specimen derefs in source yet records no body op, so it is
+reported hollow *despite being genuinely unsafe*. That false hollow is the
+standing proof that "no visible op" must never be read as "safe". Specimens in
+`UnsafeChainA.LibraryA`: positives `M1` (false hollow), `HollowUnsafe` and
+`SignatureOnlyUnsafe` (genuinely hollow); negatives are the methods with a
+realized op (`RealUnsafePointer`, `ContractUnsafe`, `EscapingStackPointer`),
+`DelegatedUnsafe` (forwards the pointer — a realized unsafe call), and the safe
+control (`Safe`).
+
+The two classifications are orthogonal: opaque-contract is about the *signature*
+(is the obligation visible to a caller?), hollow-unsafe about the *body* (does the
+IL realize an unsafe op?). Their intersection — pointerless-signature **and** no
+body op (`HollowUnsafe`, plus the `M1` trap) — is the strongest "this `unsafe`
+might be reducible" signal, but the `M1` recall gap keeps even that advisory.

--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -78,6 +78,14 @@ static int RunUnsafeReport(string[] args)
     foreach (var entry in opaque)
         Console.WriteLine($"  [{entry.Mode}]  {MethodDisplay(entry.Method)}");
 
+    var hollow = index.HollowUnsafeMethods();
+    Console.WriteLine();
+    Console.WriteLine($"Hollow-unsafe methods ({hollow.Length}): requires-unsafe with no directly-visible unsafe operation");
+    Console.WriteLine("  (an absence claim, never \"safe\" — an optimized-away pointer local can erase a real deref)");
+    Console.WriteLine();
+    foreach (var entry in hollow)
+        Console.WriteLine($"  [{entry.Mode}]  {MethodDisplay(entry.Method)}");
+
     return 0;
 }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -240,6 +240,102 @@ public class OpaqueUnsafeTests
     }
 }
 
+public class HollowUnsafeTests
+{
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    static MethodIdentity Method(string name, CallerUnsafeMode mode, TypeRef? returnType = null, params TypeRef[] parameterTypes)
+        => new(
+            AssemblyName: "Fixture",
+            ModuleVersionId: Guid.Empty,
+            DeclaringType: TypeRef.Definition("Fixture", "Ns", "Holder"),
+            Name: name,
+            ParameterTypes: [.. parameterTypes],
+            ReturnType: returnType ?? Int,
+            MetadataToken: name.GetHashCode(),
+            IsStatic: true,
+            CallerUnsafeMode: mode);
+
+    static UnsafeEvidence Structural(MethodIdentity method, string kind)
+        => new(method, "structural", kind, kind, ILOffset: null, OperandToken: null);
+
+    static UnsafeEvidence Realized(MethodIdentity method, string kind)
+        => new(method, "Unsafe operation", kind, kind, ILOffset: 0x10, OperandToken: null);
+
+    [Fact]
+    public void IsHollow_RequiresUnsafeWithNoEvidence_IsHollow()
+    {
+        var hollow = Method("HollowUnsafe", CallerUnsafeMode.Explicit);
+        Assert.True(HollowUnsafe.IsHollow(hollow, []));
+    }
+
+    [Fact]
+    public void IsHollow_OnlyStructuralEvidence_IsHollow()
+    {
+        // A pointer signature / pointer local is structural (no IL offset); the
+        // body still shows no realized unsafe operation.
+        var signatureOnly = Method("SignatureOnlyUnsafe", CallerUnsafeMode.Explicit, returnType: TypeRef.CoreLib("System", "Boolean"), TypeRef.Pointer(Int));
+        ImmutableArray<UnsafeEvidence> evidence = [Structural(signatureOnly, "signature")];
+        Assert.True(HollowUnsafe.IsHollow(signatureOnly, evidence));
+    }
+
+    [Fact]
+    public void IsHollow_RealizedBodyOp_IsNotHollow()
+    {
+        var real = Method("RealUnsafePointer", CallerUnsafeMode.Explicit, returnType: Int, TypeRef.Pointer(Int));
+        ImmutableArray<UnsafeEvidence> evidence = [Structural(real, "signature"), Realized(real, "opcode")];
+        Assert.False(HollowUnsafe.IsHollow(real, evidence));
+    }
+
+    [Fact]
+    public void IsHollow_NotRequiresUnsafe_IsNotHollow()
+    {
+        var safe = Method("Safe", CallerUnsafeMode.None);
+        Assert.False(HollowUnsafe.IsHollow(safe, []));
+    }
+
+    [Fact]
+    public void Collect_SelectsRequiresUnsafeMethodsWithoutRealizedOps_OrderedByToken()
+    {
+        var safe = Method("Safe", CallerUnsafeMode.None);
+        var hollow = Method("Hollow", CallerUnsafeMode.Explicit);
+        var signatureOnly = Method("SignatureOnly", CallerUnsafeMode.Explicit, returnType: Int, TypeRef.Pointer(Int));
+        var real = Method("Real", CallerUnsafeMode.Explicit, returnType: Int, TypeRef.Pointer(Int));
+        var delegated = Method("Delegated", CallerUnsafeMode.Implicit, returnType: Int, TypeRef.Pointer(Int));
+
+        var methods = ImmutableArray.Create(safe, hollow, signatureOnly, real, delegated);
+        ImmutableArray<UnsafeEvidence> evidence =
+        [
+            Structural(signatureOnly, "signature"),
+            Structural(real, "signature"),
+            Realized(real, "opcode"),
+            Structural(delegated, "signature"),
+            Realized(delegated, "call"),   // an unsafe call is a realized body op
+        ];
+
+        var result = HollowUnsafe.Collect(methods, evidence);
+
+        // Hollow (no realized op) and SignatureOnly (only structural) qualify;
+        // Real (deref) and Delegated (unsafe call) do not; Safe is not unsafe.
+        Assert.Equal(["Hollow", "SignatureOnly"], result.Select(h => h.Method.Name).Order());
+        Assert.All(result, h => Assert.NotEqual(CallerUnsafeMode.None, h.Mode));
+    }
+
+    [Fact]
+    public void HollowUnsafeMethods_PointerDereferenceFixtureIsNotHollow()
+    {
+        // UnsafePointerRead dereferences its pointer parameter, so it carries a
+        // realized (IL-offset-anchored) body op and must not be reported hollow.
+        var index = LibraryBodyIndex.Open(typeof(UnsafeEvidenceFixtures).Assembly.Location);
+
+        var hollow = index.HollowUnsafeMethods();
+
+        Assert.DoesNotContain(hollow, h => h.Method.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead));
+        Assert.All(hollow, h => Assert.False(
+            HollowUnsafe.HasRealizedUnsafeOp(h.Method, index.UnsafeEvidence)));
+    }
+}
+
 public class CallTreeTests
 {
     static readonly LibraryBodyIndex Index = LibraryBodyIndex.Open(typeof(CallTreeFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/HollowUnsafe.cs
+++ b/src/ILInspector.Analysis/HollowUnsafe.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// A requires-unsafe method (per <see cref="CallerUnsafeMode"/>) whose body
+/// contains no directly-visible unsafe operation — every piece of unsafe
+/// evidence, if any, is purely structural (a pointer in the signature or a
+/// pointer/pinned local), not an IL-realized operation.
+/// </summary>
+public sealed record HollowUnsafeMethod(
+    MethodIdentity Method,
+    CallerUnsafeMode Mode);
+
+public static class HollowUnsafe
+{
+    /// <summary>
+    /// Whether <paramref name="method"/> has any IL-realized unsafe operation in
+    /// its body. Realized operations (a pointer dereference, <c>calli</c>,
+    /// <c>localloc</c>/<c>cpblk</c>/<c>initblk</c>, or a call into the unsafe
+    /// surface) are anchored to an IL offset; structural evidence (signature /
+    /// local) is not. The IL offset is therefore the discriminator.
+    /// </summary>
+    public static bool HasRealizedUnsafeOp(MethodIdentity method, ImmutableArray<UnsafeEvidence> evidence)
+        => evidence.Any(e => e.Member.MetadataToken == method.MetadataToken && e.ILOffset is not null);
+
+    /// <summary>
+    /// Whether <paramref name="method"/> is requires-unsafe yet its body shows no
+    /// directly-visible unsafe operation.
+    /// </summary>
+    /// <remarks>
+    /// This is an <b>absence</b> claim, and is deliberately conservative: it states
+    /// only that no unsafe operation is <em>directly visible</em> in the scanned
+    /// body — never that the method is safe or that its <c>unsafe</c> is removable.
+    /// A pointer local can be optimized away in Release, erasing the trace of a
+    /// real dereference (the <c>UnsafeChainA.LibraryA.M1</c> specimen reproduces
+    /// exactly this), so "no visible op" must never be read as "safe".
+    /// </remarks>
+    public static bool IsHollow(MethodIdentity method, ImmutableArray<UnsafeEvidence> evidence)
+        => method.CallerUnsafeMode != CallerUnsafeMode.None
+            && !HasRealizedUnsafeOp(method, evidence);
+
+    /// <summary>
+    /// Every scanned requires-unsafe method whose body shows no directly-visible
+    /// unsafe operation, ordered by metadata token. Pure over the index's arrays
+    /// so it is testable without a real assembly.
+    /// </summary>
+    public static ImmutableArray<HollowUnsafeMethod> Collect(
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<UnsafeEvidence> evidence)
+    {
+        var realizedTokens = evidence
+            .Where(e => e.ILOffset is not null)
+            .Select(e => e.Member.MetadataToken)
+            .ToHashSet();
+
+        return methods
+            .Where(method => method.CallerUnsafeMode != CallerUnsafeMode.None
+                && !realizedTokens.Contains(method.MetadataToken))
+            .OrderBy(method => method.MetadataToken)
+            .Select(method => new HollowUnsafeMethod(method, method.CallerUnsafeMode))
+            .ToImmutableArray();
+    }
+}

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -78,6 +78,14 @@ public sealed class LibraryBodyIndex
         => OpaqueUnsafe.Collect(Methods);
 
     /// <summary>
+    /// Requires-unsafe methods whose body shows no directly-visible unsafe
+    /// operation — an absence claim (never "safe"): a pointer local optimized
+    /// away in Release erases the trace of a real dereference.
+    /// </summary>
+    public ImmutableArray<HollowUnsafeMethod> HollowUnsafeMethods()
+        => HollowUnsafe.Collect(Methods, UnsafeEvidence);
+
+    /// <summary>
     /// Builds a bounded outbound (callee) call tree rooted at the method identified by
     /// <paramref name="rootMethodToken"/>. Expansion stays within this assembly: callees that
     /// resolve to another assembly are recorded as <see cref="CallTreeStatus.External"/> leaves.


### PR DESCRIPTION
## Hollow-unsafe: requires-unsafe with no directly-visible body op

The **body-axis dual** of opaque-contract (#689, signature-axis). Flags
requires-unsafe methods (`CallerUnsafeMode != None`) whose body shows no
directly-visible unsafe operation — candidates for auditing the `unsafe` surface.

A **realized** unsafe op (a pointer dereference, `calli`,
`localloc`/`cpblk`/`initblk`, or a call into the unsafe surface) is anchored to
an IL offset in `UnsafeEvidence`; **structural** evidence (a pointer in the
signature, a pointer/pinned local) is not. The IL offset is the discriminator —
a method is hollow when none of its evidence carries one.

### What's here

- **`HollowUnsafe.IsHollow` / `HasRealizedUnsafeOp` / `Collect`** — pure over the
  index's `Methods` + `UnsafeEvidence` arrays (mirrors `OpaqueUnsafe` /
  `UnsafeLeverage`); surfaced via `LibraryBodyIndex.HollowUnsafeMethods()` and the
  Analysis.App unsafe report.
- **Docs**: `memory-safety-modes.md` gains a hollow-unsafe section; notes the two
  classifications are orthogonal (signature axis vs body axis) and that their
  intersection is the strongest "this `unsafe` might be reducible" signal — still
  advisory because of the recall gap below.

### An absence claim — deliberately caveated

Unlike the positive opaque-contract claim, hollow-unsafe is an **absence** claim.
It states only that no unsafe op is *directly visible* in the scanned body —
**never** that the method is safe or that its `unsafe` is removable. A pointer
local can be optimized away in Release, erasing the IL trace of a real
dereference: the **`M1`** specimen derefs in source yet records no body op, so it
is reported hollow *despite being genuinely unsafe*. That false hollow is the
standing proof that "no visible op" must never be read as "safe". Consistent with
the thread's principle: honest structural signals, never a verification verdict.

### Verification

- 29/29 `ILInspector.Analysis.Tests` (6 new: pure predicate incl. the
  delegated-call exclusion, ordered collect, integration negative over the
  in-test pointer-deref fixture).
- End-to-end on `UnsafeChainA`: positives **M1** (false hollow), **HollowUnsafe**,
  **SignatureOnlyUnsafe**; excluded — the realized-op methods (RealUnsafePointer,
  ContractUnsafe, EscapingStackPointer), **DelegatedUnsafe** (forwards the
  pointer — a realized unsafe call), and the safe control (Safe).
- Product builds clean; markdownlint clean.
