### PR TITLE
Add generated-code facts for lambda raising

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeFactsTests.cs
@@ -1,0 +1,46 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class GeneratedCodeFactsTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_closureHolder = TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c");
+
+    [Fact]
+    public void NonCapturingLambdaMethod_RequiresGeneratedDeclaringType()
+    {
+        var method = LambdaMethod(declaringTypeIsCompilerGenerated: true);
+
+        Assert.True(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method));
+        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with { DeclaringTypeIsCompilerGenerated = false }));
+    }
+
+    [Fact]
+    public void NonCapturingLambdaMethod_RequiresClosureHolderAndLambdaMethodName()
+    {
+        var method = LambdaMethod(declaringTypeIsCompilerGenerated: true);
+
+        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with
+        {
+            DeclaringType = TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c__DisplayClass0_0"),
+        }));
+        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with { Name = "M" }));
+    }
+
+    [Fact]
+    public void GeneratedNameHelpers_UseLeafNestedTypeName()
+    {
+        Assert.True(GeneratedCodeFacts.IsStaticLambdaClosureHolderName(s_closureHolder));
+        Assert.True(GeneratedCodeFacts.IsDisplayClassName(TypeRef.Definition(
+            "UserAssembly",
+            "Samples",
+            "Outer+<>c__DisplayClass0_0")));
+    }
+
+    static MethodRef LambdaMethod(bool declaringTypeIsCompilerGenerated)
+        => new(s_closureHolder, "<M>b__0_0", s_int, [s_int], HasThis: true)
+        {
+            DeclaringTypeIsCompilerGenerated = declaringTypeIsCompilerGenerated,
+        };
+}

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -4,6 +4,9 @@ namespace ILInspector.Decompiler.Tests;
 
 public class LambdaRaisingPassTests
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_func = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`2"), [s_int, s_int]);
+
     static string PrintRaised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -29,5 +32,59 @@ public class LambdaRaisingPassTests
         Assert.Contains("Console.WriteLine(x);", output);
         Assert.Contains("return x + 1;", output);
         Assert.DoesNotContain("new Func", output);
+    }
+
+    [Fact]
+    public void LambdaNameLookalikeWithoutCompilerGeneratedMetadata_IsNotRaised()
+    {
+        var lambdaMethod = new MethodRef(
+            TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c"),
+            "<M>b__0_0",
+            s_int,
+            [s_int],
+            HasThis: true);
+        var function = FunctionReturningDelegate(lambdaMethod);
+        var lambdaBody = LambdaBody(lambdaMethod);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method == lambdaMethod ? lambdaBody : null);
+
+        new LambdaRaisingPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+        Assert.Single(function.Descendants.OfType<DelegateCreation>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction FunctionReturningDelegate(MethodRef method)
+    {
+        var block = new Block();
+        block.Add(new Return(new DelegateCreation(
+            s_func,
+            method,
+            isVirtual: false,
+            new Constant(null, TypeRef.CoreLib("System", "Object")))));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(s_func, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction LambdaBody(MethodRef method)
+    {
+        var block = new Block();
+        block.Add(new Return(new LoadArgument(1, "x", s_int)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            method.Name,
+            method.DeclaringType,
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeFacts.cs
@@ -1,0 +1,30 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Compiler-generated shape facts over IR metadata evidence. Attribute evidence
+/// is required before generated-name patterns are trusted; the names only
+/// corroborate the compiler shape.
+/// </summary>
+public static class GeneratedCodeFacts
+{
+    public static bool IsNonCapturingLambdaMethod(MethodRef method)
+        => method.DeclaringTypeIsCompilerGenerated
+            && IsStaticLambdaClosureHolderName(method.DeclaringType)
+            && IsSynthesizedLambdaMethodName(method.Name);
+
+    public static bool IsStaticLambdaClosureHolderName(TypeRef type)
+        => LeafTypeName(type.Name) == "<>c";
+
+    public static bool IsDisplayClassName(TypeRef type)
+        => LeafTypeName(type.Name).StartsWith("<>c__DisplayClass", StringComparison.Ordinal);
+
+    public static bool IsSynthesizedLambdaMethodName(string name)
+        => name.StartsWith("<", StringComparison.Ordinal)
+            && name.Contains(">b__", StringComparison.Ordinal);
+
+    static string LeafTypeName(string name)
+    {
+        int plus = name.LastIndexOf('+');
+        return plus < 0 ? name : name[(plus + 1)..];
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1457,14 +1457,18 @@ public static class IrImporter
             case HandleKind.MethodDefinition:
             {
                 var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
-                var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, method.GetDeclaringType(), 0);
-                var typeScope = new GenericScope(GenericParameterNames(reader, reader.GetTypeDefinition(method.GetDeclaringType()).GetGenericParameters()), []);
+                var declaringTypeHandle = method.GetDeclaringType();
+                var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, declaringTypeHandle, 0);
+                var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
+                var typeScope = new GenericScope(GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
                 return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
                     ParameterRefKinds = ReadParameterRefKinds(reader, method, signature.ParameterTypes),
                     RequiresUnsafe = HasRequiresUnsafeAttribute(reader, method),
+                    IsCompilerGenerated = HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes()),
+                    DeclaringTypeIsCompilerGenerated = HasCompilerGeneratedAttribute(reader, declaringType.GetCustomAttributes()),
                 };
             }
             case HandleKind.MemberReference:
@@ -1682,6 +1686,15 @@ public static class IrImporter
         foreach (var handle in method.GetCustomAttributes())
             if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
                 is ("System.Diagnostics.CodeAnalysis", "RequiresUnsafeAttribute"))
+                return true;
+        return false;
+    }
+
+    static bool HasCompilerGeneratedAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var handle in attributes)
+            if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)
+                is ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"))
                 return true;
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -48,6 +48,20 @@ public sealed record MethodRef(
     public bool IsSpecialName { get; init; }
 
     /// <summary>
+    /// Metadata <c>[CompilerGenerated]</c> evidence on this method. Exact for
+    /// same-assembly MethodDefs; false for MemberRefs where the attribute rows
+    /// are unavailable through the call-site token.
+    /// </summary>
+    public bool IsCompilerGenerated { get; init; }
+
+    /// <summary>
+    /// Metadata <c>[CompilerGenerated]</c> evidence on the declaring type. Exact
+    /// for same-assembly MethodDefs; false for MemberRefs where the declaring
+    /// type's definition is unavailable through the call-site token.
+    /// </summary>
+    public bool DeclaringTypeIsCompilerGenerated { get; init; }
+
+    /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
     /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
     /// resolved as a MemberReference (cross-assembly, or a same-assembly call on

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -14,18 +14,19 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <para><see cref="DelegateConstructionPass"/> raises a method-group delegate —
 /// but that is a LocalRewriter <c>DelegateCreationExpression</c> (already Full),
 /// not a closure. <see cref="LambdaRaisingPass"/> recovers the first slice of a
-/// real closure: a non-capturing, expression-bodied lambda (<c>x =&gt; x + 1</c>),
-/// after <see cref="LambdaCachePass"/> strips its lazy <c>&lt;&gt;c</c> cache.
-/// Capturing lambdas, local functions, and expression trees are still owed, so
-/// they render as the synthesized <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c>
-/// shapes — a large inferior-form gap the LocalRewriter register cannot show.</para>
+/// real closure: non-capturing, zero-local lambdas whose target method sits on a
+/// compiler-generated <c>&lt;&gt;c</c> holder, after <see cref="LambdaCachePass"/>
+/// strips its lazy cache. Capturing lambdas, local functions, local-bound lambda
+/// bodies, and expression trees are still owed, so they render as synthesized
+/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — a large inferior-form
+/// gap the LocalRewriter register cannot show.</para>
 ///
 /// <para>Synced against dotnet/roslyn
 /// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.Partial, "non-capturing, expression-bodied only (x => x + 1); capturing / statement / local-bound bodies still owed")]
+    [Completeness(CompletenessLevel.Partial, "non-capturing, zero-local expression or simple block bodies on compiler-generated <>c; capturing / local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -10,15 +10,15 @@ namespace ILInspector.Decompiler.Pipeline;
 /// synthesized method through the pass context's cross-method seam, re-presents
 /// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
 ///
-/// <para>Current slice — <b>non-capturing, zero-local</b> lambdas: the target is
-/// a method on the static singleton <c>&lt;&gt;c</c> (no display class), and its
-/// body must declare no locals, read no captured <c>this</c>, and be either a
-/// single <c>return expr;</c> expression body or a simple block body ending in a
-/// return. Those bodies print correctly inside the outer function's scope
-/// without a local/parameter context of their own (arguments are self-naming). A
-/// capturing lambda or a body with locals is left as a delegate creation for a
-/// later increment. A no-op when the seam is absent (stage dumps, the
-/// lowered/annotated views).</para>
+/// <para>Current slice — <b>non-capturing, zero-local</b> lambdas: the target
+/// method and its <c>&lt;&gt;c</c> closure-holder type must carry compiler-generated
+/// metadata evidence, and its body must declare no locals, read no captured
+/// <c>this</c>, and be either a single <c>return expr;</c> expression body or a
+/// simple block body ending in a return. Those bodies print correctly inside the
+/// outer function's scope without a local/parameter context of their own
+/// (arguments are self-naming). A capturing lambda or a body with locals is left
+/// as a delegate creation for a later increment. A no-op when the seam is absent
+/// (stage dumps, the lowered/annotated views).</para>
 /// </summary>
 public sealed class LambdaRaisingPass : IIrPass
 {
@@ -33,7 +33,7 @@ public sealed class LambdaRaisingPass : IIrPass
         {
             if (creation.Parent is null)
                 continue;  // detached by an earlier rewrite in this walk
-            if (!IsNonCapturingLambdaMethod(creation.Method))
+            if (!GeneratedCodeFacts.IsNonCapturingLambdaMethod(creation.Method))
                 continue;
             if (Raise(creation, context) is not { } lambda)
                 continue;
@@ -69,13 +69,6 @@ public sealed class LambdaRaisingPass : IIrPass
         return new Lambda(creation.DelegateType, body.Signature.Parameters, container);
     }
 
-    // A non-capturing lambda's target is a method named <Outer>b__N_M on the
-    // static singleton closure holder <>c (capturing lambdas live on a
-    // <>c__DisplayClass instance instead). The leaf type name pins it.
-    static bool IsNonCapturingLambdaMethod(MethodRef method)
-        => LeafTypeName(method.DeclaringType.Name) == "<>c"
-            && method.Name.Contains(">b__", StringComparison.Ordinal);
-
     static bool IsPrintableBody(IrFunction body)
     {
         if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
@@ -91,12 +84,5 @@ public sealed class LambdaRaisingPass : IIrPass
         }
 
         return false;
-    }
-
-    // TypeRef.Name spells nesting with '+'; the closure holder is the leaf.
-    static string LeafTypeName(string name)
-    {
-        int plus = name.LastIndexOf('+');
-        return plus < 0 ? name : name[(plus + 1)..];
     }
 }


### PR DESCRIPTION
## Summary
- start phase 2 of the metadata facts substrate with generated-code facts
- add compiler-generated metadata evidence to `MethodRef` for same-assembly MethodDefs
- add `GeneratedCodeFacts` for compiler-generated `<>c` lambda holder/method patterns
- migrate `LambdaRaisingPass` to require generated holder evidence before trusting lambda name patterns
- add an adversarial spoofed `<>c` / `>b__` lookalike test

## Notes
Roslyn stamps the `<>c` closure-holder type as compiler-generated; the lambda method itself is not consistently stamped, so the guard uses declaring-type `[CompilerGenerated]` as the primary metadata evidence and method-name shape as corroboration. MemberRef/cross-assembly tokens still conservatively report no attribute evidence.

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.GeneratedCodeFactsTests -class ILInspector.Decompiler.Tests.LambdaRaisingPassTests -class ILInspector.Decompiler.Tests.IdiomShapeScorecardTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal