### PR TITLE
Rename identity helper predicates

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -2,7 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
-public class GeneratedCodeFactsTests
+public class GeneratedCodeIdentityTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_closureHolder = TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c");
@@ -12,8 +12,8 @@ public class GeneratedCodeFactsTests
     {
         var method = LambdaMethod(declaringTypeIsCompilerGenerated: true);
 
-        Assert.True(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method));
-        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with { DeclaringTypeIsCompilerGenerated = false }));
+        Assert.True(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method));
+        Assert.False(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method with { DeclaringTypeIsCompilerGenerated = false }));
     }
 
     [Fact]
@@ -21,18 +21,18 @@ public class GeneratedCodeFactsTests
     {
         var method = LambdaMethod(declaringTypeIsCompilerGenerated: true);
 
-        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with
+        Assert.False(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method with
         {
             DeclaringType = TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c__DisplayClass0_0"),
         }));
-        Assert.False(GeneratedCodeFacts.IsNonCapturingLambdaMethod(method with { Name = "M" }));
+        Assert.False(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method with { Name = "M" }));
     }
 
     [Fact]
     public void GeneratedNameHelpers_UseLeafNestedTypeName()
     {
-        Assert.True(GeneratedCodeFacts.IsStaticLambdaClosureHolderName(s_closureHolder));
-        Assert.True(GeneratedCodeFacts.IsDisplayClassName(TypeRef.Definition(
+        Assert.True(GeneratedCodeIdentity.IsStaticLambdaClosureHolderName(s_closureHolder));
+        Assert.True(GeneratedCodeIdentity.IsDisplayClassName(TypeRef.Definition(
             "UserAssembly",
             "Samples",
             "Outer+<>c__DisplayClass0_0")));

--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -2,7 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
-public class MemberIdentityFactsTests
+public class MemberIdentityTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
@@ -12,8 +12,8 @@ public class MemberIdentityFactsTests
     [Fact]
     public void IsCoreLibraryType_RequiresCoreLibraryIdentity()
     {
-        Assert.True(MemberIdentityFacts.IsCoreLibraryType(TypeRef.CoreLib("System", "Range"), "System", "Range"));
-        Assert.False(MemberIdentityFacts.IsCoreLibraryType(
+        Assert.True(MemberIdentity.IsCoreLibraryType(TypeRef.CoreLib("System", "Range"), "System", "Range"));
+        Assert.False(MemberIdentity.IsCoreLibraryType(
             TypeRef.Definition("UserAssembly", "System", "Range"),
             "System",
             "Range"));
@@ -26,22 +26,22 @@ public class MemberIdentityFactsTests
             TypeRef.CoreLib("System.Collections.Generic", "List`1"),
             [s_int]);
 
-        Assert.True(MemberIdentityFacts.IsCoreLibraryType(list, "System.Collections.Generic", "List`1"));
+        Assert.True(MemberIdentity.IsCoreLibraryType(list, "System.Collections.Generic", "List`1"));
     }
 
     [Fact]
     public void IsRuntimeHelpersGetSubArray_RequiresExactBclStaticSignature()
     {
-        Assert.True(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.CoreLib(
+        Assert.True(MemberIdentity.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.CoreLib(
             "System.Runtime.CompilerServices",
             "RuntimeHelpers"))));
 
-        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.Definition(
+        Assert.False(MemberIdentity.IsRuntimeHelpersGetSubArray(GetSubArray(TypeRef.Definition(
             "UserAssembly",
             "System.Runtime.CompilerServices",
             "RuntimeHelpers"))));
 
-        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(new Call(
+        Assert.False(MemberIdentity.IsRuntimeHelpersGetSubArray(new Call(
             GetSubArrayMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")) with
             {
                 ParameterTypes = [s_intArray, s_object],
@@ -49,7 +49,7 @@ public class MemberIdentityFactsTests
             isVirtual: false,
             [new LoadArgument(0, "a", s_intArray), new LoadArgument(1, "range", s_range)])));
 
-        Assert.False(MemberIdentityFacts.IsRuntimeHelpersGetSubArray(new Call(
+        Assert.False(MemberIdentity.IsRuntimeHelpersGetSubArray(new Call(
             GetSubArrayMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")),
             isVirtual: false,
             [new LoadArgument(0, "a", s_intArray)])));
@@ -58,26 +58,26 @@ public class MemberIdentityFactsTests
     [Fact]
     public void IsAsyncHelpersAwait_RequiresExactBclStaticSingleArgument()
     {
-        Assert.True(MemberIdentityFacts.IsAsyncHelpersAwait(Await(TypeRef.CoreLib(
+        Assert.True(MemberIdentity.IsAsyncHelpersAwait(Await(TypeRef.CoreLib(
             "System.Runtime.CompilerServices",
             "AsyncHelpers"))));
 
-        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(Await(TypeRef.Definition(
+        Assert.False(MemberIdentity.IsAsyncHelpersAwait(Await(TypeRef.Definition(
             "UserAssembly",
             "System.Runtime.CompilerServices",
             "AsyncHelpers"))));
 
-        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+        Assert.False(MemberIdentity.IsAsyncHelpersAwait(new Call(
             AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")),
             isVirtual: true,
             [new LoadArgument(0, "x", s_int)])));
 
-        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+        Assert.False(MemberIdentity.IsAsyncHelpersAwait(new Call(
             AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")),
             isVirtual: false,
             [new LoadArgument(0, "x", s_int), new LoadArgument(1, "y", s_int)])));
 
-        Assert.False(MemberIdentityFacts.IsAsyncHelpersAwait(new Call(
+        Assert.False(MemberIdentity.IsAsyncHelpersAwait(new Call(
             AwaitMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "AsyncHelpers")) with
             {
                 ParameterTypes = [s_int, s_int],

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -5,7 +5,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// is required before generated-name patterns are trusted; the names only
 /// corroborate the compiler shape.
 /// </summary>
-public static class GeneratedCodeFacts
+public static class GeneratedCodeIdentity
 {
     public static bool IsNonCapturingLambdaMethod(MethodRef method)
         => method.DeclaringTypeIsCompilerGenerated

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -5,7 +5,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// centralize exact BCL member/type checks so raising passes do not silently
 /// drift back to namespace/name-only matching.
 /// </summary>
-public static class MemberIdentityFacts
+public static class MemberIdentity
 {
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AwaitRecoveryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AwaitRecoveryPass.cs
@@ -22,7 +22,7 @@ public sealed class AwaitRecoveryPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (!MemberIdentityFacts.IsAsyncHelpersAwait(call))
+            if (!MemberIdentity.IsAsyncHelpersAwait(call))
                 continue;
 
             var operand = (IrExpression)call.DetachChildren()[0];

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -33,7 +33,7 @@ public sealed class LambdaRaisingPass : IIrPass
         {
             if (creation.Parent is null)
                 continue;  // detached by an earlier rewrite in this walk
-            if (!GeneratedCodeFacts.IsNonCapturingLambdaMethod(creation.Method))
+            if (!GeneratedCodeIdentity.IsNonCapturingLambdaMethod(creation.Method))
                 continue;
             if (Raise(creation, context) is not { } lambda)
                 continue;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -33,7 +33,7 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (!MemberIdentityFacts.IsRuntimeHelpersGetSubArray(call))
+            if (!MemberIdentity.IsRuntimeHelpersGetSubArray(call))
                 continue;
             if (call.Arguments is not [var receiver, var rangeArg])
                 continue;


### PR DESCRIPTION
## Summary
- rename `MemberIdentityFacts` to `MemberIdentity`
- rename `GeneratedCodeFacts` to `GeneratedCodeIdentity`
- update tests and call sites to avoid confusing pipeline predicate helpers with the user-facing hidden-fact annotation system

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.GeneratedCodeIdentityTests -class ILInspector.Decompiler.Tests.RangeFromGetSubArrayPassTests -class ILInspector.Decompiler.Tests.AwaitRecoveryPassTests -class ILInspector.Decompiler.Tests.AwaitAdversarialTests -class ILInspector.Decompiler.Tests.LambdaRaisingPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal