### PR TITLE
Require worktrees for raise work

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -96,16 +96,24 @@ The intended pass-improvement loop is:
    **new raise** (an owed ledger entry with no mechanism),
    **improve a raise** (a pass with known unrecovered fixtures or partial
    coverage), or **adversarial discovery** (try to falsify an existing raise).
-2. Add or identify fixture methods that represent the source idiom.
-3. For new/improved raises, add scorecard entries as unrecovered when the
+2. Create a dedicated feature worktree for the raise task. Raise work touches
+   common hotspots, so do not work directly in the main checkout or share one
+   worktree across unrelated raise/adversarial/doc tasks.
+3. Add or identify fixture methods that represent the source idiom.
+4. For new/improved raises, add scorecard entries as unrecovered when the
    current output is lower altitude.
-4. Add adversarial fixtures for nearby shapes that must not raise.
-5. Run the scorecard to capture the baseline.
-6. Implement or improve the raise pass. For a pure adversarial-discovery task,
+5. Add adversarial fixtures for nearby shapes that must not raise.
+6. Run the scorecard to capture the baseline.
+7. Implement or improve the raise pass. For a pure adversarial-discovery task,
    do not broaden the pass; narrow it only if the negative fixture exposes an
    over-match.
-7. Run the scorecard again and flip newly recovered entries in the same PR.
-8. Run fidelity/validity checks to prove the higher-altitude shape stayed
+8. Run the scorecard again and flip newly recovered entries in the same PR.
+9. Before pushing or opening the PR, synchronize with current upstream
+   `origin/main` (or recreate the work from it), resolve conflicts locally, and
+   re-check files that frequently collide in raise work: `LoweringCoverage`,
+   `LoweringCoverageTests`, `IrPasses`, `CfgSampleClass`, and the scorecard.
+10. Run fidelity/validity checks after that upstream sync to prove the final
+   branch state, not just the pre-merge local state, stayed
    semantic, valid C#.
 
 After a raise looks good, use an adversarial fixture pass before merge. Give an


### PR DESCRIPTION
## Summary

- Require dedicated feature worktrees for raise-related tasks.
- Preserve the upstream-main compatibility step in the raise workflow.
- Call out the central files that need rechecking after sync.

## Testing

- npx markdownlint-cli --fix docs/decompiler-quality.md
- npx markdownlint-cli docs/decompiler-quality.md
