### PR TITLE
Resolve cross-assembly method facts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler.Pipeline;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CrossAssemblyMethodFactsTests
+{
+    [Fact]
+    public void CrossAssemblyByRefMemberRef_RecoversParameterRefKinds()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+
+        AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseOut), "WriteOut", ArgumentRefKind.Out);
+        AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseRef), "Mutate", ArgumentRefKind.Ref);
+        AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseIn), "Read", ArgumentRefKind.In);
+    }
+
+    [Fact]
+    public void CrossAssemblyGeneratedMemberRef_RecoversCompilerGeneratedFacts()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+        var call = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseGenerated), "Run");
+
+        Assert.Equal(MetadataFactState.Yes, call.Callee.DeclaringTypeCompilerGenerated);
+        Assert.Equal(MetadataFactState.Yes, call.Callee.CompilerGenerated);
+    }
+
+    [Fact]
+    public void MissingCrossAssemblyMetadata_KeepsFactsUnknown()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: (_, _) => null);
+
+        var byRef = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseOut), "WriteOut");
+        Assert.Equal(ParameterRefKindFacts.Unknown, byRef.Callee.ParameterRefKindsFacts);
+        Assert.Empty(byRef.Callee.ParameterRefKinds);
+
+        var generated = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseGenerated), "Run");
+        Assert.Equal(MetadataFactState.Unknown, generated.Callee.DeclaringTypeCompilerGenerated);
+        Assert.Equal(MetadataFactState.Unknown, generated.Callee.CompilerGenerated);
+    }
+
+    static void AssertCallRefKind(MetadataSource source, string methodName, string calleeName, ArgumentRefKind expected)
+    {
+        var call = SingleCall(source, methodName, calleeName);
+        Assert.Equal(ParameterRefKindFacts.Known, call.Callee.ParameterRefKindsFacts);
+        Assert.Equal(expected, Assert.Single(call.Callee.ParameterRefKinds));
+    }
+
+    static Call SingleCall(MetadataSource source, string methodName, string calleeName)
+    {
+        var function = IrImporter.Import(source, "ExternalFacts.Consumer", methodName);
+        Assert.NotNull(function);
+        function.CheckInvariant();
+        return Assert.Single(function!.Descendants.OfType<Call>(), c => c.Callee.Name == calleeName);
+    }
+
+    sealed class CrossAssemblyFixture : IDisposable
+    {
+        readonly string _directory;
+
+        CrossAssemblyFixture(string directory, string consumerPath)
+        {
+            _directory = directory;
+            ConsumerPath = consumerPath;
+        }
+
+        public string ConsumerPath { get; }
+
+        public static CrossAssemblyFixture Create()
+        {
+            var directory = Directory.CreateTempSubdirectory("dotnet-inspect-method-facts-").FullName;
+            try
+            {
+                string libraryPath = Emit(
+                    directory,
+                    "ExternalFacts.Library",
+                    """
+                    using System.Runtime.CompilerServices;
+
+                    namespace ExternalFacts;
+
+                    public static class ByRefLibrary
+                    {
+                        public static void WriteOut(out int value) => value = 42;
+                        public static void Mutate(ref int value) => value++;
+                        public static void Read(in int value) { _ = value; }
+                    }
+
+                    [CompilerGenerated]
+                    public static class Generated__DisplayClass0_0
+                    {
+                        [CompilerGenerated]
+                        public static int Run(int value) => value + 1;
+                    }
+                    """);
+                string consumerPath = Emit(
+                    directory,
+                    "ExternalFacts.Consumer",
+                    """
+                    namespace ExternalFacts;
+
+                    public static class Consumer
+                    {
+                        public static int UseOut()
+                        {
+                            ByRefLibrary.WriteOut(out var value);
+                            return value;
+                        }
+
+                        public static int UseRef()
+                        {
+                            int value = 1;
+                            ByRefLibrary.Mutate(ref value);
+                            return value;
+                        }
+
+                        public static void UseIn()
+                        {
+                            int value = 1;
+                            ByRefLibrary.Read(in value);
+                        }
+
+                        public static int UseGenerated(int value)
+                            => Generated__DisplayClass0_0.Run(value);
+                    }
+                    """,
+                    [MetadataReference.CreateFromFile(libraryPath)]);
+                return new CrossAssemblyFixture(directory, consumerPath);
+            }
+            catch
+            {
+                Directory.Delete(directory, recursive: true);
+                throw;
+            }
+        }
+
+        static string Emit(string directory, string assemblyName, string source, IEnumerable<MetadataReference>? additionalReferences = null)
+        {
+            var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+            var references = ImmutableArray.CreateBuilder<MetadataReference>();
+            references.AddRange(RuntimeReferences());
+            if (additionalReferences is not null)
+                references.AddRange(additionalReferences);
+
+            var compilation = CSharpCompilation.Create(
+                assemblyName,
+                [CSharpSyntaxTree.ParseText(source, parseOptions)],
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Release));
+
+            string path = Path.Combine(directory, assemblyName + ".dll");
+            var result = compilation.Emit(path);
+            Assert.True(
+                result.Success,
+                "fixture compilation failed:\n" + string.Join("\n", result.Diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}")));
+            return path;
+        }
+
+        static ImmutableArray<MetadataReference> RuntimeReferences()
+        {
+            var trustedPlatformAssemblies =
+                (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+                    .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            var references = ImmutableArray.CreateBuilder<MetadataReference>();
+            foreach (var path in trustedPlatformAssemblies)
+            {
+                if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                try { references.Add(MetadataReference.CreateFromFile(path)); }
+                catch { }
+            }
+            return references.ToImmutable();
+        }
+
+        public void Dispose() => Directory.Delete(_directory, recursive: true);
+    }
+
+    static class CrossAssemblyFixtureMethods
+    {
+        public const string UseOut = nameof(UseOut);
+        public const string UseRef = nameof(UseRef);
+        public const string UseIn = nameof(UseIn);
+        public const string UseGenerated = nameof(UseGenerated);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -39,7 +39,7 @@ public class GeneratedCodeIdentityTests
         Assert.True(GeneratedCodeIdentity.IsCapturingLambdaMethod(onDisplayClass));
         // The non-capturing <>c singleton and the capturing display class are distinct forms.
         Assert.False(GeneratedCodeIdentity.IsCapturingLambdaMethod(LambdaMethod(declaringTypeIsCompilerGenerated: true)));
-        Assert.False(GeneratedCodeIdentity.IsCapturingLambdaMethod(onDisplayClass with { DeclaringTypeIsCompilerGenerated = false }));
+        Assert.False(GeneratedCodeIdentity.IsCapturingLambdaMethod(onDisplayClass with { DeclaringTypeCompilerGenerated = MetadataFactState.No }));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -13,7 +13,7 @@ public class GeneratedCodeIdentityTests
         var method = LambdaMethod(declaringTypeIsCompilerGenerated: true);
 
         Assert.True(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method));
-        Assert.False(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method with { DeclaringTypeIsCompilerGenerated = false }));
+        Assert.False(GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method with { DeclaringTypeCompilerGenerated = MetadataFactState.No }));
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class GeneratedCodeIdentityTests
     static MethodRef LambdaMethod(bool declaringTypeIsCompilerGenerated)
         => new(s_closureHolder, "<M>b__0_0", s_int, [s_int], HasThis: true)
         {
-            DeclaringTypeIsCompilerGenerated = declaringTypeIsCompilerGenerated,
+            DeclaringTypeCompilerGenerated = declaringTypeIsCompilerGenerated ? MetadataFactState.Yes : MetadataFactState.No,
         };
 }

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using ILInspector.Metadata;
 
@@ -15,7 +16,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <remarks>
 /// Precision-preserving: a fact is returned only when the defining assembly is
 /// located and its metadata confirms it. Anything unreachable (no locator hit,
-/// a forwarder dead-end, a nested type, an I/O or format error) yields
+/// a forwarder dead-end, an I/O or format error) yields
 /// <see cref="ValueTypeHint.Unknown"/> — never a guess. Security: a reference
 /// whose public-key token is a trusted platform key is asserted
 /// <see cref="AssemblyTrust.Platform"/> so the locator resolves it only from the
@@ -34,7 +35,7 @@ internal sealed class CrossAssemblyTypeResolver
     readonly MetadataReader _selfReader;
     readonly MetadataContext _context;
     readonly Dictionary<TypeRef, ValueTypeHint> _valueTypeCache = [];
-    readonly Dictionary<MethodRef, bool> _requiresUnsafeCache = [];
+    readonly Dictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = [];
 
     public CrossAssemblyTypeResolver(string selfSimpleName, MetadataReader selfReader, MetadataContext context)
     {
@@ -53,7 +54,7 @@ internal sealed class CrossAssemblyTypeResolver
     {
         if (type.Kind != TypeRefKind.Definition || type.ValueTypeHint != ValueTypeHint.Unknown)
             return type;
-        if (string.IsNullOrEmpty(type.Assembly) || type.Name.Contains('+'))
+        if (string.IsNullOrEmpty(type.Assembly))
             return type;
         // Same-assembly references are resolved by the importer's own shapes.
         if (type.Assembly == TypeRefDecoder.Canonical(_selfSimpleName))
@@ -64,80 +65,128 @@ internal sealed class CrossAssemblyTypeResolver
     }
 
     /// <summary>
-    /// Returns <paramref name="callee"/> with <see cref="MethodRef.RequiresUnsafe"/>
-    /// stamped when the defining assembly confirms the method — or its declaring
-    /// type — carries <c>RequiresUnsafeAttribute</c>. Same-assembly callees
-    /// already carry the flag from their MethodDef, and a pointer-in-signature
-    /// callee is caught by the printer's local heuristic; this closes the
-    /// remaining case — a <em>pointerless</em> requires-unsafe method referenced
-    /// across assemblies, whose attribute lives only on the defining MethodDef
-    /// (or its type) and is invisible in the importing assembly's MemberRef.
+    /// Returns <paramref name="callee"/> with cross-assembly MethodDef facts
+    /// stamped when the defining assembly can be resolved. Facts stay
+    /// <see cref="MetadataFactState.Unknown"/> / <see cref="ParameterRefKindFacts.Unknown"/>
+    /// when metadata is unreachable; absence of evidence is never reported as
+    /// false.
     /// </summary>
-    /// <remarks>
-    /// Precision-preserving like <see cref="Upgrade(TypeRef)"/>: the flag is set
-    /// only when the defining assembly is located and its metadata confirms the
-    /// attribute. Anything unreachable yields the callee unchanged — never a
-    /// guess. The caller should invoke this only for modules that use the
-    /// updated memory-safety rules, since the flag is inert otherwise.
-    /// </remarks>
-    public MethodRef Upgrade(MethodRef callee)
+    public MethodRef Upgrade(MethodRef callee, bool resolveRequiresUnsafe)
     {
-        if (callee.RequiresUnsafe)
+        bool needsRefKinds = NeedsParameterRefKinds(callee);
+        bool needsGenerated = NeedsGeneratedFacts(callee);
+        bool needsUnsafe = resolveRequiresUnsafe && !callee.RequiresUnsafe;
+        if (!needsRefKinds && !needsGenerated && !needsUnsafe)
             return callee;
 
-        var type = callee.DeclaringType;
-        if (type.Kind != TypeRefKind.Definition || string.IsNullOrEmpty(type.Assembly) || type.Name.Contains('+'))
+        var type = NamedDefinition(callee.DeclaringType);
+        if (type is null || string.IsNullOrEmpty(type.Assembly))
             return callee;
         // Same-assembly callees are stamped by the importer from their MethodDef.
         if (type.Assembly == TypeRefDecoder.Canonical(_selfSimpleName))
             return callee;
 
-        if (!_requiresUnsafeCache.TryGetValue(callee, out var requiresUnsafe))
+        if (!_methodFactCache.TryGetValue(callee, out var facts))
         {
-            requiresUnsafe = ResolveRequiresUnsafe(callee, type);
-            _requiresUnsafeCache[callee] = requiresUnsafe;
+            facts = ResolveMethodFacts(callee, type);
+            _methodFactCache[callee] = facts;
         }
 
-        return requiresUnsafe ? callee with { RequiresUnsafe = true } : callee;
+        if (facts is not { } resolved)
+            return callee;
+
+        return callee with
+        {
+            ParameterRefKinds = needsRefKinds && resolved.ParameterRefKinds.State != ParameterRefKindFacts.Unknown
+                ? resolved.ParameterRefKinds.Kinds
+                : callee.ParameterRefKinds,
+            ParameterRefKindsFacts = needsRefKinds && resolved.ParameterRefKinds.State != ParameterRefKindFacts.Unknown
+                ? resolved.ParameterRefKinds.State
+                : callee.ParameterRefKindsFacts,
+            RequiresUnsafe = callee.RequiresUnsafe || (needsUnsafe && resolved.RequiresUnsafe),
+            CompilerGenerated = needsGenerated ? resolved.CompilerGenerated : callee.CompilerGenerated,
+            DeclaringTypeCompilerGenerated = needsGenerated ? resolved.DeclaringTypeCompilerGenerated : callee.DeclaringTypeCompilerGenerated,
+        };
     }
 
-    bool ResolveRequiresUnsafe(MethodRef callee, TypeRef type)
+    ResolvedMethodFacts? ResolveMethodFacts(MethodRef callee, TypeRef type)
     {
         try
         {
             if (Locate(type) is not { } location)
-                return false;
+                return null;
             if (_context.Open(location.AssemblyPath) is not { } assembly)
-                return false;
+                return null;
             if (!assembly.TryGetType(location.FullTypeName, out var handle))
-                return false;
+                return null;
 
             var reader = assembly.Reader;
             var typeDef = reader.GetTypeDefinition(handle);
-            // A type-level attribute marks every member requires-unsafe.
-            if (AttributeReader.HasRequiresUnsafeAttribute(reader, typeDef.GetCustomAttributes()))
-                return true;
+            bool typeCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, typeDef.GetCustomAttributes());
+            bool typeRequiresUnsafe = MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, typeDef);
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (!string.Equals(reader.GetString(method.Name), callee.Name, StringComparison.Ordinal))
                     continue;
-                // Disambiguate overloads by arity; the pointerless requires-unsafe
-                // method we are after has a stable parameter count.
-                var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
-                if (signature.ParameterTypes.Length != callee.ParameterTypes.Length)
+                if (!TryMatchMethod(reader, typeDef, method, callee, out var parameterRefKinds))
                     continue;
-                if (AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()))
-                    return true;
+
+                bool methodCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes());
+                return new ResolvedMethodFacts(
+                    parameterRefKinds,
+                    typeRequiresUnsafe || MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
+                    FactState(methodCompilerGenerated),
+                    FactState(typeCompilerGenerated));
             }
 
-            return false;
+            return null;
         }
         catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
         {
-            return false;
+            return null;
         }
+    }
+
+    static bool TryMatchMethod(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        MethodDefinition method,
+        MethodRef callee,
+        out ParameterRefKindResult parameterRefKinds)
+    {
+        parameterRefKinds = default;
+        var scope = new GenericScope(
+            MethodDefinitionFacts.GenericParameterNames(reader, declaringType.GetGenericParameters()),
+            MethodDefinitionFacts.GenericParameterNames(reader, method.GetGenericParameters()));
+        var signature = method.DecodeSignature(TypeRefDecoder.Instance, scope);
+        if (signature.Header.IsInstance != callee.HasThis)
+            return false;
+        if (signature.GenericParameterCount != callee.TypeArguments.Length)
+            return false;
+
+        var typeArguments = callee.DeclaringType.Kind == TypeRefKind.GenericInstance
+            ? callee.DeclaringType.TypeArguments
+            : [];
+        var methodArguments = callee.TypeArguments;
+        var returnType = signature.ReturnType.Instantiate(typeArguments, methodArguments);
+        if (!returnType.Equals(callee.ReturnType))
+            return false;
+
+        if (signature.ParameterTypes.Length != callee.ParameterTypes.Length)
+            return false;
+        var parameters = ImmutableArray.CreateBuilder<TypeRef>(signature.ParameterTypes.Length);
+        for (int i = 0; i < signature.ParameterTypes.Length; i++)
+        {
+            var parameter = signature.ParameterTypes[i].Instantiate(typeArguments, methodArguments);
+            if (!parameter.Equals(callee.ParameterTypes[i]))
+                return false;
+            parameters.Add(parameter);
+        }
+
+        parameterRefKinds = MethodDefinitionFacts.ReadParameterRefKinds(reader, method, parameters.MoveToImmutable());
+        return true;
     }
 
     ValueTypeHint ResolveValueTypeHint(TypeRef type)
@@ -161,7 +210,8 @@ internal sealed class CrossAssemblyTypeResolver
 
     TypeLocation? Locate(TypeRef type)
     {
-        string fullName = string.IsNullOrEmpty(type.Namespace) ? type.Name : $"{type.Namespace}.{type.Name}";
+        string name = type.Name.Replace('+', '.');
+        string fullName = string.IsNullOrEmpty(type.Namespace) ? name : $"{type.Namespace}.{name}";
 
         if (type.Assembly == TypeRef.CoreLibrary)
         {
@@ -169,7 +219,7 @@ internal sealed class CrossAssemblyTypeResolver
             {
                 if (_context.Locator(candidate, AssemblyTrust.Platform) is not { } start || !File.Exists(start))
                     continue;
-                if (TypeForwardResolver.LocateType(start, fullName, _context.Locator, trust: AssemblyTrust.Platform) is { } located)
+                if (LocateFrom(start, fullName, AssemblyTrust.Platform) is { } located)
                     return located;
             }
             return null;
@@ -178,6 +228,13 @@ internal sealed class CrossAssemblyTypeResolver
         var trust = TrustFor(type.Assembly);
         if (_context.Locator(type.Assembly, trust) is not { } startPath || !File.Exists(startPath))
             return null;
+        return LocateFrom(startPath, fullName, trust);
+    }
+
+    TypeLocation? LocateFrom(string startPath, string fullName, AssemblyTrust trust)
+    {
+        if (_context.Open(startPath) is { } assembly && assembly.TryGetType(fullName, out _))
+            return new TypeLocation(startPath, fullName);
         return TypeForwardResolver.LocateType(startPath, fullName, _context.Locator, trust: trust);
     }
 
@@ -228,4 +285,35 @@ internal sealed class CrossAssemblyTypeResolver
         }
         return new string(chars);
     }
