### PR TITLE
Raise [LibraryImport] marshalling stubs (#697)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BoolToIntNormalizationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolToIntNormalizationPassTests.cs
@@ -1,0 +1,74 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class BoolToIntNormalizationPassTests
+{
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef UInt32 = TypeRef.CoreLib("System", "UInt32");
+
+    static IrFunction StoreOf(IrExpression value)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreLocal(0, Int32, value));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+    }
+
+    static StoreLocal RunAndGetStore(IrFunction function)
+    {
+        new BoolToIntNormalizationPass().Run(function, PassContext.None);
+        return (StoreLocal)function.Body.Blocks[0].Children[0];
+    }
+
+    [Fact]
+    public void BoolComparedGreaterThanZeroUnsigned_RaisesToConditional()
+    {
+        // `int V = bToUpper > false` — the cgt.un(bool, 0) bool→int marshalling
+        // idiom. Left flat it is CS0019; raised it is `bToUpper ? 1 : 0`.
+        var comparison = new Comparison(
+            ComparisonKind.GreaterThan, isUnsigned: true,
+            new LoadArgument(0, "bToUpper", Bool),
+            new Constant(false, Bool));
+
+        var store = RunAndGetStore(StoreOf(comparison));
+
+        var conditional = Assert.IsType<Conditional>(store.Value);
+        Assert.IsType<LoadArgument>(conditional.Condition);
+        Assert.Equal(1, Assert.IsType<Constant>(conditional.WhenTrue).Value);
+        Assert.Equal(0, Assert.IsType<Constant>(conditional.WhenFalse).Value);
+    }
+
+    [Fact]
+    public void NonBoolComparedGreaterThanZeroUnsigned_IsLeftAsComparison()
+    {
+        // cgt.un(x, 0) on a non-bool x is a genuine unsigned `x != 0` test
+        // (a null/zero check), not a bool→int normalization — it must survive.
+        var comparison = new Comparison(
+            ComparisonKind.GreaterThan, isUnsigned: true,
+            new LoadArgument(0, "count", UInt32),
+            new Constant(0, Int32));
+
+        var store = RunAndGetStore(StoreOf(comparison));
+
+        Assert.IsType<Comparison>(store.Value);
+    }
+
+    [Fact]
+    public void SignedBoolComparison_IsLeftAsComparison()
+    {
+        // Only the unsigned form is the normalization idiom; a signed comparison
+        // is not the shape the compiler emits for bool→int and is left alone.
+        var comparison = new Comparison(
+            ComparisonKind.GreaterThan, isUnsigned: false,
+            new LoadArgument(0, "flag", Bool),
+            new Constant(false, Bool));
+
+        var store = RunAndGetStore(StoreOf(comparison));
+
+        Assert.IsType<Comparison>(store.Value);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -997,6 +997,28 @@ public class CfgSampleClass
         }
     }
 
