### PR TITLE
Raise simple string interpolation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1277,13 +1277,28 @@ public class RaisingPassTests
         return result.Output!.ReplaceLineEndings("\n").TrimEnd();
     }
 
+    static IrFunction RunThroughStructConstructor(string methodName, MetadataSource source)
+    {
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        foreach (var pass in IrPasses.Default)
+        {
+            pass.Run(function!, PassContext.None);
+            if (pass is StructConstructorPass)
+                break;
+        }
+        return function!;
+    }
+
     [Fact]
     public void StructConstructor_InPlaceCtor_PrintsNewObject()
     {
         // The in-place struct .ctor (ldloca; call S::.ctor) must print as an
         // assignment of a fresh value, never the illegal handler..ctor(...).
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
-        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.InterpolatedStruct), source);
+        var result = CSharpPrinter.Print(RunThroughStructConstructor(nameof(CfgSampleClass.InterpolatedStruct), source));
+        Assert.True(result.Succeeded);
+        string output = result.Output!.ReplaceLineEndings("\n").TrimEnd();
 
         Assert.Contains("new DefaultInterpolatedStringHandler(", output);
         Assert.DoesNotContain("..ctor", output);
@@ -1293,9 +1308,7 @@ public class RaisingPassTests
     public void StructConstructor_RaisesToNewObject_AtFullFidelity()
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.InterpolatedStruct));
-        Assert.NotNull(function);
-        IrPasses.Run(function);
+        var function = RunThroughStructConstructor(nameof(CfgSampleClass.InterpolatedStruct), source);
 
         // No struct .ctor call survives on a storage-location address...
         Assert.DoesNotContain(

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -45,7 +45,7 @@ public class LoweringCoverageTests
     // attribute. Owed (None/Unhandled) only ratchets DOWN — implementing one lowers it.
     static readonly (Type Type, int OwedCeiling, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 14, "LocalRewriter"),
+        (typeof(LoweringCoverage), 13, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StringInterpolationPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void HandlerAppendSequence_RaisesToInterpolatedString()
+    {
+        var function = Raised(nameof(CfgSampleClass.StringInterpolation));
+
+        var interpolation = Assert.Single(function.Descendants.OfType<InterpolatedStringExpression>());
+        Assert.Equal(5, interpolation.Parts.Length);
+        Assert.Equal(2, interpolation.FormattedValues.Count);
+        Assert.DoesNotContain(function.Descendants.OfType<NewObject>(),
+            n => n.Constructor.DeclaringType.Name == "DefaultInterpolatedStringHandler");
+    }
+
+    [Fact]
+    public void PrintRaised_RendersInterpolatedString()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.StringInterpolation))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return $\"Hello, {name}! You are {age} years old.\";", output);
+        Assert.DoesNotContain("DefaultInterpolatedStringHandler", output);
+    }
+
+    [Fact]
+    public void RepeatedFormattedValues_RendersEachHole()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolatedStruct))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return $\"value={value} again={value}\";", output);
+        Assert.DoesNotContain("AppendFormatted", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -880,6 +880,7 @@ public sealed partial class CSharpPrinter
         Call c => CallText(c),
         CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
+        InterpolatedStringExpression i => InterpolatedStringText(i),
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
@@ -997,10 +998,47 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
+    }
+
+    string InterpolatedStringText(InterpolatedStringExpression node)
+    {
+        var sb = new StringBuilder().Append("$\"");
+        foreach (var part in node.Parts)
+        {
+            if (part.IsLiteral)
+            {
+                sb.Append(InterpolatedLiteralText(part.Literal!));
+            }
+            else if (part.ExpressionIndex >= 0 && part.ExpressionIndex < node.FormattedValues.Count)
+            {
+                sb.Append('{').Append(InterpolatedExpression(node.FormattedValues[part.ExpressionIndex])).Append('}');
+            }
+        }
+        return sb.Append('"').ToString();
+    }
+
+    string InterpolatedExpression(IrExpression value)
+        => value is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField or LoadProperty or Call
+            ? Expression(value)
+            : $"({Expression(value)})";
+
+    static string InterpolatedLiteralText(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (char c in value)
+        {
+            if (c == '{')
+                sb.Append("{{");
+            else if (c == '}')
+                sb.Append("}}");
+            else
+                sb.Append(EscapeChar(c, inString: true));
+        }
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -968,6 +968,35 @@ public sealed class NewObject : IrExpression
     public override string Describe() => $"NewObject {Constructor.DeclaringType.ToDisplayString()}";
 }
 
