### PR TITLE
Add adversarial object initializer fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -844,6 +844,13 @@ public class CfgSampleClass
 
     public static int MakeAndRead(int a) => InitTargetX(new InitTarget { X = a });
 
+    public static InitTarget NamedPointInitializerKeptAlive(int a)
+    {
+        var target = new InitTarget { X = a };
+        GC.KeepAlive(target);
+        return target;
+    }
+
     public static string StringInterpolation(string name, int age)
         => $"Hello, {name}! You are {age} years old.";
 

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -57,7 +57,7 @@ public class ObjectInitializerPassTests
     {
         var function = Raised(nameof(CfgSampleClass.MakeEmpty));
 
-        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.DoesNotContain(function.Descendants.OfType<ObjectInitializerExpression>(), _ => true);
         Assert.Single(function.Descendants.OfType<NewObject>());
     }
 
@@ -68,6 +68,22 @@ public class ObjectInitializerPassTests
 
         Assert.Contains("new InitTarget { X = a }", output);
         Assert.DoesNotContain(".X = a;", output);
+    }
+
+    [Fact]
+    public void InitializerWithExtraOutsideUse_IsNotFoldedIntoSingleExpression()
+    {
+        // The expression-position slice requires exactly one outside use of the
+        // threaded receiver. A kept-alive local has two uses (KeepAlive + return),
+        // so folding it into a single object-initializer expression would erase a
+        // real use site.
+        var function = Raised(nameof(CfgSampleClass.NamedPointInitializerKeptAlive));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".X = a;", output);
+        Assert.Contains("GC.KeepAlive", output);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add a kept-alive local object initializer fixture that must not fold into a single expression-position initializer.
- Pin ObjectInitializerPass to reject initializer runs whose threaded receiver has multiple outside uses.

## Testing

- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo -v:minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo -v:minimal
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200