### PR TITLE
Add explicit Index range boundary fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -115,6 +115,13 @@ public class CfgSampleClass
     // coverage. From-end (^n) endpoints are deferred and stay unraised.
     public static int[] ArrayRangeBoth(int[] a, int i, int j) => a[i..j];
 
+    // Negative fixture: spelling the endpoint as `new Index(i, false)` is
+    // source-equivalent to `i`, but it is not the compiler's ordinary
+    // `a[i..j]` lowering (which calls Index.op_Implicit). Raising it would lose
+    // the explicit constructor call and break opcode-exact round-trip.
+    public static int[] ArrayRangeExplicitFromStartIndex(int[] a, int i, int j)
+        => a[new System.Index(i, fromEnd: false)..j];
+
     public static int[] ArrayRangeFrom(int[] a, int i) => a[i..];
 
     public static int[] ArrayRangeTo(int[] a, int j) => a[..j];

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -33,6 +33,22 @@ public class RangeFromGetSubArrayPassTests
         => Assert.Contains("return a[i..j];", Print(nameof(CfgSampleClass.ArrayRangeBoth)));
 
     [Fact]
+    public void GetSubArray_ExplicitFromStartIndexCtor_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeExplicitFromStartIndex));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "GetSubArray");
+        Assert.Contains(function.Descendants.OfType<NewObject>(),
+            n => n.Constructor.DeclaringType is { Namespace: "System", Name: "Index" });
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("new Index(i, false)", output);
+        Assert.DoesNotContain("return a[i..j];", output);
+    }
+
+    [Fact]
     public void GetSubArray_FromOnly_RendersOpenEnd()
     {
         var function = Raised(nameof(CfgSampleClass.ArrayRangeFrom));


### PR DESCRIPTION
## Summary
- pulled latest main and inspected open PRs #743, #742, #740, and #738 for adversarial-target insight
- used #738 range-from-end work as the prompt for another RangeFromGetSubArrayPass boundary pass
- found no implementation bug, but added a negative fixture proving an explicit `new Index(i, false)` endpoint stays visible and is not normalized to `a[i..j]`

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.RangeFromGetSubArrayPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build