### PR TITLE
Improve function pointer residual diagnostics

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class FunctionPointerDiagnosticsPassTests
+{
+    private static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");
+    private static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    private static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    [Fact]
+    public void Run_DiagnosesVirtualFunctionPointerAsLdvirtftn()
+    {
+        var method = new MethodRef(Owner, "VirtualTarget", Void, [], HasThis: true);
+        var function = FunctionWith(new LoadFunctionPointer(method, isVirtual: true, new LoadArgument(0, "this", Owner)));
+
+        new FunctionPointerDiagnosticsPass().Run(function, PassContext.None);
+
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedFunctionPointer, diagnostic.Id);
+        Assert.Contains("ldvirtftn", diagnostic.Message);
+        Assert.Contains("requires a receiver", diagnostic.Message);
+        Assert.Contains("VirtualTarget", diagnostic.Message);
+        Assert.DoesNotContain("ldftn:", diagnostic.Message);
+    }
+
+    [Fact]
+    public void Run_DiagnosesStaticFunctionPointerAsLdftn()
+    {
+        var method = new MethodRef(Owner, "StaticTarget", Void, [], HasThis: false);
+        var function = FunctionWith(new LoadFunctionPointer(method, isVirtual: false, instance: null));
+
+        new FunctionPointerDiagnosticsPass().Run(function, PassContext.None);
+
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedFunctionPointer, diagnostic.Id);
+        Assert.Contains("ldftn", diagnostic.Message);
+        Assert.Contains("not a delegate construction", diagnostic.Message);
+        Assert.Contains("StaticTarget", diagnostic.Message);
+        Assert.DoesNotContain("ldvirtftn", diagnostic.Message);
+    }
+
+    private static IrFunction FunctionWith(IrExpression expression)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new ExpressionStatement(expression));
+        body.Add(block);
+
+        var signature = new MethodSignature(
+            Void,
+            ImmutableArray.Create(new Parameter("this", Owner)),
+            HasThis: true,
+            GenericParameterCount: 0);
+
+        return new IrFunction("M", Owner, signature, [], body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
@@ -18,11 +18,16 @@ public sealed class FunctionPointerDiagnosticsPass : IIrPass
     {
         foreach (var pointer in function.Descendants.OfType<LoadFunctionPointer>())
         {
-            // The second whitespace token (ldftn:) is the harness roadmap bucket.
+            var opcode = pointer.IsVirtual ? "ldvirtftn" : "ldftn";
             context.Stepper.StepOver($"diagnose residual function pointer to {pointer.Method.DeclaringType.ToDisplayString()}.{pointer.Method.Name}", pointer);
             function.Diagnostics.Add(new DecompilerDiagnostic(
                 DiagnosticIds.UnsupportedFunctionPointer,
-                $"function-pointer ldftn: {pointer.Method.DeclaringType.ToDisplayString()}.{pointer.Method.Name} is not a delegate construction"));
+                pointer.IsVirtual
+                    ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} requires a receiver; C# cannot spell a virtual method address as a delegate* target"
+                    : $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is not a delegate construction and was not raised to &Method"));
         }
     }
+
+    private static string FormatMethod(MethodRef method)
+        => $"{method.DeclaringType.ToDisplayString()}.{method.Name}";
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -59,7 +59,7 @@ internal static class NativePasses
     public static TypeOfFoldingPass TypeOfFolding => new();
 
     // ───────── Diagnostic — record an honest residual fidelity gap (does not raise) ─────────
-    [Native(NativeCategory.Diagnostic, "function-pointer load with no C# spelling — DEC#### residual")]
+    [Native(NativeCategory.Diagnostic, "function-pointer load with no C# spelling — DEC0006 residual")]
     public static FunctionPointerDiagnosticsPass FunctionPointerDiagnostics => new();
     [Native(NativeCategory.Diagnostic, "lost in/out/ref kind at a call site — DEC0007 residual")]
     public static RefKindDiagnosticsPass RefKindDiagnostics => new();


### PR DESCRIPTION
## Summary
- make residual function-pointer diagnostics distinguish `ldftn` from `ldvirtftn`
- clarify the NativePasses ledger entry as DEC0006
- add focused synthetic IR tests for static and virtual residual function pointers

## Validation
- `dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.FunctionPointerDiagnosticsPassTests`
