### PR TITLE
Reconstruct linear iterator yield sequences

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1624,6 +1624,33 @@ public class CfgSampleClass
     {
         return source;
     }
+
+    // Three linear constant yields — exercises a longer state chain (0 -> 1 -> 2 ->
+    // terminal) and distinct constant values.
+    public static System.Collections.Generic.IEnumerable<int> YieldThree()
+    {
+        yield return 10;
+        yield return 20;
+        yield return 30;
+    }
+
+    // String-element iterator: the yielded constants are reference-type literals,
+    // and the <>2__current field type is string (not int) — confirms the
+    // reconstruction is element-type agnostic.
+    public static System.Collections.Generic.IEnumerable<string> YieldStrings()
+    {
+        yield return "a";
+        yield return "b";
+    }
+
+    // IEnumerator<T>-returning iterator (not IEnumerable<T>): the kickoff creates
+    // the state machine with initial state 0 directly, but the linear MoveNext
+    // dispatch is identical, so reconstruction still applies.
+    public static System.Collections.Generic.IEnumerator<int> YieldEnumerator()
+    {
+        yield return 7;
+        yield return 8;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -1,0 +1,108 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IteratorReconstructionPassTests
+{
+    // Reconstruction needs the cross-method seam (to import the state machine's
+    // MoveNext); IrPasses.Run(function) uses PassContext.None and would leave the
+    // kickoff for the acknowledgment fallback instead.
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        var context = new PassContext(new Stepper(enabled: false),
+            importMethodBody: method => IrImporter.Import(source, method));
+        IrPasses.Run(function!, IrPasses.Default, context);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void LinearConstantIterator_ReconstructsYieldSequence()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldTwo));
+
+        var yields = function.Descendants.OfType<YieldReturn>().ToList();
+        Assert.Equal(2, yields.Count);
+        Assert.Equal(1, Assert.IsType<Constant>(yields[0].Value).Value);
+        Assert.Equal(2, Assert.IsType<Constant>(yields[1].Value).Value);
+
+        // The misleading state-machine handoff and acknowledgment marker are gone.
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+    }
+
+    [Fact]
+    public void ReconstructedIterator_RendersYieldReturns()
+    {
+        var output = Print(nameof(CfgSampleClass.YieldTwo));
+
+        Assert.Contains("yield return 1;", output);
+        Assert.Contains("yield return 2;", output);
+        Assert.DoesNotContain("not reconstructed", output);
+    }
+
+    [Fact]
+    public void ReconstructedIterator_IsFullFidelity()
+    {
+        Assert.Equal(DecompilationFidelity.Full, Raised(nameof(CfgSampleClass.YieldTwo)).Fidelity);
+    }
+
+    [Fact]
+    public void ParameterizedLoopIterator_FallsBackToAcknowledgment()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldRange));
+
+        // The captured-param + loop shape is outside the linear-constant slice, so
+        // reconstruction declines and the honest marker stands.
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+    }
+
+    [Fact]
+    public void NonIterator_IsUnaffected()
+    {
+        var function = Raised(nameof(CfgSampleClass.NotAnIterator));
+
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Contains("source", Print(nameof(CfgSampleClass.NotAnIterator)));
+    }
+
+    [Fact]
+    public void ThreeYieldChain_ReconstructsAllElements()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldThree));
+
+        var values = function.Descendants.OfType<YieldReturn>()
+            .Select(y => Assert.IsType<Constant>(y.Value).Value).ToList();
+        Assert.Equal(new object?[] { 10, 20, 30 }, values);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void StringElementIterator_ReconstructsReferenceLiterals()
+    {
+        var output = Print(nameof(CfgSampleClass.YieldStrings));
+
+        Assert.Contains("yield return \"a\";", output);
+        Assert.Contains("yield return \"b\";", output);
+    }
+
+    [Fact]
+    public void EnumeratorReturningIterator_IsAlsoReconstructed()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldEnumerator));
+
+        var values = function.Descendants.OfType<YieldReturn>()
+            .Select(y => Assert.IsType<Constant>(y.Value).Value).ToList();
+        Assert.Equal(new object?[] { 7, 8 }, values);
+        Assert.Empty(function.Descendants.OfType<UnsupportedNode>());
+    }
+}

--- a/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
+++ b/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
@@ -45,10 +45,17 @@ public static class MixedSourceRenderer
         // still visible here), then raise in place to get the C# text and the
         // statement-to-line map. Spans are computed on the now-raised tree.
         var annotations = AnnotationEngine.Default.ClassifyImported(imported);
-        var csResult = CSharpPrinter.PrintRaised(imported, out var statementLines);
+        var csResult = CSharpPrinter.PrintRaised(imported, out var statementLines,
+            importMethodBody: ImportMethodBody);
         if (csResult.Output is not { } csText)
             return "";
         var spans = AnnotationAnchor.ComputeSpans(imported);
+
+        // The cross-method import seam: passes that recover an idiom spanning a
+        // compiler-synthesized companion method (a lambda's <>c method, an
+        // iterator's MoveNext state machine) re-import that body from the same
+        // source. Null on stage dumps / direct pass tests; live here.
+        IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
 
         // C# trailing fact comments, keyed by output line.
         var commentByLine = new Dictionary<int, string>();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -899,6 +899,8 @@ public sealed partial class CSharpPrinter
         InitObject o => $"{Deref(o.Address)} = default({TypeText(o.Type)});",
         Return { Value: { } value } => $"return {CastValue(value, _function.Signature.ReturnType)};",
         Return => "return;",
+        YieldReturn y => $"yield return {Expression(y.Value)};",
+        YieldBreak => "yield break;",
         // The rethrow: the raw caught value thrown back is C#'s bare throw.
         Throw { Value: CaughtException } => "throw;",
         Throw t => $"throw {Expression(t.Value)};",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1416,6 +1416,28 @@ public sealed class Return : IrNode
 }
 
 /// <summary>
+/// <c>yield return value;</c> — one element produced by a C# iterator. Raised by
+/// <see cref="IteratorReconstructionPass"/> from a state machine's MoveNext
+/// (the <c>&lt;&gt;2__current = value</c> store plus the state advance), it has no
+/// IL of its own (the kickoff method only constructs the state machine), so it is
+/// a reconstructed-source node, not an importer-native one.
+/// </summary>
+public sealed class YieldReturn : IrNode
+{
+    public YieldReturn(IrExpression value) => AddChild(value);
+
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override string Describe() => "YieldReturn";
+}
+
+/// <summary><c>yield break;</c> — the iterator terminates with no further elements.</summary>
+public sealed class YieldBreak : IrNode
+{
+    public override string Describe() => "YieldBreak";
+}
+
+/// <summary>
 /// A synthetic variable carrying an evaluation-stack value across a block
 /// boundary (ternaries, short-circuit values) or materializing a dup.
 /// Edge slots are position-indexed so every predecessor of a join stores to

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -192,6 +192,11 @@ public static class IrPasses
         // (it feeds a calli, native callback, or delegate*-typed field — all of
         // which take a function pointer directly).
         new MethodAddressPass(),
+        // Reconstruct a compiler-generated iterator kickoff's `yield return`
+        // sequence by importing and raising its MoveNext state machine. Runs
+        // before the acknowledgment pass: reconstruction raises when it can; the
+        // acknowledgment is the honest fallback for shapes it declines.
+        new IteratorReconstructionPass(),
         // Recognize a compiler-generated iterator kickoff and replace its
         // misleading `return new <X>d__N(-2);` handoff with an honest marker
         // (the yield body in MoveNext is not yet reconstructed). Runs late with

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -50,39 +50,11 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
         stateMachine = "";
         sourceOffset = -1;
 
-        // MoveNext/GetEnumerator live on the <X>d__ type and also construct/return
-        // the state machine; the kickoff lives on the user's type.
-        if (IsStateMachineType(function.DeclaringType))
-            return false;
-        if (!ReturnsEnumerable(function.Signature.ReturnType))
+        if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return false;
 
-        var handoff = function.Descendants.OfType<NewObject>()
-            .FirstOrDefault(n => IsStateMachineType(n.Constructor.DeclaringType));
-        if (handoff is null)
-            return false;
-
-        stateMachine = MetadataName(handoff.Constructor.DeclaringType);
+        stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
         sourceOffset = handoff.SourceOffset;
         return true;
     }
-
-    static bool IsStateMachineType(TypeRef type)
-        => MetadataName(type).Contains(">d__", StringComparison.Ordinal);
-
-    static bool ReturnsEnumerable(TypeRef type)
-    {
-        var ns = Namespace(type);
-        if (ns is not ("System.Collections" or "System.Collections.Generic"))
-            return false;
-        var name = MetadataName(type);
-        return name.StartsWith("IEnumerable", StringComparison.Ordinal)
-            || name.StartsWith("IEnumerator", StringComparison.Ordinal);
-    }
-
-    static string MetadataName(TypeRef type)
-        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
-
-    static string Namespace(TypeRef type)
-        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Namespace ?? "" : type.Namespace;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a compiler-generated iterator kickoff back to its <c>yield return</c>
+/// sequence — the inverse of the C# compiler's iterator lowering. The kickoff
+/// (a method returning <c>IEnumerable</c>/<c>IEnumerator</c> that hands off to a
+/// <c>new &lt;Method&gt;d__N(...)</c> state machine) carries no yield logic of its
+/// own; the <c>yield</c> body lives in the state machine's <c>MoveNext</c>. This
+/// pass imports that <c>MoveNext</c> through the pass context's cross-method seam,
+/// recognizes the lowered state dispatch, and reconstructs the original
+/// <c>yield return</c> statements.
+///
+/// <para>Current slice — <b>linear, self-contained</b> iterators: the dispatch
+/// must be a single <c>switch (this.&lt;&gt;1__state)</c> whose case sections form
+/// a straight chain (state 0 yields and advances to 1, state 1 to 2, …, ending in
+/// a terminal <c>return false</c> section) with no back-edges (no loops), and each
+/// yielded expression must be self-contained — referencing no hoisted field,
+/// argument, or local of the state machine (constants and constant expressions).
+/// Parameterized, captured, or looping iterators do not match and fall through to
+/// <see cref="IteratorAcknowledgmentPass"/>, which keeps the gap honest. A no-op
+/// when the seam is absent (stage dumps, the lowered/annotated views).</para>
+/// </summary>
+public sealed class IteratorReconstructionPass : IIrPass
+{
+    public string Name => "iterator-reconstruction";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (context.ImportMethodBody is null)
+            return;
+        if (!IteratorShapes.TryGetKickoff(function, out var handoff))
+            return;
+
+        var moveNext = context.ImportMethodBody(handoff.Constructor with { Name = "MoveNext" });
+        if (moveNext is null)
+            return;
+
+        // Raise the MoveNext body with the same pipeline so its state dispatch
+        // lands at the altitude this pass recognizes.
+        IrPasses.Run(moveNext, IrPasses.Default, context);
+
+        if (!TryReconstruct(moveNext, out var yields))
+            return;  // leave for IteratorAcknowledgmentPass
+
+        var stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
+        context.Stepper.StepOver($"reconstruct iterator '{stateMachine}' as {yields.Count} yield(s)", handoff);
+
+        function.Body.DetachChildren();
+        var block = new Block(0);
+        foreach (var yield in yields)
+            block.Add(yield);
+        function.Body.Add(block);
+    }
+
+    static bool TryReconstruct(IrFunction moveNext, out List<YieldReturn> yields)
+    {
+        yields = [];
+
+        if (moveNext.Body.Blocks is not [{ Children: [Switch dispatch] }])
+            return false;
+        if (dispatch.Value is not LoadField { Instance: LoadArgument { Index: 0 }, Field.Name: "<>1__state" })
+            return false;
+
+        var sections = new Dictionary<int, List<IrNode>>();
+        foreach (var section in dispatch.Sections)
+        {
+            if (section.IsDefault)
+                continue;
+            if (section.Labels is not [Constant { Value: int label }])
+                return false;
+            sections[label] = Flatten(section);
+        }
+
+        var state = 0;
+        var visited = new HashSet<int>();
+        while (true)
+        {
+            if (!visited.Add(state))
+                return false;  // a back-edge: not a linear chain
+            if (!sections.TryGetValue(state, out var statements))
+                return false;
+
+            switch (Classify(statements, out var value, out var nextState, out var offset))
+            {
+                case StateKind.Yield:
+                    if (!IsSelfContained(value))
+                        return false;
+                    var yield = new YieldReturn((IrExpression)value.Clone());
+                    if (offset >= 0)
+                        yield.SetSourceOffset(offset);
+                    yields.Add(yield);
+                    state = nextState;
+                    continue;
+                case StateKind.Terminal:
+                    return yields.Count > 0;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    static List<IrNode> Flatten(SwitchSection section)
+    {
+        var statements = new List<IrNode>();
+        foreach (var block in section.Body.Blocks)
+            foreach (var statement in block.Children)
+                if (statement is not Branch)
+                    statements.Add(statement);
+        return statements;
+    }
+
+    enum StateKind { Unrecognized, Yield, Terminal }
+
+    static StateKind Classify(List<IrNode> statements, out IrExpression value, out int nextState, out int offset)
+    {
+        value = null!;
+        nextState = -1;
+        offset = -1;
+
+        // The lowered state body ends in `return true` (a yield point) or
+        // `return false` (the iterator terminates).
+        if (statements.Count == 0 || statements[^1] is not Return { Value: Constant { Value: bool returns } })
+            return StateKind.Unrecognized;
+
+        StoreField? current = null;
+        var advance = int.MinValue;
+        for (var i = 0; i < statements.Count - 1; i++)
+        {
+            // A yield/terminal state only stores the `<>2__current` value and the
+            // next `<>1__state`; anything else (locals, loop counters, captured
+            // fields) is outside this slice.
+            if (statements[i] is not StoreField { Instance: LoadArgument { Index: 0 } } store)
+                return StateKind.Unrecognized;
+
+            switch (store.Field.Name)
+            {
+                case "<>2__current":
+                    if (current is not null)
+                        return StateKind.Unrecognized;
+                    current = store;
+                    break;
+                case "<>1__state":
+                    if (store.Value is not Constant { Value: int stateValue })
+                        return StateKind.Unrecognized;
+                    if (stateValue != -1)
+                        advance = stateValue;  // the running guard store is -1; the advance is the next state
+                    break;
+                default:
+                    return StateKind.Unrecognized;
+            }
+        }
+
+        if (returns)
+        {
+            if (current is null || advance == int.MinValue)
+                return StateKind.Unrecognized;
+            value = current.Value;
+            nextState = advance;
+            offset = current.SourceOffset;
+            return StateKind.Yield;
+        }
+
+        return current is null ? StateKind.Terminal : StateKind.Unrecognized;
+    }
+
+    static bool IsSelfContained(IrExpression expression)
+        => !expression.Descendants.Prepend(expression)
+            .Any(node => node is LoadField or LoadArgument or LoadLocal or LoadStackSlot);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
@@ -1,0 +1,50 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Shared shape recognition for compiler-generated iterator state machines, used
+/// by <see cref="IteratorReconstructionPass"/> (raise the yields) and
+/// <see cref="IteratorAcknowledgmentPass"/> (honest fallback when reconstruction
+/// declines). A kickoff is a method returning <c>IEnumerable</c>/<c>IEnumerator</c>
+/// (<c>System.Collections[.Generic]</c>) on the user's own type whose body
+/// constructs a <c>&lt;Method&gt;d__N</c> state machine; the state machine's own
+/// <c>MoveNext</c>/<c>GetEnumerator</c> also construct/return a <c>&lt;X&gt;d__</c>,
+/// so the declaring-type guard excludes them.
+/// </summary>
+internal static class IteratorShapes
+{
+    public static bool TryGetKickoff(IrFunction function, out NewObject handoff)
+    {
+        handoff = null!;
+        if (IsStateMachineType(function.DeclaringType))
+            return false;
+        if (!ReturnsEnumerable(function.Signature.ReturnType))
+            return false;
+
+        var creation = function.Descendants.OfType<NewObject>()
+            .FirstOrDefault(n => IsStateMachineType(n.Constructor.DeclaringType));
+        if (creation is null)
+            return false;
+
+        handoff = creation;
+        return true;
+    }
+
+    public static bool IsStateMachineType(TypeRef type)
+        => MetadataName(type).Contains(">d__", StringComparison.Ordinal);
+
+    public static string MetadataName(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
+
+    static string Namespace(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Namespace ?? "" : type.Namespace;
+
+    static bool ReturnsEnumerable(TypeRef type)
+    {
+        var ns = Namespace(type);
+        if (ns is not ("System.Collections" or "System.Collections.Generic"))
+            return false;
+        var name = MetadataName(type);
+        return name.StartsWith("IEnumerable", StringComparison.Ordinal)
+            || name.StartsWith("IEnumerator", StringComparison.Ordinal);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -117,7 +117,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass WhileStatement => new();
-    [Completeness(CompletenessLevel.None, "yield return — iterator state machine; kickoff acknowledged honestly (IteratorAcknowledgmentPass, Partial), MoveNext yield body not reconstructed")] public static Unhandled Yield => default!;
+    [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences reconstructed (IteratorReconstructionPass), parameterized/captured/looping iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();
 }
 
 /// <summary>How much of a lowered construct comes back as the idiom.</summary>


### PR DESCRIPTION
Raises a compiler-generated iterator kickoff back to its `yield return` sequence — the inverse of the C# compiler's iterator lowering, and the reconstruction follow-up to #761 (which acknowledged the kickoff honestly without recovering the yields).

## What

`IteratorReconstructionPass` imports the state machine's `MoveNext` through the pass context's cross-method seam, raises it with the same pipeline, recognizes the lowered state dispatch, and reconstructs the original `yield return` statements.

`YieldTwo()` now decompiles to `yield return 1; yield return 2;` at Full fidelity, where #761 showed an honest `/* ... iterator state machine; yield body not reconstructed */` marker.

## Scope — linear, self-contained iterators

Recognized shape: a single `switch (this.<>1__state)` whose case sections form a straight chain (state 0 yields and advances to 1, 1 to 2, …, ending in a terminal `return false` section), no back-edges (no loops), and each yielded expression references no hoisted field / argument / local of the state machine (constants and constant expressions).

Parameterized, captured, or looping iterators (e.g. `YieldRange(int n)`) do not match and fall back to `IteratorAcknowledgmentPass` — reconstruction raises when it can; the acknowledgment is the honest fallback.

## Changes

- New `YieldReturn`/`YieldBreak` IR nodes + printer cases (valid C# -> Full fidelity, not in the Partial-capping predicate).
- `IteratorReconstructionPass` registered before `IteratorAcknowledgmentPass`; both no-op when the cross-method seam is absent (stage dumps, direct pass tests).
- Shared kickoff detection lifted into `IteratorShapes` (used by both passes).
- `LoweringCoverage.Yield` flipped None -> Partial with a gap note.
- `MixedSourceRenderer` threads the cross-method import seam so the member `Decompiled Source` view fires reconstruction (and lambda raising — a latent gap) too.
- Fixtures: `YieldThree`, `YieldStrings`, `YieldEnumerator`; `IteratorReconstructionPassTests` (8) plus existing fallback/negative coverage.

## Verification

- Decompiler suite 477 green (incl. compile-back / annotate-check / corpus-sweep gates).
- Product suite 1157 green (9 skip).
- End-to-end product CLI (`member -S "Decompiled Source"`) confirmed: reconstructed yields render, with `alloc.statemachine` + kickoff IL honestly surfaced in the mixed view.

## Follow-ups

Looping/parameterized/captured iterators (the `YieldRange` shape), `yield break` recovery, generic and nested-in-struct iterators.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
