### PR TITLE
Preserve multi-await order (fix runtime-async await reordering)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
@@ -62,4 +62,34 @@ public class AwaitRecoveryPassTests
 
         Assert.Empty(function.Descendants.OfType<AwaitExpression>());
     }
+
+    [Fact]
+    public void TwoAwaits_PreserveSourceOrder()
+    {
+        // Runtime-async keeps the first await's value on the evaluation stack
+        // across the second await, so `x = await a; y = await b;` imports with
+        // `await a` stranded below the `y = await b` store. The importer must
+        // spill the earlier await to pin its position; otherwise it reorders to
+        // `int y = await b; return (await a) + y;` — awaiting b before a.
+        var output = Print(nameof(CfgSampleClass.AwaitTwo));
+
+        int awaitA = output.IndexOf("await a", StringComparison.Ordinal);
+        int awaitB = output.IndexOf("await b", StringComparison.Ordinal);
+        Assert.True(awaitA >= 0, $"missing `await a` in:\n{output}");
+        Assert.True(awaitB >= 0, $"missing `await b` in:\n{output}");
+        Assert.True(awaitA < awaitB, $"`await a` must precede `await b`:\n{output}");
+    }
+
+    [Fact]
+    public void TwoAwaits_DoNotInlineFirstPastSecond()
+    {
+        // The first await must remain a standalone statement (spilled to a temp),
+        // never folded into the return where it would sit after the second await.
+        var function = Raised(nameof(CfgSampleClass.AwaitTwo));
+
+        var awaits = function.Descendants.OfType<AwaitExpression>().ToList();
+        Assert.Equal(2, awaits.Count);
+        // Neither await is nested inside the other (no reordering collapse).
+        Assert.DoesNotContain(awaits, outer => outer.Descendants.OfType<AwaitExpression>().Any());
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -566,13 +566,13 @@ public static class IrImporter
                     break;
 
                 case ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3:
-                    body.Add(MakeStoreLocal(method, opcode - ILOpCode.Stloc_0, Pop(stack)));
+                    body.Add(MakeStoreLocalSpilling(method, opcode - ILOpCode.Stloc_0, Pop(stack), body, stack, state));
                     break;
                 case ILOpCode.Stloc_s:
-                    body.Add(MakeStoreLocal(method, reader.ReadILByte(), Pop(stack)));
+                    body.Add(MakeStoreLocalSpilling(method, reader.ReadILByte(), Pop(stack), body, stack, state));
                     break;
                 case ILOpCode.Stloc:
-                    body.Add(MakeStoreLocal(method, reader.ReadILUInt16(), Pop(stack)));
+                    body.Add(MakeStoreLocalSpilling(method, reader.ReadILUInt16(), Pop(stack), body, stack, state));
                     break;
 
                 case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8:
@@ -693,7 +693,15 @@ public static class IrImporter
                     var call = new Call(callee, opcode == ILOpCode.Callvirt, arguments) { ConstrainedTo = constrainedTo };
                     constrainedTo = null;
                     if (callee.ReturnType is { Name: "Void", Namespace: "System" })
+                    {
+                        // Emitting the call as a statement creates a sequence
+                        // point; any IL-earlier side-effecting value still pending
+                        // lazily below must materialize first or it reorders past
+                        // this call (runtime-async keeps such values on the eval
+                        // stack across awaits — see MakeStoreLocalSpilling).
+                        SpillUnstableBeforeSideEffect(body, stack, state);
                         body.Add(new ExpressionStatement(call));
+                    }
                     else
                         stack.Push(call);
                     break;
@@ -1421,6 +1429,26 @@ public static class IrImporter
 
     static StoreLocal MakeStoreLocal(ImportedMethod method, int index, IrExpression value)
         => new(index, method.Body.Locals[index], value);
+
+    /// <summary>
+    /// Builds a <see cref="StoreLocal"/>, first pinning any IL-earlier
+    /// side-effecting value still pending lazily on the symbolic stack when the
+    /// value being stored is itself side-effecting. Storing a side-effecting
+    /// value (a call) is a sequence point; a lower lazy entry that was evaluated
+    /// earlier in IL order would otherwise materialize <em>after</em> this store
+    /// and reorder. Runtime-async (async v2) makes this reachable: it legally
+    /// keeps a value-producing <c>await</c> on the evaluation stack across a
+    /// later <c>await</c>, so <c>x = await a; y = await b;</c> imports as a bare
+    /// <c>await a</c> stranded below the <c>y = await b</c> store. Stable stored
+    /// values (locals, args, constants) carry no side effect and need no spill,
+    /// keeping output minimal.
+    /// </summary>
+    static StoreLocal MakeStoreLocalSpilling(ImportedMethod method, int index, IrExpression value, Block body, Stack<IrExpression> stack, BuildState state)
+    {
+        if (!IsStableAcrossSideEffect(value))
+            SpillUnstableBeforeSideEffect(body, stack, state);
+        return MakeStoreLocal(method, index, value);
+    }
 
     internal static MethodRef ResolveMethod(MetadataReader reader, EntityHandle handle, GenericScope callerScope)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -47,7 +47,7 @@ internal static class LoweringCoverage
     public static AnonymousObjectPass AnonymousObjectCreation => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AssignmentOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) AsyncHelpers.Await call sites recovered to `await`; classic state-machine async and multi-await ordering not raised")]
