### PR TITLE
Raise field null-coalescing assignment (obj.field ??= x)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1184,6 +1184,35 @@ public class CfgSampleClass
         return value;
     }
 
+    public static string? CachedName;
+
+    public sealed class CacheHolder
+    {
+        public string? Cache;
+    }
+
+    public static string NullCoalescingAssignStaticField(string fallback)
+    {
+        CachedName ??= fallback;
+        return CachedName;
+    }
+
+    public static string NullCoalescingAssignInstanceField(CacheHolder holder, string fallback)
+    {
+        holder.Cache ??= fallback;
+        return holder.Cache;
+    }
+
+    public static string NullCoalescingAssignFieldWithExtraThenStatement(CacheHolder holder, string fallback)
+    {
+        if (holder.Cache == null)
+        {
+            holder.Cache = fallback;
+            LastValue = fallback.Length;
+        }
+        return holder.Cache;
+    }
+
     public static string[] ArrayWithInit(string a)
     {
         return new string[] { a, "hello" };

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -56,6 +56,9 @@ public class FidelityGateTests
     /// opcode-exact (the flat goto form inverts the later branch polarities).
     /// ClassifyMode must keep raising csc's sparse switch-on-int binary-search
     /// dispatch (relational pivots over linear == chains) back into a `switch`.
+    /// NullCoalescingAssignStaticField and NullCoalescingAssignInstanceField must
+    /// keep folding the field null-test diamond into `field ??= fallback` whose
+    /// two member loads recompile opcode-exact.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -89,6 +92,8 @@ public class FidelityGateTests
         "NthFromEnd",
         "NthFromEndComputed",
         "NthCharFromEnd",
+        "NullCoalescingAssignStaticField",
+        "NullCoalescingAssignInstanceField",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -29,6 +29,8 @@ public class IdiomShapeScorecardTests
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),
         new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignLocal), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
+        new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignStaticField), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
+        new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignInstanceField), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
         new("NullConditionalPass", nameof(CfgSampleClass.NullConditionalProperty), SyntaxKind.ConditionalAccessExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -56,4 +56,56 @@ public class NullCoalescingAssignmentPassTests
         Assert.Single(function.Descendants.OfType<Coalesce>());
         Assert.DoesNotContain(function.Descendants.OfType<NullCoalescingAssignment>(), _ => true);
     }
+
+    [Fact]
+    public void StaticFieldNullAssignmentDiamond_RaisesToNullCoalescingFieldAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticField));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingFieldAssignment>());
+        Assert.Equal("CachedName", assignment.Field.Name);
+        Assert.False(assignment.HasInstance);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersStaticFieldNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticField))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("CachedName ??= fallback;", output);
+    }
+
+    [Fact]
+    public void InstanceFieldNullAssignmentDiamond_RaisesToNullCoalescingFieldAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignInstanceField));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingFieldAssignment>());
+        Assert.Equal("Cache", assignment.Field.Name);
+        Assert.True(assignment.HasInstance);
+        Assert.IsType<LoadArgument>(assignment.Instance);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersInstanceFieldNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignInstanceField))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("holder.Cache ??= fallback;", output);
+    }
+
+    [Fact]
+    public void FieldNullAssignmentWithExtraThenStatement_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignFieldWithExtraThenStatement));
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingFieldAssignment>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("??=", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -857,6 +857,7 @@ public sealed partial class CSharpPrinter
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => $"{TypeText(d.LocalTypes[i])} {LocalName(index)}"))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
+        NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -675,6 +675,34 @@ public sealed class NullCoalescingAssignment : IrNode
 }
 
 /// <summary>
+/// A raised field null-coalescing assignment (<c>obj.field ??= fallback</c>, or
+/// <c>Type.field ??= fallback</c> for a static field). Produced from csc's field
+/// null-test diamond: <c>if (obj.field is null) obj.field = fallback;</c>. The
+/// receiver — when present — is re-evaluable (a local/argument/this), so folding
+/// the two loads into one <c>??=</c> reorders nothing.
+/// </summary>
+public sealed class NullCoalescingFieldAssignment : IrNode
+{
+    public NullCoalescingFieldAssignment(FieldRef field, IrExpression? instance, IrExpression value)
+    {
+        Field = field;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        AddChild(value);
+    }
+
+    public FieldRef Field { get; }
+    public bool HasInstance { get; }
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+    public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
+
+    public override string Describe()
+        => $"NullCoalescingFieldAssignment {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
+}
+
+/// <summary>
 /// A raised null-conditional member access — <c>target?.Member</c>. The single
 /// child is the member access (a <see cref="Call"/>, <see cref="LoadProperty"/>,
 /// or <see cref="LoadField"/>) whose receiver IS the <c>?.</c> target; the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -87,7 +87,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration => default!;
     [Completeness(CompletenessLevel.Full)] public static LockSugarPass LockStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative MultipleLocalDeclarations => default!;
-    [Completeness(CompletenessLevel.Partial, "local-variable ??= only; fields/properties/indexers not raised")]
+    [Completeness(CompletenessLevel.Partial, "local-variable and field (instance + static, re-evaluable receiver) ??=; properties/indexers not raised")]
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -1,13 +1,16 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the local-variable form of csc's null-coalescing assignment lowering:
+/// Raises csc's null-coalescing assignment lowering:
 /// <code>
-/// if (V is null) { V = fallback; }
+/// if (V is null) { V = fallback; }            // local
+/// if (obj.field is null) { obj.field = fallback; }  // field
 /// </code>
-/// into <c>V ??= fallback</c>. Scoped to locals; field/property/indexer
-/// <c>??=</c> shapes carry receiver-evaluation and setter concerns left to later
-/// slices.
+/// into <c>V ??= fallback</c> / <c>obj.field ??= fallback</c>. The field form is
+/// scoped to a re-evaluable receiver (a local/argument/this, or none for a static
+/// field), so collapsing the two member loads into one <c>??=</c> reorders
+/// nothing. Property and indexer <c>??=</c> shapes carry accessor-call concerns
+/// left to later slices.
 /// </summary>
 public sealed class NullCoalescingAssignmentPass : IIrPass
 {
@@ -17,39 +20,87 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
     {
         foreach (var statement in function.Descendants.OfType<IfStatement>().ToList())
         {
-            if (TryMatch(statement) is not { } match)
+            if (TryMatchLocal(statement) is { } local)
+            {
+                var value = (IrExpression)local.Store.DetachChildren()[0];
+                var replacement = new NullCoalescingAssignment(local.Local.Index, local.Local.Type, value);
+                context.Stepper.StepOver("raise local null check assignment to ??=", statement);
+                statement.ReplaceWith(replacement);
                 continue;
+            }
 
-            var value = (IrExpression)match.Store.DetachChildren()[0];
-            var replacement = new NullCoalescingAssignment(match.Local.Index, match.Local.Type, value);
-            context.Stepper.StepOver("raise local null check assignment to ??=", statement);
-            statement.ReplaceWith(replacement);
+            if (TryMatchField(statement) is { } field)
+            {
+                var children = field.Store.DetachChildren();
+                var instance = field.Store.HasInstance ? (IrExpression)children[0] : null;
+                var value = (IrExpression)children[^1];
+                var replacement = new NullCoalescingFieldAssignment(field.Store.Field, instance, value);
+                context.Stepper.StepOver("raise field null check assignment to ??=", statement);
+                statement.ReplaceWith(replacement);
+            }
         }
     }
 
-    sealed record Match(LoadLocal Local, StoreLocal Store);
+    sealed record LocalMatch(LoadLocal Local, StoreLocal Store);
 
-    static Match? TryMatch(IfStatement statement)
+    static LocalMatch? TryMatchLocal(IfStatement statement)
     {
         if (statement.HasElse
             || statement.Then.Children is not [StoreLocal store]
-            || NullTestedLocal(statement.Condition) is not { } local
+            || NullTested(statement.Condition) is not LoadLocal local
             || store.Index != local.Index)
         {
             return null;
         }
 
-        if (TypeFamilies.Of(local.Type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+        if (IsNonNullableNumeric(local.Type))
             return null;
 
-        return new Match(local, store);
+        return new LocalMatch(local, store);
     }
 
-    static LoadLocal? NullTestedLocal(IrExpression condition) => condition switch
+    sealed record FieldMatch(StoreField Store);
+
+    static FieldMatch? TryMatchField(IfStatement statement)
     {
-        LogicalNot { Operand: LoadLocal local } => local,
-        Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal local, Right: Constant { Value: null } } => local,
-        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: LoadLocal local } => local,
+        if (statement.HasElse
+            || statement.Then.Children is not [StoreField store]
+            || NullTested(statement.Condition) is not LoadField loaded
+            || !SameField(loaded.Field, store.Field)
+            || !SameReceiver(loaded.Instance, store.Instance))
+        {
+            return null;
+        }
+
+        if (IsNonNullableNumeric(store.Field.Type))
+            return null;
+
+        return new FieldMatch(store);
+    }
+
+    static bool IsNonNullableNumeric(TypeRef type)
+        => TypeFamilies.Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F;
+
+    static bool SameField(FieldRef a, FieldRef b)
+        => a.Name == b.Name && Equals(a.DeclaringType, b.DeclaringType);
+
+    // The receiver is loaded once for the null test and once for the store; the
+    // fold is only sound when re-evaluating it is free of side effects and yields
+    // the same value — i.e. a static field (no receiver) or a plain
+    // local/argument/this variable read.
+    static bool SameReceiver(IrExpression? a, IrExpression? b) => (a, b) switch
+    {
+        (null, null) => true,
+        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
+        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
+        _ => false,
+    };
+
+    static IrExpression? NullTested(IrExpression condition) => condition switch
+    {
+        LogicalNot { Operand: var operand } => operand,
+        Comparison { Kind: ComparisonKind.Equal, Left: var left, Right: Constant { Value: null } } => left,
+        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: var right } => right,
         _ => null,
     };
 }


### PR DESCRIPTION
## What

Extends `NullCoalescingAssignmentPass` from the local-variable form to **fields** — instance and static. The ledger entry for `NullCoalescingAssignmentOperator` was `Partial` ("local-variable `??=` only; fields/properties/indexers not raised"); this advances it to cover fields.

csc lowers `obj.field ??= fallback` to the null-test diamond:

```csharp
if (obj.field is null) obj.field = fallback;
```

This folds that back into `obj.field ??= fallback` (and `Type.field ??= fallback` for a static field).

## Soundness

The receiver is loaded once for the null test and once for the store. The fold is gated on a **re-evaluable receiver** — `SameReceiver` accepts only a static field (no receiver) or a plain `local`/`argument`/`this` read, where evaluating it once instead of twice reorders nothing. This mirrors the guard the compound-assignment pass already uses. A spilled/complex receiver takes a different lowering shape and is left alone.

## How

- New IR node `NullCoalescingFieldAssignment` (field + optional instance + value). It defines no local, so `DefiniteAssignment`'s default child-walk already accounts for its reads — no special case needed.
- Printer renders it through the existing `FieldTarget` helper, inheriting backing-field/`this.`-qualification handling.
- Ledger row updated.

## Validation

Verified on the live corpus — `System.Exception.GetObjectData` faithfully recovers `_source ??= Source;`.

## Tests

- 5 pass tests: static/instance raise + render, plus an extra-then-statement negative.
- 2 idiom-shape scorecard cases.
- 2 fidelity pins — both field forms recompile **opcode-exact**.
- 460 decompiler + 1157 product tests green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
