### PR TITLE
Raise sparse switch-on-int binary-search dispatch into a switch

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -200,6 +200,22 @@ public class CfgSampleClass
         _ => 0,
     };
 
+    // A wider sparse switch — enough scattered cases that csc builds a multi-level
+    // binary-search tree (pivots branching to other pivots), exercising the
+    // sparse-int raise on a deeper dispatch than ClassifyMode's single pivot.
+    public static string ClassifyWide(int code) => code switch
+    {
+        3 => "three",
+        17 => "seventeen",
+        42 => "forty-two",
+        99 => "ninety-nine",
+        128 => "one-twenty-eight",
+        256 => "two-fifty-six",
+        500 => "five-hundred",
+        1000 => "thousand",
+        _ => "other",
+    };
+
     // Explicit gotos to a common exit — the forward-common-merge shape. The merge
     // is a short `return result;` tail reached by two unconditional gotos plus a
     // fallthrough, so the return-merge pass inlines the tail into each arm and the

--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -27,8 +27,8 @@ public class CompletenessTests
     [Fact]
     public void ComparisonTreeSwitch_FullyRaised_HasNoResidual()
     {
-        // ClassifyMode is a sparse switch the structuring pass raises to nested
-        // if/else (#640) — no surviving goto, so no gap.
+        // ClassifyMode is a sparse switch SwitchRaisingPass collects back into a
+        // `switch` statement — no surviving goto, so no gap.
         Assert.Null(Completeness.Residual(Raised(nameof(CfgSampleClass.ClassifyMode))));
     }
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -19,13 +19,10 @@ public class FidelityGateTests
     /// Methods that still recompile to a different opcode stream — the open
     /// decompiler docket. Each is a tracked defect or a benign over-render; the gate
     /// tolerates these but fails if a NEW method joins the set. Shrink this list as
-    /// fixes land. Tracked defects include StaleFieldRead (issue #605),
+    /// fixes land. Tracked defects include StaleFieldRead (issue #605) and
     /// the hash-bucket switch-on-string lowering (DayNumber — the small
     /// op_Equality-chain form is now raised; see SmallStringSwitch in
     /// PinnedExact), and benign codegen choices (BothPositive, NeitherOr).
-    /// ClassifyMode is a sparse switch csc lowers to a comparison tree the
-    /// structuring pass does not yet raise, so it round-trips through flat gotos
-    /// (tracked under the structuring docket — leaves the set when that lands).
     /// GotoCommonExit is the step-2 common-exit fold: the decompiler inlines the
     /// shared return tail into each arm, recompiling to cleaner direct-return IL
     /// than the original goto-and-merge shape — a benign equivalent restructuring.
@@ -33,7 +30,6 @@ public class FidelityGateTests
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
-        "ClassifyMode",
         "DayNumber",
         "GotoCommonExit",
         "NeitherOr",
@@ -58,6 +54,8 @@ public class FidelityGateTests
     /// SmallStringSwitch must keep raising the small op_Equality-chain
     /// switch-on-string back into a `switch` statement that recompiles
     /// opcode-exact (the flat goto form inverts the later branch polarities).
+    /// ClassifyMode must keep raising csc's sparse switch-on-int binary-search
+    /// dispatch (relational pivots over linear == chains) back into a `switch`.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -83,6 +81,8 @@ public class FidelityGateTests
         "SmallStringSwitch",
         "StringSwitchWithJoin",
         "StringSwitchNoDefault",
