### PR TITLE
Raise local null-coalescing assignment

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -860,6 +860,13 @@ public class CfgSampleClass
         return a ?? b;
     }
 
+    public static string NullCoalescingAssignLocal(string? input, string fallback)
+    {
+        string? value = input;
+        value ??= fallback;
+        return value;
+    }
+
     public static string[] ArrayWithInit(string a)
     {
         return new string[] { a, "hello" };

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 13, "LocalRewriter"),
+        (typeof(LoweringCoverage), 12, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -1,0 +1,46 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class NullCoalescingAssignmentPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void LocalNullAssignmentDiamond_RaisesToNullCoalescingAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignLocal));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.Equal("string", assignment.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(assignment.Value);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignLocal))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("value ??= fallback;", output);
+        Assert.Contains("return value;", output);
+    }
+
+    [Fact]
+    public void NullCoalescingOperator_RemainsExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalesce));
+
+        Assert.Single(function.Descendants.OfType<Coalesce>());
+        Assert.DoesNotContain(function.Descendants.OfType<NullCoalescingAssignment>(), _ => true);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -291,6 +291,7 @@ public sealed partial class CSharpPrinter
                 case LoadLocal l: locals.Add(l.Index); break;
                 case StoreLocal s: locals.Add(s.Index); break;
                 case LoadLocalAddress a: locals.Add(a.Index); break;
+                case NullCoalescingAssignment n: locals.Add(n.LocalIndex); break;
                 // A slot's declared type is the type it is loaded AS — the merged
                 // join type every predecessor's store is assignable to. A store
                 // value can be a subtype at a join (object slot fed a string),
@@ -396,6 +397,7 @@ public sealed partial class CSharpPrinter
                     break;
                 case LoadLocal load: seenLocals.Add(load.Index); break;
                 case LoadLocalAddress address: seenLocals.Add(address.Index); break;
+                case NullCoalescingAssignment assignment: seenLocals.Add(assignment.LocalIndex); break;
                 case StoreStackSlot slotStore when !seenSlots.Contains(slotStore.Slot):
                     seenSlots.Add(slotStore.Slot);
                     if (entryStatements.Contains(slotStore) && slotStore.Value.ResultType is not null
@@ -807,6 +809,7 @@ public sealed partial class CSharpPrinter
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
+        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -233,6 +233,11 @@ static class DefiniteAssignment
                             CheckReads(store.Value, running);
                             running.Add(store.Index);
                             break;
+                        case NullCoalescingAssignment assignment:
+                            CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), running);
+                            CheckReads(assignment.Value, running);
+                            running.Add(assignment.LocalIndex);
+                            break;
                         case InitObject { Address: LoadLocalAddress address }:
                             running.Add(address.Index);
                             break;
@@ -261,6 +266,11 @@ static class DefiniteAssignment
                 case StoreLocal store:
                     CheckReads(store.Value, assigned);
                     assigned.Add(store.Index);
+                    return DefiniteFlow.FallThrough;
+                case NullCoalescingAssignment assignment:
+                    CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), assigned);
+                    CheckReads(assignment.Value, assigned);
+                    assigned.Add(assignment.LocalIndex);
                     return DefiniteFlow.FallThrough;
                 case InitObject { Address: LoadLocalAddress address }:
                     assigned.Add(address.Index);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -624,6 +624,28 @@ public sealed class Coalesce : IrExpression
 }
 
 /// <summary>
+/// A raised local-variable null-coalescing assignment (<c>V ??= fallback</c>).
+/// Produced from csc's local null-test diamond:
+/// <c>if (V is null) V = fallback;</c>.
+/// </summary>
+public sealed class NullCoalescingAssignment : IrNode
+{
+    public NullCoalescingAssignment(int localIndex, TypeRef localType, IrExpression value)
+    {
+        LocalIndex = localIndex;
+        LocalType = localType;
+        AddChild(value);
+    }
+
+    public int LocalIndex { get; }
+    public TypeRef LocalType { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+    public override IEnumerable<TypeRef> DirectTypes => [LocalType];
+
+    public override string Describe() => $"NullCoalescingAssignment V_{LocalIndex}";
+}
+
+/// <summary>
 /// A raised null-conditional member access — <c>target?.Member</c>. The single
 /// child is the member access (a <see cref="Call"/>, <see cref="LoadProperty"/>,
 /// or <see cref="LoadField"/>) whose receiver IS the <c>?.</c> target; the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -76,6 +76,10 @@ public static class IrPasses
         new LockSugarPass(),
         new ForLoopPass(),
         new BooleanFoldingPass(),
+        // Raise local `if (V is null) V = fallback;` diamonds into `V ??= fallback`.
+        // Runs after structuring/boolean folding so the null test is a shaped
+        // IfStatement, before later expression inlining reshapes local uses.
+        new NullCoalescingAssignmentPass(),
         // Raise the null-conditional lowering (receiver spill + null diamond)
         // into target?.Member before the second inlining run, so the receiver
         // spill collapses into the ?. target and the reused slot stops carrying

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -63,6 +63,8 @@ internal static class LoweringCoverage
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
     public static StringInterpolationPass StringInterpolation => new();
+    [Completeness(CompletenessLevel.Partial, "local-variable ??= only; fields/properties/indexers not raised")]
+    public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -81,7 +83,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "(a, b)")]                     public static Unhandled TupleCreationExpression             => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
-    [Completeness(CompletenessLevel.None, "a ??= b")]                    public static Unhandled NullCoalescingAssignmentOperator    => default!;
     [Completeness(CompletenessLevel.None, "new T { X = 1 }")]           public static Unhandled ObjectOrCollectionInitializerExpression => default!;
     [Completeness(CompletenessLevel.None, "new { a, b }")]               public static Unhandled AnonymousObjectCreation             => default!;
     [Completeness(CompletenessLevel.None, "from x in xs select ...")]    public static Unhandled Query                               => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -1,0 +1,55 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the local-variable form of csc's null-coalescing assignment lowering:
+/// <code>
+/// if (V is null) { V = fallback; }
+/// </code>
+/// into <c>V ??= fallback</c>. Scoped to locals; field/property/indexer
+/// <c>??=</c> shapes carry receiver-evaluation and setter concerns left to later
+/// slices.
+/// </summary>
+public sealed class NullCoalescingAssignmentPass : IIrPass
+{
+    public string Name => "null-coalescing-assignment";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var statement in function.Descendants.OfType<IfStatement>().ToList())
+        {
+            if (TryMatch(statement) is not { } match)
+                continue;
+
+            var value = (IrExpression)match.Store.DetachChildren()[0];
+            var replacement = new NullCoalescingAssignment(match.Local.Index, match.Local.Type, value);
+            context.Stepper.StepOver("raise local null check assignment to ??=", statement);
+            statement.ReplaceWith(replacement);
+        }
+    }
+
+    sealed record Match(LoadLocal Local, StoreLocal Store);
+
+    static Match? TryMatch(IfStatement statement)
+    {
+        if (statement.HasElse
+            || statement.Then.Children is not [StoreLocal store]
+            || NullTestedLocal(statement.Condition) is not { } local
+            || store.Index != local.Index)
+        {
+            return null;
+        }
+
+        if (TypeFamilies.Of(local.Type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+            return null;
+
+        return new Match(local, store);
+    }
+
+    static LoadLocal? NullTestedLocal(IrExpression condition) => condition switch
+    {
+        LogicalNot { Operand: LoadLocal local } => local,
+        Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal local, Right: Constant { Value: null } } => local,
+        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: LoadLocal local } => local,
+        _ => null,
+    };
+}


### PR DESCRIPTION
## Summary

- Add NullCoalescingAssignment IR and NullCoalescingAssignmentPass for local-variable if-null assignment diamonds.
- Render local ??= statements and model them in definite-assignment analysis.
- Move NullCoalescingAssignmentOperator from owed to partial ledger coverage with focused fixture tests.

## Testing

- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
