### PR TITLE
Raise non-capturing lambdas to (params) => body

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -38,6 +38,32 @@ public class CfgSampleClass
 
     public static int Pick(bool c, int a, int b) => c ? a : b;
 
+    // A non-capturing lambda: the body reads only its own parameter, so the
+    // compiler emits it as a delegate over a static method on the singleton
+    // <>c closure holder, cached in a <>9__ field. LambdaCachePass strips the
+    // lazy cache and LambdaRaisingPass recovers `x => x + 1`.
+    public static System.Func<int, int> NonCapturingLambda() => x => x + 1;
+
+    // Boundary fixtures for the owed lambda surface: each is declined by one of
+    // LambdaRaisingPass's guards, so the scorecard pins it as unrecovered (it
+    // still renders the delegate-over-synthesized-method form). When a later
+    // slice lifts a guard, flip its scorecard entry to recovered in that PR.
+
+    // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
+    // an instance method on that class, not the static <>c singleton. Display
+    // class capture substitution is owed.
+    public static System.Func<int, int> CapturingLambda(int n) => x => x + n;
+
+    // Statement body: more than one statement, so it is not the single
+    // `return expr` the first slice admits. A block-bodied lambda is owed.
+    public static System.Func<int, int> StatementBodyLambda()
+        => x => { System.Console.WriteLine(x); return x + 1; };
+
+    // Local-bearing body: `y` is read twice, so inlining cannot fold it away and
+    // the body keeps a local of its own. A per-lambda local scope is owed.
+    public static System.Func<int, int> LocalBodyLambda()
+        => x => { int y = x + 1; return y * y; };
+
     public static int DoWhileSum(int n)
     {
         int s = 0;

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -35,6 +35,11 @@ public class IdiomShapeScorecardTests
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        // Owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
+        new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
     ];
 
     [Fact]
@@ -81,7 +86,10 @@ public class IdiomShapeScorecardTests
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
 
-        var result = CSharpPrinter.PrintRaised(function!);
+        // Wire the cross-method import seam so passes that reach a sibling body
+        // (lambda raising imports the synthesized method) run as they do on the
+        // shipped product path; without it the scorecard would understate them.
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
         Assert.NotNull(result.Output);
 
         var text = $$"""

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -74,7 +74,7 @@ public class LoweredFidelityGateTests
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()
     {
         var assembly = typeof(CfgSampleClass).Assembly.Location;
-        return FidelityCheck.Evaluate(assembly, CSharpPrinter.PrintLowered)
+        return FidelityCheck.Evaluate(assembly, lowered: true)
             .Where(r => r.Type == FixtureType)
             .ToList();
     }

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -53,7 +53,7 @@ public class LoweringCoverageTests
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
         (typeof(LoweringCoverage), 6, "LocalRewriter"),
-        (typeof(ClosureCoverage), 4, "ClosureConversion"),
+        (typeof(ClosureCoverage), 3, "ClosureConversion"),
     ];
 
     static PropertyInfo[] Props(Type t) => t.GetProperties(BindingFlags.Public | BindingFlags.Static);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -45,12 +45,23 @@ public sealed partial class CSharpPrinter
         _skipLocalsInit = function.SkipLocalsInit;
     }
 
+    // The output-path pass context: stepping off, plus the optional cross-method
+    // import seam so a pass can reach a sibling body (lambda raising).
+    static PassContext RaiseContext(Func<MethodRef, IrFunction?>? importMethodBody)
+        => importMethodBody is null
+            ? PassContext.None
+            : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
+
     /// <summary>The product path: runs the default raising passes, then prints. <see cref="Print"/> alone renders whatever tree it is given — right for stage dumps, wrong for output paths.</summary>
     public static DecompilerResult PrintRaised(IrFunction function)
+        => PrintRaised(function, importMethodBody: null);
+
+    /// <summary>As <see cref="PrintRaised(IrFunction)"/>, with <paramref name="importMethodBody"/> wiring the cross-method import seam (e.g. for lambda raising); null leaves cross-method passes as no-ops.</summary>
+    public static DecompilerResult PrintRaised(IrFunction function, Func<MethodRef, IrFunction?>? importMethodBody)
     {
         try
         {
-            IrPasses.Run(function);
+            IrPasses.Run(function, IrPasses.Default, RaiseContext(importMethodBody));
         }
         catch (Exception ex)
         {
@@ -67,11 +78,16 @@ public sealed partial class CSharpPrinter
     /// annotation-agnostic. The map is empty on failure.
     /// </summary>
     public static DecompilerResult PrintRaised(IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines)
+        => PrintRaised(function, out statementLines, importMethodBody: null);
+
+    /// <inheritdoc cref="PrintRaised(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    public static DecompilerResult PrintRaised(
+        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody)
     {
         statementLines = new Dictionary<IrNode, int>();
         try
         {
-            IrPasses.Run(function);
+            IrPasses.Run(function, IrPasses.Default, RaiseContext(importMethodBody));
         }
         catch (Exception ex)
         {
@@ -901,6 +917,7 @@ public sealed partial class CSharpPrinter
         CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
+        Lambda lam => LambdaText(lam),
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
@@ -981,6 +998,30 @@ public sealed partial class CSharpPrinter
             parts.Add(shorthand ? text : $"{name} = {text}");
         }
         return $"new {{ {string.Join(", ", parts)} }}";
+    }
+
+    /// <summary>
+    /// Renders a recovered lambda: parameter names (the delegate type supplies
+    /// their types, so they stay unannotated), then <c>=&gt; expr</c> for an
+    /// expression body or <c>=&gt; { ... }</c> otherwise. A single parameter
+    /// drops the parentheses. The body's arguments are self-naming on their
+    /// nodes, so this reuses the outer printer with no scope switch — sound only
+    /// because the raising pass admits only non-capturing, zero-local bodies.
+    /// </summary>
+    string LambdaText(Lambda lambda)
+    {
+        string parameters = lambda.Parameters is [var single]
+            ? single.Name
+            : $"({string.Join(", ", lambda.Parameters.Select(p => p.Name))})";
+
+        if (lambda.ExpressionBody is { } expr)
+            return $"{parameters} => {Expression(expr)}";
+
+        var statements = lambda.Body.Blocks
+            .SelectMany(b => b.Children)
+            .Select(Statement)
+            .Where(s => s is not null);
+        return $"{parameters} => {{ {string.Join(" ", statements)} }}";
     }
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -46,6 +46,24 @@ public static class IrImporter
     /// non-public same-name overloads — otherwise a private overload declared
     /// before a public one would be selected in its place.
     /// </param>
+    /// <summary>
+    /// Imports a method body addressed by a <see cref="MethodRef"/> — the
+    /// reference form a pass already holds (e.g. a delegate creation's target
+    /// method). Resolves the declaring type's metadata full name from the ref
+    /// (<see cref="TypeRef.Name"/> spells nesting with <c>+</c>; the importer
+    /// matches the <c>.</c> form) and forwards to the by-name front door. The
+    /// synthesized lambda/local-function methods this serves have unique names,
+    /// so overload index 0 is exact.
+    /// </summary>
+    public static IrFunction? Import(MetadataSource source, MethodRef method)
+        => Import(source, ImporterTypeName(method.DeclaringType), method.Name);
+
+    static string ImporterTypeName(TypeRef type)
+    {
+        string name = type.Name.Replace('+', '.');
+        return type.Namespace.Length == 0 ? name : $"{type.Namespace}.{name}";
+    }
+
     public static IrFunction? Import(MetadataSource source, string typeFullName, string methodName, int overloadIndex = 0, bool publicOnly = false)
     {
         // The single-method front door carries the same no-crash guarantee as

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1199,6 +1199,47 @@ public sealed class DelegateCreation : IrExpression
         => $"DelegateCreation {DelegateType.ToDisplayString()} <- {Method.DeclaringType.ToDisplayString()}.{Method.Name}";
 }
 
+/// <summary>
+/// A lambda expression <c>(params) =&gt; body</c> recovered from the compiler's
+/// closure lowering — the inverse of the delegate-over-synthesized-method shape
+/// ClosureConversion emits. Carries the lambda's parameters and its raised body
+/// (the synthesized method's block container, imported and run through the
+/// pipeline). The result type is the delegate type the lambda is converted to.
+///
+/// <para>Non-capturing only for now: the body reads no display-class state and
+/// declares no locals, so it prints inside the outer function's scope without a
+/// local context of its own (arguments are self-naming on the node). A
+/// capturing body, or one with its own locals, needs the printer to switch
+/// scope when it descends here — a later increment.</para>
+/// </summary>
+public sealed class Lambda : IrExpression
+{
+    public Lambda(TypeRef delegateType, ImmutableArray<Parameter> parameters, BlockContainer body)
+    {
+        DelegateType = delegateType;
+        Parameters = parameters;
+        AddChild(body);
+    }
+
+    public TypeRef DelegateType { get; }
+    public ImmutableArray<Parameter> Parameters { get; }
+    public BlockContainer Body => (BlockContainer)Children[0];
+    public override TypeRef? ResultType => DelegateType;
+    public override IEnumerable<TypeRef> DirectTypes
+        => Parameters.Select(p => p.Type).Append(DelegateType);
+
+    /// <summary>
+    /// The single returned expression when the body is one block ending in a
+    /// bare <c>return expr;</c> — the expression-bodied form <c>p =&gt; expr</c>.
+    /// Null when the body needs the block form <c>p =&gt; { ... }</c>.
+    /// </summary>
+    public IrExpression? ExpressionBody
+        => Body.Blocks is [{ Children: [Return { Value: { } value }] }] ? value : null;
+
+    public override string Describe()
+        => $"Lambda {DelegateType.ToDisplayString()} ({Parameters.Length} params)";
+}
+
 public sealed class Throw : IrNode
 {
     public Throw(IrExpression value) => AddChild(value);

--- a/src/ILInspector.Decompiler/Pipeline/PassContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PassContext.cs
@@ -5,14 +5,19 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>ILTransformContext</c> in this codebase's vocabulary. A pass receives one
 /// and records its rewrites through <see cref="Stepper"/>. The type is the seam
 /// for the dataflow facts and diagnostics sink the IR design calls for
-/// (docs/decompiler-ir.md); today it carries the stepper.
+/// (docs/decompiler-ir.md); today it carries the stepper and the cross-method
+/// import seam.
 /// </summary>
 public sealed class PassContext
 {
-    public PassContext(Stepper stepper, StructuringDiagnostics? structuringDiagnostics = null)
+    public PassContext(
+        Stepper stepper,
+        StructuringDiagnostics? structuringDiagnostics = null,
+        Func<MethodRef, IrFunction?>? importMethodBody = null)
     {
         Stepper = stepper;
         StructuringDiagnostics = structuringDiagnostics;
+        ImportMethodBody = importMethodBody;
     }
 
     public Stepper Stepper { get; }
@@ -23,6 +28,17 @@ public sealed class PassContext
     /// diagnostic to make the common-exit docket reproducible.
     /// </summary>
     public StructuringDiagnostics? StructuringDiagnostics { get; }
+
+    /// <summary>
+    /// The cross-method import seam: imports a sibling method's freshly-imported
+    /// (un-raised) body by reference, or null when the method is absent. The
+    /// pipeline is otherwise per-method — a pass sees only its one function — so
+    /// this is the single sanctioned way for a pass to reach another body.
+    /// <see cref="LambdaRaisingPass"/> uses it to pull in a lambda's synthesized
+    /// method. Null on runs that wired no source (stage dumps, direct pass tests,
+    /// the lowered view); a pass that needs it must no-op when it is null.
+    /// </summary>
+    public Func<MethodRef, IrFunction?>? ImportMethodBody { get; }
 
     /// <summary>A context with stepping disabled — the default for normal runs and for tests that drive a pass directly.</summary>
     public static PassContext None { get; } = new(new Stepper(enabled: false));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -11,20 +11,22 @@ namespace ILInspector.Decompiler.Pipeline;
 /// two axes as <see cref="LoweringCoverage"/>: mechanism is the property type,
 /// completeness is the <see cref="CompletenessAttribute"/>.
 ///
-/// <para>Every entry is owed today. <see cref="DelegateConstructionPass"/> raises
-/// a method-group delegate — but that is a LocalRewriter <c>DelegateCreationExpression</c>
-/// (already Full), not a closure. Nothing recovers a lambda, local function,
-/// captured closure, or expression tree, so they render as the synthesized
-/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — a large inferior-form
-/// gap that the LocalRewriter register structurally cannot show.</para>
+/// <para><see cref="DelegateConstructionPass"/> raises a method-group delegate —
+/// but that is a LocalRewriter <c>DelegateCreationExpression</c> (already Full),
+/// not a closure. <see cref="LambdaRaisingPass"/> recovers the first slice of a
+/// real closure: a non-capturing, expression-bodied lambda (<c>x =&gt; x + 1</c>),
+/// after <see cref="LambdaCachePass"/> strips its lazy <c>&lt;&gt;c</c> cache.
+/// Capturing lambdas, local functions, and expression trees are still owed, so
+/// they render as the synthesized <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c>
+/// shapes — a large inferior-form gap the LocalRewriter register cannot show.</para>
 ///
 /// <para>Synced against dotnet/roslyn
 /// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.None, "x => x + 1 — delegate over a synthesized method (non-capturing caches in <>c)")]
-    public static Unhandled Lambda => default!;
+    [Completeness(CompletenessLevel.Partial, "non-capturing, expression-bodied only (x => x + 1); capturing / statement / local-bound bodies still owed")]
+    public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]
     public static Unhandled LocalFunction => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -108,9 +108,18 @@ public static class IrPasses
         // spill collapses into the ?. target and the reused slot stops carrying
         // two unrelated types.
         new NullConditionalPass(),
+        // Collapse the lazy delegate-cache dance (the non-capturing lambda /
+        // static method-group lowering) to a bare delegate creation before the
+        // second inlining folds the surviving carrier slot into its use.
+        new LambdaCachePass(),
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // Raise the bare delegate creation left by the cache collapse into the
+        // lambda itself — imports the synthesized method's body and re-presents
+        // it as `(params) => body`. Needs the cross-method import seam on the
+        // pass context; a no-op when that seam is absent.
+        new LambdaRaisingPass(),
         // Raise the csc type-pattern lowering (a `value as T` store gating a
         // null test that scopes the narrowed local) into `value is T t`. Runs
         // after structuring and boolean folding so the `if` guard and the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -1,0 +1,76 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Collapses the compiler's lazy delegate-cache idiom — the lowering that backs
+/// a non-capturing lambda (and a static method group). The compiler caches the
+/// one delegate instance in a static <c>&lt;&gt;9__N_M</c> field, guarded by a
+/// null check:
+/// <code>
+///   s = &lt;&gt;9__N_M;
+///   if (s is null) { t = new D(&lt;&gt;9, &lt;Outer&gt;b__N_M); &lt;&gt;9__N_M = t; s = t; }
+///   // ... use s
+/// </code>
+/// This pass rewrites that whole dance to a single <c>s = new D(...)</c>,
+/// dropping the cache field, the null guard, and the carrier slots. The cache is
+/// a pure codegen artifact (re-emitting the C# restores an equivalent one), so
+/// erasing it is sound for the raised view — only fidelity to the exact IL is
+/// lost, which the lowered view never promises here.
+///
+/// <para>Anchored on the cache field's <c>&lt;&gt;9__</c> name — only this idiom
+/// emits it. Runs before the second inlining pass, which folds the surviving
+/// carrier slot into its use; <see cref="LambdaRaisingPass"/> then raises the
+/// bare delegate creation to the lambda itself. A <see cref="NativePasses"/>
+/// member (it inverts a codegen artifact, not a named Roslyn lowering).</para>
+/// </summary>
+public sealed class LambdaCachePass : IIrPass
+{
+    public string Name => "lambda-cache";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var ifStmt in function.Descendants.OfType<IfStatement>().ToList())
+        {
+            if (ifStmt.Parent is not Block block || ifStmt.HasElse || ifStmt.ChildIndex < 2)
+                continue;
+            if (ifStmt.Condition is not LogicalNot { Operand: LoadStackSlot cacheRead })
+                continue;
+
+            // Then arm: t = new D(...); <>9__N_M = t; result = t;  (one carrier slot t)
+            if (ifStmt.Then.Children is not
+                [
+                    StoreStackSlot { Value: DelegateCreation delegateCreation } createStore,
+                    StoreField { Field: { } cacheField, Value: LoadStackSlot fieldCarrier },
+                    StoreStackSlot { Value: LoadStackSlot resultCarrier } resultStore,
+                ])
+                continue;
+            if (!IsClosureCacheField(cacheField))
+                continue;
+            int carrierSlot = createStore.Slot;
+            if (fieldCarrier.Slot != carrierSlot || resultCarrier.Slot != carrierSlot)
+                continue;
+            int resultSlot = resultStore.Slot;
+
+            // The two statements ahead of the guard: cacheSlot = <>9__N_M; result = cacheSlot;
+            if (block.Children[ifStmt.ChildIndex - 2] is not
+                    StoreStackSlot { Value: LoadField { Field: { } loadedField, Instance: null } } cacheLoad
+                || block.Children[ifStmt.ChildIndex - 1] is not
+                    StoreStackSlot { Value: LoadStackSlot seedFrom } seedResult)
+                continue;
+            if (cacheLoad.Slot != cacheRead.Slot || loadedField != cacheField)
+                continue;
+            if (seedResult.Slot != resultSlot || seedFrom.Slot != cacheRead.Slot)
+                continue;
+
+            context.Stepper.StepOver($"collapse lazy delegate cache {cacheField.Name}", ifStmt);
+            delegateCreation.Detach();
+            ifStmt.ReplaceWith(new StoreStackSlot(resultSlot, delegateCreation));
+            seedResult.Detach();
+            cacheLoad.Detach();
+        }
+    }
+
+    // The compiler names the per-lambda cache field <>9__N_M (on the static <>c
+    // closure holder); the name is the unique anchor for the whole idiom.
+    static bool IsClosureCacheField(FieldRef field)
+        => field.Name.StartsWith("<>9__", StringComparison.Ordinal);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -1,0 +1,84 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a delegate creation over a compiler-synthesized lambda method back to
+/// the lambda itself — the inverse of ClosureConversion's "lower <c>x =&gt; e</c>
+/// to a delegate over a method on the <c>&lt;&gt;c</c> closure holder" step. By
+/// the time this runs, <see cref="LambdaCachePass"/> and the second inlining
+/// have stripped the lazy cache, leaving a bare
+/// <c>new Func&lt;…&gt;(&lt;&gt;c.&lt;Outer&gt;b__N_M)</c>; this imports that
+/// synthesized method through the pass context's cross-method seam, re-presents
+/// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
+///
+/// <para>First slice — <b>non-capturing, expression-bodied</b> only: the target
+/// is a method on the static singleton <c>&lt;&gt;c</c> (no display class), and
+/// its body must declare no locals, read no captured <c>this</c>, and be a
+/// single <c>return expr;</c>. Those are exactly the bodies that print correctly
+/// inside the outer function's scope without a local/parameter context of their
+/// own (arguments are self-naming). A capturing lambda, a body with locals, or a
+/// statement body is left as a delegate creation for a later increment. A no-op
+/// when the seam is absent (stage dumps, the lowered/annotated views).</para>
+/// </summary>
+public sealed class LambdaRaisingPass : IIrPass
+{
+    public string Name => "lambda-raising";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (context.ImportMethodBody is null)
+            return;
+
+        foreach (var creation in function.Descendants.OfType<DelegateCreation>().ToList())
+        {
+            if (creation.Parent is null)
+                continue;  // detached by an earlier rewrite in this walk
+            if (!IsNonCapturingLambdaMethod(creation.Method))
+                continue;
+            if (Raise(creation, context) is not { } lambda)
+                continue;
+            context.Stepper.StepOver($"raise lambda {creation.Method.Name}", creation);
+            creation.ReplaceWith(lambda);
+        }
+    }
+
+    static Lambda? Raise(DelegateCreation creation, PassContext context)
+    {
+        var body = context.ImportMethodBody!(creation.Method);
+        if (body is null)
+            return null;
+
+        // Raise the imported body with the same pipeline so it lands at the
+        // shipped altitude (and any nested lambda resolves through the seam).
+        IrPasses.Run(body, IrPasses.Default, context);
+
+        // Admit only what prints soundly in the outer scope: no locals of its
+        // own, no read of the captured-this slot (arg 0), and a single returned
+        // expression. Anything else needs printer scope-switching — not yet.
+        if (!body.Locals.IsEmpty)
+            return null;
+        if (body.Descendants.OfType<UnsupportedNode>().Any())
+            return null;
+        if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
+            return null;
+        if (body.Body.Blocks is not [{ Children: [Return { Value: not null }] }])
+            return null;
+
+        var container = body.Body;
+        container.Detach();
+        return new Lambda(creation.DelegateType, body.Signature.Parameters, container);
+    }
+
+    // A non-capturing lambda's target is a method named <Outer>b__N_M on the
+    // static singleton closure holder <>c (capturing lambdas live on a
+    // <>c__DisplayClass instance instead). The leaf type name pins it.
+    static bool IsNonCapturingLambdaMethod(MethodRef method)
+        => LeafTypeName(method.DeclaringType.Name) == "<>c"
+            && method.Name.Contains(">b__", StringComparison.Ordinal);
+
+    // TypeRef.Name spells nesting with '+'; the closure holder is the leaf.
+    static string LeafTypeName(string name)
+    {
+        int plus = name.LastIndexOf('+');
+        return plus < 0 ? name : name[(plus + 1)..];
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -47,6 +47,8 @@ internal static class NativePasses
     public static IdentityConvertPass IdentityConvert => new();
     [Native(NativeCategory.EmitArtifact, "constant-data RVA blob (RuntimeHelpers.CreateSpan) back to a span literal")]
     public static RvaSpanPass RvaSpan => new();
+    [Native(NativeCategory.EmitArtifact, "the lazy <>9__ delegate cache (non-capturing lambda / static method group) collapsed to a bare delegate creation")]
+    public static LambdaCachePass LambdaCache => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -542,7 +542,8 @@ public static class TypeSourceComposer
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
-        var result = Pipeline.CSharpPrinter.PrintRaised(function);
+        var result = Pipeline.CSharpPrinter.PrintRaised(
+            function, importMethodBody: method => Pipeline.IrImporter.Import(pipelineSource, method));
         constructorChain = result.ConstructorChain;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -32,9 +32,17 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 static class FidelityCheck
 {
+    // The render path for one source: the lowered view, or the shipped raised
+    // view with the cross-method import seam bound (so lambda raising can reach
+    // a synthesized body in the same module). The lowered view carries no seam
+    // yet, so a lambda there stays a delegate creation.
+    static Func<IrFunction, DecompilerResult> Renderer(MetadataSource source, bool lowered)
+        => lowered
+            ? CSharpPrinter.PrintLowered
+            : function => CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool lowered = false)
     {
-        var render = lowered ? CSharpPrinter.PrintLowered : (Func<IrFunction, DecompilerResult>)CSharpPrinter.PrintRaised;
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         // Release codegen so the recompiled stream is compared against the
         // optimization shape the BCL ships; the fixture assembly is built the
@@ -67,6 +75,7 @@ static class FidelityCheck
                 var references = RuntimeReferences(path);
                 using (source)
                 {
+                    var render = Renderer(source, lowered);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {
                         if (total >= cap)
@@ -112,15 +121,16 @@ static class FidelityCheck
     /// opcode-comparison machinery so the two paths can never drift.
     /// </summary>
     public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath)
-        => Evaluate(assemblyPath, CSharpPrinter.PrintRaised);
+        => Evaluate(assemblyPath, lowered: false);
 
     /// <summary>
-    /// Runs the fidelity check roundtrip with a chosen render path — pass
-    /// <see cref="CSharpPrinter.PrintRaised"/> for the shipped (sugared) view or
-    /// <see cref="CSharpPrinter.PrintLowered"/> for the lowered view, so each
-    /// official C# view earns its own compiler→decompiler→compiler validation.
+    /// Runs the fidelity check roundtrip for a chosen view — the shipped raised
+    /// view (<paramref name="lowered"/> false) or the lowered view (true), so
+    /// each official C# view earns its own compiler→decompiler→compiler
+    /// validation. The renderer is built here so the raised path can bind the
+    /// cross-method import seam from the open source (lambda raising).
     /// </summary>
-    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, Func<IrFunction, DecompilerResult> render)
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
@@ -134,6 +144,7 @@ static class FidelityCheck
             return results;
         var reader = pe.GetMetadataReader();
         using var source = MetadataSource.Open(assemblyPath);
+        var render = Renderer(source, lowered);
         var references = RuntimeReferences(assemblyPath);
 
         foreach (var typeHandle in reader.TypeDefinitions)


### PR DESCRIPTION
## What

Recovers a non-capturing lambda — `x => x + 1` — from its lowered form (a delegate over a compiler-synthesized method on the static `<>c` closure holder, behind a lazy cache). This is the first closure-raising pass; until now a lambda rendered as the inferior `new Func<int, int>(<>c.<M>b__0_0)` (an unspeakable name that does not recompile).

## How

Two passes plus a new cross-method import seam:

- **`LambdaCachePass`** (`NativePasses` / `EmitArtifact`) — collapses the lazy `<>9__` delegate-cache dance (`s = <>9__; if (s is null) { s = new D(...); <>9__ = s; } …`) to a bare delegate creation, before the second inlining folds the carrier slot.
- **`PassContext.ImportMethodBody`** — the cross-method import seam. The pipeline is otherwise strictly per-method (a pass sees only its one function), so this is the single sanctioned way for a pass to reach a sibling body. `CSharpPrinter.PrintRaised` threads it; the whole-type product path, the fidelity gate, and the idiom scorecard wire it from the open source. `IrImporter` gains an `Import(source, MethodRef)` overload (resolving the `+`-spelled nested name to the `.`-form the importer matches).
- **`LambdaRaisingPass`** (`ClosureCoverage.Lambda`: `None` → **`Partial`**, owed 4 → 3) — imports the synthesized body through the seam and re-presents it as the lambda.

### Scope (first slice)

Non-capturing, expression-bodied, zero-local bodies only. Those print correctly inside the outer function's scope without a local/parameter context of their own (arguments are self-naming on their nodes). Capturing bodies, statement bodies, and bodies with their own locals are deliberately declined and left as delegate creations.

## Tests

`IdiomShapeScorecardTests` (the #723 syntax-altitude scorecard) gains **1 recovered + 3 owed** lambda entries:

| Fixture | Result | Boundary it pins |
| --- | --- | --- |
| `NonCapturingLambda` | recovers `SimpleLambdaExpression` | — |
| `CapturingLambda` | owed | display-class capture substitution |
| `StatementBodyLambda` | owed | block body (not single-return) |
| `LocalBodyLambda` | owed | a body local of its own |

`NonCapturingLambda` also round-trips **opcode-exact** in the fidelity gate (`FidelityCheck` now binds the seam on the raised render path, so the gate measures the shipped capability). The three owed boundaries flip to recovered when a later slice lifts their guard — the scorecard ratchet flags the unexpected recovery so the entry can't be forgotten.

391/391 decompiler tests green.

### Incidental

Corrected a latent ledger drift: the exact-owed test counts `Unhandled` register entries against a checked-in number, and the only net change here is `ClosureConversion` 4 → 3 (main's recent raises had already re-synced the `LocalRewriter` count).

## Follow-ups

Each its own ledger line: capturing lambdas (display-class field → captured-local substitution), statement/local-bearing bodies (printer scope-switching), then local functions and expression trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
