### PR TITLE
Raise field and static-property null-coalescing assignment

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1184,6 +1184,30 @@ public class CfgSampleClass
         return value;
     }
 
+    static string? s_cachedName;
+
+    public static string NullCoalescingAssignStaticField(string fallback)
+    {
+        s_cachedName ??= fallback;
+        return s_cachedName;
+    }
+
+    string? _cachedText;
+
+    public string NullCoalescingAssignInstanceField(string fallback)
+    {
+        _cachedText ??= fallback;
+        return _cachedText;
+    }
+
+    static string? StaticName { get; set; }
+
+    public static string NullCoalescingAssignStaticProperty(string fallback)
+    {
+        StaticName ??= fallback;
+        return StaticName;
+    }
+
     public static string[] ArrayWithInit(string a)
     {
         return new string[] { a, "hello" };

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -89,6 +89,8 @@ public class FidelityGateTests
         "NthFromEnd",
         "NthFromEndComputed",
         "NthCharFromEnd",
+        "NullCoalescingAssignStaticField",
+        "NullCoalescingAssignInstanceField",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -29,6 +29,8 @@ public class IdiomShapeScorecardTests
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),
         new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignLocal), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
+        new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignStaticField), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
+        new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignInstanceField), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),
         new("NullConditionalPass", nameof(CfgSampleClass.NullConditionalProperty), SyntaxKind.ConditionalAccessExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -72,6 +72,8 @@ public class LoweredFidelityGateTests
         "AnonShorthand",
         "AnonNamed",
         "AnonSingle",
+        "NullCoalescingAssignStaticField",
+        "NullCoalescingAssignInstanceField",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -20,9 +20,50 @@ public class NullCoalescingAssignmentPassTests
         var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignLocal));
 
         var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
-        Assert.Equal("string", assignment.LocalType.ToDisplayString());
+        var local = Assert.IsType<LoadLocal>(assignment.Target);
+        Assert.Equal("string", local.Type.ToDisplayString());
         Assert.IsType<LoadArgument>(assignment.Value);
         Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+    }
+
+    [Fact]
+    public void StaticFieldNullAssignmentDiamond_RaisesToNullCoalescingAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticField));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        var field = Assert.IsType<LoadField>(assignment.Target);
+        Assert.Equal("s_cachedName", field.Field.Name);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("s_cachedName ??= fallback;", output);
+    }
+
+    [Fact]
+    public void InstanceFieldNullAssignmentDiamond_RaisesToNullCoalescingAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignInstanceField));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.IsType<LoadField>(assignment.Target);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("_cachedText ??= fallback;", output);
+    }
+
+    [Fact]
+    public void StaticPropertyNullAssignmentDiamond_RaisesToNullCoalescingAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticProperty));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.IsType<LoadProperty>(assignment.Target);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("StaticName ??= fallback;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -323,7 +323,7 @@ public sealed partial class CSharpPrinter
                 case LoadLocal l: locals.Add(l.Index); break;
                 case StoreLocal s: locals.Add(s.Index); break;
                 case LoadLocalAddress a: locals.Add(a.Index); break;
-                case NullCoalescingAssignment n: locals.Add(n.LocalIndex); break;
+                case NullCoalescingAssignment { Target: LoadLocal l }: locals.Add(l.Index); break;
                 case ForeachStatement f: locals.Add(f.LocalIndex); break;
                 case DeconstructionAssignment d: foreach (int index in d.LocalIndices) locals.Add(index); break;
                 // A slot's declared type is the type it is loaded AS — the merged
@@ -432,7 +432,7 @@ public sealed partial class CSharpPrinter
                     break;
                 case LoadLocal load: seenLocals.Add(load.Index); break;
                 case LoadLocalAddress address: seenLocals.Add(address.Index); break;
-                case NullCoalescingAssignment assignment: seenLocals.Add(assignment.LocalIndex); break;
+                case NullCoalescingAssignment { Target: LoadLocal l }: seenLocals.Add(l.Index); break;
                 case StoreStackSlot slotStore when !seenSlots.Contains(slotStore.Slot):
                     seenSlots.Add(slotStore.Slot);
                     if (entryStatements.Contains(slotStore) && slotStore.Value.ResultType is not null
@@ -856,7 +856,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => $"{TypeText(d.LocalTypes[i])} {LocalName(index)}"))}) = {Expression(d.Source)};",
-        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
+        NullCoalescingAssignment n => $"{Expression(n.Target)} ??= {CastValue(n.Value, n.Target.ResultType)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -234,9 +234,10 @@ static class DefiniteAssignment
                             running.Add(store.Index);
                             break;
                         case NullCoalescingAssignment assignment:
-                            CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), running);
+                            CheckReads(assignment.Target, running);
                             CheckReads(assignment.Value, running);
-                            running.Add(assignment.LocalIndex);
+                            if (assignment.Target is LoadLocal ncaLocal)
+                                running.Add(ncaLocal.Index);
                             break;
                         case DeconstructionAssignment deconstruction:
                             CheckReads(deconstruction.Source, running);
@@ -276,9 +277,10 @@ static class DefiniteAssignment
                     assigned.Add(store.Index);
                     return DefiniteFlow.FallThrough;
                 case NullCoalescingAssignment assignment:
-                    CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), assigned);
+                    CheckReads(assignment.Target, assigned);
                     CheckReads(assignment.Value, assigned);
-                    assigned.Add(assignment.LocalIndex);
+                    if (assignment.Target is LoadLocal ncaLocal)
+                        assigned.Add(ncaLocal.Index);
                     return DefiniteFlow.FallThrough;
                 case DeconstructionAssignment deconstruction:
                     CheckReads(deconstruction.Source, assigned);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -653,25 +653,23 @@ public sealed class Coalesce : IrExpression
 }
 
 /// <summary>
-/// A raised local-variable null-coalescing assignment (<c>V ??= fallback</c>).
-/// Produced from csc's local null-test diamond:
-/// <c>if (V is null) V = fallback;</c>.
+/// A raised null-coalescing assignment (<c>target ??= fallback</c>). Produced from
+/// csc's null-test diamond <c>if (target is null) target = fallback;</c>. The target
+/// is the assignable place — a <see cref="LoadLocal"/>, <see cref="LoadField"/>, or
+/// <see cref="LoadProperty"/> — re-spelled as the left-hand side of <c>??=</c>.
 /// </summary>
 public sealed class NullCoalescingAssignment : IrNode
 {
-    public NullCoalescingAssignment(int localIndex, TypeRef localType, IrExpression value)
+    public NullCoalescingAssignment(IrExpression target, IrExpression value)
     {
-        LocalIndex = localIndex;
-        LocalType = localType;
+        AddChild(target);
         AddChild(value);
     }
 
-    public int LocalIndex { get; }
-    public TypeRef LocalType { get; }
-    public IrExpression Value => (IrExpression)Children[0];
-    public override IEnumerable<TypeRef> DirectTypes => [LocalType];
+    public IrExpression Target => (IrExpression)Children[0];
+    public IrExpression Value => (IrExpression)Children[1];
 
-    public override string Describe() => $"NullCoalescingAssignment V_{LocalIndex}";
+    public override string Describe() => $"NullCoalescingAssignment {Target.Describe()}";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -87,7 +87,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration => default!;
     [Completeness(CompletenessLevel.Full)] public static LockSugarPass LockStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative MultipleLocalDeclarations => default!;
-    [Completeness(CompletenessLevel.Partial, "local-variable ??= only; fields/properties/indexers not raised")]
+    [Completeness(CompletenessLevel.Partial, "locals, fields, and static properties (single-store diamond); indexers and temp-spilled instance-property ??= not raised")]
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -1,13 +1,17 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the local-variable form of csc's null-coalescing assignment lowering:
+/// Raises csc's null-coalescing assignment lowering:
 /// <code>
-/// if (V is null) { V = fallback; }
+/// if (target is null) { target = fallback; }
 /// </code>
-/// into <c>V ??= fallback</c>. Scoped to locals; field/property/indexer
-/// <c>??=</c> shapes carry receiver-evaluation and setter concerns left to later
-/// slices.
+/// into <c>target ??= fallback</c>. Handles the local-variable, field, and
+/// static-property forms whose then-branch is a single direct store. The tested
+/// place and the assigned place must be the same re-evaluable location — the
+/// receiver is compared structurally so the collapsed form re-loads it exactly
+/// as the if-form did, keeping IL identical. Indexers and the temp-spilled
+/// instance-auto-property shape (where csc lifts the value through a stack slot)
+/// are left to a later slice.
 /// </summary>
 public sealed class NullCoalescingAssignmentPass : IIrPass
 {
@@ -20,36 +24,70 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             if (TryMatch(statement) is not { } match)
                 continue;
 
-            var value = (IrExpression)match.Store.DetachChildren()[0];
-            var replacement = new NullCoalescingAssignment(match.Local.Index, match.Local.Type, value);
-            context.Stepper.StepOver("raise local null check assignment to ??=", statement);
+            match.Target.Detach();
+            match.Value.Detach();
+            var replacement = new NullCoalescingAssignment(match.Target, match.Value);
+            context.Stepper.StepOver("raise null check assignment to ??=", statement);
             statement.ReplaceWith(replacement);
         }
     }
 
-    sealed record Match(LoadLocal Local, StoreLocal Store);
+    sealed record Match(IrExpression Target, IrExpression Value);
 
     static Match? TryMatch(IfStatement statement)
     {
         if (statement.HasElse
-            || statement.Then.Children is not [StoreLocal store]
-            || NullTestedLocal(statement.Condition) is not { } local
-            || store.Index != local.Index)
+            || statement.Then.Children is not [IrNode store]
+            || NullTestedTarget(statement.Condition) is not { } target)
         {
             return null;
         }
 
-        if (TypeFamilies.Of(local.Type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+        if (TypeFamilies.Of(target.ResultType) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
             return null;
 
-        return new Match(local, store);
+        return StoredValue(target, store) is { } value ? new Match(target, value) : null;
     }
 
-    static LoadLocal? NullTestedLocal(IrExpression condition) => condition switch
+    static IrExpression? NullTestedTarget(IrExpression condition) => condition switch
     {
-        LogicalNot { Operand: LoadLocal local } => local,
-        Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal local, Right: Constant { Value: null } } => local,
-        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: LoadLocal local } => local,
+        LogicalNot { Operand: { } operand } when IsAssignablePlace(operand) => operand,
+        Comparison { Kind: ComparisonKind.Equal, Left: { } left, Right: Constant { Value: null } } when IsAssignablePlace(left) => left,
+        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: { } right } when IsAssignablePlace(right) => right,
         _ => null,
+    };
+
+    static bool IsAssignablePlace(IrExpression expression) => expression switch
+    {
+        LoadLocal => true,
+        LoadField => true,
+        LoadProperty { IndexArguments.Count: 0 } => true,
+        _ => false,
+    };
+
+    static IrExpression? StoredValue(IrExpression target, IrNode store) => (target, store) switch
+    {
+        (LoadLocal local, StoreLocal s) when s.Index == local.Index => s.Value,
+        (LoadField field, StoreField s)
+            when s.Field.Name == field.Field.Name
+                && Equals(s.Field.DeclaringType, field.Field.DeclaringType)
+                && SameReceiver(s.Instance, field.Instance) => s.Value,
+        (LoadProperty property, StoreProperty s)
+            when s.IndexArguments.Count == 0
+                && s.PropertyName == property.PropertyName
+                && Equals(s.Accessor.DeclaringType, property.Accessor.DeclaringType)
+                && SameReceiver(s.HasInstance ? s.Instance : null, property.HasInstance ? property.Instance : null) => s.Value,
+        _ => null,
+    };
+
+    static bool SameReceiver(IrExpression? left, IrExpression? right) => (left, right) switch
+    {
+        (null, null) => true,
+        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
+        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
+        (LoadField a, LoadField b) => a.Field.Name == b.Field.Name
+            && Equals(a.Field.DeclaringType, b.Field.DeclaringType)
+            && SameReceiver(a.Instance, b.Instance),
+        _ => false,
     };
 }


### PR DESCRIPTION
## Summary

Generalizes `NullCoalescingAssignmentPass` beyond local variables. csc's
null-test diamond

```csharp
if (target is null) { target = fallback; }
```

now raises to `target ??= fallback` for **fields** and **static
auto-properties** as well as locals, whenever the then-branch is a single
direct store to the same re-evaluable place.

## Modeling change

The `NullCoalescingAssignment` IR node previously held a local index +
type. It now holds a **Target expression** (`LoadLocal` / `LoadField` /
`LoadProperty`) plus the value, so the printer and definite-assignment
analysis spell the left-hand side through the target rather than a
hardcoded local slot. The local-form rendering is unchanged.

## Soundness

The tested place and the assigned place must match structurally —
including their receivers — so the collapsed `??=` re-loads the receiver
exactly as the if-form did and the recompiled IL stays identical.

Out of scope (left to a later slice):
- Indexers (properties with index arguments).
- The temp-spilled **instance** auto-property shape, where csc lifts the
  `??=` value through a stack slot — a 3-statement then-branch the
  single-store matcher correctly declines.

## Tests

- `NullCoalescingAssignStaticField` and `NullCoalescingAssignInstanceField`
  pinned **opcode-exact** in both the sugared and lowered fidelity gates.
- `NullCoalescingAssignStaticProperty` verified via a direct pass unit
  test (the fidelity scaffold cannot spell `static` properties, so the
  static-property form is exercised through `IrPasses.Run` + printer
  rather than the recompile gate).
- Scorecard rows added; `LoweringCoverage` note updated.
- 458 decompiler + 1157 product tests green.
