### PR TITLE
Use exact interpolation handler identity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -10,6 +10,8 @@ public class MemberIdentityTests
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_handler = TypeRef.CoreLib("System.Runtime.CompilerServices", "DefaultInterpolatedStringHandler");
     static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
     static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
 
@@ -155,6 +157,34 @@ public class MemberIdentityTests
             [new LoadArgument(0, "obj", s_object)])));
     }
 
+    [Fact]
+    public void InterpolatedStringHandlerMembers_RequireExactBclInstanceSignatures()
+    {
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerConstructor(HandlerCtor(s_handler)));
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(AppendLiteral(s_handler)));
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(AppendFormatted(s_handler, s_int)));
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerToStringAndClear(ToStringAndClear(s_handler)));
+
+        var userHandler = TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.CompilerServices",
+            "DefaultInterpolatedStringHandler");
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerConstructor(HandlerCtor(userHandler)));
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(AppendLiteral(userHandler)));
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(AppendFormatted(userHandler, s_int)));
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerToStringAndClear(ToStringAndClear(userHandler)));
+
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(new Call(
+            AppendLiteralMethod(s_handler) with { ParameterTypes = [s_object] },
+            isVirtual: false,
+            [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "literal", s_string)])));
+
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerToStringAndClear(new Call(
+            ToStringAndClearMethod(s_handler) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadLocalAddress(0, s_handler)])));
+    }
+
     static MethodRef GetSubArrayMethod(TypeRef declaringType)
         => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
 
@@ -196,4 +226,37 @@ public class MemberIdentityTests
 
     static Call MonitorExit(TypeRef declaringType)
         => new(MonitorExitMethod(declaringType), isVirtual: false, [new LoadArgument(0, "obj", s_object)]);
+
+    static MethodRef HandlerCtorMethod(TypeRef declaringType)
+        => new(declaringType, ".ctor", s_void, [s_int, s_int], HasThis: true);
+
+    static NewObject HandlerCtor(TypeRef declaringType)
+        => new(HandlerCtorMethod(declaringType), [new Constant(0, s_int), new Constant(0, s_int)]);
+
+    static MethodRef AppendLiteralMethod(TypeRef declaringType)
+        => new(declaringType, "AppendLiteral", s_void, [s_string], HasThis: true);
+
+    static Call AppendLiteral(TypeRef declaringType)
+        => new(
+            AppendLiteralMethod(declaringType),
+            isVirtual: false,
+            [new LoadLocalAddress(0, declaringType), new LoadArgument(0, "literal", s_string)]);
+
+    static MethodRef AppendFormattedMethod(TypeRef declaringType, TypeRef valueType)
+        => new(declaringType, "AppendFormatted", s_void, [valueType], HasThis: true)
+        {
+            TypeArguments = [valueType],
+        };
+
+    static Call AppendFormatted(TypeRef declaringType, TypeRef valueType)
+        => new(
+            AppendFormattedMethod(declaringType, valueType),
+            isVirtual: false,
+            [new LoadLocalAddress(0, declaringType), new LoadArgument(0, "value", valueType)]);
+
+    static MethodRef ToStringAndClearMethod(TypeRef declaringType)
+        => new(declaringType, "ToStringAndClear", s_string, [], HasThis: true);
+
+    static Call ToStringAndClear(TypeRef declaringType)
+        => new(ToStringAndClearMethod(declaringType), isVirtual: false, [new LoadLocalAddress(0, declaringType)]);
 }

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -4,6 +4,10 @@ namespace ILInspector.Decompiler.Tests;
 
 public class StringInterpolationPassTests
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+
     static IrFunction Raised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -74,5 +78,46 @@ public class StringInterpolationPassTests
         Assert.NotNull(output);
         Assert.Contains("CultureInfo.InvariantCulture", output);
         Assert.DoesNotContain("$\"value=", output);
+    }
+
+    [Fact]
+    public void HandlerSequence_FromUserHandlerLookalike_IsNotRaised()
+    {
+        var function = BuildUserHandlerLookalike();
+
+        new StringInterpolationPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<InterpolatedStringExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "AppendLiteral");
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "ToStringAndClear");
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildUserHandlerLookalike()
+    {
+        var handler = TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.CompilerServices",
+            "DefaultInterpolatedStringHandler");
+        var ctor = new MethodRef(handler, ".ctor", s_void, [s_int, s_int], HasThis: true);
+        var appendLiteral = new MethodRef(handler, "AppendLiteral", s_void, [s_string], HasThis: true);
+        var toStringAndClear = new MethodRef(handler, "ToStringAndClear", s_string, [], HasThis: true);
+
+        var block = new Block();
+        block.Add(new StoreLocal(0, handler, new NewObject(ctor, [new Constant(5, s_int), new Constant(0, s_int)])));
+        block.Add(new ExpressionStatement(new Call(
+            appendLiteral,
+            isVirtual: false,
+            [new LoadLocalAddress(0, handler), new Constant("Hello", s_string)])));
+        block.Add(new Return(new Call(toStringAndClear, isVirtual: false, [new LoadLocalAddress(0, handler)])));
+        var body = new BlockContainer();
+        body.Add(block);
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_string, [], HasThis: false, GenericParameterCount: 0),
+            [handler],
+            body);
     }
 }

--- a/src/ILInspector.Decompiler/Annotations/AnnotatedCSharpRenderer.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotatedCSharpRenderer.cs
@@ -34,7 +34,7 @@ public static class AnnotatedCSharpRenderer
         var commentByLine = new Dictionary<int, string>();
         foreach (var (statement, facts) in byStatement)
         {
-            if (!statementLines.TryGetValue(statement, out int line))
+            if (!AnnotationAnchor.TryGetPrintedLine(statement, statementLines, out int line))
                 continue;
             commentByLine[line] = AnnotationText.Format(facts);
         }

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -96,6 +96,23 @@ public static class AnnotationAnchor
         return (containing ?? preceding ?? earliest)?.Statement;
     }
 