+    // Two pinned locals in one method — the [LibraryImport] custom-marshaller
+    // stub shape (one pin per marshalled argument). The compiler nests the pins
+    // LIFO (pin a, pin b, ..., unpin b, unpin a). FixedStatementPass must raise
+    // them into stacked `fixed` headers over a shared body, folding each pin's
+    // derived pointer into the `fixed` variable; a single-pinned-local guard
+    // would leave both flat as the unspellable `pinned ref int`. The loop deref
+    // keeps both pins alive through csc optimization (a single deref is elided).
+    // Deref directly (mirroring SumPinnedArray) rather than index — indexed `p[i]`
+    // renders as explicit pointer arithmetic that recompiles with extra conv
+    // chains, an unrelated rendering trait that would mask the pin fidelity.
+    public static unsafe int SumTwoPinned(int[] a, int[] b)
+    {
+        int sum = 0;
+        fixed (int* pa = &a[0])
+        fixed (int* pb = &b[0])
+        {
+            for (int i = 0; i < a.Length; i++)
+                sum += *pa + *pb;
+        }
+        return sum;
+    }
+
     public static unsafe nuint ArrayElementAddressAsNativeUInt(int[] values)
     {
         fixed (int* p = &values[0])

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -52,9 +52,9 @@ public class FidelityGateTests
     /// prefix, and the return-accumulator elimination must
     /// keep sinking the result temp out of an EH region or lock (TryFinallyAdd,
     /// TryFinallyTwoReturns, CatchEverything, ClassicLock,
-    /// ManualDisposeAsyncInFinally), and SumPinnedArray must keep raising the
-    /// csc pin lowering into a `fixed` statement whose derived pointer recompiles
-    /// opcode-exact (#622 item F).
+    /// ManualDisposeAsyncInFinally), and SumPinnedArray and SumTwoPinned must keep
+    /// raising the csc pin lowering into one or more `fixed` statements whose
+    /// derived pointers recompile opcode-exact (#622 item F; multi-pin #697).
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -71,6 +71,7 @@ public class FidelityGateTests
         "ClassicLock",
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
+        "SumTwoPinned",
         "ConstantUIntSpan",
         "InlineArraySpan",
     };

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -295,19 +295,43 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void PinnedLocal_DerivedPointerRendersAsPointerCast()
+    public void PinnedLocal_DerivedPointerFoldsIntoFixedVariable()
     {
-        // A pointer derived from the pinned local — IL conv.u over the pinned
-        // load into a pointer slot — must render as a pointer cast `(int*)V`, not
-        // a managed-reference-to-nuint conversion. Both lower to `ldloc; conv.u`,
-        // so the cast keeps the recompiled opcode stream faithful.
+        // csc derives the unmanaged pointer into its own local
+        // (`V_ptr = (int*)V_pin; ... *V_ptr`). FixedStatementPass folds that single
+        // derived pointer into the `fixed` variable itself, so the redundant copy
+        // and its `(int*)` cast disappear — the derived local IS the fixed pointer
+        // (`fixed (int* p = &values[0]) { ... *p }`). This recompiles to csc's own
+        // lowering (opcode-exact, PinnedExact) and never renders a
+        // managed-reference-to-nuint `(nuint)` conversion.
         var function = ImportFixture(nameof(CfgSampleClass.SumPinnedArray));
         IrPasses.Run(function);
         string output = CSharpPrinter.PrintRaised(function).Output!;
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
-        Assert.Contains("(int*)", output);
+        Assert.Single(function.Descendants.OfType<Fixed>());
+        Assert.DoesNotContain("(int*)", output);
         Assert.DoesNotContain("(nuint)", output);
+    }
+
+    [Fact]
+    public void MultiplePinnedLocals_RaiseToNestedFixedStatements()
+    {
+        // A [LibraryImport] custom-marshaller stub pins several arguments at once,
+        // so the method carries multiple `pinned ref` locals nested LIFO. The
+        // single-pinned-local guard left every such method flat as the unspellable
+        // `pinned ref int` (the dominant CoreLib CS1002 family). FixedStatementPass
+        // now nests them into stacked `fixed` headers over a shared body.
+        var function = ImportFixture(nameof(CfgSampleClass.SumTwoPinned));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(2, function.Descendants.OfType<Fixed>().Count());
+        Assert.Contains("fixed (int* ", output);
+        Assert.Contains("= &a[0])", output);
+        Assert.Contains("= &b[0])", output);
+        Assert.DoesNotContain("pinned", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -60,6 +60,7 @@ public class LoweredFidelityGateTests
         "CatchEverything",
         "ManualDisposeAsyncInFinally",
         "SumPinnedArray",
+        "SumTwoPinned",
         "ConstantUIntSpan",
         "InlineArraySpan",
     };

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BoolToIntNormalizationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BoolToIntNormalizationPass.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's bool→int normalization idiom back into a conditional.
+/// Converting a <c>bool</c> to an <c>int</c> (a <c>[LibraryImport]</c> stub
+/// marshalling a <c>bool</c> parameter to a 4-byte native int, among others)
+/// lowers to <c>ldarg b; ldc.i4.0; cgt.un</c> — an unsigned "greater than zero"
+/// that yields the strict 0/1 form of the bool:
+/// <code>
+///   int V_0 = bToUpper > false;   // cgt.un(bToUpper, 0)
+/// </code>
+/// Rendered literally that is <c>CS0019</c> (<c>&gt;</c> is not defined on two
+/// bools) and the method never binds. Recognized, it is exactly <c>bToUpper ? 1
+/// : 0</c> — the normalized int the idiom computes.
+///
+/// <para>The discriminator is the left operand's type: <c>cgt.un(x, 0)</c> on a
+/// non-bool <c>x</c> is a genuine unsigned <c>x != 0</c> test (a pointer or
+/// unsigned-int null check) and is left alone. Only a <c>bool</c> left operand
+/// makes the comparison a normalization, so the rewrite keys on it.</para>
+/// </summary>
+public sealed class BoolToIntNormalizationPass : IIrPass
+{
+    public string Name => "bool-to-int-normalization";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        var matches = function.Descendants
+            .OfType<Comparison>()
+            .Where(IsBoolToIntNormalization)
+            .ToList();
+
+        var intType = TypeRef.CoreLib("System", "Int32");
+        foreach (var comparison in matches)
+        {
+            var operand = (IrExpression)comparison.DetachChildren()[0];
+            var conditional = new Conditional(
+                operand,
+                new Constant(1, intType),
+                new Constant(0, intType));
+            context.Stepper.StepOver("raise bool→int normalization to conditional", comparison);
+            comparison.ReplaceWith(conditional);
+        }
+    }
+
+    /// <summary>An unsigned <c>cgt.un(boolExpr, 0/false)</c> — the bool→int normalization idiom.</summary>
+    static bool IsBoolToIntNormalization(Comparison comparison)
+        => comparison is { Kind: ComparisonKind.GreaterThan, IsUnsigned: true }
+            && comparison.Left.ResultType is { Namespace: "System", Name: "Boolean" }
+            && comparison.Right is Constant { Value: false or 0 or 0L };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
@@ -1,13 +1,15 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the csc pin lowering into a <see cref="Fixed"/> statement. C#'s
-/// <c>fixed (T* p = &amp;place) { ... }</c> compiles to a <c>pinned T&amp;</c>
-/// local assigned the managed reference, an unmanaged pointer derived from it
-/// (<c>ldloc; conv.u</c>) inside the pinned region, and — when the region ends
-/// before the method does — a store of zero into the local that unpins it:
+/// Raises the csc pin lowering into one or more nested <see cref="Fixed"/>
+/// statements. C#'s <c>fixed (T* p = &amp;place) { ... }</c> compiles to a
+/// <c>pinned T&amp;</c> local assigned the managed reference, an unmanaged
+/// pointer derived from it (<c>ldloc; conv.u</c>) inside the pinned region, and
+/// — when the region ends before the method does — a store of zero into the
+/// local that unpins it:
 /// <code>
 ///   pinned ref char V_0 = ref _firstChar;   // pin
 ///   uint* V_3 = (nuint)V_0;                  // derive pointer
@@ -17,105 +19,283 @@ namespace ILInspector.Decompiler.Pipeline;
 /// becomes <c>fixed (char* V_0 = &amp;_firstChar) { uint* V_3 = (uint*)V_0; ... }</c>.
 /// Left flat, the pinned local renders as the non-C# <c>pinned ref T</c> with a
 /// managed-reference-to-pointer cast that does not bind — every such method is
-/// syntactically malformed, so it contributes no validity/fidelity
-/// signal at all.
+/// syntactically malformed, so it contributes no validity/fidelity signal at
+/// all.
 ///
-/// <para>Scoped to the well-understood shape: exactly one pinned local, pinning
-/// a managed reference (<c>pinned T&amp;</c>), assigned once in the entry block,
-/// used only to derive pointers (every load feeds a <see cref="Convert"/>), and
-/// either never unpinned (the pin runs to method end — the fixed region is the
-/// whole tail) or unpinned by a single later store in the same block (the fixed
-/// region is the run between them). Anything outside this — multiple pinned
-/// locals, array/string pinning, an escaping or address-taken pinned local, a
-/// reference used before the pin or after the unpin — is left flat. The whole
-/// shape is proven before any node is detached.</para>
+/// <para>A <c>[LibraryImport]</c> source-generated stub pins several arguments
+/// at once (one <c>*Marshaller.GetPinnableReference</c> pin per marshalled
+/// parameter), producing several pinned locals in one method — the dominant
+/// <c>pinned ref</c>/<c>CS1002</c> family in CoreLib. These nest LIFO (last
+/// pinned, first unpinned), so the pass raises them into stacked <c>fixed</c>
+/// headers over a shared body.</para>
+///
+/// <para>Scoped to the well-understood shape: every pinned local pins a managed
+/// reference (<c>pinned T&amp;</c>), is assigned once in the entry block, used
+/// only to derive pointers (every load feeds a <see cref="Convert"/>), and is
+/// either never unpinned (the pin runs to the last use) or unpinned by a single
+/// later store in the same block. The shared body holds the pointer derives and
+/// their uses; statements that sit between two pins must be pure pointer derives
+/// (they are reordered under the innermost <c>fixed</c>, so they may not observe
+/// side effects), and a pin's source may not read a pinned slot or a
+/// body-written local (it is evaluated before the body). Anything outside this —
+/// an escaping or address-taken pinned local, a non-derive wedged between pins,
+/// a pin source that depends on the body — leaves the whole method flat. The
+/// entire shape is proven before any node is detached.</para>
 /// </summary>
 public sealed class FixedStatementPass : IIrPass
 {
     public string Name => "fixed-statement";
 
+    /// <summary>A proven pinned local: the slot, the pointed-to element type, the defining pin store, and the optional unpin store that ends its region.</summary>
+    private sealed record PinnedShape(int Slot, TypeRef ElementType, StoreLocal DefStore, StoreLocal? Unpin);
+
     public void Run(IrFunction function, PassContext context)
     {
-        // Exactly one pinned local, pinning a managed reference. More than one,
-        // or a pinned array/string (a non-byref pinned element), is out of scope.
-        var pinned = Enumerable.Range(0, function.Locals.Length)
-            .Where(i => function.Locals[i].Kind == TypeRefKind.Pinned)
-            .ToList();
-        if (pinned is not [int idx]
-            || function.Locals[idx].ElementType is not { Kind: TypeRefKind.ByRef } byRef)
-        {
+        // Every pinned local pins a managed reference (`pinned T&`). A pinned
+        // array/string (a non-byref pinned element) is out of scope.
+        var pinnedSlots = Enumerable.Range(0, function.Locals.Length)
+            .Where(i => function.Locals[i].Kind == TypeRefKind.Pinned
+                && function.Locals[i].ElementType is { Kind: TypeRefKind.ByRef })
+            .ToHashSet();
+        if (pinnedSlots.Count == 0)
             return;
-        }
 
         if (function.Body.Blocks.Count == 0)
             return;
         var entry = function.Body.Blocks[0];
 
-        // The pinned slot's stores: a single defining store, plus at most one
-        // unpinning store (a store of null/zero that ends the pinned region).
-        var stores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == idx).ToList();
+        // Prove each pinned slot independently. A pinned slot that fails its
+        // proof aborts the whole rewrite: a half-raised method would mix `fixed`
+        // with a leftover `pinned ref`, which is worse than leaving it all flat.
+        var pins = new List<PinnedShape>(pinnedSlots.Count);
+        foreach (var slot in pinnedSlots)
+        {
+            if (!TryProvePin(function, entry, slot, out var shape))
+                return;
+            pins.Add(shape);
+        }
+
+        // The first-pinned slot becomes the outermost `fixed`.
+        pins.Sort((a, b) => a.DefStore.ChildIndex - b.DefStore.ChildIndex);
+        int firstPin = pins[0].DefStore.ChildIndex;
+        int lastPin = pins[^1].DefStore.ChildIndex;
+
+        var pinStores = pins.Select(p => p.DefStore).ToHashSet();
+        var unpins = pins.Where(p => p.Unpin is not null).Select(p => p.Unpin!).ToHashSet();
+
+        // csc derives the unmanaged pointer one of two ways. When the pinned slot
+        // is consumed inline with no copy — passed straight into a call or
+        // dereferenced through its own Convert (the [LibraryImport] GetCalendars
+        // shape) — the pinned slot itself is the `fixed` pointer variable. When the
+        // pointer is instead copied once into its own local (`V_ptr = (T*)V_pin;
+        // ... *V_ptr ...` — the SumPinnedArray shape and the indexed multi-pin
+        // stubs), that copy is the redundant tail of the pin: the derived local IS
+        // the fixed pointer. Fold it — use the derived slot as the `fixed` variable
+        // and drop the copy — so the rendered `fixed` recompiles to csc's own
+        // lowering (opcode-exact) rather than re-pinning a temp and copying it. A
+        // pin is foldable when its slot is read exactly once across the method, that
+        // read is the value of a single derived-pointer store into a non-pinned
+        // entry-block slot, and that slot has no other defining store.
+        var foldedDerives = new Dictionary<int, StoreLocal>();
+        foreach (var pin in pins)
+        {
+            if (FoldTarget(function, entry, pinnedSlots, pin.Slot) is { } derive)
+                foldedDerives[pin.Slot] = derive;
+        }
+        int FixedLocal(PinnedShape pin)
+            => foldedDerives.TryGetValue(pin.Slot, out var d) ? d.Index : pin.Slot;
+
+        // Non-pinned slots holding a pointer derived from a pin (`void* V = (nuint)V_pin`).
+        // A use of one of these after the pin ends is invalid scoping, so any
+        // statement reading one must stay under the `fixed` with the derives.
+        var derivedSlots = entry.Children.OfType<StoreLocal>()
+            .Where(s => !pinnedSlots.Contains(s.Index)
+                && StripConverts(s.Value) is LoadLocal source && pinnedSlots.Contains(source.Index))
+            .Select(s => s.Index)
+            .ToHashSet();
+
+        // The fixed body runs from the first pin to the last statement that uses
+        // a pinned slot or a pin-derived pointer (the unpin stores, which we
+        // drop, do not count). The window also covers every unpin so each is
+        // dropped rather than left dangling as a write to an out-of-scope local.
+        int lastUse = firstPin;
+        foreach (var child in entry.Children)
+        {
+            if (child.ChildIndex <= firstPin || pinStores.Contains(child) || unpins.Contains(child))
+                continue;
+            if (ReferencesAnySlot(child, pinnedSlots, derivedSlots))
+                lastUse = child.ChildIndex;
+        }
+        int windowEnd = lastUse;
+        foreach (var unpin in unpins)
+            windowEnd = System.Math.Max(windowEnd, unpin.ChildIndex);
+
+        var bodyStmts = entry.Children
+            .Where(c => c.ChildIndex > firstPin && c.ChildIndex <= windowEnd
+                && !pinStores.Contains(c) && !unpins.Contains(c))
+            .OrderBy(c => c.ChildIndex)
+            .ToList();
+
+        // A body statement wedged before the innermost pin is reordered under it,
+        // so it must be a pure pointer derive (a store of a pin-derived pointer)
+        // with no side effect to observe. Anything else is rejected.
+        foreach (var stmt in bodyStmts)
+        {
+            if (stmt.ChildIndex < lastPin && !IsPointerDerive(stmt, pinnedSlots))
+                return;
+        }
+
+        // Each pin source is evaluated before the body, so it may not read a
+        // pinned slot or a body-written local — either would move relative to it.
+        var bodyWritten = bodyStmts.OfType<StoreLocal>().Select(s => s.Index).ToHashSet();
+        foreach (var pin in pins)
+        {
+            foreach (var load in Loads(pin.DefStore.Value))
+            {
+                if (pinnedSlots.Contains(load.Index) || bodyWritten.Contains(load.Index))
+                    return;
+            }
+        }
+
+        // Every reference to a pinned slot must live in a body statement, so
+        // dropping the pin/unpin stores cannot orphan a use.
+        foreach (var node in function.Descendants)
+        {
+            if (node is LoadLocal l && pinnedSlots.Contains(l.Index)
+                && !bodyStmts.Any(stmt => IsInside(node, stmt)))
+            {
+                return;
+            }
+        }
+
+        // Shape proven — detach the body, drop the inner pins and every unpin,
+        // and nest the fixed statements (innermost first) over the shared body.
+        // A folded derive store is dropped: its derived slot is promoted to the
+        // `fixed` variable, so the copy is redundant.
+        var droppedDerives = foldedDerives.Values.ToHashSet();
+        foreach (var stmt in bodyStmts)
+            stmt.Detach();
+        foreach (var pin in pins.Skip(1))
+            pin.DefStore.Detach();
+        foreach (var unpin in unpins)
+            unpin.Detach();
+
+        var body = new BlockContainer();
+        var bodyBlock = new Block(entry.StartOffset);
+        foreach (var stmt in bodyStmts)
+            if (!droppedDerives.Contains(stmt))
+                bodyBlock.Add(stmt);
+        body.Add(bodyBlock);
+
+        for (int i = pins.Count - 1; i >= 1; i--)
+        {
+            var pin = pins[i];
+            var pinSource = (IrExpression)pin.DefStore.DetachChildren()[0];
+            var inner = new Fixed(pin.ElementType, FixedLocal(pin), pinSource, body);
+            var wrapper = new BlockContainer();
+            var wrapperBlock = new Block(entry.StartOffset);
+            wrapperBlock.Add(inner);
+            wrapper.Add(wrapperBlock);
+            body = wrapper;
+        }
+
+        var outer = pins[0];
+        var outerSource = (IrExpression)outer.DefStore.DetachChildren()[0];
+        var outerFixed = new Fixed(outer.ElementType, FixedLocal(outer), outerSource, body);
+        context.Stepper.StepOver("raise pinned locals to fixed statements", outer.DefStore);
+        outer.DefStore.ReplaceWith(outerFixed);
+    }
+
+    /// <summary>
+    /// Proves the single-pinned-local shape for <paramref name="slot"/>: one
+    /// defining pin store in the entry block assigning a managed reference (not a
+    /// value-type receiver's <c>this</c>), at most one later unpin store, and
+    /// every load feeding a pointer-deriving <see cref="Convert"/> (no address-of).
+    /// </summary>
+    static bool TryProvePin(IrFunction function, Block entry, int slot, out PinnedShape shape)
+    {
+        shape = null!;
+        if (function.Locals[slot].ElementType is not { Kind: TypeRefKind.ByRef } byRef)
+            return false;
+
+        var stores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == slot).ToList();
         if (stores is not [var defStore, ..] || !ReferenceEquals(defStore.Parent, entry))
-            return;
+            return false;
         if (defStore.Value.ResultType is not { Kind: TypeRefKind.ByRef })
-            return;
+            return false;
         // Pinning `this` (a value-type receiver's `ldarg.0`) has no `&this`
         // spelling; leave it flat. A static method's first parameter is also
         // index 0 but is a normal `&param`, so key on the receiver name.
         if (defStore.Value is LoadArgument { Index: 0, Name: "this" })
-            return;
+            return false;
 
         StoreLocal? unpin = null;
         if (stores.Count == 2 && IsUnpin(stores[1]) && ReferenceEquals(stores[1].Parent, entry))
             unpin = stores[1];
         else if (stores.Count != 1)
-            return;
+            return false;
 
-        // Every other reference to the pinned slot must be a load that derives a
-        // pointer (feeds a Convert). An address-of the pinned local, or a load
-        // used some other way, is a shape this rewrite does not model.
         foreach (var node in function.Descendants)
         {
             switch (node)
             {
-                case LoadLocalAddress a when a.Index == idx:
-                    return;
-                case LoadLocal l when l.Index == idx && l.Parent is not Convert:
-                    return;
+                case LoadLocalAddress a when a.Index == slot:
+                    return false;
+                case LoadLocal l when l.Index == slot && l.Parent is not Convert:
+                    return false;
             }
         }
 
-        int d = defStore.ChildIndex;
-        int end = unpin?.ChildIndex ?? entry.Children.Count;
-        if (unpin is not null && end <= d)
-            return;
-        var scope = entry.Children.Skip(d + 1).Take(end - (d + 1)).ToList();
+        shape = new PinnedShape(slot, byRef.ElementType!, defStore, unpin);
+        return true;
+    }
 
