### PR TITLE
Raise enumerator foreach loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
@@ -49,10 +49,10 @@ public class AnnotatedCSharpRendererTests
     }
 
     [Fact]
-    public void RefTypeEnumerator_IsAnnotatedOnItsGetEnumeratorStatement()
+    public void RefTypeEnumerator_IsAnnotatedOnItsForeachStatement()
     {
         var output = Render(nameof(AllocSampleClass.SumEnumerable));
-        var line = output.Split('\n').Single(l => l.Contains("GetEnumerator()"));
+        var line = output.Split('\n').Single(l => l.Contains("foreach"));
         Assert.Contains("// alloc.enumerator", line);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -1,0 +1,50 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ForeachStatementPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void EnumeratorUsingLoop_RaisesToForeach()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachLoop));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.DoesNotContain(function.Descendants.OfType<UsingStatement>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersForeach()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ForeachLoop))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("foreach (int item in items)", output);
+        Assert.Contains("result.Add(item.ToString());", output);
+        Assert.DoesNotContain("GetEnumerator", output);
+        Assert.DoesNotContain("MoveNext", output);
+    }
+
+    [Fact]
+    public void SourceNamedEnumeratorUsingLoop_StaysUsingWhile()
+    {
+        var function = Raised(nameof(CfgSampleClass.StructUsing));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -33,6 +33,7 @@ public class IdiomShapeScorecardTests
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
+        new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -191,6 +191,9 @@ public sealed partial class CSharpPrinter
     /// <summary>Resource local slots a <see cref="UsingStatement"/> owns: declared by the using header, not up front.</summary>
     readonly HashSet<int> _usingLocals = [];
 
+    /// <summary>Iteration variable local slots declared by a <see cref="ForeachStatement"/> header.</summary>
+    readonly HashSet<int> _foreachLocals = [];
+
     /// <summary>Pattern variable slots an <see cref="IsPattern"/> binds: declared by the <c>is T t</c> pattern, not up front.</summary>
     readonly HashSet<int> _isPatternLocals = [];
 
@@ -211,6 +214,8 @@ public sealed partial class CSharpPrinter
             _fixedLocals.Add(fixedNode.LocalIndex);
         foreach (var usingNode in function.Descendants.OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
+        foreach (var foreachNode in function.Descendants.OfType<ForeachStatement>())
+            _foreachLocals.Add(foreachNode.LocalIndex);
         foreach (var pattern in function.Descendants.OfType<IsPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
         foreach (var deconstruction in function.Descendants.OfType<DeconstructionAssignment>())
@@ -319,6 +324,7 @@ public sealed partial class CSharpPrinter
                 case StoreLocal s: locals.Add(s.Index); break;
                 case LoadLocalAddress a: locals.Add(a.Index); break;
                 case NullCoalescingAssignment n: locals.Add(n.LocalIndex); break;
+                case ForeachStatement f: locals.Add(f.LocalIndex); break;
                 case DeconstructionAssignment d: foreach (int index in d.LocalIndices) locals.Add(index); break;
                 // A slot's declared type is the type it is loaded AS — the merged
                 // join type every predecessor's store is assignable to. A store
@@ -339,7 +345,7 @@ public sealed partial class CSharpPrinter
         {
             // Fixed/using headers and `is T t` patterns declare their owned
             // locals, not the up-front declaration block.
-            if (_fixedLocals.Contains(index) || _usingLocals.Contains(index)
+            if (_fixedLocals.Contains(index) || _usingLocals.Contains(index) || _foreachLocals.Contains(index)
                 || _isPatternLocals.Contains(index) || _deconstructionLocals.Contains(index))
                 continue;
             bool declaredAtStore = _declaringStores.Any(s =>
@@ -582,6 +588,17 @@ public sealed partial class CSharpPrinter
                 .Append(CastValue(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
             AppendContainer(sb, usingStatement.Body, indent + 1);
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
+        if (node is ForeachStatement foreachStatement)
+        {
+            sb.Append(pad)
+                .Append("foreach (").Append(TypeText(foreachStatement.LocalType)).Append(' ')
+                .Append(LocalName(foreachStatement.LocalIndex)).Append(" in ")
+                .Append(Expression(foreachStatement.Collection)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            AppendStatements(sb, foreachStatement.Body.Children, indent + 1);
             sb.Append(pad).AppendLine("}");
             return;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -243,6 +243,9 @@ static class DefiniteAssignment
                             foreach (int index in deconstruction.LocalIndices)
                                 running.Add(index);
                             break;
+                        case ForeachStatement foreachStatement:
+                            CheckReads(foreachStatement.Collection, running);
+                            break;
                         case InitObject { Address: LoadLocalAddress address }:
                             running.Add(address.Index);
                             break;
@@ -308,6 +311,12 @@ static class DefiniteAssignment
                     return DoWhile(loop, assigned);
                 case ForLoop loop:
                     return For(loop, assigned);
+                case ForeachStatement foreachStatement:
+                    CheckReads(foreachStatement.Collection, assigned);
+                    var foreachSet = new HashSet<int>(assigned) { foreachStatement.LocalIndex };
+                    if (Statement(foreachStatement.Body, foreachSet) == DefiniteFlow.Bail)
+                        return DefiniteFlow.Bail;
+                    return DefiniteFlow.FallThrough;
                 // A lock runs its body in program order — the monitor
                 // enter/exit around it does not perturb assignment — so model it
                 // as the lock object's read followed by the sequential body.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -531,6 +531,30 @@ public sealed class UsingStatement : IrNode
     public override string Describe() => $"UsingStatement V_{LocalIndex} ({ResourceType.ToDisplayString()})";
 }
 
+/// <summary>
+/// A raised <c>foreach</c> statement. Produced by <see cref="ForeachStatementPass"/>
+/// from csc's enumerator lowering: hidden enumerator resource, MoveNext loop,
+/// and Current assignment to the iteration variable.
+/// </summary>
+public sealed class ForeachStatement : IrNode
+{
+    public ForeachStatement(int localIndex, TypeRef localType, IrExpression collection, Block body)
+    {
+        LocalIndex = localIndex;
+        LocalType = localType;
+        AddChild(collection);
+        AddChild(body);
+    }
+
+    public int LocalIndex { get; }
+    public TypeRef LocalType { get; }
+    public IrExpression Collection => (IrExpression)Children[0];
+    public Block Body => (Block)Children[1];
+    public override IEnumerable<TypeRef> DirectTypes => [LocalType];
+
+    public override string Describe() => $"ForeachStatement V_{LocalIndex} ({LocalType.ToDisplayString()})";
+}
+
 /// <summary>An unconditional branch to the block starting at <see cref="TargetOffset"/>.</summary>
 public sealed class Branch : IrNode
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -1,0 +1,105 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the narrow enumerator-lowering slice of <c>foreach</c>:
+/// <code>
+/// using (var e = collection.GetEnumerator())
+/// {
+///     while (e.MoveNext())
+///     {
+///         T item = e.Current;
+///         BODY
+///     }
+/// }
+/// </code>
+/// into <c>foreach (T item in collection) { BODY }</c>. The enumerator local must
+/// be compiler-hidden (no source local name) so hand-written using/while loops stay
+/// at their source altitude.
+/// </summary>
+public sealed class ForeachStatementPass : IIrPass
+{
+    public string Name => "foreach-statement";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var usingStatement in function.Descendants.OfType<UsingStatement>().ToList())
+        {
+            if (TryMatch(function, usingStatement) is not { } match)
+                continue;
+
+            var collection = match.Collection;
+            collection.Detach();
+            match.CurrentStore.Detach();
+            var body = match.Loop.Body;
+            body.Detach();
+            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
+            context.Stepper.StepOver("raise enumerator loop to foreach", usingStatement);
+            usingStatement.ReplaceWith(foreachStatement);
+            return;
+        }
+    }
+
+    sealed record Match(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
+
+    static Match? TryMatch(IrFunction function, UsingStatement usingStatement)
+    {
+        int enumeratorIndex = usingStatement.LocalIndex;
+        if (HasSourceLocalName(function, enumeratorIndex))
+            return null;
+
+        if (usingStatement.Resource is not Call getEnumerator
+            || !IsGetEnumerator(getEnumerator)
+            || getEnumerator.Arguments is not [_])
+        {
+            return null;
+        }
+
+        if (usingStatement.Body.Blocks is not [{ Children: [WhileLoop loop] }]
+            || !IsMoveNextOn(loop.Condition, enumeratorIndex)
+            || loop.Body.Children is not [StoreLocal { Value: LoadProperty current } currentStore, ..]
+            || !IsCurrentOn(current, enumeratorIndex))
+        {
+            return null;
+        }
+
+        if (loop.Body.Children.Skip(1).Any(child => ReferencesEnumerator(child, enumeratorIndex)))
+            return null;
+
+        return new Match(getEnumerator.Arguments[0], loop, currentStore);
+    }
+
+    static bool HasSourceLocalName(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && !string.IsNullOrWhiteSpace(function.LocalNames[index]);
+
+    static bool IsGetEnumerator(Call call)
+        => call.Callee is { Name: "GetEnumerator", HasThis: true } && call.Arguments.Count == 1;
+
+    static bool IsMoveNextOn(IrExpression condition, int enumeratorIndex)
+        => condition is Call
+        {
+            Callee: { Name: "MoveNext", HasThis: true, ReturnType: { Namespace: "System", Name: "Boolean" } },
+            Arguments: [var receiver],
+        } && IsEnumeratorReceiver(receiver, enumeratorIndex);
+
+    static bool IsCurrentOn(LoadProperty property, int enumeratorIndex)
+        => property is { HasInstance: true, PropertyName: "Current", Instance: { } receiver }
+            && IsEnumeratorReceiver(receiver, enumeratorIndex);
+
+    static bool IsEnumeratorReceiver(IrExpression receiver, int enumeratorIndex) => receiver switch
+    {
+        LoadLocal load => load.Index == enumeratorIndex,
+        LoadLocalAddress address => address.Index == enumeratorIndex,
+        _ => false,
+    };
+
+    static bool ReferencesEnumerator(IrNode node, int enumeratorIndex)
+        => node.Descendants.Prepend(node).Any(candidate => candidate switch
+        {
+            LoadLocal load => load.Index == enumeratorIndex,
+            LoadLocalAddress address => address.Index == enumeratorIndex,
+            StoreLocal store => store.Index == enumeratorIndex,
+            _ => false,
+        });
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -160,6 +160,8 @@ public static class IrPasses
         // using statement. Runs after return sinking so a `return` from inside
         // the protected body stays inside the using body.
         new UsingStatementPass(),
+        // Raise compiler-hidden enumerator using/while/current loops to foreach.
+        new ForeachStatementPass(),
         // Raise the csc pin lowering (a pinned managed-ref local + derived
         // pointer + optional unpin store) into fixed (T* p = &place) { ... }.
         // Runs after structuring and the second inlining so the pinned region's

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -69,7 +69,8 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ExpressionStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field => default!;
     [Completeness(CompletenessLevel.Full)] public static FixedStatementPass FixedStatement => new();
-    [Completeness(CompletenessLevel.None, "foreach (var x in xs)")] public static Unhandled ForEachStatement => default!;
+    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local; arrays and custom pattern enumerators not raised")]
+    public static ForeachStatementPass ForEachStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static ForLoopPass ForStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative FunctionPointerInvocation => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative GotoStatement => default!;


### PR DESCRIPTION
## Summary

- Add ForeachStatement IR and ForeachStatementPass for compiler-hidden enumerator using/while/current lowering.
- Render foreach statements and model iteration-variable definite assignment.
- Update ledger, scorecard, focused tests, and annotated C# expectation for enumerator allocation on the foreach header.

## Testing

- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo -v:minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release --nologo -v:minimal
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --fidelity-check --compile-cap 200
