### PR TITLE
Raise capturing lambdas by substituting the display-class environment

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -48,14 +48,17 @@ public class CfgSampleClass
     // lazy cache and LambdaRaisingPass recovers `x => x + 1`.
     public static System.Func<int, int> NonCapturingLambda() => x => x + 1;
 
+    // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
+    // an instance method on that class. LambdaRaisingPass substitutes the body's
+    // `this.n` read with the captured value and recovers `x => x + n`.
+    public static System.Func<int, int> CapturingLambda(int n) => x => x + n;
+
+    // Two captured parameters, both substituted into the recovered body.
+    public static System.Func<int, int> TwoCaptureLambda(int a, int b) => x => x + a - b;
+
     // Boundary fixtures for the lambda surface: each exercises a distinct
     // LambdaRaisingPass guard. When a later slice lifts a guard, flip its
     // scorecard entry to recovered in that PR.
-
-    // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
-    // an instance method on that class, not the static <>c singleton. Display
-    // class capture substitution is owed.
-    public static System.Func<int, int> CapturingLambda(int n) => x => x + n;
 
     // Statement body: no captures or locals, so LambdaRaisingPass can render the
     // recovered block-bodied lambda in the outer scope.

--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -29,6 +29,20 @@ public class GeneratedCodeIdentityTests
     }
 
     [Fact]
