### PR TITLE
Reconstruct empty iterators as yield break

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1665,6 +1665,14 @@ public class CfgSampleClass
         yield return 7;
         yield return 8;
     }
+
+    // Empty iterator: a bare `yield break;` makes this an iterator that yields
+    // nothing. Its MoveNext never stores <>2__current (and csc emits an `if`, not a
+    // `switch`), so reconstruction rebuilds the body as `yield break;`.
+    public static System.Collections.Generic.IEnumerable<int> JustBreak()
+    {
+        yield break;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -105,4 +105,35 @@ public class IteratorReconstructionPassTests
         Assert.Equal(new object?[] { 7, 8 }, values);
         Assert.Empty(function.Descendants.OfType<UnsupportedNode>());
     }
+
+    [Fact]
+    public void EmptyIterator_ReconstructsYieldBreak()
+    {
+        var function = Raised(nameof(CfgSampleClass.JustBreak));
+
+        // No yields, exactly one `yield break;`, and no acknowledgment marker.
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        Assert.Single(function.Descendants.OfType<YieldBreak>());
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void EmptyIterator_RendersYieldBreak()
+    {
+        var output = Print(nameof(CfgSampleClass.JustBreak));
+
+        Assert.Contains("yield break;", output);
+        Assert.DoesNotContain("not reconstructed", output);
+    }
+
+    [Fact]
+    public void NonEmptyIterator_HasNoSpuriousYieldBreak()
+    {
+        // A normal linear iterator falls off the end implicitly; reconstruction
+        // must not append a trailing `yield break;`.
+        var function = Raised(nameof(CfgSampleClass.YieldTwo));
+
+        Assert.Empty(function.Descendants.OfType<YieldBreak>());
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -19,6 +19,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// a terminal <c>return false</c> section) with no back-edges (no loops), and each
 /// yielded expression must be self-contained — referencing no hoisted field,
 /// argument, or local of the state machine (constants and constant expressions).
+/// An <b>empty</b> iterator — one whose <c>MoveNext</c> never stores
+/// <c>&lt;&gt;2__current</c> (so it yields nothing, e.g. a bare <c>yield break;</c>) —
+/// is reconstructed as <c>yield break;</c> regardless of dispatch shape (csc emits
+/// an <c>if</c> rather than a <c>switch</c> for a single state).
 /// Parameterized, captured, or looping iterators do not match and fall through to
 /// <see cref="IteratorAcknowledgmentPass"/>, which keeps the gap honest. A no-op
 /// when the seam is absent (stage dumps, the lowered/annotated views).</para>
@@ -42,20 +46,46 @@ public sealed class IteratorReconstructionPass : IIrPass
         // lands at the altitude this pass recognizes.
         IrPasses.Run(moveNext, IrPasses.Default, context);
 
-        if (!TryReconstruct(moveNext, out var yields))
+        if (!TryReconstruct(moveNext, handoff, out var statements))
             return;  // leave for IteratorAcknowledgmentPass
 
         var stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
-        context.Stepper.StepOver($"reconstruct iterator '{stateMachine}' as {yields.Count} yield(s)", handoff);
+        context.Stepper.StepOver($"reconstruct iterator '{stateMachine}' as {statements.Count} statement(s)", handoff);
 
         function.Body.DetachChildren();
         var block = new Block(0);
-        foreach (var yield in yields)
-            block.Add(yield);
+        foreach (var statement in statements)
+            block.Add(statement);
         function.Body.Add(block);
     }
 
-    static bool TryReconstruct(IrFunction moveNext, out List<YieldReturn> yields)
+    static bool TryReconstruct(IrFunction moveNext, NewObject handoff, out List<IrNode> statements)
+    {
+        statements = [];
+
+        // An iterator yields exactly where MoveNext stores `<>2__current`; with no
+        // such store the sequence is empty regardless of the dispatch shape (csc
+        // emits an `if` rather than a `switch` for a single state), so the whole
+        // body reduces to `yield break;`.
+        if (!moveNext.Descendants.OfType<StoreField>().Any(s => s.Field.Name == "<>2__current"))
+        {
+            var brk = new YieldBreak();
+            // Carry the handoff's provenance so the state-machine allocation fact
+            // (classified at import) still anchors onto the reconstructed body.
+            if (handoff.SourceOffset >= 0)
+                brk.SetSourceOffset(handoff.SourceOffset);
+            statements.Add(brk);
+            return true;
+        }
+
+        if (!TryReconstructLinear(moveNext, out var yields))
+            return false;
+
+        statements.AddRange(yields);
+        return true;
+    }
+
+    static bool TryReconstructLinear(IrFunction moveNext, out List<YieldReturn> yields)
     {
         yields = [];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -63,7 +63,7 @@ public sealed class LambdaRaisingPass : IIrPass
         if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
             return null;
 
-        return Finish(creation, body);
+        return Finish(creation, body, creation);
     }
 
     static Lambda? RaiseCapturing(DelegateCreation creation, PassContext context)
@@ -107,7 +107,11 @@ public sealed class LambdaRaisingPass : IIrPass
                 load.ReplaceWith(value.Clone());
         }
 
