### PR TITLE
Capture the traffic-logging sink at Enable time (proper #705 fix)

### DIFF
--- a/src/DotnetInspector.Core/HttpClientFactory.cs
+++ b/src/DotnetInspector.Core/HttpClientFactory.cs
@@ -26,12 +26,23 @@ public static class HttpClientFactory
     }
 
     /// <summary>
-    /// Enables stderr logging for managed HTTP request observations.
-    /// Requests are still allowed to proceed; use offline mode to block network access.
+    /// Enables logging for managed HTTP request observations. Requests are still
+    /// allowed to proceed; use offline mode to block network access.
     /// </summary>
-    public static void EnableNetworkTrafficLogging()
+    /// <param name="sink">
+    /// Where to write the log. The default (<c>null</c>) binds <see cref="Console.Error"/>
+    /// once, as a process-lifetime subscription kept in a static field. Pass an explicit
+    /// sink to get a fresh, caller-owned subscription — dispose the returned handle to
+    /// unsubscribe. The sink is captured here, not read at publish time, so logging never
+    /// follows a later <see cref="Console.Error"/> swap (issue #705).
+    /// </param>
+    public static IDisposable EnableNetworkTrafficLogging(System.IO.TextWriter? sink = null)
     {
-        _networkTrafficLoggingSubscription ??= NetworkTelemetry.Subscribe(new NetworkTrafficConsoleConsumer());
+        if (sink is not null)
+            return NetworkTelemetry.Subscribe(new NetworkTrafficLogConsumer(sink));
+
+        return _networkTrafficLoggingSubscription ??=
+            NetworkTelemetry.Subscribe(new NetworkTrafficLogConsumer(Console.Error));
     }
 
     /// <summary>

--- a/src/DotnetInspector.Core/NetworkTelemetry.cs
+++ b/src/DotnetInspector.Core/NetworkTelemetry.cs
@@ -484,16 +484,21 @@ internal static class NetworkClientKinds
     public const string UntrustedFetch = "untrusted-source-fetch";
 }
 
-internal sealed class NetworkTrafficConsoleConsumer : IObserver<NetworkRequestObservation>
+// Writes traffic observations to a sink captured when logging is enabled — not to
+// the ambient Console.Error at publish time. Publishing runs on the async HTTP
+// pipeline, so a write that targeted the ambient Console.Error could land after a
+// test had swapped/disposed it (issue #705); binding the sink up front removes that
+// coupling, and the caller scopes the subscription's lifetime around the sink's.
+internal sealed class NetworkTrafficLogConsumer(System.IO.TextWriter sink) : IObserver<NetworkRequestObservation>
 {
     public void OnNext(NetworkRequestObservation observation)
     {
-        Console.Error.WriteLine(
+        sink.WriteLine(
             $"Network traffic [{observation.TrafficKind.ToTelemetryName()}]: {observation.Method} {observation.Url}");
 
         if (observation is { TrafficKind: NetworkTrafficKind.VulnerabilityData, IsAllowedByPolicy: false })
         {
-            Console.Error.WriteLine(
+            sink.WriteLine(
                 $"Network policy error [vulnerability-data]: NuGet vulnerability service was accessed outside detailed view or an explicit network-using section: {observation.Method} {observation.Url}");
         }
     }

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -110,13 +110,9 @@ public class HttpClientFactoryTests : IDisposable
     [Fact]
     public async Task EnableNetworkTrafficLogging_PrintsTrafficKindWithoutBlocking()
     {
-        var originalError = Console.Error;
         using var error = new StringWriter();
-        Console.SetError(error);
-
-        try
+        using (DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging(error))
         {
-            DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging();
             using var client = new HttpClient(new NetworkTelemetryHandler(
                 new StubHttpMessageHandler(),
                 NetworkClientKinds.UntrustedFetch));
@@ -127,10 +123,6 @@ public class HttpClientFactoryTests : IDisposable
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-        finally
-        {
-            Console.SetError(originalError);
         }
 
         var stderr = error.ToString();
@@ -280,13 +272,9 @@ public class HttpClientFactoryTests : IDisposable
         NetworkTrafficKind trafficKind,
         bool allowTrafficKind)
     {
-        var originalError = Console.Error;
         using var error = new StringWriter();
-        Console.SetError(error);
-
-        try
+        using (DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging(error))
         {
-            DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging();
             using var client = new HttpClient(new NetworkTelemetryHandler(
                 new StubHttpMessageHandler(),
                 NetworkClientKinds.Shared));
@@ -298,10 +286,6 @@ public class HttpClientFactoryTests : IDisposable
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-        finally
-        {
-            Console.SetError(originalError);
         }
 
         return error.ToString();


### PR DESCRIPTION
The product-side fix for the network-traffic-logging flake — **option 3** from #705, the one that removes the coupling rather than tolerating it. Supersedes the #707 band-aid.

## The race

The consumer wrote to the **ambient `Console.Error` at publish time**, and a **process-global** subscription kept it alive across tests. Publishing runs on the **async HTTP pipeline**, so a write could land just after a test swapped/disposed its per-test `Console.Error` capture → `ObjectDisposedException`. Two independently-lived things (a global subscription, an ambient sink) racing.

## The fix — decouple sink and subscription, both caller-owned

- **Bind the sink at `Enable`.** `NetworkTrafficLogConsumer` (renamed) takes a `TextWriter` and writes to it, never to ambient `Console.Error`.
- **Return the subscription.** `EnableNetworkTrafficLogging(TextWriter? sink = null)` returns the `IDisposable`. The no-arg form is unchanged — binds `Console.Error` once, process-lifetime, idempotent via the static field. Passing a sink returns a fresh, caller-owned subscription.

Production (`Program.cs`) is untouched: it calls the no-arg form and ignores the now-`IDisposable` return (source-compatible).

The tests scope the subscription and **drop the `Console.SetError` dance entirely** — they no longer touch global `Console` at all:

```csharp
using var error = new StringWriter();
using (HttpClientFactory.EnableNetworkTrafficLogging(error)) { ... await request ... }
var stderr = error.ToString();
```

## Why it's structurally race-free

Lifetimes now **nest and are caller-owned**: the request is awaited *inside* the subscription scope (every publish completes), the subscription `using` sits *inside* the writer `using` (unsubscribe before dispose), and nothing reads global `Console` at publish. No window for a write to reach a disposed sink — so no dispose-tolerant sink is needed (the #707 band-aid becomes unnecessary).

## Verification
- `DotnetInspector.Core` + `dotnet-inspect` build clean (production's ignored `IDisposable` return is source-compatible).
- `dotnet run --project src/dotnet-inspect.Tests` — **1157 passed**.
- `Console.SetError` no longer appears in `HttpClientFactoryTests`.

Closes #705. Recommend closing #707 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)