### PR TITLE
Expose a telemetry-free decompiler trace shape for request diagnostics

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -59,4 +59,36 @@ public class MixedSourceRendererTests
             if (line.Contains("IL_") && line.Contains(": "))
                 Assert.Contains("//", line);
     }
+
+    [Fact]
+    public void Render_AttachesTrace_MirroringResultOutcome()
+    {
+        // The decompiler returns a telemetry-free trace shape a host can convert
+        // into its own diagnostics: it mirrors the result's fidelity and
+        // diagnostics, and reports the symbol source actually consulted.
+        var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
+        var result = MixedSourceRenderer.Render(
+            source, typeof(AllocSampleClass).FullName!, nameof(AllocSampleClass.SumList));
+
+        Assert.NotNull(result.Trace);
+        Assert.Equal(result.Fidelity, result.Trace!.Fidelity);
+        Assert.Equal(result.Diagnostics, result.Trace.Diagnostics);
+        Assert.Equal(result.Succeeded, result.Trace.Succeeded);
+        // SumList has locals and the test assembly ships a PDB, so a symbol
+        // source was consulted (embedded or sidecar, depending on build config).
+        Assert.NotEqual(DecompilerSymbolSource.None, result.Trace.Symbols);
+    }
+
+    [Fact]
+    public void Render_WithoutSymbols_ReportsNoSymbolSource()
+    {
+        // OpenWithoutSymbols never consults a PDB, so the trace honestly reports
+        // that no symbol source was used even when one exists on disk.
+        var source = MetadataSource.OpenWithoutSymbols(typeof(AllocSampleClass).Assembly.Location);
+        var result = MixedSourceRenderer.Render(
+            source, typeof(AllocSampleClass).FullName!, nameof(AllocSampleClass.SumList));
+
+        Assert.NotNull(result.Trace);
+        Assert.Equal(DecompilerSymbolSource.None, result.Trace!.Symbols);
+    }
 }

