### PR TITLE
Raise capturing lambdas from local display-class environments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -56,6 +56,21 @@ public class CfgSampleClass
     // Two captured parameters, both substituted into the recovered body.
     public static System.Func<int, int> TwoCaptureLambda(int a, int b) => x => x + a - b;
 
+    // Multi-statement display-class environment: the closure is a local that is
+    // allocated, field-set, and bound to a local across separate statements (not
+    // the folded `new DC { ... }`). LambdaRaisingPass elides the allocation and
+    // capture store and recovers `f = x => x + n`.
+    public static int InvokeLocalCapture(int n)
+    {
+        System.Func<int, int> f = x => x + n;
+        return f(5) + f(6);
+    }
+
+    // Two lambdas share one display-class environment (`n` captured once); both
+    // are raised and the shared allocation is elided.
+    public static (System.Func<int, int>, System.Func<int, int>) SharedCaptureLambdas(int n)
+        => (x => x + n, y => y - n);
+
     // Boundary fixtures for the lambda surface: each exercises a distinct
     // LambdaRaisingPass guard. When a later slice lifts a guard, flip its
     // scorecard entry to recovered in that PR.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -62,6 +62,7 @@ public class FidelityGateTests
     /// </summary>
     static readonly string[] PinnedExact =
     {
+        "SharedCaptureLambdas",
         "CheckedAdd",
         "UnsignedShift",
         "Shadowed",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -48,10 +48,12 @@ public class IdiomShapeScorecardTests
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        // Local display-class environments (allocated and field-set across statements).
+        new("LambdaRaisingPass", nameof(CfgSampleClass.InvokeLocalCapture), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.SharedCaptureLambdas), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         // Owed: a lambda body that keeps a local of its own (declined by the zero-local guard).
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
-        // Owed: a capture whose display class is spread across statements (not a folded environment).
-        new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -52,6 +52,27 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
+    public void LocalDisplayClassEnvironment_RaisesLambdaAndElidesSetup()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.InvokeLocalCapture));
+
+        Assert.Contains("x => x + n", output);
+        Assert.DoesNotContain("DisplayClass", output);   // allocation + capture store elided
+        Assert.DoesNotContain("new Func", output);
+    }
+
+    [Fact]
+    public void SharedDisplayClassEnvironment_RaisesEveryLambda()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.SharedCaptureLambdas));
+
+        Assert.Contains("x => x + n", output);
+        Assert.Contains("y => y - n", output);
+        Assert.DoesNotContain("DisplayClass", output);
+        Assert.DoesNotContain("new Func", output);
+    }
+
+    [Fact]
     public void LambdaNameLookalikeWithoutCompilerGeneratedMetadata_IsNotRaised()
     {
         var lambdaMethod = new MethodRef(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -32,7 +32,7 @@ internal static class ClosureCoverage
     [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]
     public static Unhandled LocalFunction => default!;
 
-    [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from a folded <>c__DisplayClass environment; a display class spread across statements, or captured by a local function, is still owed")]
+    [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from its <>c__DisplayClass environment — folded onto the delegate, or a local set up and shared across statements (allocation/stores elided); a class captured by a local function, or nested environments, still owed")]
     public static LambdaRaisingPass CapturedClosure => new();
 
     [Completeness(CompletenessLevel.None, "Expression<Func<...>> built via Expression.Lambda/Call/... (ExpressionLambdaRewriter)")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -14,13 +14,15 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <list type="bullet">
 /// <item><b>Non-capturing</b> — the target runs on the static <c>&lt;&gt;c</c>
 /// singleton and reads no <c>this</c>.</item>
-/// <item><b>Capturing</b> — the delegate target is a folded
-/// <c>new &lt;&gt;c__DisplayClass { f = v, ... }</c> environment; each member binds
-/// a hoisted field to a value captured from the outer scope. The body's
-/// <c>this.f</c> reads are substituted with those captured values, which then
-/// print in the outer scope. Only the inlined single-expression environment is
-/// taken; a display class spread across statements is left for a later
-/// increment.</item>
+/// <item><b>Capturing</b> — captured variables are hoisted into a
+/// <c>&lt;&gt;c__DisplayClass</c> environment; the body's <c>this.f</c> reads are
+/// substituted with the captured values, which then print in the outer scope.
+/// Two environment shapes are taken: the <b>folded</b>
+/// <c>new &lt;&gt;c__DisplayClass { f = v, ... }</c> on the delegate target, and the
+/// <b>local</b> form where the environment is a local allocated and field-set
+/// across statements (its allocation and capture stores are then elided). A
+/// display class read in any way other than its capture stores and lambda
+/// delegate targets is left as-is.</item>
 /// </list>
 /// <para>In both cases the body must carry compiler-generated metadata evidence,
 /// declare no locals of its own, and be a single <c>return expr;</c> or a simple
@@ -36,6 +38,11 @@ public sealed class LambdaRaisingPass : IIrPass
     {
         if (context.ImportMethodBody is null)
             return;
+
+        // A local display-class environment is a multi-statement shape, so it is
+        // raised (and its setup elided) block-first, before the per-creation walk
+        // picks up the folded and non-capturing forms left standing.
+        RaiseLocalDisplayClasses(function, context);
 
         foreach (var creation in function.Descendants.OfType<DelegateCreation>().ToList())
         {
@@ -76,23 +83,111 @@ public sealed class LambdaRaisingPass : IIrPass
             || !Equals(env.Creation.Constructor.DeclaringType, creation.Method.DeclaringType))
             return null;
 
+        var outer = RootFunction(creation);
         var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
         var values = env.Values;
         for (int i = 0; i < values.Count; i++)
         {
-            // The compiler hoists variables, not expressions, so a capture value
-            // is a bare parameter/local/this load that re-prints in the outer scope.
-            if (env.Members[i] is not { } field || values[i] is not (LoadArgument or LoadLocal))
+            if (env.Members[i] is not { } field || !IsCaptureValue(values[i], outer))
                 return null;
             captures[field] = values[i];
         }
 
+        // Anchor to the folded environment's allocation (new <>c__DisplayClass)
+        // rather than the delegate creation: it is the earliest outer offset the
+        // lambda subsumes, so the closure allocation fact and its setup IL anchor
+        // to this statement in the mixed view (see Finish).
+        return RaiseWithCaptures(creation, captures, env.Creation, context);
+    }
+
+    // Recover lambdas whose captured environment is a local <>c__DisplayClass set
+    // up across statements: `dc = new DC(); dc.f = v; ... use(new Func(dc.b__N))`.
+    // Each delegate creation over the local is raised by substituting the captured
+    // values, then the allocation and capture stores are elided so the environment
+    // disappears (the now-unreferenced local prints nothing).
+    static void RaiseLocalDisplayClasses(IrFunction function, PassContext context)
+    {
+        foreach (var alloc in function.Descendants.OfType<StoreLocal>().ToList())
+        {
+            if (alloc.Parent is null
+                || alloc.Value is not NewObject { Arguments.Count: 0, Constructor.DeclaringType: { } dcType }
+                || !GeneratedCodeIdentity.IsDisplayClassName(dcType))
+                continue;
+            int slot = alloc.Index;
+
+            // The allocation must be the only store to the slot — otherwise the
+            // environment outlives this setup and elision is unsound.
+            if (function.Descendants.OfType<StoreLocal>().Count(s => s.Index == slot) != 1)
+                continue;
+
+            // Classify every read of the local: a capture store's receiver, or a
+            // lambda delegate target. Any other use means we cannot elide it.
+            var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
+            var captureStores = new List<StoreField>();
+            var creations = new List<DelegateCreation>();
+            bool elidable = true;
+            foreach (var load in function.Descendants.OfType<LoadLocal>().Where(l => l.Index == slot))
+            {
+                if (load.Parent is StoreField store
+                    && ReferenceEquals(store.Instance, load)
+                    && Equals(store.Field.DeclaringType, dcType)
+                    && IsCaptureValue(store.Value, function))
+                {
+                    captures[store.Field.Name] = store.Value;
+                    captureStores.Add(store);
+                }
+                else if (load.Parent is DelegateCreation creation
+                    && ReferenceEquals(creation.Target, load)
+                    && GeneratedCodeIdentity.IsCapturingLambdaMethod(creation.Method)
+                    && Equals(creation.Method.DeclaringType, dcType))
+                {
+                    creations.Add(creation);
+                }
+                else
+                {
+                    elidable = false;
+                    break;
+                }
+            }
+            if (!elidable || creations.Count == 0)
+                continue;
+
+            // Raise every lambda first; commit nothing unless all succeed. The
+            // environment allocation is each lambda's outer provenance anchor.
+            var raised = new List<(DelegateCreation Creation, Lambda Lambda)>(creations.Count);
+            foreach (var creation in creations)
+            {
+                if (RaiseWithCaptures(creation, captures, alloc.Value, context) is not { } lambda)
+                {
+                    raised = null!;
+                    break;
+                }
+                raised.Add((creation, lambda));
+            }
+            if (raised is null)
+                continue;
+
+            foreach (var (creation, lambda) in raised)
+            {
+                context.Stepper.StepOver($"raise captured lambda {creation.Method.Name}", creation);
+                creation.ReplaceWith(lambda);
+            }
+            foreach (var store in captureStores)
+                store.Detach();
+            alloc.Detach();
+        }
+    }
+
+    // Import and raise the lambda body, then substitute each read of a captured
+    // field (through the display-class `this`, arg 0) with the captured value.
+    // Bails if `this` is used any way other than reading a known captured field.
+    static Lambda? RaiseWithCaptures(
+        DelegateCreation creation, Dictionary<string, IrExpression> captures, IrNode provenance, PassContext context)
+    {
         var body = RaisedBody(creation, context);
         if (body is null)
             return null;
 
-        // Every read of the display-class `this` (arg 0) must be a captured-field
-        // load we can substitute; any other use of `this` we cannot represent.
         var thisReads = body.Descendants.OfType<LoadArgument>().Where(a => a.Index == 0).ToList();
         if (!thisReads.All(a => a.Parent is LoadField field
                 && Equals(field.Field.DeclaringType, creation.Method.DeclaringType)
@@ -107,11 +202,24 @@ public sealed class LambdaRaisingPass : IIrPass
                 load.ReplaceWith(value.Clone());
         }
 
-        // Anchor to the folded environment's allocation (new <>c__DisplayClass)
-        // rather than the delegate creation: it is the earliest outer offset the
-        // lambda subsumes, so the closure allocation fact and its setup IL anchor
-        // to this statement in the mixed view (see Finish).
-        return Finish(creation, body, env.Creation);
+        return Finish(creation, body, provenance);
+    }
+
+    // A hoisted capture binds a variable, not an expression: a parameter/this load
+    // or a non-display-class local (a display-class local would be a nested
+    // environment we do not yet flatten).
+    static bool IsCaptureValue(IrExpression value, IrFunction function) => value switch
+    {
+        LoadArgument => true,
+        LoadLocal local => !GeneratedCodeIdentity.IsDisplayClassName(function.Locals[local.Index]),
+        _ => false,
+    };
+
+    static IrFunction RootFunction(IrNode node)
+    {
+        while (node.Parent is not null)
+            node = node.Parent;
+        return (IrFunction)node;
     }
 
     // Import the synthesized method and raise it with the same pipeline so it


### PR DESCRIPTION
## What

Recovers a capturing lambda whose display-class environment is **spread across statements** — the shape the compiler emits when the closure is stored in a local, shared by several lambdas, or passed to a method:

- `xs.Where(x => x > t).ToList()` → `Enumerable.ToList(Enumerable.Where(xs, x => x > t))`
- `Func<int,int> f = x => x + n; return f(5) + f(6);` → recovers `f = x => x + n`
- `(x => x + n, y => y - n)` (two lambdas, one shared environment) → both recovered

Previously only the **folded** `new <>c__DisplayClass { f = v }`-on-the-delegate form raised (#768); this adds the local form, which is the common one (LINQ, stored delegates).

## How

`RaiseLocalDisplayClasses` runs block-first, before the per-creation walk:

1. Find `local = new <>c__DisplayClass()`.
2. Require it to be the only store to that local, and confirm **every** read of the local is either a capture store's receiver (`local.f = v`) or a lambda delegate target. Any other use means the environment outlives this setup → bail.
3. Build the `field -> value` capture map from the stores (capture values are bare variable loads, not nested display classes).
4. Raise every delegate creation over the local by substituting the captured values (shared `RaiseWithCaptures` core, also used by the folded path), transactionally — commit nothing unless all succeed.
5. Elide the allocation and capture stores. The now-unreferenced display-class local prints nothing, since `CollectDeclarations` only declares locals that still appear in the tree.

The lambda anchors its source offset to the environment allocation (provenance), so the mixed view keeps the closure-allocation facts on that statement.

## Tests

- **Fidelity:** `SharedCaptureLambdas` is **pinned opcode-exact** in the gate — the durable proof the rewrite is fidelity-preserving. (`InvokeLocalCapture` declares a `Func` local the no-`using` gate skeleton can't resolve, so it stays an unpinned scorecard/unit fixture — a skeleton limitation, not a logic one; the product path adds usings.)
- **Scorecard:** `ClosureWithLinq` flips to recovered; `InvokeLocalCapture`, `SharedCaptureLambdas` added as recovered.
- **Unit:** `LambdaRaisingPassTests` for the local single-lambda and shared-environment forms.
- `ClosureCoverage.CapturedClosure` note widened to the local/shared forms.
- 504/504 decompiler tests green; no new opcode diffs in the gate or BCL corpus sweep.

## Follow-ups

Nested environments (a display class capturing another), and local-function captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
