### PR TITLE
Raise anonymous-object creation into new { ... }

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
@@ -1,0 +1,67 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class AnonymousObjectPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void Shorthand_RaisesAnonymousTypeConstructor()
+    {
+        // `new { a, b }` lowers to `new <>f__AnonymousType0<int, string>(a, b)`.
+        var function = Raised(nameof(CfgSampleClass.AnonShorthand));
+
+        var anonymous = Assert.Single(function.Descendants.OfType<AnonymousObject>());
+        Assert.Equal(["a", "b"], anonymous.PropertyNames);
+        Assert.Equal(2, anonymous.Values.Count);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void Shorthand_RendersProjectionShorthand()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.AnonShorthand))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("new { a, b }", output);
+        Assert.DoesNotContain("f__AnonymousType", output);
+    }
+
+    [Fact]
+    public void NamedMembers_RenderExplicitAssignments()
+    {
+        // The values are named x/y but the properties are Id/Name, so the
+        // shorthand cannot apply — the explicit `Name = value` form is required.
+        var function = Raised(nameof(CfgSampleClass.AnonNamed));
+
+        var anonymous = Assert.Single(function.Descendants.OfType<AnonymousObject>());
+        Assert.Equal(["Id", "Name"], anonymous.PropertyNames);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("new { Id = x, Name = y }", output);
+    }
+
+    [Fact]
+    public void SingleMember_Renders()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.AnonSingle))).Output;
+        Assert.Contains("new { a }", output);
+    }
+
+    [Fact]
+    public void MemberAccess_UsesShorthandWhenNamesMatch()
+    {
+        // `new { t.X, t.Y }` projects properties X/Y from the member names.
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.AnonMemberShorthand))).Output;
+        Assert.Contains("new { t.X, t.Y }", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -806,6 +806,14 @@ public class CfgSampleClass
 
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
+    public static object AnonShorthand(int a, string b) => new { a, b };
+
+    public static object AnonNamed(int x, string y) => new { Id = x, Name = y };
+
+    public static object AnonSingle(int a) => new { a };
+
+    public static object AnonMemberShorthand(InitTarget t) => new { t.X, t.Y };
+
     public sealed class InitTarget
     {
         public int X { get; set; }

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -77,6 +77,9 @@ public class FidelityGateTests
         "IsPatternGuard",
         "IsPatternConjunction",
         "IsPatternProperty",
+        "AnonShorthand",
+        "AnonNamed",
+        "AnonSingle",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -21,6 +21,7 @@ public class IdiomShapeScorecardTests
     [
         new("SwitchRaisingPass", nameof(CfgSampleClass.PowerOfTwo), SyntaxKind.SwitchExpression, [SyntaxKind.SwitchStatement], CurrentlyRecovered: false),
         new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("AnonymousObjectPass", nameof(CfgSampleClass.AnonShorthand), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -66,6 +66,9 @@ public class LoweredFidelityGateTests
         "IsPatternGuard",
         "IsPatternConjunction",
         "IsPatternProperty",
+        "AnonShorthand",
+        "AnonNamed",
+        "AnonSingle",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 10, "LocalRewriter"),
+        (typeof(LoweringCoverage), 8, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -906,6 +906,7 @@ public sealed partial class CSharpPrinter
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
+        AnonymousObject a => AnonymousObjectText(a),
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
         ArrayLength l => $"{Operand(l.Array)}.Length",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
@@ -951,6 +952,32 @@ public sealed partial class CSharpPrinter
             ? string.Join(", ", initializer.Values.Select(Expression))
             : string.Join(", ", initializer.Members.Zip(initializer.Values, (member, value) => $"{member} = {Expression(value)}"));
         return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+    }
+
+    /// <summary>
+    /// Renders <c>new { Name = value, ... }</c>. A member uses the projection
+    /// shorthand (<c>new { x }</c> / <c>new { obj.Member }</c>) only when the value
+    /// expression's own member name exactly matches the property name — an
+    /// identifier whose text equals the name, or a field/property access ending in
+    /// <c>.Name</c>. Any mismatch keeps the explicit <c>Name = value</c> form, so
+    /// the recovered name is never silently changed.
+    /// </summary>
+    string AnonymousObjectText(AnonymousObject anonymous)
+    {
+        if (anonymous.Values.Count == 0)
+            return "new { }";
+        var parts = new List<string>(anonymous.Values.Count);
+        for (int i = 0; i < anonymous.Values.Count; i++)
+        {
+            var value = anonymous.Values[i];
+            string name = anonymous.PropertyNames[i];
+            string text = Expression(value);
+            bool shorthand = text == name
+                || (value is LoadField field && field.Field.Name == name && text.EndsWith("." + name, StringComparison.Ordinal))
+                || (value is LoadProperty property && property.PropertyName == name && text.EndsWith("." + name, StringComparison.Ordinal));
+            parts.Add(shorthand ? text : $"{name} = {text}");
+        }
+        return $"new {{ {string.Join(", ", parts)} }}";
     }
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
@@ -1039,7 +1066,7 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or ObjectInitializerExpression or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or AnonymousObject or ObjectInitializerExpression or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -827,7 +827,8 @@ public static class IrImporter
 
                 case ILOpCode.Newobj:
                 {
-                    var constructor = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var ctorHandle = MetadataTokens.EntityHandle(reader.ReadILToken());
+                    var constructor = ResolveMethod(source.Reader, ctorHandle, callerScope);
                     // A bare cross-assembly struct token carries no VALUETYPE
                     // byte; resolve its value-type-ness so a struct constructor
                     // (new DateTime(...)) is not misread as a heap allocation.
@@ -835,7 +836,10 @@ public static class IrImporter
                     var arguments = new IrExpression[constructor.ParameterTypes.Length];
                     for (int i = arguments.Length - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
-                    stack.Push(new NewObject(constructor, arguments));
+                    stack.Push(new NewObject(constructor, arguments)
+                    {
+                        AnonymousPropertyNames = ReadAnonymousPropertyNames(source.Reader, ctorHandle),
+                    });
                     break;
                 }
 
@@ -1464,6 +1468,37 @@ public static class IrImporter
             default:
                 return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
         }
+    }
+
+    /// <summary>
+    /// The property names of an anonymous-type constructor, in argument order, or
+    /// empty when the constructor's declaring type is not a compiler-generated
+    /// anonymous type. Anonymous types are always same-assembly MethodDefs, so the
+    /// declaring <see cref="TypeDefinition"/> and its property rows are readable
+    /// directly; the property table order matches the constructor's parameter
+    /// order (Roslyn emits both in source-declaration order), so the names align
+    /// 1:1 with the <c>newobj</c> arguments. Used by <c>AnonymousObjectPass</c>.
+    /// </summary>
+    static ImmutableArray<string> ReadAnonymousPropertyNames(MetadataReader reader, EntityHandle ctorHandle)
+    {
+        TypeDefinitionHandle typeHandle = ctorHandle.Kind switch
+        {
+            // A non-generic anonymous type's ctor is a MethodDef; a generic one
+            // (the usual case — any anonymous type with properties is generic) is
+            // a MemberRef whose parent TypeSpec resolves to the same-assembly def.
+            HandleKind.MethodDefinition => reader.GetMethodDefinition((MethodDefinitionHandle)ctorHandle).GetDeclaringType(),
+            HandleKind.MemberReference => DeclaringTypeDefinition(reader, reader.GetMemberReference((MemberReferenceHandle)ctorHandle).Parent) ?? default,
+            _ => default,
+        };
+        if (typeHandle.IsNil)
+            return [];
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        if (!reader.GetString(typeDef.Name).StartsWith("<>f__AnonymousType", StringComparison.Ordinal))
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>();
+        foreach (var handle in typeDef.GetProperties())
+            names.Add(reader.GetString(reader.GetPropertyDefinition(handle).Name));
+        return names.ToImmutable();
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -977,6 +977,15 @@ public sealed class NewObject : IrExpression
     public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
 
     /// <summary>
+    /// For a constructor of a compiler-generated anonymous type
+    /// (<c>&lt;&gt;f__AnonymousType*</c>), the property names in argument order —
+    /// the metadata the importer captures so <see cref="AnonymousObjectPass"/> can
+    /// raise the call to a <c>new { Name = value, ... }</c> literal. Empty for
+    /// every ordinary constructor; a pass keys off non-emptiness.
+    /// </summary>
+    public ImmutableArray<string> AnonymousPropertyNames { get; init; } = [];
+
+    /// <summary>
     /// A by-ref constructor argument forwarded against an unknown call-site
     /// ref-kind. Lowers fidelity. See
     /// <see cref="MethodRef.HasUnverifiableByRefArgument"/>.
@@ -988,6 +997,33 @@ public sealed class NewObject : IrExpression
         => Constructor.ParameterTypes.Append(Constructor.DeclaringType);
 
     public override string Describe() => $"NewObject {Constructor.DeclaringType.ToDisplayString()}";
+}
+
+/// <summary>
+/// A raised C# anonymous-object creation — <c>new { a = x, b = y }</c> — produced
+/// by <see cref="AnonymousObjectPass"/> from the compiler's lowering of an
+/// anonymous-type construction to <c>new &lt;&gt;f__AnonymousType0&lt;...&gt;(x, y)</c>.
+/// The child slots are the member value expressions; <see cref="PropertyNames"/>
+/// is the parallel name list (argument order), carried as metadata rather than
+/// child nodes since names are not expressions.
+/// </summary>
+public sealed class AnonymousObject : IrExpression
+{
+    public AnonymousObject(TypeRef type, ImmutableArray<string> propertyNames, IEnumerable<IrExpression> values)
+    {
+        Type = type;
+        PropertyNames = propertyNames;
+        foreach (var value in values)
+            AddChild(value);
+    }
+
+    public TypeRef Type { get; }
+    public ImmutableArray<string> PropertyNames { get; }
+    public IReadOnlyList<IrExpression> Values => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Type];
+
+    public override string Describe() => $"AnonymousObject ({Children.Count} properties)";
 }
 
 /// <summary>One segment in a raised interpolated string: either literal text or a formatted-expression child by index.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
@@ -1,0 +1,34 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises an anonymous-type construction back into a C# anonymous-object literal:
+/// the compiler lowers <c>new { a = x, b = y }</c> to a constructor call on a
+/// generated <c>&lt;&gt;f__AnonymousType0&lt;...&gt;(x, y)</c>, whose type name is
+/// unspeakable in C#, so left flat the printer emits invalid source. This folds it
+/// back to <c>new { a = x, b = y }</c>.
+///
+/// The match keys off the metadata the importer captured on the
+/// <see cref="NewObject"/>: <see cref="NewObject.AnonymousPropertyNames"/> is
+/// non-empty only for anonymous-type constructors, and aligns 1:1 with the
+/// arguments. No metadata is read here — the pass operates purely on the captured
+/// names, like every other raising pass.
+/// </summary>
+public sealed class AnonymousObjectPass : IIrPass
+{
+    public string Name => "anonymous-object";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
+        {
+            var names = newObject.AnonymousPropertyNames;
+            if (names.IsDefaultOrEmpty || names.Length != newObject.Arguments.Count)
+                continue;
+
+            var values = newObject.DetachChildren().Cast<IrExpression>().ToList();
+            var anonymous = new AnonymousObject(newObject.Constructor.DeclaringType, names, values);
+            context.Stepper.StepOver("raise anonymous-type constructor to anonymous object", newObject);
+            newObject.ReplaceWith(anonymous);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -53,6 +53,12 @@ public static class IrPasses
         // Runs after struct-constructor so in-place struct .ctor calls have
         // already been normalized to NewObject when they are spellable.
         new TupleCreationPass(),
+        // Raise an anonymous-type constructor (new <>f__AnonymousTypeN(...)) back
+        // into a new { Name = value, ... } literal, using the property names the
+        // importer captured on the NewObject. Runs in the expression-sugar band
+        // next to tuple-creation; the unspeakable generated type name means the
+        // flat form is invalid C#, so this also lifts fidelity to valid source.
+        new AnonymousObjectPass(),
         new PropertySugarPass(),
         // Raise the object/collection-initializer lowering (a NewObject threaded
         // through a dup chain and mutated by a run of member stores or Add calls)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -71,6 +71,8 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
+    [Completeness(CompletenessLevel.Partial, "new { a = x, ... } from the generated anonymous-type constructor, with projection shorthand; equality/ToString members and nested anonymous types are unaffected")]
+    public static AnonymousObjectPass AnonymousObjectCreation => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -87,7 +89,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "a[^1]")]                      public static Unhandled Index                               => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
-    [Completeness(CompletenessLevel.None, "new { a, b }")]               public static Unhandled AnonymousObjectCreation             => default!;
     [Completeness(CompletenessLevel.None, "from x in xs select ...")]    public static Unhandled Query                               => default!;
     [Completeness(CompletenessLevel.None, "await t — async state machine")]      public static Unhandled Await => default!;
     [Completeness(CompletenessLevel.None, "yield return — iterator state machine")] public static Unhandled Yield => default!;


### PR DESCRIPTION
## Summary

Raises the compiler-generated anonymous-type construction back into idiomatic C#:

```csharp
// before (lowered IR exposed)
return new <>f__AnonymousType0<int, string>(id, name);
// after
return new { Id = id, Name = name };
```

## What changed

- **New `AnonymousObject` IR node + `AnonymousObjectPass`** mirroring the `TupleCreationPass` shape: matches a `NewObject` of a `<>f__AnonymousType*` type and raises it to a structural anonymous-object node.
- **Importer name capture.** Property names are read at import (passes have no `MetadataReader`). Crucially, anonymous types are generic, so the `newobj` operand is a `MemberReference` whose parent is a `TypeSpecification` — resolved to the backing `TypeDefinition` via the existing `DeclaringTypeDefinition` helper.
- **Printer.** Emits explicit `Name = value`, or projection shorthand (`new { a }`, `new { obj.Member }`) only when the value's own name already matches the property name. Any mismatch stays explicit — never silently renames a property.
- **Ledger.** `AnonymousObjectCreation` flipped `None → Partial`; owed count decremented in lockstep.

## Fidelity

`AnonShorthand` / `AnonNamed` / `AnonSingle` are pinned opcode-exact in both fidelity gates. `AnonMemberShorthand` rendering is covered by a unit test but unpinned — its nested `InitTarget` getters hit the known skeleton-recompile limitation (same as the existing `MakePoint` fixtures).

## Tests

390 decompiler + 1157 product tests green.
