### PR TITLE
Add LoweringCoverage: a typed completeness ledger vs Roslyn's LocalRewriter

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -4,21 +4,20 @@ using ILInspector.Decompiler.Pipeline;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Guards the <see cref="LoweringCoverage"/> ledger — the typed completeness
-/// checklist mapping each Roslyn <c>LocalRewriter</c> lowering to the raising
-/// pass that inverts it (docs/decompiler.md). The ledger is the roadmap; these
-/// tests keep it honest: it cannot silently drift from Roslyn, claim a pass that
-/// is not wired, or let owed-idiom coverage regress.
+/// Guards the <see cref="LoweringCoverage"/> ledger — the two-axis completeness
+/// checklist mapping each Roslyn <c>LocalRewriter</c> lowering to a mechanism (the
+/// property type: a raising pass, <see cref="ImporterNative"/>, or
+/// <see cref="Unhandled"/>) and a completeness level (the
+/// <see cref="CompletenessAttribute"/>). These keep it honest: it cannot drift
+/// from Roslyn, claim an unregistered pass, violate the cross-axis invariants, or
+/// let owed-idiom coverage regress.
 /// </summary>
 public class LoweringCoverageTests
 {
-    // The authoritative denominator: every file in dotnet/roslyn
-    // src/Compilers/CSharp/Portable/Lowering/LocalRewriter/ (LocalRewriter_*.cs),
-    // synced @ main. Re-fetch with:
+    // The authoritative denominator: every LocalRewriter_*.cs in dotnet/roslyn
+    // src/Compilers/CSharp/Portable/Lowering/LocalRewriter/, synced @ main. Re-fetch:
     //   gh api repos/dotnet/roslyn/contents/src/Compilers/CSharp/Portable/Lowering/LocalRewriter \
     //     --jq '.[].name' | sed 's/^LocalRewriter_//;s/\.cs$//'
-    // When this changes (a new C# lowering), add the matching LoweringCoverage
-    // property (NoImpl until raised) and update this list in the same PR.
     static readonly string[] RoslynLocalRewriters =
     [
         "AnonymousObjectCreation", "AsOperator", "AssignmentOperator", "Await",
@@ -39,12 +38,20 @@ public class LoweringCoverageTests
         "WhileStatement", "Yield",
     ];
 
-    // Ratchet: owed idioms (NoImpl) must only go DOWN. Implementing one (flipping
-    // its property from NoImpl to a pass) lowers this; tighten it in that PR.
+    // Ratchet: owed idioms (mechanism Unhandled / completeness None) only go DOWN.
+    // Implementing one lowers it; tighten this in that PR.
     const int OwedCeiling = 15;
 
     static PropertyInfo[] Ledger() =>
         typeof(LoweringCoverage).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
+    static bool IsPass(PropertyInfo p) => typeof(IIrPass).IsAssignableFrom(p.PropertyType);
+
+    // NOTE: keep the internal CompletenessLevel / CompletenessAttribute types out
+    // of any member SIGNATURE here — the fidelity gate reconstructs this test
+    // assembly as a whole-module skeleton and a signature referencing an internal
+    // decompiler type fails to recompile. Read the attribute inside method bodies
+    // only (skeleton stubs erase bodies).
 
     [Fact]
     public void PropertySet_ExactlyMatchesRoslynLocalRewriters()
@@ -56,42 +63,68 @@ public class LoweringCoverageTests
         var extra = properties.Except(roslyn).Order().ToArray();
 
         Assert.True(missing.Length == 0,
-            $"Roslyn lowerings with no LoweringCoverage property (add them, NoImpl until raised): {string.Join(", ", missing)}");
+            $"Roslyn lowerings with no LoweringCoverage property (add them, Unhandled/None until raised): {string.Join(", ", missing)}");
         Assert.True(extra.Length == 0,
-            $"LoweringCoverage properties that are not Roslyn lowerings (remove or fix the name): {string.Join(", ", extra)}");
+            $"LoweringCoverage properties that are not Roslyn lowerings (remove or rename): {string.Join(", ", extra)}");
         Assert.Equal(RoslynLocalRewriters.Length, properties.Count);
     }
 
     [Fact]
