### PR TITLE
Raise property null-coalescing assignment (obj.Prop ??= x)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1203,7 +1203,11 @@ public class CfgSampleClass
     public sealed class CacheHolder
     {
         public string? Cache;
+        public string? CacheProp { get; set; }
+        public CacheHolder? Next;
     }
+
+    public static string? StaticNameProp { get; set; }
 
     public static string NullCoalescingAssignStaticField(string fallback)
     {
@@ -1225,6 +1229,34 @@ public class CfgSampleClass
             LastValue = fallback.Length;
         }
         return holder.Cache;
+    }
+
+    public static string NullCoalescingAssignInstanceProperty(CacheHolder holder, string fallback)
+    {
+        holder.CacheProp ??= fallback;
+        return holder.CacheProp;
+    }
+
+    public static string NullCoalescingAssignStaticProperty(string fallback)
+    {
+        StaticNameProp ??= fallback;
+        return StaticNameProp;
+    }
+
+    public static string NullCoalescingAssignChainedProperty(CacheHolder holder, string fallback)
+    {
+        holder.Next!.CacheProp ??= fallback;
+        return holder.Next!.CacheProp!;
+    }
+
+    public static string NullCoalescingAssignPropertyWithExtraThenStatement(CacheHolder holder, string fallback)
+    {
+        if (holder.CacheProp == null)
+        {
+            holder.CacheProp = fallback;
+            LastValue = fallback.Length;
+        }
+        return holder.CacheProp;
     }
 
     public static string[] ArrayWithInit(string a)

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -108,4 +108,77 @@ public class NullCoalescingAssignmentPassTests
         Assert.NotNull(output);
         Assert.DoesNotContain("??=", output);
     }
+
+    [Fact]
+    public void InstancePropertyNullAssignmentDiamond_RaisesToNullCoalescingPropertyAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignInstanceProperty));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Equal("CacheProp", assignment.PropertyName);
+        Assert.True(assignment.HasInstance);
+        Assert.IsType<LoadArgument>(assignment.Instance);
+        Assert.IsType<LoadArgument>(assignment.Value);
+        // The setter value-spill (stack slot + dead result local) is gone.
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<StoreProperty>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersInstancePropertyNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignInstanceProperty))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("holder.CacheProp ??= fallback;", output);
+    }
+
+    [Fact]
+    public void StaticPropertyNullAssignmentDiamond_RaisesToNullCoalescingPropertyAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticProperty));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Equal("StaticNameProp", assignment.PropertyName);
+        Assert.False(assignment.HasInstance);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersStaticPropertyNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticProperty))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("StaticNameProp ??= fallback;", output);
+    }
+
+    [Fact]
+    public void ChainedPropertyNullAssignment_RaisesThroughSpilledReceiverLocal()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignChainedProperty));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Equal("CacheProp", assignment.PropertyName);
+        Assert.True(assignment.HasInstance);
+        // csc spills the holder.Next receiver to a local that both accessors read,
+        // so PlaceIdentity.SameVariable proves the place re-evaluable; the later
+        // inlining pass folds that single-use local back to the field chain.
+        Assert.IsType<LoadField>(assignment.Instance);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("holder.Next.CacheProp ??= fallback;", output);
+    }
+
+    [Fact]
+    public void PropertyNullAssignmentWithExtraThenStatement_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignPropertyWithExtraThenStatement));
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("??=", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -859,6 +859,7 @@ public sealed partial class CSharpPrinter
         DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclaration ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
+        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, [], n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -717,6 +717,42 @@ public sealed class NullCoalescingFieldAssignment : IrNode
 }
 
 /// <summary>
+/// A raised property null-coalescing assignment (<c>obj.Prop ??= fallback</c>, or
+/// <c>Type.Prop ??= fallback</c> for a static property). Produced from csc's
+/// property null-test diamond: <c>if (obj.Prop is null) obj.Prop = fallback;</c>,
+/// where the getter and setter are paired as one property and the receiver — when
+/// present — is re-evaluable (a local/argument/this), so collapsing the two
+/// accessor calls into one <c>??=</c> reorders nothing. Indexers are deferred to a
+/// later slice (their index arguments carry their own re-evaluation concern).
+/// </summary>
+public sealed class NullCoalescingPropertyAssignment : IrNode
+{
+    public NullCoalescingPropertyAssignment(MethodRef setter, IrExpression? instance, IrExpression value, bool isVirtual)
+    {
+        Setter = setter;
+        IsVirtual = isVirtual;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        AddChild(value);
+    }
+
+    public MethodRef Setter { get; }
+    public bool IsVirtual { get; }
+    public bool HasInstance { get; }
+    public string PropertyName => Setter.Name["set_".Length..];
+
+    /// <summary>The property's type — the setter's value parameter.</summary>
+    public TypeRef PropertyType => Setter.ParameterTypes[^1];
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+    public override IEnumerable<TypeRef> DirectTypes => Setter.ParameterTypes.Append(Setter.DeclaringType);
+
+    public override string Describe()
+        => $"NullCoalescingPropertyAssignment {Setter.DeclaringType.ToDisplayString()}.{PropertyName}";
+}
+
+/// <summary>
 /// A raised null-conditional member access — <c>target?.Member</c>. The single
 /// child is the member access (a <see cref="Call"/>, <see cref="LoadProperty"/>,
 /// or <see cref="LoadField"/>) whose receiver IS the <c>?.</c> target; the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -87,7 +87,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration => default!;
     [Completeness(CompletenessLevel.Full)] public static LockSugarPass LockStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative MultipleLocalDeclarations => default!;
-    [Completeness(CompletenessLevel.Partial, "local-variable and field (instance + static, re-evaluable receiver) ??=; properties/indexers not raised")]
+    [Completeness(CompletenessLevel.Partial, "local-variable, field, and property (instance + static, re-evaluable receiver) ??=; indexers not raised")]
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -9,8 +9,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// into <c>V ??= fallback</c> / <c>obj.field ??= fallback</c>. The field form is
 /// scoped to a re-evaluable receiver (a local/argument/this, or none for a static
 /// field), so collapsing the two member loads into one <c>??=</c> reorders
-/// nothing. Property and indexer <c>??=</c> shapes carry accessor-call concerns
-/// left to later slices.
+/// nothing. The property form (<c>obj.Prop ??= fallback</c>) pairs the getter and
+/// setter as one property and folds csc's value-spill (the setter takes the value
+/// through a temp so the assignment can also be the expression's result; in
+/// statement position that result is dead). Indexer <c>??=</c> is deferred — its
+/// index arguments carry their own re-evaluation concern.
 /// </summary>
 public sealed class NullCoalescingAssignmentPass : IIrPass
 {
@@ -36,6 +39,19 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 var value = (IrExpression)children[^1];
                 var replacement = new NullCoalescingFieldAssignment(field.Store.Field, instance, value);
                 context.Stepper.StepOver("raise field null check assignment to ??=", statement);
+                statement.ReplaceWith(replacement);
+                continue;
+            }
+
+            if (TryMatchProperty(function, statement) is { } property)
+            {
+                var instance = property.Store.Instance;
+                var value = property.Value;
+                instance?.Detach();
+                value.Detach();
+                var replacement = new NullCoalescingPropertyAssignment(
+                    property.Store.Accessor, instance, value, property.Store.IsVirtual);
+                context.Stepper.StepOver("raise property null check assignment to ??=", statement);
                 statement.ReplaceWith(replacement);
             }
         }
@@ -83,6 +99,76 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     static bool SameField(FieldRef a, FieldRef b)
         => a.Name == b.Name && Equals(a.DeclaringType, b.DeclaringType);
+
+    sealed record PropertyMatch(StoreProperty Store, IrExpression Value);
+
+    // obj.Prop ??= fallback lowers to a get/set diamond:
+    //   if (obj.get_Prop() is null) obj.set_Prop(fallback);
+    // The setter is a call, so csc routes the value through a temp — the slot the
+    // setter reads is also stored to a (dead, in statement position) local so the
+    // assignment can double as the ??= expression's result. We pair the getter and
+    // setter as one property, require a re-evaluable receiver, and recover the
+    // original value from behind that spill.
+    static PropertyMatch? TryMatchProperty(IrFunction function, IfStatement statement)
+    {
+        if (statement.HasElse
+            || NullTested(statement.Condition) is not LoadProperty getter
+            || getter.IndexArguments.Count != 0
+            || statement.Then.Children is not [.., StoreProperty store]
+            || store.IndexArguments.Count != 0
+            || store.PropertyName != getter.PropertyName
+            || !Equals(store.Accessor.DeclaringType, getter.Accessor.DeclaringType)
+            || !SameReceiver(getter.Instance, store.Instance))
+        {
+            return null;
+        }
+
+        if (IsNonNullableNumeric(store.Accessor.ParameterTypes[^1]))
+            return null;
+
+        var value = RecoverSpilledValue(function, statement.Then, store);
+        return value is null ? null : new PropertyMatch(store, value);
+    }
+
+    // The clean form is `Then = [store]` with the value inline (a static property,
+    // or any setter csc fed directly). The spilled form is
+    //   [StoreStackSlot S = fallback, (StoreLocal dead = S)*, store(value: load S)]
+    // where the setter and the dead ??= result both read slot S. We return the real
+    // value (fallback) only when slot S and the dead local are confined to this
+    // block — i.e. nothing else in the function reads them, so dropping the spill is
+    // sound.
+    static IrExpression? RecoverSpilledValue(IrFunction function, Block then, StoreProperty store)
+    {
+        var children = then.Children;
+        if (store.Value is not LoadStackSlot slot)
+            return children.Count == 1 ? store.Value : null;
+
+        if (children.Count < 2 || children[0] is not StoreStackSlot spill || spill.Slot != slot.Slot)
+            return null;
+
+        // Every statement between the spill and the store is the dead capture of the
+        // ??= result: a local store of the same slot, never read elsewhere.
+        for (int i = 1; i < children.Count - 1; i++)
+        {
+            if (children[i] is not StoreLocal { Value: LoadStackSlot read } dead
+                || read.Slot != slot.Slot
+                || function.Descendants.OfType<LoadLocal>().Any(l => l.Index == dead.Index))
+            {
+                return null;
+            }
+        }
+
+        // The slot is a single-assignment spill local to this idiom: one store (the
+        // spill) and reads only from the statements matched above.
+        int expectedLoads = children.Count - 1;
+        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot.Slot) != 1
+            || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == slot.Slot) != expectedLoads)
+        {
+            return null;
+        }
+
+        return spill.Value;
+    }
 
     // The receiver is loaded once for the null test and once for the store; the
     // fold is only sound when re-evaluating it is free of side effects and yields


### PR DESCRIPTION
## What

Raise property null-coalescing assignment — `obj.Prop ??= x` and `Type.Prop ??= x` —
extending `NullCoalescingAssignmentPass` from its local/field coverage. This is
the next consumer of the `PlaceIdentity` substrate (#767): the receiver
re-evaluability check is `PlaceIdentity.SameVariable`.

**Before** (instance property — leaks the setter's value-spill):

```csharp
string V_0; string S_256;
if (Prop is null) { S_256 = fallback; V_0 = S_256; Prop = S_256; }
```

**After:**

```csharp
Prop ??= fallback;
```

## How

csc lowers `obj.Prop ??= x` to a get/set diamond — `if (obj.get_Prop() is null) obj.set_Prop(x);` —
with two wrinkles a field store doesn't have:

1. **Accessor pairing.** The getter and setter are separate calls; the match
   pairs `get_`/`set_` on declaring-type + property-name identity.
2. **Value-spill.** Because the setter is a call, csc routes the value through a
   stack-slot temp and also stores it to a (dead, in statement position) local so
   the assignment can double as the `??=` expression's result.

`TryMatchProperty`:

- pairs the accessors, index-arg-free (**indexers deferred** — their index
  arguments carry their own re-evaluation concern, like field `??=` deferred
  properties);
- requires a re-evaluable receiver via `PlaceIdentity.SameVariable` (or both-null
  for a static property). For a chained receiver (`a.b.Prop ??= x`) csc spills the
  receiver to a local that **both** accessors read — `SameVariable` matches that,
  and a later inlining pass folds the single-use local back to the field chain;
- recovers the real value from behind the spill, proving **whole-function** that
  the spill slot and the dead result local are confined to the matched statement
  (one slot store; reads only here; dead local never read) before dropping them.

## Soundness

The fold is the exact inverse of csc's lowering, and the receiver/value
re-evaluation is gated on `PlaceIdentity` + the whole-function confinement check.
The **fidelity gate** (`FidelityGateTests.NoNewOpcodeDiffsBeyondKnownDocket`)
decompiles every `CfgSampleClass` method — including the four new property `??=`
fixtures — recompiles, and compares opcode streams: all opcode-exact.

## Tests / verification

- New IR node `NullCoalescingPropertyAssignment` + printer case.
- Fixtures: instance, static, chained (spilled-receiver), and a negative
  (extra then-statement) case; 8 new pass tests.
- Ledger line flipped: `local-variable, field, and property … ??=; indexers not raised`.
- 495/496 decompiler tests green. The single failure
  (`MixedSourceRendererTests.ClosureAndDelegateAllocations_BothInterleave`) is
  **pre-existing on main** (reproduced with this branch's changes stashed) and
  unrelated to `??=`.
- Product build clean.
