### PR TITLE
Use exact IDisposable identity for using sugar

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -185,6 +185,35 @@ public class MemberIdentityTests
             [new LoadLocalAddress(0, s_handler)])));
     }
 
+    [Fact]
+    public void IsIDisposableDispose_RequiresExactBclVirtualSignature()
+    {
+        var disposable = TypeRef.CoreLib("System", "IDisposable");
+        Assert.True(MemberIdentity.IsIDisposableDispose(Dispose(disposable)));
+        Assert.True(MemberIdentity.IsIDisposableDispose(Dispose(TypeRef.Definition(
+            "System.Runtime",
+            "System",
+            "IDisposable"))));
+
+        var userDisposable = TypeRef.Definition("UserAssembly", "System", "IDisposable");
+        Assert.False(MemberIdentity.IsIDisposableDispose(Dispose(userDisposable)));
+
+        Assert.False(MemberIdentity.IsIDisposableDispose(new Call(
+            DisposeMethod(disposable) with { ReturnType = s_object },
+            isVirtual: true,
+            [new LoadLocal(0, disposable)])));
+
+        Assert.False(MemberIdentity.IsIDisposableDispose(new Call(
+            DisposeMethod(disposable) with { ParameterTypes = [s_object] },
+            isVirtual: true,
+            [new LoadLocal(0, disposable)])));
+
+        Assert.False(MemberIdentity.IsIDisposableDispose(new Call(
+            DisposeMethod(disposable),
+            isVirtual: false,
+            [new LoadLocal(0, disposable)])));
+    }
+
     static MethodRef GetSubArrayMethod(TypeRef declaringType)
         => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
 
@@ -259,4 +288,10 @@ public class MemberIdentityTests
 
     static Call ToStringAndClear(TypeRef declaringType)
         => new(ToStringAndClearMethod(declaringType), isVirtual: false, [new LoadLocalAddress(0, declaringType)]);
+
+    static MethodRef DisposeMethod(TypeRef declaringType)
+        => new(declaringType, "Dispose", s_void, [], HasThis: true);
+
+    static Call Dispose(TypeRef declaringType)
+        => new(DisposeMethod(declaringType), isVirtual: true, [new LoadLocal(0, declaringType)]);
 }

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -48,13 +48,27 @@ public class UsingStatementPassTests
     [Fact]
     public void ResourceReassignedInsideTry_IsLeftAsTryFinally()
     {
-        var function = BuildUsingLookalikeWithResourceReassignment();
+        var function = BuildUsingLookalike(TypeRef.CoreLib("System", "IDisposable"), reassignInsideTry: true);
 
         new UsingStatementPass().Run(function, PassContext.None);
 
         Assert.Empty(function.Descendants.OfType<UsingStatement>());
         Assert.Single(function.Descendants.OfType<TryFinally>());
         Assert.Equal(2, function.Descendants.OfType<StoreLocal>().Count(store => store.Index == 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void UserIDisposableLookalike_IsLeftAsTryFinally()
+    {
+        var function = BuildUsingLookalike(
+            TypeRef.Definition("UserAssembly", "System", "IDisposable"),
+            reassignInsideTry: false);
+
+        new UsingStatementPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
         function.CheckInvariant();
     }
 
@@ -83,14 +97,14 @@ public class UsingStatementPassTests
         Assert.DoesNotContain("Dispose", output);
     }
 
-    static IrFunction BuildUsingLookalikeWithResourceReassignment()
+    static IrFunction BuildUsingLookalike(TypeRef disposableType, bool reassignInsideTry)
     {
         var voidType = TypeRef.CoreLib("System", "Void");
-        var disposableType = TypeRef.CoreLib("System", "IDisposable");
         var dispose = new MethodRef(disposableType, "Dispose", voidType, [], HasThis: true);
 
         var tryBlock = new Block(0);
-        tryBlock.Add(new StoreLocal(0, disposableType, new Constant(null, disposableType)));
+        if (reassignInsideTry)
+            tryBlock.Add(new StoreLocal(0, disposableType, new Constant(null, disposableType)));
         var tryBody = new BlockContainer();
         tryBody.Add(tryBlock);
 

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -104,6 +104,19 @@ public static class MemberIdentity
             && call.Callee.ParameterTypes.IsEmpty
             && call.Arguments.Count == 1;
 
+    public static bool IsIDisposableDispose(Call call)
+        => call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: true,
+                Name: "Dispose",
+                TypeArguments.IsEmpty: true,
+                ParameterTypes.IsEmpty: true,
+                ReturnType: var returnType,
+            }
+            && returnType.Equals(s_void)
+            && IsCoreLibraryOrFacadeType(call.Callee.DeclaringType, "System", "IDisposable", "System.Runtime");
+
     public static bool IsRuntimeHelpersCreateSpan(Call call)
     {
         if (call.IsVirtual

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -114,7 +114,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative UnaryOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "reference-type IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
+    [Completeness(CompletenessLevel.Partial, "reference-type exact BCL IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass WhileStatement => new();
     [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences reconstructed (IteratorReconstructionPass), parameterized/captured/looping iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -24,8 +24,6 @@ public sealed class UsingStatementPass : IIrPass
 
     sealed record Match(StoreLocal StoreResource, TryFinally TryFinally);
 
-    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
-
     public void Run(IrFunction function, PassContext context)
     {
         while (TransformOne(function, context.Stepper))
@@ -91,7 +89,7 @@ public sealed class UsingStatementPass : IIrPass
     /// <summary>An <c>IDisposable.Dispose()</c> call whose receiver is the resource local, loaded by value (reference type) or by address (value-type constrained dispose).</summary>
     static bool IsDisposeOf(Call dispose, int index)
     {
-        if (!IsIDisposableDispose(dispose) || dispose.Arguments is not [var receiver])
+        if (!MemberIdentity.IsIDisposableDispose(dispose) || dispose.Arguments is not [var receiver])
             return false;
         return receiver switch
         {
@@ -100,16 +98,6 @@ public sealed class UsingStatementPass : IIrPass
             _ => false,
         };
     }
-
-    static bool IsIDisposableDispose(Call call)
-        => call.IsVirtual
-            && call.Callee.Name == "Dispose"
-            && call.Callee.HasThis
-            && call.Callee.TypeArguments.IsEmpty
-            && call.Callee.ParameterTypes.IsEmpty
-            && call.Callee.ReturnType.Equals(s_void)
-            && call.Callee.DeclaringType is
-                { Namespace: "System", Name: "IDisposable", Assembly: TypeRef.CoreLibrary or "System.Runtime" };
 
     static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
     {


### PR DESCRIPTION
## Summary
- add `MemberIdentity.IsIDisposableDispose`
- migrate `UsingStatementPass` from a local `IDisposable.Dispose` matcher to the shared predicate
- add direct identity coverage and a synthetic user-defined `System.IDisposable` lookalike that must stay `try/finally`
- update the lowering ledger note to call out exact BCL `IDisposable` identity

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.UsingStatementPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal