### PR TITLE
Consolidate exact member identity facts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityFactsTests.cs
@@ -1,0 +1,103 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class MemberIdentityFactsTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
+
+    [Fact]
+    public void IsCoreLibraryType_RequiresCoreLibraryIdentity()
+    {
+        Assert.True(MemberIdentityFacts.IsCoreLibraryType(TypeRef.CoreLib("System", "Range"), "System", "Range"));
+        Assert.False(MemberIdentityFacts.IsCoreLibraryType(
+            TypeRef.Definition("UserAssembly", "System", "Range"),
+            "System",
+            "Range"));
+    }
+
+    [Fact]
+    public void IsCoreLibraryType_UnwrapsGenericInstanceDefinition()
+    {
+        var list = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "List`1"),
+            [s_int]);
+
+        Assert.True(MemberIdentityFacts.IsCoreLibraryType(list, "System.Collections.Generic", "List`1"));
+    }
+
+    [Fact]
+    public void IsRuntimeHelpersGetSubArray_RequiresExactBclStaticSignature()
+    {
+        Assert.True(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.CoreLib(
+            "System.Runtime.CompilerServices",
+            "RuntimeHelpers"))));
+
+        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.CompilerServices",
+            "RuntimeHelpers"))));
+
+        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(new Call(
+            GetSubArrayMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")) with
+            {
+                ParameterTypes = [s_intArray, s_object],
+            },
+            isVirtual: false,
+            [new LoadArgument(0, "a", s_intArray), new LoadArgument(1, "range", s_range)])));
+
+        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(new Call(
+            GetSubArrayMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")),
+            isVirtual: false,
+            [new LoadArgument(0, "a", s_intArray)])));
+    }
+
+    [Fact]
+    public void IsAsyncHelpersAwait_RequiresExactBclStaticSingleArgument()
+    {
+        Assert.True(MemberIdentityFacts.IsAsyncHelpersAwait(Await(TypeRef.CoreLib(
+            "System.Runtime.CompilerServices",
+            "AsyncHelpers"))));
+
+        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(Await(TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.CompilerServices",
+            "AsyncHelpers"))));
+
+        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+            AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")),
+            isVirtual: true,
+            [new LoadArgument(0, "x", s_int)])));
+
+        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+            AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")),
+            isVirtual: false,
+            [new LoadArgument(0, "x", s_int), new LoadArgument(1, "y", s_int)])));
+
+        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+            AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")) with
+            {
+                ParameterTypes = [s_int, s_int],
+            },
+            isVirtual: false,
+            [new LoadArgument(0, "x", s_int)])));
+    }
+
+    static MethodRef GetSubArrayMethod(TypeRef declaringType)
+        => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
+
+    static Call GetSubArray(TypeRef declaringType)
+        => new(
+            GetSubArrayMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "a", s_intArray), new LoadArgument(1, "range", s_range)]);
+
+    static MethodRef AwaitMethod(TypeRef declaringType)
+        => new(declaringType, "Await", s_int, [s_int], HasThis: false);
+
+    static Call Await(TypeRef declaringType)
+        => new(AwaitMethod(declaringType), isVirtual: false, [new LoadArgument(0, "x", s_int)]);
+}

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentityFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentityFacts.cs
@@ -1,0 +1,59 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Thin, SRM-native identity facts over the decompiler IR. These helpers
+/// centralize exact BCL member/type checks so raising passes do not silently
+/// drift back to namespace/name-only matching.
+/// </summary>
+public static class MemberIdentityFacts
+{
+    static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+
+    public static bool IsCoreLibraryType(TypeRef? type, string ns, string name)
+        => NamedDefinition(type) is
+        {
+            Kind: TypeRefKind.Definition,
+            Assembly: TypeRef.CoreLibrary,
+            Namespace: var typeNamespace,
+            Name: var typeName,
+        }
+        && typeNamespace == ns
+        && typeName == name;
+
+    public static bool IsStaticCoreLibraryMethod(MethodRef method, string typeNamespace, string typeName, string methodName)
+        => !method.HasThis
+            && method.Name == methodName
+            && IsCoreLibraryType(method.DeclaringType, typeNamespace, typeName);
+
+    public static bool IsRuntimeHelpersGetSubArray(Call call)
+    {
+        if (call.IsVirtual
+            || !IsStaticCoreLibraryMethod(
+                call.Callee,
+                "System.Runtime.CompilerServices",
+                "RuntimeHelpers",
+                "GetSubArray")
+            || call.Arguments.Count != 2
+            || call.Callee.ParameterTypes is not [var arrayParameter, var rangeParameter])
+        {
+            return false;
+        }
+
+        return call.Callee.ReturnType is { Kind: TypeRefKind.SzArray } arrayReturn
+            && arrayParameter.Equals(arrayReturn)
+            && rangeParameter.Equals(s_range);
+    }
+
+    public static bool IsAsyncHelpersAwait(Call call)
+        => !call.IsVirtual
+            && IsStaticCoreLibraryMethod(
+                call.Callee,
+                "System.Runtime.CompilerServices",
+                "AsyncHelpers",
+                "Await")
+            && call.Callee.ParameterTypes.Length == 1
+            && call.Arguments.Count == 1;
+
+    static TypeRef? NamedDefinition(TypeRef? type)
+        => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AwaitRecoveryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AwaitRecoveryPass.cs
@@ -22,7 +22,7 @@ public sealed class AwaitRecoveryPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (!IsAwaitHelper(call))
+            if (!MemberIdentityFacts.IsAsyncHelpersAwait(call))
                 continue;
 
             var operand = (IrExpression)call.DetachChildren()[0];
@@ -33,12 +33,4 @@ public sealed class AwaitRecoveryPass : IIrPass
         }
     }
 
-    static bool IsAwaitHelper(Call call)
-        => call.Callee is
-           {
-               Name: "Await",
-               HasThis: false,
-               DeclaringType: { Namespace: "System.Runtime.CompilerServices", Name: "AsyncHelpers", Assembly: TypeRef.CoreLibrary },
-           }
-           && call.Children.Count == 1;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -47,7 +47,7 @@ internal static class LoweringCoverage
     public static AnonymousObjectPass AnonymousObjectCreation => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AssignmentOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) AsyncHelpers.Await call sites recovered to `await`, multi-await order preserved; classic state-machine async not raised")]
+    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) exact corelib AsyncHelpers.Await call sites recovered to `await`, multi-await order preserved; classic state-machine async not raised")]
     public static AwaitRecoveryPass Await => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BasePatternSwitchLocalRewriter => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BinaryOperator => default!;
@@ -99,7 +99,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess => new();
     [Completeness(CompletenessLevel.None, "from x in xs select ...")] public static Unhandled Query => default!;
-    [Completeness(CompletenessLevel.Partial, "array GetSubArray range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...); string/span Substring/Slice forms not raised")]
+    [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...); string/span Substring/Slice forms not raised")]
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -33,7 +33,7 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (!IsRuntimeHelpersGetSubArray(call))
+            if (!MemberIdentityFacts.IsRuntimeHelpersGetSubArray(call))
                 continue;
             if (call.Arguments is not [var receiver, var rangeArg])
                 continue;
@@ -53,30 +53,6 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
             context.Stepper.StepOver("raise GetSubArray range slice to a[..] indexer", call);
             call.ReplaceWith(slice);
         }
-    }
-
-    static bool IsRuntimeHelpersGetSubArray(Call call)
-    {
-        if (call.IsVirtual
-            || call.Callee is not
-            {
-                Name: "GetSubArray",
-                HasThis: false,
-                DeclaringType:
-                {
-                    Namespace: "System.Runtime.CompilerServices",
-                    Name: "RuntimeHelpers",
-                    Assembly: TypeRef.CoreLibrary or "System.Runtime",
-                },
-                ParameterTypes: [var arrayParameter, var rangeParameter],
-            })
-        {
-            return false;
-        }
-
-        return call.Callee.ReturnType is { Kind: TypeRefKind.SzArray } arrayReturn
-            && arrayParameter.Equals(arrayReturn)
-            && rangeParameter.Equals(TypeRef.CoreLib("System", "Range"));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- start phase 1 of the SRM-native metadata facts substrate with thin IR-level member/type identity helpers
- add `MemberIdentityFacts` over `TypeRef`, `MethodRef`, and `Call`
- migrate `RangeFromGetSubArrayPass` and `AwaitRecoveryPass` onto shared exact-identity predicates
- add focused helper tests and ledger notes for exact BCL helper facts

## Design note
This keeps the first slice intentionally small: no runtime type-system import, no `MetadataLoadContext`, no broad output-shape changes. The helper surface consolidates existing evidence (`TypeRef` assembly/name/namespace and call signatures) so passes do not duplicate namespace/name-only checks. Runtime `Internal.TypeSystem` remains prior art/vocabulary, not a product dependency.

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityFactsTests -class ILInspector.Decompiler.Tests.RangeFromGetSubArrayPassTests -class ILInspector.Decompiler.Tests.AwaitRecoveryPassTests -class ILInspector.Decompiler.Tests.AwaitAdversarialTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal