### PR TITLE
Raise array and string index-from-end

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -69,6 +69,13 @@ public class CfgSampleClass
 
     public static int LastElement(int[] a) => a[^1];
 
+    // Negative fixture: hand-written `a[a.Length - 1]` re-loads the array
+    // directly (two ldarg, no receiver spill), unlike the `^1` lowering which
+    // spills into one stack slot. IndexFromEndPass must NOT raise this — doing
+    // so would recompile to a different opcode stream (ldarg dup … vs ldarg
+    // ldarg …). Kept opcode-exact by the fidelity gate.
+    public static int LastElementHandWritten(int[] a) => a[a.Length - 1];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // Compound assignment over an array element: `a[i] += v` captures &a[i] in a

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -18,6 +18,8 @@ public class CfgSampleClass
 
     public static int LengthOf(string s) => s.Length;
 
+    public static char LastChar(string s) => s[^1];
+
     public static int Twice(int x) { var t = x + x; return t; }
 
     public static int Reused(int x) { var n = x + 1; return n * n; }
@@ -64,6 +66,8 @@ public class CfgSampleClass
     public static int ParseOrZero(string s) => int.TryParse(s, out var v) ? v : 0;
 
     public static int FirstElement(int[] a) => a[0];
+
+    public static int LastElement(int[] a) => a[^1];
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -32,6 +32,7 @@ public class IdiomShapeScorecardTests
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -41,4 +41,17 @@ public class IndexFromEndPassTests
         Assert.NotNull(output);
         Assert.Equal("return s[^1];", output.ReplaceLineEndings("\n").Trim());
     }
+
+    [Fact]
+    public void HandWrittenLengthMinusConstant_IsNotRaised()
+    {
+        // `a[a.Length - 1]` re-loads the array directly (no receiver spill), so
+        // it is not the compiler's `^n` lowering. Raising it would change the
+        // opcode stream on recompile, so the pass must leave it alone.
+        var function = Raised(nameof(CfgSampleClass.LastElementHandWritten));
+
+        Assert.Empty(function.Descendants.OfType<IndexFromEnd>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return a[a.Length - 1];", output!.ReplaceLineEndings("\n").Trim());
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -1,0 +1,44 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IndexFromEndPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void ArrayLengthMinusConstant_RaisesToIndexFromEnd()
+    {
+        var function = Raised(nameof(CfgSampleClass.LastElement));
+
+        var index = Assert.Single(function.Descendants.OfType<IndexFromEnd>());
+        Assert.Equal(1, Assert.IsType<Constant>(index.Offset).Value);
+        Assert.Single(function.Descendants.OfType<LoadElement>());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersArrayIndexFromEnd()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.LastElement))).Output;
+
+        Assert.NotNull(output);
+        Assert.Equal("return a[^1];", output.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersStringIndexFromEnd()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.LastChar))).Output;
+
+        Assert.NotNull(output);
+        Assert.Equal("return s[^1];", output.ReplaceLineEndings("\n").Trim());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 11, "LocalRewriter"),
+        (typeof(LoweringCoverage), 10, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 10, "LocalRewriter"),
+        (typeof(LoweringCoverage), 8, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -902,6 +902,7 @@ public sealed partial class CSharpPrinter
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
         ArrayLength l => $"{Operand(l.Array)}.Length",
+        IndexFromEnd i => $"^{Operand(i.Offset)}",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
@@ -1014,7 +1015,7 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or IndexFromEnd or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1229,6 +1229,17 @@ public sealed class ArrayLength : IrExpression
     public override string Describe() => "ArrayLength";
 }
 
