### PR TITLE
Raise value-producing switch tables to switch expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -19,7 +19,7 @@ public class IdiomShapeScorecardTests
 
     private static readonly Case[] Cases =
     [
-        new("SwitchRaisingPass", nameof(CfgSampleClass.PowerOfTwo), SyntaxKind.SwitchExpression, [SyntaxKind.SwitchStatement], CurrentlyRecovered: false),
+        new("SwitchRaisingPass", nameof(CfgSampleClass.PowerOfTwo), SyntaxKind.SwitchExpression, [SyntaxKind.SwitchStatement]),
         new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 10, "LocalRewriter"),
+        (typeof(LoweringCoverage), 9, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -65,9 +65,9 @@ public sealed class SwitchRaisingPass : IIrPass
             for (int s = 0; s < blocks.Count; s++)
             {
                 if (blocks[s].Children is [.., SwitchBranch sw]
-                    && (Raise(container, s, sw, leaveTargets, stepper)
-                        || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)
-                        || RaiseSwitchExpressionReturn(container, s, sw, stepper)))
+                    && (RaiseSwitchExpressionReturn(container, s, sw, stepper)
+                        || Raise(container, s, sw, leaveTargets, stepper)
+                        || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
                     return true;
             }
         }
@@ -390,7 +390,8 @@ public sealed class SwitchRaisingPass : IIrPass
             if (!Probe(target))
                 return false;
 
-        // The default arm: a value block, or one conditional over two value blocks.
+        // The default arm: a value block, a bare jump to a separate value block
+        // laid out after the cases, or one conditional over two value blocks.
         var owned = new HashSet<int>(caseTargets) { defaultIndex };
         IrExpression defaultArm;
         if (TryValueBlock(blocks, defaultIndex, offsetToIndex, out _, out _))
@@ -398,6 +399,15 @@ public sealed class SwitchRaisingPass : IIrPass
             if (!Probe(defaultIndex))
                 return false;
             defaultArm = (IrExpression)ValueBlockExpr(blocks[defaultIndex]).Clone();
+        }
+        else if (blocks[defaultIndex].Children is [Branch defaultJump]
+            && offsetToIndex.TryGetValue(defaultJump.TargetOffset, out int defaultValueIdx)
+            && defaultValueIdx > s
+            && TryValueBlock(blocks, defaultValueIdx, offsetToIndex, out _, out _)
+            && Probe(defaultValueIdx))
+        {
+            owned.Add(defaultValueIdx);
+            defaultArm = (IrExpression)ValueBlockExpr(blocks[defaultValueIdx]).Clone();
         }
         else if (blocks[defaultIndex].Children is [ConditionalBranch dispatch]
             && offsetToIndex.TryGetValue(dispatch.TargetOffset, out int whenTrueIdx)


### PR DESCRIPTION
## What

Raises a value-producing `switch` jump table to a C# **switch expression** instead of a lower-altitude switch statement that assigns a temp and then returns it.

Before / after on the `PowerOfTwo` fixture (`x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 }`):

```csharp
// before
int V_0;
switch (x) { case 0: V_0 = 1; break; /* ... */ default: V_0 = 0; break; }
return V_0;

// after
return x switch { 0 => 1, 1 => 2, 2 => 4, 3 => 8, _ => 0 };
```

## How

The `SwitchExpression` IR node and the `RaiseSwitchExpressionReturn` recognizer already existed, but two things kept this shape lowered:

1. **Ordering.** `RaiseSwitchExpressionReturn` was tried *last*, after the statement raisers. Any table the statement raiser could also fold won as a statement. It's now tried **first**. The expression recognizer is strictly more conservative — every arm must be a single-store value block and the local must be read exactly once at a `return` — so preferring it only lifts tables that are genuinely switch expressions; every other shape falls through to the statement raisers unchanged.

2. **Default layout.** The recognizer handled an inline value-block default or a conditional-over-two-value-blocks default, but not the compiler's common layout where the default (`_ => expr`) is a **bare jump to a separate value block laid out after the cases**. Added that case.

The ledger entry stays `Partial` ("value-producing jump tables only; sparse + pattern switches still emit a statement") — that's still accurate.

## Scorecard

`IdiomShapeScorecardTests` had `SwitchRaisingPass/PowerOfTwo` as `CurrentlyRecovered: false`. It now recovers `SwitchExpression`, so the ratchet is flipped to recovered (aggregate 11/13 → 12/13).

## Drive-by fix

`CoverageRegisters_OwedCountIsExact` was **already red on `main`**: #721 raised `IsPatternOperator` to partial but didn't decrement the `LoweringCoverage` owed register (9 owed entries, register said 10). Corrected 10 → 9.

## Tests

Full decompiler suite: **385/385 green** (was 383/385 on `main` due to the pre-existing off-by-one + the now-flipped ratchet). The fidelity/compile-back harness fixtures guard that the higher-altitude shape stays semantic, valid C#.
