### PR TITLE
Tighten the lowering ledger's honesty: fix mechanism grouping + exact owed count

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -10,7 +10,7 @@ namespace ILInspector.Decompiler.Tests;
 /// compiler lowering to a mechanism (the property type) and a completeness level
 /// (<see cref="CompletenessAttribute"/>); <see cref="NativePasses"/> captures the
 /// passes that invert no Roslyn lowering. These tests enforce the cross-axis
-/// invariants, the checked-in Roslyn snapshot, the owed ratchet, and the
+/// invariants, the checked-in Roslyn snapshot, the exact owed count, and the
 /// partition: every <see cref="IrPasses.Default"/> pass type is classified by
 /// one register.
 /// </summary>
@@ -18,7 +18,11 @@ public class LoweringCoverageTests
 {
     // The checked-in denominator: every LocalRewriter_*.cs in dotnet/roslyn
     // src/Compilers/CSharp/Portable/Lowering/LocalRewriter/, synced @ main.
-    // Re-fetch:
+    // PropertySet_ExactlyMatchesRoslynLocalRewriters guards this list against the
+    // ledger's properties — an in-repo consistency check. Keeping the list itself
+    // current with upstream Roslyn is a human responsibility (no live fetch at test
+    // time); when Roslyn adds/renames a lowering, a maintainer re-fetches and updates
+    // this list and the ledger together. Re-fetch:
     //   gh api repos/dotnet/roslyn/contents/src/Compilers/CSharp/Portable/Lowering/LocalRewriter \
     //     --jq '.[] | select(.name | startswith("LocalRewriter_") and endswith(".cs")) | .name | sub("^LocalRewriter_"; "") | sub("\\.cs$"; "")'
     static readonly string[] RoslynLocalRewriters =
@@ -42,8 +46,11 @@ public class LoweringCoverageTests
     ];
 
     // Roslyn-forward registers: mechanism is the property type, completeness is the
-    // attribute. Owed (None/Unhandled) only ratchets DOWN — implementing one lowers it.
-    static readonly (Type Type, int OwedCeiling, string Name)[] CoverageRegisters =
+    // attribute. Owed (None/Unhandled) is an EXACT count, not a ceiling: implementing
+    // a lowering lowers it, and a newly-added Roslyn owed lowering raises it — either
+    // way the count edit lands in the same change, so the ledger can never quietly
+    // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
+    static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
         (typeof(LoweringCoverage), 14, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
@@ -102,15 +109,16 @@ public class LoweringCoverageTests
     }
 
     [Fact]
-    public void CoverageRegisters_OwedDoNotRegress()
+    public void CoverageRegisters_OwedCountIsExact()
     {
-        foreach (var (type, ceiling, name) in CoverageRegisters)
+        foreach (var (type, expected, name) in CoverageRegisters)
         {
             var owed = Props(type).Where(p => p.PropertyType == typeof(Unhandled))
                 .Select(p => $"{p.Name} ({p.GetCustomAttribute<CompletenessAttribute>()!.Note})").Order().ToArray();
 
-            Assert.True(owed.Length <= ceiling,
-                $"{name}: owed rose to {owed.Length} (ceiling {ceiling}). Implementing one lowers it; if Roslyn added a lowering, account for it.\n  "
+            Assert.True(owed.Length == expected,
+                $"{name}: owed is {owed.Length} but the register's Owed count says {expected}. "
+                    + "Implementing a lowering lowers both; a new Roslyn owed lowering raises both — keep them in lockstep in the same change.\n  "
                     + string.Join("\n  ", owed));
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -21,10 +21,18 @@ namespace ILInspector.Decompiler.Pipeline;
 /// lowering that needs no pass; <c>(Partial, SwitchRaisingPass)</c> is a dedicated
 /// pass that only covers some shapes; <c>(None, Unhandled)</c> is an owed idiom. A
 /// PR that raises an idiom flips its line — the type to the pass, the completeness
-/// up. <c>LoweringCoverageTests</c> reflects over it: it reports both axes,
-/// cross-checks every pass is registered in <see cref="IrPasses.Default"/>,
-/// enforces the cross-axis invariants, and fails on drift from the checked-in
-/// snapshot of Roslyn's <c>LocalRewriter/</c> directory.</para>
+/// up. The structuring rows (if/while/for/try, …) are <c>Partial</c> as a
+/// pointer, not a measure: their real completeness is the structurer's <c>--gaps</c>
+/// metric, not this attribute. <c>LoweringCoverageTests</c> reflects over it: it
+/// reports both axes, cross-checks every pass is registered in
+/// <see cref="IrPasses.Default"/>, and enforces the cross-axis invariants.</para>
+///
+/// <para>The property set is checked for exact equality against the in-repo
+/// <c>RoslynLocalRewriters</c> list — an <em>in-repo consistency</em> guard, not a
+/// live diff against upstream. Keeping that list synced to dotnet/roslyn's
+/// <c>LocalRewriter/</c> directory is a human responsibility (the re-fetch command
+/// is in <c>LoweringCoverageTests</c>); when Roslyn adds or renames a lowering, a
+/// maintainer updates the list and this ledger together.</para>
 ///
 /// <para>Internal and never invoked on a product path (trim-removable) — a
 /// build-time checklist. Synced against dotnet/roslyn
@@ -41,6 +49,8 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static FixedStatementPass             FixedStatement             => new();
     [Completeness(CompletenessLevel.Full)] public static LockSugarPass                  LockStatement              => new();
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass             StackAlloc                 => new();
+    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass              PropertyAccess             => new();
+    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass              IndexerAccess              => new();
 
     // ───────── Raised by a pass — partially (the "finish these" roadmap) ─────────
     [Completeness(CompletenessLevel.Partial, "value-producing jump tables only; sparse + pattern switches still emit a statement")]
@@ -84,7 +94,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call                      => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field                     => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Event                     => default!;
-    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess         => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal                   => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration          => default!;
@@ -96,7 +105,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative HostObjectMemberReference => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess      => default!;
-    [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess          => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator                => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat              => default!;


### PR DESCRIPTION
Two corrections to the lowering completeness ledger (`LoweringCoverage`) so the register reads truthfully, plus doc clarifications on what the drift check actually guards.

## 1. Fix the mechanism column for property/indexer access

`PropertyAccess` and `IndexerAccess` were filed under the **"Importer-native — no idiom to recover"** banner. But they are *not* importer-native — they're recovered by `PropertySugarPass` (`get_X()`/`set_X()`/`get_Item()` → `obj.X` / `obj[i]`). Moved them into the **"Raised by a pass — fully"** section so the mechanism column matches the actual pipeline.

The enforcement tests read each entry's property **type**, not its file position, so this is a verbatim relocation — human-readable grouping only, zero behavior change.

## 2. Make the owed count exact, not a ceiling

The owed-idiom ratchet asserted `owed.Length <= ceiling`. A `<=` only catches *regressions* — a forgotten tighten (you implement a lowering but never lower the number) passes silently. Changed to `==`:

- implementing a lowering lowers the count,
- a newly-added Roslyn owed lowering raises it,

…and either way the count edit must land in the *same* change. The ledger can no longer quietly drift loose. Renamed the tuple field `OwedCeiling` → `Owed` and the test `OwedDoNotRegress` → `OwedCountIsExact`.

## 3. Doc honesty

Clarified in both the register and the test that the property-set check is an **in-repo consistency** guard (ledger ↔ the checked-in `RoslynLocalRewriters` list) — *not* a live diff against upstream Roslyn. Keeping that list synced to dotnet/roslyn's `LocalRewriter/` directory is a human responsibility (the `gh api` re-fetch command is in the test). Also noted the structuring rows are `Partial` as a pointer to `--gaps`, not a binary measure.

## Verification

- 5/5 `LoweringCoverageTests` green; 350/350 full decompiler suite green.
- Rebased clean onto current `origin/main` (#713).
