### PR TITLE
Raise array GetSubArray range slices to a[i..j] indexer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -67,6 +67,19 @@ public class CfgSampleClass
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
+    // Array range slices: the compiler lowers these to
+    // RuntimeHelpers.GetSubArray(a, <Range>); the decompiler raises them back to
+    // the a[i..j] indexer (RangeFromGetSubArrayPass). All four endpoint forms are
+    // kept (both bounds, from-start-only, to-only, and all) for round-trip
+    // coverage. From-end (^n) endpoints are deferred and stay unraised.
+    public static int[] ArrayRangeBoth(int[] a, int i, int j) => a[i..j];
+
+    public static int[] ArrayRangeFrom(int[] a, int i) => a[i..];
+
+    public static int[] ArrayRangeTo(int[] a, int j) => a[..j];
+
+    public static int[] ArrayRangeAll(int[] a) => a[..];
+
     // Compound assignment over an array element: `a[i] += v` captures &a[i] in a
     // dup slot and stores back through it. The expanded `a[i] = a[i] + v` form
     // (no slot) must NOT fold, so both spellings are kept for contrast.

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -32,6 +32,7 @@ public class IdiomShapeScorecardTests
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 9, "LocalRewriter"),
+        (typeof(LoweringCoverage), 8, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class RangeFromGetSubArrayPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void GetSubArray_BothBounds_RaisesToRangeSlice()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeBoth));
+
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.True(slice.Range.HasStart);
+        Assert.True(slice.Range.HasEnd);
+        Assert.Empty(function.Descendants.OfType<Call>());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void GetSubArray_BothBounds_RendersIndexer()
+        => Assert.Contains("return a[i..j];", Print(nameof(CfgSampleClass.ArrayRangeBoth)));
+
+    [Fact]
+    public void GetSubArray_FromOnly_RendersOpenEnd()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeFrom));
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.True(slice.Range.HasStart);
+        Assert.False(slice.Range.HasEnd);
+        Assert.Contains("return a[i..];", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void GetSubArray_ToOnly_RendersOpenStart()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeTo));
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.False(slice.Range.HasStart);
+        Assert.True(slice.Range.HasEnd);
+        Assert.Contains("return a[..j];", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void GetSubArray_All_RendersBareRange()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeAll));
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.False(slice.Range.HasStart);
+        Assert.False(slice.Range.HasEnd);
+        Assert.Contains("return a[..];", CSharpPrinter.Print(function).Output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -908,6 +908,8 @@ public sealed partial class CSharpPrinter
         TupleExpression t => $"({Arguments(t.Elements)})",
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
         ArrayLength l => $"{Operand(l.Array)}.Length",
+        SliceExpression sl => $"{Operand(sl.Receiver)}[{Expression(sl.Range)}]",
+        RangeExpression r => $"{(r.HasStart ? Expression(r.Start!) : "")}..{(r.HasEnd ? Expression(r.End!) : "")}",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
@@ -1038,7 +1040,7 @@ public sealed partial class CSharpPrinter
         // any other binary/unary — otherwise an enclosing `!`/`-`/binary
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
-            or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
+            or NewObject or ArrayLength or LoadElement or SliceExpression or RangeExpression or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or ObjectInitializerExpression or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1272,6 +1272,54 @@ public sealed class ArrayLength : IrExpression
     public override string Describe() => "ArrayLength";
 }
 
