### PR TITLE
Raise value-producing jump tables to C# switch expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2398,6 +2398,53 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void JumpTable_ValueBlocksReturnedAtJoin_RaisesToSwitchExpression()
+    {
+        // switch (ch - 9) goto [T, T, F, F, T] where each target is a one-block
+        // value block assigning a single bool local and converging on the join
+        // `return local`. The default (IL_0008) is a conditional choosing between
+        // the same two value blocks. The whole dispatch is one value, so it raises
+        // to `return (ch - 9) switch { 0 or 1 or 4 => true, 2 or 3 => false, _ => … };`
+        // — the AssemblyNameParser::IsWhiteSpace shape. Without it the switch is
+        // left flat (`switch (ch - 9) goto [...]`), which is invalid C#.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new SwitchBranch(
+            new Binary(BinaryKind.Subtract, false, false, new LoadArgument(0, "ch", intType), new Constant(9, intType)),
+            [14, 14, 20, 20, 14]));
+        var defaultChoice = new Block(8);   // IL_0008 — default: if (ch != 32) -> false-block else true-block
+        defaultChoice.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.NotEqual, false, new LoadArgument(0, "ch", intType), new Constant(32, intType)),
+            20));
+        var trueBlock = new Block(14);      // IL_000E — cases 0/1/4, and the default's fall-through
+        trueBlock.Add(new StoreLocal(0, boolType, new Constant(true, boolType)));
+        trueBlock.Add(new Branch(24));
+        var falseBlock = new Block(20);     // IL_0014 — cases 2/3, and the default's taken branch
+        falseBlock.Add(new StoreLocal(0, boolType, new Constant(false, boolType)));
+        var join = new Block(24);           // IL_0018 — the join: returns the assigned local
+        join.Add(new Return(new LoadLocal(0, boolType)));
+        foreach (var block in (Block[])[head, defaultChoice, trueBlock, falseBlock, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(boolType,
+            [new Parameter("ch", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("switch", output);
+        Assert.Contains("0 or 1 or 4 => true", output);
+        Assert.Contains("2 or 3 => false", output);
+        Assert.Contains("_ =>", output);
+        Assert.DoesNotContain("case ", output);     // an expression, not a statement
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
     public void TopTestedLoopWithBreak_RaisesBreak()
     {
         // A forward exit out of a top-tested (while/for) loop body raises to a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -900,6 +900,19 @@ public sealed class CSharpPrinter
             _statementLines.TryAdd(node, startLine);
         }
         string pad = new(' ', indent * 4);
+        if (node is Return { Value: SwitchExpression returnedSwitch })
+        {
+            // A switch expression returned spans several lines, one arm per line,
+            // indented under the governing value — the statement context knows the
+            // indent the inline Expression() form cannot.
+            string inner = pad + "    ";
+            sb.Append(pad).Append("return ").Append(Operand(returnedSwitch.Value)).AppendLine(" switch");
+            sb.Append(pad).AppendLine("{");
+            foreach (var arm in returnedSwitch.Arms)
+                sb.Append(inner).Append(SwitchArmText(arm)).AppendLine(",");
+            sb.Append(pad).AppendLine("};");
+            return;
+        }
         if (node is ForLoop forLoop)
         {
             string initializer = Statement(forLoop.Initializer)?.TrimEnd(';') ?? "";
@@ -1275,6 +1288,7 @@ public sealed class CSharpPrinter
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
         Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
+        SwitchExpression se => SwitchExpressionInline(se),
         Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
         NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
@@ -1468,6 +1482,14 @@ public sealed class CSharpPrinter
             _ => null,   // a struct cannot be a branch operand; unknown stays raw
         };
     }
+
+    /// <summary>The text of one switch-expression arm: its labels (or <c>_</c>) and the value it yields.</summary>
+    string SwitchArmText(SwitchExpressionArm arm)
+        => $"{(arm.IsDefault ? "_" : string.Join(" or ", arm.Labels))} => {Expression(arm.Value)}";
+
+    /// <summary>The single-line form of a switch expression, used when it is nested inside another expression.</summary>
+    string SwitchExpressionInline(SwitchExpression node)
+        => $"{Operand(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(SwitchArmText))} }}";
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -401,6 +401,49 @@ public sealed class SwitchSection : IrNode
 }
 
 /// <summary>
+/// A raised C# <c>switch</c> expression (<c>value switch { labels =&gt; v, …, _ =&gt; v }</c>),
+/// produced by the switch pass from a value-producing IL jump table: every case
+/// target (and the default) assigns one local that a single downstream read
+/// consumes at the join, so the whole dispatch yields one value. Each arm carries
+/// its case labels (the zero-based jump-table indices) or is the default, and the
+/// expression it yields. Unlike <see cref="Switch"/> (a statement) this is an
+/// expression, so it appears as the value of a <see cref="Return"/> or a store.
+/// </summary>
+public sealed class SwitchExpression : IrExpression
+{
+    public SwitchExpression(IrExpression value, IEnumerable<SwitchExpressionArm> arms)
+    {
+        AddChild(value);
+        foreach (var arm in arms)
+            AddChild(arm);
+    }
+
+    public IrExpression Value => (IrExpression)Children[0];
+    public IReadOnlyList<SwitchExpressionArm> Arms => Children.Skip(1).Cast<SwitchExpressionArm>().ToList();
+
+    public override TypeRef? ResultType => Arms.Select(a => a.Value.ResultType).FirstOrDefault(t => t is not null);
+
+    public override string Describe() => $"SwitchExpression ({Children.Count - 1} arms)";
+}
+
+/// <summary>One arm of a <see cref="SwitchExpression"/>: its case labels (empty for the default) and the value it yields.</summary>
+public sealed class SwitchExpressionArm : IrNode
+{
+    public SwitchExpressionArm(ImmutableArray<int> labels, bool isDefault, IrExpression value)
+    {
+        Labels = labels;
+        IsDefault = isDefault;
+        AddChild(value);
+    }
+
+    public ImmutableArray<int> Labels { get; }
+    public bool IsDefault { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => IsDefault ? "default arm" : $"arm {string.Join(", ", Labels)}";
+}
+
+/// <summary>
 /// A raised <c>lock</c> statement. Produced by the lock-sugar pass from the
 /// csc Monitor lowering — <c>Monitor.Enter(obj, ref taken)</c> in a try whose
 /// finally is <c>if (taken) Monitor.Exit(obj)</c>.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -36,6 +36,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// shared case bodies: one case target is the post-switch join, so cases reaching
 /// it are empty <c>break;</c> sections and the default may break to it through a
 /// conditional (<c>if (c) break;</c>) and fall through into a terminating case.
+///
+/// A third attempt (<see cref="RaiseSwitchExpressionReturn"/>) handles
+/// value-producing tables — the source of a C# <c>switch</c> expression: every
+/// case target (and the default) is a one-block value block assigning a single
+/// local that the join then returns, so the whole table is one value
+/// (<c>return v switch { … };</c>).
 /// </summary>
 public sealed class SwitchRaisingPass : IIrPass
 {
@@ -60,7 +66,8 @@ public sealed class SwitchRaisingPass : IIrPass
             {
                 if (blocks[s].Children is [.., SwitchBranch sw]
                     && (Raise(container, s, sw, leaveTargets, stepper)
-                        || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
+                        || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)
+                        || RaiseSwitchExpressionReturn(container, s, sw, stepper)))
                     return true;
             }
         }
@@ -329,6 +336,188 @@ public sealed class SwitchRaisingPass : IIrPass
         BuildCaseTargetJoin(container, s, sw, caseTargets, regions, defaultIndex, join,
             fallThroughCase, regionEnd, stepper);
         return true;
+    }
+
+    /// <summary>
+    /// A third raising attempt, tried only when both statement-raisers leave the
+    /// switch flat: a value-producing jump table that is the source of a C# switch
+    /// expression. Every case target (and the default) is a one-block <em>value
+    /// block</em> — a single <c>StoreLocal L = expr</c> that then reaches a common
+    /// join — and the join is exactly <c>return L</c>, reading L once. Such a table
+    /// is one value: <c>return v switch { labels =&gt; expr, …, _ =&gt; expr };</c>.
+    /// The default may itself be a value block or a single conditional choosing
+    /// between two value blocks (lowered to a <c>?:</c> arm). This is the
+    /// AssemblyNameParser::IsWhiteSpace shape.
+    /// </summary>
+    static bool RaiseSwitchExpressionReturn(BlockContainer container, int s, SwitchBranch sw, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        int defaultIndex = s + 1;
+        if (defaultIndex >= blocks.Count)
+            return false;
+
+        var caseTargets = new int[sw.TargetOffsets.Length];
+        for (int i = 0; i < caseTargets.Length; i++)
+            if (!offsetToIndex.TryGetValue(sw.TargetOffsets[i], out caseTargets[i]) || caseTargets[i] <= s)
+                return false;
+
+        // The default head being a case target is the SpinLock fold (handled by Raise).
+        if (caseTargets.Contains(defaultIndex))
+            return false;
+
+        // Every case target must be a value block; they must agree on one local
+        // and one join. Probe the first to fix L and J, then require the rest match.
+        int? local = null;
+        int? joinIndex = null;
+        bool Probe(int idx)
+        {
+            if (!TryValueBlock(blocks, idx, offsetToIndex, out int l, out int j))
+                return false;
+            if (local is { } el && el != l)
+                return false;
+            if (joinIndex is { } ej && ej != j)
+                return false;
+            local = l;
+            joinIndex = j;
+            return true;
+        }
+
+        foreach (int target in caseTargets.Distinct())
+            if (!Probe(target))
+                return false;
+
+        // The default arm: a value block, or one conditional over two value blocks.
+        var owned = new HashSet<int>(caseTargets) { defaultIndex };
+        IrExpression defaultArm;
+        if (TryValueBlock(blocks, defaultIndex, offsetToIndex, out _, out _))
+        {
+            if (!Probe(defaultIndex))
+                return false;
+            defaultArm = (IrExpression)ValueBlockExpr(blocks[defaultIndex]).Clone();
+        }
+        else if (blocks[defaultIndex].Children is [ConditionalBranch dispatch]
+            && offsetToIndex.TryGetValue(dispatch.TargetOffset, out int whenTrueIdx)
+            && whenTrueIdx > s)
+        {
+            int whenFalseIdx = defaultIndex + 1;
+            if (whenFalseIdx >= blocks.Count || !Probe(whenTrueIdx) || !Probe(whenFalseIdx))
+                return false;
+            owned.Add(whenTrueIdx);
+            owned.Add(whenFalseIdx);
+            var condition = (IrExpression)dispatch.Children[0].Clone();
+            defaultArm = new Conditional(
+                condition,
+                (IrExpression)ValueBlockExpr(blocks[whenTrueIdx]).Clone(),
+                (IrExpression)ValueBlockExpr(blocks[whenFalseIdx]).Clone());
+        }
+        else
+        {
+            return false;
+        }
+
+        int join = joinIndex!.Value;
+        int theLocal = local!.Value;
+
+        // The join reads the local exactly once and returns it.
+        if (blocks[join].Children is not [Return { Value: LoadLocal joinRead }] || joinRead.Index != theLocal)
+            return false;
+
+        // The local is private to this dispatch: assigned only in the owned value
+        // blocks, read only at the join. Otherwise raising would drop a live store.
+        var ownedBlocks = owned.Select(i => blocks[i]).ToHashSet();
+        bool InOwned(IrNode node)
+        {
+            for (var current = node; current is not null; current = current.Parent)
+                if (current is Block block && ownedBlocks.Contains(block))
+                    return true;
+            return false;
+        }
+        foreach (var node in container.Descendants)
+        {
+            if (node is StoreLocal store && store.Index == theLocal && !InOwned(store))
+                return false;
+            if (node is LoadLocal load && load.Index == theLocal && !ReferenceEquals(load, joinRead))
+                return false;
+        }
+
+        // The owned blocks must tile [s+1, join) exactly, the join just past them,
+        // and nothing outside the table may enter them.
+        if (join <= s || owned.Contains(join))
+            return false;
+        if (owned.Count != join - defaultIndex)
+            return false;
+        foreach (int idx in owned)
+            if (idx < defaultIndex || idx >= join)
+                return false;
+        if (!OnlyReachedByTable(blocks, owned, s, []))
+            return false;
+
+        BuildSwitchExpression(container, s, sw, caseTargets, defaultArm, join, stepper);
+        return true;
+    }
+
+    /// <summary>
+    /// A value block is one block that assigns a single local and then reaches a
+    /// join — either by an unconditional branch to it, or by falling through to
+    /// the next block. Returns the assigned local and the join's block index.
+    /// </summary>
+    static bool TryValueBlock(IReadOnlyList<Block> blocks, int idx, Dictionary<int, int> offsetToIndex, out int local, out int joinIndex)
+    {
+        local = -1;
+        joinIndex = -1;
+        var block = blocks[idx];
+        switch (block.Children)
+        {
+            case [StoreLocal store]:
+                local = store.Index;
+                joinIndex = idx + 1;
+                return joinIndex < blocks.Count;
+            case [StoreLocal store, Branch branch]:
+                if (!offsetToIndex.TryGetValue(branch.TargetOffset, out joinIndex))
+                    return false;
+                local = store.Index;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static IrExpression ValueBlockExpr(Block block) => ((StoreLocal)block.Children[0]).Value;
+
+    /// <summary>Replaces a value-producing jump table with <c>return v switch { … };</c>: the arms group case labels by their value block, and the default arm is supplied by the recognizer.</summary>
+    static void BuildSwitchExpression(BlockContainer container, int s, SwitchBranch sw, int[] caseTargets, IrExpression defaultArm, int join, Stepper stepper)
+    {
+        var all = container.Blocks.ToList();
+
+        var labelsByTarget = new Dictionary<int, List<int>>();
+        for (int i = 0; i < caseTargets.Length; i++)
+            (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
+
+        var arms = new List<SwitchExpressionArm>();
+        foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
+            arms.Add(new SwitchExpressionArm([.. labels], isDefault: false, (IrExpression)ValueBlockExpr(all[target]).Clone()));
+        arms.Add(new SwitchExpressionArm([], isDefault: true, defaultArm));
+
+        var value = (IrExpression)sw.DetachChildren()[0];
+        sw.Detach();
+
+        foreach (var block in all)
+            block.Detach();
+
+        var switchBlock = all[s];
+        switchBlock.Add(new Return(new SwitchExpression(value, arms)));
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx <= s; idx++)
+            rebuilt.Add(all[idx]);
+        for (int idx = join + 1; idx < all.Count; idx++)
+            rebuilt.Add(all[idx]);
+        stepper.StepOver("raise value-producing jump table to switch expression", container);
+        container.ReplaceWith(rebuilt);
     }
 
     /// <summary>The default region escapes only through a conditional / unconditional branch to the join, a fall-through, or a terminator — every conditional must target the join (it becomes <c>if (c) break;</c>).</summary>


### PR DESCRIPTION
Adds the first **switch-expression output** to the decompiler (issue #694). A value-producing IL jump table — every case target and the default assign one local that a single downstream read returns at the join — is one value, so it raises to a `return v switch { ... };`.

## What

- **New IR nodes** `SwitchExpression` / `SwitchExpressionArm` (expression form). The existing `Switch` / `SwitchSection` stay statement-only.
- **Printer**: multi-line `return ... switch { ... }` at statement level, plus a single-line `Expression()` fallback for nested use. Arm labels render as `0 or 1 or 4 => ...`, default as `_ => ...`.
- **`SwitchRaisingPass`**: a third *isolated* attempt `RaiseSwitchExpressionReturn`, tried only when both statement-raisers (`Raise`, `RaiseCaseTargetJoin`) leave the switch flat — so zero behavioral risk to the ~39.8k already-raising methods. It recognizes one-block *value blocks* converging on a `return local` join (the local assigned only in those blocks and read exactly once at the join); the default may itself be a value block or a single conditional choosing between two value blocks (lowered to a ternary arm).

## Why

Closes the `default-routes-into-cases` switch-branch gap — `System.Reflection.AssemblyNameParser::IsWhiteSpace`, which previously emitted **invalid** C# (a residual `switch (ch - 9) goto [...]`). Now:

```csharp
return (ch - 9) switch
{
    0 or 1 or 4 => true,
    2 or 3 => false,
    _ => ch != ' ' ? false : true,
};
```

## Rails

- **339** decompiler tests (+1 synthetic fixture asserting the raised switch-expression output).
- `--gaps --by-shape`: switch-branch **9 -> 8**, `default-routes-into-cases` **1 -> 0**, fully-raised **+1**.
- `--validity-check` diff vs main: **0 only-current** (no newly-defective); `IsWhiteSpace` drops out of the defect set (invalid -> valid).
- `--pass-impact switch`: **149** methods, **0 pass bugs** — exactly **+1** method changed corpus-wide, confirming the new attempt is tightly scoped.

Refs #694.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
