### PR TITLE
Extract shared PlaceIdentity re-evaluable-place substrate

### DIFF
--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -127,4 +127,5 @@ How the checks (`--fidelity-check`, `--validity-check`, `--annotation-check`), t
 - Name passes after what they raise, in the neighbors' vocabulary (`LockSugarPass`, `SwitchRaisingPass`, `StructuringPass`) — an engineer who knows the Roslyn lowering or ILSpy transform of the same name should find the inverse here.
 - One pass, one job, one file under `Pipeline/Passes/`, registered in `IrPasses.Default`. The ordered list *is* the architecture document.
 - Passes communicate through the tree (typed nodes via `ReplaceWith`), never side-channel state. A pass-local dictionary is acceptable; a field that outlives the pass is not.
+- Shared *facts* a pass needs (BCL member identity, compiler-generated shape, re-evaluable place identity) live in thin substrate layers under `Pipeline/` (`MemberIdentity`, `GeneratedCodeIdentity`, `PlaceIdentity`), exposed as composable atoms — see [design/decompiler-substrate.md](design/decompiler-substrate.md) for the pattern and when to promote a third copy into a layer.
 - Every pass change ships with the corpus diff in the PR description, per the taste-doc checklist.

--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -1,0 +1,126 @@
+# Decompiler Substrate Layers
+
+How shared *facts* are factored out from the raising passes, and how we notice
+when several passes have independently grown the same need. This is a design
+note about a recurring shape, not a tour of every helper. See
+[decompiler.md](../decompiler.md) for the IR pipeline the passes run over,
+[decompiler-quality.md](../decompiler-quality.md) for the correctness oracle the
+passes are held to, and [hidden-fact-annotations.md](hidden-fact-annotations.md)
+for the read-only fact layer modelled on the same instinct.
+
+## The shape
+
+A raising pass turns an IL idiom back into its C# spelling. To do that safely it
+must keep asking the same small questions: *is this the BCL member I think it
+is?* *is this type compiler-generated?* *are these two expressions the same
+re-evaluable place?* Each question is a **fact** about the IR — structural,
+side-effect-free, answerable without rewriting anything.
+
+When a fact is answered inline inside one pass, the next pass that needs it
+copies the code. The copies drift: one matches a member on namespace and name,
+another on assembly identity and exact signature; one admits a local read where
+another must not. Drift in a fact check is a soundness bug waiting to happen,
+because the whole point of the check is to gate a rewrite.
+
+The fix is a **substrate layer**: a thin `public static class` in
+`Pipeline/` that owns one fact category, exposed as small composable atoms the
+passes call. Three exist today:
+
+| Layer | Fact category | Example question |
+| --- | --- | --- |
+| `MemberIdentity` | Exact BCL member / type identity | Is this `RuntimeHelpers.GetSubArray`? |
+| `GeneratedCodeIdentity` | Compiler-generated shape (attribute-gated) | Is this a non-capturing lambda holder? |
+| `PlaceIdentity` | Intra-method re-evaluable place identity | Are these two reads the same local? |
+
+They are siblings by construction — thin, allocation-light, no pass state, named
+for the fact not the caller — but each owns a different category of evidence:
+metadata identity, compiler-shape evidence, and intra-method place identity.
+
+## Atoms, not one maximal predicate
+
+The load-bearing design choice is that a substrate layer exposes **atoms the
+caller composes**, never a single "does everything" predicate. The equality
+logic is shared; *which node kinds a pass admits* is not — that admissibility is
+a deliberate soundness discriminator the pass still owns.
+
+`PlaceIdentity` is the clearest illustration. Five passes — `??=`, `?.`, switch
+dispatch, boolean folding, and `^n` from-end — all need "same re-evaluable
+place", and several had byte-identical `Same*` helpers. But they do **not** all
+admit the same nodes:
+
+- Most fold a bare variable read (`SameVariable` — local, argument, or `this`).
+- Boolean folding also accepts a spilled stack slot (`SameVariable ||
+  SameStackSlot`).
+- `IndexFromEndPass` accepts **only** a stack slot (`SameStackSlot`). Broadening
+  it to a direct local read would rewrite a faithful `a[a.Length - n]` into
+  `a[^n]`, whose recompiled IL differs — an opcode-exactness break. The
+  stack-slot restriction is what proves the compiler actually spilled the
+  receiver, i.e. that the source really was `^n`.
+
+A single maximal `SamePlace(a, b)` predicate would have silently handed
+`IndexFromEndPass` the broadening that breaks it. Exposing `SameVariable` and
+`SameStackSlot` as separate atoms keeps the equality honest in one place while
+each pass keeps its discriminator explicit at the call site. The same principle
+governs `MemberIdentity`: it offers `IsCoreLibraryType`,
+`IsStaticCoreLibraryMethod`, and named member checks, not one fuzzy "is this the
+method I mean".
+
+The testing dividend is concrete: adversarial lookalikes (a property getter or a
+method call is *not* a place; a same-named method on a different assembly is
+*not* the member) live once as unit tests on the substrate atom. Consuming
+passes then need only an integration fixture per idiom, not a re-derivation of
+the full adversarial matrix.
+
+## Noticing convergence
+
+The hard part is not building a layer — it is noticing that three discrete
+implementations should have been one. Two mechanisms, one proactive and one
+reactive:
+
+### Proactive — the ledger names its facts
+
+`LoweringCoverage` is the compiled completeness ledger: one row per Roslyn
+`LocalRewriter` lowering, recording the mechanism (which pass) and completeness.
+It already makes the *dedicated-vs-shared* gradient derivable — a pass type used
+by one row is dedicated, by several is shared. The substrate extension is to let
+a row also name the **fact primitives** its pass depends on. When three or more
+rows cite the same primitive, that is the signal to promote it to a substrate
+layer before the fourth copy is written — the ledger turns "we keep needing this"
+from tribal memory into a queryable fact. (This annotation is described here as
+the strategy; it is added incrementally as rows are touched, not retrofitted in
+one sweep.)
+
+### Reactive — a duplication census
+
+The cheaper guard is a census test that flags un-migrated copies: a
+`static bool Same*(…)` / `static bool Is*(…)` fact helper living inside a pass
+rather than in a substrate layer is a smell the test can surface. It does not
+forbid a pass-local helper — sometimes a fact genuinely belongs to one pass —
+but it forces the question into review: *is this the third copy of a fact that
+should be shared?* The answer is recorded, not assumed.
+
+Both mechanisms encode the same rule of thumb: **the third occurrence builds the
+layer.** One use is local; two is a coincidence; three is a category. Building
+the layer earlier risks a speculative atom with no second consumer (a real cost —
+an atom with one caller is just a renamed helper), and the discipline is to add
+only atoms that already have two or more behavior-preserving consumers.
+
+## Adding or extending a layer
+
+A change that touches this substrate states, in its PR:
+
+1. **The fact category and its evidence.** Metadata identity, compiler shape,
+   intra-method place — which existing layer, or why a new sibling.
+2. **The atoms, and why they are atoms.** What each admits, and the
+   discriminator each leaves to the caller. If a proposed atom would let any
+   current caller broaden unsafely, it is the wrong shape.
+3. **At least two real consumers per atom.** No speculative primitives; an atom
+   with a single caller is a pass-local helper wearing a substrate coat.
+4. **Behavior preservation for migrations.** Each migrated call site reproduces
+   its old predicate exactly (the composition, not just the name), verified by
+   the unchanged fidelity gates plus the existing pass fixtures.
+
+Adversarial coverage lives on the atom; the consuming pass keeps its integration
+fixture. The full decompiler suite plus the product build remain the backstop —
+because the substrate exists to make the passes *safer*, the passes' own gates
+are what prove a migration changed nothing.