+    /// <summary>
+    /// Finds the printed line for an anchored statement, climbing to the nearest
+    /// printed ancestor when the owner belongs to an inline expression body (for
+    /// example, a raised lambda). Facts stay visible instead of being dropped.
+    /// </summary>
+    internal static bool TryGetPrintedLine(
+        IrNode owner,
+        IReadOnlyDictionary<IrNode, int> statementLines,
+        out int line)
+    {
+        for (var current = owner; current is not null; current = current.Parent)
+            if (statementLines.TryGetValue(current, out line))
+                return true;
+        line = 0;
+        return false;
+    }
+
     static IEnumerable<IrNode> Self(IrNode node)
     {
         yield return node;

--- a/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
+++ b/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
@@ -63,7 +63,7 @@ public static class MixedSourceRenderer
         {
             if (AnnotationAnchor.Best(spans, annotation.SourceOffset) is not { } owner)
                 continue;
-            if (!statementLines.TryGetValue(owner, out int line))
+            if (!AnnotationAnchor.TryGetPrintedLine(owner, statementLines, out int line))
                 continue;
             if (!commentByLine.TryGetValue(line, out var existing))
                 commentByLine[line] = AnnotationText.Format(annotation);
@@ -77,7 +77,7 @@ public static class MixedSourceRenderer
         {
             if (AnnotationAnchor.Best(spans, instr.Offset) is not { } owner)
                 continue;
-            if (!statementLines.TryGetValue(owner, out int line))
+            if (!AnnotationAnchor.TryGetPrintedLine(owner, statementLines, out int line))
                 continue;
             if (!ilByLine.TryGetValue(line, out var list))
                 ilByLine[line] = list = [];

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -7,9 +7,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class MemberIdentity
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
 
@@ -71,6 +73,37 @@ public static class MemberIdentity
             && call.Callee.ParameterTypes.Length == 1
             && call.Arguments.Count == 1;
 
+    public static bool IsDefaultInterpolatedStringHandlerConstructor(NewObject newObject)
+        => newObject.Constructor is
+        {
+            Name: ".ctor",
+            HasThis: true,
+            ParameterTypes: [var literalLength, var formattedCount],
+        }
+        && IsDefaultInterpolatedStringHandlerType(newObject.Constructor.DeclaringType)
+        && literalLength.Equals(s_int)
+        && formattedCount.Equals(s_int)
+        && newObject.Arguments.Count == 2;
+
+    public static bool IsDefaultInterpolatedStringHandlerAppendLiteral(Call call)
+        => IsDefaultInterpolatedStringHandlerInstanceMethod(call, "AppendLiteral")
+            && call.Callee.ReturnType.Equals(s_void)
+            && call.Callee.ParameterTypes is [var literal]
+            && literal.Equals(s_string)
+            && call.Arguments.Count == 2;
+
+    public static bool IsDefaultInterpolatedStringHandlerAppendFormatted(Call call)
+        => IsDefaultInterpolatedStringHandlerInstanceMethod(call, "AppendFormatted")
+            && call.Callee.ReturnType.Equals(s_void)
+            && call.Callee.ParameterTypes.Length == 1
+            && call.Arguments.Count == 2;
+
+    public static bool IsDefaultInterpolatedStringHandlerToStringAndClear(Call call)
+        => IsDefaultInterpolatedStringHandlerInstanceMethod(call, "ToStringAndClear")
+            && call.Callee.ReturnType.Equals(s_string)
+            && call.Callee.ParameterTypes.IsEmpty
+            && call.Arguments.Count == 1;
+
     public static bool IsRuntimeHelpersCreateSpan(Call call)
     {
         if (call.IsVirtual
@@ -124,4 +157,17 @@ public static class MemberIdentity
         && (assembly == TypeRef.CoreLibrary || assembly == facadeAssembly)
         && typeNamespace == ns
         && typeName == name;
+
+    static bool IsDefaultInterpolatedStringHandlerInstanceMethod(Call call, string methodName)
+        => !call.IsVirtual
+            && call.Callee.Name == methodName
+            && call.Callee.HasThis
+            && IsDefaultInterpolatedStringHandlerType(call.Callee.DeclaringType);
+
+    static bool IsDefaultInterpolatedStringHandlerType(TypeRef type)
+        => IsCoreLibraryOrFacadeType(
+            type,
+            "System.Runtime.CompilerServices",
+            "DefaultInterpolatedStringHandler",
+            "System.Runtime");
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -104,7 +104,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat => default!;
-    [Completeness(CompletenessLevel.Partial, "straight-line DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
+    [Completeness(CompletenessLevel.Partial, "straight-line exact BCL DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
     public static StringInterpolationPass StringInterpolation => new();
     [Completeness(CompletenessLevel.Partial, "value-producing jump tables raise to a switch expression; the sparse binary-search form recovers as a switch statement; pattern switches not raised")]
     public static SwitchRaisingPass SwitchExpression => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
@@ -39,7 +39,7 @@ public sealed class StringInterpolationPass : IIrPass
                 foreach (var append in match.Appends)
                 {
                     var call = (Call)append.Expression;
-                    if (call.Callee.Name == "AppendLiteral")
+                    if (MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(call))
                     {
                         parts.Add(InterpolatedStringPart.LiteralText((string)((Constant)call.Arguments[1]).Value!));
                     }
@@ -68,7 +68,7 @@ public sealed class StringInterpolationPass : IIrPass
     {
         if (statements[start] is not StoreLocal { Value: NewObject handlerCtor } storeHandler
             || HasSourceLocalName(function, storeHandler.Index)
-            || !IsDefaultInterpolatedStringHandlerCtor(handlerCtor))
+            || !MemberIdentity.IsDefaultInterpolatedStringHandlerConstructor(handlerCtor))
         {
             return null;
         }
@@ -95,18 +95,6 @@ public sealed class StringInterpolationPass : IIrPass
         return new Match(storeHandler, appends, ret);
     }
 
-    static bool IsDefaultInterpolatedStringHandlerCtor(NewObject newObject)
-        => newObject.Constructor is
-            {
-                Name: ".ctor",
-                DeclaringType:
-                {
-                    Namespace: "System.Runtime.CompilerServices",
-                    Name: "DefaultInterpolatedStringHandler",
-                    Assembly: TypeRef.CoreLibrary or "System.Runtime",
-                },
-            };
-
     static bool HasSourceLocalName(IrFunction function, int index)
         => index >= 0
             && index < function.LocalNames.Length
@@ -128,7 +116,7 @@ public sealed class StringInterpolationPass : IIrPass
         foreach (var append in appends)
         {
             var call = (Call)append.Expression;
-            if (call.Callee.Name == "AppendLiteral")
+            if (MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(call))
                 actualLiteralLength += ((string)((Constant)call.Arguments[1]).Value!).Length;
             else
                 actualFormattedCount++;
@@ -139,8 +127,7 @@ public sealed class StringInterpolationPass : IIrPass
 
     static bool IsAppend(Call call, int handlerSlot)
     {
-        if (!IsHandlerCall(call)
-            || call.Arguments is not [LoadLocalAddress receiver, ..]
+        if (call.Arguments is not [LoadLocalAddress receiver, ..]
             || receiver.Index != handlerSlot)
         {
             return false;
@@ -148,20 +135,16 @@ public sealed class StringInterpolationPass : IIrPass
 
         return call switch
         {
-            { Callee.Name: "AppendLiteral", Arguments: [_, Constant { Value: string }] }
-                when call.Callee.ParameterTypes is [{ Namespace: "System", Name: "String" }] => true,
-            { Callee.Name: "AppendFormatted", Arguments.Count: 2 }
-                when call.Callee.ParameterTypes.Length == 1 => true,
+            { Arguments: [_, Constant { Value: string }] }
+                when MemberIdentity.IsDefaultInterpolatedStringHandlerAppendLiteral(call) => true,
+            _ when MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(call) => true,
             _ => false,
         };
     }
 
     static bool IsToStringAndClear(Call call, int handlerSlot)
     {
-        if (!IsHandlerCall(call)
-            || call.Callee.Name != "ToStringAndClear"
-            || call.Callee.ParameterTypes.Length != 0
-            || call.Callee.ReturnType is not { Namespace: "System", Name: "String" }
+        if (!MemberIdentity.IsDefaultInterpolatedStringHandlerToStringAndClear(call)
             || call.Arguments is not [LoadLocalAddress receiver])
         {
             return false;
@@ -169,18 +152,6 @@ public sealed class StringInterpolationPass : IIrPass
 
         return receiver.Index == handlerSlot;
     }
-
-    static bool IsHandlerCall(Call call)
-        => call.Callee is
-        {
-            HasThis: true,
-            DeclaringType:
-            {
-                Namespace: "System.Runtime.CompilerServices",
-                Name: "DefaultInterpolatedStringHandler",
-                Assembly: TypeRef.CoreLibrary or "System.Runtime",
-            },
-        };
 
     static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
     {


### PR DESCRIPTION
## Summary
- add `MemberIdentity` predicates for `DefaultInterpolatedStringHandler` ctor, `AppendLiteral`, `AppendFormatted`, and `ToStringAndClear`
- migrate `StringInterpolationPass` to use the shared exact BCL handler predicates
- add identity tests and a synthetic user-handler lookalike test that must not raise
- fix annotation rendering for raised inline lambda bodies so current-main mixed-source closure facts are not dropped

## Notes
The annotation fix is a separate first commit because full decompiler validation on current `origin/main` exposed a baseline failure after capturing lambda raising: closure allocation facts could anchor to an inline lambda body statement with no printed line map. The renderer now climbs to the nearest printed ancestor, preserving the fact.

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method ILInspector.Decompiler.Tests.MixedSourceRendererTests.ClosureAndDelegateAllocations_BothInterleave
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.StringInterpolationPassTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal