### PR TITLE
Add ternary adversarial boundary fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -815,6 +815,34 @@ public class CfgSampleClass
 
     public static int TernaryInt(int a, int b) => a > b ? a : b;
 
+    public static int EqualityGuardReturn(int value, int whenZero, int otherwise)
+    {
+        if (value == 0)
+            return whenZero;
+        return otherwise;
+    }
+
+    public static int ObjectReferenceEqualityGuardReturn(object left, object right, int whenSame, int whenDifferent)
+    {
+        if (left == right)
+            return whenSame;
+        return whenDifferent;
+    }
+
+    public static int StringEqualityGuardReturn(string left, string right, int whenSame, int whenDifferent)
+    {
+        if (left == right)
+            return whenSame;
+        return whenDifferent;
+    }
+
+    public static int FloatUnorderedGuardReturn(double value, double limit, int whenLessOrEqual, int whenGreaterOrUnordered)
+    {
+        if (value <= limit)
+            return whenLessOrEqual;
+        return whenGreaterOrUnordered;
+    }
+
     public static string UnsignedBoundsGuard(int index, int length)
     {
         if ((uint)index >= (uint)length)

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1926,6 +1926,61 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void BooleanFolding_EqualityGuardReturn_StaysStatementForm()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.EqualityGuardReturn), source);
+
+        Assert.Equal("""
+            if (value == 0)
+            {
+                return whenZero;
+            }
+            return otherwise;
+            """.ReplaceLineEndings("\n"), output);
+        Assert.DoesNotContain("?", output);
+    }
+
+    [Fact]
+    public void BooleanFolding_ObjectReferenceGuardReturn_RaisesCanonicalConditional()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ObjectReferenceEqualityGuardReturn), source);
+
+        Assert.Equal("return left != right ? whenDifferent : whenSame;", output);
+    }
+
+    [Fact]
+    public void BooleanFolding_StringEqualityGuardReturn_StaysStatementForm()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StringEqualityGuardReturn), source);
+
+        Assert.Equal("""
+            if (left == right)
+            {
+                return whenSame;
+            }
+            return whenDifferent;
+            """.ReplaceLineEndings("\n"), output);
+        Assert.DoesNotContain("?", output);
+    }
+
+    [Fact]
+    public void BooleanFolding_FloatGuardReturn_PreservesUnorderedDual()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.FloatUnorderedGuardReturn), source);
+
+        Assert.Equal("return !(value <= limit) ? whenGreaterOrUnordered : whenLessOrEqual;", output);
+        Assert.DoesNotContain("value > limit ?", output);
+    }
+
+    [Fact]
     public void BooleanFolding_UnsignedGuardReturn_StaysStatementForm()
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);


### PR DESCRIPTION
## Summary
- performed a second adversarial pass over BooleanFoldingPass return-ternary matching
- found no additional implementation bug
- added boundary fixtures/tests for int equality, object reference equality, string equality, and floating-point unordered inversion

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_EqualityGuardReturn_StaysStatementForm -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_ObjectReferenceGuardReturn_RaisesCanonicalConditional -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_StringEqualityGuardReturn_StaysStatementForm -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_FloatGuardReturn_PreservesUnorderedDual
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build