### PR TITLE
Raise switches whose default routes into shared case bodies (AddArray, #694)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2351,6 +2351,53 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void JumpTable_DefaultRoutesIntoCases_RaisesWithConditionalBreak()
+    {
+        // switch (x) goto [J, J, T, J] where J (IL_0014) is the post-switch join
+        // — itself a case target — and T (IL_000C) is a throw case. The default
+        // (IL_0008) is a conditional ladder that either breaks to J (`x == 100`)
+        // or falls into the throw case T. The cases targeting J become empty
+        // `break;` sections, the default's branch to J becomes `if (x == 100)
+        // break;`, and the fall-through into T duplicates its `throw`. This is the
+        // TraceLoggingMetadataCollector::AddArray shape. Without it the switch is
+        // left flat (`switch (x) goto [...]`).
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var objType = TypeRef.CoreLib("System", "Object");
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new SwitchBranch(new LoadArgument(0, "x", intType), [20, 20, 12, 20]));
+        var defaultLadder = new Block(8);   // IL_0008 — default: if (x == 100) break; else throw
+        defaultLadder.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, false, new LoadArgument(0, "x", intType), new Constant(100, intType)),
+            20));
+        var throwCase = new Block(12);      // IL_000C — case 2, and the default's fall-through
+        throwCase.Add(new Throw(new Constant(null, objType)));
+        var join = new Block(20);           // IL_0014 — the join, also cases 0/1/3
+        join.Add(new Return(new LoadArgument(0, "x", intType)));
+        foreach (var block in (Block[])[head, defaultLadder, throwCase, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("switch (x)", output);
+        Assert.Contains("case 0:", output);
+        Assert.Contains("case 3:", output);
+        Assert.Contains("case 2:", output);
+        Assert.Contains("default:", output);
+        Assert.Contains("if (x == 100)", output);
+        Assert.Contains("break;", output);
+        Assert.Contains("throw null;", output);
+        Assert.Contains("return x;", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
     public void TopTestedLoopWithBreak_RaisesBreak()
     {
         // A forward exit out of a top-tested (while/for) loop body raises to a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -30,6 +30,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// (<c>case N: default: throw;</c>). Each section exits
 /// through <c>break;</c> (its join branch, or an appended one for a fall-through);
 /// the bodies are containers the structuring pass then raises.
+///
+/// When that model leaves the switch flat, a second attempt
+/// (<see cref="RaiseCaseTargetJoin"/>) handles tables whose default routes into
+/// shared case bodies: one case target is the post-switch join, so cases reaching
+/// it are empty <c>break;</c> sections and the default may break to it through a
+/// conditional (<c>if (c) break;</c>) and fall through into a terminating case.
 /// </summary>
 public sealed class SwitchRaisingPass : IIrPass
 {
@@ -52,7 +58,9 @@ public sealed class SwitchRaisingPass : IIrPass
             var blocks = container.Blocks;
             for (int s = 0; s < blocks.Count; s++)
             {
-                if (blocks[s].Children is [.., SwitchBranch sw] && Raise(container, s, sw, leaveTargets, stepper))
+                if (blocks[s].Children is [.., SwitchBranch sw]
+                    && (Raise(container, s, sw, leaveTargets, stepper)
+                        || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
                     return true;
             }
         }
@@ -189,6 +197,160 @@ public sealed class SwitchRaisingPass : IIrPass
             return false;
 
         Build(container, s, sw, caseTargets, regions, defaultBodyHead, defaultSharesTarget, join, regionEnd, stepper);
+        return true;
+    }
+
+    /// <summary>
+    /// A second raising attempt, tried only when <see cref="Raise"/> leaves the
+    /// switch flat: for switches whose default <em>routes into</em> shared case
+    /// bodies. One case target is the post-switch <em>join</em> — the
+    /// continuation — so the cases reaching it are empty <c>break;</c> sections
+    /// and the rest of the table (the other case targets and the default) tile the
+    /// span before it. The default may break to the join through a conditional
+    /// (<c>if (c) break;</c>) and may fall through into a single-block terminating
+    /// case, whose terminator is duplicated into the default body (C# forbids
+    /// falling from <c>default:</c> into a case). This is the
+    /// TraceLoggingMetadataCollector::AddArray shape.
+    /// </summary>
+    static bool RaiseCaseTargetJoin(BlockContainer container, int s, SwitchBranch sw, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        int defaultIndex = s + 1;
+        if (defaultIndex >= blocks.Count)
+            return false;
+
+        var caseTargets = new int[sw.TargetOffsets.Length];
+        for (int i = 0; i < caseTargets.Length; i++)
+            if (!offsetToIndex.TryGetValue(sw.TargetOffsets[i], out caseTargets[i]) || caseTargets[i] <= s)
+                return false;
+
+        // The default head being a case target is the SpinLock fold (handled by Raise).
+        if (caseTargets.Contains(defaultIndex))
+            return false;
+
+        var preds = BuildPredecessors(blocks, s, caseTargets, offsetToIndex);
+        foreach (int joinCandidate in caseTargets.Distinct())
+        {
+            if (TryCaseTargetJoin(container, blocks, s, sw, caseTargets, defaultIndex,
+                    offsetToIndex, preds, leaveTargets, joinCandidate, stepper))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryCaseTargetJoin(
+        BlockContainer container, IReadOnlyList<Block> blocks, int s, SwitchBranch sw,
+        int[] caseTargets, int defaultIndex, Dictionary<int, int> offsetToIndex,
+        Dictionary<int, List<int>> preds, HashSet<int> leaveTargets, int join, Stepper stepper)
+    {
+        if (join <= s)
+            return false;
+        int joinOffset = blocks[join].StartOffset;
+
+        var owned = new HashSet<int>();
+        var regions = new Dictionary<int, List<int>>();
+        var terminatingCases = new HashSet<int>();
+        bool anyExitToJoin = false;
+
+        // Every distinct case target other than the join grows into a region that
+        // terminates or exits only (unconditionally) to the join.
+        foreach (int target in caseTargets.Distinct())
+        {
+            if (target == join)
+                continue;
+            if (!GrowRegion(blocks, target, s, offsetToIndex, preds, out var region, out var exits))
+                return false;
+            if (owned.Overlaps(region))
+                return false;
+            foreach (int e in exits)
+                if (e != join)
+                    return false;
+            if (exits.Count == 0)
+                terminatingCases.Add(target);
+            else if (!ExitsAreUnconditional(blocks, region, offsetToIndex))
+                return false;
+            else
+                anyExitToJoin = true;
+            regions[target] = region;
+            owned.UnionWith(region);
+        }
+
+        // The default region: breaks to the join (conditionally or not) and may
+        // fall through into a single-block terminating case (whose terminator is
+        // cloned into the default body).
+        if (!GrowRegion(blocks, defaultIndex, s, offsetToIndex, preds, out var defaultRegion, out var defaultExits))
+            return false;
+        if (owned.Overlaps(defaultRegion))
+            return false;
+        int? fallThroughCase = null;
+        foreach (int e in defaultExits)
+        {
+            if (e == join)
+            {
+                anyExitToJoin = true;
+                continue;
+            }
+            if (terminatingCases.Contains(e) && regions[e] is [int only] && only == e)
+            {
+                if (fallThroughCase is { } existing && existing != e)
+                    return false;
+                fallThroughCase = e;
+                continue;
+            }
+            return false;
+        }
+        if (!DefaultExitsAreBreakable(blocks, defaultRegion, offsetToIndex, joinOffset))
+            return false;
+        regions[defaultIndex] = defaultRegion;
+        owned.UnionWith(defaultRegion);
+
+        // The join must be a genuine merge a section breaks to — never an arbitrary
+        // terminating case (which would wrongly empty-case it).
+        if (!anyExitToJoin)
+            return false;
+
+        // The owned blocks must tile [s+1, join) exactly, with the join just past them.
+        int regionEnd = join;
+        if (owned.Contains(join))
+            return false;
+        if (owned.Count != regionEnd - defaultIndex)
+            return false;
+        foreach (int idx in owned)
+            if (idx < defaultIndex || idx >= regionEnd)
+                return false;
+
+        if (!OnlyReachedByTable(blocks, owned, s, leaveTargets))
+            return false;
+
+        BuildCaseTargetJoin(container, s, sw, caseTargets, regions, defaultIndex, join,
+            fallThroughCase, regionEnd, stepper);
+        return true;
+    }
+
+    /// <summary>The default region escapes only through a conditional / unconditional branch to the join, a fall-through, or a terminator — every conditional must target the join (it becomes <c>if (c) break;</c>).</summary>
+    static bool DefaultExitsAreBreakable(IReadOnlyList<Block> blocks, List<int> region, Dictionary<int, int> offsetToIndex, int joinOffset)
+    {
+        foreach (int idx in region)
+        {
+            var last = blocks[idx].Children.Count > 0 ? blocks[idx].Children[^1] : null;
+            switch (last)
+            {
+                case ConditionalBranch conditional:
+                    if (conditional.TargetOffset != joinOffset)
+                        return false;
+                    break;
+                case Branch branch:
+                    if (branch.TargetOffset != joinOffset)
+                        return false;
+                    break;
+                case SwitchBranch:
+                    return false;
+            }
+        }
         return true;
     }
 
@@ -413,6 +575,104 @@ public sealed class SwitchRaisingPass : IIrPass
         }
 
         var tail = sectionBlocks[^1];
+        var tailLast = tail.Children.Count > 0 ? tail.Children[^1] : null;
+        if (tailLast is not (Return or Throw or Break or Branch or ConditionalBranch or SwitchBranch))
+            tail.Add(new Break());
+
+        var body = new BlockContainer();
+        foreach (var block in sectionBlocks)
+            body.Add(block);
+        return body;
+    }
+
+    static void BuildCaseTargetJoin(
+        BlockContainer container, int s, SwitchBranch sw, int[] caseTargets,
+        Dictionary<int, List<int>> regions, int defaultIndex, int join,
+        int? fallThroughCase, int regionEnd, Stepper stepper)
+    {
+        var all = container.Blocks.ToList();
+        int joinOffset = all[join].StartOffset;
+
+        var labelsByTarget = new Dictionary<int, List<int>>();
+        for (int i = 0; i < caseTargets.Length; i++)
+            (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
+
+        // Clone the shared terminator before detaching: the default falls into a
+        // single-block terminating case, which C# cannot do, so its body is
+        // duplicated into the default section.
+        var duplicatedTerminator = fallThroughCase is { } fc
+            ? all[fc].Children.Select(child => child.Clone()).ToList()
+            : null;
+
+        foreach (var block in all)
+            block.Detach();
+
+        var sections = new List<SwitchSection>();
+        foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
+        {
+            if (target == join)
+                sections.Add(new SwitchSection([.. labels], isDefault: false, EmptyBreakBody()));
+            else
+                sections.Add(new SwitchSection([.. labels], isDefault: false,
+                    SectionBody(regions[target].Select(i => all[i]).ToList(), joinOffset)));
+        }
+        sections.Add(new SwitchSection([], isDefault: true,
+            DefaultSectionBody(regions[defaultIndex].Select(i => all[i]).ToList(), joinOffset, duplicatedTerminator)));
+
+        var switchBlock = all[s];
+        var value = (IrExpression)sw.DetachChildren()[0];
+        sw.Detach();
+        switchBlock.Add(new Switch(value, sections));
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx <= s; idx++)
+            rebuilt.Add(all[idx]);
+        for (int idx = regionEnd; idx < all.Count; idx++)
+            rebuilt.Add(all[idx]);
+        stepper.StepOver("raise IL jump table to switch (default routes into cases)", container);
+        container.ReplaceWith(rebuilt);
+    }
+
+    /// <summary>A case whose target is the join carries no body — just <c>break;</c>.</summary>
+    static BlockContainer EmptyBreakBody()
+    {
+        var block = new Block();
+        block.Add(new Break());
+        var body = new BlockContainer();
+        body.Add(block);
+        return body;
+    }
+
+    /// <summary>
+    /// Wraps the default region, turning each branch to the join into a
+    /// <c>break;</c> — a conditional branch becomes <c>if (c) break;</c> — and
+    /// appending the duplicated terminator the default falls through into.
+    /// </summary>
+    static BlockContainer DefaultSectionBody(List<Block> sectionBlocks, int joinOffset, List<IrNode>? duplicatedTerminator)
+    {
+        foreach (var block in sectionBlocks)
+        {
+            var last = block.Children.Count > 0 ? block.Children[^1] : null;
+            if (last is ConditionalBranch conditional && conditional.TargetOffset == joinOffset)
+            {
+                var condition = (IrExpression)conditional.DetachChildren()[0];
+                conditional.Detach();
+                var thenArm = new Block();
+                thenArm.Add(new Break());
+                block.Add(new IfStatement(condition, thenArm, elseArm: null));
+            }
+            else if (last is Branch branch && branch.TargetOffset == joinOffset)
+            {
+                branch.Detach();
+                block.Add(new Break());
+            }
+        }
+
+        var tail = sectionBlocks[^1];
+        if (duplicatedTerminator is not null)
+            foreach (var node in duplicatedTerminator)
+                tail.Add(node);
+
         var tailLast = tail.Children.Count > 0 ? tail.Children[^1] : null;
         if (tailLast is not (Return or Throw or Break or Branch or ConditionalBranch or SwitchBranch))
             tail.Add(new Break());


### PR DESCRIPTION
## Summary

Implements **Shape A of #694**: switches whose default **routes into shared case bodies**. Adds a second raising attempt in `SwitchRaisingPass`, tried **only when the primary `Raise` leaves the switch flat** — so the ~39,816 already-raising methods keep their exact path (zero behavioral risk to them; the validity-defect rail gates the rest).

## The shape

One case target is the post-switch **join** (the continuation). Cases reaching it become empty `break;` sections; the other case targets and the default tile the span before it. The default may:

- break to the join through a conditional → `if (c) break;` (the previously-unmodeled conditional escape), and
- fall through into a single-block terminating case → its terminator is duplicated (via `IrNode.Clone`, the documented duplication primitive) because C# forbids falling from `default:` into a case.

The candidate join is searched among the distinct case targets and validated by the existing region-tiling / `OnlyReachedByTable` invariants, plus a guard that **some section actually breaks to the join** (never empty-casing an arbitrary terminating target).

## Effect

Clears `System.Diagnostics.Tracing.TraceLoggingMetadataCollector::AddArray`, which now raises to:

```csharp
switch (V_0 - 3)
{
    case 0: ... case 10: case 12: case 14: case 17: case 18:
        break;
    case 11: case 13: case 15: case 16:
        throw new ArgumentOutOfRangeException("type");
    default:
        if (V_0 == TraceLoggingDataType.Char8) break;
        if (V_0 == TraceLoggingDataType.Char16) break;
        throw new ArgumentOutOfRangeException("type");
}
if (BeginningBufferedArray)
    throw new NotSupportedException(...);
impl.AddScalar(2); impl.AddNonscalar(); AddField(...); return;
```

`System.Reflection.AssemblyNameParser::IsWhiteSpace` (the value-block / switch-expression shape, **Shape B**) remains and is still tracked by #694.

## Rails

- 338 decompiler tests green (+1 fixture `JumpTable_DefaultRoutesIntoCases_RaisesWithConditionalBreak`).
- `--gaps --by-shape`: switch-branch 10 → 9; default-routes-into-cases 2 → 1.
- `--validity-check --diff-validity-defects` vs main `8e91535`: **0 newly-defective**, 0 regressed, 3 improved.
- `--pass-impact switch`: 148 methods, **0 pass bugs**.

Part of #694.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
