### PR TITLE
Add adversarial + ordering fixtures for runtime-async await recovery

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AwaitAdversarialTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AwaitAdversarialTests.cs
@@ -1,0 +1,110 @@
+// Adversarial cover for AwaitRecoveryPass. Each negative fixture is a method
+// call that resembles the runtime-async `AsyncHelpers.Await` lowering but differs
+// by exactly one of the matcher's discriminators (namespace, declaring type name,
+// declaring assembly, instance-ness). None may be raised to `await`; together
+// they pin the matcher so a future loosening that drops a discriminator fails
+// loudly. Pair these with the positive ordering fixtures in CfgSampleClass
+// (AwaitThree / AwaitInArguments / AwaitAcrossVoidCall) which prove multi-await
+// order is preserved across every statement-emitting spill site.
+
+// The look-alike below deliberately redeclares System.Runtime.CompilerServices
+// .AsyncHelpers in this assembly to isolate the assembly discriminator; the
+// local type shadows the corelib one (CS0436) on purpose.
+#pragma warning disable CS0436
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests
+{
+    public class AwaitAdversarialTests
+    {
+        static IrFunction Raised(string methodName, Type type)
+        {
+            using var source = MetadataSource.Open(type.Assembly.Location);
+            var function = IrImporter.Import(source, type.FullName!, methodName);
+            Assert.NotNull(function);
+            IrPasses.Run(function!);
+            function.CheckInvariant();
+            return function!;
+        }
+
+        static void AssertNoAwaitButCallSurvives(IrFunction function)
+        {
+            Assert.Empty(function.Descendants.OfType<AwaitExpression>());
+            // The look-alike call must remain a call (named `Await`) in the
+            // output — proving the shape was recognized as a call site, just not
+            // as an await.
+            var output = CSharpPrinter.Print(function).Output;
+            Assert.NotNull(output);
+            Assert.Contains("Await", output);        // the method call, capital A
+            Assert.DoesNotContain("await ", output);  // never the await keyword
+        }
+
+        // Discriminator: declaring assembly. Same namespace, same type name, same
+        // arity, same static-ness as the real helper — only the assembly differs.
+        [Fact]
+        public void SameNamespaceTypeAndArity_DifferentAssembly_IsNotRaised()
+            => AssertNoAwaitButCallSurvives(Raised(nameof(AwaitLookAlikes.ViaShadowedCorelibType), typeof(AwaitLookAlikes)));
+
+        // Discriminator: declaring type name (right namespace, wrong type).
+        [Fact]
+        public void RightNamespaceWrongTypeName_IsNotRaised()
+            => AssertNoAwaitButCallSurvives(Raised(nameof(AwaitLookAlikes.ViaWrongTypeName), typeof(AwaitLookAlikes)));
+
+        // Discriminator: declaring namespace (right type name, wrong namespace).
+        [Fact]
+        public void RightTypeNameWrongNamespace_IsNotRaised()
+            => AssertNoAwaitButCallSurvives(Raised(nameof(AwaitLookAlikes.ViaWrongNamespace), typeof(AwaitLookAlikes)));
+
+        // Discriminator: instance-ness. The real helper is static; an instance
+        // `Await` of the same name/arity must not raise.
+        [Fact]
+        public void InstanceAwaitMethod_IsNotRaised()
+            => AssertNoAwaitButCallSurvives(Raised(nameof(AwaitLookAlikes.ViaInstanceMethod), typeof(AwaitLookAlikes)));
+    }
+
+    internal static class AwaitLookAlikes
+    {
+        // Resolves to the shadowing AsyncHelpers below (this assembly), not corelib.
+        public static int ViaShadowedCorelibType(int x)
+            => System.Runtime.CompilerServices.AsyncHelpers.Await(x);
+
+        public static int ViaWrongTypeName(int x)
+            => System.Runtime.CompilerServices.AwaitHelper.Await(x);
+
+        public static int ViaWrongNamespace(int x)
+            => AdversarialAwait.AsyncHelpers.Await(x);
+
+        public static int ViaInstanceMethod(int x)
+            => new InstanceAwaiter().Await(x);
+    }
+
+    internal sealed class InstanceAwaiter
+    {
+        public int Await<T>(T value) => 0;
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    // Shadows the corelib AsyncHelpers to isolate the assembly discriminator.
+    internal static class AsyncHelpers
+    {
+        public static T Await<T>(T value) => value;
+    }
+
+    // Right namespace, wrong type name.
+    internal static class AwaitHelper
+    {
+        public static T Await<T>(T value) => value;
+    }
+}
+
+namespace AdversarialAwait
+{
+    // Right type name, wrong namespace.
+    internal static class AsyncHelpers
+    {
+        public static T Await<T>(T value) => value;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
@@ -92,4 +92,42 @@ public class AwaitRecoveryPassTests
         // Neither await is nested inside the other (no reordering collapse).
         Assert.DoesNotContain(awaits, outer => outer.Descendants.OfType<AwaitExpression>().Any());
     }
+
+    [Fact]
+    public void ThreeAwaits_PreserveSourceOrder()
+    {
+        var output = Print(nameof(CfgSampleClass.AwaitThree));
+
+        int a = output.IndexOf("await a", StringComparison.Ordinal);
+        int b = output.IndexOf("await b", StringComparison.Ordinal);
+        int c = output.IndexOf("await c", StringComparison.Ordinal);
+        Assert.True(a >= 0 && b >= 0 && c >= 0, $"missing an await in:\n{output}");
+        Assert.True(a < b && b < c, $"awaits must read a, b, c in order:\n{output}");
+        Assert.Equal(3, Raised(nameof(CfgSampleClass.AwaitThree)).Descendants.OfType<AwaitExpression>().Count());
+    }
+
+    [Fact]
+    public void AwaitsAsCallArguments_PreserveArgumentOrder()
+    {
+        // Combine(x, y) => x - y, so a reordering would silently flip the result.
+        var output = Print(nameof(CfgSampleClass.AwaitInArguments));
+
+        int a = output.IndexOf("await a", StringComparison.Ordinal);
+        int b = output.IndexOf("await b", StringComparison.Ordinal);
+        Assert.True(a >= 0 && b >= 0, $"missing an await in:\n{output}");
+        Assert.True(a < b, $"`await a` must precede `await b`:\n{output}");
+    }
+
+    [Fact]
+    public void AwaitAcrossVoidCall_KeepsAwaitBeforeCall()
+    {
+        // The void call sequences between the await and its use; the await must
+        // materialize before the call, not slide past it (void-call spill path).
+        var output = Print(nameof(CfgSampleClass.AwaitAcrossVoidCall));
+
+        int awaitPos = output.IndexOf("await a", StringComparison.Ordinal);
+        int sink = output.IndexOf("Sink(", StringComparison.Ordinal);
+        Assert.True(awaitPos >= 0 && sink >= 0, $"missing await or call in:\n{output}");
+        Assert.True(awaitPos < sink, $"`await a` must precede the void call:\n{output}");
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1512,6 +1512,41 @@ public class CfgSampleClass
         int y = await b;
         return x + y;
     }
+
+    // Ordering stress: three awaits combined. Each earlier await sits on the
+    // runtime-async eval stack across the later ones, so all but the last must
+    // spill to keep source order (await a, then b, then c).
+    public static async System.Threading.Tasks.Task<int> AwaitThree(System.Threading.Tasks.Task<int> a, System.Threading.Tasks.Task<int> b, System.Threading.Tasks.Task<int> c)
+    {
+        int x = await a;
+        int y = await b;
+        int z = await c;
+        return x + y + z;
+    }
+
+    // Ordering stress: two awaits consumed as call arguments. They sit on the
+    // stack together and are consumed in order by the call — no statement
+    // boundary strands the first, so order is preserved without a spill.
+    public static async System.Threading.Tasks.Task<int> AwaitInArguments(System.Threading.Tasks.Task<int> a, System.Threading.Tasks.Task<int> b)
+    {
+        return AwaitOrderingHelpers.Combine(await a, await b);
+    }
+
+    // Ordering stress for the void-call statement path: a void call sequences
+    // between the first await and its use, so the first await must spill ahead
+    // of the call instead of materializing after it.
+    public static async System.Threading.Tasks.Task<int> AwaitAcrossVoidCall(System.Threading.Tasks.Task<int> a, int seed)
+    {
+        int x = await a;
+        AwaitOrderingHelpers.Sink(seed);
+        return x + seed;
+    }
+}
+
+internal static class AwaitOrderingHelpers
+{
+    public static int Combine(int x, int y) => x - y;
+    public static void Sink(int value) { }
 }
 
 // A top-level type sharing the nested type's leaf name, to prove the importer


### PR DESCRIPTION
## What

Adversarial + ordering fixture cover for the two runtime-async `await` PRs (#742 recovery, #750 ordering). **No pass changes** — this is pure fixture/test hardening per the decompiler-quality "adversarial discovery" loop: try to falsify the existing raises and pin the discriminators.

## Negative fixtures — `AwaitAdversarialTests`

`AwaitRecoveryPass` matches a call on five discriminators (name `Await`, static, namespace `System.Runtime.CompilerServices`, type `AsyncHelpers`, **corelib assembly**, single arg). Each negative is a look-alike that differs by exactly one discriminator and must **not** raise to `await`:

| Fixture | Discriminator isolated | Renders as |
| --- | --- | --- |
| `ViaShadowedCorelibType` | declaring **assembly** | `AsyncHelpers.Await<int>(x)` |
| `ViaWrongTypeName` | declaring **type name** | `AwaitHelper.Await<int>(x)` |
| `ViaWrongNamespace` | declaring **namespace** | `AsyncHelpers.Await<int>(x)` |
| `ViaInstanceMethod` | **instance-ness** | `new InstanceAwaiter().Await<int>(x)` |

The assembly case is the subtle one: it redeclares `System.Runtime.CompilerServices.AsyncHelpers` *in the test assembly* (shadowing corelib via a deliberate `CS0436`), so the call site matches name + namespace + type + arity + static-ness and differs **only** by assembly. This also confirms a nice invariant: the compiler still lowers real `await` to **corelib's** `AsyncHelpers` by identity, so the shadow only affects explicit user calls — the existing `AwaitOnce/Two/Three` fixtures keep raising.

## Positive fixtures — ordering stress (`CfgSampleClass` + `AwaitRecoveryPassTests`)

Exercise the order-preserving spill at every statement-emitting site:

- **`AwaitThree`** — three combined awaits (two spills) must read `a, b, c` in order.
- **`AwaitInArguments`** — two awaits as arguments to `Combine(x, y) => x - y`, where a reorder would silently flip the result.
- **`AwaitAcrossVoidCall`** — a void call sequenced between an await and its use, covering the void-call `ExpressionStatement` spill path added in #750.

## Tests

Full decompiler suite **441/441** green. Negatives live in pass-level tests, positives in `AwaitRecoveryPassTests`, matching the convention (scorecard keeps the positive altitude ratchet; near-miss negatives are pinned in pass tests).