+    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) AsyncHelpers.Await call sites recovered to `await`, multi-await order preserved; classic state-machine async not raised")]
     public static AwaitRecoveryPass Await => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BasePatternSwitchLocalRewriter => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BinaryOperator => default!;


### PR DESCRIPTION
## What

Fixes a reordering miscompile in runtime-async (async v2) `await` recovery: two awaits combined in an expression were emitted out of source order.

Given:

```csharp
int x = await a;
int y = await b;
return x + y;
```

`dotnet-inspect` previously decompiled this to:

```csharp
int y = await b;
return (await a) + y;   // ❌ awaits b before a
```

Now it recovers source order:

```csharp
int S_256 = await a;
int y = await b;
return S_256 + y;       // ✅
```

## Why it happened

Runtime async (this repo: net11 + `runtime-async=on`) has no state machine, and the runtime **legally keeps a value-producing `await` on the IL evaluation stack across a later `await`** — something classic async never did (it had to spill to display-class fields at every await point). So Roslyn emits `await a`, leaves it on the stack, computes `await b`, stores `b` into the user local, then adds.

The importer models stack entries as lazy expression trees. It left `await a` lazy and only materialized it at its use site in the `return` — textually **after** the `y = await b` store statement. Materializing an IL-earlier side effect after a later one is a reordering miscompile (the same class as #605 StaleFieldRead, but for call ordering rather than field reads).

## The fix

The `Stloc` handlers and the void-call statement path now call `SpillUnstableBeforeSideEffect` before emitting their statement — the identical protection the heap-store handlers (`stfld`/`stsfld`/`stobj`/`stelem`) already use. This pins any IL-earlier unstable lazy entry (a pending call such as `await a`) to a temp before the sequence point, so it can't slide past.

`Stloc` spills **only when the stored value is itself side-effecting** (a call), via `IsStableAcrossSideEffect`. Storing a stable value (local/arg/constant) carries no side effect and needs no spill, so existing minimal output is unchanged — the blast radius is limited to exactly the reorder-hazard case.

## Tests

- `AwaitRecoveryPassTests`: +2 regression tests — `await a` precedes `await b` in the rendered text, and neither await is nested inside the other (no reordering collapse).
- Full decompiler suite **423/423**; `dotnet-inspect.Tests` **1157** green (9 ilasm-dependent skips). No golden-output regressions from the spill change.
- Ledger: the `Await` note drops the "multi-await ordering not raised" caveat.

## Follow-ups

Classic state-machine async recovery (down-level TFMs) and iterator `yield` remain separate, larger projects.
