### PR TITLE
Raise anonymous-type newobj to new { ... } anonymous object

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
@@ -1,0 +1,47 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class AnonymousObjectPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void AnonymousNewObject_RaisesToAnonymousObjectExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.AnonymousPair));
+
+        var anonymous = Assert.Single(function.Descendants.OfType<AnonymousObjectExpression>());
+        Assert.Equal(["a", "b"], anonymous.MemberNames);
+        Assert.Equal(2, anonymous.Values.Count);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void AnonymousProjection_RendersNamedMembers()
+        => Assert.Contains("return new { a = a, b = b };", Print(nameof(CfgSampleClass.AnonymousPair)));
+
+    [Fact]
+    public void AnonymousExplicitNames_PreservesNamesAndOrder()
+        => Assert.Contains("return new { Id = x, Name = s };", Print(nameof(CfgSampleClass.AnonymousNamed)));
+
+    [Fact]
+    public void AnonymousNested_RaisesBothLevels()
+    {
+        var function = Raised(nameof(CfgSampleClass.AnonymousNested));
+
+        Assert.Equal(2, function.Descendants.OfType<AnonymousObjectExpression>().Count());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Contains("return new { p = new { a = a }, q = b };", CSharpPrinter.Print(function).Output!);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -837,6 +837,16 @@ public class CfgSampleClass
 
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
+    // Anonymous object creation: the compiler lowers `new { ... }` to a newobj on
+    // a generated <>f__AnonymousType type; the decompiler raises it back to the
+    // anonymous object literal (AnonymousObjectPass). Projection (new { a }),
+    // explicitly-named (new { Id = x }), and nested forms are all kept.
+    public static object AnonymousPair(int a, int b) => new { a, b };
+
+    public static object AnonymousNamed(int x, string s) => new { Id = x, Name = s };
+
+    public static object AnonymousNested(int a, int b) => new { p = new { a }, q = b };
+
     public sealed class InitTarget
     {
         public int X { get; set; }

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -34,6 +34,7 @@ public class IdiomShapeScorecardTests
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
+        new("AnonymousObjectPass", nameof(CfgSampleClass.AnonymousPair), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -52,7 +52,7 @@ public class LoweringCoverageTests
     // drift loose. (If <= a ceiling, a forgotten tighten would pass unnoticed.)
     static readonly (Type Type, int Owed, string Name)[] CoverageRegisters =
     [
-        (typeof(LoweringCoverage), 7, "LocalRewriter"),
+        (typeof(LoweringCoverage), 6, "LocalRewriter"),
         (typeof(ClosureCoverage), 4, "ClosureConversion"),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -907,6 +907,7 @@ public sealed partial class CSharpPrinter
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
+        AnonymousObjectExpression ao => AnonymousObjectText(ao),
         ArrayLength l => $"{Operand(l.Array)}.Length",
         SliceExpression sl => $"{Operand(sl.Receiver)}[{Expression(sl.Range)}]",
         RangeExpression r => $"{(r.HasStart ? Expression(r.Start!) : "")}..{(r.HasEnd ? Expression(r.End!) : "")}",
@@ -954,6 +955,13 @@ public sealed partial class CSharpPrinter
             ? string.Join(", ", initializer.Values.Select(Expression))
             : string.Join(", ", initializer.Members.Zip(initializer.Values, (member, value) => $"{member} = {Expression(value)}"));
         return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+    }
+
+    string AnonymousObjectText(AnonymousObjectExpression anonymous)
+    {
+        var members = string.Join(", ", anonymous.MemberNames.Zip(
+            anonymous.Values, (name, value) => $"{name} = {Expression(value)}"));
+        return $"new {{ {members} }}";
     }
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
@@ -1041,7 +1049,7 @@ public sealed partial class CSharpPrinter
         // any other binary/unary — otherwise an enclosing `!`/`-`/binary
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
-            or NewObject or ArrayLength or LoadElement or SliceExpression or RangeExpression or CaughtException or SizeOf or LoadToken
+            or NewObject or ArrayLength or LoadElement or SliceExpression or RangeExpression or AnonymousObjectExpression or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or ObjectInitializerExpression or IndexFromEnd or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -832,6 +832,12 @@ public static class IrImporter
                     // byte; resolve its value-type-ness so a struct constructor
                     // (new DateTime(...)) is not misread as a heap allocation.
                     constructor = constructor with { DeclaringType = source.CrossAssembly.Upgrade(constructor.DeclaringType) };
+                    // An anonymous-type ctor is a MemberRef on a TypeSpec, which
+                    // carries no parameter names; recover the member names from
+                    // the anonymous type's property metadata for the raise pass.
+                    var anonymousMembers = ResolveAnonymousMemberNames(source.Reader, constructor.DeclaringType);
+                    if (!anonymousMembers.IsEmpty)
+                        constructor = constructor with { AnonymousMemberNames = anonymousMembers };
                     var arguments = new IrExpression[constructor.ParameterTypes.Length];
                     for (int i = arguments.Length - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
@@ -1399,6 +1405,39 @@ public static class IrImporter
 
     static StoreLocal MakeStoreLocal(ImportedMethod method, int index, IrExpression value)
         => new(index, method.Body.Locals[index], value);
+
+    /// <summary>
+    /// For an anonymous-type constructor, the property names in declaration
+    /// (constructor-argument) order; empty for any other type. The ctor token is
+    /// a MemberRef on a TypeSpec (a generic instance), so it carries no parameter
+    /// names — but the names are recoverable from the same-module anonymous
+    /// TypeDefinition's properties, which metadata emits in declaration order. The
+    /// <c>&lt;&gt;f__AnonymousType</c> prefix is compiler-generated and
+    /// unspeakable, so the match is unambiguous.
+    /// </summary>
+    static ImmutableArray<string> ResolveAnonymousMemberNames(MetadataReader reader, TypeRef declaringType)
+    {
+        var definition = declaringType.Kind == TypeRefKind.GenericInstance
+            ? declaringType.ElementType
+            : declaringType;
+        if (definition is null
+            || definition.Namespace.Length != 0
+            || !definition.Name.StartsWith("<>f__AnonymousType", StringComparison.Ordinal))
+            return [];
+
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (reader.GetString(typeDef.Name) != definition.Name)
+                continue;
+            var names = ImmutableArray.CreateBuilder<string>();
+            foreach (var propertyHandle in typeDef.GetProperties())
+                names.Add(reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name));
+            return names.ToImmutable();
+        }
+
+        return [];
+    }
 
     internal static MethodRef ResolveMethod(MetadataReader reader, EntityHandle handle, GenericScope callerScope)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -48,6 +48,16 @@ public sealed record MethodRef(
     public bool IsSpecialName { get; init; }
 
     /// <summary>
+    /// For an anonymous-type constructor (<c>new { a, b }</c> lowers to a
+    /// <c>newobj</c> on a compiler-generated <c>&lt;&gt;f__AnonymousType*</c>
+    /// type), the property names in constructor-argument order; empty for every
+    /// other callee. Resolved at import from the anonymous type's property
+    /// metadata (a MemberRef on a TypeSpec carries no parameter names), and
+    /// consumed by <see cref="AnonymousObjectPass"/> to recover the member names.
+    /// </summary>
+    public ImmutableArray<string> AnonymousMemberNames { get; init; } = [];
+
+    /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
     /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
     /// resolved as a MemberReference (cross-assembly, or a same-assembly call on
@@ -1329,6 +1339,32 @@ public sealed class IndexFromEnd : IrExpression
     public override TypeRef? ResultType => TypeRef.CoreLib("System", "Index");
 
     public override string Describe() => "IndexFromEnd";
+}
+
+/// <summary>
+/// A raised C# anonymous object creation (<c>new { Name = value, ... }</c>) — the
+/// inverse of the compiler's anonymous-type lowering, where <c>new { a, b }</c>
+/// becomes a <c>newobj</c> on a generated <c>&lt;&gt;f__AnonymousType*</c> type.
+/// The member names (in argument order) come from the anonymous type's property
+/// metadata; the value expressions are the constructor arguments. The result
+/// type is the anonymous type itself (an unspeakable name), so this node is the
+/// only valid C# spelling of the construction.
+/// </summary>
+public sealed class AnonymousObjectExpression : IrExpression
+{
+    public AnonymousObjectExpression(ImmutableArray<string> memberNames, IEnumerable<IrExpression> values, TypeRef? resultType)
+    {
+        MemberNames = memberNames;
+        foreach (var value in values)
+            AddChild(value);
+        ResultType = resultType;
+    }
+
+    public ImmutableArray<string> MemberNames { get; }
+    public IReadOnlyList<IrExpression> Values => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType { get; }
+
+    public override string Describe() => "AnonymousObjectExpression";
 }
 
 public sealed class Box : IrExpression

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's anonymous-type lowering back into a C# anonymous object
+/// creation: a <c>newobj</c> on a generated <c>&lt;&gt;f__AnonymousType*</c> type
+/// becomes <c>new { Name = value, ... }</c>. The member names (in argument order)
+/// are recovered at import from the anonymous type's property metadata and
+/// carried on <see cref="MethodRef.AnonymousMemberNames"/>.
+///
+/// <para>The anonymous type name is compiler-generated and unspeakable, so the
+/// match is unambiguous (no hand-written false positives), and the round-trip is
+/// opcode-exact: csc re-lowers <c>new { a = a, b = b }</c> to the same anonymous
+/// type construction. Without this raise the printer emits the raw
+/// <c>&lt;&gt;f__AnonymousType*</c> name, which does not compile — so this fixes
+/// a validity defect, not merely syntax altitude.</para>
+/// </summary>
+public sealed class AnonymousObjectPass : IIrPass
+{
+    public string Name => "anonymous-object";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
+        {
+            var memberNames = newObject.Constructor.AnonymousMemberNames;
+            if (memberNames.IsEmpty)
+                continue;
+            // The ctor arity and the property count always agree for an anonymous
+            // type; guard anyway so a malformed shape is left untouched.
+            if (memberNames.Length != newObject.Arguments.Count)
+                continue;
+
+            var values = newObject.Arguments.ToList();
+            foreach (var value in values)
+                value.Detach();
+            var anonymous = new AnonymousObjectExpression(memberNames, values, newObject.ResultType);
+            context.Stepper.StepOver("raise anonymous-type newobj to new { ... }", newObject);
+            newObject.ReplaceWith(anonymous);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -59,6 +59,11 @@ public static class IrPasses
         // back into new T { X = a, ... }. Runs after property-sugar so the member
         // setters are already StoreProperty nodes, uniform with field stores.
         new ObjectInitializerPass(),
+        // Raise anonymous-type construction (newobj on a generated
+        // <>f__AnonymousType*) back into new { Name = value, ... }. The type is
+        // compiler-only, so the match is unambiguous and the round-trip is
+        // opcode-exact; without it the raw unspeakable type name is emitted.
+        new AnonymousObjectPass(),
         // Raise array range-slice lowering (RuntimeHelpers.GetSubArray(a, range))
         // back into a[range]. GetSubArray is a compiler-only helper, so the match
         // is unambiguous and the round-trip is opcode-exact.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -75,6 +75,8 @@ internal static class LoweringCoverage
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Partial, "array/string constant-from-end indexing only; Range/slicing not raised")]
     public static IndexFromEndPass Index => new();
+    [Completeness(CompletenessLevel.Partial, "anonymous object creation new { Name = value, ... } from <>f__AnonymousType newobj; query-comprehension transparent identifiers not specially handled")]
+    public static AnonymousObjectPass AnonymousObjectCreation => new();
 
     // ───────── Raised by the structuring subsystem — completeness is --gaps, not binary ─────────
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass   IfStatement       => new();
@@ -89,7 +91,6 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.None, "foreach (var x in xs)")]      public static Unhandled ForEachStatement                    => default!;
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")]           public static Unhandled TupleBinaryOperator                 => default!;
     [Completeness(CompletenessLevel.None, "(a, b) = t")]                 public static Unhandled DeconstructionAssignmentOperator    => default!;