--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -100,10 +100,17 @@ but it forces the question into review: *is this the third copy of a fact that
 should be shared?* The answer is recorded, not assumed.
 
 Both mechanisms encode the same rule of thumb: **the third occurrence builds the
-layer.** One use is local; two is a coincidence; three is a category. Building
-the layer earlier risks a speculative atom with no second consumer (a real cost —
-an atom with one caller is just a renamed helper), and the discipline is to add
-only atoms that already have two or more behavior-preserving consumers.
+layer.** One use is local; two is a coincidence; three is a category.
+
+The "two or more consumers" bar applies to a *composable atom* like
+`SameVariable` — there, an atom with a single caller is just a renamed helper,
+and building it early risks a speculative shape with no second consumer (a real
+cost). It does **not** apply rigidly to a *named member predicate* like
+`MemberIdentity.IsRuntimeHelpersGetSubArray`: the shared thing there is the
+*category* (exact BCL-member identity, matched on assembly + signature, never
+namespace/name), and a one-consumer member check still belongs in the layer so
+it cannot drift back to fuzzy matching. So: shared *category* admits a
+single-consumer named predicate; a shared *atom* wants two.
 
 ## Adding or extending a layer
 
@@ -114,8 +121,11 @@ A change that touches this substrate states, in its PR:
 2. **The atoms, and why they are atoms.** What each admits, and the
    discriminator each leaves to the caller. If a proposed atom would let any
    current caller broaden unsafely, it is the wrong shape.
-3. **At least two real consumers per atom.** No speculative primitives; an atom
-   with a single caller is a pass-local helper wearing a substrate coat.
+3. **The right granularity.** A composable *atom* (`SameVariable`) needs two or
+   more behavior-preserving consumers — no speculative primitives. A named
+   *member predicate* for a shared category (`IsRuntimeHelpersGetSubArray`) may
+   have one consumer: it belongs in the layer so it cannot drift back to fuzzy
+   matching, even if only one pass needs it today.
 4. **Behavior preservation for migrations.** Each migrated call site reproduces
    its old predicate exactly (the composition, not just the name), verified by
    the unchanged fidelity gates plus the existing pass fixtures.

--- a/src/ILInspector.Decompiler.Tests/PlaceIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PlaceIdentityTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class PlaceIdentityTests
+{
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Obj = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Str = TypeRef.CoreLib("System", "String");
+
+    [Fact]
+    public void SameVariable_MatchesSameLocalAndArgument()
+    {
+        Assert.True(PlaceIdentity.SameVariable(new LoadLocal(2, Int), new LoadLocal(2, Int)));
+        Assert.True(PlaceIdentity.SameVariable(new LoadArgument(0, "this", Obj), new LoadArgument(0, "this", Obj)));
+    }
+
+    [Fact]
+    public void SameVariable_RejectsDifferentSlotKindOrIndex()
+    {
+        Assert.False(PlaceIdentity.SameVariable(new LoadLocal(1, Int), new LoadLocal(2, Int)));
+        Assert.False(PlaceIdentity.SameVariable(new LoadArgument(0, "a", Int), new LoadArgument(1, "b", Int)));
+        // A local and an argument at the same index are different places.
+        Assert.False(PlaceIdentity.SameVariable(new LoadLocal(0, Int), new LoadArgument(0, "a", Int)));
+        // A stack slot is not a variable.
+        Assert.False(PlaceIdentity.SameVariable(new LoadStackSlot(0, Int), new LoadStackSlot(0, Int)));
+        Assert.False(PlaceIdentity.SameVariable(null, null));
+    }
+
+    [Fact]
+    public void SameStackSlot_MatchesOnlyMatchingSlots()
+    {
+        Assert.True(PlaceIdentity.SameStackSlot(new LoadStackSlot(256, Int), new LoadStackSlot(256, Int)));
+        Assert.False(PlaceIdentity.SameStackSlot(new LoadStackSlot(256, Int), new LoadStackSlot(257, Int)));
+        // A re-loaded variable is not the spilled slot — the discriminator that
+        // separates a genuine compiler spill from hand-written source.
+        Assert.False(PlaceIdentity.SameStackSlot(new LoadLocal(0, Int), new LoadLocal(0, Int)));
+        Assert.False(PlaceIdentity.SameStackSlot(null, null));
+    }
+
+    [Fact]
+    public void NeitherAtom_TreatsAPropertyGetterOrCallAsAPlace()
+    {
+        // A property getter / method call has side effects and is not a
+        // re-evaluable place — both atoms must reject it even against itself.
+        var getter = new MethodRef(Obj, "get_Value", Str, ImmutableArray<TypeRef>.Empty, HasThis: true);
+        var property = new LoadProperty(getter, new LoadArgument(0, "this", Obj), []);
+        var property2 = new LoadProperty(getter, new LoadArgument(0, "this", Obj), []);
+
+        Assert.False(PlaceIdentity.SameVariable(property, property2));
+        Assert.False(PlaceIdentity.SameStackSlot(property, property2));
+
+        var call = new Call(getter, isVirtual: false, [new LoadArgument(0, "this", Obj)]);
+        var call2 = new Call(getter, isVirtual: false, [new LoadArgument(0, "this", Obj)]);
+        Assert.False(PlaceIdentity.SameVariable(call, call2));
+        Assert.False(PlaceIdentity.SameStackSlot(call, call2));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -364,9 +364,9 @@ public sealed class BooleanFoldingPass : IIrPass
         bool match = (previous, inner) switch
         {
             (StoreStackSlot p, StoreStackSlot i) when p.Slot == i.Slot
-                => SameLoad(tested, p.Value),
+                => SameNullTestedLoad(tested, p.Value),
             (StoreLocal p, StoreLocal i) when p.Index == i.Index
-                => SameLoad(tested, p.Value),
+                => SameNullTestedLoad(tested, p.Value),
             _ => false,
         };
         if (!match)
@@ -389,13 +389,11 @@ public sealed class BooleanFoldingPass : IIrPass
         return true;
     }
 
-    static bool SameLoad(IrExpression tested, IrExpression stored) => (tested, stored) switch
-    {
-        (LoadStackSlot a, LoadStackSlot b) => a.Slot == b.Slot,
-        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
-        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
-        _ => false,
-    };
+    // The ?? coalesce reads the tested place once for the brfalse and once as the
+    // store value; folding is sound for a re-evaluable place — a variable or the
+    // spilled stack slot csc emits for the value.
+    static bool SameNullTestedLoad(IrExpression tested, IrExpression stored)
+        => PlaceIdentity.SameVariable(tested, stored) || PlaceIdentity.SameStackSlot(tested, stored);
 
     /// <summary>if (c) { S = A } else { S = B } → S = c ? A : B;</summary>
     static bool FoldSlotDiamond(IrFunction function, IfStatement diamond, Stepper stepper)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
@@ -45,7 +45,7 @@ public sealed class IndexFromEndPass : IIrPass
         if (index is not Binary { Kind: BinaryKind.Subtract } subtract
             || (subtract.Right is Constant { Value: int offset } && offset < 0)
             || LengthReceiver(subtract.Left) is not { } lengthReceiver
-            || !SamePlace(receiver, lengthReceiver))
+            || !PlaceIdentity.SameStackSlot(receiver, lengthReceiver))
         {
             return false;
         }
@@ -69,10 +69,7 @@ public sealed class IndexFromEndPass : IIrPass
     // point in the pipeline a genuine `^n` always presents as two reads of the
     // same stack slot. Hand-written `a[a.Length - n]` re-loads the receiver
     // directly (two ldarg/ldloc, no spill); matching those would rewrite faithful
-    // source into `^n` whose recompile produces a different opcode stream.
-    static bool SamePlace(IrExpression left, IrExpression right) => (left, right) switch
-    {
-        (LoadStackSlot a, LoadStackSlot b) => a.Slot == b.Slot,
-        _ => false,
-    };
+    // source into `^n` whose recompile produces a different opcode stream. That
+    // narrowing — stack-slot only, never a variable — is the discriminator this
+    // pass keeps; PlaceIdentity.SameStackSlot supplies the equality.
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -87,14 +87,9 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
     // The receiver is loaded once for the null test and once for the store; the
     // fold is only sound when re-evaluating it is free of side effects and yields
     // the same value — i.e. a static field (no receiver) or a plain
-    // local/argument/this variable read.
-    static bool SameReceiver(IrExpression? a, IrExpression? b) => (a, b) switch
-    {
-        (null, null) => true,
-        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
-        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
-        _ => false,
-    };
+    // local/argument/this variable read (PlaceIdentity.SameVariable).
+    static bool SameReceiver(IrExpression? a, IrExpression? b)
+        => (a is null && b is null) || PlaceIdentity.SameVariable(a, b);
 
     static IrExpression? NullTested(IrExpression condition) => condition switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -92,7 +92,7 @@ public sealed class NullConditionalPass : IIrPass
         {
             if (!IsNullConditionalShape(conditional, out var member))
                 continue;
-            if (MemberReceiver(member) is not { } receiver || !SameReevaluableLoad(conditional.Condition, receiver))
+            if (MemberReceiver(member) is not { } receiver || !PlaceIdentity.SameVariable(conditional.Condition, receiver))
                 continue;
 
             member.Detach();
@@ -126,13 +126,5 @@ public sealed class NullConditionalPass : IIrPass
         LoadProperty { HasInstance: true } property => property.Instance,
         LoadField { Instance: not null } field => field.Instance,
         _ => null,
-    };
-
-    /// <summary>True when both nodes load the same argument or local — a pure re-evaluation the <c>?.</c> can fold.</summary>
-    static bool SameReevaluableLoad(IrNode condition, IrNode receiver) => (condition, receiver) switch
-    {
-        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
-        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
-        _ => false,
     };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -120,9 +120,9 @@ public sealed class NullConditionalPass : IIrPass
     }
 
     /// <summary>The receiver child of an instance member access — always its first child.</summary>
-    static IrNode? MemberReceiver(IrExpression member) => member switch
+    static IrExpression? MemberReceiver(IrExpression member) => member switch
     {
-        Call { Callee.HasThis: true } call when call.Children.Count > 0 => call.Children[0],
+        Call { Callee.HasThis: true } call when call.Children.Count > 0 => (IrExpression)call.Children[0],
         LoadProperty { HasInstance: true } property => property.Instance,
         LoadField { Instance: not null } field => field.Instance,
         _ => null,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -764,7 +764,7 @@ public sealed class SwitchRaisingPass : IIrPass
         while (idx < blocks.Count
             && blocks[idx].Children is [ConditionalBranch cb]
             && TryStringEqualityTest(cb.Condition, out var testValue, out var literal)
-            && SameValue(value, testValue))
+            && PlaceIdentity.SameVariable(value, testValue))
         {
             caseLabels.Add(StringConst(literal));
             caseTargetOffsets.Add(cb.TargetOffset);
@@ -838,7 +838,7 @@ public sealed class SwitchRaisingPass : IIrPass
 
             if (term is ConditionalBranch cb
                 && TryIntComparison(cb.Condition, out var testValue, out int constant, out bool isEqual)
-                && SameValue(value, testValue))
+                && PlaceIdentity.SameVariable(value, testValue))
             {
                 if (isEqual)
                 {
@@ -1032,14 +1032,6 @@ public sealed class SwitchRaisingPass : IIrPass
         }
         return false;
     }
-
-    /// <summary>Structural equality for the switch governing value — the simple loads csc emits (a parameter or a temp local).</summary>
-    static bool SameValue(IrExpression a, IrExpression b) => (a, b) switch
-    {
-        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
-        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
-        _ => false,
-    };
 
     /// <summary>Predecessor edges across every block, read from each block's successors.</summary>
     static Dictionary<int, List<int>> ChainPredecessors(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex)

--- a/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
@@ -32,7 +32,7 @@ public static class PlaceIdentity
     /// variable read has no side effect, so evaluating it once instead of twice
     /// reorders nothing.
     /// </summary>
-    public static bool SameVariable(IrNode? left, IrNode? right) => (left, right) switch
+    public static bool SameVariable(IrExpression? left, IrExpression? right) => (left, right) switch
     {
         (LoadArgument a, LoadArgument b) => a.Index == b.Index,
         (LoadLocal a, LoadLocal b) => a.Index == b.Index,
@@ -45,6 +45,6 @@ public static class PlaceIdentity
     /// a re-loaded variable) is what proves the spill happened — the discriminator
     /// that separates a genuine compiler lowering from hand-written source.
     /// </summary>
-    public static bool SameStackSlot(IrNode? left, IrNode? right)
+    public static bool SameStackSlot(IrExpression? left, IrExpression? right)
         => (left, right) is (LoadStackSlot a, LoadStackSlot b) && a.Slot == b.Slot;
 }

