### PR TITLE
Add third-round adversarial fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -20,6 +20,10 @@ public class CfgSampleClass
 
     public static char LastChar(string s) => s[^1];
 
+    // Negative fixture: hand-written string indexing re-loads the receiver
+    // directly, unlike the compiler's `^1` lowering which spills the receiver.
+    public static char LastCharHandWritten(string s) => s[s.Length - 1];
+
     public static int Twice(int x) { var t = x + x; return t; }
 
     public static int Reused(int x) { var n = x + 1; return n * n; }
@@ -828,6 +832,16 @@ public class CfgSampleClass
 
     public static int TernaryInt(int a, int b) => a > b ? a : b;
 
+    public static int GuardReturnAfterLocalPrelude(int value, int whenPositive, int otherwise)
+    {
+        int positive = whenPositive;
+        int negative = otherwise;
+        LastValue = positive + negative;
+        if (value > 0)
+            return positive;
+        return negative;
+    }
+
     public static int EqualityGuardReturn(int value, int whenZero, int otherwise)
     {
         if (value == 0)
@@ -1035,6 +1049,17 @@ public class CfgSampleClass
     {
         string? value = input;
         value ??= fallback;
+        return value;
+    }
+
+    public static string NullCoalescingAssignLocalWithExtraThenStatement(string? input, string fallback)
+    {
+        string? value = input;
+        if (value == null)
+        {
+            value = fallback;
+            LastValue = value.Length;
+        }
         return value;
     }
 

--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -43,6 +43,16 @@ public class IndexFromEndPassTests
     }
 
     [Fact]
+    public void HandWrittenStringLengthMinusConstant_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.LastCharHandWritten));
+
+        Assert.Empty(function.Descendants.OfType<IndexFromEnd>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return s[s.Length - 1];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
     public void HandWrittenLengthMinusConstant_IsNotRaised()
     {
         // `a[a.Length - 1]` re-loads the array directly (no receiver spill), so

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1926,6 +1926,18 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void BooleanFolding_GuardReturn_AfterLocalPrelude_StaysStatementForm()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.GuardReturnAfterLocalPrelude), source);
+
+        Assert.DoesNotContain("?", output);
+        Assert.Contains("LastValue = positive + negative;", output);
+        Assert.Contains("if (value > 0)", output);
+    }
+
+    [Fact]
     public void BooleanFolding_EqualityGuardReturn_StaysStatementForm()
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -36,6 +36,19 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void LocalNullAssignmentWithExtraThenStatement_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignLocalWithExtraThenStatement));
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingAssignment>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("??=", output);
+        Assert.Contains("if (value is null)", output);
+        Assert.Contains("LastValue = value.Length;", output);
+    }
+
+    [Fact]
     public void NullCoalescingOperator_RemainsExpression()
     {
         var function = Raised(nameof(CfgSampleClass.NullCoalesce));


### PR DESCRIPTION
## Summary
- ran a third adversarial fixture pass after the ternary and index-from-end follow-ups
- found no new implementation bug
- added negative fixtures for hand-written string index-from-end, guard-return with a local prelude, and a `??=` lookalike with an extra then statement

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method ILInspector.Decompiler.Tests.RaisingPassTests.BooleanFolding_GuardReturn_AfterLocalPrelude_StaysStatementForm -method ILInspector.Decompiler.Tests.IndexFromEndPassTests.HandWrittenStringLengthMinusConstant_IsNotRaised -method ILInspector.Decompiler.Tests.NullCoalescingAssignmentPassTests.LocalNullAssignmentWithExtraThenStatement_IsNotRaised
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build