### PR TITLE
Raise simple return ternaries

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -81,16 +81,33 @@ The current ratchet records the fixture idioms that are recovered today; when an
 owed fixture starts passing, flip its scorecard entry to recovered in the same PR
 so the aggregate score moves forward and future regressions fail.
 
+The scorecard is a positive altitude signal, not a soundness proof. A raise that
+recovers the target idiom can still be too broad, so each new or expanded raise
+should also add at least one adversarial fixture when a nearby non-idiom shape is
+plausible. Good negative fixtures include hand-written spellings that resemble
+the lowering, older-C# equivalents, unsigned/null/pattern variants, and source
+that differs only in an important compiler discriminator such as a receiver spill.
+Pin those in pass-level tests or the fidelity gate; the scorecard keeps the
+positive ratchet.
+
 The intended pass-improvement loop is:
 
 1. Pick a ledger-owned raise pass or owed idiom.
 2. Add or identify fixture methods that represent the source idiom.
-3. Add scorecard entries as unrecovered when the current output is lower altitude.
-4. Run the scorecard to capture the baseline.
-5. Implement or improve the raise pass.
-6. Run the scorecard again and flip newly recovered entries in the same PR.
-7. Run fidelity/validity checks to prove the higher-altitude shape stayed
+3. Add adversarial fixtures for nearby shapes that must not raise.
+4. Add scorecard entries as unrecovered when the current output is lower altitude.
+5. Run the scorecard to capture the baseline.
+6. Implement or improve the raise pass.
+7. Run the scorecard again and flip newly recovered entries in the same PR.
+8. Run fidelity/validity checks to prove the higher-altitude shape stayed
    semantic, valid C#.
+
+After a raise looks good, use an adversarial fixture pass before merge. Give an
+agent the pass, its intended discriminator, the positive fixtures, and the
+soundness checklist below; ask it to add or update fixtures that try to falsify
+the match without changing the pass first. A useful run either finds a false
+positive that needs a narrower discriminator, or adds negative fixtures proving
+the pass rejects the nearest lookalikes.
 
 ### The two floor-only properties
 

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -26,7 +26,7 @@ public class IdiomShapeScorecardTests
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),
         new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignLocal), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
         new("NullConditionalPass", nameof(CfgSampleClass.NullConditionalProperty), SyntaxKind.ConditionalAccessExpression, [SyntaxKind.IfStatement]),
-        new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement], CurrentlyRecovered: false),
+        new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1896,8 +1896,8 @@ public class RaisingPassTests
     {
         // Debug lowers the ternary through a stack-slot diamond, which folds
         // back to the ternary (with the double-negative unwrapped and arms
-        // swapped). Release lowers it as dual returns, which stay in
-        // statement form — the same negation-shaped rule (PR #421).
+        // swapped). Release lowers it as bool-guard dual returns, outside the
+        // narrow non-bool relational ternary-return fold.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(
             typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.Pick), source);
@@ -1913,6 +1913,16 @@ public class RaisingPassTests
             return a;
             """.ReplaceLineEndings("\n"), output);
 #endif
+    }
+
+    [Fact]
+    public void BooleanFolding_GuardReturn_NonBoolArms_RaisesConditional()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.TernaryInt), source);
+
+        Assert.Equal("return a > b ? a : b;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 10, "LocalRewriter"),
+        (typeof(LoweringCoverage), 9, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -126,6 +126,7 @@ public sealed class BooleanFoldingPass : IIrPass
             bool folded = node switch
             {
                 IfStatement statement => FoldNestedGuard(statement, stepper) || FoldGuardReturn(statement, stepper)
+                    || FoldTernaryReturn(statement, stepper)
                     || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(statement, stepper),
                 Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
                 Conditional conditional => MaterializeBoolConditional(function, conditional, stepper),
@@ -264,6 +265,72 @@ public sealed class BooleanFoldingPass : IIrPass
         guard.ReplaceWith(new Return(folded));
         return true;
     }
+
+    /// <summary>
+    /// <c>if (c) return A; return B;</c> → <c>return !c ? B : A;</c> for simple
+    /// top-level relational value arms. The polarity swap recovers the source-like
+    /// comparison shape csc lowered into the guard.
+    /// </summary>
+    static bool FoldTernaryReturn(IfStatement guard, Stepper stepper)
+    {
+        if (guard.HasElse || guard.Parent is not Block container)
+            return false;
+        if (container.Parent is not BlockContainer { Parent: IrFunction } || container.Children.Count != 2)
+            return false;
+        if (guard.Then.Children.Count != 1 || guard.Then.Children[0] is not Return { Value: { } thenValue })
+            return false;
+        if (guard.ChildIndex + 1 >= container.Children.Count
+            || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
+        {
+            return false;
+        }
+        if (thenValue.ResultType is { Namespace: "System", Name: "Boolean" }
+            || tailValue.ResultType is { Namespace: "System", Name: "Boolean" })
+        {
+            return false;
+        }
+        if (!IsTernaryComparison(guard.Condition) || !IsSimpleTernaryArm(thenValue) || !IsSimpleTernaryArm(tailValue))
+            return false;
+
+        TypeRef? mergedType = null;
+        if (thenValue.ResultType is { } thenType
+            && tailValue.ResultType is { } tailType
+            && thenType.Equals(tailType))
+        {
+            mergedType = thenType;
+        }
+
+        var condition = guard.Condition;
+        condition.Detach();
+        thenValue.Detach();
+        tailValue.Detach();
+        tailReturn.Detach();
+
+        stepper.StepOver("fold guarded return into ternary", guard);
+        guard.ReplaceWith(new Return(
+            new Conditional(Conditions.Negate(condition), tailValue, thenValue) { MergedType = mergedType }));
+        return true;
+    }
+
+    static bool IsTernaryComparison(IrExpression condition)
+    {
+        if (condition is not Comparison comparison)
+            return false;
+        if (IsNullLiteral(comparison.Left) || IsNullLiteral(comparison.Right))
+            return false;
+        if (IsUnsignedIntegral(comparison.Left.ResultType) || IsUnsignedIntegral(comparison.Right.ResultType))
+            return false;
+        return true;
+    }
+
+    static bool IsSimpleTernaryArm(IrExpression value)
+        => value is LoadArgument or LoadLocal or Constant;
+
+    static bool IsNullLiteral(IrExpression expression)
+        => expression is Constant { Value: null };
+
+    static bool IsUnsignedIntegral(TypeRef? type)
+        => type is { Namespace: "System", Name: "UInt32" or "UInt64" or "UInt16" or "Byte" or "UIntPtr" };
 
     /// <summary>
     /// T = X; if (X is null) { T = Y; } → T = X ?? Y; — the compiler's


### PR DESCRIPTION
## Summary
- raise simple top-level relational guard-return pairs into conditional expressions
- move the TernaryInt idiom scorecard fixture to recovered
- document adversarial/negative fixture passes for scorecard-guided raises
- tighten the LocalRewriter owed-count ratchet to the current ledger

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- npx markdownlint-cli docs/decompiler-quality.md