### PR TITLE
Raise simple ValueTuple creation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -731,6 +731,8 @@ public class CfgSampleClass
 
     public static int TernaryInt(int a, int b) => a > b ? a : b;
 
+    public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
+
     public static string StringInterpolation(string name, int age)
         => $"Hello, {name}! You are {age} years old.";
 

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 13, "LocalRewriter"),
+        (typeof(LoweringCoverage), 12, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
@@ -1,0 +1,37 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TupleCreationPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void ValueTupleConstructor_RaisesToTupleExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.TuplePair));
+
+        var tuple = Assert.Single(function.Descendants.OfType<TupleExpression>());
+        Assert.Equal(2, tuple.Elements.Count);
+        Assert.StartsWith("ValueTuple<", tuple.TupleType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersTupleLiteral()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.TuplePair))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return (a + b, a * b);", output);
+        Assert.DoesNotContain("new ValueTuple", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using System.Collections.Immutable;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -33,5 +34,31 @@ public class TupleCreationPassTests
         Assert.NotNull(output);
         Assert.Contains("return (a + b, a * b);", output);
         Assert.DoesNotContain("new ValueTuple", output);
+    }
+
+    [Fact]
+    public void ValueTupleConstructor_AsExpressionStatement_StaysNewObject()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var tupleType = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "ValueTuple`2"),
+            [intType, intType]);
+        var ctor = new MethodRef(tupleType, ".ctor", TypeRef.CoreLib("System", "Void"), [intType, intType], HasThis: false);
+        var newObject = new NewObject(ctor, [new Constant(1, intType), new Constant(2, intType)]);
+        var block = new Block();
+        block.Add(new ExpressionStatement(newObject));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new TupleCreationPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<TupleExpression>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -885,6 +885,7 @@ public sealed partial class CSharpPrinter
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
+        TupleExpression t => $"({Arguments(t.Elements)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
@@ -998,7 +999,7 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -998,6 +998,29 @@ public sealed class InterpolatedStringExpression : IrExpression
 }
 
 /// <summary>
+/// A raised C# tuple literal, produced by <see cref="TupleCreationPass"/> from
+/// a direct <c>System.ValueTuple&lt;...&gt;</c> constructor call. The binary only
+/// records the element values and the underlying ValueTuple type; tuple element
+/// names are a signature/custom-attribute concern and are not recovered here.
+/// </summary>
+public sealed class TupleExpression : IrExpression
+{
+    public TupleExpression(TypeRef tupleType, IEnumerable<IrExpression> elements)
+    {
+        TupleType = tupleType;
+        foreach (var element in elements)
+            AddChild(element);
+    }
+
+    public TypeRef TupleType { get; }
+    public IReadOnlyList<IrExpression> Elements => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => TupleType;
+    public override IEnumerable<TypeRef> DirectTypes => [TupleType];
+
+    public override string Describe() => $"TupleExpression ({Children.Count} elements)";
+}
+
+/// <summary>
 /// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native
 /// int. C# has no spelling for a bare function-pointer load, so this only
 /// reaches print as a comment; the dominant case — feeding a delegate

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -49,6 +49,10 @@ public static class IrPasses
         // into $"..." before later passes have a chance to inline or reshape
         // the handler local.
         new StringInterpolationPass(),
+        // Raise direct ValueTuple constructor calls back into tuple literals.
+        // Runs after struct-constructor so in-place struct .ctor calls have
+        // already been normalized to NewObject when they are spellable.
+        new TupleCreationPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -63,6 +63,8 @@ internal static class LoweringCoverage
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
     public static StringInterpolationPass StringInterpolation => new();
+    [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
+    public static TupleCreationPass TupleCreationExpression => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -78,7 +80,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
     [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;
     [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
-    [Completeness(CompletenessLevel.None, "(a, b)")]                     public static Unhandled TupleCreationExpression             => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
     [Completeness(CompletenessLevel.None, "a ??= b")]                    public static Unhandled NullCoalescingAssignmentOperator    => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
@@ -17,6 +17,8 @@ public sealed class TupleCreationPass : IIrPass
         {
             if (!IsTupleConstructor(newObject))
                 continue;
+            if (newObject.Parent is ExpressionStatement)
+                continue;
 
             var elements = newObject.DetachChildren().Cast<IrExpression>().ToList();
             var tuple = new TupleExpression(newObject.Constructor.DeclaringType, elements);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
@@ -1,0 +1,49 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises direct <c>System.ValueTuple&lt;...&gt;</c> constructor calls into C#
+/// tuple literals. This covers the compiler's ordinary tuple-creation lowering:
+/// <c>(a, b)</c> becomes <c>new ValueTuple&lt;T1, T2&gt;(a, b)</c>. Scoped to
+/// arities 2-7; eight-or-more tuples use the nested <c>TRest</c> representation
+/// and stay as constructors for a later slice.
+/// </summary>
+public sealed class TupleCreationPass : IIrPass
+{
+    public string Name => "tuple-creation";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
+        {
+            if (!IsTupleConstructor(newObject))
+                continue;
+
+            var elements = newObject.DetachChildren().Cast<IrExpression>().ToList();
+            var tuple = new TupleExpression(newObject.Constructor.DeclaringType, elements);
+            context.Stepper.StepOver("raise ValueTuple constructor to tuple literal", newObject);
+            newObject.ReplaceWith(tuple);
+        }
+    }
+
+    static bool IsTupleConstructor(NewObject newObject)
+    {
+        var ctor = newObject.Constructor;
+        if (ctor.Name != ".ctor" || ctor.DeclaringType is not { Kind: TypeRefKind.GenericInstance } tupleType)
+            return false;
+
+        var definition = tupleType.ElementType;
+        if (definition is not
+            {
+                Namespace: "System",
+                Assembly: TypeRef.CoreLibrary or "System.Runtime",
+            } || !definition.Name.StartsWith("ValueTuple`", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int arity = tupleType.TypeArguments.Length;
+        return arity is >= 2 and <= 7
+            && ctor.ParameterTypes.Length == arity
+            && newObject.Arguments.Count == arity;
+    }
+}


### PR DESCRIPTION
## Summary

- Add TupleExpression IR and TupleCreationPass for direct System.ValueTuple constructor calls with arities 2 through 7.
- Render tuple literals and register the pass in the default pipeline.
- Move TupleCreationExpression from owed to partial ledger coverage with focused fixture tests.

## Testing

- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
