### PR TITLE
Give the lowering ledger's prose teeth: require gap notes where they carry the gap

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -124,7 +124,10 @@ public class LoweringCoverageTests
         foreach (var p in Props(typeof(NativePasses)))
         {
             Assert.True(IsPass(p), $"NativePasses.{p.Name}: must be a pass type ({p.PropertyType.Name} is not an IIrPass).");
-            Assert.True(p.GetCustomAttribute<NativeAttribute>() is not null, $"NativePasses.{p.Name}: missing [Native] — say what it reconstructs.");
+            var native = p.GetCustomAttribute<NativeAttribute>();
+            Assert.True(native is not null, $"NativePasses.{p.Name}: missing [Native] — say what it reconstructs.");
+            Assert.False(string.IsNullOrWhiteSpace(native!.What),
+                $"NativePasses.{p.Name}: [Native] What is empty — the whole point of this register is to say what the pass reconstructs.");
             Assert.True(registered.Contains(p.PropertyType), $"NativePasses.{p.Name} -> {p.PropertyType.Name}: not in IrPasses.Default.");
             Assert.False(coveragePassTypes.Contains(p.PropertyType),
                 $"NativePasses.{p.Name}: {p.PropertyType.Name} also inverts a Roslyn lowering — it belongs in a coverage register, not here.");
@@ -146,5 +149,26 @@ public class LoweringCoverageTests
             $"Pipeline pass types classified by neither a Roslyn-forward register nor NativePasses: {string.Join(", ", unclassified)}");
         Assert.True(phantom.Length == 0,
             $"Ledger references pass types not in IrPasses.Default: {string.Join(", ", phantom)}");
+    }
+
+    // Where the mechanism axis already tells the full story (a Full importer-native
+    // lowering needs no caveat), a note is optional. But anything LESS than Full is a
+    // gap, and an undocumented gap is a silent "trust me": a Partial row must say what
+    // it does NOT cover, and an owed (None) row must name the idiom it owes. This keeps
+    // the "finish these" / "start these" roadmap from decaying into bare property names.
+    [Fact]
+    public void NonFullCoverageEntries_CarryAGapNote()
+    {
+        foreach (var (type, _, name) in CoverageRegisters)
+            foreach (var p in Props(type))
+            {
+                var attr = p.GetCustomAttribute<CompletenessAttribute>()!;
+                if (attr.Level == CompletenessLevel.Full)
+                    continue;
+
+                Assert.False(string.IsNullOrWhiteSpace(attr.Note),
+                    $"{name}.{p.Name}: {attr.Level} with no note. A Partial row must state what it does not cover; "
+                        + "an owed (None) row must name the idiom it owes — otherwise the gap is undocumented.");
+            }
     }
 }


### PR DESCRIPTION
The completeness notes are the lowering ledger's "finish these" (Partial) / "start these" (owed) roadmap — but nothing enforced their *presence*. A `Partial` or owed (`None`) row could quietly decay into a bare property name with no explanation: a silent "trust me." Same for `[Native]` passes, whose entire purpose is to *say what they reconstruct*.

Two additive invariants, both **green on arrival** (every entry already complies — this locks the discipline in):

## 1. Non-Full coverage entries must carry a gap note

Where the mechanism axis already tells the whole story — a `Full` importer-native lowering — a note is optional and stays so. But anything **less than Full is a gap**, and an undocumented gap is the thing the ledger exists to prevent:

- a `Partial` row must state what it does **not** cover,
- an owed (`None`) row must name the **idiom it owes**.

New test `NonFullCoverageEntries_CarryAGapNote`.

## 2. Every `[Native]` `What` must be non-empty

Saying what a decompiler-native pass reconstructs is the *entire point* of `NativePasses`; an empty string defeats the register. Tightened the existing `NativePasses_AreRegistered_AndDisjointFromCoverage`.

## Verification

- Confirmed the first test has **teeth**: blanking `IsPatternOperator`'s note makes it fail, then reverted.
- 356/356 decompiler suite green.
- Branched off current `origin/main` (#713); additive (new method at file end + one assertion), independent of #715.
