### PR TITLE
Raise general compound assignment (x op= v) for array/field/property/ref targets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -67,6 +67,28 @@ public class CfgSampleClass
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
+    // Compound assignment over an array element: `a[i] += v` captures &a[i] in a
+    // dup slot and stores back through it. The expanded `a[i] = a[i] + v` form
+    // (no slot) must NOT fold, so both spellings are kept for contrast.
+    public static void ArrayElementAdd(int[] a, int i, int v) => a[i] += v;
+
+    public static void ArrayElementShift(int[] a, int i, int n) => a[i] <<= n;
+
+    public static void ArrayElementInc(int[] a, int i) => a[i]++;
+
+    public static void ArrayElementExpandedAdd(int[] a, int i, int v) => a[i] = a[i] + v;
+
+    public int CompoundField;
+
+    // Compound assignment over an instance property and a ref target — both
+    // compile identically to their `x = x + v` expansion (no dup), so folding to
+    // `x += v` is unconditionally faithful.
+    public int CompoundProperty { get; set; }
+
+    public void PropertyAdd(int v) => CompoundProperty += v;
+
+    public static void RefAdd(ref int p, int v) => p += v;
+
     public static int TryFinallyAdd(int x)
     {
         try { return x + 1; }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1387,6 +1387,72 @@ public class RaisingPassTests
         Assert.DoesNotContain("S_", output);
     }
 
+    [Fact]
+    public void CompoundAssignment_ArrayElement_FoldsToCompoundOperator()
+    {
+        // `a[i] += v` lowers to &a[i] captured in a dup slot, then a store-back
+        // through that slot. The pass inlines the slot so the printer can spell
+        // the compound operator — and the spill slot must not leak.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ArrayElementAdd), source);
+
+        Assert.Contains("a[i] += v;", output);
+        Assert.DoesNotContain("S_", output);
+        Assert.DoesNotContain("ref int", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_ArrayElementShift_FoldsToCompoundOperator()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ArrayElementShift), source);
+
+        Assert.Contains("a[i] <<= n;", output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_ArrayElementIncrement_FoldsToIncrementOperator()
+    {
+        // `a[i]++` shares the address-slot shape; the ±1 case still spells ++.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ArrayElementInc), source);
+
+        Assert.Contains("a[i]++;", output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_ExpandedArrayElement_DoesNotFold()
+    {
+        // `a[i] = a[i] + v` evaluates the index twice (no address slot); it is a
+        // structurally different shape and must keep its expanded spelling.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ArrayElementExpandedAdd), source);
+
+        Assert.Contains("a[i] = a[i] + v;", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_RefTarget_FoldsToCompoundOperator()
+    {
+        // `p += v` through a ref parameter — compiles identically to `p = p + v`,
+        // so folding is faithful; the spurious parens around the deref also drop.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.RefAdd), source);
+
+        Assert.Contains("p += v;", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_Property_FoldsToCompoundOperator()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.PropertyAdd), source);
+
+        Assert.Contains("CompoundProperty += v;", output);
+    }
+
 
     [Fact]
     public void LocalNames_RecoveredFromPdb_RenderSourceNamesNotVSlots()
@@ -1967,7 +2033,8 @@ public class RaisingPassTests
     public void Indirect_ThroughManagedRef_HasNoPointerStar()
     {
         // *x = *x + 1 where x is a ref int param: a managed ref dereferences
-        // implicitly in C#, so no `*` — `*x` would be CS0193.
+        // implicitly in C#, so no `*` — `*x` would be CS0193. The self-reading
+        // store also folds to the increment operator (`x++`).
         var intType = TypeRef.CoreLib("System", "Int32");
         var refInt = TypeRef.ByRef(intType);
         LoadArgument X() => new(0, "x", refInt);
@@ -1985,8 +2052,7 @@ public class RaisingPassTests
         IrPasses.Run(function);
         string output = CSharpPrinter.Print(function).Output!;
 
-        Assert.Contains("x = ", output);
-        Assert.Contains("+ 1", output);
+        Assert.Contains("x++;", output);
         Assert.DoesNotContain("*", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -806,9 +806,21 @@ public sealed partial class CSharpPrinter
                 && Equals(load.Field.DeclaringType, s.Field.DeclaringType)
                 && SamePlace(load.Instance, s.Instance),
             s.Field.Type),
-        StoreProperty s => $"{PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual)} = {Expression(s.Value)};",
+        StoreProperty s => AssignmentText(
+            PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual),
+            s.Value,
+            left => s.IndexArguments.Count == 0
+                && left is LoadProperty load
+                && load.IndexArguments.Count == 0
+                && load.PropertyName == s.PropertyName
+                && Equals(load.Accessor.DeclaringType, s.Accessor.DeclaringType)
+                && SameLValue(load.Instance, s.Instance)),
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
-        StoreIndirect s => $"{Deref(s.Address)} = {CastValue(s.Value, IndirectStoreType(s.Address, s.Type))};",
+        StoreIndirect s => AssignmentText(
+            Deref(s.Address),
+            s.Value,
+            left => left is LoadIndirect load && SameLValue(load.Address, s.Address),
+            IndirectStoreType(s.Address, s.Type)),
         // default-initialization of a named place spells through the place,
         // not its address.
         InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
@@ -1082,7 +1094,13 @@ public sealed partial class CSharpPrinter
             // — no conversion is involved on this path.
             if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
                 return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
-            return $"{target} {BinaryOperator(binary)}= {Operand(binary.Right)};";
+            // A shift count carries the compiler's implicit width mask; strip it
+            // exactly as the expression form does so `x <<= n` does not re-mask on
+            // recompile (see ShiftCount).
+            string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
+                ? ShiftCount(binary)
+                : Operand(binary.Right);
+            return $"{target} {BinaryOperator(binary)}= {rightText};";
         }
         return $"{target} = {CastValue(value, targetType)};";
     }
@@ -1093,6 +1111,29 @@ public sealed partial class CSharpPrinter
         (null, null) => true,
         (LoadArgument x, LoadArgument y) => x.Index == y.Index,
         (LoadLocal x, LoadLocal y) => x.Index == y.Index,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Structural, side-effect-free equality for compound-assignment lvalues — the
+    /// receiver/address an <c>x op= v</c> fold reads on its right and writes on its
+    /// left. Restricted to leaves whose re-evaluation is observably free (locals,
+    /// arguments, constants, and field/element addresses rooted in those), so
+    /// collapsing the two evaluations into one preserves the opcode stream. A
+    /// shape with any potential side effect (a call, an arbitrary expression)
+    /// falls through to <c>false</c> and keeps the expanded spelling.
+    /// </summary>
+    static bool SameLValue(IrExpression? a, IrExpression? b) => (a, b) switch
+    {
+        (null, null) => true,
+        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
+        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
+        (Constant x, Constant y) => Equals(x.Value, y.Value),
+        (LoadField x, LoadField y) => x.Field.Name == y.Field.Name
+            && Equals(x.Field.DeclaringType, y.Field.DeclaringType) && SameLValue(x.Instance, y.Instance),
+        (LoadFieldAddress x, LoadFieldAddress y) => x.Field.Name == y.Field.Name
+            && Equals(x.Field.DeclaringType, y.Field.DeclaringType) && SameLValue(x.Instance, y.Instance),
+        (LoadElementAddress x, LoadElementAddress y) => SameLValue(x.Array, y.Array) && SameLValue(x.Index, y.Index),
         _ => false,
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -40,6 +40,8 @@ public sealed class IncrementDecrementPass : IIrPass
             {
                 if (TryFold(function, block, i, stepper))
                     return true;
+                if (TryFoldAddressCompound(function, block, i, stepper))
+                    return true;
             }
         }
         return false;
@@ -113,6 +115,63 @@ public sealed class IncrementDecrementPass : IIrPass
         stepper.StepOver($"fold dup {(isIncrement ? "++" : "--")} idiom into operator", useLoad);
         useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix));
         update.Detach();
+        slotStore.Detach();
+        return true;
+    }
+
+    /// <summary>
+    /// Folds the address-captured compound-assignment idiom — <c>a[i] += v</c>,
+    /// <c>a[i] &lt;&lt;= n</c>, <c>a[i]++</c> as a statement — back into the operator.
+    ///
+    /// A compound assignment to an lvalue whose address is non-trivial (an array
+    /// element, a struct field) evaluates that address once and stores back
+    /// through it via a <c>dup</c>: the importer raises the dup into a single-use
+    /// stack slot, leaving
+    ///
+    /// <code>
+    /// S = &amp;a[i];   *S = (*S) op v;
+    /// </code>
+    ///
+    /// Inlining the captured address into both the read and the write turns this
+    /// into a plain self-reading <c>StoreIndirect</c>, which the printer spells as
+    /// <c>a[i] op= v</c>. The fold is opcode-exact: the captured address proves the
+    /// receiver was evaluated once (the expanded <c>a[i] = a[i] + v</c> has no
+    /// address slot and a structurally different tree), so collapsing the two
+    /// reads of the slot back onto one address reorders nothing. A checked binary
+    /// is left alone — the printer would not fold it, and spelling two reads of the
+    /// element would re-evaluate the index.
+    /// </summary>
+    static bool TryFoldAddressCompound(IrFunction function, Block block, int i, Stepper stepper)
+    {
+        if (block.Children[i] is not StoreStackSlot slotStore)
+            return false;
+        if (slotStore.Value.ResultType is not { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer })
+            return false;
+        if (block.Children[i + 1] is not StoreIndirect store)
+            return false;
+        if (store.Address is not LoadStackSlot storeSlot || storeSlot.Slot != slotStore.Slot)
+            return false;
+        if (store.Value is not Binary { IsChecked: false } binary)
+            return false;
+        if (binary.Left is not LoadIndirect { Address: LoadStackSlot readSlot } || readSlot.Slot != slotStore.Slot)
+            return false;
+
+        // The captured address slot must be written once and read exactly twice —
+        // the store-back target and the read inside the operator — with nothing
+        // else, including the right operand, touching it.
+        int slot = slotStore.Slot;
+        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot) != 1)
+            return false;
+        var loads = function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == slot).ToList();
+        if (loads.Count != 2 || !loads.All(l => IsInside(l, store)))
+            return false;
+
+        stepper.StepOver("inline captured address into compound assignment", store);
+        var address = slotStore.Value;
+        address.Detach();
+        var readAddress = address.Clone();
+        store.SetChild(0, address);
+        ((LoadIndirect)binary.Left).SetChild(0, readAddress);
         slotStore.Detach();
         return true;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -47,7 +47,7 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass SwitchExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table switch statements; pattern + switch-on-string not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();
-    [Completeness(CompletenessLevel.Partial, "++/-- only; general compound assignment (+=, ...) not raised")]
+    [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, and ref targets raised; checked-context and indexer/nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────


### PR DESCRIPTION
## What

Finishes the **CompoundAssignmentOperator** idiom in the C# decompiler. Previously `x = x + v` folded to `x += v` only for locals, arguments, and fields. Three target shapes were left expanded:

| Source | Before | After |
|---|---|---|
| `a[i] += v` | `ref int S = ref a[i]; S = (S) + v;` | `a[i] += v;` |
| `a[i]++` (statement) | `ref int S = ref a[i]; S = S + 1;` | `a[i]++;` |
| `obj.Prop += v` | `obj.Prop = obj.Prop + v;` | `obj.Prop += v;` |
| `p += v` (ref) | `p = (p) + v;` | `p += v;` |

## How

- **`IncrementDecrementPass`** — a new fold inlines the address-captured dup form (`S = &a[i]; *S = (*S) op v`) into a plain self-reading `StoreIndirect`, which the printer spells `a[i] op= v`. The captured address slot is the *unambiguous* signature of compound assignment: the expanded `a[i] = a[i] + v` evaluates the index twice and has no slot, so the fold is opcode-exact. Checked binaries are left alone.
- **`CSharpPrinter`** — routes `StoreProperty` and `StoreIndirect` through the existing compound-fold path, guarded by a new side-effect-free `SameLValue` check. These idempotent receivers compile *identically* for the `x += v` and `x = x + v` source forms (verified — no `dup`), so the fold is unconditionally faithful. The compound path now also strips the shift-width mask via `ShiftCount`, matching the expression form.
- **Ledger** — `CompoundAssignmentOperator` stays `Partial` (checked-context, indexer, and nested-struct field compound remain unraised) with an updated note.

## Validation

- 356 decompiler + 1157 `dotnet-inspect` tests pass.
- New fixtures (`ArrayElementAdd/Shift/Inc`, `ArrayElementExpandedAdd`, `RefAdd`, `PropertyAdd`) are covered by the **opcode-fidelity gate** (`FidelityGateTests`) — they recompile opcode-exact, and the expanded form correctly stays unfolded.
- CoreLib `--validity-check` diff vs main: **0 new defects, 0 regressions** over 3,556 methods; `--gaps` shows **0 pass bugs**.