--- a/src/ILInspector.Decompiler/Analysis/MixedSourceRenderer.cs
+++ b/src/ILInspector.Decompiler/Analysis/MixedSourceRenderer.cs
@@ -20,9 +20,20 @@ public static class MixedSourceRenderer
 {
     public static DecompilerResult Render(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false)
-        => DecompilerResult.Run(
+    {
+        var result = DecompilerResult.Run(
             () => RenderMixed(source, type, method, overloadIndex, publicOnly),
             emptyOutputIsFailure: true);
+
+        // Assemble the telemetry-free trace shape from the result's outcome and
+        // the source's post-render symbol state, for a host to convert into its
+        // own diagnostics. Read Symbols after Run so the lazy PDB probe (driven
+        // by a body with locals) has settled.
+        return result with
+        {
+            Trace = new DecompilerTrace(result.Fidelity, source.Symbols, result.Diagnostics),
+        };
+    }
 
     static string RenderMixed(
         MetadataSource source, string type, string method, int overloadIndex, bool publicOnly)

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -120,6 +120,14 @@ public sealed record DecompilerResult(
     /// </summary>
     public IReadOnlyList<(string Field, string Value)> FieldInitializers { get; init; } = [];
 
+    /// <summary>
+    /// A telemetry-free record of what the decompilation observed — its fidelity
+    /// outcome, the symbol source it used, and its diagnostics — for a host to
+    /// convert into its own diagnostics. Null for projections that do not build
+    /// one (only the C# render entry points populate it today).
+    /// </summary>
+    public DecompilerTrace? Trace { get; init; }
+
     public static DecompilerResult Success(string output)
         => new(output, DecompilationFidelity.Full, []);
 

--- a/src/ILInspector.Decompiler/DecompilerTrace.cs
+++ b/src/ILInspector.Decompiler/DecompilerTrace.cs
@@ -1,0 +1,38 @@
+namespace ILInspector.Decompiler;
+
+/// <summary>
+/// Where a method's source symbols (local names) came from for a render, or
+/// <see cref="None"/> when none were consulted — no PDB was found, symbols were
+/// disabled, or the body had no locals to name. A host surfaces this to explain
+/// local-name quality and to tie a decompile to any preceding symbol-server fetch.
+/// </summary>
+public enum DecompilerSymbolSource
+{
+    /// <summary>No PDB was consulted (none found, disabled, or no locals to name).</summary>
+    None,
+
+    /// <summary>A portable PDB embedded in the PE.</summary>
+    Embedded,
+
+    /// <summary>A sidecar <c>.pdb</c> next to the assembly.</summary>
+    Sidecar,
+
+    /// <summary>An external PDB supplied at open (e.g. a symbol-server download).</summary>
+    External,
+}
+
+/// <summary>
+/// A telemetry-free, structured record of what a decompilation observed — its
+/// fidelity outcome, the symbol source it used, and any diagnostics. The
+/// decompiler depends only on <c>ILInspector.Metadata</c> and never emits
+/// telemetry itself; a host converts this shape into its own diagnostics (e.g.
+/// the CLI's request-trace breadcrumbs).
+/// </summary>
+public sealed record DecompilerTrace(
+    DecompilationFidelity Fidelity,
+    DecompilerSymbolSource Symbols,
+    IReadOnlyList<DecompilerDiagnostic> Diagnostics)
+{
+    /// <summary>True when the decompiler produced usable output.</summary>
+    public bool Succeeded => Fidelity != DecompilationFidelity.Failed;
+}

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -19,6 +19,7 @@ public sealed class MetadataSource : IDisposable
     MetadataReaderProvider? _pdbProvider;
     MetadataReader? _pdbReader;
     bool _pdbProbed;
+    DecompilerSymbolSource _symbols = DecompilerSymbolSource.None;
     readonly string? _externalPdbPath;
     readonly bool _readSymbols;
     readonly AssemblyLocator _locator;
@@ -59,6 +60,14 @@ public sealed class MetadataSource : IDisposable
     internal PEReader Pe { get; }
 
     internal MetadataReader Reader { get; }
+
+    /// <summary>
+    /// The symbol source consulted for local names so far: <see cref="DecompilerSymbolSource.None"/>
+    /// until a method with locals triggers the lazy PDB probe, then the kind of PDB found
+    /// (embedded, sidecar, or the external path supplied at open). Reflects observed work,
+    /// so a host can report honestly whether symbols were actually used for a render.
+    /// </summary>
+    public DecompilerSymbolSource Symbols => _symbols;
 
     /// <summary>
     /// Opens an assembly. Throws <see cref="BadImageFormatException"/> for files
@@ -475,11 +484,14 @@ public sealed class MetadataSource : IDisposable
             return null;
         try
         {
-            if (Pe.TryOpenAssociatedPortablePdb(Path, p => File.Exists(p) ? File.OpenRead(p) : null, out var provider, out _)
+            if (Pe.TryOpenAssociatedPortablePdb(Path, p => File.Exists(p) ? File.OpenRead(p) : null, out var provider, out var pdbPath)
                 && provider is not null)
             {
                 _pdbProvider = provider;
                 _pdbReader = provider.GetMetadataReader();
+                _symbols = string.IsNullOrEmpty(pdbPath)
+                    ? DecompilerSymbolSource.Embedded
+                    : DecompilerSymbolSource.Sidecar;
             }
             else if (!string.IsNullOrEmpty(_externalPdbPath) && File.Exists(_externalPdbPath))
             {
@@ -489,6 +501,7 @@ public sealed class MetadataSource : IDisposable
                 using var pdbStream = File.OpenRead(_externalPdbPath);
                 _pdbProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream, MetadataStreamOptions.PrefetchMetadata);
                 _pdbReader = _pdbProvider.GetMetadataReader();
+                _symbols = DecompilerSymbolSource.External;
             }
         }
         catch

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using System.Text.Json;
 using DotnetInspector.Commands;
+using DotnetInspector.Core;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -1659,6 +1660,31 @@ public class CommandExecutionTests
         // comment lines.
         Assert.Contains("```csharp", output);
         Assert.Matches(@"// IL_[0-9A-Fa-f]{4}: ", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectDecompiledSource_RequestTrace_RecordsDecompileOutcome()
+    {
+        // The app converts the decompiler's telemetry-free trace shape into a
+        // request-trace breadcrumb: a decompile.method stage carrying the
+        // fidelity outcome and the symbol source the render actually consulted.
+        using var diagram = RequestMermaidDiagram.Start();
+
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToElement" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source" }
+        };
+
+        var (exit, _, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        var mermaid = diagram.ToMermaid();
+        Assert.Matches(@"decompile\.method<br/>SerializeToElement \(\w+, pdb:\w+\)", mermaid);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -31,7 +31,8 @@ internal static class MemberCodeProvider
         IReadOnlyList<(string Name, string? Value)>? Attributes,
         string? StagesText = null,
         string? StagesDiagnostic = null,
-        IReadOnlyList<Decompiler.Analysis.Annotation>? Facts = null);
+        IReadOnlyList<Decompiler.Analysis.Annotation>? Facts = null,
+        Decompiler.DecompilerTrace? DecompileTrace = null);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -97,10 +98,12 @@ internal static class MemberCodeProvider
             // or an import failure, which surfaces as a diagnostic. Render never
             // throws.
             string? loweredBody = null, loweredDiagnostic = null;
+            Decompiler.DecompilerTrace? decompileTrace = null;
             if (request.DecompiledSource && pipelineSource is not null)
             {
                 var result = Decompiler.Analysis.MixedSourceRenderer.Render(
                     pipelineSource, lookupType, method.Name, lookupOverloadIndex, publicOnly);
+                decompileTrace = result.Trace;
                 if (result.Output is { } annotated)
                     loweredBody = annotated.TrimEnd();
                 else
@@ -158,7 +161,8 @@ internal static class MemberCodeProvider
                 attributes,
                 stagesText,
                 stagesDiagnostic,
-                facts)));
+                facts,
+                decompileTrace)));
         }
 
         return results;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1091,7 +1091,7 @@ public static class ApiOutputFormatter
 
             if (code.LoweredBody is { } lowered)
             {
-                RequestTelemetry.Breadcrumb("decompile.method", member.Name);
+                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
                 string source;
                 try
                 {
@@ -1106,6 +1106,7 @@ public static class ApiOutputFormatter
             }
             else if (code.LoweredDiagnostic is { } loweredDiagnostic)
             {
+                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
                 memberCode.DecompiledSourceCode = new CodeSection("csharp", loweredDiagnostic);
                 hasCode = true;
             }
@@ -1253,6 +1254,37 @@ public static class ApiOutputFormatter
         => typeRef.Kind == Analysis.TypeRefKind.Definition
            && string.Equals(typeRef.Namespace, type.Namespace ?? "", StringComparison.Ordinal)
            && string.Equals(typeRef.Name, type.Name, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Converts the decompiler's telemetry-free <see cref="Decompiler.DecompilerTrace"/>
+    /// shape into a request-trace breadcrumb: a <c>decompile.method</c> stage on
+    /// success or <c>decompile.fallback</c> on failure, with the fidelity outcome,
+    /// the symbol source used, and (on failure) the leading diagnostic id. Falls
+    /// back to a bare crumb when no trace is available.
+    /// </summary>
+    private static void EmitDecompileBreadcrumb(string member, Decompiler.DecompilerTrace? trace)
+    {
+        if (trace is null)
+        {
+            RequestTelemetry.Breadcrumb("decompile.method", member);
+            return;
+        }
+
+        var symbols = trace.Symbols switch
+        {
+            Decompiler.DecompilerSymbolSource.Embedded => "pdb:embedded",
+            Decompiler.DecompilerSymbolSource.Sidecar => "pdb:sidecar",
+            Decompiler.DecompilerSymbolSource.External => "pdb:external",
+            _ => "pdb:none",
+        };
+
+        var stage = trace.Succeeded ? "decompile.method" : "decompile.fallback";
+        var detail = $"{member} ({trace.Fidelity}, {symbols})";
+        if (!trace.Succeeded && trace.Diagnostics.Count > 0)
+            detail += $" [{trace.Diagnostics[0].Id}]";
+
+        RequestTelemetry.Breadcrumb(stage, detail);
+    }
 
     private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, IReadOnlyList<string>? methodGenericParameters, string lowered)
     {


### PR DESCRIPTION
## What

The `--trace-mermaid` request diagnostic showed a bare `decompile.method` breadcrumb that only fired on success and carried no outcome detail. This exposes a cohesive, telemetry-free **trace shape** from the decompiler library that the app converts into richer request-trace breadcrumbs.

## Why

The decompiler library (`ILInspector.Decompiler`) is deliberately telemetry-free — it only references `ILInspector.Metadata`, not `DotnetInspector.Core` (home of the telemetry observers). So the decompiler cannot emit breadcrumbs directly. The "shape" pattern keeps that separation: the decompiler returns data; the app converts it.

## Changes

- **`DecompilerTrace`** (new) — a record carrying `Fidelity`, `Symbols`, and `Diagnostics`, plus a `DecompilerSymbolSource` enum (`None`/`Embedded`/`Sidecar`/`External`). `Succeeded => Fidelity != Failed`.
- **`MetadataSource`** — tracks the symbol source actually consulted in the lazy `PdbReader()` probe; `Symbols` is `None` when no PDB was used (a method with no locals never triggers the probe).
- **`MixedSourceRenderer.Render`** — attaches the trace to its `DecompilerResult`.
- **App layer** — `MemberCodeProvider.Item` carries the trace; `ApiOutputFormatter.EmitDecompileBreadcrumb` converts it into a `decompile.method` (success) / `decompile.fallback` (failure) crumb with the fidelity outcome, the symbol source (`pdb:embedded|sidecar|external|none`), and the first diagnostic id on failure.

Example breadcrumb now seen in `--trace-mermaid`:

```text
decompile.method<br/>SerializeToElement (Full, pdb:external)
```

## Tests

- Decompiler unit tests: trace mirrors result outcome (with symbols), and `OpenWithoutSymbols` reports `None`.
- App-level converter test drives a real Decompiled Source render under a subscribed `RequestMermaidDiagram` and asserts the breadcrumb detail.
- 339 decompiler + 1157 product tests green.