-        return Finish(creation, body);
+        // Anchor to the folded environment's allocation (new <>c__DisplayClass)
+        // rather than the delegate creation: it is the earliest outer offset the
+        // lambda subsumes, so the closure allocation fact and its setup IL anchor
+        // to this statement in the mixed view (see Finish).
+        return Finish(creation, body, env.Creation);
     }
 
     // Import the synthesized method and raise it with the same pipeline so it
@@ -124,7 +128,7 @@ public sealed class LambdaRaisingPass : IIrPass
 
     // Shared finisher: admit only a body that prints soundly in the outer scope —
     // no locals of its own, nothing unsupported, and a single printable block.
-    static Lambda? Finish(DelegateCreation creation, IrFunction body)
+    static Lambda? Finish(DelegateCreation creation, IrFunction body, IrNode provenance)
     {
         if (!body.Locals.IsEmpty)
             return null;
@@ -135,7 +139,27 @@ public sealed class LambdaRaisingPass : IIrPass
 
         var container = body.Body;
         container.Detach();
-        return new Lambda(creation.DelegateType, body.Signature.Parameters, container);
+
+        // The body comes from a different method, so its IL offsets live in that
+        // method's offset space and would collide with the host method's — a stray
+        // inner offset can form a tighter span that steals the host's offset-keyed
+        // annotations and interleaved IL (the lambda is rendered inline; its own IL
+        // is never projected into the host). Clear them, then anchor the whole
+        // lambda to its outer provenance so the host's surrounding facts/IL (the
+        // delegate creation, and for a capturing lambda its <>c__DisplayClass
+        // allocation) anchor to this statement.
+        foreach (var node in Self(container))
+            node.SetSourceOffset(-1);
+        var lambda = new Lambda(creation.DelegateType, body.Signature.Parameters, container);
+        lambda.InheritSourceOffset(provenance);
+        return lambda;
+    }
+
+    static IEnumerable<IrNode> Self(IrNode node)
+    {
+        yield return node;
+        foreach (var descendant in node.Descendants)
+            yield return descendant;
     }
 
     static bool IsPrintableBody(IrFunction body)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -117,7 +117,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass WhileStatement => new();
-    [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences reconstructed (IteratorReconstructionPass), parameterized/captured/looping iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();
+    [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences and empty (`yield break;`) iterators reconstructed (IteratorReconstructionPass), parameterized/captured/looping iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();
 }
 
 /// <summary>How much of a lowered construct comes back as the idiom.</summary>


### PR DESCRIPTION
Follow-up to #765 (linear yield reconstruction): recovers the empty-iterator case.

## What

An iterator yields exactly where its `MoveNext` stores `<>2__current`. With no such store the sequence is empty — a bare `yield break;`. `IteratorReconstructionPass` now recognizes this and rebuilds the kickoff body as `yield break;`.

`JustBreak()` now decompiles to:

```csharp
public static IEnumerable<int> JustBreak()
{
    yield break;
}
```

(Full fidelity), where it previously fell back to the honest acknowledgment marker.

## Why it's clean

This is an airtight invariant: every `yield return X` lowers to a `<>2__current = X` store, so "no such store" exactly means "no elements". It's also independent of the dispatch shape — the C# compiler emits an `if` rather than a `switch` for a single-state (empty) state machine, which the linear switch recognizer from #765 does not match, so the empty case is checked first.

## Changes

- `TryReconstruct` handles the empty case (no `<>2__current` store anywhere in `MoveNext`) before the linear switch chain; the reconstructed `yield break;` carries the kickoff handoff's provenance so the state-machine allocation fact still anchors.
- `YieldBreak` node already existed (printer case + Full fidelity, not in the Partial-capping predicate) — now actually produced.
- `LoweringCoverage.Yield` note extended to mention empty (`yield break;`).
- Fixture `JustBreak` + tests: reconstructs/renders `yield break;`, Full fidelity, plus a guard that a normal linear iterator (`YieldTwo`) gets no spurious trailing `yield break;`.

## Verification

- Decompiler suite 483 green (incl. compile-back / annotate-check / corpus-sweep gates).
- Product suite 1157 green (9 skip).
- End-to-end product CLI confirmed: `JustBreak` renders `yield break;` with `alloc.statemachine` + kickoff IL honestly surfaced underneath.

## Follow-ups

Conditional `yield break` (`if (cond) yield break;`) and looping/parameterized iterators (the `YieldRange`/`ConstBoundLoop` shapes) share the hoisted-field recovery problem (`this.<>3__x` -> parameter, `this.<i>5__2` -> local) and still fall back to honest acknowledgment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