+/// <summary>One segment in a raised interpolated string: either literal text or a formatted-expression child by index.</summary>
+public sealed record InterpolatedStringPart(string? Literal, int ExpressionIndex)
+{
+    public static InterpolatedStringPart LiteralText(string text) => new(text, -1);
+    public static InterpolatedStringPart FormattedValue(int expressionIndex) => new(null, expressionIndex);
+    public bool IsLiteral => Literal is not null;
+}
+
+/// <summary>
+/// A raised C# interpolated string. Produced by
+/// <see cref="StringInterpolationPass"/> from csc's straight-line
+/// <c>DefaultInterpolatedStringHandler</c> lowering.
+/// </summary>
+public sealed class InterpolatedStringExpression : IrExpression
+{
+    public InterpolatedStringExpression(IEnumerable<InterpolatedStringPart> parts, IEnumerable<IrExpression> formattedValues)
+    {
+        Parts = [.. parts];
+        foreach (var value in formattedValues)
+            AddChild(value);
+    }
+
+    public ImmutableArray<InterpolatedStringPart> Parts { get; }
+    public IReadOnlyList<IrExpression> FormattedValues => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "String");
+
+    public override string Describe() => $"InterpolatedString ({Parts.Length} parts)";
+}
+
 /// <summary>
 /// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native
 /// int. C# has no spelling for a bare function-pointer load, so this only

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -45,6 +45,10 @@ public static class IrPasses
         // (CS0201). Runs after the constructor-chain canonicalization so the
         // this/base receiver is already off the table.
         new StructConstructorPass(),
+        // Raise simple DefaultInterpolatedStringHandler append sequences back
+        // into $"..." before later passes have a chance to inline or reshape
+        // the handler local.
+        new StringInterpolationPass(),
         new PropertySugarPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -51,6 +51,8 @@ internal static class LoweringCoverage
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "reference-type local using with IDisposable null guard; value-type/constrained dispose not raised")]
     public static UsingStatementPass UsingStatement => new();
+    [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
+    public static StringInterpolationPass StringInterpolation => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -64,7 +66,6 @@ internal static class LoweringCoverage
     // ───────── Owed — no mechanism yet (the "start these" roadmap) ─────────
     [Completeness(CompletenessLevel.None, "x is T t / { Prop: ... }")]   public static Unhandled IsPatternOperator                   => default!;
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
-    [Completeness(CompletenessLevel.None, "$\"{a}{b}\"")]                public static Unhandled StringInterpolation                 => default!;
     [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;
     [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
     [Completeness(CompletenessLevel.None, "(a, b)")]                     public static Unhandled TupleCreationExpression             => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
@@ -1,0 +1,170 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the simple csc <c>DefaultInterpolatedStringHandler</c> lowering into a
+/// C# interpolated string. Scoped to straight-line handler construction followed
+/// by <c>AppendLiteral(string)</c> / <c>AppendFormatted&lt;T&gt;(T)</c> calls and a
+/// final <c>ToStringAndClear()</c> return in the same block.
+/// </summary>
+public sealed class StringInterpolationPass : IIrPass
+{
+    public string Name => "string-interpolation";
+
+    sealed record Match(StoreLocal StoreHandler, List<ExpressionStatement> Appends, Return ReturnStatement);
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (TransformOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool TransformOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i < children.Count; i++)
+            {
+                if (TryMatch(children, i) is not { } match)
+                    continue;
+
+                var consumed = new IrNode[] { match.StoreHandler, match.ReturnStatement, };
+                consumed = [.. consumed, .. match.Appends];
+                if (!ReferencedOnlyWithin(function, match.StoreHandler.Index, consumed))
+                    continue;
+
+                var parts = new List<InterpolatedStringPart>();
+                var values = new List<IrExpression>();
+                foreach (var append in match.Appends)
+                {
+                    var call = (Call)append.Expression;
+                    if (call.Callee.Name == "AppendLiteral")
+                    {
+                        parts.Add(InterpolatedStringPart.LiteralText((string)((Constant)call.Arguments[1]).Value!));
+                    }
+                    else
+                    {
+                        var callParts = call.DetachChildren().Cast<IrExpression>().ToList();
+                        var value = callParts[1];
+                        parts.Add(InterpolatedStringPart.FormattedValue(values.Count));
+                        values.Add(value);
+                    }
+                }
+
+                var interpolation = new InterpolatedStringExpression(parts, values);
+                stepper.StepOver("raise DefaultInterpolatedStringHandler sequence to interpolated string", match.StoreHandler);
+                match.ReturnStatement.ReplaceWith(new Return(interpolation));
+                foreach (var append in match.Appends)
+                    append.Detach();
+                match.StoreHandler.Detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static Match? TryMatch(IReadOnlyList<IrNode> statements, int start)
+    {
+        if (statements[start] is not StoreLocal { Value: NewObject handlerCtor } storeHandler
+            || !IsDefaultInterpolatedStringHandlerCtor(handlerCtor))
+        {
+            return null;
+        }
+
+        var appends = new List<ExpressionStatement>();
+        int i = start + 1;
+        while (i < statements.Count
+            && statements[i] is ExpressionStatement { Expression: Call append } expression
+            && IsAppend(append, storeHandler.Index))
+        {
+            appends.Add(expression);
+            i++;
+        }
+
+        if (appends.Count == 0
+            || i >= statements.Count
+            || statements[i] is not Return { Value: Call toString } ret
+            || !IsToStringAndClear(toString, storeHandler.Index))
+        {
+            return null;
+        }
+
+        return new Match(storeHandler, appends, ret);
+    }
+
+    static bool IsDefaultInterpolatedStringHandlerCtor(NewObject newObject)
+        => newObject.Constructor is
+            {
+                Name: ".ctor",
+                DeclaringType:
+                {
+                    Namespace: "System.Runtime.CompilerServices",
+                    Name: "DefaultInterpolatedStringHandler",
+                    Assembly: TypeRef.CoreLibrary or "System.Runtime",
+                },
+            }
+            && newObject.Arguments.Count >= 2;
+
+    static bool IsAppend(Call call, int handlerSlot)
+    {
+        if (!IsHandlerCall(call)
+            || call.Arguments is not [LoadLocalAddress receiver, ..]
+            || receiver.Index != handlerSlot)
+        {
+            return false;
+        }
+
+        return call switch
+        {
+            { Callee.Name: "AppendLiteral", Arguments: [_, Constant { Value: string }] } => true,
+            { Callee.Name: "AppendFormatted", Arguments.Count: 2 } => true,
+            _ => false,
+        };
+    }
+
+    static bool IsToStringAndClear(Call call, int handlerSlot)
+        => IsHandlerCall(call)
+            && call.Callee.Name == "ToStringAndClear"
+            && call.Arguments is [LoadLocalAddress receiver]
+            && receiver.Index == handlerSlot;
+
+    static bool IsHandlerCall(Call call)
+        => call.Callee is
+        {
+            HasThis: true,
+            DeclaringType:
+            {
+                Namespace: "System.Runtime.CompilerServices",
+                Name: "DefaultInterpolatedStringHandler",
+                Assembly: TypeRef.CoreLibrary or "System.Runtime",
+            },
+        };
+
+    static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                StoreLocal store => store.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                _ => false,
+            };
+            if (references && !allowed.Any(root => IsInside(node, root)))
+                return false;
+        }
+        return true;
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Add InterpolatedStringExpression IR and StringInterpolationPass for straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted sequences.
- Render raised interpolated string literals and register the pass in the default pipeline.
- Move StringInterpolation from owed to partial ledger coverage and add focused fixture tests.

## Testing

- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
