### PR TITLE
Add idiom shape scorecard

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -67,6 +67,31 @@ compiler. The supporting evidence:
 - **Corpus sweeps.** Emit-all stress over each platform's CoreLib (three OSes in
   CI = three corpora), measured by the floors below.
 
+### Fixture idiom-shape scorecard
+
+`IdiomShapeScorecardTests` is the fixture-backed C# altitude check. It renders
+raised fixture bodies, parses the output with Roslyn, and asserts that the
+expected syntax nodes appear (`TupleExpressionSyntax`, `UsingStatementSyntax`,
+`LockStatementSyntax`, etc.) while lower-altitude substitutes stay absent. This
+is deliberately not a compile/fidelity check: valid C# can still be the wrong
+idiom, such as a switch expression recovered as a switch statement.
+
+Run it after changing a raising pass or printer path that can affect C# shape.
+The current ratchet records the fixture idioms that are recovered today; when an
+owed fixture starts passing, flip its scorecard entry to recovered in the same PR
+so the aggregate score moves forward and future regressions fail.
+
+The intended pass-improvement loop is:
+
+1. Pick a ledger-owned raise pass or owed idiom.
+2. Add or identify fixture methods that represent the source idiom.
+3. Add scorecard entries as unrecovered when the current output is lower altitude.
+4. Run the scorecard to capture the baseline.
+5. Implement or improve the raise pass.
+6. Run the scorecard again and flip newly recovered entries in the same PR.
+7. Run fidelity/validity checks to prove the higher-altitude shape stayed
+   semantic, valid C#.
+
 ### The two floor-only properties
 
 Two properties have no per-method check at all — they exist only as corpus

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -1,0 +1,100 @@
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Fixture-backed idiom recovery scorecard: proves selected raise passes recover
+/// the intended C# syntax altitude, not merely C# that parses or recompiles.
+/// </summary>
+public class IdiomShapeScorecardTests
+{
+    private sealed record Case(
+        string Pass,
+        string Method,
+        SyntaxKind Expected,
+        SyntaxKind[] Rejected,
+        bool CurrentlyRecovered = true);
+
+    private static readonly Case[] Cases =
+    [
+        new("SwitchRaisingPass", nameof(CfgSampleClass.PowerOfTwo), SyntaxKind.SwitchExpression, [SyntaxKind.SwitchStatement], CurrentlyRecovered: false),
+        new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
+        new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
+        new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),
+        new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignLocal), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
+        new("NullConditionalPass", nameof(CfgSampleClass.NullConditionalProperty), SyntaxKind.ConditionalAccessExpression, [SyntaxKind.IfStatement]),
+        new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement], CurrentlyRecovered: false),
+        new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),
+        new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
+        new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
+        new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
+        new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
+    ];
+
+    [Fact]
+    public void FixtureIdioms_RecoverExpectedSyntaxShapes()
+    {
+        List<string> failures = [];
+        List<string> unexpectedRecoveries = [];
+        var recovered = 0;
+
+        foreach (var testCase in Cases)
+        {
+            var syntaxKinds = RenderSyntaxKinds(testCase.Method);
+            var hasExpected = syntaxKinds.Contains(testCase.Expected);
+            var lowerAltitude = testCase.Rejected.Where(syntaxKinds.Contains).ToArray();
+            var isRecovered = hasExpected && lowerAltitude.Length == 0;
+
+            if (isRecovered)
+            {
+                recovered++;
+                if (!testCase.CurrentlyRecovered)
+                    unexpectedRecoveries.Add($"{testCase.Pass}/{testCase.Method}: now recovers {testCase.Expected}; update the scorecard ratchet");
+                continue;
+            }
+
+            if (testCase.CurrentlyRecovered)
+            {
+                if (!hasExpected)
+                    failures.Add($"{testCase.Pass}/{testCase.Method}: missing {testCase.Expected}");
+                foreach (var rejected in lowerAltitude)
+                    failures.Add($"{testCase.Pass}/{testCase.Method}: still contains lower-altitude {rejected}");
+            }
+        }
+
+        var expectedRecovered = Cases.Count(c => c.CurrentlyRecovered);
+        Assert.True(
+            failures.Count == 0 && unexpectedRecoveries.Count == 0 && recovered == expectedRecovered,
+            $"Idiom recovery scorecard: {recovered}/{Cases.Length} fixture idioms recovered (expected {expectedRecovered}/{Cases.Length}).\n"
+            + string.Join('\n', failures.Concat(unexpectedRecoveries)));
+    }
+
+    private static HashSet<SyntaxKind> RenderSyntaxKinds(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!);
+        Assert.NotNull(result.Output);
+
+        var text = $$"""
+            class C
+            {
+                object M()
+                {
+            {{result.Output}}
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(
+            text,
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        var root = tree.GetRoot();
+        return root.DescendantNodesAndSelf().Select(node => node.Kind()).ToHashSet();
+    }
+}


### PR DESCRIPTION
## Summary
- add a fixture-backed idiom shape scorecard that parses raised C# and checks syntax-node altitude
- ratchet current idiom recovery at 11/13 fixtures, with known unrecovered switch-expression and ternary-expression fixtures
- document the pass-improvement workflow for using the scorecard

## Validation
- `npx markdownlint-cli --fix docs/decompiler-quality.md`
- `npx markdownlint-cli docs/decompiler-quality.md`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.IdiomShapeScorecardTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build`
