### PR TITLE
Raise interpolated strings consumed beyond return position

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1078,6 +1078,17 @@ public class CfgSampleClass
         return handler.ToStringAndClear();
     }
 
+    public static int InterpolationToLocal(string name, int age)
+    {
+        string greeting = $"Hello {name}, you are {age}";
+        return greeting.Length;
+    }
+
+    public static int InterpolationAsArgument(string name, int age)
+        => ConsumeInterpolation($"Hello {name}, you are {age}");
+
+    static int ConsumeInterpolation(string text) => text.Length;
+
     public static int UsingStatement(string path)
     {
         using var stream = System.IO.File.OpenRead(path);

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -26,6 +26,8 @@ public class IdiomShapeScorecardTests
         new("AnonymousObjectPass", nameof(CfgSampleClass.AnonShorthand), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),
         new("AwaitRecoveryPass", nameof(CfgSampleClass.AwaitOnce), SyntaxKind.AwaitExpression, [SyntaxKind.InvocationExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
+        new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationToLocal), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
+        new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationAsArgument), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),
         new("NullCoalescingAssignmentPass", nameof(CfgSampleClass.NullCoalescingAssignLocal), SyntaxKind.CoalesceAssignmentExpression, [SyntaxKind.IfStatement]),

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -51,6 +51,35 @@ public class StringInterpolationPassTests
     }
 
     [Fact]
