### PR TITLE
Require BCL GetSubArray for range raising

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -4,6 +4,12 @@ namespace ILInspector.Decompiler.Tests;
 
 public class RangeFromGetSubArrayPassTests
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
+    static readonly TypeRef s_index = TypeRef.CoreLib("System", "Index");
+    static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+
     static IrFunction Raised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -46,6 +52,18 @@ public class RangeFromGetSubArrayPassTests
         Assert.NotNull(output);
         Assert.Contains("new Index(i, false)", output);
         Assert.DoesNotContain("return a[i..j];", output);
+    }
+
+    [Fact]
+    public void GetSubArray_FromUserRuntimeHelpersLookalike_IsNotRaised()
+    {
+        var function = BuildGetSubArrayLookalike();
+
+        new RangeFromGetSubArrayPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "GetSubArray");
+        function.CheckInvariant();
     }
 
     [Fact]
@@ -105,5 +123,33 @@ public class RangeFromGetSubArrayPassTests
         Assert.False(slice.Range.HasStart);
         Assert.IsType<IndexFromEnd>(slice.Range.End);
         Assert.Contains("return a[..^1];", CSharpPrinter.Print(function).Output);
+    }
+
+    static IrFunction BuildGetSubArrayLookalike()
+    {
+        var indexImplicit = new MethodRef(s_index, "op_Implicit", s_index, [s_int], HasThis: false);
+        var rangeCtor = new MethodRef(s_range, ".ctor", s_void, [s_index, s_index], HasThis: false);
+        var getSubArray = new MethodRef(
+            TypeRef.Definition("UserAssembly", "System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "GetSubArray",
+            s_intArray,
+            [s_intArray, s_range],
+            HasThis: false);
+
+        var range = new NewObject(rangeCtor,
+        [
+            new Call(indexImplicit, isVirtual: false, [new LoadArgument(1, "i", s_int)]),
+            new Call(indexImplicit, isVirtual: false, [new LoadArgument(2, "j", s_int)]),
+        ]);
+        var block = new Block();
+        block.Add(new Return(new Call(getSubArray, isVirtual: false, [new LoadArgument(0, "a", s_intArray), range])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            s_intArray,
+            [new Parameter("a", s_intArray), new Parameter("i", s_int), new Parameter("j", s_int)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -16,11 +16,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// via an <see cref="IndexFromEnd"/> node — so the whole space of array range
 /// slices (<c>a[i..^1]</c>, <c>a[^3..^1]</c>, <c>a[..^1]</c>, …) is recovered.</para>
 ///
-/// <para><c>GetSubArray</c> is a compiler-only helper with no hand-written
-/// spelling, so recognizing it is unambiguous and the round-trip is opcode-exact:
-/// the recovered <c>a[range]</c> re-lowers to the same call. The string/span
-/// <c>Substring</c> / <c>Slice</c> forms are a separate lowering and left
-/// untouched here.</para>
+/// <para>The BCL <c>GetSubArray</c> is a compiler helper with no ordinary
+/// user-facing spelling in range syntax, so recognizing that exact helper is
+/// unambiguous and the round-trip is opcode-exact: the recovered
+/// <c>a[range]</c> re-lowers to the same call. The string/span <c>Substring</c>
+/// / <c>Slice</c> forms are a separate lowering and left untouched here.</para>
 /// </summary>
 public sealed class RangeFromGetSubArrayPass : IIrPass
 {
@@ -33,7 +33,7 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (call.Callee is not { Name: "GetSubArray", DeclaringType.Namespace: "System.Runtime.CompilerServices", DeclaringType.Name: "RuntimeHelpers" })
+            if (!IsRuntimeHelpersGetSubArray(call))
                 continue;
             if (call.Arguments is not [var receiver, var rangeArg])
                 continue;
@@ -53,6 +53,30 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
             context.Stepper.StepOver("raise GetSubArray range slice to a[..] indexer", call);
             call.ReplaceWith(slice);
         }
+    }
+
+    static bool IsRuntimeHelpersGetSubArray(Call call)
+    {
+        if (call.IsVirtual
+            || call.Callee is not
+            {
+                Name: "GetSubArray",
+                HasThis: false,
+                DeclaringType:
+                {
+                    Namespace: "System.Runtime.CompilerServices",
+                    Name: "RuntimeHelpers",
+                    Assembly: TypeRef.CoreLibrary or "System.Runtime",
+                },
+                ParameterTypes: [var arrayParameter, var rangeParameter],
+            })
+        {
+            return false;
+        }
+
+        return call.Callee.ReturnType is { Kind: TypeRefKind.SzArray } arrayReturn
+            && arrayParameter.Equals(arrayReturn)
+            && rangeParameter.Equals(TypeRef.CoreLib("System", "Range"));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- pulled latest main and inspected open PRs before another adversarial pass
- used range-related PRs #738/#746 as the target signal
- found RangeFromGetSubArrayPass matched a user-defined `System.Runtime.CompilerServices.RuntimeHelpers.GetSubArray` lookalike by namespace/name
- require the exact BCL helper shape and add a synthetic negative fixture

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.RangeFromGetSubArrayPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal