### PR TITLE
Add adversarial interpolation handler fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -847,6 +847,23 @@ public class CfgSampleClass
     public static string StringInterpolation(string name, int age)
         => $"Hello, {name}! You are {age} years old.";
 
+    public static string ManualInterpolatedStringHandler(string name)
+    {
+        var handler = new System.Runtime.CompilerServices.DefaultInterpolatedStringHandler(7, 1);
+        handler.AppendLiteral("Hello, ");
+        handler.AppendFormatted(name);
+        return handler.ToStringAndClear();
+    }
+
+    public static string ManualInterpolatedStringHandlerWithProvider(int value)
+    {
+        var handler = new System.Runtime.CompilerServices.DefaultInterpolatedStringHandler(
+            6, 1, System.Globalization.CultureInfo.InvariantCulture);
+        handler.AppendLiteral("value=");
+        handler.AppendFormatted(value);
+        return handler.ToStringAndClear();
+    }
+
     public static int UsingStatement(string path)
     {
         using var stream = System.IO.File.OpenRead(path);

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -45,4 +45,34 @@ public class StringInterpolationPassTests
         Assert.Contains("return $\"value={value} again={value}\";", output);
         Assert.DoesNotContain("AppendFormatted", output);
     }
+
+    [Fact]
+    public void ManualHandlerSourceLocal_IsNotRaised()
+    {
+        // This is a source-level handler local, not the compiler's hidden temp
+        // for `$"..."`. Raising it would erase the user's chosen lower-level
+        // spelling and, for richer overloads, can drop semantics.
+        var function = Raised(nameof(CfgSampleClass.ManualInterpolatedStringHandler));
+
+        Assert.DoesNotContain(function.Descendants.OfType<InterpolatedStringExpression>(), _ => true);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("DefaultInterpolatedStringHandler handler", output);
+        Assert.Contains("handler.AppendLiteral", output);
+        Assert.DoesNotContain("$\"Hello", output);
+    }
+
+    [Fact]
+    public void ManualHandlerProviderCtor_IsNotRaised()
+    {
+        // The provider overload carries formatting semantics not represented by
+        // a plain interpolated string in this IR slice.
+        var function = Raised(nameof(CfgSampleClass.ManualInterpolatedStringHandlerWithProvider));
+
+        Assert.DoesNotContain(function.Descendants.OfType<InterpolatedStringExpression>(), _ => true);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("CultureInfo.InvariantCulture", output);
+        Assert.DoesNotContain("$\"value=", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
@@ -26,7 +26,7 @@ public sealed class StringInterpolationPass : IIrPass
             var children = block.Children;
             for (int i = 0; i < children.Count; i++)
             {
-                if (TryMatch(children, i) is not { } match)
+                if (TryMatch(function, children, i) is not { } match)
                     continue;
 
                 var consumed = new IrNode[] { match.StoreHandler, match.ReturnStatement, };
@@ -64,9 +64,10 @@ public sealed class StringInterpolationPass : IIrPass
         return false;
     }
 
-    static Match? TryMatch(IReadOnlyList<IrNode> statements, int start)
+    static Match? TryMatch(IrFunction function, IReadOnlyList<IrNode> statements, int start)
     {
         if (statements[start] is not StoreLocal { Value: NewObject handlerCtor } storeHandler
+            || HasSourceLocalName(function, storeHandler.Index)
             || !IsDefaultInterpolatedStringHandlerCtor(handlerCtor))
         {
             return null;
@@ -83,6 +84,7 @@ public sealed class StringInterpolationPass : IIrPass
         }
 
         if (appends.Count == 0
+            || !CtorArgumentsMatchAppends(handlerCtor, appends)
             || i >= statements.Count
             || statements[i] is not Return { Value: Call toString } ret
             || !IsToStringAndClear(toString, storeHandler.Index))
@@ -103,8 +105,37 @@ public sealed class StringInterpolationPass : IIrPass
                     Name: "DefaultInterpolatedStringHandler",
                     Assembly: TypeRef.CoreLibrary or "System.Runtime",
                 },
-            }
-            && newObject.Arguments.Count >= 2;
+            };
+
+    static bool HasSourceLocalName(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && !string.IsNullOrWhiteSpace(function.LocalNames[index]);
+
+    static bool CtorArgumentsMatchAppends(NewObject handlerCtor, IReadOnlyList<ExpressionStatement> appends)
+    {
+        if (handlerCtor.Arguments is not
+            [
+                Constant { Value: int literalLength },
+                Constant { Value: int formattedCount },
+            ])
+        {
+            return false;
+        }
+
+        int actualLiteralLength = 0;
+        int actualFormattedCount = 0;
+        foreach (var append in appends)
+        {
+            var call = (Call)append.Expression;
+            if (call.Callee.Name == "AppendLiteral")
+                actualLiteralLength += ((string)((Constant)call.Arguments[1]).Value!).Length;
+            else
+                actualFormattedCount++;
+        }
+
+        return literalLength == actualLiteralLength && formattedCount == actualFormattedCount;
+    }
 
     static bool IsAppend(Call call, int handlerSlot)
     {
@@ -117,17 +148,27 @@ public sealed class StringInterpolationPass : IIrPass
 
         return call switch
         {
-            { Callee.Name: "AppendLiteral", Arguments: [_, Constant { Value: string }] } => true,
-            { Callee.Name: "AppendFormatted", Arguments.Count: 2 } => true,
+            { Callee.Name: "AppendLiteral", Arguments: [_, Constant { Value: string }] }
+                when call.Callee.ParameterTypes is [{ Namespace: "System", Name: "String" }] => true,
+            { Callee.Name: "AppendFormatted", Arguments.Count: 2 }
+                when call.Callee.ParameterTypes.Length == 1 => true,
             _ => false,
         };
     }
 
     static bool IsToStringAndClear(Call call, int handlerSlot)
-        => IsHandlerCall(call)
-            && call.Callee.Name == "ToStringAndClear"
-            && call.Arguments is [LoadLocalAddress receiver]
-            && receiver.Index == handlerSlot;
+    {
+        if (!IsHandlerCall(call)
+            || call.Callee.Name != "ToStringAndClear"
+            || call.Callee.ParameterTypes.Length != 0
+            || call.Callee.ReturnType is not { Namespace: "System", Name: "String" }
+            || call.Arguments is not [LoadLocalAddress receiver])
+        {
+            return false;
+        }
+
+        return receiver.Index == handlerSlot;
+    }
 
     static bool IsHandlerCall(Call call)
         => call.Callee is


### PR DESCRIPTION
## Summary

- Add manual DefaultInterpolatedStringHandler adversarial fixtures that must stay in handler form.
- Narrow StringInterpolationPass to compiler-hidden handler temps with exact two-argument literal/formatted counts.
- Require exact simple AppendLiteral/AppendFormatted/ToStringAndClear signatures so provider/format overload semantics are not erased.

## Testing

- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo -v:minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.StringInterpolationPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo -v:minimal
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