-    public void EveryImplementedEntry_IsRegisteredInThePipeline()
+    public void CrossAxisInvariants_Hold()
     {
         var registered = IrPasses.Default.Select(p => p.GetType()).ToHashSet();
 
-        var phantom = Ledger()
-            .Where(p => typeof(IIrPass).IsAssignableFrom(p.PropertyType))
-            .Where(p => !registered.Contains(p.PropertyType))
-            .Select(p => $"{p.Name} -> {p.PropertyType.Name}")
-            .ToArray();
+        foreach (var p in Ledger())
+        {
+            var attr = p.GetCustomAttribute<CompletenessAttribute>();
+            Assert.True(attr is not null, $"{p.Name}: missing [Completeness] — every entry states its completeness axis.");
+            var level = attr!.Level;
 
-        Assert.True(phantom.Length == 0,
-            $"Ledger claims a raising pass that is not registered in IrPasses.Default: {string.Join(", ", phantom)}");
+            if (p.PropertyType == typeof(ImporterNative))
+                Assert.True(level == CompletenessLevel.Full, $"{p.Name}: importer-native must be Full (it is built directly).");
+            else if (p.PropertyType == typeof(Unhandled))
+                Assert.True(level == CompletenessLevel.None, $"{p.Name}: Unhandled must be None (no mechanism).");
+            else if (IsPass(p))
+            {
+                Assert.True(level is CompletenessLevel.Full or CompletenessLevel.Partial,
+                    $"{p.Name}: a pass-handled lowering is Full or Partial, not None.");
+                Assert.True(registered.Contains(p.PropertyType),
+                    $"{p.Name} -> {p.PropertyType.Name}: pass is not registered in IrPasses.Default.");
+            }
+            else
+                Assert.Fail($"{p.Name}: unknown mechanism type {p.PropertyType.Name} (expected a pass, ImporterNative, or Unhandled).");
+        }
     }
 
     [Fact]
-    public void OwedIdioms_DoNotRegress()
+    public void OwedIdioms_DoNotRegress_AndReportBothAxes()
     {
-        var owed = Ledger()
-            .Where(p => p.PropertyType == typeof(NoImpl))
-            .Select(p => $"{p.Name} ({((NoImpl)p.GetValue(null)!).Form})")
-            .Order()
-            .ToArray();
+        var props = Ledger();
 
-        int implemented = Ledger().Count(p => typeof(IIrPass).IsAssignableFrom(p.PropertyType));
-        int direct = Ledger().Count(p => p.PropertyType == typeof(Direct));
+        // Specialization gradient (derived): a pass used by one property is
+        // dedicated; by several, a shared/general pass.
+        var passUsage = props.Where(IsPass).GroupBy(p => p.PropertyType).ToDictionary(g => g.Key, g => g.Count());
+
+        int dedicated = passUsage.Count(kv => kv.Value == 1);
+        int shared = passUsage.Count(kv => kv.Value > 1);
+        int sharedProps = passUsage.Where(kv => kv.Value > 1).Sum(kv => kv.Value);
+        int importer = props.Count(p => p.PropertyType == typeof(ImporterNative));
+
+        int full = props.Count(p => IsPass(p) && p.GetCustomAttribute<CompletenessAttribute>()!.Level == CompletenessLevel.Full);
+        var partial = props.Where(p => IsPass(p) && p.GetCustomAttribute<CompletenessAttribute>()!.Level == CompletenessLevel.Partial)
+            .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
+        var owed = props.Where(p => p.PropertyType == typeof(Unhandled))
+            .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
+
+        string report =
+            $"Lowering coverage over {props.Length} Roslyn LocalRewriter phases\n"
+            + $"  Completeness (idioms): {full} Full, {partial.Length} Partial, {owed.Length} None "
+            + $"(+ {importer} importer-native mechanical lowerings)\n"
+            + $"  Specialization: {dedicated} dedicated passes, {shared} shared passes ({sharedProps} entries), {importer} importer-native\n"
+            + $"  Partial — finish these:\n    {string.Join("\n    ", partial)}\n"
+            + $"  Owed — start these:\n    {string.Join("\n    ", owed)}";
 
         Assert.True(owed.Length <= OwedCeiling,
-            $"Owed idioms rose to {owed.Length} (ceiling {OwedCeiling}). If you implemented one, lower the ceiling; "
-            + $"if Roslyn added a lowering, account for it.\nCoverage: {implemented} raised, {owed.Length} owed, {direct} direct.\n"
-            + $"Owed roadmap:\n  {string.Join("\n  ", owed)}");
+            $"Owed idioms rose to {owed.Length} (ceiling {OwedCeiling}). Implementing one lowers it; if Roslyn added a lowering, account for it.\n\n{report}");
     }
 }

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Guards the <see cref="LoweringCoverage"/> ledger — the typed completeness
+/// checklist mapping each Roslyn <c>LocalRewriter</c> lowering to the raising
+/// pass that inverts it (docs/decompiler.md). The ledger is the roadmap; these
+/// tests keep it honest: it cannot silently drift from Roslyn, claim a pass that
+/// is not wired, or let owed-idiom coverage regress.
+/// </summary>
+public class LoweringCoverageTests
+{
+    // The authoritative denominator: every file in dotnet/roslyn
+    // src/Compilers/CSharp/Portable/Lowering/LocalRewriter/ (LocalRewriter_*.cs),
+    // synced @ main. Re-fetch with:
+    //   gh api repos/dotnet/roslyn/contents/src/Compilers/CSharp/Portable/Lowering/LocalRewriter \
+    //     --jq '.[].name' | sed 's/^LocalRewriter_//;s/\.cs$//'
+    // When this changes (a new C# lowering), add the matching LoweringCoverage
+    // property (NoImpl until raised) and update this list in the same PR.
+    static readonly string[] RoslynLocalRewriters =
+    [
+        "AnonymousObjectCreation", "AsOperator", "AssignmentOperator", "Await",
+        "BasePatternSwitchLocalRewriter", "BinaryOperator", "Block", "BreakStatement",
+        "Call", "CollectionExpression", "CompoundAssignmentOperator", "ConditionalAccess",
+        "ConditionalOperator", "ContinueStatement", "Conversion", "DeconstructionAssignmentOperator",
+        "DelegateCreationExpression", "DoStatement", "Event", "ExpressionStatement",
+        "Field", "FixedStatement", "ForEachStatement", "ForStatement",
+        "FunctionPointerInvocation", "GotoStatement", "HostObjectMemberReference", "IfStatement",
+        "Index", "IndexerAccess", "IsOperator", "IsPatternOperator",
+        "LabeledStatement", "Literal", "LocalDeclaration", "LockStatement",
+        "MultipleLocalDeclarations", "NullCoalescingAssignmentOperator", "NullCoalescingOperator",
+        "ObjectCreationExpression", "ObjectOrCollectionInitializerExpression", "PatternSwitchStatement",
+        "PointerElementAccess", "PreviousSubmissionReference", "PropertyAccess", "Query",
+        "Range", "ReturnStatement", "StackAlloc", "StringConcat",
+        "StringInterpolation", "SwitchExpression", "ThrowStatement", "TryStatement",
+        "TupleBinaryOperator", "TupleCreationExpression", "UnaryOperator", "UsingStatement",
+        "WhileStatement", "Yield",
+    ];
+
+    // Ratchet: owed idioms (NoImpl) must only go DOWN. Implementing one (flipping
+    // its property from NoImpl to a pass) lowers this; tighten it in that PR.
+    const int OwedCeiling = 15;
+
+    static PropertyInfo[] Ledger() =>
+        typeof(LoweringCoverage).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
+    [Fact]
+    public void PropertySet_ExactlyMatchesRoslynLocalRewriters()
+    {
+        var properties = Ledger().Select(p => p.Name).ToHashSet();
+        var roslyn = RoslynLocalRewriters.ToHashSet();
+
+        var missing = roslyn.Except(properties).Order().ToArray();
+        var extra = properties.Except(roslyn).Order().ToArray();
+
+        Assert.True(missing.Length == 0,
+            $"Roslyn lowerings with no LoweringCoverage property (add them, NoImpl until raised): {string.Join(", ", missing)}");
+        Assert.True(extra.Length == 0,
+            $"LoweringCoverage properties that are not Roslyn lowerings (remove or fix the name): {string.Join(", ", extra)}");
+        Assert.Equal(RoslynLocalRewriters.Length, properties.Count);
+    }
+
+    [Fact]
+    public void EveryImplementedEntry_IsRegisteredInThePipeline()
+    {
+        var registered = IrPasses.Default.Select(p => p.GetType()).ToHashSet();
+
+        var phantom = Ledger()
+            .Where(p => typeof(IIrPass).IsAssignableFrom(p.PropertyType))
+            .Where(p => !registered.Contains(p.PropertyType))
+            .Select(p => $"{p.Name} -> {p.PropertyType.Name}")
+            .ToArray();
+
+        Assert.True(phantom.Length == 0,
+            $"Ledger claims a raising pass that is not registered in IrPasses.Default: {string.Join(", ", phantom)}");
+    }
+
+    [Fact]
+    public void OwedIdioms_DoNotRegress()
+    {
+        var owed = Ledger()
+            .Where(p => p.PropertyType == typeof(NoImpl))
+            .Select(p => $"{p.Name} ({((NoImpl)p.GetValue(null)!).Form})")
+            .Order()
+            .ToArray();
+
+        int implemented = Ledger().Count(p => typeof(IIrPass).IsAssignableFrom(p.PropertyType));
+        int direct = Ledger().Count(p => p.PropertyType == typeof(Direct));
+
+        Assert.True(owed.Length <= OwedCeiling,
+            $"Owed idioms rose to {owed.Length} (ceiling {OwedCeiling}). If you implemented one, lower the ceiling; "
+            + $"if Roslyn added a lowering, account for it.\nCoverage: {implemented} raised, {owed.Length} owed, {direct} direct.\n"
+            + $"Owed roadmap:\n  {string.Join("\n  ", owed)}");
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -2,125 +2,123 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// The compiled completeness ledger for C# idiom recovery: one property per
-/// Roslyn <c>LocalRewriter</c> lowering, typed as the raising pass that inverts
-/// it — or <see cref="NoImpl"/> for an idiom we still owe, or <see cref="Direct"/>
-/// for a lowering the importer or the structuring subsystem handle with no
-/// dedicated pass. This is the typed form of the principle in docs/decompiler.md:
-/// "Roslyn's <c>Lowering/</c> directory is our completeness checklist."
+/// Roslyn <c>LocalRewriter</c> lowering (docs/decompiler.md, "Roslyn's
+/// <c>Lowering/</c> directory is our completeness checklist"). Each entry is two
+/// orthogonal axes:
+/// <list type="bullet">
+/// <item><b>Mechanism</b> — the property's <em>type</em>: the raising pass that
+/// handles it, <see cref="ImporterNative"/> (the importer builds it directly, no
+/// transform), or <see cref="Unhandled"/> (no mechanism). The dedicated-vs-shared
+/// gradient is derived: a pass type used by one property is dedicated, by several
+/// is a shared/general pass.</item>
+/// <item><b>Completeness</b> — the <see cref="CompletenessAttribute"/>: how much
+/// of the construct comes back as the idiom (<see cref="CompletenessLevel.Full"/>
+/// / <see cref="CompletenessLevel.Partial"/> / <see cref="CompletenessLevel.None"/>),
+/// with a note for the partial/owed cases.</item>
+/// </list>
 ///
-/// <para>A PR that adds a raising pass flips its one property from
-/// <see cref="NoImpl"/> to the pass type — the ledger is the roadmap and the
-/// burn-down in one place. <c>LoweringCoverageTests</c> reflects over it: it
-/// reports idiom coverage, cross-checks every pass-typed entry is registered in
-/// <see cref="IrPasses.Default"/>, and fails if this property set drifts from the
-/// checked-in snapshot of Roslyn's <c>LocalRewriter/</c> directory.</para>
+/// <para>These are independent: <c>(Full, ImporterNative)</c> is a mechanical
+/// lowering that needs no pass; <c>(Partial, SwitchRaisingPass)</c> is a dedicated
+/// pass that only covers some shapes; <c>(None, Unhandled)</c> is an owed idiom. A
+/// PR that raises an idiom flips its line — the type to the pass, the completeness
+/// up. <c>LoweringCoverageTests</c> reflects over it: it reports both axes,
+/// cross-checks every pass is registered in <see cref="IrPasses.Default"/>,
+/// enforces the cross-axis invariants, and fails on drift from the checked-in
+/// snapshot of Roslyn's <c>LocalRewriter/</c> directory.</para>
 ///
 /// <para>Internal and never invoked on a product path (trim-removable) — a
-/// build-time checklist, not a runtime component. Synced against dotnet/roslyn
-/// <c>src/Compilers/CSharp/Portable/Lowering/LocalRewriter/</c> @ main (60
-/// lowerings).</para>
+/// build-time checklist. Synced against dotnet/roslyn
+/// <c>src/Compilers/CSharp/Portable/Lowering/LocalRewriter/</c> @ main (60 lowerings).</para>
 /// </summary>
 internal static class LoweringCoverage
 {
-    // ───────── Idiom lowerings we INVERT — property type IS the raising pass ─────────
+    // ───────── Raised by a pass — fully ─────────
+    [Completeness(CompletenessLevel.Full)] public static InlineArrayCollectionPass      CollectionExpression       => new();
+    [Completeness(CompletenessLevel.Full)] public static NullConditionalPass            ConditionalAccess          => new();
+    [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass             ConditionalOperator        => new();
+    [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass             NullCoalescingOperator     => new();
+    [Completeness(CompletenessLevel.Full)] public static DelegateConstructionPass       DelegateCreationExpression => new();
+    [Completeness(CompletenessLevel.Full)] public static FixedStatementPass             FixedStatement             => new();
+    [Completeness(CompletenessLevel.Full)] public static LockSugarPass                  LockStatement              => new();
+    [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass             StackAlloc                 => new();
 
-    public static InlineArrayCollectionPass CollectionExpression       => new();
-    public static NullConditionalPass       ConditionalAccess          => new();
-    public static BooleanFoldingPass        ConditionalOperator        => new();
-    public static BooleanFoldingPass        NullCoalescingOperator     => new();
-    public static DelegateConstructionPass  DelegateCreationExpression => new();
-    public static FixedStatementPass        FixedStatement             => new();
-    public static LockSugarPass             LockStatement              => new();
-    public static StackAllocSpanPass        StackAlloc                 => new();
-    public static IncrementDecrementPass    CompoundAssignmentOperator => new();
-    public static SwitchRaisingPass         SwitchExpression           => new();
-    public static SwitchRaisingPass         PatternSwitchStatement     => new();
+    // ───────── Raised by a pass — partially (the "finish these" roadmap) ─────────
+    [Completeness(CompletenessLevel.Partial, "value-producing jump tables only; sparse + pattern switches still emit a statement")]
+    public static SwitchRaisingPass SwitchExpression => new();
+    [Completeness(CompletenessLevel.Partial, "jump-table switch statements; pattern + switch-on-string not raised")]
+    public static SwitchRaisingPass PatternSwitchStatement => new();
+    [Completeness(CompletenessLevel.Partial, "++/-- only; general compound assignment (+=, ...) not raised")]
+    public static IncrementDecrementPass CompoundAssignmentOperator => new();
 
-    // Control flow is raised by the structuring subsystem; per-method completeness
-    // is measured by --gaps, not all-or-nothing here. Mapped to the owning pass.
-    public static ForLoopPass               ForStatement               => new();
-    public static DoWhileLoopPass           DoStatement                => new();
-    public static StructuringPass           WhileStatement             => new();
-    public static StructuringPass           IfStatement                => new();
-    public static StructuringPass           BreakStatement             => new();
-    public static StructuringPass           ContinueStatement          => new();
-    public static EhStructuringPass         TryStatement               => new();
+    // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   WhileStatement    => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   BreakStatement    => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   ContinueStatement => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static DoWhileLoopPass  DoStatement       => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static ForLoopPass      ForStatement      => new();
+    [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement      => new();
 
-    // ───────── Idiom lowerings we still OWE — the roadmap (flip to a pass when done) ─────────
+    // ───────── Owed — no mechanism yet (the "start these" roadmap) ─────────
+    [Completeness(CompletenessLevel.None, "x is T t / { Prop: ... }")]   public static Unhandled IsPatternOperator                   => default!;
+    [Completeness(CompletenessLevel.None, "using (var x = ...) { }")]    public static Unhandled UsingStatement                      => default!;
+    [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
+    [Completeness(CompletenessLevel.None, "$\"{a}{b}\"")]                public static Unhandled StringInterpolation                 => default!;
+    [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;
+    [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
+    [Completeness(CompletenessLevel.None, "(a, b)")]                     public static Unhandled TupleCreationExpression             => default!;
+    [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
+    [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
+    [Completeness(CompletenessLevel.None, "a ??= b")]                    public static Unhandled NullCoalescingAssignmentOperator    => default!;
+    [Completeness(CompletenessLevel.None, "new T { X = 1 }")]           public static Unhandled ObjectOrCollectionInitializerExpression => default!;
+    [Completeness(CompletenessLevel.None, "new { a, b }")]               public static Unhandled AnonymousObjectCreation             => default!;
+    [Completeness(CompletenessLevel.None, "from x in xs select ...")]    public static Unhandled Query                               => default!;
+    [Completeness(CompletenessLevel.None, "await t — async state machine")]      public static Unhandled Await => default!;
+    [Completeness(CompletenessLevel.None, "yield return — iterator state machine")] public static Unhandled Yield => default!;
 
-    public static NoImpl IsPatternOperator                   => NoImpl.Owed("x is T t / { Prop: ... }");
-    public static NoImpl UsingStatement                      => NoImpl.Owed("using (var x = ...) { }");
-    public static NoImpl ForEachStatement                    => NoImpl.Owed("foreach (var x in xs)");
-    public static NoImpl StringInterpolation                 => NoImpl.Owed("$\"{a}{b}\"");
-    public static NoImpl Range                               => NoImpl.Owed("a[i..j]");
-    public static NoImpl Index                               => NoImpl.Owed("a[^1]");
-    public static NoImpl TupleCreationExpression             => NoImpl.Owed("(a, b)");
-    public static NoImpl TupleBinaryOperator                 => NoImpl.Owed("(a, b) == (c, d)");
-    public static NoImpl DeconstructionAssignmentOperator    => NoImpl.Owed("(a, b) = t");
-    public static NoImpl NullCoalescingAssignmentOperator    => NoImpl.Owed("a ??= b");
-    public static NoImpl ObjectOrCollectionInitializerExpression => NoImpl.Owed("new T { X = 1 }");
-    public static NoImpl AnonymousObjectCreation             => NoImpl.Owed("new { a, b }");
-    public static NoImpl Query                               => NoImpl.Owed("from x in xs select ...");
-    public static NoImpl Await                               => NoImpl.Owed("await t — async state machine");
-    public static NoImpl Yield                               => NoImpl.Owed("yield return — iterator state machine");
-
-    // ───────── No idiom to recover: importer-built, or structuring residual (Direct) ─────────
-
-    public static Direct AssignmentOperator        => Direct.Importer;
-    public static Direct BinaryOperator            => Direct.Importer;
-    public static Direct UnaryOperator             => Direct.Importer;
-    public static Direct Call                      => Direct.Importer;
-    public static Direct Field                     => Direct.Importer;
-    public static Direct Event                     => Direct.Importer;
-    public static Direct PropertyAccess            => Direct.Importer;
-    public static Direct Conversion                => Direct.Importer;
-    public static Direct Literal                   => Direct.Importer;
-    public static Direct LocalDeclaration          => Direct.Importer;
-    public static Direct MultipleLocalDeclarations => Direct.Importer;
-    public static Direct ObjectCreationExpression  => Direct.Importer;
-    public static Direct ExpressionStatement       => Direct.Importer;
-    public static Direct Block                     => Direct.Importer;
-    public static Direct FunctionPointerInvocation => Direct.Importer;
-    public static Direct HostObjectMemberReference => Direct.Importer;
-    public static Direct PreviousSubmissionReference => Direct.Importer;
-    public static Direct PointerElementAccess      => Direct.Importer;
-    public static Direct IndexerAccess             => Direct.Importer;
-    public static Direct AsOperator                => Direct.Importer;
-    public static Direct IsOperator                => Direct.Importer;
-    public static Direct StringConcat              => Direct.Importer;
-    public static Direct BasePatternSwitchLocalRewriter => Direct.Importer;
-    public static Direct ReturnStatement           => Direct.Importer;
-    public static Direct ThrowStatement            => Direct.Importer;
-    public static Direct GotoStatement             => Direct.Structuring;
-    public static Direct LabeledStatement          => Direct.Structuring;
+    // ───────── Importer-native — no idiom to recover (built directly by the stack simulation) ─────────
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative AssignmentOperator        => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative BinaryOperator            => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative UnaryOperator             => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Call                      => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Field                     => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Event                     => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative PropertyAccess            => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion                => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal                   => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration          => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative MultipleLocalDeclarations => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression  => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative ExpressionStatement       => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative Block                     => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative FunctionPointerInvocation => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative HostObjectMemberReference => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess      => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative IndexerAccess             => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator                => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator                => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat              => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative BasePatternSwitchLocalRewriter => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement           => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement            => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative GotoStatement             => default!;
+    [Completeness(CompletenessLevel.Full)] public static ImporterNative LabeledStatement          => default!;
 }
 
-/// <summary>
-/// An idiom Roslyn lowers to IL that the decompiler does not yet raise — the
-/// property's type marks the gap; <see cref="Form"/> is the C# shape we owe.
-/// </summary>
-internal sealed class NoImpl
+/// <summary>How much of a lowered construct comes back as the idiom.</summary>
+internal enum CompletenessLevel { None, Partial, Full }
+
+/// <summary>The completeness axis of a <see cref="LoweringCoverage"/> entry (the property type carries the mechanism axis).</summary>
+[AttributeUsage(AttributeTargets.Property)]
+internal sealed class CompletenessAttribute(CompletenessLevel level, string? note = null) : Attribute
 {
-    public string Form { get; }
-    public string? Issue { get; }
-
-    NoImpl(string form, string? issue) { Form = form; Issue = issue; }
-
-    public static NoImpl Owed(string form, string? issue = null) => new(form, issue);
+    public CompletenessLevel Level => level;
+    public string? Note => note;
 }
 
-/// <summary>
-/// A lowering with no dedicated raising pass: either the importer builds the
-/// construct directly (no distinct idiom to recover), or the structuring
-/// subsystem owns it (control-flow completeness is measured by <c>--gaps</c>,
-/// not this ledger).
-/// </summary>
-internal sealed class Direct
-{
-    public string Reason { get; }
+/// <summary>Mechanism marker: the importer builds this construct directly out of the stack simulation — no raising pass, no idiom to recover.</summary>
+internal sealed class ImporterNative;
 
-    Direct(string reason) { Reason = reason; }
-
-    public static Direct Importer { get; } = new("importer/printer builds it directly — no idiom to recover");
-    public static Direct Structuring { get; } = new("control-flow residual — completeness tracked by --gaps");
-}
+/// <summary>Mechanism marker: no mechanism yet — the lowered form is emitted as-is. The owed roadmap.</summary>
+internal sealed class Unhandled;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -1,0 +1,126 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The compiled completeness ledger for C# idiom recovery: one property per
+/// Roslyn <c>LocalRewriter</c> lowering, typed as the raising pass that inverts
+/// it — or <see cref="NoImpl"/> for an idiom we still owe, or <see cref="Direct"/>
+/// for a lowering the importer or the structuring subsystem handle with no
+/// dedicated pass. This is the typed form of the principle in docs/decompiler.md:
+/// "Roslyn's <c>Lowering/</c> directory is our completeness checklist."
+///
+/// <para>A PR that adds a raising pass flips its one property from
+/// <see cref="NoImpl"/> to the pass type — the ledger is the roadmap and the
+/// burn-down in one place. <c>LoweringCoverageTests</c> reflects over it: it
+/// reports idiom coverage, cross-checks every pass-typed entry is registered in
+/// <see cref="IrPasses.Default"/>, and fails if this property set drifts from the
+/// checked-in snapshot of Roslyn's <c>LocalRewriter/</c> directory.</para>
+///
+/// <para>Internal and never invoked on a product path (trim-removable) — a
+/// build-time checklist, not a runtime component. Synced against dotnet/roslyn
+/// <c>src/Compilers/CSharp/Portable/Lowering/LocalRewriter/</c> @ main (60
+/// lowerings).</para>
+/// </summary>
+internal static class LoweringCoverage
+{
+    // ───────── Idiom lowerings we INVERT — property type IS the raising pass ─────────
+
+    public static InlineArrayCollectionPass CollectionExpression       => new();
+    public static NullConditionalPass       ConditionalAccess          => new();
+    public static BooleanFoldingPass        ConditionalOperator        => new();
+    public static BooleanFoldingPass        NullCoalescingOperator     => new();
+    public static DelegateConstructionPass  DelegateCreationExpression => new();
+    public static FixedStatementPass        FixedStatement             => new();
+    public static LockSugarPass             LockStatement              => new();
+    public static StackAllocSpanPass        StackAlloc                 => new();
+    public static IncrementDecrementPass    CompoundAssignmentOperator => new();
+    public static SwitchRaisingPass         SwitchExpression           => new();
+    public static SwitchRaisingPass         PatternSwitchStatement     => new();
+
+    // Control flow is raised by the structuring subsystem; per-method completeness
+    // is measured by --gaps, not all-or-nothing here. Mapped to the owning pass.
+    public static ForLoopPass               ForStatement               => new();
+    public static DoWhileLoopPass           DoStatement                => new();
+    public static StructuringPass           WhileStatement             => new();
+    public static StructuringPass           IfStatement                => new();
+    public static StructuringPass           BreakStatement             => new();
+    public static StructuringPass           ContinueStatement          => new();
+    public static EhStructuringPass         TryStatement               => new();
+
+    // ───────── Idiom lowerings we still OWE — the roadmap (flip to a pass when done) ─────────
+
+    public static NoImpl IsPatternOperator                   => NoImpl.Owed("x is T t / { Prop: ... }");
+    public static NoImpl UsingStatement                      => NoImpl.Owed("using (var x = ...) { }");
+    public static NoImpl ForEachStatement                    => NoImpl.Owed("foreach (var x in xs)");
+    public static NoImpl StringInterpolation                 => NoImpl.Owed("$\"{a}{b}\"");
+    public static NoImpl Range                               => NoImpl.Owed("a[i..j]");
+    public static NoImpl Index                               => NoImpl.Owed("a[^1]");
+    public static NoImpl TupleCreationExpression             => NoImpl.Owed("(a, b)");
+    public static NoImpl TupleBinaryOperator                 => NoImpl.Owed("(a, b) == (c, d)");
+    public static NoImpl DeconstructionAssignmentOperator    => NoImpl.Owed("(a, b) = t");
+    public static NoImpl NullCoalescingAssignmentOperator    => NoImpl.Owed("a ??= b");
+    public static NoImpl ObjectOrCollectionInitializerExpression => NoImpl.Owed("new T { X = 1 }");
+    public static NoImpl AnonymousObjectCreation             => NoImpl.Owed("new { a, b }");
+    public static NoImpl Query                               => NoImpl.Owed("from x in xs select ...");
+    public static NoImpl Await                               => NoImpl.Owed("await t — async state machine");
+    public static NoImpl Yield                               => NoImpl.Owed("yield return — iterator state machine");
+
+    // ───────── No idiom to recover: importer-built, or structuring residual (Direct) ─────────
+
+    public static Direct AssignmentOperator        => Direct.Importer;
+    public static Direct BinaryOperator            => Direct.Importer;
+    public static Direct UnaryOperator             => Direct.Importer;
+    public static Direct Call                      => Direct.Importer;
+    public static Direct Field                     => Direct.Importer;
+    public static Direct Event                     => Direct.Importer;
+    public static Direct PropertyAccess            => Direct.Importer;
+    public static Direct Conversion                => Direct.Importer;
+    public static Direct Literal                   => Direct.Importer;
+    public static Direct LocalDeclaration          => Direct.Importer;
+    public static Direct MultipleLocalDeclarations => Direct.Importer;
+    public static Direct ObjectCreationExpression  => Direct.Importer;
+    public static Direct ExpressionStatement       => Direct.Importer;
+    public static Direct Block                     => Direct.Importer;
+    public static Direct FunctionPointerInvocation => Direct.Importer;
+    public static Direct HostObjectMemberReference => Direct.Importer;
+    public static Direct PreviousSubmissionReference => Direct.Importer;
+    public static Direct PointerElementAccess      => Direct.Importer;
+    public static Direct IndexerAccess             => Direct.Importer;
+    public static Direct AsOperator                => Direct.Importer;
+    public static Direct IsOperator                => Direct.Importer;
+    public static Direct StringConcat              => Direct.Importer;
+    public static Direct BasePatternSwitchLocalRewriter => Direct.Importer;
+    public static Direct ReturnStatement           => Direct.Importer;
+    public static Direct ThrowStatement            => Direct.Importer;
+    public static Direct GotoStatement             => Direct.Structuring;
+    public static Direct LabeledStatement          => Direct.Structuring;
+}
+
+/// <summary>
+/// An idiom Roslyn lowers to IL that the decompiler does not yet raise — the
+/// property's type marks the gap; <see cref="Form"/> is the C# shape we owe.
+/// </summary>
+internal sealed class NoImpl
+{
+    public string Form { get; }
+    public string? Issue { get; }
+
+    NoImpl(string form, string? issue) { Form = form; Issue = issue; }
+
+    public static NoImpl Owed(string form, string? issue = null) => new(form, issue);
+}
+
+/// <summary>
+/// A lowering with no dedicated raising pass: either the importer builds the
+/// construct directly (no distinct idiom to recover), or the structuring
+/// subsystem owns it (control-flow completeness is measured by <c>--gaps</c>,
+/// not this ledger).
+/// </summary>
+internal sealed class Direct
+{
+    public string Reason { get; }
+
+    Direct(string reason) { Reason = reason; }
+
+    public static Direct Importer { get; } = new("importer/printer builds it directly — no idiom to recover");
+    public static Direct Structuring { get; } = new("control-flow residual — completeness tracked by --gaps");
+}


### PR DESCRIPTION
Mechanizes the principle already stated in `docs/decompiler.md` — *"Roslyn's `Lowering/` directory is our completeness checklist"* — into a **compiler-checked artifact**. It answers "where does the decompiler emit valid-but-inferior C#" with an authoritative, enumerable denominator instead of a fuzzy oracle.

## What it is

One property per Roslyn `LocalRewriter` lowering (the authoritative 60-phase list, pulled from `dotnet/roslyn` `src/Compilers/CSharp/Portable/Lowering/LocalRewriter/`), **typed as the raising pass that inverts it**:

```csharp
public static SwitchRaisingPass  SwitchExpression  => new();   // implemented
public static NoImpl             UsingStatement    => NoImpl.Owed("using (var x = ...) { }");   // owed — roadmap
public static Direct             Call              => Direct.Importer;   // no idiom to recover
```

A PR that adds a raising pass **flips its one property** from `NoImpl` to the pass type — the ledger is the roadmap and the burn-down in one place. (Switch expressions, just landed in #694/#699, already map to `SwitchRaisingPass`.)

The type is `internal` and never invoked on a product path (trim-removable) — a build-time checklist, not a runtime component.

## Three states, deliberately

- **`<Pass>` type** — we invert this lowering with a dedicated pass.
- **`NoImpl`** — an idiom we owe (the actionable roadmap; carries the C# shape).
- **`Direct`** — the importer builds it directly (mechanical), or the structuring subsystem owns it (control-flow completeness is `--gaps`, not this ledger).

This keeps `NoImpl` meaning *"owed idiom"* rather than polluting the gap list with `Call`/`Field`/`BinaryOperator`.

## The tests keep it honest

- **drift** — `PropertySet_ExactlyMatchesRoslynLocalRewriters`: fails if Roslyn adds/removes a lowering the ledger doesn't account for (against a checked-in snapshot; re-fetch command is in the test).
- **no phantom** — `EveryImplementedEntry_IsRegisteredInThePipeline`: every pass-typed entry must actually be wired in `IrPasses.Default`.
- **ratchet** — `OwedIdioms_DoNotRegress`: the `NoImpl` count only goes down; the failure message prints the full owed-idiom roadmap.

## Current coverage (60 lowerings)

**18 raised**, **15 owed**, **27 direct**. The owed roadmap (the inferior-form surface): patterns (`is T`), `using`, `foreach`, string interpolation, range/index (`..`/`^`), tuples + deconstruction, `??=`, object/collection initializers, anonymous types, LINQ query, and async/iterator state machines.

This is the typed form of `--gaps`-for-idiom and the natural home for the "find inferior-form cases" work (issue #697 is the *validity* docket; this is the *idiom* one). ILSpy never enters the picture — the denominator is the compiler itself, matching the ildasm-over-ILSpy preference.

## Verification
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **344 passed** (3 new).
- Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)