--- a/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
@@ -1,0 +1,50 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Thin, SRM-native structural-identity facts over <em>re-evaluable places</em>
+/// in the decompiler IR: "are these two expressions the same side-effect-free
+/// location, so a raise can fold their repeated evaluation into one?"
+///
+/// <para>
+/// Every fold that collapses a load-test/load-store pair — <c>??=</c>, <c>??</c>,
+/// <c>?.</c>, switch dispatch, field <c>??=</c>, <c>^n</c> from-end — needs this
+/// question. Each pass previously hand-rolled a near-identical <c>Same*</c>
+/// switch. The equality logic belongs in one place; what legitimately differs
+/// between passes is <em>which node kinds each admits</em>, and that is a
+/// deliberate soundness discriminator the pass still owns. So this type exposes
+/// the kinds as separate atoms the caller composes, rather than one maximal
+/// predicate that would silently broaden a pass.
+/// </para>
+///
+/// <para>
+/// The canonical example is <c>IndexFromEndPass</c>: it must restrict to a
+/// spilled stack slot (<see cref="SameStackSlot"/>), because broadening to a
+/// direct local/argument read would rewrite a faithful <c>a[a.Length - n]</c>
+/// into <c>a[^n]</c> whose recompiled IL differs. The shared atom keeps the
+/// equality honest; the pass keeps the discriminator.
+/// </para>
+/// </summary>
+public static class PlaceIdentity
+{
+    /// <summary>
+    /// Two reads of the same variable — a local, an argument, or <c>this</c>
+    /// (argument 0). The atomic re-evaluation every fold relies on: a bare
+    /// variable read has no side effect, so evaluating it once instead of twice
+    /// reorders nothing.
+    /// </summary>
+    public static bool SameVariable(IrNode? left, IrNode? right) => (left, right) switch
+    {
+        (LoadArgument a, LoadArgument b) => a.Index == b.Index,
+        (LoadLocal a, LoadLocal b) => a.Index == b.Index,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Two reads of the same stack slot. The compiler spills a once-evaluated
+    /// receiver into a slot and reads it twice; matching on the slot (rather than
+    /// a re-loaded variable) is what proves the spill happened — the discriminator
+    /// that separates a genuine compiler lowering from hand-written source.
+    /// </summary>
+    public static bool SameStackSlot(IrNode? left, IrNode? right)
+        => (left, right) is (LoadStackSlot a, LoadStackSlot b) && a.Slot == b.Slot;
+}


### PR DESCRIPTION
## What

Extract a shared `PlaceIdentity` re-evaluable-place substrate. Five raising
passes — `??=`, `?.`, switch dispatch, boolean folding, and `^n` from-end —
each hand-rolled a near-identical `Same*` helper for "are these two expressions
the same side-effect-free place, so a raise can fold their repeated evaluation
into one?". Several were byte-identical. Drift in a fact check that *gates a
rewrite* is a soundness bug waiting to happen.

This is a sibling slice to the `MemberIdentity` / `GeneratedCodeIdentity`
substrate landed in #757–#759 — same architectural slot (a thin static fact
layer in `Pipeline/`), a different fact category (intra-method place identity
rather than metadata-member identity).

## Design: atoms, not one maximal predicate

`PlaceIdentity` exposes two composable atoms:

- `SameVariable` — local / argument / `this` read
- `SameStackSlot` — spilled receiver slot

The load-bearing choice is that the caller composes atoms rather than calling
one `SamePlace`. *Which node kinds a pass admits is a deliberate soundness
discriminator the pass still owns.* `IndexFromEndPass` is the canonical
counter-example: it must match a stack slot **only**, because broadening to a
direct local read would rewrite faithful `a[a.Length - n]` into `a[^n]` whose
recompiled IL differs (an opcode-exactness break). A single maximal predicate
would have silently handed it the broadening that breaks it.

Behavior-preservation mapping (each migrated call site reproduces its old
predicate exactly):

| Pass | Old helper | New composition |
| --- | --- | --- |
| NullConditional | `SameReevaluableLoad` | `SameVariable` |
| SwitchRaising | `SameValue` | `SameVariable` |
| NullCoalescingAssignment | `SameReceiver` | `(both null) \|\| SameVariable` |
| BooleanFolding | `SameLoad` | `SameVariable \|\| SameStackSlot` |
| IndexFromEnd | `SamePlace` | `SameStackSlot` |

## Strategy doc

`docs/design/decompiler-substrate.md` documents the pattern as implemented
(`MemberIdentity` / `GeneratedCodeIdentity` / `PlaceIdentity`), the
discriminator-admissibility lesson with the IndexFromEnd example, and — per the
SRM-native-substrate vision — a **strategy to notice convergence** so three
discrete copies become one layer before the fourth is written:

- **proactive** — let `LoweringCoverage` rows name the fact primitives they
  depend on; ≥3 citations is the promote signal.
- **reactive** — a duplication census flagging un-migrated pass-local `Same*` /
  `Is*` fact helpers.

Rule of thumb: *the third occurrence builds the layer* — and only atoms with ≥2
behavior-preserving consumers are added (no speculative primitives). Linked from
`decompiler.md`.

## Tests / verification

- New `PlaceIdentityTests`: the atoms plus adversarial lookalikes (a property
  getter / method call is **not** a place; a stack slot is not a variable).
- 473 decompiler tests green (was 458).
- Product build clean.
- Migrations are behavior-preserving, so the unchanged fidelity gates + pass
  fixtures are the backstop; the new tests add primitive-level coverage.