+/// <summary>A raised C# index-from-end operand (<c>^n</c>), used inside array/string element access.</summary>
+public sealed class IndexFromEnd : IrExpression
+{
+    public IndexFromEnd(IrExpression offset) => AddChild(offset);
+
+    public IrExpression Offset => (IrExpression)Children[0];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Index");
+
+    public override string Describe() => "IndexFromEnd";
+}
+
 public sealed class Box : IrExpression
 {
     public Box(TypeRef type, IrExpression operand)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
@@ -1,0 +1,67 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's index-from-end lowering for arrays and strings:
+/// <c>receiver[receiver.Length - n]</c> becomes <c>receiver[^n]</c>. The pass
+/// rewrites only the index operand; the second expression-inlining pass then
+/// collapses the compiler's duplicated receiver stack slot back into the
+/// element receiver when it is single-use.
+/// </summary>
+public sealed class IndexFromEndPass : IIrPass
+{
+    public string Name => "index-from-end";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            switch (node)
+            {
+                case LoadElement element:
+                    TryRewrite(element.Array, element.Index, context.Stepper);
+                    break;
+                case LoadElementAddress address:
+                    TryRewrite(address.Array, address.Index, context.Stepper);
+                    break;
+                case StoreElement store:
+                    TryRewrite(store.Array, store.Index, context.Stepper);
+                    break;
+                case LoadProperty property when property is { HasInstance: true, PropertyName: "Chars", IndexArguments.Count: 1 }:
+                    TryRewrite(property.Instance!, property.IndexArguments[0], context.Stepper);
+                    break;
+            }
+        }
+    }
+
+    static bool TryRewrite(IrExpression receiver, IrExpression index, Stepper stepper)
+    {
+        if (index is not Binary { Kind: BinaryKind.Subtract, Right: Constant { Value: int offset } } subtract
+            || offset < 0
+            || LengthReceiver(subtract.Left) is not { } lengthReceiver
+            || !SamePlace(receiver, lengthReceiver))
+        {
+            return false;
+        }
+
+        var offsetNode = (IrExpression)subtract.DetachChildren()[1];
+        var raised = new IndexFromEnd(offsetNode);
+        stepper.StepOver("raise receiver.Length - n to ^n index", subtract);
+        subtract.ReplaceWith(raised);
+        return true;
+    }
+
+    static IrExpression? LengthReceiver(IrExpression expression) => expression switch
+    {
+        ArrayLength length => length.Array,
+        LoadProperty { HasInstance: true, PropertyName: "Length" } property => property.Instance,
+        _ => null,
+    };
+
+    static bool SamePlace(IrExpression left, IrExpression right) => (left, right) switch
+    {
+        (LoadStackSlot a, LoadStackSlot b) => a.Slot == b.Slot,
+        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
+        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
+        _ => false,
+    };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
@@ -57,11 +57,15 @@ public sealed class IndexFromEndPass : IIrPass
         _ => null,
     };
 
+    // The compiler's index-from-end lowering spills the receiver into a single
+    // stack slot and reads it twice (for .Length and for the index), so at this
+    // point in the pipeline a genuine `^n` always presents as two reads of the
+    // same stack slot. Hand-written `a[a.Length - n]` re-loads the receiver
+    // directly (two ldarg/ldloc, no spill); matching those would rewrite faithful
+    // source into `^n` whose recompile produces a different opcode stream.
     static bool SamePlace(IrExpression left, IrExpression right) => (left, right) switch
     {
         (LoadStackSlot a, LoadStackSlot b) => a.Slot == b.Slot,
-        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
-        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
         _ => false,
     };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -54,6 +54,10 @@ public static class IrPasses
         // already been normalized to NewObject when they are spellable.
         new TupleCreationPass(),
         new PropertySugarPass(),
+        // Raise array/string receiver.Length - n index operands into ^n. This
+        // removes the duplicate receiver use so the later inlining pass can
+        // collapse the compiler's dup spill back into the element receiver.
+        new IndexFromEndPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once
         // inlining has placed the function-pointer load in the ctor's argument

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -67,6 +67,8 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
+    [Completeness(CompletenessLevel.Partial, "array/string constant-from-end indexing only; Range/slicing not raised")]
+    public static IndexFromEndPass Index => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -81,7 +83,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "x is T t / { Prop: ... }")]   public static Unhandled IsPatternOperator                   => default!;
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
     [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;
-    [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
     [Completeness(CompletenessLevel.None, "new T { X = 1 }")]           public static Unhandled ObjectOrCollectionInitializerExpression => default!;


### PR DESCRIPTION
## Summary

- Add IndexFromEnd IR and IndexFromEndPass for receiver.Length - n index operands in array and string element access.
- Render ^n indexes and register the pass before later receiver-spill inlining.
- Move Index from owed to partial ledger coverage with focused fixture tests.

## Testing

- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