+
+    static TypeRef? NamedDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+
+    static bool NeedsParameterRefKinds(MethodRef method)
+    {
+        if (method.ParameterRefKindsFacts != ParameterRefKindFacts.Unknown)
+            return false;
+        foreach (var parameter in method.ParameterTypes)
+            if (parameter.Kind == TypeRefKind.ByRef)
+                return true;
+        return false;
+    }
+
+    static bool NeedsGeneratedFacts(MethodRef method)
+        => (method.CompilerGenerated == MetadataFactState.Unknown
+            || method.DeclaringTypeCompilerGenerated == MetadataFactState.Unknown)
+            && LooksCompilerGenerated(method);
+
+    static bool LooksCompilerGenerated(MethodRef method)
+        => method.Name.Contains('<', StringComparison.Ordinal)
+            || method.DeclaringType.Name.Contains('<', StringComparison.Ordinal)
+            || method.DeclaringType.Name.Contains("__DisplayClass", StringComparison.Ordinal);
+
+    static MetadataFactState FactState(bool value) => value ? MetadataFactState.Yes : MetadataFactState.No;
+
+    readonly record struct ResolvedMethodFacts(
+        ParameterRefKindResult ParameterRefKinds,
+        bool RequiresUnsafe,
+        MetadataFactState CompilerGenerated,
+        MetadataFactState DeclaringTypeCompilerGenerated);
 }

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -18,7 +18,7 @@ public static class GeneratedCodeIdentity
     /// <c>this</c> rather than running on the static <c>&lt;&gt;c</c> singleton.
     /// </summary>
     public static bool IsCapturingLambdaMethod(MethodRef method)
-        => method.DeclaringTypeIsCompilerGenerated
+        => method.DeclaringTypeCompilerGenerated == MetadataFactState.Yes
             && IsDisplayClassName(method.DeclaringType)
             && IsSynthesizedLambdaMethodName(method.Name);
 

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -8,7 +8,7 @@ namespace ILInspector.Decompiler.Pipeline;
 public static class GeneratedCodeIdentity
 {
     public static bool IsNonCapturingLambdaMethod(MethodRef method)
-        => method.DeclaringTypeIsCompilerGenerated
+        => method.DeclaringTypeCompilerGenerated == MetadataFactState.Yes
             && IsStaticLambdaClosureHolderName(method.DeclaringType)
             && IsSynthesizedLambdaMethodName(method.Name);
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -678,14 +678,9 @@ public static class IrImporter
                         Stop(function, body, stack, offset, "call", $"unresolvable callee: {callee.DeclaringType.UnsupportedReason}");
                         return false;
                     }
-                    // A pointerless requires-unsafe callee in another assembly
-                    // carries its RequiresUnsafeAttribute only on its own
-                    // MethodDef, invisible in our MemberRef; resolve it so the
-                    // call site gets its unsafe context. Only new-rules modules
-                    // consume the flag, so don't pay the cross-assembly cost
-                    // otherwise.
-                    if (function.UsesUpdatedMemorySafetyRules)
-                        callee = source.CrossAssembly.Upgrade(callee);
+                    // MemberRefs carry no MethodDef rows; resolve only the
+                    // missing cross-assembly facts this callee can consume.
+                    callee = source.CrossAssembly.Upgrade(callee, function.UsesUpdatedMemorySafetyRules);
                     int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
@@ -859,6 +854,7 @@ public static class IrImporter
                     // byte; resolve its value-type-ness so a struct constructor
                     // (new DateTime(...)) is not misread as a heap allocation.
                     constructor = constructor with { DeclaringType = source.CrossAssembly.Upgrade(constructor.DeclaringType) };
+                    constructor = source.CrossAssembly.Upgrade(constructor, function.UsesUpdatedMemorySafetyRules);
                     var arguments = new IrExpression[constructor.ParameterTypes.Length];
                     for (int i = arguments.Length - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
@@ -1462,13 +1458,17 @@ public static class IrImporter
                 var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
                 var typeScope = new GenericScope(GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
+                var parameterRefKinds = MethodDefinitionFacts.ReadParameterRefKinds(reader, method, signature.ParameterTypes);
+                bool methodCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes());
+                bool typeCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, declaringType.GetCustomAttributes());
                 return new MethodRef(declaring, reader.GetString(method.Name), signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
-                    ParameterRefKinds = ReadParameterRefKinds(reader, method, signature.ParameterTypes),
-                    RequiresUnsafe = HasRequiresUnsafeAttribute(reader, method),
-                    IsCompilerGenerated = HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes()),
-                    DeclaringTypeIsCompilerGenerated = HasCompilerGeneratedAttribute(reader, declaringType.GetCustomAttributes()),
+                    ParameterRefKinds = parameterRefKinds.Kinds,
+                    ParameterRefKindsFacts = parameterRefKinds.State,
+                    RequiresUnsafe = MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
+                    CompilerGenerated = FactState(methodCompilerGenerated),
+                    DeclaringTypeCompilerGenerated = FactState(typeCompilerGenerated),
                 };
             }
             case HandleKind.MemberReference:
@@ -1481,11 +1481,13 @@ public static class IrImporter
                 // call on List<int> reports int, not T.
                 var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
                 string memberName = reader.GetString(member.Name);
+                var parameterTypes = ImmutableArray.CreateRange(signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, [])));
+                var parameterRefKinds = MemberReferenceRefKinds(reader, member, memberName, parameterTypes);
                 return new MethodRef(
                     declaring,
                     memberName,
                     signature.ReturnType.Instantiate(typeArguments, []),
-                    [.. signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, []))],
+                    parameterTypes,
                     signature.Header.IsInstance)
                 {
                     // MemberRefs carry no flags; accessor-shape naming is the
@@ -1497,7 +1499,8 @@ public static class IrImporter
                     // A same-assembly call on a generic type instance is a
                     // MemberRef (TypeSpec parent), so its ref/out/in would
                     // otherwise be lost; recover it from the underlying MethodDef.
-                    ParameterRefKinds = MemberReferenceRefKinds(reader, member, memberName, signature.ParameterTypes),
+                    ParameterRefKinds = parameterRefKinds.Kinds,
+                    ParameterRefKindsFacts = parameterRefKinds.State,
                 };
             }
             case HandleKind.MethodSpecification:
@@ -1519,6 +1522,8 @@ public static class IrImporter
                 return new MethodRef(TypeRef.Unsupported($"callee handle kind {handle.Kind}"), "?", TypeRef.Unsupported("unknown return"), [], false);
         }
     }
+
+    static MetadataFactState FactState(bool value) => value ? MetadataFactState.Yes : MetadataFactState.No;
 
     /// <summary>
     /// The property names of an anonymous-type constructor, in argument order, or
@@ -1590,13 +1595,15 @@ public static class IrImporter
     /// keeps its default spelling) when the declaring type is not a same-assembly
     /// definition or no signature-matching method is found.
     /// </summary>
-    static ImmutableArray<ArgumentRefKind> MemberReferenceRefKinds(MetadataReader reader, MemberReference member, string memberName, ImmutableArray<TypeRef> parameterTypes)
+    static ParameterRefKindResult MemberReferenceRefKinds(MetadataReader reader, MemberReference member, string memberName, ImmutableArray<TypeRef> parameterTypes)
     {
         bool anyByRef = false;
         foreach (var p in parameterTypes)
             if (p.Kind == TypeRefKind.ByRef) { anyByRef = true; break; }
-        if (!anyByRef || DeclaringTypeDefinition(reader, member.Parent) is not { } typeHandle)
-            return [];
+        if (!anyByRef)
+            return new ParameterRefKindResult([], ParameterRefKindFacts.NotRequired);
+        if (DeclaringTypeDefinition(reader, member.Parent) is not { } typeHandle)
+            return new ParameterRefKindResult([], ParameterRefKindFacts.Unknown);
 
         var memberSignature = reader.GetBlobBytes(member.Signature);
         foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
@@ -1608,9 +1615,9 @@ public static class IrImporter
             // terms (!0/!1) as the MethodDef's, so the blobs match byte-for-byte
             // for the referenced method — a robust overload-safe match.
             if (reader.GetBlobBytes(method.Signature).AsSpan().SequenceEqual(memberSignature))
-                return ReadParameterRefKinds(reader, method, parameterTypes);
+                return MethodDefinitionFacts.ReadParameterRefKinds(reader, method, parameterTypes);
         }
-        return [];
+        return new ParameterRefKindResult([], ParameterRefKindFacts.Unknown);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -64,16 +64,12 @@ public sealed record MethodRef(
     /// </summary>
     public MetadataFactState CompilerGenerated { get; init; } = MetadataFactState.Unknown;
 
-    public bool IsCompilerGenerated => CompilerGenerated == MetadataFactState.Yes;
-
     /// <summary>
     /// Metadata <c>[CompilerGenerated]</c> evidence on the declaring type, or
     /// <see cref="MetadataFactState.Unknown"/> when the defining TypeDef was
     /// unreachable from the call-site token.
     /// </summary>
     public MetadataFactState DeclaringTypeCompilerGenerated { get; init; } = MetadataFactState.Unknown;
-
-    public bool DeclaringTypeIsCompilerGenerated => DeclaringTypeCompilerGenerated == MetadataFactState.Yes;
 
     /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -5,6 +5,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <summary>How a by-reference argument must be spelled at a C# call site — recovered from the callee's parameter metadata.</summary>
 public enum ArgumentRefKind { Value, Ref, Out, In }
 
+/// <summary>A metadata fact whose evidence may be unavailable from the current token.</summary>
+public enum MetadataFactState { Unknown, No, Yes }
+
+/// <summary>Whether by-ref parameter keyword metadata was needed and recovered.</summary>
+public enum ParameterRefKindFacts { Unknown, NotRequired, Known }
+
 /// <summary>A materialized method reference — callee identity with symbolic types, no metadata handles.</summary>
 public sealed record MethodRef(
     TypeRef DeclaringType,
@@ -19,23 +25,27 @@ public sealed record MethodRef(
     /// <summary>
     /// Per-parameter call-site ref-kind (ref/out/in), aligned 1:1 with
     /// <see cref="ParameterTypes"/>. Populated for callees resolved as a
-    /// MethodDef, from the parameter rows (IsReadOnlyAttribute / the Out flag);
-    /// empty when the callee resolves as a MemberReference — both cross-assembly
-    /// references AND same-assembly calls on a generic type instance (the parent
-    /// is a TypeSpecification), since a MemberRef carries no parameter rows. When
-    /// empty the printer keeps its by-ref argument spelling unchanged, so an
-    /// out/in parameter on such a call still renders as ref (a known gap).
+    /// MethodDef, from the parameter rows (IsReadOnlyAttribute / the Out flag),
+    /// either directly or by resolving a MemberRef through the metadata context.
+    /// Empty means either no by-ref facts were needed or the rows were
+    /// unreachable; <see cref="ParameterRefKindsFacts"/> disambiguates.
     /// </summary>
     public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; init; } = [];
+
+    /// <summary>
+    /// Whether <see cref="ParameterRefKinds"/> is known. Distinguishes "no by-ref
+    /// parameters needed spelling facts" from "a MemberRef did not expose rows."
+    /// </summary>
+    public ParameterRefKindFacts ParameterRefKindsFacts { get; init; } = ParameterRefKindFacts.Unknown;
 
     /// <summary>
     /// The callee is <em>requires-unsafe</em>: under the updated memory-safety
     /// rules a member declared <c>unsafe</c>/<c>extern</c> is stamped with
     /// <c>RequiresUnsafeAttribute</c>, and every call site needs an unsafe
     /// context even when no pointer crosses the call boundary. Recovered from
-    /// the callee MethodDef's attributes; false for cross-assembly MemberRefs
-    /// (whose attributes aren't readable) — the printer's signature-pointer
-    /// heuristic covers the compat-mode cross-assembly case instead.
+    /// the callee MethodDef's attributes when reachable. The printer's
+    /// signature-pointer heuristic covers the compat-mode cross-assembly case
+    /// when the attribute cannot be read.
     /// </summary>
     public bool RequiresUnsafe { get; init; }
 
@@ -48,18 +58,22 @@ public sealed record MethodRef(
     public bool IsSpecialName { get; init; }
 
     /// <summary>
-    /// Metadata <c>[CompilerGenerated]</c> evidence on this method. Exact for
-    /// same-assembly MethodDefs; false for MemberRefs where the attribute rows
-    /// are unavailable through the call-site token.
+    /// Metadata <c>[CompilerGenerated]</c> evidence on this method, or
+    /// <see cref="MetadataFactState.Unknown"/> when the defining MethodDef was
+    /// unreachable from the call-site token.
     /// </summary>
-    public bool IsCompilerGenerated { get; init; }
+    public MetadataFactState CompilerGenerated { get; init; } = MetadataFactState.Unknown;
+
+    public bool IsCompilerGenerated => CompilerGenerated == MetadataFactState.Yes;
 
     /// <summary>
-    /// Metadata <c>[CompilerGenerated]</c> evidence on the declaring type. Exact
-    /// for same-assembly MethodDefs; false for MemberRefs where the declaring
-    /// type's definition is unavailable through the call-site token.
+    /// Metadata <c>[CompilerGenerated]</c> evidence on the declaring type, or
+    /// <see cref="MetadataFactState.Unknown"/> when the defining TypeDef was
+    /// unreachable from the call-site token.
     /// </summary>
-    public bool DeclaringTypeIsCompilerGenerated { get; init; }
+    public MetadataFactState DeclaringTypeCompilerGenerated { get; init; } = MetadataFactState.Unknown;
+
+    public bool DeclaringTypeIsCompilerGenerated => DeclaringTypeCompilerGenerated == MetadataFactState.Yes;
 
     /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
@@ -74,7 +88,7 @@ public sealed record MethodRef(
     /// </summary>
     public bool HasUnverifiableByRefArgument(IReadOnlyList<IrExpression> nonReceiverArguments)
     {
-        if (!ParameterRefKinds.IsDefaultOrEmpty)
+        if (ParameterRefKindsFacts != ParameterRefKindFacts.Unknown || !ParameterRefKinds.IsDefaultOrEmpty)
             return false;
         for (int i = 0; i < ParameterTypes.Length && i < nonReceiverArguments.Count; i++)
             if (ParameterTypes[i].Kind == TypeRefKind.ByRef

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+internal readonly record struct ParameterRefKindResult(
+    ImmutableArray<ArgumentRefKind> Kinds,
+    ParameterRefKindFacts State);
+
+internal static class MethodDefinitionFacts
+{
+    internal static ParameterRefKindResult ReadParameterRefKinds(
+        MetadataReader reader,
+        MethodDefinition method,
+        ImmutableArray<TypeRef> parameterTypes)
+    {
+        bool anyByRef = false;
+        foreach (var p in parameterTypes)
+            if (p.Kind == TypeRefKind.ByRef) { anyByRef = true; break; }
+        if (!anyByRef)
+            return new ParameterRefKindResult([], ParameterRefKindFacts.NotRequired);
+
+        var kinds = new ArgumentRefKind[parameterTypes.Length];
+        for (int i = 0; i < kinds.Length; i++)
+            kinds[i] = parameterTypes[i].Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value;
+        foreach (var handle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(handle);
+            int index = parameter.SequenceNumber - 1;  // sequence 0 is the return parameter
+            if (index < 0 || index >= kinds.Length || parameterTypes[index].Kind != TypeRefKind.ByRef)
+                continue;
+            kinds[index] = ClassifyByRefParameter(reader, parameter);
+        }
+        return new ParameterRefKindResult(ImmutableArray.Create(kinds), ParameterRefKindFacts.Known);
+    }
+
+    internal static bool HasRequiresUnsafeAttribute(MetadataReader reader, MethodDefinition method)
+        => HasAttribute(reader, method.GetCustomAttributes(), "System.Diagnostics.CodeAnalysis", "RequiresUnsafeAttribute");
+
+    internal static bool HasRequiresUnsafeAttribute(MetadataReader reader, TypeDefinition type)
+        => HasAttribute(reader, type.GetCustomAttributes(), "System.Diagnostics.CodeAnalysis", "RequiresUnsafeAttribute");
+
+    internal static bool HasCompilerGeneratedAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+        => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+
+    internal static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    internal static (string Namespace, string Name) AttributeTypeName(MetadataReader reader, EntityHandle constructor)
+    {
+        switch (constructor.Kind)
+        {
+            case HandleKind.MemberReference
+                when reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent:
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)parent);
+                return (reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            case HandleKind.MethodDefinition:
+                var declaring = reader.GetTypeDefinition(reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
+                return (reader.GetString(declaring.Namespace), reader.GetString(declaring.Name));
+            default:
+                return ("", "");
+        }
+    }
+
+    static ArgumentRefKind ClassifyByRefParameter(MetadataReader reader, System.Reflection.Metadata.Parameter parameter)
+    {
+        if (HasReadOnlyRefAttribute(reader, parameter.GetCustomAttributes()))
+            return ArgumentRefKind.In;
+        var attributes = parameter.Attributes;
+        if ((attributes & System.Reflection.ParameterAttributes.Out) != 0
+            && (attributes & System.Reflection.ParameterAttributes.In) == 0)
+            return ArgumentRefKind.Out;
+        return ArgumentRefKind.Ref;
+    }
+
+    static bool HasReadOnlyRefAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+        => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "IsReadOnlyAttribute")
+            || HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "RequiresLocationAttribute");
+
+    static bool HasAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes, string ns, string name)
+    {
+        foreach (var handle in attributes)
+            if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor) is var attr
+                && attr.Namespace == ns
+                && attr.Name == name)
+            {
+                return true;
+            }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit unknown states for MethodRef compiler-generated and by-ref parameter facts
- upgrade external MemberRefs from defining assembly metadata via CrossAssemblyTypeResolver
- add cross-assembly tests for ref/out/in, compiler-generated, and missing-metadata unknown behavior

## Validation
- dotnet build src/dotnet-inspect -c Release --no-restore
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore