### PR TITLE
Raise reference-type using statements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -43,7 +43,7 @@ public class LoweringCoverageTests
     // attribute. Owed (None/Unhandled) only ratchets DOWN — implementing one lowers it.
     static readonly (Type Type, int OwedCeiling, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 15, "LocalRewriter"),
+        (typeof(LoweringCoverage), 14, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -1,0 +1,47 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class UsingStatementPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void ReferenceTypeUsingWithDisposeGuard_RaisesToUsingStatement()
+    {
+        var function = Raised(nameof(CfgSampleClass.NormalUsing));
+
+        var usingStatement = Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Equal("StringReader", usingStatement.ResourceType.ToDisplayString());
+        Assert.IsType<NewObject>(usingStatement.Resource);
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersUsingHeaderAndBody()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NormalUsing))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("using (StringReader reader = new StringReader(s))", output);
+        Assert.Contains("return reader.Read();", output);
+        Assert.DoesNotContain("finally", output);
+    }
+
+    [Fact]
+    public void FinallyWithExtraWork_IsLeftAsTryFinally()
+    {
+        var function = Raised(nameof(CfgSampleClass.FinallyWithExtraWork));
+
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -172,6 +172,9 @@ public sealed partial class CSharpPrinter
     /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
     readonly HashSet<int> _fixedLocals = [];
 
+    /// <summary>Resource local slots a <see cref="UsingStatement"/> owns: declared by the using header, not up front.</summary>
+    readonly HashSet<int> _usingLocals = [];
+
     /// <summary>Ref-struct locals whose hoisted declaration must spell <c>scoped</c>: a <c>stackalloc</c>-initialized span whose declaration was split from its assignment (out of the unsafe block) would otherwise warn CS9081. A stackalloc result is always scoped, so this is faithful, not a guess.</summary>
     readonly HashSet<int> _scopedLocals = [];
 
@@ -184,6 +187,8 @@ public sealed partial class CSharpPrinter
         _labelTargets = CollectBranchTargets(function);
         foreach (var fixedNode in function.Descendants.OfType<Fixed>())
             _fixedLocals.Add(fixedNode.LocalIndex);
+        foreach (var usingNode in function.Descendants.OfType<UsingStatement>())
+            _usingLocals.Add(usingNode.LocalIndex);
         CollectDeclaringStores(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
@@ -303,9 +308,9 @@ public sealed partial class CSharpPrinter
         }
         foreach (int index in locals)
         {
-            // A fixed-statement pinned local is declared by the fixed header
-            // (fixed (T* V = &place)), not up front.
-            if (_fixedLocals.Contains(index))
+            // Fixed/using headers declare their owned locals, not the up-front
+            // declaration block.
+            if (_fixedLocals.Contains(index) || _usingLocals.Contains(index))
                 continue;
             bool declaredAtStore = _declaringStores.Any(s =>
                 s is StoreLocal store && store.Index == index
@@ -538,6 +543,17 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             return;
         }
+        if (node is UsingStatement usingStatement)
+        {
+            sb.Append(pad)
+                .Append("using (").Append(TypeText(usingStatement.ResourceType)).Append(' ')
+                .Append(LocalName(usingStatement.LocalIndex)).Append(" = ")
+                .Append(CastValue(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            AppendContainer(sb, usingStatement.Body, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (node is TryFinally tryFinally)
         {
             sb.Append(pad).AppendLine("try");
@@ -639,6 +655,7 @@ public sealed partial class CSharpPrinter
         Switch s => HasUnsafeOperation(s.Value),
         Lock l => HasUnsafeOperation(l.LockObject),
         Fixed fx => HasUnsafeOperation(fx.PinSource),
+        UsingStatement u => HasUnsafeOperation(u.Resource),
         TryCatch or TryFinally => false,
         _ => HasUnsafeOperation(node),
     };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -303,6 +303,10 @@ static class DefiniteAssignment
                     CheckReads(fixedNode.PinSource, assigned);
                     assigned.Add(fixedNode.LocalIndex);
                     return Container(fixedNode.Body, assigned);
+                case UsingStatement usingNode:
+                    CheckReads(usingNode.Resource, assigned);
+                    assigned.Add(usingNode.LocalIndex);
+                    return Container(usingNode.Body, assigned);
                 // Unmodeled control flow: stop trusting the program order.
                 case Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter:
                     BailAll();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -499,6 +499,33 @@ public sealed class Fixed : IrNode
     public override string Describe() => $"Fixed V_{LocalIndex} ({ElementType.ToDisplayString()}*)";
 }
 
+/// <summary>
+/// A raised <c>using</c> statement. Produced by <see cref="UsingStatementPass"/>
+/// from csc's reference-type disposal lowering: a resource local initialized
+/// immediately before a try/finally whose finally null-checks the resource and
+/// calls <c>IDisposable.Dispose</c>. <see cref="LocalIndex"/> is the resource
+/// slot declared by the using header.
+/// </summary>
+public sealed class UsingStatement : IrNode
+{
+    public UsingStatement(int localIndex, TypeRef resourceType, IrExpression resource, BlockContainer body)
+    {
+        LocalIndex = localIndex;
+        ResourceType = resourceType;
+        AddChild(resource);
+        AddChild(body);
+    }
+
+    public int LocalIndex { get; }
+    public TypeRef ResourceType { get; }
+    public IrExpression Resource => (IrExpression)Children[0];
+    public BlockContainer Body => (BlockContainer)Children[1];
+
+    public override IEnumerable<TypeRef> DirectTypes => [ResourceType];
+
+    public override string Describe() => $"UsingStatement V_{LocalIndex} ({ResourceType.ToDisplayString()})";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -103,6 +103,11 @@ public static class IrPasses
         // formed; expression inlining leaves these temps standing because it
         // refuses to move a value across a leave/region edge.
         new ReturnSinkingPass(),
+        // Raise the csc reference-type using lowering (resource local +
+        // try/finally with an IDisposable.Dispose null guard) back into a
+        // using statement. Runs after return sinking so a `return` from inside
+        // the protected body stays inside the using body.
+        new UsingStatementPass(),
         // Raise the csc pin lowering (a pinned managed-ref local + derived
         // pointer + optional unpin store) into fixed (T* p = &place) { ... }.
         // Runs after structuring and the second inlining so the pinned region's

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -49,6 +49,8 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass PatternSwitchStatement => new();
     [Completeness(CompletenessLevel.Partial, "++/-- only; general compound assignment (+=, ...) not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
+    [Completeness(CompletenessLevel.Partial, "reference-type local using with IDisposable null guard; value-type/constrained dispose not raised")]
+    public static UsingStatementPass UsingStatement => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -61,7 +63,6 @@ internal static class LoweringCoverage
 
     // ───────── Owed — no mechanism yet (the "start these" roadmap) ─────────
     [Completeness(CompletenessLevel.None, "x is T t / { Prop: ... }")]   public static Unhandled IsPatternOperator                   => default!;
-    [Completeness(CompletenessLevel.None, "using (var x = ...) { }")]    public static Unhandled UsingStatement                      => default!;
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
     [Completeness(CompletenessLevel.None, "$\"{a}{b}\"")]                public static Unhandled StringInterpolation                 => default!;
     [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -1,0 +1,125 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises csc's reference-type <c>using</c> lowering into a
+/// <see cref="UsingStatement"/>. The proven shape, after EH and guard
+/// structuring plus return sinking:
+/// <code>
+///   T V_0 = resource;
+///   try { BODY }
+///   finally { if (V_0) ((IDisposable)V_0).Dispose(); }
+/// </code>
+/// becomes <c>using (T V_0 = resource) { BODY }</c>. Scoped to the
+/// interface-dispose/null-guard shape csc emits for reference-type resources;
+/// value-type/constrained dispose remains flat for a later slice.
+/// </summary>
+public sealed class UsingStatementPass : IIrPass
+{
+    public string Name => "using-statement";
+
+    sealed record Match(StoreLocal StoreResource, TryFinally TryFinally);
+
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (TransformOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool TransformOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (TryMatch(children[i], children[i + 1]) is not { } match)
+                    continue;
+
+                if (ReferencesLocal(match.StoreResource.Value, match.StoreResource.Index)
+                    || !ReferencedOnlyWithin(function, match.StoreResource.Index, [match.StoreResource, match.TryFinally]))
+                {
+                    continue;
+                }
+
+                var resource = (IrExpression)match.StoreResource.DetachChildren()[0];
+                var body = match.TryFinally.TryBody;
+                body.Detach();
+                var usingStatement = new UsingStatement(match.StoreResource.Index, match.StoreResource.Type, resource, body);
+                stepper.StepOver("raise dispose try/finally to using", match.TryFinally);
+                match.TryFinally.ReplaceWith(usingStatement);
+                match.StoreResource.Detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static Match? TryMatch(IrNode first, IrNode second)
+    {
+        if (first is not StoreLocal storeResource || second is not TryFinally tryFinally)
+            return null;
+
+        if (tryFinally.FinallyBody.Blocks is not [{ Children: [IfStatement guard] }]
+            || guard.Else is not null
+            || guard.Condition is not LoadLocal guardLoad
+            || guardLoad.Index != storeResource.Index
+            || guard.Then.Children is not [ExpressionStatement { Expression: Call dispose }]
+            || !IsIDisposableDispose(dispose)
+            || dispose.Arguments is not [LoadLocal disposed]
+            || disposed.Index != storeResource.Index)
+        {
+            return null;
+        }
+
+        return new Match(storeResource, tryFinally);
+    }
+
+    static bool IsIDisposableDispose(Call call)
+        => call.IsVirtual
+            && call.Callee.Name == "Dispose"
+            && call.Callee.HasThis
+            && call.Callee.TypeArguments.IsEmpty
+            && call.Callee.ParameterTypes.IsEmpty
+            && call.Callee.ReturnType.Equals(s_void)
+            && call.Callee.DeclaringType is
+                { Namespace: "System", Name: "IDisposable", Assembly: TypeRef.CoreLibrary or "System.Runtime" };
+
+    static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                StoreLocal store => store.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                _ => false,
+            };
+            if (references && !allowed.Any(root => IsInside(node, root)))
+                return false;
+        }
+        return true;
+    }
+
+    static bool ReferencesLocal(IrNode root, int index)
+        => root.Descendants.Prepend(root).Any(node => node switch
+        {
+            LoadLocal load => load.Index == index,
+            StoreLocal store => store.Index == index,
+            LoadLocalAddress address => address.Index == index,
+            _ => false,
+        });
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Add UsingStatement IR and a UsingStatementPass for csc reference-type resource-local plus IDisposable.Dispose null-guard lowering.
- Render raised using statements and model the resource local in definite assignment.
- Move the lowering ledger entry from owed to partial coverage and add focused pass tests.

## Testing

- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200