-        // The pinned region must lexically contain every pinned-local reference:
-        // each load lives in one of the statements between the pin and the unpin
-        // (or method end). A reference outside that run cannot be brought under
-        // the fixed block without reordering, so the whole shape is rejected.
-        foreach (var node in function.Descendants)
-        {
-            bool refsPin = node is LoadLocal l && l.Index == idx;
-            if (refsPin && !scope.Any(stmt => IsInside(node, stmt)))
-                return;
-        }
+    /// <summary>
+    /// Returns the single derived-pointer store <c>V_ptr = (T*)V_pin</c> that a
+    /// foldable pin's slot feeds, or null when the pin is not foldable (the slot
+    /// is dereferenced inline, read more than once, or its derived slot is not a
+    /// once-assigned non-pinned local). When non-null, the derived slot becomes
+    /// the <c>fixed</c> pointer variable and the store is dropped.
+    /// </summary>
+    static StoreLocal? FoldTarget(IrFunction function, Block entry, IReadOnlySet<int> pinnedSlots, int slot)
+    {
+        var loads = function.Descendants.OfType<LoadLocal>().Where(l => l.Index == slot).ToList();
+        if (loads.Count != 1)
+            return null;
 
-        // Shape proven — detach the scope statements into the fixed body, drop
-        // the unpin, and replace the defining store with the fixed statement.
-        var body = new BlockContainer();
-        var bodyBlock = new Block(entry.StartOffset);
-        foreach (var stmt in scope)
-        {
-            stmt.Detach();
-            bodyBlock.Add(stmt);
-        }
-        body.Add(bodyBlock);
-        unpin?.Detach();
-        var pinSource = (IrExpression)defStore.DetachChildren()[0];
-        var fixedNode = new Fixed(byRef.ElementType!, idx, pinSource, body);
-        context.Stepper.StepOver("raise pinned local to fixed statement", defStore);
-        defStore.ReplaceWith(fixedNode);
+        // Climb the pointer-deriving converts above the single load to its store.
+        IrNode node = loads[0];
+        while (node.Parent is Convert convert)
+            node = convert;
+        if (node.Parent is not StoreLocal derive
+            || pinnedSlots.Contains(derive.Index)
+            || !ReferenceEquals(derive.Parent, entry))
+            return null;
+
+        // The derived slot must be defined only by this store, so promoting it to
+        // the fixed variable cannot drop a second assignment.
+        var derivedStores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == derive.Index).ToList();
+        return derivedStores.Count == 1 ? derive : null;
+    }
+
+    /// <summary>A pure pointer derive: a store of a pin-derived pointer (<c>V = (nuint)V_pin</c>) into a non-pinned slot — no side effect to observe under reordering.</summary>
+    static bool IsPointerDerive(IrNode stmt, IReadOnlySet<int> pinnedSlots)
+        => stmt is StoreLocal store
+            && !pinnedSlots.Contains(store.Index)
+            && StripConverts(store.Value) is LoadLocal load
+            && pinnedSlots.Contains(load.Index);
+
+    static bool ReferencesAnySlot(IrNode root, IReadOnlySet<int> pinnedSlots, IReadOnlySet<int> derivedSlots)
+        => Loads(root).Any(l => pinnedSlots.Contains(l.Index) || derivedSlots.Contains(l.Index));
+
+    static IEnumerable<LoadLocal> Loads(IrNode root)
+        => root.Descendants.Prepend(root).OfType<LoadLocal>();
+
+    static IrExpression StripConverts(IrExpression value)
+    {
+        while (value is Convert convert)
+            value = convert.Operand;
+        return value;
     }
 
     /// <summary>A store that ends the pinned region: null or zero, possibly through a conv to a native pointer.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -85,6 +85,11 @@ public static class IrPasses
         // operator at the use site, so a[--i] = src[j++] recompiles to the same
         // dup rather than spilling the captured value to extra locals.
         new IncrementDecrementPass(),
+        // Raise the compiler's bool→int normalization (cgt.un(boolExpr, 0), the
+        // [LibraryImport] bool-marshalling shape) back into `b ? 1 : 0`. Left
+        // flat it renders `b > false` (CS0019) and the method never binds. Runs
+        // after inlining so the bool operand is in its final position.
+        new BoolToIntNormalizationPass(),
         // With structuring done, a spilled base/this constructor argument is a
         // folded expression (base(message ?? "default")); collapse it into the
         // chain call so the call lands as the body's first statement and the


### PR DESCRIPTION
Closes #697.

Improves decompiler validity (does rendered C# compile) for the `[LibraryImport]` source-generated marshalling stubs that dominate CoreLib's syntactically-malformed set.

## Changes

**`FixedStatementPass` — generalize to N pinned locals.** The pass raised only a single pinned local; a `[LibraryImport]` stub pins one argument per marshalled parameter, producing several `pinned ref` locals nested LIFO. These now raise into stacked `fixed` headers over a shared body. Left flat each rendered as the unspellable `pinned ref T` (CS1002), the top malformedness driver.

Each pin's single derived-pointer copy (`V_ptr = (T*)V_pin`) is **folded into the `fixed` variable** itself, so the rendered `fixed` recompiles to csc's own lowering opcode-exact instead of re-pinning a temp + copy. This also cleans the existing single-pin case.

**`BoolToIntNormalizationPass` (new).** The bool→int marshalling idiom `cgt.un(boolExpr, 0)` rendered literally as `b > false` (CS0019: `>` not defined on two bools). Rewritten to `b ? 1 : 0`. Keyed on a `bool` left operand, so a genuine unsigned `x != 0` on a pointer/uint is left alone.

## Validity deltas (corpus `--validity-check`, 38204 methods)

| metric | before | after |
| --- | --- | --- |
| Full malformed | 1063 (2.78%) | **1014 (2.66%)** (−49) |
| CS0019 | 83 | **56** (−27) |
| CS0030 | 101 | **98** |

Concretely: `Interop.Globalization::GetCalendars` now raises nested `fixed` blocks (was `pinned ref CalendarId`); `Interop.Globalization::ChangeCase` renders `int V_0 = bToUpper ? 1 : 0;` (was `bToUpper > false`).

## Tests

- New `SumTwoPinned` fixture, locked into both fidelity gates' `PinnedExact` set (recompiles opcode-exact).
- `MultiplePinnedLocals_RaiseToNestedFixedStatements`, `BoolToIntNormalizationPassTests` (3), and the repurposed `PinnedLocal_DerivedPointerFoldsIntoFixedVariable`.
- 344 decompiler + 1157 product tests green.

## Follow-up (not in scope)

The `GetSortHandle` family pins inside a `try/finally` with a stateful marshaller (unpin in the `finally` block); the entry-block-scoped pass correctly leaves it flat.