+/// <summary>
+/// A raised C# range expression (<c>start..end</c>), used as the index of a
+/// <see cref="SliceExpression"/>. Either endpoint may be omitted, spelling the
+/// open forms <c>start..</c>, <c>..end</c>, and <c>..</c>.
+/// </summary>
+public sealed class RangeExpression : IrExpression
+{
+    public RangeExpression(IrExpression? start, IrExpression? end)
+    {
+        HasStart = start is not null;
+        HasEnd = end is not null;
+        if (start is not null)
+            AddChild(start);
+        if (end is not null)
+            AddChild(end);
+    }
+
+    public bool HasStart { get; }
+    public bool HasEnd { get; }
+    public IrExpression? Start => HasStart ? (IrExpression)Children[0] : null;
+    public IrExpression? End => HasEnd ? (IrExpression)Children[HasStart ? 1 : 0] : null;
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Range");
+
+    public override string Describe() => "RangeExpression";
+}
+
+/// <summary>
+/// A raised C# range-indexer access (<c>receiver[start..end]</c>) — the inverse
+/// of the compiler's range-slice lowering (<c>RuntimeHelpers.GetSubArray</c> for
+/// arrays). The result type is the slice's type (the receiver's array type), not
+/// an element type.
+/// </summary>
+public sealed class SliceExpression : IrExpression
+{
+    public SliceExpression(IrExpression receiver, RangeExpression range, TypeRef? resultType)
+    {
+        AddChild(receiver);
+        AddChild(range);
+        ResultType = resultType;
+    }
+
+    public IrExpression Receiver => (IrExpression)Children[0];
+    public RangeExpression Range => (RangeExpression)Children[1];
+    public override TypeRef? ResultType { get; }
+
+    public override string Describe() => "SliceExpression";
+}
+
 public sealed class Box : IrExpression
 {
     public Box(TypeRef type, IrExpression operand)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -59,6 +59,10 @@ public static class IrPasses
         // back into new T { X = a, ... }. Runs after property-sugar so the member
         // setters are already StoreProperty nodes, uniform with field stores.
         new ObjectInitializerPass(),
+        // Raise array range-slice lowering (RuntimeHelpers.GetSubArray(a, range))
+        // back into a[range]. GetSubArray is a compiler-only helper, so the match
+        // is unambiguous and the round-trip is opcode-exact.
+        new RangeFromGetSubArrayPass(),
         new TypeOfFoldingPass(),
         // Raise method-group delegate creation (ldftn + delegate ctor) once
         // inlining has placed the function-pointer load in the ctor's argument

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -71,6 +71,8 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
+    [Completeness(CompletenessLevel.Partial, "array GetSubArray range slice (a[i..j], a[i..], a[..j], a[..]); from-end (^n) endpoints and string/span Substring/Slice forms not raised")]
+    public static RangeFromGetSubArrayPass Range => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -83,7 +85,6 @@ internal static class LoweringCoverage
 
     // ───────── Owed — no mechanism yet (the "start these" roadmap) ─────────
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
-    [Completeness(CompletenessLevel.None, "a[i..j]")]                    public static Unhandled Range                               => default!;
     [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's array range-slice lowering back into a C# range indexer:
+/// <c>RuntimeHelpers.GetSubArray(a, range)</c> becomes <c>a[range]</c>. The
+/// <c>range</c> argument is one of the compiler's <see cref="System.Range"/>
+/// constructions — <c>new Range((Index)i, (Index)j)</c>, <c>Range.StartAt</c>,
+/// <c>Range.EndAt</c>, or <c>Range.All</c> — which the pass rewrites into a
+/// <see cref="RangeExpression"/> (<c>i..j</c>, <c>i..</c>, <c>..j</c>, <c>..</c>).
+///
+/// <para><c>GetSubArray</c> is a compiler-only helper with no hand-written
+/// spelling, so recognizing it is unambiguous and the round-trip is opcode-exact:
+/// the recovered <c>a[range]</c> re-lowers to the same call. This first slice
+/// covers from-start endpoints (the implicit <c>int</c>-to-<see cref="System.Index"/>
+/// conversion); from-end endpoints (<c>^n</c>) and the string/span <c>Substring</c>
+/// / <c>Slice</c> forms are left untouched (a later slice).</para>
+/// </summary>
+public sealed class RangeFromGetSubArrayPass : IIrPass
+{
+    public string Name => "range-getsubarray";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            if (call.Callee is not { Name: "GetSubArray", DeclaringType.Namespace: "System.Runtime.CompilerServices", DeclaringType.Name: "RuntimeHelpers" })
+                continue;
+            if (call.Arguments is not [var receiver, var rangeArg])
+                continue;
+            if (call.ResultType is not { } resultType)
+                continue;
+            if (!TryReadRange(rangeArg, out var start, out var end))
+                continue;
+
+            // Validation is complete; now detach the parts we keep (the receiver
+            // and the from-start endpoint values) and discard the lowering
+            // wrappers (the Range/Index construction) by replacing the call.
+            receiver.Detach();
+            start?.Detach();
+            end?.Detach();
+            var range = new RangeExpression(start, end);
+            var slice = new SliceExpression(receiver, range, resultType);
+            context.Stepper.StepOver("raise GetSubArray range slice to a[..] indexer", call);
+            call.ReplaceWith(slice);
+        }
+    }
+
+    /// <summary>
+    /// Recognizes a <see cref="System.Range"/> construction and yields its
+    /// endpoint value expressions (still attached — the caller detaches them only
+    /// after the whole shape is confirmed). A null endpoint is an omitted side of
+    /// the range. Returns false for any shape that is not a from-start range
+    /// construction (e.g. a from-end <c>^n</c> endpoint), leaving the call as-is.
+    /// </summary>
+    static bool TryReadRange(IrExpression rangeArg, out IrExpression? start, out IrExpression? end)
+    {
+        start = null;
+        end = null;
+        switch (rangeArg)
+        {
+            case NewObject { Constructor.DeclaringType: { Namespace: "System", Name: "Range" }, Arguments: [var lo, var hi] }:
+                return TryFromStartEndpoint(lo, out start) && TryFromStartEndpoint(hi, out end);
+            case Call { Callee: { Name: "StartAt", DeclaringType: { Namespace: "System", Name: "Range" } }, Arguments: [var lo] }:
+                return TryFromStartEndpoint(lo, out start);
+            case Call { Callee: { Name: "EndAt", DeclaringType: { Namespace: "System", Name: "Range" } }, Arguments: [var hi] }:
+                return TryFromStartEndpoint(hi, out end);
+            case LoadProperty { HasInstance: false, PropertyName: "All", Accessor.DeclaringType: { Namespace: "System", Name: "Range" } }:
+                return true; // Range.All → `..`
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// A from-start endpoint is the implicit <c>int</c>-to-<see cref="System.Index"/>
+    /// conversion (<c>(Index)expr</c>); the inner <c>int</c> expression is the
+    /// range endpoint. A from-end <c>new Index(n, fromEnd: true)</c> is not
+    /// matched here.
+    /// </summary>
+    static bool TryFromStartEndpoint(IrExpression index, out IrExpression? value)
+    {
+        if (index is Call { Callee: { Name: "op_Implicit", DeclaringType: { Namespace: "System", Name: "Index" } }, Arguments: [var inner] })
+        {
+            value = inner;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

The compiler lowers an array range slice `a[i..j]` to `RuntimeHelpers.GetSubArray(a, <Range>)`. The decompiler left this call unraised, so the product emitted the raw `GetSubArray` helper — an invalid spelling no human writes. New `RangeFromGetSubArrayPass` raises it back into the C# range indexer.

`GetSubArray` is a compiler-only helper, so recognizing it is unambiguous (no hand-written false positives, unlike `Index`). csc re-lowers the raised `a[range]` to the same call, so the round-trip is **opcode-exact**.

## Endpoint forms (all raised, all opcode-exact)

| Source | Lowering | Raised |
| --- | --- | --- |
| `a[i..j]` | `GetSubArray(a, new Range((Index)i, (Index)j))` | `a[i..j]` |
| `a[i..]` | `GetSubArray(a, Range.StartAt((Index)i))` | `a[i..]` |
| `a[..j]` | `GetSubArray(a, Range.EndAt((Index)j))` | `a[..j]` |
| `a[..]` | `GetSubArray(a, Range.All)` | `a[..]` |

## Scope

First slice covers **from-start** endpoints (the implicit `int`->`Index` conversion). From-end (`^n`) endpoints and string/span `Substring`/`Slice` forms are **deferred** and stay unraised — the pass validates the full shape before mutating and bails the whole call cleanly on any unmodeled endpoint. (Deferring `^n` keeps this independent of the in-flight `Index` raise PR #720.)

## Changes

- New `RangeExpression` + `SliceExpression` IR nodes (printer + atomic-operand registration).
- New `RangeFromGetSubArrayPass`, registered after `ObjectInitializerPass`.
- Ledger: `Range` None -> Partial; owed register 9 -> 8.
- Four `CfgSampleClass` range fixtures (all four endpoint forms), new pass tests, scorecard entry (`RangeExpression`, reject `InvocationExpression`).

## Verification

- 391 decompiler tests green (incl. fidelity/lowered gates + scorecard).
- Probe fixture: 4 raised range forms 100% opcode-exact on `--fidelity-check`.
- Main product builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