+    public void CapturingLambdaMethod_RequiresGeneratedDisplayClass()
+    {
+        var onDisplayClass = LambdaMethod(declaringTypeIsCompilerGenerated: true) with
+        {
+            DeclaringType = TypeRef.Definition("UserAssembly", "Samples", "Outer+<>c__DisplayClass0_0"),
+        };
+
+        Assert.True(GeneratedCodeIdentity.IsCapturingLambdaMethod(onDisplayClass));
+        // The non-capturing <>c singleton and the capturing display class are distinct forms.
+        Assert.False(GeneratedCodeIdentity.IsCapturingLambdaMethod(LambdaMethod(declaringTypeIsCompilerGenerated: true)));
+        Assert.False(GeneratedCodeIdentity.IsCapturingLambdaMethod(onDisplayClass with { DeclaringTypeIsCompilerGenerated = false }));
+    }
+
+    [Fact]
     public void GeneratedNameHelpers_UseLeafNestedTypeName()
     {
         Assert.True(GeneratedCodeIdentity.IsStaticLambdaClosureHolderName(s_closureHolder));

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -44,10 +44,12 @@ public class IdiomShapeScorecardTests
         new("IndexFromEndPass", nameof(CfgSampleClass.NthFromEnd), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructTuplePair), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
-        // Remaining owed lambda shapes — each declined by a distinct LambdaRaisingPass guard.
-        new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        // Owed: a lambda body that keeps a local of its own (declined by the zero-local guard).
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        // Owed: a capture whose display class is spread across statements (not a folded environment).
+        new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -35,6 +35,23 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
+    public void CapturingExpressionBody_SubstitutesCaptureAndRaisesLambda()
+        => Assert.Equal("return x => x + n;", PrintRaised(nameof(CfgSampleClass.CapturingLambda)));
+
+    [Fact]
+    public void MultipleCaptures_AllSubstitutedIntoRaisedBody()
+        => Assert.Equal("return x => (x + a) - b;", PrintRaised(nameof(CfgSampleClass.TwoCaptureLambda)));
+
+    [Fact]
+    public void LocalBearingBody_IsNotRaised()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.LocalBodyLambda));
+
+        Assert.DoesNotContain("=>", output);
+        Assert.Contains("new Func", output);
+    }
+
+    [Fact]
     public void LambdaNameLookalikeWithoutCompilerGeneratedMetadata_IsNotRaised()
     {
         var lambdaMethod = new MethodRef(

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -12,6 +12,16 @@ public static class GeneratedCodeIdentity
             && IsStaticLambdaClosureHolderName(method.DeclaringType)
             && IsSynthesizedLambdaMethodName(method.Name);
 
+    /// <summary>
+    /// A lambda body method on a <c>&lt;&gt;c__DisplayClass</c> environment — the
+    /// capturing form, where the lambda reads hoisted fields through its instance
+    /// <c>this</c> rather than running on the static <c>&lt;&gt;c</c> singleton.
+    /// </summary>
+    public static bool IsCapturingLambdaMethod(MethodRef method)
+        => method.DeclaringTypeIsCompilerGenerated
+            && IsDisplayClassName(method.DeclaringType)
+            && IsSynthesizedLambdaMethodName(method.Name);
+
     public static bool IsStaticLambdaClosureHolderName(TypeRef type)
         => LeafTypeName(type.Name) == "<>c";
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -13,27 +13,27 @@ namespace ILInspector.Decompiler.Pipeline;
 ///
 /// <para><see cref="DelegateConstructionPass"/> raises a method-group delegate —
 /// but that is a LocalRewriter <c>DelegateCreationExpression</c> (already Full),
-/// not a closure. <see cref="LambdaRaisingPass"/> recovers the first slice of a
-/// real closure: non-capturing, zero-local lambdas whose target method sits on a
-/// compiler-generated <c>&lt;&gt;c</c> holder, after <see cref="LambdaCachePass"/>
-/// strips its lazy cache. Capturing lambdas, local functions, local-bound lambda
-/// bodies, and expression trees are still owed, so they render as synthesized
-/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — a large inferior-form
-/// gap the LocalRewriter register cannot show.</para>
+/// not a closure. <see cref="LambdaRaisingPass"/> recovers zero-local lambdas,
+/// non-capturing (on the <c>&lt;&gt;c</c> holder, after <see cref="LambdaCachePass"/>
+/// strips its lazy cache) and capturing (a folded <c>&lt;&gt;c__DisplayClass</c>
+/// environment whose hoisted fields are substituted back into the body). Local
+/// functions, local-bound lambda bodies, and expression trees are still owed, so
+/// they render as synthesized <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c>
+/// shapes — an inferior-form gap the LocalRewriter register cannot show.</para>
 ///
 /// <para>Synced against dotnet/roslyn
 /// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.Partial, "non-capturing, zero-local expression or simple block bodies on compiler-generated <>c; capturing / local-bound bodies still owed")]
+    [Completeness(CompletenessLevel.Partial, "zero-local expression or simple block bodies, capturing or not; local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]
     public static Unhandled LocalFunction => default!;
 
-    [Completeness(CompletenessLevel.None, "captured locals hoisted into a <>c__DisplayClass environment")]
-    public static Unhandled CapturedClosure => default!;
+    [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from a folded <>c__DisplayClass environment; a display class spread across statements, or captured by a local function, is still owed")]
+    public static LambdaRaisingPass CapturedClosure => new();
 
     [Completeness(CompletenessLevel.None, "Expression<Func<...>> built via Expression.Lambda/Call/... (ExpressionLambdaRewriter)")]
     public static Unhandled ExpressionTreeLambda => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -10,14 +10,22 @@ namespace ILInspector.Decompiler.Pipeline;
 /// synthesized method through the pass context's cross-method seam, re-presents
 /// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
 ///
-/// <para>Current slice — <b>non-capturing, zero-local</b> lambdas: the target
-/// method and its <c>&lt;&gt;c</c> closure-holder type must carry compiler-generated
-/// metadata evidence, and its body must declare no locals, read no captured
-/// <c>this</c>, and be either a single <c>return expr;</c> expression body or a
-/// simple block body ending in a return. Those bodies print correctly inside the
-/// outer function's scope without a local/parameter context of their own
-/// (arguments are self-naming). A capturing lambda or a body with locals is left
-/// as a delegate creation for a later increment. A no-op when the seam is absent
+/// <para>Current slice — <b>zero-local</b> lambdas, capturing or not:</para>
+/// <list type="bullet">
+/// <item><b>Non-capturing</b> — the target runs on the static <c>&lt;&gt;c</c>
+/// singleton and reads no <c>this</c>.</item>
+/// <item><b>Capturing</b> — the delegate target is a folded
+/// <c>new &lt;&gt;c__DisplayClass { f = v, ... }</c> environment; each member binds
+/// a hoisted field to a value captured from the outer scope. The body's
+/// <c>this.f</c> reads are substituted with those captured values, which then
+/// print in the outer scope. Only the inlined single-expression environment is
+/// taken; a display class spread across statements is left for a later
+/// increment.</item>
+/// </list>
+/// <para>In both cases the body must carry compiler-generated metadata evidence,
+/// declare no locals of its own, and be a single <c>return expr;</c> or a simple
+/// block ending in a return — bodies that print correctly inside the outer
+/// function's scope (arguments are self-naming). A no-op when the seam is absent
 /// (stage dumps, the lowered/annotated views).</para>
 /// </summary>
 public sealed class LambdaRaisingPass : IIrPass
@@ -33,33 +41,94 @@ public sealed class LambdaRaisingPass : IIrPass
         {
             if (creation.Parent is null)
                 continue;  // detached by an earlier rewrite in this walk
-            if (!GeneratedCodeIdentity.IsNonCapturingLambdaMethod(creation.Method))
-                continue;
-            if (Raise(creation, context) is not { } lambda)
+            Lambda? lambda =
+                GeneratedCodeIdentity.IsNonCapturingLambdaMethod(creation.Method) ? RaiseNonCapturing(creation, context)
+                : GeneratedCodeIdentity.IsCapturingLambdaMethod(creation.Method) ? RaiseCapturing(creation, context)
+                : null;
+            if (lambda is null)
                 continue;
             context.Stepper.StepOver($"raise lambda {creation.Method.Name}", creation);
             creation.ReplaceWith(lambda);
         }
     }
 
-    static Lambda? Raise(DelegateCreation creation, PassContext context)
+    static Lambda? RaiseNonCapturing(DelegateCreation creation, PassContext context)
+    {
+        var body = RaisedBody(creation, context);
+        if (body is null)
+            return null;
+
+        // A non-capturing body holds no state, so it reads its receiver (arg 0,
+        // the <>c singleton) never; any such read is a shape we cannot present.
+        if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
+            return null;
+
+        return Finish(creation, body);
+    }
+
+    static Lambda? RaiseCapturing(DelegateCreation creation, PassContext context)
+    {
+        // The delegate target is the folded environment: new <>c__DisplayClass
+        // { field = capturedValue, ... }. Anything else (a display class kept in a
+        // local across statements) is out of this slice.
+        if (creation.Target is not ObjectInitializerExpression env
+            || env.IsCollection
+            || !Equals(env.Creation.Constructor.DeclaringType, creation.Method.DeclaringType))
+            return null;
+
+        var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
+        var values = env.Values;
+        for (int i = 0; i < values.Count; i++)
+        {
+            // The compiler hoists variables, not expressions, so a capture value
+            // is a bare parameter/local/this load that re-prints in the outer scope.
+            if (env.Members[i] is not { } field || values[i] is not (LoadArgument or LoadLocal))
+                return null;
+            captures[field] = values[i];
+        }
+
+        var body = RaisedBody(creation, context);
+        if (body is null)
+            return null;
+
+        // Every read of the display-class `this` (arg 0) must be a captured-field
+        // load we can substitute; any other use of `this` we cannot represent.
+        var thisReads = body.Descendants.OfType<LoadArgument>().Where(a => a.Index == 0).ToList();
+        if (!thisReads.All(a => a.Parent is LoadField field
+                && Equals(field.Field.DeclaringType, creation.Method.DeclaringType)
+                && captures.ContainsKey(field.Field.Name)))
+            return null;
+
+        foreach (var load in body.Descendants.OfType<LoadField>().ToList())
+        {
+            if (load.Instance is LoadArgument { Index: 0 }
+                && Equals(load.Field.DeclaringType, creation.Method.DeclaringType)
+                && captures.TryGetValue(load.Field.Name, out var value))
+                load.ReplaceWith(value.Clone());
+        }
+
+        return Finish(creation, body);
+    }
+
+    // Import the synthesized method and raise it with the same pipeline so it
+    // lands at the shipped altitude (and any nested lambda resolves through the
+    // seam). Null when the body is absent.
+    static IrFunction? RaisedBody(DelegateCreation creation, PassContext context)
     {
         var body = context.ImportMethodBody!(creation.Method);
         if (body is null)
             return null;
-
-        // Raise the imported body with the same pipeline so it lands at the
-        // shipped altitude (and any nested lambda resolves through the seam).
         IrPasses.Run(body, IrPasses.Default, context);
+        return body;
+    }
 
-        // Admit only what prints soundly in the outer scope: no locals of its
-        // own, no read of the captured-this slot (arg 0), and a single block the
-        // lambda printer can render without switching local scope.
+    // Shared finisher: admit only a body that prints soundly in the outer scope —
+    // no locals of its own, nothing unsupported, and a single printable block.
+    static Lambda? Finish(DelegateCreation creation, IrFunction body)
+    {
         if (!body.Locals.IsEmpty)
             return null;
         if (body.Descendants.OfType<UnsupportedNode>().Any())
-            return null;
-        if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
             return null;
         if (!IsPrintableBody(body))
             return null;


### PR DESCRIPTION
## What

Recovers a **capturing** lambda — `Func<int,int> Capturing(int n) => x => x + n` now renders `x => x + n` instead of `new Func<int, int>(new <>c__DisplayClass { n = n }.<Capturing>b__0)`. This extends `LambdaRaisingPass` (which already handled non-capturing lambdas) to the capturing form, and is the natural follow-on to the cross-method import seam added with non-capturing lambda raising.

## How

When a lambda captures outer variables, the compiler hoists them into a `<>c__DisplayClass` and the body reads them through its instance `this`. Inlining folds the environment allocation into the delegate target as `new <>c__DisplayClass { f = capturedValue, ... }`, so the capture bindings sit right on the `DelegateCreation`:

```
DelegateCreation Func<int,int> <- <>c__DisplayClass0_0.<Capturing>b__0
  ObjectInitializer <>c__DisplayClass0_0 (1 members)   // Members: ["n"], Values: [LoadArgument n]
```

`RaiseCapturing`:
1. Reads the `field → capturedValue` map off the folded `ObjectInitializer`.
2. Imports the body through the pass-context seam and raises it (the body reads `this.n` as `LoadField { <>c__DisplayClass.n, Instance: arg0 }`).
3. Verifies **every** `this` (arg 0) read is a captured-field load it can substitute — anything else is `this` use it can't represent, so it bails.
4. Substitutes each `this.field` load with a clone of the captured value, which then prints correctly in the outer scope (arguments are self-naming).
5. Runs the shared `Finish` guards (zero-local, single printable return block) and emits the lambda.

## Scope

Zero-local bodies whose environment is the **folded single-expression form**. A display class spread across statements — e.g. a lambda passed to `Where` after separate `dc = new(); dc.x = x;` setup — is declined and left as the synthesized shape. That boundary is pinned on the scorecard as `ClosureWithLinq` (`CurrentlyRecovered: false`), so a future increment flips it.

## Tests

- `ClosureCoverage.CapturedClosure`: `None → Partial` (the `Lambda` row note also updated; `LambdaRaisingPass` now backs both rows — the partition test dedups by type).
- Scorecard: `CapturingLambda` flips to recovered; `ClosureWithLinq` added as the owed multi-statement boundary.
- `CapturingLambda` / `TwoCaptureLambda` round-trip **opcode-exact** in the fidelity gate (verified directly: `x => x + n`, `x => (x + a) - b`); `LocalBodyLambda` stays owed (zero-local guard).
- Unit tests for the new `GeneratedCodeIdentity.IsCapturingLambdaMethod` fact and the pass.

475/475 decompiler tests pass.

## Note

Branched while several ledger/area PRs were landing (incl. #759 renaming `GeneratedCodeFacts` → `GeneratedCodeIdentity`); rebuilt cleanly on the current main so this is a tidy 7-file diff with no rename churn.

## Follow-ups

Multi-statement display-class environments (the `ClosureWithLinq` boundary), then local functions and expression trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