+        "ClassifyMode",
+        "ClassifyWide",
         "AnonShorthand",
         "AnonNamed",
         "AnonSingle",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -21,6 +21,7 @@ public class IdiomShapeScorecardTests
     [
         new("SwitchRaisingPass", nameof(CfgSampleClass.PowerOfTwo), SyntaxKind.SwitchExpression, [SyntaxKind.SwitchStatement]),
         new("SwitchRaisingPass", nameof(CfgSampleClass.SmallStringSwitch), SyntaxKind.SwitchStatement, [SyntaxKind.GotoStatement]),
+        new("SwitchRaisingPass", nameof(CfgSampleClass.ClassifyMode), SyntaxKind.SwitchStatement, [SyntaxKind.IfStatement]),
         new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
         new("AnonymousObjectPass", nameof(CfgSampleClass.AnonShorthand), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),
         new("AwaitRecoveryPass", nameof(CfgSampleClass.AwaitOnce), SyntaxKind.AwaitExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -444,19 +444,20 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void ComparisonTree_StructuresToNestedGuardsWithoutGotos()
+    public void ComparisonTree_RaisesSparseSwitchWithoutGotos()
     {
-        // ClassifyMode is a sparse switch csc lowered to a comparison tree, each
-        // arm storing its result and jumping to one ldloc; ret tail. The
-        // return-merge fold turns the arms into straight returns and the guard
-        // inlining nests the comparisons — no surviving goto and no `= default`.
+        // ClassifyMode is a sparse switch csc lowered to a binary-search comparison
+        // tree (relational pivots over linear == chains). SwitchRaisingPass collects
+        // the equality leaves back into a `switch` statement — no surviving goto, no
+        // nested `if`, and no `= default` dead initializer.
         var function = ImportFixture(nameof(CfgSampleClass.ClassifyMode));
         IrPasses.Run(function);
         var output = CSharpPrinter.PrintRaised(function).Output!;
 
         Assert.DoesNotContain("goto ", output);
         Assert.DoesNotContain("= default", output);
-        Assert.Contains("if (", output);
+        Assert.DoesNotContain("if (", output);
+        Assert.Contains("switch (", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -19,7 +19,7 @@ public class LoweredFidelityGateTests
     /// <summary>
     /// Methods whose lowered C# still recompiles to a different opcode stream — the open
     /// lowered docket. The gate tolerates these but fails if a NEW method joins the set.
-    /// Beyond the shared sugared docket (BothPositive, ClassifyMode, DayNumber,
+    /// Beyond the shared sugared docket (BothPositive, DayNumber,
     /// GotoCommonExit, NeitherOr), the lowered view adds ReverseCopy:
     /// lowering deliberately skips
     /// IncrementDecrementPass, so the dup-based ++/-- idiom round-trips as an explicit temp
@@ -28,7 +28,6 @@ public class LoweredFidelityGateTests
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
-        "ClassifyMode",
         "DayNumber",
         "GotoCommonExit",
         "NeitherOr",
@@ -68,6 +67,8 @@ public class LoweredFidelityGateTests
         "SmallStringSwitch",
         "StringSwitchWithJoin",
         "StringSwitchNoDefault",
+        "ClassifyMode",
+        "ClassifyWide",
         "AnonShorthand",
         "AnonNamed",
         "AnonSingle",

--- a/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class SparseIntSwitchRaisingTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void ClassifyMode_RaisesBinarySearchDispatchToSwitch()
+    {
+        var function = Raised(nameof(CfgSampleClass.ClassifyMode));
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        // Six int cases plus the default.
+        Assert.Equal(7, node.Sections.Count);
+        Assert.Single(node.Sections, s => s.IsDefault);
+
+        var labels = node.Sections.Where(s => !s.IsDefault)
+            .SelectMany(s => s.Labels).Select(l => l.Value).ToArray();
+        Assert.Equal(new object[] { 0x1000, 0x2000, 0x4000, 0x8000, 0xA000, 0xC000 }, labels);
+
+        // The relational pivots and equality tests are all consumed by the raise.
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Empty(function.Descendants.OfType<Comparison>());
+    }
+
+    [Fact]
+    public void ClassifyMode_RendersSwitchOnTheGoverningExpression()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ClassifyMode)))
+            .Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("switch (mode & 61440)", output);
+        Assert.Contains("case 4096:", output);
+        Assert.Contains("default:", output);
+        Assert.DoesNotContain("if (", output);
+    }
+
+    [Fact]
+    public void ClassifyWide_RaisesMultiLevelBinarySearchTree()
+    {
+        // Enough scattered cases that csc builds a multi-level pivot tree; every
+        // equality leaf is still collected into one flat switch.
+        var function = Raised(nameof(CfgSampleClass.ClassifyWide));
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal(9, node.Sections.Count);
+        Assert.Single(node.Sections, s => s.IsDefault);
+
+        var labels = node.Sections.Where(s => !s.IsDefault)
+            .SelectMany(s => s.Labels).Select(l => l.Value).ToArray();
+        Assert.Equal(new object[] { 3, 17, 42, 99, 128, 256, 500, 1000 }, labels);
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -92,7 +92,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
     [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position); named-local, indexer-element, nested, and multi-arg Add (dictionary) initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
-    [Completeness(CompletenessLevel.Partial, "jump-table switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
+    [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
@@ -105,7 +105,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat => default!;
     [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
     public static StringInterpolationPass StringInterpolation => new();
-    [Completeness(CompletenessLevel.Partial, "value-producing jump tables only; sparse + pattern switches still emit a statement")]
+    [Completeness(CompletenessLevel.Partial, "value-producing jump tables raise to a switch expression; the sparse binary-search form recovers as a switch statement; pattern switches not raised")]
     public static SwitchRaisingPass SwitchExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -70,7 +70,8 @@ public sealed class SwitchRaisingPass : IIrPass
                         || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
                     return true;
                 if (blocks[s].Children is [.., ConditionalBranch]
-                    && RaiseStringEqualityChain(container, s, leaveTargets, stepper))
+                    && (RaiseStringEqualityChain(container, s, leaveTargets, stepper)
+                        || RaiseSparseIntSwitch(container, s, leaveTargets, stepper)))
                     return true;
             }
         }
@@ -721,11 +722,13 @@ public sealed class SwitchRaisingPass : IIrPass
 
     /// <summary>Jump-table indices as <c>int</c> case-label constants.</summary>
     static ImmutableArray<Constant> IntLabels(IEnumerable<int> indices)
-        => [.. indices.Select(i => new Constant(i, TypeRef.CoreLib("System", "Int32")))];
+        => [.. indices.Select(IntConst)];
 
-    /// <summary>String literals as <c>string</c> case-label constants.</summary>
-    static ImmutableArray<Constant> StringLabels(IEnumerable<string> literals)
-        => [.. literals.Select(l => new Constant(l, TypeRef.CoreLib("System", "String")))];
+    /// <summary>A single <c>int</c> case-label constant.</summary>
+    static Constant IntConst(int value) => new(value, TypeRef.CoreLib("System", "Int32"));
+
+    /// <summary>A single <c>string</c> case-label constant.</summary>
+    static Constant StringConst(string value) => new(value, TypeRef.CoreLib("System", "String"));
 
     /// <summary>
     /// Raises csc's small switch-on-string lowering — a run of
@@ -746,23 +749,16 @@ public sealed class SwitchRaisingPass : IIrPass
     static bool RaiseStringEqualityChain(BlockContainer container, int s, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
-        var offsetToIndex = new Dictionary<int, int>();
-        for (int i = 0; i < blocks.Count; i++)
-            offsetToIndex[blocks[i].StartOffset] = i;
 
         // The dispatch chain: a run of equality tests against the same value, each
         // branching to a case body when equal. The first test may share its block
         // with the straight-line setup that precedes the switch (e.g. spilling the
         // governing expression to a temp); the rest are single-statement blocks.
-        var caseLabels = new List<string>();
-        var caseTargetOffsets = new List<int>();
-
         if (blocks[s].Children is not [.., ConditionalBranch first]
-            || !TryStringEqualityTest(first.Condition, out var firstValue, out var firstLiteral))
+            || !TryStringEqualityTest(first.Condition, out var value, out var firstLiteral))
             return false;
-        var value = firstValue;
-        caseLabels.Add(firstLiteral);
-        caseTargetOffsets.Add(first.TargetOffset);
+        var caseLabels = new List<Constant> { StringConst(firstLiteral) };
+        var caseTargetOffsets = new List<int> { first.TargetOffset };
 
         int idx = s + 1;
         while (idx < blocks.Count
@@ -770,7 +766,7 @@ public sealed class SwitchRaisingPass : IIrPass
             && TryStringEqualityTest(cb.Condition, out var testValue, out var literal)
             && SameValue(value, testValue))
         {
-            caseLabels.Add(literal);
+            caseLabels.Add(StringConst(literal));
             caseTargetOffsets.Add(cb.TargetOffset);
             idx++;
         }
@@ -791,6 +787,119 @@ public sealed class SwitchRaisingPass : IIrPass
             defaultOffset = blocks[idx].StartOffset;
             dispatchEnd = idx - 1;
         }
+
+        return FinishSwitchRaise(container, s, dispatchEnd, value, caseTargetOffsets,
+            caseLabels, defaultOffset, leaveTargets, stepper);
+    }
+
+    /// <summary>
+    /// Raises csc's sparse switch-on-int lowering. When the case labels are too
+    /// scattered for a jump table, csc emits a binary-search dispatch: a tree of
+    /// relational pivots (<c>if (v &gt; k) …</c>) partitioning the value range,
+    /// whose leaves are linear <c>if (v == k) goto case;</c> equality chains, each
+    /// chain ending in a branch to the shared default. The decompiler renders that
+    /// as nested <c>if</c>s; recompiling them re-derives a different branch shape,
+    /// so they never round-trip opcode-exact. Collecting every equality leaf back
+    /// into a <c>switch (v) { case k: … }</c> lets csc re-emit the original tree.
+    ///
+    /// The dispatch blocks (pivots, equality tests, and chain-terminating branches)
+    /// are contiguous and precede the case bodies; pivots must route within that
+    /// region, and the bodies must tile the span after it through the same
+    /// single-entry-region model the other raises use. Anything irregular is left
+    /// flat for soundness.
+    /// </summary>
+    static bool RaiseSparseIntSwitch(BlockContainer container, int s, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+
+        // The first dispatch block carries the governing value (often a spilled
+        // temp) and ends in a comparison against it — an equality test (a case) or
+        // a relational pivot.
+        if (blocks[s].Children is not [.., ConditionalBranch firstBranch]
+            || !TryIntComparison(firstBranch.Condition, out var value, out _, out _))
+            return false;
+
+        var caseLabels = new List<Constant>();
+        var caseTargetOffsets = new List<int>();
+        var pivotTargets = new List<int>();
+        var dispatchOffsets = new HashSet<int>();
+        int? defaultOffset = null;
+        bool DefaultConsistent(int off) => (defaultOffset ??= off) == off;
+
+        int idx = s;
+        int dispatchEnd = s - 1;
+        while (idx < blocks.Count)
+        {
+            // The first block may carry leading setup; the rest are single statements.
+            var children = blocks[idx].Children;
+            IrNode? term = idx == s
+                ? (children is [.., ConditionalBranch or Branch] ? children[^1] : null)
+                : (children is [ConditionalBranch] or [Branch] ? children[0] : null);
+
+            if (term is ConditionalBranch cb
+                && TryIntComparison(cb.Condition, out var testValue, out int constant, out bool isEqual)
+                && SameValue(value, testValue))
+            {
+                if (isEqual)
+                {
+                    caseLabels.Add(IntConst(constant));
+                    caseTargetOffsets.Add(cb.TargetOffset);
+                }
+                else
+                {
+                    pivotTargets.Add(cb.TargetOffset);   // a range pivot, not a case
+                }
+            }
+            else if (term is Branch br && DefaultConsistent(br.TargetOffset))
+            {
+                // A chain terminator branching to the shared default.
+            }
+            else
+            {
+                break;   // the first case/default body block
+            }
+
+            dispatchOffsets.Add(blocks[idx].StartOffset);
+            dispatchEnd = idx;
+            idx++;
+        }
+
+        if (caseLabels.Count < 2)
+            return false;   // a single test is an `if`, not a switch
+
+        // Every relational pivot must branch back into the dispatch region.
+        foreach (int t in pivotTargets)
+            if (!dispatchOffsets.Contains(t))
+                return false;
+
+        // A switch with no explicit default branch falls through to the block
+        // immediately after the dispatch region.
+        if (defaultOffset is null)
+        {
+            if (dispatchEnd + 1 >= blocks.Count)
+                return false;
+            defaultOffset = blocks[dispatchEnd + 1].StartOffset;
+        }
+
+        return FinishSwitchRaise(container, s, dispatchEnd, value, caseTargetOffsets,
+            caseLabels, defaultOffset.Value, leaveTargets, stepper);
+    }
+
+    /// <summary>
+    /// Shared tail for the equality-chain raises: given the dispatch range, the
+    /// governing value, and the collected case labels/targets plus the default,
+    /// grow each case body into a single-entry region, verify the bodies tile the
+    /// span after the dispatch, and emit the <c>switch</c> statement. Returns false
+    /// (leaving the flat form) if anything is irregular.
+    /// </summary>
+    static bool FinishSwitchRaise(BlockContainer container, int s, int dispatchEnd, IrExpression value,
+        List<int> caseTargetOffsets, List<Constant> caseLabels, int defaultOffset,
+        HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
 
         if (!offsetToIndex.TryGetValue(defaultOffset, out int defaultIndex) || defaultIndex <= dispatchEnd)
             return false;
@@ -863,7 +972,7 @@ public sealed class SwitchRaisingPass : IIrPass
         if (!OnlyReachedByChain(blocks, owned, s, dispatchEnd, leaveTargets))
             return false;
 
-        BuildStringSwitch(container, s, dispatchEnd, value, caseTargets, caseLabels,
+        BuildSwitchStatement(container, s, dispatchEnd, value, caseTargets, caseLabels,
             regions, defaultBodyHead, defaultSharesTarget, join, regionEnd, stepper);
         return true;
     }
@@ -888,6 +997,38 @@ public sealed class SwitchRaisingPass : IIrPass
                 literal = left;
                 return true;
             }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// An integer comparison <c>v &lt;op&gt; const</c> (in either operand order)
+    /// against an <c>int</c> constant — the equality leaves and relational pivots
+    /// of csc's sparse switch dispatch. <paramref name="isEqual"/> distinguishes a
+    /// case test (<c>==</c>) from a range pivot.
+    /// </summary>
+    static bool TryIntComparison(IrExpression condition, out IrExpression value, out int constant, out bool isEqual)
+    {
+        value = null!;
+        constant = 0;
+        isEqual = false;
+        if (condition is not Comparison cmp
+            || cmp.Kind is not (ComparisonKind.Equal or ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
+                                or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual))
+            return false;
+        if (cmp.Right is Constant { Value: int right })
+        {
+            value = cmp.Left;
+            constant = right;
+            isEqual = cmp.Kind == ComparisonKind.Equal;
+            return true;
+        }
+        if (cmp.Left is Constant { Value: int left })
+        {
+            value = cmp.Right;
+            constant = left;
+            isEqual = cmp.Kind == ComparisonKind.Equal;
+            return true;
         }
         return false;
     }
@@ -929,16 +1070,16 @@ public sealed class SwitchRaisingPass : IIrPass
         return true;
     }
 
-    static void BuildStringSwitch(
+    static void BuildSwitchStatement(
         BlockContainer container, int s, int dispatchEnd, IrExpression value, int[] caseTargets,
-        List<string> caseLabels, Dictionary<int, List<int>> regions, int? defaultBodyHead,
+        IReadOnlyList<Constant> caseLabels, Dictionary<int, List<int>> regions, int? defaultBodyHead,
         int? defaultSharesTarget, int? join, int regionEnd, Stepper stepper)
     {
         var all = container.Blocks.ToList();
         int? joinOffset = join is { } j ? all[j].StartOffset : null;
 
         // Case labels grouped by target, in first-appearance order.
-        var labelsByTarget = new Dictionary<int, List<string>>();
+        var labelsByTarget = new Dictionary<int, List<Constant>>();
         var targetOrder = new List<int>();
         for (int i = 0; i < caseTargets.Length; i++)
         {
@@ -957,7 +1098,7 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var sections = new List<SwitchSection>();
         foreach (int target in targetOrder)
-            sections.Add(new SwitchSection(StringLabels(labelsByTarget[target]), isDefault: target == defaultSharesTarget,
+            sections.Add(new SwitchSection([.. labelsByTarget[target]], isDefault: target == defaultSharesTarget,
                 SectionBody(regions[target].Select(i => all[i]).ToList(), joinOffset)));
         if (defaultBodyHead is { } dh)
             sections.Add(new SwitchSection([], isDefault: true,
@@ -975,7 +1116,7 @@ public sealed class SwitchRaisingPass : IIrPass
         rebuilt.Add(switchBlock);
         for (int i = regionEnd; i < all.Count; i++)
             rebuilt.Add(all[i]);
-        stepper.StepOver("raise switch-on-string equality chain to switch", container);
+        stepper.StepOver("raise switch equality chain to switch", container);
         container.ReplaceWith(rebuilt);
     }
 


### PR DESCRIPTION
## Summary

Raises csc's **sparse switch-on-int** lowering back into a `switch` statement, closing the `ClassifyMode` opcode-diff docket entry.

When the case labels are too scattered for a jump table, csc lowers a `switch(int)` to a **binary-search dispatch**: relational pivots (`if (v > k) …`) partition the value range, and the leaves are linear `if (v == k) goto case;` equality chains, each chain ending in a branch to the shared default. The decompiler rendered that tree as nested `if`s; recompiling them re-derives a different branch shape, so it never round-tripped opcode-exact. Collecting every equality leaf back into `switch (v) { case k: … }` makes csc re-emit the original dispatch — **opcode-exact**.

## Changes

- **`SwitchRaisingPass.RaiseSparseIntSwitch`**: scans the contiguous dispatch region (pivots, equality tests, and chain-terminating branches), collecting the int case labels and the shared default. Relational pivots must route back within the region; anything irregular is left flat for soundness. The case bodies are assembled through the **same single-entry-region model** the jump-table and string-switch raises use — extracted into a shared `FinishSwitchRaise`.
- **`TryIntComparison`** matches `v <op> const` in either operand order (equality leaf vs relational pivot). The string and int label paths now share `BuildSwitchStatement` over `Constant` labels.
- **Fixtures** `ClassifyMode` (single pivot) and `ClassifyWide` (multi-level tree) move from `KnownDiffs` to `PinnedExact` in both fidelity gates. Idiom scorecard entry + `SparseIntSwitchRaisingTests` added; the obsolete nested-guard expectation in `IrImporterTests`/`CompletenessTests` updated to the switch outcome. Ledger notes (`PatternSwitchStatement`, `SwitchExpression`) refreshed.

## Validation

- 431 decompiler tests green; 1157 product tests green.
- Harness fidelity-check: `ClassifyMode` and `ClassifyWide` recompile opcode-exact; the remaining `Full` diffs (`BothPositive`, `DayNumber`, `GotoCommonExit`, `NeitherOr`) are the unchanged docket.

## Out of scope

`DayNumber`'s hash-bucket string switch (`ComputeStringHash` + bucket tree) is a different, csc-version-sensitive shape and stays in `KnownDiffs`.
