### PR TITLE
Raise value-type using statements (constrained dispose)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -463,6 +463,22 @@ public class CfgSampleClass
         return reader.Read();
     }
 
+    // A `using` over a value-type resource (List<T>.Enumerator is a struct
+    // IDisposable). csc emits no null guard — the finally is a bare constrained
+    // `e.Dispose();` through the local's address — exercising the value-type slice
+    // of the using raise that UsingStatementPass covers beyond the reference-type
+    // IDisposable null-guard shape.
+    public static int StructUsing(System.Collections.Generic.List<int> items)
+    {
+        int sum = 0;
+        using (var e = items.GetEnumerator())
+        {
+            while (e.MoveNext())
+                sum += e.Current;
+        }
+        return sum;
+    }
+
     public static int FinallyWithExtraWork(string s)
     {
         var reader = new System.IO.StringReader(s);

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -44,4 +44,29 @@ public class UsingStatementPassTests
         Assert.Empty(function.Descendants.OfType<UsingStatement>());
         Assert.Single(function.Descendants.OfType<TryFinally>());
     }
+
+    [Fact]
+    public void ValueTypeUsingWithUnguardedDispose_RaisesToUsingStatement()
+    {
+        // List<T>.Enumerator is a struct IDisposable: csc emits no null guard,
+        // disposing through the local's address (constrained callvirt). The
+        // value-type slice of the pass must raise this just like the
+        // reference-type null-guarded shape.
+        var function = Raised(nameof(CfgSampleClass.StructUsing));
+
+        var usingStatement = Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Equal("Enumerator", usingStatement.ResourceType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void ValueTypeUsing_RendersUsingHeaderWithoutFinally()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.StructUsing))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("using (Enumerator e = items.GetEnumerator())", output);
+        Assert.DoesNotContain("finally", output);
+        Assert.DoesNotContain("Dispose", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -49,7 +49,7 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass PatternSwitchStatement => new();
     [Completeness(CompletenessLevel.Partial, "++/-- only; general compound assignment (+=, ...) not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
-    [Completeness(CompletenessLevel.Partial, "reference-type local using with IDisposable null guard; value-type/constrained dispose not raised")]
+    [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -1,17 +1,22 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises csc's reference-type <c>using</c> lowering into a
-/// <see cref="UsingStatement"/>. The proven shape, after EH and guard
-/// structuring plus return sinking:
+/// Raises csc's <c>using</c> lowering into a <see cref="UsingStatement"/>. Two
+/// shapes are recognized, after EH and guard structuring plus return sinking:
 /// <code>
+///   // reference type — null-guarded interface dispose
 ///   T V_0 = resource;
 ///   try { BODY }
 ///   finally { if (V_0) ((IDisposable)V_0).Dispose(); }
+///
+///   // value type — unguarded constrained dispose (no null check)
+///   T V_0 = resource;
+///   try { BODY }
+///   finally { V_0.Dispose(); }
 /// </code>
-/// becomes <c>using (T V_0 = resource) { BODY }</c>. Scoped to the
-/// interface-dispose/null-guard shape csc emits for reference-type resources;
-/// value-type/constrained dispose remains flat for a later slice.
+/// both become <c>using (T V_0 = resource) { BODY }</c>. The dispose receiver is
+/// a <c>LoadLocal</c> (reference type) or <c>LoadLocalAddress</c> (value type,
+/// constrained callvirt).
 /// </summary>
 public sealed class UsingStatementPass : IIrPass
 {
@@ -62,19 +67,37 @@ public sealed class UsingStatementPass : IIrPass
         if (first is not StoreLocal storeResource || second is not TryFinally tryFinally)
             return null;
 
-        if (tryFinally.FinallyBody.Blocks is not [{ Children: [IfStatement guard] }]
-            || guard.Else is not null
-            || guard.Condition is not LoadLocal guardLoad
-            || guardLoad.Index != storeResource.Index
-            || guard.Then.Children is not [ExpressionStatement { Expression: Call dispose }]
-            || !IsIDisposableDispose(dispose)
-            || dispose.Arguments is not [LoadLocal disposed]
-            || disposed.Index != storeResource.Index)
-        {
+        if (tryFinally.FinallyBody.Blocks is not [{ Children: [var only] }])
             return null;
-        }
 
-        return new Match(storeResource, tryFinally);
+        bool disposes = only switch
+        {
+            // Reference type: finally { if (V_0) ((IDisposable)V_0).Dispose(); }
+            IfStatement
+            {
+                Else: null,
+                Condition: LoadLocal guardLoad,
+                Then.Children: [ExpressionStatement { Expression: Call guardedDispose }],
+            } => guardLoad.Index == storeResource.Index && IsDisposeOf(guardedDispose, storeResource.Index),
+            // Value type: finally { V_0.Dispose(); } — no null guard.
+            ExpressionStatement { Expression: Call bareDispose } => IsDisposeOf(bareDispose, storeResource.Index),
+            _ => false,
+        };
+
+        return disposes ? new Match(storeResource, tryFinally) : null;
+    }
+
+    /// <summary>An <c>IDisposable.Dispose()</c> call whose receiver is the resource local, loaded by value (reference type) or by address (value-type constrained dispose).</summary>
+    static bool IsDisposeOf(Call dispose, int index)
+    {
+        if (!IsIDisposableDispose(dispose) || dispose.Arguments is not [var receiver])
+            return false;
+        return receiver switch
+        {
+            LoadLocal load => load.Index == index,
+            LoadLocalAddress address => address.Index == index,
+            _ => false,
+        };
     }
 
     static bool IsIDisposableDispose(Call call)


### PR DESCRIPTION
## Summary

Follow-up to #711, which raised the **reference-type** `using` lowering and explicitly deferred "value-type/constrained dispose ... for a later slice." This PR is that slice.

For a struct `IDisposable` resource (e.g. `List<T>.Enumerator`), csc emits **no null guard** — the finally is a bare constrained `V_0.Dispose();` disposing through the local's address. #711's reference-type-only match left it as a hand-rolled try/finally; now it raises to `using (...)`.

## What changed

- **`UsingStatementPass.TryMatch`** recognizes both finally shapes:
  - reference type: `if (V_0) ((IDisposable)V_0).Dispose();` (null guard)
  - value type: `V_0.Dispose();` (no guard)

  A shared `IsDisposeOf` helper accepts a `LoadLocal` (reference) or `LoadLocalAddress` (value-type constrained) receiver.
- **Fixture** `StructUsing` (`List<int>.Enumerator`) in `CfgSampleClass`; tests assert the raise, the `Enumerator` resource type, and the rendered `using` header with no `finally`/`Dispose` left.
- **Ledger** annotation broadened: reference-type IDisposable null-guard **and** value-type constrained dispose now covered; ref-struct pattern dispose and `await using` remain the open slices.

## Tests

357 decompiler + 1157 product tests green.

🤖 Generated with Copilot
