### PR TITLE
Use shared Monitor identity for lock sugar

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -8,6 +8,8 @@ public class MemberIdentityTests
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
     static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
     static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
 
@@ -122,6 +124,37 @@ public class MemberIdentityTests
             [])));
     }
 
+    [Fact]
+    public void IsMonitorEnterExit_RequireExactBclStaticSignature()
+    {
+        var monitor = TypeRef.CoreLib("System.Threading", "Monitor");
+        Assert.True(MemberIdentity.IsMonitorEnter(MonitorEnter(monitor)));
+        Assert.True(MemberIdentity.IsMonitorExit(MonitorExit(monitor)));
+        Assert.True(MemberIdentity.IsMonitorEnter(MonitorEnter(TypeRef.Definition(
+            "System.Threading",
+            "System.Threading",
+            "Monitor"))));
+
+        var userMonitor = TypeRef.Definition("UserAssembly", "System.Threading", "Monitor");
+        Assert.False(MemberIdentity.IsMonitorEnter(MonitorEnter(userMonitor)));
+        Assert.False(MemberIdentity.IsMonitorExit(MonitorExit(userMonitor)));
+
+        Assert.False(MemberIdentity.IsMonitorEnter(new Call(
+            MonitorEnterMethod(monitor) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadArgument(0, "obj", s_object), new LoadArgumentAddress(1, "taken", TypeRef.CoreLib("System", "Boolean"))])));
+
+        Assert.False(MemberIdentity.IsMonitorEnter(new Call(
+            MonitorEnterMethod(monitor) with { ParameterTypes = [s_object, TypeRef.CoreLib("System", "Boolean")] },
+            isVirtual: false,
+            [new LoadArgument(0, "obj", s_object), new LoadArgumentAddress(1, "taken", TypeRef.CoreLib("System", "Boolean"))])));
+
+        Assert.False(MemberIdentity.IsMonitorExit(new Call(
+            MonitorExitMethod(monitor),
+            isVirtual: true,
+            [new LoadArgument(0, "obj", s_object)])));
+    }
+
     static MethodRef GetSubArrayMethod(TypeRef declaringType)
         => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
 
@@ -148,4 +181,19 @@ public class MemberIdentityTests
             CreateSpanMethod(declaringType),
             isVirtual: false,
             [new LoadArgument(0, "field", s_runtimeFieldHandle)]);
