### PR TITLE
Printer decomposition 1/3: extract pure C# name utilities into CSharpNaming

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -1,0 +1,64 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Pure C# identifier and name spelling utilities used by <see cref="CSharpPrinter"/>:
+/// reserved-keyword recognition, usable-identifier validation, and the decoding of
+/// compiler-generated metadata names (auto-property backing fields, local-function
+/// mangled names) back to their source spelling. These are stateless functions of
+/// their string inputs — they hold no per-function printer state.
+/// </summary>
+internal static class CSharpNaming
+{
+    /// <summary>A name safe to emit bare as a C# identifier: letters/digits/underscore, no leading digit, and not a reserved keyword (which would need an <c>@</c> escape).</summary>
+    public static bool IsUsableIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
+            return false;
+        foreach (char c in name)
+        {
+            if (!(char.IsLetterOrDigit(c) || c == '_'))
+                return false;
+        }
+        return !ReservedKeywords.Contains(name);
+    }
+
+    static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while",
+    };
+
+    /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>
+    public static string? BackingFieldProperty(string fieldName)
+    {
+        const string suffix = ">k__BackingField";
+        return fieldName.Length > suffix.Length + 1 && fieldName[0] == '<' && fieldName.EndsWith(suffix, StringComparison.Ordinal)
+            ? fieldName[1..^suffix.Length]
+            : null;
+    }
+
+    /// <summary>
+    /// The source name of a call target. A compiler-generated local function
+    /// carries the metadata name <c>&lt;Enclosing&gt;g__Local|N_M</c>, which is
+    /// not a valid C# identifier; the source name is the segment between
+    /// <c>g__</c> and the <c>|</c> ordinal suffix.
+    /// </summary>
+    public static string MethodName(string name)
+    {
+        if (!name.StartsWith('<'))
+            return name;
+        int marker = name.IndexOf("g__", StringComparison.Ordinal);
+        if (marker < 0)
+            return name;
+        int start = marker + 3;
+        int bar = name.IndexOf('|', start);
+        return bar > start ? name[start..bar] : name[start..];
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1746,7 +1746,7 @@ public sealed class CSharpPrinter
         // C# name; render it as the property it backs. `this.` qualifies the
         // instance form so a constructor assignment whose parameter shadows the
         // property still binds to it (and is legal even for a get-only property).
-        if (BackingFieldProperty(field.Name) is { } property)
+        if (CSharpNaming.BackingFieldProperty(field.Name) is { } property)
             return instance switch
             {
                 null => $"{TypeText(field.DeclaringType)}.{property}",
@@ -1793,7 +1793,7 @@ public sealed class CSharpPrinter
                     taken.Add(parameter.Name);
                 for (int i = 0; i < count && i < names.Length; i++)
                 {
-                    if (names[i] is { } name && IsUsableIdentifier(name) && taken.Add(name))
+                    if (names[i] is { } name && CSharpNaming.IsUsableIdentifier(name) && taken.Add(name))
                         display[i] = name;
                 }
             }
@@ -1801,32 +1801,6 @@ public sealed class CSharpPrinter
         }
         return index >= 0 && index < _localDisplayNames.Length ? _localDisplayNames[index] : $"V_{index}";
     }
-
-    /// <summary>A name safe to emit bare as a C# identifier: letters/digits/underscore, no leading digit, and not a reserved keyword (which would need an <c>@</c> escape).</summary>
-    static bool IsUsableIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
-            return false;
-        foreach (char c in name)
-        {
-            if (!(char.IsLetterOrDigit(c) || c == '_'))
-                return false;
-        }
-        return !ReservedKeywords.Contains(name);
-    }
-
-    static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
-    {
-        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
-        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
-        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
-        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
-        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
-        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
-        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
-        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while",
-    };
 
     /// <summary>
     /// True when an instance-method parameter or local would shadow a field of
@@ -1845,15 +1819,6 @@ public sealed class CSharpPrinter
                 _localScopeNames.Add(LocalName(i));
         }
         return _localScopeNames.Contains(fieldName);
