### PR TITLE
Raise object and collection initializers (stack-slot dup form)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -771,6 +771,26 @@ public class CfgSampleClass
 
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
+    public sealed class InitTarget
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Z;
+    }
+
+    public static InitTarget MakePoint(int a, int b) => new InitTarget { X = a, Y = b };
+
+    public static InitTarget MakePointWithField(int a, int b) => new InitTarget { X = a, Z = b };
+
+    public static System.Collections.Generic.List<int> MakeList(int a, int b)
+        => new System.Collections.Generic.List<int> { a, b, 42 };
+
+    public static InitTarget MakeEmpty() => new InitTarget();
+
+    public static int InitTargetX(InitTarget target) => target.X;
+
+    public static int MakeAndRead(int a) => InitTargetX(new InitTarget { X = a });
+
     public static string StringInterpolation(string name, int age)
         => $"Hello, {name}! You are {age} years old.";
 

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 11, "LocalRewriter"),
+        (typeof(LoweringCoverage), 10, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -1,0 +1,80 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ObjectInitializerPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void ObjectInitializer_RaisesPropertyMembers()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakePoint));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["X", "Y"], initializer.Members);
+        // The creation is retained as a child so fidelity/unsafe scans still see it.
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        // The lowered dup chain is gone.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+    }
+
+    [Fact]
+    public void ObjectInitializer_RaisesFieldMembers()
+    {
+        var initializer = Assert.Single(Raised(nameof(CfgSampleClass.MakePointWithField)).Descendants.OfType<ObjectInitializerExpression>());
+
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["X", "Z"], initializer.Members);
+    }
+
+    [Fact]
+    public void CollectionInitializer_RaisesAddCalls()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeList));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.True(initializer.IsCollection);
+        Assert.Equal(3, initializer.Values.Count);
+        // No Add call survives as a standalone statement.
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
+    }
+
+    [Fact]
+    public void PlainConstruction_WithoutInitializer_StaysNewObject()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeEmpty));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void Initializer_InArgumentPosition_IsRaised()
+    {
+        var output = Print(nameof(CfgSampleClass.MakeAndRead));
+
+        Assert.Contains("new InitTarget { X = a }", output);
+        Assert.DoesNotContain(".X = a;", output);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersInitializers()
+    {
+        Assert.Contains("return new InitTarget { X = a, Y = b };", Print(nameof(CfgSampleClass.MakePoint)));
+        Assert.Contains("return new InitTarget { X = a, Z = b };", Print(nameof(CfgSampleClass.MakePointWithField)));
+        Assert.Contains("return new List<int> { a, b, 42 };", Print(nameof(CfgSampleClass.MakeList)));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -901,6 +901,7 @@ public sealed partial class CSharpPrinter
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
+        ObjectInitializerExpression oi => ObjectInitializerText(oi),
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
@@ -927,6 +928,24 @@ public sealed partial class CSharpPrinter
         UnsupportedNode u => $"/* {u.Describe()} */",
         _ => $"/* {node.Describe()} */",
     };
+
+    /// <summary>
+    /// Renders a raised object/collection initializer: <c>new T(args) { ... }</c>
+    /// where the body is <c>Member = value</c> entries (object form) or bare
+    /// element expressions (collection form). Constructor parens are omitted when
+    /// the creation takes no arguments, matching idiomatic C#.
+    /// </summary>
+    string ObjectInitializerText(ObjectInitializerExpression initializer)
+    {
+        var creation = initializer.Creation;
+        var arguments = creation.Arguments.Count == 0
+            ? string.Empty
+            : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
+        var body = initializer.IsCollection
+            ? string.Join(", ", initializer.Values.Select(Expression))
+            : string.Join(", ", initializer.Members.Zip(initializer.Values, (member, value) => $"{member} = {Expression(value)}"));
+        return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+    }
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch
@@ -1014,7 +1033,7 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or ObjectInitializerExpression or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1043,6 +1043,49 @@ public sealed class TupleExpression : IrExpression
 }
 
 /// <summary>
+/// A raised C# object or collection initializer, produced by
+/// <see cref="ObjectInitializerPass"/> from the compiler's lowering of
+/// <c>new T { X = a, ... }</c> / <c>new C { e0, e1, ... }</c> — a constructor
+/// call whose result is threaded through a dup chain, mutated by a run of member
+/// stores (object form) or <c>Add</c> calls (collection form), then consumed
+/// once. Child 0 is the <see cref="NewObject"/> creation; the remaining children
+/// are the entry values, parallel to <see cref="Members"/> (a member name for the
+/// object form, <c>null</c> for a collection element).
+/// </summary>
+public sealed class ObjectInitializerExpression : IrExpression
+{
+    public ObjectInitializerExpression(NewObject creation, bool isCollection, IEnumerable<(string? Member, IrExpression Value)> entries)
+    {
+        IsCollection = isCollection;
+        AddChild(creation);
+        var members = ImmutableArray.CreateBuilder<string?>();
+        foreach (var (member, value) in entries)
+        {
+            members.Add(member);
+            AddChild(value);
+        }
+        Members = members.ToImmutable();
+    }
+
+    /// <summary>Collection-initializer (<c>{ e0, e1 }</c> via <c>Add</c>) vs object-initializer (<c>{ X = a }</c> via member stores).</summary>
+    public bool IsCollection { get; }
+
+    /// <summary>The <c>new T(...)</c> creation the initializer decorates.</summary>
+    public NewObject Creation => (NewObject)Children[0];
+
+    /// <summary>Target member name per entry value, parallel to <see cref="Values"/>; <c>null</c> for a collection element.</summary>
+    public ImmutableArray<string?> Members { get; }
+
+    /// <summary>The entry values, in source order.</summary>
+    public IReadOnlyList<IrExpression> Values => Children.Skip(1).Cast<IrExpression>().ToList();
+
+    public override TypeRef? ResultType => Creation.ResultType;
+
+    public override string Describe()
+        => $"ObjectInitializer {Creation.Constructor.DeclaringType.ToDisplayString()} ({Members.Length} {(IsCollection ? "elements" : "members")})";
+}
+
+/// <summary>
 /// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native
 /// int. C# has no spelling for a bare function-pointer load, so this only
 /// reaches print as a comment; the dominant case — feeding a delegate

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -54,6 +54,11 @@ public static class IrPasses
         // already been normalized to NewObject when they are spellable.
         new TupleCreationPass(),
         new PropertySugarPass(),
+        // Raise the object/collection-initializer lowering (a NewObject threaded
+        // through a dup chain and mutated by a run of member stores or Add calls)
+        // back into new T { X = a, ... }. Runs after property-sugar so the member
+        // setters are already StoreProperty nodes, uniform with field stores.
+        new ObjectInitializerPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once
         // inlining has placed the function-pointer load in the ctor's argument

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -59,6 +59,8 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass PatternSwitchStatement => new();
     [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, and ref targets raised; checked-context and indexer/nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position); named-local, indexer-element, nested, and multi-arg Add (dictionary) initializers not raised")]
+    public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
@@ -84,7 +86,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
-    [Completeness(CompletenessLevel.None, "new T { X = 1 }")]           public static Unhandled ObjectOrCollectionInitializerExpression => default!;
     [Completeness(CompletenessLevel.None, "new { a, b }")]               public static Unhandled AnonymousObjectCreation             => default!;
     [Completeness(CompletenessLevel.None, "from x in xs select ...")]    public static Unhandled Query                               => default!;
     [Completeness(CompletenessLevel.None, "await t — async state machine")]      public static Unhandled Await => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -1,0 +1,166 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's object/collection-initializer lowering back into
