### PR TITLE
Raise the is-pattern type test (value is T t)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -457,6 +457,41 @@ public class CfgSampleClass
         }
     }
 
+    // `is T t` type pattern as a statement guard. csc lowers it to a
+    // `t = o as T;` store gating an `if (t != null)`; IsPatternPass raises that
+    // back to `if (o is string s)`, which recompiles to the same as/brtrue.
+    public static int IsPatternGuard(object o)
+    {
+        if (o is string s)
+            return s.Length;
+        return -1;
+    }
+
+    // `is T t` used as a value in a short-circuit `&&` expression. The pattern
+    // binds in the left conjunct and is read in the right.
+    public static bool IsPatternConjunction(object o) => o is string s && s.Length > 0;
+
+    // A property pattern lowers to the same as-store plus `t != null && t.P == k`;
+    // recovered as `o is string s && s.Length == 5` (the deconstructed `{ ... }`
+    // form is a later slice).
+    public static int IsPatternProperty(object o)
+    {
+        if (o is string { Length: 5 })
+            return 1;
+        return 0;
+    }
+
+    // Negative: a plain `as` whose local is read on BOTH the matched and the
+    // fall-through paths is not a pattern binding (the variable would not be
+    // definitely assigned), so it must stay a flat `as` + null test.
+    public static string AsWithoutPattern(object o)
+    {
+        var s = o as string;
+        if (s != null)
+            return s;
+        return s ?? "none";
+    }
+
     public static int NormalUsing(string s)
     {
         using var reader = new System.IO.StringReader(s);

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -74,6 +74,9 @@ public class FidelityGateTests
         "SumTwoPinned",
         "ConstantUIntSpan",
         "InlineArraySpan",
+        "IsPatternGuard",
+        "IsPatternConjunction",
+        "IsPatternProperty",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -1,0 +1,78 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IsPatternPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void StatementGuard_RaisesAsNullTestToIsPattern()
+    {
+        // `if (o is string s)` lowers to `string s = o as string; if (s != null)`.
+        // The pass folds the as-store and null test into one `is` pattern.
+        var function = Raised(nameof(CfgSampleClass.IsPatternGuard));
+
+        var pattern = Assert.Single(function.Descendants.OfType<IsPattern>());
+        Assert.Equal("string", pattern.Type.ToDisplayString());
+        Assert.IsType<LoadArgument>(pattern.Value);
+        Assert.Empty(function.Descendants.OfType<IsInstance>());
+    }
+
+    [Fact]
+    public void StatementGuard_RendersIsPatternHeader()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.IsPatternGuard))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("if (o is string s)", output);
+        Assert.DoesNotContain("as string", output);
+        Assert.DoesNotContain("is not null", output);
+    }
+
+    [Fact]
+    public void Conjunction_RaisesLeftOperandToIsPattern()
+    {
+        // `o is string s && s.Length > 0` — the pattern binds in the left
+        // conjunct and is read in the right.
+        var function = Raised(nameof(CfgSampleClass.IsPatternConjunction));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("o is string s && s.Length > 0", output);
+    }
+
+    [Fact]
+    public void PropertyPattern_RecoversAsTypePatternConjunction()
+    {
+        // `o is string { Length: 5 }` lowers to the same as-store plus
+        // `s != null && s.Length == 5`; recovered as `o is string s && ...`.
+        var function = Raised(nameof(CfgSampleClass.IsPatternProperty));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("is string", output);
+        Assert.Contains("&& ", output);
+        Assert.Contains("== 5", output);
+    }
+
+    [Fact]
+    public void AsLocalReadOnFallThroughPath_StaysFlat()
+    {
+        // The `as` local is read on both the matched and fall-through paths, so
+        // binding it inside the pattern would leave it not definitely assigned
+        // on the false path. The pass must leave the flat `as` + null test.
+        var function = Raised(nameof(CfgSampleClass.AsWithoutPattern));
+
+        Assert.Empty(function.Descendants.OfType<IsPattern>());
+        Assert.Single(function.Descendants.OfType<IsInstance>());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -63,6 +63,9 @@ public class LoweredFidelityGateTests
         "SumTwoPinned",
         "ConstantUIntSpan",
         "InlineArraySpan",
+        "IsPatternGuard",
+        "IsPatternConjunction",
+        "IsPatternProperty",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 14, "LocalRewriter"),
+        (typeof(LoweringCoverage), 13, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -175,6 +175,9 @@ public sealed partial class CSharpPrinter
     /// <summary>Resource local slots a <see cref="UsingStatement"/> owns: declared by the using header, not up front.</summary>
     readonly HashSet<int> _usingLocals = [];
 
+    /// <summary>Pattern variable slots an <see cref="IsPattern"/> binds: declared by the <c>is T t</c> pattern, not up front.</summary>
+    readonly HashSet<int> _isPatternLocals = [];
+
     /// <summary>Ref-struct locals whose hoisted declaration must spell <c>scoped</c>: a <c>stackalloc</c>-initialized span whose declaration was split from its assignment (out of the unsafe block) would otherwise warn CS9081. A stackalloc result is always scoped, so this is faithful, not a guess.</summary>
     readonly HashSet<int> _scopedLocals = [];
 
@@ -189,6 +192,8 @@ public sealed partial class CSharpPrinter
             _fixedLocals.Add(fixedNode.LocalIndex);
         foreach (var usingNode in function.Descendants.OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
+        foreach (var pattern in function.Descendants.OfType<IsPattern>())
+            _isPatternLocals.Add(pattern.LocalIndex);
         CollectDeclaringStores(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
@@ -308,9 +313,9 @@ public sealed partial class CSharpPrinter
         }
         foreach (int index in locals)
         {
-            // Fixed/using headers declare their owned locals, not the up-front
-            // declaration block.
-            if (_fixedLocals.Contains(index) || _usingLocals.Contains(index))
+            // Fixed/using headers and `is T t` patterns declare their owned
+            // locals, not the up-front declaration block.
+            if (_fixedLocals.Contains(index) || _usingLocals.Contains(index) || _isPatternLocals.Contains(index))
                 continue;
             bool declaredAtStore = _declaringStores.Any(s =>
                 s is StoreLocal store && store.Index == index
@@ -893,6 +898,7 @@ public sealed partial class CSharpPrinter
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
+        IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
         UnboxAny u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1188,6 +1188,38 @@ public sealed class IsInstance : IrExpression
     public override string Describe() => $"IsInstance {Type.ToDisplayString()}";
 }
 
+/// <summary>
+/// A raised <c>is</c> type pattern with a binding: <c>value is T t</c>. Produced
+/// by <see cref="IsPatternPass"/> from csc's type-pattern lowering — a local
+/// assigned <c>value as T</c> immediately before a null test that gates a scope
+/// using the local as the narrowed <c>T</c>. The null test becomes this
+/// expression; <see cref="LocalIndex"/> is the bound pattern variable, declared
+/// by the pattern itself (so the printer skips its up-front declaration).
+/// </summary>
+public sealed class IsPattern : IrExpression
+{
+    public IsPattern(IrExpression value, TypeRef type, int localIndex)
+    {
+        Type = type;
+        LocalIndex = localIndex;
+        AddChild(value);
+    }
+
+    /// <summary>The type the value is tested against — the <c>T</c> in <c>value is T t</c>.</summary>
+    public TypeRef Type { get; }
+
+    /// <summary>The local slot bound by the pattern when the test succeeds.</summary>
+    public int LocalIndex { get; }
+
+    /// <summary>The value being tested.</summary>
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"IsPattern {Type.ToDisplayString()} V_{LocalIndex}";
+}
+
 public sealed class CastClass : IrExpression
 {
     public CastClass(TypeRef type, IrExpression operand)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -80,6 +80,12 @@ public static class IrPasses
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // Raise the csc type-pattern lowering (a `value as T` store gating a
+        // null test that scopes the narrowed local) into `value is T t`. Runs
+        // after structuring and boolean folding so the `if` guard and the
+        // `&&` short-circuit operand are both formed; left flat it renders as
+        // a separate `T t = value as T; if (t is not null)`.
+        new IsPatternPass(),
         // Fold the compiler's dup-based ++/-- idiom (a value-carrying increment
         // spilled to a single-use slot beside the local update) back into the
         // operator at the use site, so a[--i] = src[j++] recompiles to the same

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -1,0 +1,153 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises csc's type-pattern lowering into an <see cref="IsPattern"/>
+/// expression — <c>value is T t</c>. The proven shape, after structuring and
+/// boolean folding:
+/// <code>
+///   T t = value as T;          // StoreLocal t = IsInstance T(value)
+///   if (t != null) { ...t... } // statement guard
+///   // or, as a short-circuit expression:
+///   ... t != null &amp;&amp; ...t... // LogicalAnd(LoadLocal t, rest)
+/// </code>
+/// The null test on <c>t</c> becomes <c>value is T t</c>, binding the pattern
+/// variable for the guarded scope; the separate <c>as</c> store is dropped.
+///
+/// <para>Left flat the construct renders as a valid-but-inferior
+/// <c>T t = value as T; if (t is not null) { ... }</c> — the owed
+/// <c>is</c>-pattern idiom. Transactional: the pattern local must be referenced
+/// only by the <c>as</c> store, the null test being replaced, and the scope the
+/// test gates (the <c>if</c>-body or the <c>&amp;&amp;</c> right operand), and
+/// the tested value must be side-effect-free so moving it into the pattern
+/// cannot reorder observable effects. Otherwise the construct is left flat.</para>
+///
+/// <para>A property pattern <c>value is T { P: k }</c> lowers to the same
+/// <c>as</c> store followed by <c>t != null &amp;&amp; t.P == k</c>; this pass
+/// recovers it as <c>value is T t &amp;&amp; t.P == k</c> (semantically identical,
+/// the deconstructed-property form is a later slice).</para>
+/// </summary>
+public sealed class IsPatternPass : IIrPass
+{
+    public string Name => "is-pattern";
+
+    sealed record TestSite(IrExpression TestNode, IrNode TrueScope);
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (TransformOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool TransformOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not StoreLocal { Value: IsInstance asCast } store)
+                    continue;
+
+                // The tested value is inlined into the pattern, so it must not
+                // depend on the pattern local and must be reorder-safe.
+                if (ReferencesLocal(asCast.Operand, store.Index) || !IsSideEffectFree(asCast.Operand))
+                    continue;
+
+                if (FindTest(children[i + 1], store.Index) is not { } site)
+                    continue;
+
+                // Soundness: the pattern local must be referenced ONLY by the
+                // as-cast store, the null test being replaced, and the scope that
+                // test gates. A reference before the store or outside the gated
+                // region means binding it inside the pattern would change which
+                // paths see it definitely assigned — leave it flat.
+                if (!ReferencedOnlyWithin(function, store.Index, [store, site.TestNode, site.TrueScope]))
+                    continue;
+
+                var value = (IrExpression)asCast.DetachChildren()[0];
+                var pattern = new IsPattern(value, asCast.Type, store.Index);
+                stepper.StepOver("raise as/null-test to is pattern", site.TestNode);
+                site.TestNode.ReplaceWith(pattern);
+                store.Detach();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Locates the null test on the pattern local in the statement that follows
+    /// the <c>as</c> store, plus the scope that test gates.
+    /// </summary>
+    static TestSite? FindTest(IrNode next, int index)
+    {
+        // Short-circuit form: `t != null && rest` — the leading conjunct is the
+        // bare truthy load of the pattern local; the right operand is the scope
+        // entered only when the pattern matched.
+        foreach (var logical in next.Descendants.OfType<LogicalBinary>())
+        {
+            if (logical.Kind == LogicalKind.And && logical.Left is LoadLocal andLoad && andLoad.Index == index)
+                return new TestSite(logical.Left, logical.Right);
+        }
+
+        // Statement-guard form: `if (t != null) { ...t... }` — the whole
+        // condition is the bare truthy load; the then-arm is the gated scope.
+        if (next is IfStatement { Condition: LoadLocal guardLoad } guard && guardLoad.Index == index && guard.Else is null)
+            return new TestSite(guard.Condition, guard.Then);
+
+        return null;
+    }
+
+    /// <summary>
+    /// An expression with no observable side effects: loads of locals,
+    /// arguments, fields, and constants, plus reference conversions over them.
+    /// Excludes calls (including property getters), allocations, and increments.
+    /// </summary>
+    static bool IsSideEffectFree(IrExpression expr) => expr switch
+    {
+        Constant or LoadLocal or LoadArgument or LoadLocalAddress or LoadArgumentAddress => true,
+        LoadField field => field.Instance is null || IsSideEffectFree(field.Instance),
+        LoadFieldAddress fieldAddress => fieldAddress.Instance is null || IsSideEffectFree(fieldAddress.Instance),
+        Convert convert => IsSideEffectFree(convert.Operand),
+        CastClass cast => IsSideEffectFree(cast.Operand),
+        IsInstance isInstance => IsSideEffectFree(isInstance.Operand),
+        _ => false,
+    };
+
+    static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                StoreLocal store => store.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                _ => false,
+            };
+            if (references && !allowed.Any(root => IsInside(node, root)))
+                return false;
+        }
+        return true;
+    }
+
+    static bool ReferencesLocal(IrNode root, int index)
+        => root.Descendants.Prepend(root).Any(node => node switch
+        {
+            LoadLocal load => load.Index == index,
+            StoreLocal store => store.Index == index,
+            LoadLocalAddress address => address.Index == index,
+            _ => false,
+        });
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -61,6 +61,8 @@ internal static class LoweringCoverage
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "reference-type local using with IDisposable null guard; value-type/constrained dispose not raised")]
     public static UsingStatementPass UsingStatement => new();
+    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression); property/positional/list sub-patterns recover as `is T t && ...`, not the deconstructed syntax")]
+    public static IsPatternPass IsPatternOperator => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -72,7 +74,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement      => new();
 
     // ───────── Owed — no mechanism yet (the "start these" roadmap) ─────────
-    [Completeness(CompletenessLevel.None, "x is T t / { Prop: ... }")]   public static Unhandled IsPatternOperator                   => default!;
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
     [Completeness(CompletenessLevel.None, "$\"{a}{b}\"")]                public static Unhandled StringInterpolation                 => default!;
     [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;


### PR DESCRIPTION
## Summary

Raises the **`is`-pattern type test** — the next owed idiom on the lowering coverage ledger. csc lowers `value is T t` to a `T t = value as T;` store gating a null test that scopes the narrowed local; left flat the decompiler emits a valid-but-inferior `T t = value as T; if (t is not null)`. This folds it back to `value is T t`.

## What changed

- **New `IsPattern` IR expression node** (`value is T t`, result `bool`).
- **`IsPatternPass`** recognizes two shapes:
  - statement guard: `if (t != null) { ...t... }` → `if (value is T t) { ... }`
  - short-circuit: `t != null && ...t...` → `value is T t && ...`
- A **property pattern** `value is T { P: k }` lowers to the same store plus `t != null && t.P == k`, so it recovers as `value is T t && t.P == k` (semantically identical; the deconstructed `{ ... }` syntax is a later slice).
- **Soundness** (transactional, mirrors lock/using/fixed): the pattern local must be referenced only by the as-store, the null test being replaced, and the gated scope; and the tested value must be side-effect-free so inlining it into the pattern can't reorder effects. A plain `as` whose local is read on the fall-through path stays flat.
- **Printer** renders `value is T t` and skips the pattern local's up-front declaration (`_isPatternLocals`, parallel to `_fixedLocals`/`_usingLocals`).
- **Ledger**: `IsPatternOperator` flipped owed → `Partial`; exact owed count 14 → 13.

## Tests

- Fixtures `IsPatternGuard` / `IsPatternConjunction` / `IsPatternProperty` — all **recompile opcode-exact**, pinned in both `FidelityGateTests` and `LoweredFidelityGateTests`. `AsWithoutPattern` is a negative fixture (stays flat).
- Dedicated `IsPatternPassTests` (raise assertions, rendering, negative).
- **360 decompiler + 1157 product tests green.**

🤖 Generated with Copilot