-    }
-
-    /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>
-    static string? BackingFieldProperty(string fieldName)
-    {
-        const string suffix = ">k__BackingField";
-        return fieldName.Length > suffix.Length + 1 && fieldName[0] == '<' && fieldName.EndsWith(suffix, StringComparison.Ordinal)
-            ? fieldName[1..^suffix.Length]
-            : null;
     }
 
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
@@ -1899,7 +1864,7 @@ public sealed class CSharpPrinter
     /// </summary>
     string MethodGroupText(MethodRef method, IrExpression target)
     {
-        string name = MethodName(method.Name);
+        string name = CSharpNaming.MethodName(method.Name);
         if (target is Constant { Value: null })
             return $"{TypeText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
@@ -1919,28 +1884,10 @@ public sealed class CSharpPrinter
         string typeArguments = method.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", method.TypeArguments.Select(TypeText))}>";
-        string name = $"{MethodName(method.Name)}{typeArguments}";
+        string name = $"{CSharpNaming.MethodName(method.Name)}{typeArguments}";
         return IsCrossType(method.DeclaringType)
             ? $"&{TypeText(method.DeclaringType)}.{name}"
             : $"&{name}";
-    }
-
-    /// <summary>
-    /// The source name of a call target. A compiler-generated local function
-    /// carries the metadata name <c>&lt;Enclosing&gt;g__Local|N_M</c>, which is
-    /// not a valid C# identifier; the source name is the segment between
-    /// <c>g__</c> and the <c>|</c> ordinal suffix.
-    /// </summary>
-    static string MethodName(string name)
-    {
-        if (!name.StartsWith('<'))
-            return name;
-        int marker = name.IndexOf("g__", StringComparison.Ordinal);
-        if (marker < 0)
-            return name;
-        int start = marker + 3;
-        int bar = name.IndexOf('|', start);
-        return bar > start ? name[start..bar] : name[start..];
     }
 
     string CallText(Call call)
@@ -1955,7 +1902,7 @@ public sealed class CSharpPrinter
             // operator spelling is the faithful inverse.
             if (IsOperatorCall(call))
                 return OperatorSpelling(call)!;
-            return $"{TypeText(call.Callee.DeclaringType)}.{MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+            return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
@@ -1970,10 +1917,10 @@ public sealed class CSharpPrinter
             // Non-virtual this-receiver call to a base-declared method is
             // C#'s base.M() — the call opcode deliberately skips dispatch.
             return !call.IsVirtual && IsCrossType(call.Callee.DeclaringType)
-                ? $"base.{MethodName(call.Callee.Name)}{typeArguments}({rest})"
-                : $"{MethodName(call.Callee.Name)}{typeArguments}({rest})";
+                ? $"base.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})"
+                : $"{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
-        return $"{ReceiverText(receiver)}.{MethodName(call.Callee.Name)}{typeArguments}({rest})";
+        return $"{ReceiverText(receiver)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})";
     }
 
     string Arguments(IEnumerable<IrExpression> arguments)
@@ -2088,7 +2035,7 @@ public sealed class CSharpPrinter
         string typeArguments = call.Callee.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
-        return $".{MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+        return $".{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
     }
 
     string ConvertText(Convert convert)


### PR DESCRIPTION
## Printer decomposition 1/3 — extract pure name utilities

Acts on the optional follow-up from the **decompiler architecture review (A− → A)**:
the printer (`CSharpPrinter`, 2203 LOC, the largest file) has quietly accumulated
the last-mile spelling logic the architecture's own narrative says lives elsewhere.
The review's suggestion is to split it into the tree-walk visitor + a cast/spelling
policy module + name utilities. This is the **first, lowest-risk slice**: the name
utilities.

### What moved

A new pure `CSharpNaming` static module gets the stateless name helpers:

- `IsUsableIdentifier` + `ReservedKeywords` — usable-identifier / keyword recognition
- `BackingFieldProperty` — decode `<Prop>k__BackingField` → `Prop`
- `MethodName` — decode a local-function mangled name `<Enclosing>g__Local|N_M` → `Local`

These are functions of their string inputs only — they held **no** per-function
printer state, so the move is verbatim and behavior-preserving. Call sites now read
`CSharpNaming.X` directly (no forwarders). `CSharpPrinter` drops 2203 → 2150 LOC.

### Verification

- **340/340 `ILInspector.Decompiler.Tests`** green. The suite asserts printer
  output directly, including `BackingField_RendersAsProperty` and the
  local-function `g__` decoding that exercise the moved logic.
- Verbatim extraction: identical code, identical call semantics.

### Next slices (separate PRs)

2. Cast / numeric spelling policy (`CastValue`, `NumericConstant`, shift-mask, NaN rules) → a policy module.
3. Promote the embedded `DefiniteFlow` definite-assignment analysis (~640 LOC) to a tree-annotating pass the printer reads.
