### PR TITLE
[codex] Add range from-end adversarial fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -117,6 +117,8 @@ public class CfgSampleClass
 
     public static int[] ArrayRangeFrom(int[] a, int i) => a[i..];
 
+    public static int[] ArrayRangeFromEnd(int[] a, int i) => a[^i..];
+
     public static int[] ArrayRangeTo(int[] a, int j) => a[..j];
 
     public static int[] ArrayRangeAll(int[] a) => a[..];

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -77,13 +77,14 @@ public class RangeFromGetSubArrayPassTests
     }
 
     [Fact]
-    public void GetSubArray_FromEndEndpoint_IsNotRaised()
+    public void GetSubArray_FromEndToOpenEnd_RendersHatOpenEnd()
     {
         var function = Raised(nameof(CfgSampleClass.ArrayRangeFromEnd));
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
 
-        Assert.Empty(function.Descendants.OfType<SliceExpression>());
-        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "GetSubArray");
-        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.DeclaringType is { Namespace: "System", Name: "Index" });
+        Assert.IsType<IndexFromEnd>(slice.Range.Start);
+        Assert.False(slice.Range.HasEnd);
+        Assert.Contains("return a[^i..];", CSharpPrinter.Print(function).Output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -43,6 +43,16 @@ public class RangeFromGetSubArrayPassTests
     }
 
     [Fact]
+    public void GetSubArray_FromEndEndpoint_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.ArrayRangeFromEnd));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "GetSubArray");
+        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.DeclaringType is { Namespace: "System", Name: "Index" });
+    }
+
+    [Fact]
     public void GetSubArray_ToOnly_RendersOpenStart()
     {
         var function = Raised(nameof(CfgSampleClass.ArrayRangeTo));


### PR DESCRIPTION
## Summary

Adds an adversarial fixture for `RangeFromGetSubArrayPass` covering a near-miss range slice shape: `a[^i..]`.

The pass currently raises from-start `RuntimeHelpers.GetSubArray` range endpoints, while the lowering ledger explicitly leaves from-end endpoints deferred. This test pins that boundary by proving the from-end `System.Index` endpoint stays lowered instead of being raised to a `SliceExpression`.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`