+/// <c>new T { X = a, ... }</c> / <c>new C { e0, e1, ... }</c>. The lowering
+/// threads a freshly-constructed reference through a dup chain — modeled here as
+/// stack slots — applying a contiguous run of member stores (object form) or
+/// single-argument <c>Add</c> calls (collection form) to the threaded reference,
+/// then consuming it exactly once downstream. This pass folds that run into an
+/// initializer at the single use site and removes the now-dead chain.
+///
+/// <para>Slice scope: the stack-slot dup form, which is what the compiler emits
+/// in expression position (a <c>return</c>/argument initializer). Named-local
+/// initializers, indexer-element initializers, nested initializers, and
+/// multi-argument <c>Add</c> (dictionary) initializers are left for a later
+/// slice — those shapes simply fail to match and stay lowered.</para>
+///
+/// <para>Runs after <see cref="PropertySugarPass"/> so property setters are
+/// already <see cref="StoreProperty"/> nodes, uniform with field stores.</para>
+/// </summary>
+public sealed class ObjectInitializerPass : IIrPass
+{
+    public string Name => "object-initializer";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var seed in function.Descendants.OfType<StoreStackSlot>().ToList())
+        {
+            if (seed.Parent is not Block || seed.Value is not NewObject creation)
+                continue;
+
+            if (TryBuild(function, seed, creation) is not { } plan)
+                continue;
+
+            context.Stepper.StepOver(
+                $"raise {creation.Constructor.DeclaringType.Name} {(plan.IsCollection ? "collection" : "object")} initializer", seed);
+            Apply(plan);
+        }
+    }
+
+    sealed record Plan(
+        IReadOnlyList<IrNode> Consumed,
+        NewObject Creation,
+        bool IsCollection,
+        IReadOnlyList<(string? Member, IrExpression Value)> Entries,
+        LoadStackSlot Use);
+
+    static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation)
+    {
+        var statements = seed.Parent!.Children;
+        var aliasSlots = new HashSet<int> { seed.Slot };
+        var consumed = new List<IrNode> { seed };
+        var entries = new List<(string? Member, IrExpression Value)>();
+        bool? isCollection = null;
+
+        for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
+        {
+            var statement = statements[i];
+
+            // A dup of the threaded reference: sNew = LoadStackSlot(sKnown).
+            if (statement is StoreStackSlot { Value: LoadStackSlot source } copy && aliasSlots.Contains(source.Slot))
+            {
+                aliasSlots.Add(copy.Slot);
+                consumed.Add(copy);
+                continue;
+            }
+
+            // An object-initializer member store on the threaded reference.
+            if (TryMemberStore(statement, aliasSlots) is { } member)
+            {
+                if (isCollection == true)
+                    break;  // C# initializers are member-only or element-only, never mixed
+                isCollection = false;
+                entries.Add(member);
+                consumed.Add(statement);
+                continue;
+            }
+
+            // A collection-initializer element: receiver.Add(value) on the reference.
+            if (TryCollectionAdd(statement, aliasSlots) is { } element)
+            {
+                if (isCollection == false)
+                    break;
+                isCollection = true;
+                entries.Add(element);
+                consumed.Add(statement);
+                continue;
+            }
+
+            break;
+        }
+
+        if (entries.Count == 0)
+            return null;  // a bare `new T()` with no initializer — nothing to raise
+
+        // A self-referential entry (t.Next = t) cannot fold into a single expression.
+        foreach (var (_, value) in entries)
+            if (ReferencesAnySlot(value, aliasSlots))
+                return null;
+
+        // The threaded reference must escape the run exactly once: that single
+        // downstream load is where the initializer expression belongs.
+        var consumedSet = consumed.ToHashSet();
+        var outsideUses = function.Descendants.OfType<LoadStackSlot>()
+            .Where(load => aliasSlots.Contains(load.Slot) && !HasAncestorIn(load, consumedSet))
+            .ToList();
+        if (outsideUses.Count != 1)
+            return null;
+
+        return new Plan(consumed, creation, isCollection ?? false, entries, outsideUses[0]);
+    }
+
+    static (string? Member, IrExpression Value)? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    {
+        StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
+            => (property.PropertyName, property.Value),
+        StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
+            when aliasSlots.Contains(slot.Slot)
+            => (field.Field.Name, field.Value),
+        _ => null,
+    };
+
+    static (string? Member, IrExpression Value)? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
+    {
+        if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
+            return null;
+        if (call.Callee.Name != "Add" || call.Arguments.Count != 2)
+            return null;  // single-element Add only (receiver + one value); dictionary Add(k, v) is a later slice
+        if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
+            return null;
+        return (null, call.Arguments[1]);
+    }
+
+    static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
+        => (node is LoadStackSlot load && slots.Contains(load.Slot))
+            || node.Descendants.OfType<LoadStackSlot>().Any(descendant => slots.Contains(descendant.Slot));
+
+    static bool HasAncestorIn(IrNode node, HashSet<IrNode> set)
+    {
+        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+            if (set.Contains(parent))
+                return true;
+        return false;
+    }
+
+    static void Apply(Plan plan)
+    {
+        // Drop the lowered run from the block, then lift the creation and entry
+        // values out of those now-detached statements into the initializer.
+        foreach (var statement in plan.Consumed)
+            statement.Detach();
+
+        plan.Creation.Detach();
+        var entries = new List<(string?, IrExpression)>(plan.Entries.Count);
+        foreach (var (member, value) in plan.Entries)
+        {
+            value.Detach();
+            entries.Add((member, value));
+        }
+
+        var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);
+        initializer.InheritSourceOffset(plan.Creation);
+        plan.Use.ReplaceWith(initializer);
+    }
+}


### PR DESCRIPTION
## What

Raises **object and collection initializers** (the stack-slot dup form, expression position) back to C# initializer syntax. Continues the lowering-ledger roadmap of recovering owed idioms.

Before / after, on the test fixtures:

```
// MakePoint
return new InitTarget { X = a, Y = b };
// MakeList
return new List<int> { a, b, 42 };
```

## How

The compiler lowers `new T { X = a, Y = b }` in expression position to a `dup`-chain that the importer models as **stack slots**:

```
s0 = new T();
s0.X = a;
s1 = s0;      // alias copy
s1.Y = b;
<use sN>      // single downstream use, e.g. a Return operand
```

`ObjectInitializerPass` (registered after `PropertySugarPass`, so setters are already `StoreProperty`):

- threads the alias-slot set from `s0`,
- collects object entries (`StoreProperty`/`StoreField` with no index args) or collection entries (2-arg `Add` calls),
- **bails** on: zero entries, mixed object+collection forms, an entry value that references an alias slot, or anything other than exactly one downstream use,
- replaces the whole run with a single `ObjectInitializerExpression` at the use site.

The `NewObject` stays as child[0] of the wrapper, so existing `Descendants`-based scans (unsafe detection, fidelity `DirectTypes`) keep working unchanged.

## Scope (intentionally Partial)

Only the stack-slot dup form. **Not** raised (stays lowered, matches nothing): named-local (`var x = new T {...}`), indexer-element, nested, and multi-arg/dictionary `Add` initializers. The ledger entry moves owed → partial with a note listing these gaps; the exact owed count drops 11 → 10.

## Tests

- New `ObjectInitializerPassTests` (6): property members, field members, collection `Add`, plain construction stays `NewObject`, argument-position raise, print rendering.
- `LoweringCoverageTests` owed count reconciled to 10.
- Full decompiler suite: **379/379 green** (the compile-back / fidelity harness fixtures guard against bad output).
