### PR TITLE
Reject mutable using lookalikes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -46,6 +46,19 @@ public class UsingStatementPassTests
     }
 
     [Fact]
+    public void ResourceReassignedInsideTry_IsLeftAsTryFinally()
+    {
+        var function = BuildUsingLookalikeWithResourceReassignment();
+
+        new UsingStatementPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Equal(2, function.Descendants.OfType<StoreLocal>().Count(store => store.Index == 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void ValueTypeUsingWithUnguardedDispose_RaisesToUsingStatement()
     {
         // List<T>.Enumerator is a struct IDisposable: csc emits no null guard,
@@ -68,5 +81,33 @@ public class UsingStatementPassTests
         Assert.Contains("using (Enumerator e = items.GetEnumerator())", output);
         Assert.DoesNotContain("finally", output);
         Assert.DoesNotContain("Dispose", output);
+    }
+
+    static IrFunction BuildUsingLookalikeWithResourceReassignment()
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var disposableType = TypeRef.CoreLib("System", "IDisposable");
+        var dispose = new MethodRef(disposableType, "Dispose", voidType, [], HasThis: true);
+
+        var tryBlock = new Block(0);
+        tryBlock.Add(new StoreLocal(0, disposableType, new Constant(null, disposableType)));
+        var tryBody = new BlockContainer();
+        tryBody.Add(tryBlock);
+
+        var thenBlock = new Block(0);
+        thenBlock.Add(new ExpressionStatement(new Call(dispose, isVirtual: true, [new LoadLocal(0, disposableType)])));
+        var finallyBlock = new Block(0);
+        finallyBlock.Add(new IfStatement(new LoadLocal(0, disposableType), thenBlock, null));
+        var finallyBody = new BlockContainer();
+        finallyBody.Add(finallyBlock);
+
+        var entry = new Block(0);
+        entry.Add(new StoreLocal(0, disposableType, new Constant(null, disposableType)));
+        entry.Add(new TryFinally(tryBody, finallyBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [disposableType], body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -44,6 +44,7 @@ public sealed class UsingStatementPass : IIrPass
                     continue;
 
                 if (ReferencesLocal(match.StoreResource.Value, match.StoreResource.Index)
+                    || StoresLocal(match.TryFinally, match.StoreResource.Index)
                     || !ReferencedOnlyWithin(function, match.StoreResource.Index, [match.StoreResource, match.TryFinally]))
                 {
                     continue;
@@ -135,6 +136,9 @@ public sealed class UsingStatementPass : IIrPass
             LoadLocalAddress address => address.Index == index,
             _ => false,
         });
+
+    static bool StoresLocal(IrNode root, int index)
+        => root.Descendants.Prepend(root).Any(node => node is StoreLocal store && store.Index == index);
 
     static bool IsInside(IrNode node, IrNode root)
     {


### PR DESCRIPTION
## Summary
- ran a fourth adversarial fixture pass focused on scorecard-adjacent raises
- found a UsingStatementPass false positive where a resource local reassigned inside the try was still raised to `using`
- reject using raises when the resource local is stored inside the matched try/finally and add a synthetic negative fixture

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.UsingStatementPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build