### PR TITLE
Extend the lowering ledger: ClosureConversion + NativePasses registers (a pipeline partition)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -4,13 +4,14 @@ using ILInspector.Decompiler.Pipeline;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Guards the <see cref="LoweringCoverage"/> ledger — the two-axis completeness
-/// checklist mapping each Roslyn <c>LocalRewriter</c> lowering to a mechanism (the
-/// property type: a raising pass, <see cref="ImporterNative"/>, or
-/// <see cref="Unhandled"/>) and a completeness level (the
-/// <see cref="CompletenessAttribute"/>). These keep it honest: it cannot drift
-/// from Roslyn, claim an unregistered pass, violate the cross-axis invariants, or
-/// let owed-idiom coverage regress.
+/// Guards the lowering ledger — a self-checking map of the whole pipeline.
+/// Two Roslyn-forward registers (<see cref="LoweringCoverage"/> for
+/// <c>LocalRewriter</c>, <see cref="ClosureCoverage"/> for closures) map each
+/// compiler lowering to a mechanism (the property type) and a completeness level
+/// (<see cref="CompletenessAttribute"/>); <see cref="NativePasses"/> captures the
+/// passes that invert no Roslyn lowering. These tests enforce the cross-axis
+/// invariants, the Roslyn drift check, the owed ratchet, and the partition: every
+/// <see cref="IrPasses.Default"/> pass is classified by exactly one register.
 /// </summary>
 public class LoweringCoverageTests
 {
@@ -38,25 +39,26 @@ public class LoweringCoverageTests
         "WhileStatement", "Yield",
     ];
 
-    // Ratchet: owed idioms (mechanism Unhandled / completeness None) only go DOWN.
-    // Implementing one lowers it; tighten this in that PR.
-    const int OwedCeiling = 15;
+    // Roslyn-forward registers: mechanism is the property type, completeness is the
+    // attribute. Owed (None/Unhandled) only ratchets DOWN — implementing one lowers it.
+    static readonly (Type Type, int OwedCeiling, string Name)[] CoverageRegisters =
+    [
+        (typeof(LoweringCoverage), 15, "LocalRewriter"),
+        (typeof(ClosureCoverage), 4, "ClosureConversion"),
+    ];
 
-    static PropertyInfo[] Ledger() =>
-        typeof(LoweringCoverage).GetProperties(BindingFlags.Public | BindingFlags.Static);
-
+    static PropertyInfo[] Props(Type t) => t.GetProperties(BindingFlags.Public | BindingFlags.Static);
     static bool IsPass(PropertyInfo p) => typeof(IIrPass).IsAssignableFrom(p.PropertyType);
 
-    // NOTE: keep the internal CompletenessLevel / CompletenessAttribute types out
-    // of any member SIGNATURE here — the fidelity gate reconstructs this test
-    // assembly as a whole-module skeleton and a signature referencing an internal
-    // decompiler type fails to recompile. Read the attribute inside method bodies
-    // only (skeleton stubs erase bodies).
+    // NOTE: keep the internal CompletenessLevel / CompletenessAttribute / NativeAttribute
+    // types out of any member SIGNATURE here — the fidelity gate reconstructs this
+    // test assembly as a whole-module skeleton and a signature referencing an
+    // internal decompiler type fails to recompile. Read them inside method bodies.
 
     [Fact]
     public void PropertySet_ExactlyMatchesRoslynLocalRewriters()
     {
-        var properties = Ledger().Select(p => p.Name).ToHashSet();
+        var properties = Props(typeof(LoweringCoverage)).Select(p => p.Name).ToHashSet();
         var roslyn = RoslynLocalRewriters.ToHashSet();
 
         var missing = roslyn.Except(properties).Order().ToArray();
@@ -70,61 +72,77 @@ public class LoweringCoverageTests
     }
 
     [Fact]
-    public void CrossAxisInvariants_Hold()
+    public void CoverageRegisters_CrossAxisInvariants_Hold()
     {
         var registered = IrPasses.Default.Select(p => p.GetType()).ToHashSet();
 
-        foreach (var p in Ledger())
-        {
-            var attr = p.GetCustomAttribute<CompletenessAttribute>();
-            Assert.True(attr is not null, $"{p.Name}: missing [Completeness] — every entry states its completeness axis.");
-            var level = attr!.Level;
-
-            if (p.PropertyType == typeof(ImporterNative))
-                Assert.True(level == CompletenessLevel.Full, $"{p.Name}: importer-native must be Full (it is built directly).");
-            else if (p.PropertyType == typeof(Unhandled))
-                Assert.True(level == CompletenessLevel.None, $"{p.Name}: Unhandled must be None (no mechanism).");
-            else if (IsPass(p))
+        foreach (var (type, _, name) in CoverageRegisters)
+            foreach (var p in Props(type))
             {
-                Assert.True(level is CompletenessLevel.Full or CompletenessLevel.Partial,
-                    $"{p.Name}: a pass-handled lowering is Full or Partial, not None.");
-                Assert.True(registered.Contains(p.PropertyType),
-                    $"{p.Name} -> {p.PropertyType.Name}: pass is not registered in IrPasses.Default.");
+                var attr = p.GetCustomAttribute<CompletenessAttribute>();
+                Assert.True(attr is not null, $"{name}.{p.Name}: missing [Completeness] — every entry states its completeness axis.");
+                var level = attr!.Level;
+
+                if (p.PropertyType == typeof(ImporterNative))
+                    Assert.True(level == CompletenessLevel.Full, $"{name}.{p.Name}: importer-native must be Full.");
+                else if (p.PropertyType == typeof(Unhandled))
+                    Assert.True(level == CompletenessLevel.None, $"{name}.{p.Name}: Unhandled must be None.");
+                else if (IsPass(p))
+                {
+                    Assert.True(level is CompletenessLevel.Full or CompletenessLevel.Partial,
+                        $"{name}.{p.Name}: a pass-handled lowering is Full or Partial, not None.");
+                    Assert.True(registered.Contains(p.PropertyType),
+                        $"{name}.{p.Name} -> {p.PropertyType.Name}: pass is not registered in IrPasses.Default.");
+                }
+                else
+                    Assert.Fail($"{name}.{p.Name}: unknown mechanism type {p.PropertyType.Name} (expected a pass, ImporterNative, or Unhandled).");
             }
-            else
-                Assert.Fail($"{p.Name}: unknown mechanism type {p.PropertyType.Name} (expected a pass, ImporterNative, or Unhandled).");
+    }
+
+    [Fact]
+    public void CoverageRegisters_OwedDoNotRegress()
+    {
+        foreach (var (type, ceiling, name) in CoverageRegisters)
+        {
+            var owed = Props(type).Where(p => p.PropertyType == typeof(Unhandled))
+                .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
+
+            Assert.True(owed.Length <= ceiling,
+                $"{name}: owed rose to {owed.Length} (ceiling {ceiling}). Implementing one lowers it; if Roslyn added a lowering, account for it.\n  "
+                    + string.Join("\n  ", owed));
         }
     }
 
     [Fact]
-    public void OwedIdioms_DoNotRegress_AndReportBothAxes()
+    public void NativePasses_AreRegistered_AndDisjointFromCoverage()
     {
-        var props = Ledger();
+        var registered = IrPasses.Default.Select(p => p.GetType()).ToHashSet();
+        var coveragePassTypes = CoverageRegisters.SelectMany(r => Props(r.Type)).Where(IsPass).Select(p => p.PropertyType).ToHashSet();
 
-        // Specialization gradient (derived): a pass used by one property is
-        // dedicated; by several, a shared/general pass.
-        var passUsage = props.Where(IsPass).GroupBy(p => p.PropertyType).ToDictionary(g => g.Key, g => g.Count());
+        foreach (var p in Props(typeof(NativePasses)))
+        {
+            Assert.True(IsPass(p), $"NativePasses.{p.Name}: must be a pass type ({p.PropertyType.Name} is not an IIrPass).");
+            Assert.True(p.GetCustomAttribute<NativeAttribute>() is not null, $"NativePasses.{p.Name}: missing [Native] — say what it reconstructs.");
+            Assert.True(registered.Contains(p.PropertyType), $"NativePasses.{p.Name} -> {p.PropertyType.Name}: not in IrPasses.Default.");
+            Assert.False(coveragePassTypes.Contains(p.PropertyType),
+                $"NativePasses.{p.Name}: {p.PropertyType.Name} also inverts a Roslyn lowering — it belongs in a coverage register, not here.");
+        }
+    }
 
-        int dedicated = passUsage.Count(kv => kv.Value == 1);
-        int shared = passUsage.Count(kv => kv.Value > 1);
-        int sharedProps = passUsage.Where(kv => kv.Value > 1).Sum(kv => kv.Value);
-        int importer = props.Count(p => p.PropertyType == typeof(ImporterNative));
+    [Fact]
+    public void EveryPipelinePass_IsClassified_ExactlyOnce()
+    {
+        var defaultTypes = IrPasses.Default.Select(p => p.GetType()).ToHashSet();
+        var coveragePassTypes = CoverageRegisters.SelectMany(r => Props(r.Type)).Where(IsPass).Select(p => p.PropertyType).ToHashSet();
+        var nativeTypes = Props(typeof(NativePasses)).Select(p => p.PropertyType).ToHashSet();
+        var classified = coveragePassTypes.Concat(nativeTypes).ToHashSet();
 
-        int full = props.Count(p => IsPass(p) && p.GetCustomAttribute<CompletenessAttribute>()!.Level == CompletenessLevel.Full);
-        var partial = props.Where(p => IsPass(p) && p.GetCustomAttribute<CompletenessAttribute>()!.Level == CompletenessLevel.Partial)
-            .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
-        var owed = props.Where(p => p.PropertyType == typeof(Unhandled))
-            .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
+        var unclassified = defaultTypes.Except(classified).Select(t => t.Name).Order().ToArray();
+        var phantom = classified.Except(defaultTypes).Select(t => t.Name).Order().ToArray();
 
-        string report =
-            $"Lowering coverage over {props.Length} Roslyn LocalRewriter phases\n"
-            + $"  Completeness (idioms): {full} Full, {partial.Length} Partial, {owed.Length} None "
-            + $"(+ {importer} importer-native mechanical lowerings)\n"
-            + $"  Specialization: {dedicated} dedicated passes, {shared} shared passes ({sharedProps} entries), {importer} importer-native\n"
-            + $"  Partial — finish these:\n    {string.Join("\n    ", partial)}\n"
-            + $"  Owed — start these:\n    {string.Join("\n    ", owed)}";
-
-        Assert.True(owed.Length <= OwedCeiling,
-            $"Owed idioms rose to {owed.Length} (ceiling {OwedCeiling}). Implementing one lowers it; if Roslyn added a lowering, account for it.\n\n{report}");
+        Assert.True(unclassified.Length == 0,
+            $"Pipeline passes classified by neither a Roslyn-forward register nor NativePasses: {string.Join(", ", unclassified)}");
+        Assert.True(phantom.Length == 0,
+            $"Ledger references passes not in IrPasses.Default: {string.Join(", ", phantom)}");
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -1,0 +1,37 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The ClosureConversion register of the lowering ledger (the LocalRewriter
+/// register is <see cref="LoweringCoverage"/>). Roslyn's
+/// <c>Lowering/ClosureConversion/</c> is a single transform implemented across a
+/// handful of files (<c>ClosureConversion.cs</c>, <c>SynthesizedClosureMethod.cs</c>,
+/// <c>ExpressionLambdaRewriter.cs</c>, …), not a per-construct file set like
+/// <c>LocalRewriter_*.cs</c>. So this register is <b>curated</b> — anchored to the
+/// phase, enumerated by hand — rather than drift-checked against a directory. Same
+/// two axes as <see cref="LoweringCoverage"/>: mechanism is the property type,
+/// completeness is the <see cref="CompletenessAttribute"/>.
+///
+/// <para>Every entry is owed today. <see cref="DelegateConstructionPass"/> raises
+/// a method-group delegate — but that is a LocalRewriter <c>DelegateCreationExpression</c>
+/// (already Full), not a closure. Nothing recovers a lambda, local function,
+/// captured closure, or expression tree, so they render as the synthesized
+/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — a large inferior-form
+/// gap that the LocalRewriter register structurally cannot show.</para>
+///
+/// <para>Synced against dotnet/roslyn
+/// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
+/// </summary>
+internal static class ClosureCoverage
+{
+    [Completeness(CompletenessLevel.None, "x => x + 1 — delegate over a synthesized method (non-capturing caches in <>c)")]
+    public static Unhandled Lambda => default!;
+
+    [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]
+    public static Unhandled LocalFunction => default!;
+
+    [Completeness(CompletenessLevel.None, "captured locals hoisted into a <>c__DisplayClass environment")]
+    public static Unhandled CapturedClosure => default!;
+
+    [Completeness(CompletenessLevel.None, "Expression<Func<...>> built via Expression.Lambda/Call/... (ExpressionLambdaRewriter)")]
+    public static Unhandled ExpressionTreeLambda => default!;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -83,7 +83,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call                      => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field                     => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Event                     => default!;
-    [Completeness(CompletenessLevel.Full)] public static ImporterNative PropertyAccess            => default!;
+    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess         => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal                   => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration          => default!;
@@ -95,7 +95,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative HostObjectMemberReference => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess      => default!;
-    [Completeness(CompletenessLevel.Full)] public static ImporterNative IndexerAccess             => default!;
+    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess          => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat              => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -1,0 +1,76 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The decompiler-native register: the <see cref="IrPasses.Default"/> passes that
+/// invert <b>no</b> Roslyn lowering, so they have no <see cref="LoweringCoverage"/>
+/// or <see cref="ClosureCoverage"/> entry. The Roslyn-forward registers ask "for
+/// each compiler lowering, do we raise it"; this is the inverse — "which of our
+/// passes reconstruct what the compiler <em>erased</em> or shaped <em>below</em>
+/// the LocalRewriter, rather than un-lowering a named construct."
+///
+/// <para>Property type = the pass; <see cref="NativeAttribute"/> = what it
+/// reconstructs:</para>
+/// <list type="bullet">
+/// <item><b>EmitArtifact</b> — a codegen/spilling shape the compiler emits below
+/// LocalRewriter: temp spilling, control-flow prep, return/constructor spilling,
+/// constant-data blobs.</item>
+/// <item><b>IlErasure</b> — information the IL type system dropped: constant types,
+/// bool-as-int, function-pointer spelling.</item>
+/// <item><b>Diagnostic</b> — records an honest residual fidelity gap; does not raise.</item>
+/// </list>
+///
+/// <para><c>LoweringCoverageTests</c> asserts the partition: every
+/// <see cref="IrPasses.Default"/> pass is EITHER a mechanism in a Roslyn-forward
+/// register OR here — exactly once. Internal, trim-removable build-time checklist.</para>
+/// </summary>
+internal static class NativePasses
+{
+    // ───────── EmitArtifact — inverse of codegen/spilling, not a LocalRewriter ─────────
+    [Native(NativeCategory.EmitArtifact, "inverse of expression spilling — fold single-use temps back into their use")]
+    public static ExpressionInliningPass ExpressionInlining => new();
+    [Native(NativeCategory.EmitArtifact, "in-place struct .ctor (ldloca; call S::.ctor) back to s = new S(...)")]
+    public static StructConstructorPass StructConstructor => new();
+    [Native(NativeCategory.EmitArtifact, "spilled-this base()/this() call back to a chain initializer")]
+    public static ConstructorChainPass ConstructorChain => new();
+    [Native(NativeCategory.EmitArtifact, "spilled base/this constructor argument back into the chain call")]
+    public static ConstructorChainArgumentPass ConstructorChainArgument => new();
+    [Native(NativeCategory.EmitArtifact, "shared multi-way return-merge inlined into its arms")]
+    public static ReturnMergePass ReturnMerge => new();
+    [Native(NativeCategory.EmitArtifact, "return-accumulator temp spilled across an EH/lock region eliminated")]
+    public static ReturnSinkingPass ReturnSinking => new();
+    [Native(NativeCategory.EmitArtifact, "short-circuit OR-guard chains folded so structuring can consume them")]
+    public static OrChainGuardPass OrChainGuard => new();
+    [Native(NativeCategory.EmitArtifact, "branch-to-adjacent / dead branches removed before structuring")]
+    public static RedundantBranchEliminationPass RedundantBranchElimination => new();
+    [Native(NativeCategory.EmitArtifact, "identity conversions dropped (ldlen; conv.i4 array-length idiom)")]
+    public static IdentityConvertPass IdentityConvert => new();
+    [Native(NativeCategory.EmitArtifact, "constant-data RVA blob (RuntimeHelpers.CreateSpan) back to a span literal")]
+    public static RvaSpanPass RvaSpan => new();
+
+    // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
+    [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]
+    public static TypedConstantsPass TypedConstants => new();
+    [Native(NativeCategory.IlErasure, "bool marshalled as int (cgt against 0) normalized")]
+    public static BoolToIntNormalizationPass BoolToIntNormalization => new();
+    [Native(NativeCategory.IlErasure, "a standing static function-pointer load (ldftn) spelled &Method")]
+    public static MethodAddressPass MethodAddress => new();
+    [Native(NativeCategory.IlErasure, "typeof(T) == typeof(U) / typeof type-switch folded")]
+    public static TypeOfFoldingPass TypeOfFolding => new();
+
+    // ───────── Diagnostic — record an honest residual fidelity gap (does not raise) ─────────
+    [Native(NativeCategory.Diagnostic, "function-pointer load with no C# spelling — DEC#### residual")]
+    public static FunctionPointerDiagnosticsPass FunctionPointerDiagnostics => new();
+    [Native(NativeCategory.Diagnostic, "lost in/out/ref kind at a call site — DEC0007 residual")]
+    public static RefKindDiagnosticsPass RefKindDiagnostics => new();
+}
+
+/// <summary>What a decompiler-native pass reconstructs (it inverts no Roslyn lowering).</summary>
+internal enum NativeCategory { EmitArtifact, IlErasure, Diagnostic }
+
+/// <summary>Marks a <see cref="NativePasses"/> entry with what it reconstructs.</summary>
+[AttributeUsage(AttributeTargets.Property)]
+internal sealed class NativeAttribute(NativeCategory category, string what) : Attribute
+{
+    public NativeCategory Category => category;
+    public string What => what;
+}


### PR DESCRIPTION
Follow-up to #700. That ledger mirrored one Roslyn lowering phase (`LocalRewriter`) — but that isn't the whole raising spec, and (as you noted) the passes that *don't* fit the Roslyn paradigm are equally interesting. Two registers turn the ledger into a **self-checking map of the whole pipeline**.

## `ClosureCoverage` — continue shadowing the Roslyn shape

The Roslyn `Lowering/ClosureConversion/` phase (lambdas, local functions, captured closures, expression trees). Unlike `LocalRewriter`, this phase is a **monolithic transform**, not per-construct files — so the register is **curated** (anchored to the phase, enumerated by hand) rather than directory-drift-checked. **Every entry is owed**: nothing recovers a lambda/closure today, so they render as `<>c__DisplayClass` / `g__Local|` shapes — a large inferior-form gap the `LocalRewriter` register *structurally cannot show*. (Async/iterator are already on the board as the `Await`/`Yield` `LocalRewriter` lines.)

## `NativePasses` — the passes that don't fit the Roslyn paradigm

The inverse view: the `IrPasses.Default` passes that invert **no** Roslyn lowering, classified by what they reconstruct:
- **EmitArtifact** — codegen/spilling shaped *below* `LocalRewriter` (temp spilling → `ExpressionInlining`, return/ctor spilling, constant-data blobs, control-flow prep).
- **IlErasure** — information the IL type system dropped (`TypedConstants`, `BoolToIntNormalization`, function-pointer spelling).
- **Diagnostic** — records an honest residual fidelity gap; doesn't raise.

These show what the decompiler does *beyond* un-lowering — the reconstruction work the IL's lossiness forces on us.

## The payoff: a partition invariant

`EveryPipelinePass_IsClassified_ExactlyOnce` asserts that **every `IrPasses.Default` pass is either a mechanism in a Roslyn-forward register or in `NativePasses` — exactly once**, none unclassified, no overlap. **14 coverage + 16 native = 30.** Adding a pass forces classifying it; the ledger can't silently fall behind the pipeline.

The partition immediately surfaced a mis-map I fixed: `PropertyAccess` / `IndexerAccess` are raised by `PropertySugarPass` (Full), not importer-native.

## Verification
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **350 passed** (5 ledger tests: Roslyn drift, cross-axis invariants, owed ratchet per register, native-pass validity, the partition).
- Builds clean. (Kept internal types out of test member signatures — the fidelity-skeleton landmine from #700.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)