### PR TITLE
Raise non-capturing statement lambdas

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -48,18 +48,17 @@ public class CfgSampleClass
     // lazy cache and LambdaRaisingPass recovers `x => x + 1`.
     public static System.Func<int, int> NonCapturingLambda() => x => x + 1;
 
-    // Boundary fixtures for the owed lambda surface: each is declined by one of
-    // LambdaRaisingPass's guards, so the scorecard pins it as unrecovered (it
-    // still renders the delegate-over-synthesized-method form). When a later
-    // slice lifts a guard, flip its scorecard entry to recovered in that PR.
+    // Boundary fixtures for the lambda surface: each exercises a distinct
+    // LambdaRaisingPass guard. When a later slice lifts a guard, flip its
+    // scorecard entry to recovered in that PR.
 
     // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
     // an instance method on that class, not the static <>c singleton. Display
     // class capture substitution is owed.
     public static System.Func<int, int> CapturingLambda(int n) => x => x + n;
 
-    // Statement body: more than one statement, so it is not the single
-    // `return expr` the first slice admits. A block-bodied lambda is owed.
+    // Statement body: no captures or locals, so LambdaRaisingPass can render the
+    // recovered block-bodied lambda in the outer scope.
     public static System.Func<int, int> StatementBodyLambda()
         => x => { System.Console.WriteLine(x); return x + 1; };
 

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -39,9 +39,9 @@ public class IdiomShapeScorecardTests
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructTuplePair), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
-        // Owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
+        // Remaining owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
         new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
-        new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
     ];
 

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -1,0 +1,33 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LambdaRaisingPassTests
+{
+    static string PrintRaised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void NonCapturingExpressionBody_RaisesSimpleLambda()
+        => Assert.Equal("return x => x + 1;", PrintRaised(nameof(CfgSampleClass.NonCapturingLambda)));
+
+    [Fact]
+    public void NonCapturingStatementBody_RaisesBlockLambda()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.StatementBodyLambda));
+
+        Assert.Contains("return x => {", output);
+        Assert.Contains("Console.WriteLine(x);", output);
+        Assert.Contains("return x + 1;", output);
+        Assert.DoesNotContain("new Func", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -68,10 +68,17 @@ public sealed partial class CSharpPrinter
 
         var statements = lambda.Body.Blocks
             .SelectMany(b => b.Children)
-            .Select(Statement)
+            .Select(LambdaStatement)
             .Where(s => s is not null);
         return $"{parameters} => {{ {string.Join(" ", statements)} }}";
     }
+
+    string? LambdaStatement(IrNode node) => node switch
+    {
+        Return { Value: { } value } => $"return {Expression(value)};",
+        Return => "return;",
+        _ => Statement(node),
+    };
 
     /// <summary>The text of one switch-expression arm: its labels (or <c>_</c>) and the value it yields.</summary>
     string SwitchArmText(SwitchExpressionArm arm)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1253,11 +1253,11 @@ public sealed class DelegateCreation : IrExpression
 /// (the synthesized method's block container, imported and run through the
 /// pipeline). The result type is the delegate type the lambda is converted to.
 ///
-/// <para>Non-capturing only for now: the body reads no display-class state and
-/// declares no locals, so it prints inside the outer function's scope without a
-/// local context of its own (arguments are self-naming on the node). A
-/// capturing body, or one with its own locals, needs the printer to switch
-/// scope when it descends here — a later increment.</para>
+/// <para>Non-capturing, zero-local bodies only for now: the body reads no
+/// display-class state and declares no locals, so it prints inside the outer
+/// function's scope without a local context of its own (arguments are
+/// self-naming on the node). A capturing body, or one with its own locals, needs
+/// the printer to switch scope when it descends here — a later increment.</para>
 /// </summary>
 public sealed class Lambda : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -10,14 +10,15 @@ namespace ILInspector.Decompiler.Pipeline;
 /// synthesized method through the pass context's cross-method seam, re-presents
 /// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
 ///
-/// <para>First slice — <b>non-capturing, expression-bodied</b> only: the target
-/// is a method on the static singleton <c>&lt;&gt;c</c> (no display class), and
-/// its body must declare no locals, read no captured <c>this</c>, and be a
-/// single <c>return expr;</c>. Those are exactly the bodies that print correctly
-/// inside the outer function's scope without a local/parameter context of their
-/// own (arguments are self-naming). A capturing lambda, a body with locals, or a
-/// statement body is left as a delegate creation for a later increment. A no-op
-/// when the seam is absent (stage dumps, the lowered/annotated views).</para>
+/// <para>Current slice — <b>non-capturing, zero-local</b> lambdas: the target is
+/// a method on the static singleton <c>&lt;&gt;c</c> (no display class), and its
+/// body must declare no locals, read no captured <c>this</c>, and be either a
+/// single <c>return expr;</c> expression body or a simple block body ending in a
+/// return. Those bodies print correctly inside the outer function's scope
+/// without a local/parameter context of their own (arguments are self-naming). A
+/// capturing lambda or a body with locals is left as a delegate creation for a
+/// later increment. A no-op when the seam is absent (stage dumps, the
+/// lowered/annotated views).</para>
 /// </summary>
 public sealed class LambdaRaisingPass : IIrPass
 {
@@ -52,15 +53,15 @@ public sealed class LambdaRaisingPass : IIrPass
         IrPasses.Run(body, IrPasses.Default, context);
 
         // Admit only what prints soundly in the outer scope: no locals of its
-        // own, no read of the captured-this slot (arg 0), and a single returned
-        // expression. Anything else needs printer scope-switching — not yet.
+        // own, no read of the captured-this slot (arg 0), and a single block the
+        // lambda printer can render without switching local scope.
         if (!body.Locals.IsEmpty)
             return null;
         if (body.Descendants.OfType<UnsupportedNode>().Any())
             return null;
         if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
             return null;
-        if (body.Body.Blocks is not [{ Children: [Return { Value: not null }] }])
+        if (!IsPrintableBody(body))
             return null;
 
         var container = body.Body;
@@ -74,6 +75,23 @@ public sealed class LambdaRaisingPass : IIrPass
     static bool IsNonCapturingLambdaMethod(MethodRef method)
         => LeafTypeName(method.DeclaringType.Name) == "<>c"
             && method.Name.Contains(">b__", StringComparison.Ordinal);
+
+    static bool IsPrintableBody(IrFunction body)
+    {
+        if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
+            return false;
+
+        for (int i = 0; i < statements.Count; i++)
+        {
+            var statement = statements[i];
+            if (statement is Return { Value: not null })
+                return i == statements.Count - 1;
+            if (statement is not ExpressionStatement)
+                return false;
+        }
+
+        return false;
+    }
 
     // TypeRef.Name spells nesting with '+'; the closure holder is the leaf.
     static string LeafTypeName(string name)


### PR DESCRIPTION
## Summary
- picked the next scorecard project from current main: `LambdaRaisingPass/StatementBodyLambda`
- recover zero-local non-capturing block-bodied lambdas with simple statements ending in return
- render lambda return statements without using the outer method return type for casts
- move the statement-body lambda scorecard case to recovered

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.LambdaRaisingPassTests -class ILInspector.Decompiler.Tests.IdiomShapeScorecardTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal