### PR TITLE
Fold default onto a case when the fall-through block is itself a case target

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2314,6 +2314,43 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void JumpTable_DefaultBlockIsCaseTarget_FoldsDefaultOntoCase()
+    {
+        // switch (x) goto [IL_0008, IL_0004]; the table's fall-through default is
+        // IL_0004 — which is also case 1's target. The `default:` label folds onto
+        // that case section (`case 1: default: …`): the block right after the
+        // switch is itself a case body, so no separate default is built. This is
+        // the ReaderWriterLockSlim.SpinLock::IsEnterDeprioritized shape. Without
+        // the fold the block is double-owned and the switch stays flat.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new SwitchBranch(new LoadArgument(0, "x", intType), [8, 4]));
+        var case1AndDefault = new Block(4);   // IL_0004 — both case 1 and the default
+        case1AndDefault.Add(new Return(new Constant(99, intType)));
+        var case0 = new Block(8);
+        case0.Add(new Return(new Constant(10, intType)));
+        foreach (var block in (Block[])[head, case1AndDefault, case0])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("switch (x)", output);
+        Assert.Contains("case 0:", output);
+        Assert.Contains("case 1:", output);
+        Assert.Contains("default:", output);
+        Assert.Contains("return 10;", output);
+        Assert.Contains("return 99;", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
     public void TopTestedLoopWithBreak_RaisesBreak()
     {
         // A forward exit out of a top-tested (while/for) loop body raises to a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -23,9 +23,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// unconditional branch / fall-through (a conditional or switch escaping a
 /// section is left flat for soundness), and be entered only through the table —
 /// otherwise the switch is left flat. The default may instead be a bare dispatch
-/// jumping once to its body, an omitted jump to the join, or — when it jumps into
-/// a case body that returns / throws — a <c>default:</c> label folded onto that
-/// shared case section (<c>case N: default: throw;</c>). Each section exits
+/// jumping once to its body, an omitted jump to the join, the case body the table
+/// falls through to (the block right after the switch is itself a case target, so
+/// <c>default:</c> folds onto it), or — when it jumps into a case body that
+/// returns / throws — a <c>default:</c> label folded onto that shared case section
+/// (<c>case N: default: throw;</c>). Each section exits
 /// through <c>break;</c> (its join branch, or an appended one for a fall-through);
 /// the bodies are containers the structuring pass then raises.
 /// </summary>
@@ -105,7 +107,15 @@ public sealed class SwitchRaisingPass : IIrPass
         int? defaultBodyHead = null;
         int? defaultSharesTarget = null;
         var dispatch = blocks[defaultIndex];
-        if (dispatch.Children is [Branch d] && offsetToIndex.TryGetValue(d.TargetOffset, out int dt) && dt > s)
+        if (caseTargets.Contains(defaultIndex))
+        {
+            // The block immediately after the switch is itself a case body: the
+            // table's fall-through default lands on it, so the `default:` label
+            // folds onto that case's section (`case N: default: …`). It is already
+            // owned by that case — no separate default section is built.
+            defaultSharesTarget = defaultIndex;
+        }
+        else if (dispatch.Children is [Branch d] && offsetToIndex.TryGetValue(d.TargetOffset, out int dt) && dt > s)
         {
             bool isCase = caseTargets.Contains(dt);
             if (isCase && regions.TryGetValue(dt, out var sharedRegion) && SectionTerminates(blocks, sharedRegion, offsetToIndex))


### PR DESCRIPTION
## Summary

When a jump table's fall-through default — the block immediately after the switch (`s+1`) — is **itself one of the case targets**, the `default:` label now folds onto that case's section (`case N: default: …`) instead of leaving the switch flat.

The block is already owned and grown by the case loop, so no separate default section is built. Previously the inline-default path tried to re-own it and bailed via `owned.Overlaps(region)`, leaving goto-soup.

## Change

A new first branch in the default-disposition block: when `caseTargets.Contains(defaultIndex)`, set `defaultSharesTarget = defaultIndex` so `Build` marks that case section `isDefault`.

**Soundness:** no terminate-restriction is needed (unlike the dispatch-fold) — the shared section was already validated and grown in the case loop, so folding `default:` onto it is sound whether it terminates or breaks to a join.

## Effect

Clears `ReaderWriterLockSlim.SpinLock::IsEnterDeprioritized` from the `default-routes-into-cases` bucket. It now raises to:

```csharp
switch (reason)
{
    case 0:
        return EnterForEnterAnyReadDeprioritizedCount > (uint)0;
    case 1:
    default:
        return false;
    case 2:
        return EnterForEnterAnyWriteDeprioritizedCount > (uint)0;
    case 3:
        return EnterForEnterAnyWriteDeprioritizedCount > 1;
}
```

## Rails

- 337 decompiler tests green (+1 fixture: `JumpTable_DefaultBlockIsCaseTarget_FoldsDefaultOntoCase`).
- `--gaps --by-shape`: switch-branch 11 → 10; default-routes-into-cases 3 → 2.
- `--validity-check --diff-validity-defects`: **0 newly-defective** (1 improved: SpinLock).
- `--pass-impact switch`: 145 methods, **0 pass bugs**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>