+    public void InterpolationAssignedToLocal_RaisesToInterpolatedString()
+    {
+        var function = Raised(nameof(CfgSampleClass.InterpolationToLocal));
+
+        Assert.Single(function.Descendants.OfType<InterpolatedStringExpression>());
+        Assert.DoesNotContain(function.Descendants.OfType<NewObject>(),
+            n => n.Constructor.DeclaringType.Name == "DefaultInterpolatedStringHandler");
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("$\"Hello {name}, you are {age}\"", output);
+        Assert.DoesNotContain("DefaultInterpolatedStringHandler", output);
+    }
+
+    [Fact]
+    public void InterpolationPassedAsArgument_RaisesToInterpolatedString()
+    {
+        var function = Raised(nameof(CfgSampleClass.InterpolationAsArgument));
+
+        Assert.Single(function.Descendants.OfType<InterpolatedStringExpression>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("ConsumeInterpolation($\"Hello {name}, you are {age}\")", output);
+        Assert.DoesNotContain("DefaultInterpolatedStringHandler", output);
+        Assert.DoesNotContain("AppendFormatted", output);
+    }
+
+    [Fact]
     public void ManualHandlerSourceLocal_IsNotRaised()
     {
         // This is a source-level handler local, not the compiler's hidden temp

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -104,7 +104,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat => default!;
-    [Completeness(CompletenessLevel.Partial, "straight-line exact BCL DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted-to-return only")]
+    [Completeness(CompletenessLevel.Partial, "straight-line exact BCL DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted; the result is raised wherever the ToStringAndClear call is consumed in the next statement (return, local assignment, argument)")]
     public static StringInterpolationPass StringInterpolation => new();
     [Completeness(CompletenessLevel.Partial, "value-producing jump tables raise to a switch expression; the sparse binary-search form recovers as a switch statement; pattern switches not raised")]
     public static SwitchRaisingPass SwitchExpression => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
@@ -4,13 +4,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// Raises the simple csc <c>DefaultInterpolatedStringHandler</c> lowering into a
 /// C# interpolated string. Scoped to straight-line handler construction followed
 /// by <c>AppendLiteral(string)</c> / <c>AppendFormatted&lt;T&gt;(T)</c> calls and a
-/// final <c>ToStringAndClear()</c> return in the same block.
+/// final <c>ToStringAndClear()</c> in the next statement — the result is consumed
+/// in place wherever that call sits (a <c>return</c>, a local assignment, or an
+/// argument), so <c>string s = $"{x}";</c> and <c>Log($"{x}");</c> raise alongside
+/// <c>return $"{x}";</c>.
 /// </summary>
 public sealed class StringInterpolationPass : IIrPass
 {
     public string Name => "string-interpolation";
 
-    sealed record Match(StoreLocal StoreHandler, List<ExpressionStatement> Appends, Return ReturnStatement);
+    sealed record Match(StoreLocal StoreHandler, List<ExpressionStatement> Appends, Call ToStringCall);
 
     public void Run(IrFunction function, PassContext context)
     {
@@ -29,7 +32,7 @@ public sealed class StringInterpolationPass : IIrPass
                 if (TryMatch(function, children, i) is not { } match)
                     continue;
 
-                var consumed = new IrNode[] { match.StoreHandler, match.ReturnStatement, };
+                var consumed = new IrNode[] { match.StoreHandler, match.ToStringCall, };
                 consumed = [.. consumed, .. match.Appends];
                 if (!ReferencedOnlyWithin(function, match.StoreHandler.Index, consumed))
                     continue;
@@ -54,7 +57,7 @@ public sealed class StringInterpolationPass : IIrPass
 
                 var interpolation = new InterpolatedStringExpression(parts, values);
                 stepper.StepOver("raise DefaultInterpolatedStringHandler sequence to interpolated string", match.StoreHandler);
-                match.ReturnStatement.ReplaceWith(new Return(interpolation));
+                match.ToStringCall.ReplaceWith(interpolation);
                 foreach (var append in match.Appends)
                     append.Detach();
                 match.StoreHandler.Detach();
@@ -85,14 +88,22 @@ public sealed class StringInterpolationPass : IIrPass
 
         if (appends.Count == 0
             || !CtorArgumentsMatchAppends(handlerCtor, appends)
-            || i >= statements.Count
-            || statements[i] is not Return { Value: Call toString } ret
-            || !IsToStringAndClear(toString, storeHandler.Index))
+            || i >= statements.Count)
         {
             return null;
         }
 
-        return new Match(storeHandler, appends, ret);
+        // The handler is consumed by a single ToStringAndClear() call in the next
+        // statement; that call can sit anywhere in the statement (a return value, a
+        // local assignment, an argument) — it is replaced with the interpolation
+        // in place.
+        var toStringCalls = statements[i].Descendants.OfType<Call>()
+            .Where(call => IsToStringAndClear(call, storeHandler.Index))
+            .ToList();
+        if (toStringCalls.Count != 1)
+            return null;
+
+        return new Match(storeHandler, appends, toStringCalls[0]);
     }
 
     static bool HasSourceLocalName(IrFunction function, int index)


### PR DESCRIPTION
## Summary

`StringInterpolationPass` recovers a `DefaultInterpolatedStringHandler` spill + `AppendLiteral`/`AppendFormatted` sequence into a C# interpolated string — but only when the terminal `ToStringAndClear()` was the value of a `return`. The handler dance csc emits is identical regardless of what consumes the result, so the restriction left the two most common forms lowered:

```csharp
string s = $"{x}";      // local assignment
Log($"{x}");            // argument
```

This generalises the consumer. After the straight-line append statements, the single `ToStringAndClear()` call in the next statement is located **wherever it sits** — a return value, a local assignment, or a call argument — and replaced **in place** with the interpolated string. The handler-local liveness guard is tightened to exactly the store, the appends, and that call, so any stray handler reference still bails.

## Soundness

csc lowers `$"..."` to the same handler-spill + append dance in every position, so the raised interpolation re-lowers opcode-exact — consistent with the project's accepted-equivalence doctrine. Hand-written handler locals (source-named, or the provider overload) remain excluded by the existing guards.

## Validation

- `--pass-impact string-interpolation`: **0 pass bugs**.
- Corpus fidelity and validity **neutral**: `40984/41012 Full`, `995 Full malformed`, `0 importer bugs` — identical before and after (pure sugar).
- Decompiler (499) and product (1157) test suites green.
- New fixtures for the local-assignment and argument forms; the fidelity gate auto-verifies both round-trip opcode-exact, and idiom-scorecard coverage was added. (The local-assignment fixture also exercises a later single-use inlining of the local, confirming the raise composes.)