-    [Completeness(CompletenessLevel.None, "new { a, b }")]               public static Unhandled AnonymousObjectCreation             => default!;
     [Completeness(CompletenessLevel.None, "from x in xs select ...")]    public static Unhandled Query                               => default!;
     [Completeness(CompletenessLevel.None, "await t — async state machine")]      public static Unhandled Await => default!;
     [Completeness(CompletenessLevel.None, "yield return — iterator state machine")] public static Unhandled Yield => default!;


### PR DESCRIPTION
## Summary

The compiler lowers `new { a, b }` to a `newobj` on a generated `<>f__AnonymousType*` type. The decompiler left it unraised, so the product emitted `new <>f__AnonymousType0<int, int>(a, b)` — an **unspeakable type name that does not compile**. This is a genuine validity defect, not just low syntax altitude.

New `AnonymousObjectPass` raises the construction back into the C# anonymous object literal. Like `GetSubArray`, anonymous types are compiler-only, so the match is **unambiguous** (no hand-written false positives) and csc re-lowers the raised literal to the same construction — the round-trip is **opcode-exact**.

## Examples

| Source | Before (uncompilable) | After |
| --- | --- | --- |
| `new { a, b }` | `new <>f__AnonymousType0<int, int>(a, b)` | `new { a = a, b = b }` |
| `new { Id = x, Name = s }` | `new <>f__AnonymousType1<int, string>(x, s)` | `new { Id = x, Name = s }` |
| `new { p = new { a }, q = b }` | nested `<>f__AnonymousType*` | `new { p = new { a = a }, q = b }` |

## Member-name recovery

The member names are **not** on the ctor token — for a generic anonymous type the `newobj` is a `MemberRef` on a `TypeSpec`, which carries no parameter names. They are recovered at **import** (where metadata is live) from the anonymous type's property metadata, which is emitted in declaration/argument order, and carried on a new `MethodRef.AnonymousMemberNames` field. The pass (which has no metadata access) consumes that field.

## Changes

- New `AnonymousObjectExpression` IR node (printer arm + atomic registration).
- `MethodRef.AnonymousMemberNames`, populated only for anonymous-type ctors in the `Newobj` import case via a name-scan helper.
- `AnonymousObjectPass`, registered after `ObjectInitializerPass`.
- Ledger: `AnonymousObjectCreation` None -> Partial; owed register 7 -> 6.
- Three `CfgSampleClass` fixtures (projection, explicit names, nested), pass tests, scorecard entry (`AnonymousObjectCreationExpression`, reject `ObjectCreationExpression`).

## Verification

- 402 decompiler tests green (incl. fidelity/lowered gates + scorecard); 205 metadata tests green.
- Probe fixture (incl. nested): 100% opcode-exact on `--fidelity-check`.
- Main product builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