+
+    static MethodRef MonitorEnterMethod(TypeRef declaringType)
+        => new(declaringType, "Enter", s_void, [s_object, s_refBool], HasThis: false);
+
+    static Call MonitorEnter(TypeRef declaringType)
+        => new(
+            MonitorEnterMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "obj", s_object), new LoadArgumentAddress(1, "taken", TypeRef.CoreLib("System", "Boolean"))]);
+
+    static MethodRef MonitorExitMethod(TypeRef declaringType)
+        => new(declaringType, "Exit", s_void, [s_object], HasThis: false);
+
+    static Call MonitorExit(TypeRef declaringType)
+        => new(MonitorExitMethod(declaringType), isVirtual: false, [new LoadArgument(0, "obj", s_object)]);
 }

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -7,8 +7,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class MemberIdentity
 {
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
 
     public static bool IsCoreLibraryType(TypeRef? type, string ns, string name)
         => NamedDefinition(type) is
@@ -25,6 +28,19 @@ public static class MemberIdentity
         => !method.HasThis
             && method.Name == methodName
             && IsCoreLibraryType(method.DeclaringType, typeNamespace, typeName);
+
+    public static bool IsMonitorEnter(Call call)
+        => IsMonitorMethod(call, "Enter")
+            && call.Arguments.Count == 2
+            && call.Callee.ParameterTypes is [var obj, var taken]
+            && obj.Equals(s_object)
+            && taken.Equals(s_refBool);
+
+    public static bool IsMonitorExit(Call call)
+        => IsMonitorMethod(call, "Exit")
+            && call.Arguments.Count == 1
+            && call.Callee.ParameterTypes is [var obj]
+            && obj.Equals(s_object);
 
     public static bool IsRuntimeHelpersGetSubArray(Call call)
     {
@@ -83,4 +99,29 @@ public static class MemberIdentity
 
     static TypeRef? NamedDefinition(TypeRef? type)
         => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
+
+    static bool IsMonitorMethod(Call call, string methodName)
+        => !call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: false,
+                Name: var name,
+                ReturnType: var returnType,
+                TypeArguments.IsEmpty: true,
+            }
+            && name == methodName
+            && returnType.Equals(s_void)
+            && IsCoreLibraryOrFacadeType(call.Callee.DeclaringType, "System.Threading", "Monitor", "System.Threading");
+
+    static bool IsCoreLibraryOrFacadeType(TypeRef? type, string ns, string name, string facadeAssembly)
+        => NamedDefinition(type) is
+        {
+            Kind: TypeRefKind.Definition,
+            Assembly: var assembly,
+            Namespace: var typeNamespace,
+            Name: var typeName,
+        }
+        && (assembly == TypeRef.CoreLibrary || assembly == facadeAssembly)
+        && typeNamespace == ns
+        && typeName == name;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -90,7 +90,7 @@ public sealed class LockSugarPass : IIrPass
         if (tryFinally.TryBody.Blocks is not [{ Children: [var firstStatement, ..] }, ..])
             return null;
         if (firstStatement is not ExpressionStatement { Expression: Call enter }
-            || !IsMonitorEnter(enter)
+            || !MemberIdentity.IsMonitorEnter(enter)
             || enter.Arguments is not [LoadLocal enterObject, LoadLocalAddress enterTaken]
             || enterObject.Index != storeObject.Index
             || enterTaken.Index != storeTaken.Index)
@@ -105,7 +105,7 @@ public sealed class LockSugarPass : IIrPass
             || guard.Condition is not LoadLocal { } takenLoad
             || takenLoad.Index != storeTaken.Index
             || guard.Then.Children is not [ExpressionStatement { Expression: Call exit }]
-            || !IsMonitorExit(exit)
+            || !MemberIdentity.IsMonitorExit(exit)
             || exit.Arguments is not [LoadLocal exitObject]
             || exitObject.Index != storeObject.Index)
         {
@@ -114,42 +114,6 @@ public sealed class LockSugarPass : IIrPass
 
         return new Match(storeObject, storeTaken, tryFinally, (ExpressionStatement)firstStatement, storeObject.Value);
     }
-
-    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
-    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
-    static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
-
-    /// <summary>The exact static <c>void Monitor.Enter(object, ref bool)</c>.</summary>
-    static bool IsMonitorEnter(Call call)
-        => IsMonitorCall(call, "Enter")
-            && call.Callee.ParameterTypes is [var obj, var taken]
-            && obj.Equals(s_object)
-            && taken.Equals(s_refBool);
-
-    /// <summary>The exact static <c>void Monitor.Exit(object)</c>.</summary>
-    static bool IsMonitorExit(Call call)
-        => IsMonitorCall(call, "Exit")
-            && call.Callee.ParameterTypes is [var obj]
-            && obj.Equals(s_object);
-
-    /// <summary>
-    /// The real <c>System.Threading.Monitor</c> only — matched on assembly
-    /// identity (not just namespace/name), a static <c>void</c> non-generic
-    /// shape, and the exact name, so neither a same-named type in a user
-    /// assembly nor a malformed same-named member is sugared into a C#
-    /// <c>lock</c>. Monitor lives in corelib (the canonical facade set) but is
-    /// referenced through the <c>System.Threading</c> contract — the scope a
-    /// caller actually binds — so both assemblies are accepted; the parameter
-    /// shapes are checked by the callers.
-    /// </summary>
-    static bool IsMonitorCall(Call call, string method)
-        => !call.IsVirtual
-            && call.Callee.Name == method
-            && !call.Callee.HasThis
-            && call.Callee.TypeArguments.IsEmpty
-            && call.Callee.ReturnType.Equals(s_void)
-            && call.Callee.DeclaringType is
-                { Namespace: "System.Threading", Name: "Monitor", Assembly: TypeRef.CoreLibrary or "System.Threading" };
 
     /// <summary>True when every reference to <paramref name="index"/> in the function sits inside one of the allowed subtrees.</summary>
     static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)


### PR DESCRIPTION
## Summary
- add `MemberIdentity.IsMonitorEnter/Exit`
- migrate `LockSugarPass` from local Monitor identity checks to shared predicates
- keep existing lock soundness coverage for non-BCL `System.Threading.Monitor` lookalikes and malformed signatures

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.LockSugarTests -class ILInspector.Decompiler.Tests.LockSugarSoundnessTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal