### PR TITLE
Prototype sidecar lowering fact providers

### DIFF
--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -82,13 +82,17 @@ reactive:
 `LoweringCoverage` is the compiled completeness ledger: one row per Roslyn
 `LocalRewriter` lowering, recording the mechanism (which pass) and completeness.
 It already makes the *dedicated-vs-shared* gradient derivable — a pass type used
-by one row is dedicated, by several is shared. The substrate extension is to let
-a row also name the **fact primitives** its pass depends on. When three or more
-rows cite the same primitive, that is the signal to promote it to a substrate
-layer before the fourth copy is written — the ledger turns "we keep needing this"
-from tribal memory into a queryable fact. (This annotation is described here as
-the strategy; it is added incrementally as rows are touched, not retrofitted in
-one sweep.)
+by one row is dedicated, by several is shared. The substrate extension is for
+sidecar fact providers to name the **fact primitives** their rows depend on,
+keyed by the stable ledger row name. When three or more rows cite the same
+primitive, that is the signal to promote it to a substrate layer before the
+fourth copy is written — the ledger turns "we keep needing this" from tribal
+memory into a queryable fact.
+
+The fact metadata deliberately stays out of the central ledger rows. This keeps
+the conflict-reduction shape from PRs such as the stable ledger and printer
+splits: the central ledger remains the stable denominator, while additive
+per-pass sidecars carry the changing work-queue metadata.
 
 ### Reactive — a duplication census
 

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LoweringFactCatalogTests
+{
+    [Fact]
+    public void CatalogDiscoversSidecarProviders()
+    {
+        var entries = DiscoverFactEntries().Cast<LoweringFactEntry>().ToList();
+
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Await");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
+        Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");
+        Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.CapturedClosure");
+    }
+
+    [Fact]
+    public void EntriesTargetExistingCoverageRowsAndMechanisms()
+    {
+        var rows = CoverageRows();
+
+        foreach (var entry in DiscoverFactEntries().Cast<LoweringFactEntry>())
+        {
+            Assert.True(rows.TryGetValue(entry.Key.ToString(), out var mechanism),
+                $"{entry.Key}: fact sidecar targets no LoweringCoverage/ClosureCoverage row.");
+            Assert.Equal(mechanism, entry.Mechanism);
+            Assert.False(entry.RequiredFacts.IsDefaultOrEmpty, $"{entry.Key}: no required facts named.");
+            Assert.All(entry.RequiredFacts, fact =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(fact.Id), $"{entry.Key}: empty fact id.");
+                Assert.False(string.IsNullOrWhiteSpace(fact.Evidence), $"{entry.Key}/{fact.Id}: empty evidence.");
+            });
+            Assert.False(string.IsNullOrWhiteSpace(entry.PositiveCoverage), $"{entry.Key}: positive coverage is empty.");
+            Assert.False(string.IsNullOrWhiteSpace(entry.AdversarialCoverage), $"{entry.Key}: adversarial coverage is empty.");
+        }
+    }
+
+    [Fact]
+    public void EntriesAreUniquePerCoverageRow()
+    {
+        var duplicates = DiscoverFactEntries().Cast<LoweringFactEntry>()
+            .GroupBy(e => e.Key)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key.ToString())
+            .Order()
+            .ToArray();
+
+        Assert.True(duplicates.Length == 0,
+            "Fact sidecars should keep one entry per coverage row; duplicates fragment the work queue: "
+                + string.Join(", ", duplicates));
+    }
+
+    static Dictionary<string, Type> CoverageRows()
+    {
+        var rows = new Dictionary<string, Type>(StringComparer.Ordinal);
+        AddRows(rows, typeof(LoweringCoverage), "LocalRewriter");
+        AddRows(rows, typeof(ClosureCoverage), "ClosureConversion");
+        return rows;
+    }
+
+    static void AddRows(Dictionary<string, Type> rows, Type register, string name)
+    {
+        foreach (var property in register.GetProperties(BindingFlags.Public | BindingFlags.Static))
+            rows.Add($"{name}.{property.Name}", property.PropertyType);
+    }
+
+    static List<object> DiscoverFactEntries()
+    {
+        var entries = new List<object>();
+        foreach (var type in typeof(ILoweringFactProvider).Assembly.GetTypes())
+        {
+            if (type is { IsAbstract: false, IsInterface: false }
+                && typeof(ILoweringFactProvider).IsAssignableFrom(type)
+                && Activator.CreateInstance(type) is ILoweringFactProvider provider)
+            {
+                entries.AddRange(provider.Entries);
+            }
+        }
+        return entries;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/AwaitRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/AwaitRecoveryFacts.cs
@@ -1,0 +1,19 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class AwaitRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.Await)),
+            typeof(AwaitRecoveryPass),
+            [
+                new FactPrimitive("member.corelib-identity:AsyncHelpers.Await", "MemberIdentity.IsAsyncHelpersAwait"),
+            ],
+            PositiveCoverage: "CfgSampleClass runtime-async await fixtures",
+            AdversarialCoverage: "AwaitAdversarialTests namespace/type/assembly/instance lookalikes",
+            MissingDiscriminator: "classic async state-machine awaits require PDB/state-machine facts"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -1,0 +1,29 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.Lambda)),
+            typeof(LambdaRaisingPass),
+            [
+                new FactPrimitive("generated-type:lambda-holder", "GeneratedCodeIdentity.IsNonCapturingLambdaMethod"),
+                new FactPrimitive("generated-type:display-class", "GeneratedCodeIdentity.IsCapturingLambdaMethod"),
+            ],
+            PositiveCoverage: "LambdaRaisingPassTests non-capturing and capturing fixtures",
+            AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata",
+            MissingDiscriminator: "local-bound bodies and expression trees need additional closure/state facts"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.CapturedClosure)),
+            typeof(LambdaRaisingPass),
+            [
+                new FactPrimitive("generated-type:display-class", "GeneratedCodeIdentity.IsCapturingLambdaMethod"),
+                new FactPrimitive("place.re-evaluable", "PlaceIdentity same-place atoms for safe environment substitution"),
+            ],
+            PositiveCoverage: "LambdaRaisingPassTests capturing lambda fixture",
+            AdversarialCoverage: "LambdaRaisingPassTests guards for unsupported local/captured forms",
+            MissingDiscriminator: "display classes spread across statements are still owed"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LoweringFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LoweringFacts.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+internal enum LoweringFactRegister
+{
+    LocalRewriter,
+    ClosureConversion,
+}
+
+internal readonly record struct LoweringFactKey(LoweringFactRegister Register, string Row)
+{
+    public override string ToString() => $"{Register}.{Row}";
+}
+
+internal readonly record struct FactPrimitive(string Id, string Evidence)
+{
+    public override string ToString() => Id;
+}
+
+internal sealed record LoweringFactEntry(
+    LoweringFactKey Key,
+    Type Mechanism,
+    ImmutableArray<FactPrimitive> RequiredFacts,
+    string PositiveCoverage,
+    string AdversarialCoverage,
+    string? MissingDiscriminator = null);
+
+internal interface ILoweringFactProvider
+{
+    IEnumerable<LoweringFactEntry> Entries { get; }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
@@ -1,0 +1,19 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class RangeRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.Range)),
+            typeof(RangeFromGetSubArrayPass),
+            [
+                new FactPrimitive("member.corelib-identity:RuntimeHelpers.GetSubArray", "MemberIdentity.IsRuntimeHelpersGetSubArray"),
+                new FactPrimitive("member.corelib-identity:System.Range", "MemberIdentity.IsCoreLibraryType"),
+                new FactPrimitive("member.corelib-identity:System.Index", "MemberIdentity.IsCoreLibraryType"),
+            ],
+            PositiveCoverage: "RangeFromGetSubArrayPassTests range endpoint matrix",
+            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike",
+            MissingDiscriminator: "string/span Slice and Substring forms are separate lowerings"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
@@ -1,0 +1,17 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class StringInterpolationFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.StringInterpolation)),
+            typeof(StringInterpolationPass),
+            [
+                new FactPrimitive("member.corelib-identity:DefaultInterpolatedStringHandler", "MemberIdentity interpolated-string handler predicates"),
+            ],
+            PositiveCoverage: "StringInterpolationPassTests straight-line handler append fixtures",
+            AdversarialCoverage: "StringInterpolationPassTests user handler lookalike",
+            MissingDiscriminator: "non-straight-line handler flows need dataflow facts"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/UsingRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/UsingRecoveryFacts.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class UsingRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.UsingStatement)),
+            typeof(UsingStatementPass),
+            [
+                new FactPrimitive("member.corelib-identity:IDisposable.Dispose", "MemberIdentity.IsIDisposableDispose"),
+                new FactPrimitive("dataflow.local-write-region", "UsingStatementPass local reference/write checks"),
+            ],
+            PositiveCoverage: "UsingStatementPassTests reference and value-type dispose shapes",
+            AdversarialCoverage: "UsingStatementPassTests resource reassignment lookalike",
+            MissingDiscriminator: "ref-struct pattern dispose and await using are not raised"),
+    ];
+}


### PR DESCRIPTION
## Motivation

Substrate facts are now part of the raise workflow (`MemberIdentity`, `GeneratedCodeIdentity`, `PlaceIdentity`), but today their use is scattered across pass code, PR descriptions, and docs. We need a queryable way to ask which ledger rows depend on exact member identity, generated-code facts, place identity, or future substrate facts without turning `LoweringCoverage` / `ClosureCoverage` back into frequently edited registries.

Sidecar providers keep the stable ledger rows as the denominator while letting each pass area declare its fact dependencies, positive/adversarial coverage, and missing discriminator additively. That preserves the conflict-reduction work from the stable ledger/printer split: central files provide the join keys and invariants, while evolving metadata lives next to the pass family. This PR is intentionally metadata-only and should not change decompiler output.

## Summary
- add a sidecar lowering fact-provider model keyed to stable LoweringCoverage/ClosureCoverage rows
- add example providers for Await, Range, Lambda/CapturedClosure, Using, and StringInterpolation
- add tests that discover providers and validate keys, mechanisms, duplicate entries, and coverage metadata without editing central ledger rows
- update the substrate design note to describe the conflict-safe sidecar strategy

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore
- dotnet build src/dotnet-inspect -c Release --no-restore
- npx markdownlint-cli docs/design/decompiler-substrate.md