### PR TITLE
Acknowledge iterator kickoffs honestly instead of a misleading state-machine stub

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1572,6 +1572,29 @@ public class CfgSampleClass
         AwaitOrderingHelpers.Sink(seed);
         return x + seed;
     }
+
+    // ---- iterator fixtures: kickoff hands off to a <Method>d__N state machine ----
+    // The simplest linear case: two constant yields, no params or captures.
+    public static System.Collections.Generic.IEnumerable<int> YieldTwo()
+    {
+        yield return 1;
+        yield return 2;
+    }
+
+    // Parameterized + loop: the kickoff still only constructs the state machine
+    // (the param is hoisted to a <>3__ field), so it acknowledges the same way.
+    public static System.Collections.Generic.IEnumerable<int> YieldRange(int n)
+    {
+        for (int i = 0; i < n; i++)
+            yield return i;
+    }
+
+    // Negative: returns IEnumerable<int> but is NOT an iterator (no state machine);
+    // array covariance, a plain `return source;`. The pass must not fire.
+    public static System.Collections.Generic.IEnumerable<int> NotAnIterator(int[] source)
+    {
+        return source;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -1,0 +1,72 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IteratorAcknowledgmentPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void IteratorKickoff_ReplacesHandoffWithHonestMarker()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldTwo));
+
+        // The misleading `return new <YieldTwo>d__0(-2);` handoff is gone.
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.DoesNotContain(function.Descendants.OfType<Return>(), _ => true);
+
+        // An honest iterator marker stands in its place.
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Contains("yield body", marker.Reason);
+        Assert.Contains(">d__", marker.Reason);
+    }
+
+    [Fact]
+    public void IteratorKickoff_CapsFidelityAtPartial()
+    {
+        Assert.Equal(DecompilationFidelity.Partial, Raised(nameof(CfgSampleClass.YieldTwo)).Fidelity);
+    }
+
+    [Fact]
+    public void IteratorKickoff_RendersMarkerComment_NotAStub()
+    {
+        var output = Print(nameof(CfgSampleClass.YieldTwo));
+
+        Assert.Contains("iterator", output);
+        Assert.Contains("not reconstructed", output);
+        // No plausible-but-meaningless state-machine construction stub.
+        Assert.DoesNotContain("return new", output);
+    }
+
+    [Fact]
+    public void ParameterizedIterator_IsAlsoAcknowledged()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldRange));
+
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+    }
+
+    [Fact]
+    public void NonIteratorReturningEnumerable_IsNotAcknowledged()
+    {
+        var function = Raised(nameof(CfgSampleClass.NotAnIterator));
+
+        // No iterator marker: the method has no state machine to acknowledge.
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Contains("source", Print(nameof(CfgSampleClass.NotAnIterator)));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -192,6 +192,11 @@ public static class IrPasses
         // (it feeds a calli, native callback, or delegate*-typed field — all of
         // which take a function pointer directly).
         new MethodAddressPass(),
+        // Recognize a compiler-generated iterator kickoff and replace its
+        // misleading `return new <X>d__N(-2);` handoff with an honest marker
+        // (the yield body in MoveNext is not yet reconstructed). Runs late with
+        // the other honesty/diagnostic passes; the kickoff carries no user logic.
+        new IteratorAcknowledgmentPass(),
         // Last: any function-pointer load still standing fed something other
         // than a delegate constructor — record the honest residual diagnostic.
         new FunctionPointerDiagnosticsPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -1,0 +1,88 @@
+using ILInspector.Decompiler;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Recognizes a compiler-generated iterator kickoff — a method returning
+/// <c>IEnumerable</c>/<c>IEnumerator</c> whose body merely hands off to a
+/// <c>new &lt;Method&gt;d__N(...)</c> state machine — and replaces the
+/// misleading handoff (<c>return new &lt;X&gt;d__0(-2);</c>, which reads like
+/// ordinary user code) with an honest <see cref="UnsupportedNode"/> marker.
+///
+/// <para>The <c>yield</c> body lives in the state machine's <c>MoveNext</c> and
+/// is not yet reconstructed; this pass keeps that gap visible — fidelity drops to
+/// <see cref="DecompilationFidelity.Partial"/> (DEC0004) — instead of emitting a
+/// plausible-but-meaningless stub. It does not raise the idiom (a Diagnostic
+/// native pass): the kickoff carries no user logic to preserve, so the whole
+/// body is replaced.</para>
+///
+/// <para>The kickoff lives on the user's type; the state machine's own
+/// <c>MoveNext</c>/<c>GetEnumerator</c> also construct and return a
+/// <c>&lt;X&gt;d__</c> — they are excluded by requiring the declaring type to not
+/// itself be a state machine.</para>
+/// </summary>
+public sealed class IteratorAcknowledgmentPass : IIrPass
+{
+    public string Name => "iterator-acknowledgment";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (!IsIteratorKickoff(function, out var stateMachine, out var sourceOffset))
+            return;
+
+        context.Stepper.StepOver($"acknowledge iterator kickoff '{stateMachine}' (yield body not reconstructed)");
+
+        function.Body.DetachChildren();
+        var marker = new UnsupportedNode(0, "iterator",
+            $"compiler-generated iterator state machine '{stateMachine}'; yield body (MoveNext) not reconstructed");
+        // Carry the handoff's provenance so the state-machine allocation fact
+        // (classified at import) still anchors onto the marker in the C# view.
+        marker.SetSourceOffset(sourceOffset);
+        var statement = new ExpressionStatement(marker);
+        statement.SetSourceOffset(sourceOffset);
+        var block = new Block(0);
+        block.Add(statement);
+        function.Body.Add(block);
+    }
+
+    static bool IsIteratorKickoff(IrFunction function, out string stateMachine, out int sourceOffset)
+    {
+        stateMachine = "";
+        sourceOffset = -1;
+
+        // MoveNext/GetEnumerator live on the <X>d__ type and also construct/return
+        // the state machine; the kickoff lives on the user's type.
+        if (IsStateMachineType(function.DeclaringType))
+            return false;
+        if (!ReturnsEnumerable(function.Signature.ReturnType))
+            return false;
+
+        var handoff = function.Descendants.OfType<NewObject>()
+            .FirstOrDefault(n => IsStateMachineType(n.Constructor.DeclaringType));
+        if (handoff is null)
+            return false;
+
+        stateMachine = MetadataName(handoff.Constructor.DeclaringType);
+        sourceOffset = handoff.SourceOffset;
+        return true;
+    }
+
+    static bool IsStateMachineType(TypeRef type)
+        => MetadataName(type).Contains(">d__", StringComparison.Ordinal);
+
+    static bool ReturnsEnumerable(TypeRef type)
+    {
+        var ns = Namespace(type);
+        if (ns is not ("System.Collections" or "System.Collections.Generic"))
+            return false;
+        var name = MetadataName(type);
+        return name.StartsWith("IEnumerable", StringComparison.Ordinal)
+            || name.StartsWith("IEnumerator", StringComparison.Ordinal);
+    }
+
+    static string MetadataName(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
+
+    static string Namespace(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Namespace ?? "" : type.Namespace;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -117,7 +117,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass WhileStatement => new();
-    [Completeness(CompletenessLevel.None, "yield return — iterator state machine")] public static Unhandled Yield => default!;
+    [Completeness(CompletenessLevel.None, "yield return — iterator state machine; kickoff acknowledged honestly (IteratorAcknowledgmentPass, Partial), MoveNext yield body not reconstructed")] public static Unhandled Yield => default!;
 }
 
 /// <summary>How much of a lowered construct comes back as the idiom.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -65,6 +65,8 @@ internal static class NativePasses
     public static FunctionPointerDiagnosticsPass FunctionPointerDiagnostics => new();
     [Native(NativeCategory.Diagnostic, "lost in/out/ref kind at a call site — DEC0007 residual")]
     public static RefKindDiagnosticsPass RefKindDiagnostics => new();
+    [Native(NativeCategory.Diagnostic, "compiler-generated iterator kickoff acknowledged honestly (Partial) instead of a misleading <X>d__N handoff stub — DEC0004 residual; yield body not yet reconstructed")]
+    public static IteratorAcknowledgmentPass IteratorAcknowledgment => new();
 }
 
 /// <summary>What a decompiler-native pass reconstructs (it inverts no Roslyn lowering).</summary>


### PR DESCRIPTION
## What

The first slice of yield/iterator recovery (honest acknowledgment, chosen over going straight for reconstruction).

A compiler-generated iterator kickoff lowers to `return new <Method>d__N(-2);` — a handoff to the state machine that reads like ordinary user code. The decompiler rendered it verbatim at **Full** fidelity, which is misleading: the `<X>d__N` type is unspeakable and the actual `yield` logic lives in the state machine's `MoveNext`.

`IteratorAcknowledgmentPass` recognizes the kickoff and replaces the handoff with an honest marker, capping fidelity at **Partial** (DEC0004):

```csharp
public static IEnumerable<int> YieldRange(int n)
{
    /* Unsupported IL_0000 iterator: compiler-generated iterator state machine '<YieldRange>d__263'; yield body (MoveNext) not reconstructed */  // alloc.statemachine(<YieldRange>d__263)
}
```

It does **not** reconstruct the yields — the `MoveNext` body is a separate, larger slice — but it stops the silent-Full stub.

## How

- **Detection** (precision-over-recall): a method returning `IEnumerable`/`IEnumerator` (`System.Collections[.Generic]`) **on the user's type** (not the `<X>d__` type — that excludes the state machine's own `MoveNext`/`GetEnumerator`, which also construct/return a `<X>d__`) whose body constructs a `<X>d__` state machine.
- **Honesty**: replaces the whole kickoff body (no user logic to preserve) with an `UnsupportedNode` marker. Fidelity drops to Partial via the existing tree-computed predicate — no new fidelity wiring.
- **Annotation anchoring**: the marker carries the handoff `NewObject`'s `SourceOffset`, so the `alloc.statemachine` fact (classified at import) still anchors onto it in the annotated C# view.
- **Ledger**: registered as a **Diagnostic** native pass (`NativePasses`); `LoweringCoverage.Yield` stays `None`/`Unhandled` (not recovered) with an updated note. No coverage-count change.

## Tests

- `IteratorAcknowledgmentPassTests` (5): marker replaces handoff, fidelity Partial, marker renders (not a stub), parameterized iterator acknowledged, negative `NotAnIterator` (returns `IEnumerable<int>` via array covariance) does not fire.
- Fixtures `YieldTwo` / `YieldRange` / `NotAnIterator` in `CfgSampleClass`.
- Decompiler **460** green, product **1157** green (9 skip). Compile-back / annotate-check / corpus-sweep gates unaffected (annotate-check classifies at import, independent of this raise pass).
- Verified end-to-end via the product CLI (`member -S "Decompiled Source"`).

## Not in scope (follow-ups)

`MoveNext` import currently crashes (`TypedConstantsPass` NRE on state-machine bodies); fixing that plus reconstructing linear `yield return <expr>;` is the next slice. Adversarial kickoff fixtures (IEnumerator-returning kickoff, nested-in-struct) also remain.
