### PR TITLE
De-flake HttpClientFactory traffic-logging tests (dispose-tolerant capture sink)

### DIFF
--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -111,7 +111,7 @@ public class HttpClientFactoryTests : IDisposable
     public async Task EnableNetworkTrafficLogging_PrintsTrafficKindWithoutBlocking()
     {
         var originalError = Console.Error;
-        using var error = new StringWriter();
+        using var error = new DisposeTolerantWriter();
         Console.SetError(error);
 
         try
@@ -281,7 +281,7 @@ public class HttpClientFactoryTests : IDisposable
         bool allowTrafficKind)
     {
         var originalError = Console.Error;
-        using var error = new StringWriter();
+        using var error = new DisposeTolerantWriter();
         Console.SetError(error);
 
         try
@@ -305,6 +305,47 @@ public class HttpClientFactoryTests : IDisposable
         }
 
         return error.ToString();
+    }
+
+    /// <summary>
+    /// A Console capture sink that tolerates writes after disposal. Network-traffic
+    /// telemetry publishes on the async HTTP pipeline, so a continuation can write to
+    /// the captured <see cref="Console.Error"/> after the capture scope ends — writing
+    /// to a disposed <see cref="StringWriter"/> throws <see cref="ObjectDisposedException"/>
+    /// (issue #705). This sink's <see cref="Dispose(bool)"/> is a no-op and its buffer is
+    /// synchronized, so a late or racing write is harmlessly recorded, never thrown.
+    /// </summary>
+    private sealed class DisposeTolerantWriter : TextWriter
+    {
+        private readonly System.Text.StringBuilder _buffer = new();
+        private readonly object _gate = new();
+
+        public override System.Text.Encoding Encoding => System.Text.Encoding.Unicode;
+
+        public override void Write(char value)
+        {
+            lock (_gate) { _buffer.Append(value); }
+        }
+
+        public override void Write(string? value)
+        {
+            lock (_gate) { _buffer.Append(value); }
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            lock (_gate) { _buffer.Append(buffer, index, count); }
+        }
+
+        public override string ToString()
+        {
+            lock (_gate) { return _buffer.ToString(); }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // No-op: tolerate late writes from async telemetry continuations (issue #705).
+        }
     }
 
     private static int CountOccurrences(string value, string substring)


### PR DESCRIPTION
Fixes the intermittent `ObjectDisposedException: Cannot write to a closed TextWriter` in the network-traffic-logging tests — **option 1** from #705.

## Why it flakes

`EnableNetworkTrafficLogging()` installs a **process-global** telemetry subscription that writes to the **ambient `Console.Error` at publish time**, and publishing happens on the **async HTTP pipeline**. The tests capture `Console.Error` into a per-test `StringWriter` disposed at scope end — so a telemetry write whose continuation lands a hair outside that window hits a closed writer and throws. (Full diagnosis in #705; the class already does the obvious hygiene — `ResetSharedForTesting` in ctor/`Dispose`, `[Collection("Console")]` — so this is the residual async-timing edge.)

## The fix

Replace the per-test `StringWriter` capture with a small `DisposeTolerantWriter`: a `TextWriter` whose `Dispose` is a **no-op** and whose buffer is **synchronized**, so a late or racing telemetry write is harmlessly recorded instead of throwing. Behavior is otherwise identical — it still captures stderr and `ToString()` still returns it. Applied at both capture sites (the inline test and the `CaptureTrafficLogAsync` helper).

This makes the failure mode structurally impossible: the only way the test failed was a write-after-dispose throwing, and the sink no longer throws.

## Not in this PR

The proper product-side fix — capture the logging sink at `Enable` time instead of following ambient `Console.Error`, so tests aren't fighting global `Console` state — is tracked as option 3 on #705.

## Verification
- `dotnet run --project src/dotnet-inspect.Tests` — **1157 passed** (the 13 `HttpClientFactory` tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)