### PR TITLE
Add adversarial ternary guard fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -815,6 +815,13 @@ public class CfgSampleClass
 
     public static int TernaryInt(int a, int b) => a > b ? a : b;
 
+    public static string UnsignedBoundsGuard(int index, int length)
+    {
+        if ((uint)index >= (uint)length)
+            return "out";
+        return "in";
+    }
+
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
     public sealed class InitTarget

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1926,6 +1926,23 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void BooleanFolding_UnsignedGuardReturn_StaysStatementForm()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.UnsignedBoundsGuard), source);
+
+        Assert.Equal("""
+            if ((uint)index >= (uint)length)
+            {
+                return "out";
+            }
+            return "in";
+            """.ReplaceLineEndings("\n"), output);
+        Assert.DoesNotContain("?", output);
+    }
+
+    [Fact]
     public void BooleanFolding_GuardReturn_BothConstantArms_CollapseToCondition()
     {
         // if (a > 0) { if (b > 0) return true; } return false; folds the nested

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -316,6 +316,8 @@ public sealed class BooleanFoldingPass : IIrPass
     {
         if (condition is not Comparison comparison)
             return false;
+        if (comparison.IsUnsigned)
+            return false;
         if (IsNullLiteral(comparison.Left) || IsNullLiteral(comparison.Right))
             return false;
         if (IsUnsignedIntegral(comparison.Left.ResultType) || IsUnsignedIntegral(comparison.Right.ResultType))


### PR DESCRIPTION
## Summary
- tried the adversarial fixture path against the BooleanFoldingPass return-ternary raise
- found that unsigned guard-return comparisons over-matched and rendered as ternaries
- added an unsigned guard-return fixture/test and narrowed the ternary raise to reject unsigned comparisons

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_UnsignedGuardReturn_StaysStatementForm
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.IndexFromEndPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build