### PR TITLE
Use exact CreateSpan identity for RVA spans

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -7,7 +7,9 @@ public class MemberIdentityTests
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
     static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
+    static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
 
     [Fact]
     public void IsCoreLibraryType_RequiresCoreLibraryIdentity()
@@ -86,6 +88,40 @@ public class MemberIdentityTests
             [new LoadArgument(0, "x", s_int)])));
     }
 
+    [Fact]
+    public void IsRuntimeHelpersCreateSpan_RequiresExactBclStaticSignature()
+    {
+        Assert.True(MemberIdentity.IsRuntimeHelpersCreateSpan(CreateSpan(TypeRef.CoreLib(
+            "System.Runtime.CompilerServices",
+            "RuntimeHelpers"))));
+
+        Assert.False(MemberIdentity.IsRuntimeHelpersCreateSpan(CreateSpan(TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.CompilerServices",
+            "RuntimeHelpers"))));
+
+        Assert.False(MemberIdentity.IsRuntimeHelpersCreateSpan(new Call(
+            CreateSpanMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")) with
+            {
+                ParameterTypes = [s_object],
+            },
+            isVirtual: false,
+            [new LoadArgument(0, "field", s_runtimeFieldHandle)])));
+
+        Assert.False(MemberIdentity.IsRuntimeHelpersCreateSpan(new Call(
+            CreateSpanMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")) with
+            {
+                ReturnType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [s_int]),
+            },
+            isVirtual: false,
+            [new LoadArgument(0, "field", s_runtimeFieldHandle)])));
+
+        Assert.False(MemberIdentity.IsRuntimeHelpersCreateSpan(new Call(
+            CreateSpanMethod(TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers")),
+            isVirtual: false,
+            [])));
+    }
+
     static MethodRef GetSubArrayMethod(TypeRef declaringType)
         => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
 
@@ -100,4 +136,16 @@ public class MemberIdentityTests
 
     static Call Await(TypeRef declaringType)
         => new(AwaitMethod(declaringType), isVirtual: false, [new LoadArgument(0, "x", s_int)]);
+
+    static MethodRef CreateSpanMethod(TypeRef declaringType)
+        => new(declaringType, "CreateSpan", s_readOnlySpanInt, [s_runtimeFieldHandle], HasThis: false)
+        {
+            TypeArguments = [s_int],
+        };
+
+    static Call CreateSpan(TypeRef declaringType)
+        => new(
+            CreateSpanMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "field", s_runtimeFieldHandle)]);
 }

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -1,0 +1,46 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class RvaSpanPassTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
+    static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
+
+    [Fact]
+    public void CreateSpan_FromUserRuntimeHelpersLookalike_IsNotRaised()
+    {
+        var function = BuildCreateSpanLookalike();
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "CreateSpan");
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildCreateSpanLookalike()
+    {
+        var createSpan = new MethodRef(
+            TypeRef.Definition("UserAssembly", "System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "CreateSpan",
+            s_readOnlySpanInt,
+            [s_runtimeFieldHandle],
+            HasThis: false)
+        {
+            TypeArguments = [s_int],
+        };
+        var token = new LoadToken(RuntimeTokenKind.Field, null, "User.Field")
+        {
+            FieldRvaData = [1, 0, 0, 0],
+        };
+
+        var block = new Block();
+        block.Add(new Return(new Call(createSpan, isVirtual: false, [token])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(s_readOnlySpanInt, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -8,6 +8,7 @@ namespace ILInspector.Decompiler.Pipeline;
 public static class MemberIdentity
 {
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
 
     public static bool IsCoreLibraryType(TypeRef? type, string ns, string name)
         => NamedDefinition(type) is
@@ -53,6 +54,32 @@ public static class MemberIdentity
                 "Await")
             && call.Callee.ParameterTypes.Length == 1
             && call.Arguments.Count == 1;
+
+    public static bool IsRuntimeHelpersCreateSpan(Call call)
+    {
+        if (call.IsVirtual
+            || !IsStaticCoreLibraryMethod(
+                call.Callee,
+                "System.Runtime.CompilerServices",
+                "RuntimeHelpers",
+                "CreateSpan")
+            || call.Arguments.Count != 1
+            || call.Callee.TypeArguments is not [var element]
+            || call.Callee.ParameterTypes is not [var parameter]
+            || !parameter.Equals(s_runtimeFieldHandle))
+        {
+            return false;
+        }
+
+        return call.Callee.ReturnType is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType: { } definition,
+            TypeArguments: [var returnedElement],
+        }
+        && IsCoreLibraryType(definition, "System", "ReadOnlySpan`1")
+        && returnedElement.Equals(element);
+    }
 
     static TypeRef? NamedDefinition(TypeRef? type)
         => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -45,7 +45,7 @@ internal static class NativePasses
     public static RedundantBranchEliminationPass RedundantBranchElimination => new();
     [Native(NativeCategory.EmitArtifact, "identity conversions dropped (ldlen; conv.i4 array-length idiom)")]
     public static IdentityConvertPass IdentityConvert => new();
-    [Native(NativeCategory.EmitArtifact, "constant-data RVA blob (RuntimeHelpers.CreateSpan) back to a span literal")]
+    [Native(NativeCategory.EmitArtifact, "constant-data RVA blob (exact BCL RuntimeHelpers.CreateSpan) back to a span literal")]
     public static RvaSpanPass RvaSpan => new();
     [Native(NativeCategory.EmitArtifact, "the lazy <>9__ delegate cache (non-capturing lambda / static method group) collapsed to a bare delegate creation")]
     public static LambdaCachePass LambdaCache => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -8,7 +8,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// context. A constant array/span initializer like
 /// <c>static ReadOnlySpan&lt;uint&gt; Powers => new uint[] { 1, 10, 100, ... };</c>
 /// is lowered by Roslyn to a <c>&lt;PrivateImplementationDetails&gt;</c> field whose
-/// RVA maps the raw little-endian element bytes, loaded through
+/// RVA maps the raw little-endian element bytes, loaded through the exact BCL
 /// <c>RuntimeHelpers.CreateSpan&lt;T&gt;(ldtoken field)</c>. Left as-is that renders
 /// as <c>RuntimeHelpers.CreateSpan&lt;uint&gt;(/* LoadToken Field ... */)</c> — the
 /// unspellable <c>ldtoken</c> of a compiler-internal field name with angle brackets,
@@ -29,7 +29,7 @@ public sealed class RvaSpanPass : IIrPass
     {
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
-            if (call.Callee is not { Name: "CreateSpan", DeclaringType.Namespace: "System.Runtime.CompilerServices", DeclaringType.Name: "RuntimeHelpers" })
+            if (!MemberIdentity.IsRuntimeHelpersCreateSpan(call))
                 continue;
             if (call.Arguments is not [LoadToken { Kind: RuntimeTokenKind.Field, FieldRvaData: { } data }])
                 continue;


### PR DESCRIPTION
## Summary
- add `MemberIdentity.IsRuntimeHelpersCreateSpan`
- migrate `RvaSpanPass` from namespace/name matching to the shared exact BCL helper predicate
- add helper tests and a synthetic `RuntimeHelpers.CreateSpan` lookalike that must not raise
- update the native-pass note to call out exact BCL identity

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.RvaSpanPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method ILInspector.Decompiler.Tests.IrImporterTests.ConstantSpan_RaisesToArrayLiteral
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal