### PR TITLE
Raise existing-local tuple deconstruction, not just declarations

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -986,6 +986,17 @@ public class CfgSampleClass
         return sum + product;
     }
 
+    public static int DeconstructIntoExistingLocals((int Sum, int Product) pair, bool flag)
+    {
+        int sum = 10;
+        int product = 20;
+        if (flag)
+        {
+            (sum, product) = pair;
+        }
+        return sum + product;
+    }
+
     public static object AnonShorthand(int a, string b) => new { a, b };
 
     public static object AnonNamed(int x, string y) => new { Id = x, Name = y };

--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -22,8 +22,31 @@ public class DeconstructionAssignmentPassTests
 
         var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
         Assert.Equal(2, deconstruction.LocalIndices.Length);
+        Assert.True(deconstruction.IsDeclaration);
         Assert.IsType<LoadArgument>(deconstruction.Source);
         Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), f => f.Field.Name is "Item1" or "Item2");
+    }
+
+    [Fact]
+    public void ExistingLocalStores_RaiseToDeconstructionAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.DeconstructIntoExistingLocals));
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Equal(2, deconstruction.LocalIndices.Length);
+        Assert.False(deconstruction.IsDeclaration);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), f => f.Field.Name is "Item1" or "Item2");
+    }
+
+    [Fact]
+    public void PrintRaised_RendersDeconstructionAssignment_WithoutTypes()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.DeconstructIntoExistingLocals))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("(sum, product) = pair;", output);
+        Assert.DoesNotContain("(int sum, int product) = pair;", output);
+        Assert.DoesNotContain(".Item", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -43,6 +43,7 @@ public class IdiomShapeScorecardTests
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.NthFromEnd), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructTuplePair), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),
+        new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructIntoExistingLocals), SyntaxKind.TupleExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         // Remaining owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
         new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -219,8 +219,9 @@ public sealed partial class CSharpPrinter
         foreach (var pattern in function.Descendants.OfType<IsPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
         foreach (var deconstruction in function.Descendants.OfType<DeconstructionAssignment>())
-            foreach (int index in deconstruction.LocalIndices)
-                _deconstructionLocals.Add(index);
+            if (deconstruction.IsDeclaration)
+                foreach (int index in deconstruction.LocalIndices)
+                    _deconstructionLocals.Add(index);
         CollectDeclaringStores(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
@@ -855,7 +856,7 @@ public sealed partial class CSharpPrinter
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
-        DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => $"{TypeText(d.LocalTypes[i])} {LocalName(index)}"))}) = {Expression(d.Source)};",
+        DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclaration ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1170,25 +1170,38 @@ public sealed class TupleExpression : IrExpression
 }
 
 /// <summary>
-/// A raised local tuple deconstruction declaration, produced by
+/// A raised tuple deconstruction, produced by
 /// <see cref="DeconstructionAssignmentPass"/> from the compiler's
 /// <c>ValueTuple</c> receiver spill followed by sequential <c>ItemN</c> stores.
+/// <see cref="IsDeclaration"/> distinguishes a deconstruction <em>declaration</em>
+/// (<c>(T1 a, T2 b) = tuple;</c>, the targets are fresh locals declared here)
+/// from a deconstruction <em>assignment</em> into pre-existing locals
+/// (<c>(a, b) = tuple;</c>, the targets are declared elsewhere).
 /// </summary>
 public sealed class DeconstructionAssignment : IrNode
 {
-    public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source)
+    public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source, bool isDeclaration = true)
     {
         LocalIndices = localIndices;
         LocalTypes = localTypes;
+        IsDeclaration = isDeclaration;
         AddChild(source);
     }
 
     public ImmutableArray<int> LocalIndices { get; }
     public ImmutableArray<TypeRef> LocalTypes { get; }
+
+    /// <summary>
+    /// True when the targets are fresh locals introduced by this deconstruction
+    /// (rendered with their declared types); false when assigning into existing
+    /// locals (rendered as bare names).
+    /// </summary>
+    public bool IsDeclaration { get; }
+
     public IrExpression Source => (IrExpression)Children[0];
     public override IEnumerable<TypeRef> DirectTypes => LocalTypes;
 
-    public override string Describe() => $"DeconstructionAssignment ({LocalIndices.Length} locals)";
+    public override string Describe() => $"DeconstructionAssignment ({LocalIndices.Length} locals, {(IsDeclaration ? "declaration" : "assignment")})";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -3,15 +3,18 @@ using System.Collections.Immutable;
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the narrow tuple deconstruction-declaration lowering:
+/// Raises the narrow tuple deconstruction lowering:
 /// <code>
 /// S = tuple;
 /// T1 a = S.Item1;
 /// T2 b = S.Item2;
 /// </code>
-/// into <c>(T1 a, T2 b) = tuple;</c>. Scoped to local declarations from direct
-/// <c>System.ValueTuple</c> fields, arities 2-7. Existing-local assignments,
-/// nested/rest tuples, and user-defined <c>Deconstruct</c> calls are later slices.
+/// into <c>(T1 a, T2 b) = tuple;</c> when the targets are fresh locals declared
+/// here, or <c>(a, b) = tuple;</c> when they assign into pre-existing locals.
+/// Scoped to direct <c>System.ValueTuple</c> fields, arities 2-7, with every
+/// target uniformly a declaration or uniformly an existing local (no mixed
+/// deconstruction). Nested/rest tuples and user-defined <c>Deconstruct</c> calls
+/// are later slices.
 /// </summary>
 public sealed class DeconstructionAssignmentPass : IIrPass
 {
@@ -54,16 +57,31 @@ public sealed class DeconstructionAssignmentPass : IIrPass
                 }
 
                 if (stores.Count != arity
-                    || !ReferencedOnlyWithin(function, seed.Slot, stores)
-                    || stores.Any(store => !IsFirstLocalReference(function, store)))
+                    || !ReferencedOnlyWithin(function, seed.Slot, stores))
                 {
                     continue;
+                }
+
+                // Every target must be uniformly a fresh local (declaration) or
+                // uniformly a pre-existing local (assignment): C# has no spelling
+                // for the lowering that mixes the two here. Existing-local
+                // assignment additionally requires distinct targets — `(a, a) =`
+                // is not a valid deconstruction.
+                int firstRefCount = stores.Count(store => IsFirstLocalReference(function, store));
+                bool isDeclaration = firstRefCount == arity;
+                if (!isDeclaration)
+                {
+                    if (firstRefCount != 0
+                        || stores.Select(store => store.Index).Distinct().Count() != arity)
+                    {
+                        continue;
+                    }
                 }
 
                 var source = (IrExpression)seed.DetachChildren()[0];
                 var localIndices = stores.Select(store => store.Index).ToImmutableArray();
                 var localTypes = stores.Select(store => store.Type).ToImmutableArray();
-                var deconstruction = new DeconstructionAssignment(localIndices, localTypes, source);
+                var deconstruction = new DeconstructionAssignment(localIndices, localTypes, source, isDeclaration);
                 context.Stepper.StepOver("raise ValueTuple field stores to deconstruction", seed);
                 seed.ReplaceWith(deconstruction);
                 foreach (var store in stores)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -61,7 +61,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass ContinueStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion => default!;
-    [Completeness(CompletenessLevel.Partial, "local ValueTuple deconstruction declaration arities 2-7 only; existing-local assignment and Deconstruct methods not raised")]
+    [Completeness(CompletenessLevel.Partial, "local ValueTuple deconstruction, arities 2-7, as both a fresh-local declaration and an existing-local assignment; mixed declaration/assignment and Deconstruct methods not raised")]
     public static DeconstructionAssignmentPass DeconstructionAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static DelegateConstructionPass DelegateCreationExpression => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static DoWhileLoopPass DoStatement => new();


### PR DESCRIPTION
## Summary

Extends `DeconstructionAssignmentPass` to raise tuple deconstruction **into pre-existing locals** (`(a, b) = tuple;`), not only fresh-local declarations (`(T1 a, T2 b) = tuple;`).

Previously any non-first-reference target bailed the whole match, leaving the de-sugared form:

```csharp
S = tuple;
a = S.Item1;
b = S.Item2;
```

## Approach

Classify the matched store run instead of rejecting it:

- every target a fresh local → **declaration** (unchanged behavior)
- no target a fresh local → **existing-local assignment** (new)
- mixed, or non-distinct existing targets (`(a, a) =`) → bail (no faithful single C# spelling)

A new `DeconstructionAssignment.IsDeclaration` flag drives the printer: declarations keep their per-target types and own the local declarations; the assignment form renders bare names and leaves the targets' own declarations in place.

## Soundness

csc lowers `(a, b) = src` and `(T a, T b) = src` to the **same** receiver-spill + `ItemN` store sequence, so the raised assignment re-lowers to the exact IL it came from — the faithfulness already accepted for the declaration form. The source is detached and evaluated first, matching C#'s left-to-right deconstruction evaluation.

## Measurements

- Idiom recovery: `--pass-impact deconstruction-assignment` 70 → 77 methods (+7 existing-local sites, e.g. `Half::op_Explicit`, `Matrix3x2.Impl::CreateRotation`), 0 pass bugs.
- Corpus fidelity unchanged: 40984/41012 Full.
- Compile-check unchanged: 995 Full malformed — a pure sugar transformation.
- Decompiler tests 470 → 473 (+3: existing-local raise, render, scorecard).

Ledger note on `LoweringCoverage.DeconstructionAssignmentOperator` updated accordingly.
