### PR TITLE
Raise variable index-from-end (a[^n]), not just constant ^1

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -99,6 +99,20 @@ public class CfgSampleClass
 
     public static int LastElement(int[] a) => a[^1];
 
+    // Variable / computed from-end index: `a[^n]` lowers to `a[a.Length - n]`
+    // with the same receiver spill as the constant `^1` form, so IndexFromEndPass
+    // raises it back to `^n` for any integer offset expression.
+    public static int NthFromEnd(int[] a, int n) => a[^n];
+
+    public static int NthFromEndComputed(int[] a, int n) => a[^(n + 1)];
+
+    public static char NthCharFromEnd(string s, int n) => s[^n];
+
+    // Negative fixture: hand-written `a[a.Length - n]` re-loads the array
+    // directly (no receiver spill), so it must NOT be raised even though the
+    // offset is a variable.
+    public static int NthFromEndHandWritten(int[] a, int n) => a[a.Length - n];
+
     // Negative fixture: hand-written `a[a.Length - 1]` re-loads the array
     // directly (two ldarg, no receiver spill), unlike the `^1` lowering which
     // spills into one stack slot. IndexFromEndPass must NOT raise this — doing

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -80,6 +80,9 @@ public class FidelityGateTests
         "AnonShorthand",
         "AnonNamed",
         "AnonSingle",
+        "NthFromEnd",
+        "NthFromEndComputed",
+        "NthCharFromEnd",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -35,6 +35,7 @@ public class IdiomShapeScorecardTests
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
+        new("IndexFromEndPass", nameof(CfgSampleClass.NthFromEnd), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         // Owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
         new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),

--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -43,6 +43,50 @@ public class IndexFromEndPassTests
     }
 
     [Fact]
+    public void ArrayLengthMinusVariable_RaisesToIndexFromEnd()
+    {
+        var function = Raised(nameof(CfgSampleClass.NthFromEnd));
+
+        var index = Assert.Single(function.Descendants.OfType<IndexFromEnd>());
+        Assert.IsType<LoadArgument>(index.Offset);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return a[^n];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
+    public void ArrayLengthMinusComputed_RaisesToIndexFromEnd()
+    {
+        var function = Raised(nameof(CfgSampleClass.NthFromEndComputed));
+
+        var index = Assert.Single(function.Descendants.OfType<IndexFromEnd>());
+        Assert.IsType<Binary>(index.Offset);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return a[^(n + 1)];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
+    public void StringLengthMinusVariable_RaisesToIndexFromEnd()
+    {
+        var function = Raised(nameof(CfgSampleClass.NthCharFromEnd));
+
+        Assert.Single(function.Descendants.OfType<IndexFromEnd>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return s[^n];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
+    public void HandWrittenLengthMinusVariable_IsNotRaised()
+    {
+        // `a[a.Length - n]` re-loads the array directly (no receiver spill), so
+        // even with a variable offset it is not the compiler's `^n` lowering.
+        var function = Raised(nameof(CfgSampleClass.NthFromEndHandWritten));
+
+        Assert.Empty(function.Descendants.OfType<IndexFromEnd>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Equal("return a[a.Length - n];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
     public void HandWrittenStringLengthMinusConstant_IsNotRaised()
     {
         var function = Raised(nameof(CfgSampleClass.LastCharHandWritten));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
@@ -2,7 +2,9 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// Raises the compiler's index-from-end lowering for arrays and strings:
-/// <c>receiver[receiver.Length - n]</c> becomes <c>receiver[^n]</c>. The pass
+/// <c>receiver[receiver.Length - n]</c> becomes <c>receiver[^n]</c>, where the
+/// offset <c>n</c> is any integer expression (a constant such as <c>^1</c> or a
+/// variable/computed value such as <c>^n</c> or <c>^(n + 1)</c>). The pass
 /// rewrites only the index operand; the second expression-inlining pass then
 /// collapses the compiler's duplicated receiver stack slot back into the
 /// element receiver when it is single-use.
@@ -35,8 +37,13 @@ public sealed class IndexFromEndPass : IIrPass
 
     static bool TryRewrite(IrExpression receiver, IrExpression index, Stepper stepper)
     {
-        if (index is not Binary { Kind: BinaryKind.Subtract, Right: Constant { Value: int offset } } subtract
-            || offset < 0
+        // The offset is any integer expression: a constant (`^1`) or a
+        // variable/computed value (`^n`, `^(n + 1)`). A negative constant is the
+        // one shape that cannot come from `^` (it would be `receiver.Length + k`),
+        // so it is excluded; every other offset is admitted because the
+        // receiver-spill discriminator below already proves the `^` lowering.
+        if (index is not Binary { Kind: BinaryKind.Subtract } subtract
+            || (subtract.Right is Constant { Value: int offset } && offset < 0)
             || LengthReceiver(subtract.Left) is not { } lengthReceiver
             || !SamePlace(receiver, lengthReceiver))
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -73,7 +73,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative GotoStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative HostObjectMemberReference => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass IfStatement => new();
-    [Completeness(CompletenessLevel.Partial, "array/string constant-from-end indexing only; Range/slicing not raised")]
+    [Completeness(CompletenessLevel.Partial, "array/string from-end indexing (constant and variable, a[^n]); Range/slicing not raised")]
     public static IndexFromEndPass Index => new();
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator => default!;


### PR DESCRIPTION
## Summary

`IndexFromEndPass` raised the compiler's index-from-end lowering
(`receiver[receiver.Length - n]` becomes `receiver[^n]`) **only when the offset
was a non-negative integer constant** (`^1`). The lowering is identical for a
variable or computed offset — the receiver is still spilled into one stack slot
and read twice — so `a[^n]` and `a[^(n + 1)]` leaked as the lowered
`a[S.Length - n]` form.

This relaxes the offset match to **any** expression: the `Right: Constant`
pattern is dropped and only the negative-constant exclusion is kept (a negative
constant is the one shape that cannot come from `^`, since it would be
`receiver.Length + k`).

## Soundness

The receiver-spill discriminator (`SamePlace` on the compiler's stack slot) is
**unchanged**. It already separates the `^` lowering — which spills the receiver
to a stack slot and reads it twice — from hand-written `a[a.Length - n]`, which
re-loads the receiver directly (two argument loads, no spill). Verified
empirically:

| input | receiver shape | raised |
|---|---|---|
| `a[^n]` | stack-slot x2 | `a[^n]` |
| `a[a.Length - n]` | argument x2 | unchanged |
| `s[^n]` | stack-slot x2 | `s[^n]` |

Variable offsets are admitted with the same soundness basis as constants; csc
re-lowers `a[^n]` to the same `a.Length - n` index, so the round-trip stays
opcode-exact.

## Tests

- Fixtures: `NthFromEnd` (`a[^n]`), `NthFromEndComputed` (`a[^(n + 1)]`),
  `NthCharFromEnd` (`s[^n]`), negative `NthFromEndHandWritten` (`a[a.Length - n]`,
  stays unraised).
- 4 new `IndexFromEndPassTests` + a scorecard case asserting `IndexExpression`
  altitude (rejecting `SubtractExpression`).
- Pinned the three raised fixtures **opcode-exact** in `FidelityGateTests`.
- Ledger `Index` entry updated to note constant+variable from-end coverage
  (stays `Partial` — Range/slicing still owed; owed count unchanged).
- **415 decompiler tests green**; `--pass-impact index-from-end`: 16 methods,
  0 pass bugs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
