### PR TITLE
Raise indexer ??= and indexer compound assignment

### DIFF
--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -43,10 +43,10 @@ caller composes**, never a single "does everything" predicate. The equality
 logic is shared; *which node kinds a pass admits* is not — that admissibility is
 a deliberate soundness discriminator the pass still owns.
 
-`PlaceIdentity` is the clearest illustration. Five passes — `??=`, `?.`, switch
-dispatch, boolean folding, and `^n` from-end — all need "same re-evaluable
-place", and several had byte-identical `Same*` helpers. But they do **not** all
-admit the same nodes:
+`PlaceIdentity` is the clearest illustration. Several passes — `??=`, `?.`, switch
+dispatch, boolean folding, `^n` from-end, and indexer fold targets — all need
+"same re-evaluable place", and several had byte-identical `Same*` helpers. But
+they do **not** all admit the same nodes:
 
 - Most fold a bare variable read (`SameVariable` — local, argument, or `this`).
 - Boolean folding also accepts a spilled stack slot (`SameVariable ||
@@ -56,6 +56,14 @@ admit the same nodes:
   `a[^n]`, whose recompiled IL differs — an opcode-exactness break. The
   stack-slot restriction is what proves the compiler actually spilled the
   receiver, i.e. that the source really was `^n`.
+- Indexer folds (`d[k] ??= v`, `d[k] += v`) reduce to "same re-evaluable place"
+  on the *index arguments* too: `SameOperand` (a variable read or an identical
+  literal) and its pairwise list form `SameOperands`. This is a live instance of
+  the convergence rule below — two unrelated consumers, the
+  `NullCoalescingAssignmentPass` and the printer's compound-assignment fold,
+  independently needed "are these two index-argument lists the same re-evaluable
+  place", so the check became one atom both compose rather than two hand-rolled
+  loops.
 
 A single maximal `SamePlace(a, b)` predicate would have silently handed
 `IndexFromEndPass` the broadening that breaks it. Exposing `SameVariable` and

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1309,6 +1309,42 @@ public class CfgSampleClass
         return holder.CacheProp;
     }
 
+    // Indexer ??= — the property form plus index arguments. csc spills the receiver
+    // and index to locals read identically by the get and set, so the two accesses
+    // fold into one re-evaluable d[k] place.
+    public static string NullCoalescingAssignIndexer(StringIndexer cache, int key, string fallback)
+    {
+        cache[key] ??= fallback;
+        return cache[key]!;
+    }
+
+    // Constant index — exercises the SameOperand equal-constant path (no spill).
+    public static string NullCoalescingAssignIndexerConstKey(StringIndexer cache, string fallback)
+    {
+        cache[0] ??= fallback;
+        return cache[0]!;
+    }
+
+    public static string NullCoalescingAssignDictionaryIndexer(System.Collections.Generic.Dictionary<string, string> map, string key, string fallback)
+    {
+        map[key] ??= fallback;
+        return map[key];
+    }
+
+    // Indexer compound += — set(recv, idx, get(recv, idx) + delta) with a
+    // re-evaluable member place folds to recv[idx] += delta.
+    public static int CompoundAssignIndexer(CounterIndexer counter, int key, int delta)
+    {
+        counter[key] += delta;
+        return counter[key];
+    }
+
+    public static int CompoundAssignDictionaryIndexer(System.Collections.Generic.Dictionary<string, int> map, string key, int delta)
+    {
+        map[key] += delta;
+        return map[key];
+    }
+
     public static string[] ArrayWithInit(string a)
     {
         return new string[] { a, "hello" };
@@ -1835,6 +1871,30 @@ public sealed class CfgNullableTarget
     {
         get => Value + index;
         set => Value = value + index;
+    }
+}
+
+/// <summary>Reference-typed indexer for indexer <c>??=</c> fixtures.</summary>
+public sealed class StringIndexer
+{
+    private readonly string?[] _slots = new string?[8];
+
+    public string? this[int index]
+    {
+        get => _slots[index];
+        set => _slots[index] = value;
+    }
+}
+
+/// <summary>Numeric indexer for indexer compound-assignment fixtures.</summary>
+public sealed class CounterIndexer
+{
+    private readonly int[] _counts = new int[8];
+
+    public int this[int index]
+    {
+        get => _counts[index];
+        set => _counts[index] = value;
     }
 }
 

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -181,4 +181,69 @@ public class NullCoalescingAssignmentPassTests
         Assert.NotNull(output);
         Assert.DoesNotContain("??=", output);
     }
+
+    [Fact]
+    public void IndexerNullAssignmentDiamond_RaisesToNullCoalescingPropertyAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignIndexer));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Equal("Item", assignment.PropertyName);
+        Assert.True(assignment.HasInstance);
+        // Receiver and index are compiler-spilled locals folded back to the
+        // parameters by the inlining pass: the one re-evaluable cache[key] place.
+        Assert.Single(assignment.IndexArguments);
+        Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<StoreProperty>(), _ => true);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersIndexerNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignIndexer))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("cache[key] ??= fallback;", output);
+    }
+
+    [Fact]
+    public void ConstantIndexNullAssignment_RaisesThroughEqualConstantOperand()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignIndexerConstKey));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.IsType<Constant>(Assert.Single(assignment.IndexArguments));
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("cache[0] ??= fallback;", output);
+    }
+
+    [Fact]
+    public void DictionaryIndexerNullAssignment_RaisesToNullCoalescingPropertyAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignDictionaryIndexer))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("map[key] ??= fallback;", output);
+    }
+
+    [Fact]
+    public void IndexerCompoundAssignment_RendersAsCompoundOnReevaluablePlace()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.CompoundAssignIndexer))).Output;
+
+        Assert.NotNull(output);
+        // The receiver/index stay as csc's spill locals (folding them would drop the
+        // spill and change the IL); the get/set fold to one += on that place.
+        Assert.Contains("[V_1] += delta;", output);
+        Assert.DoesNotContain("= V_0[V_1] +", output);
+    }
+
+    [Fact]
+    public void DictionaryIndexerCompoundAssignment_RendersAsCompound()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.CompoundAssignDictionaryIndexer))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("[V_1] += delta;", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/PlaceIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PlaceIdentityTests.cs
@@ -56,4 +56,37 @@ public class PlaceIdentityTests
         Assert.False(PlaceIdentity.SameVariable(call, call2));
         Assert.False(PlaceIdentity.SameStackSlot(call, call2));
     }
+
+    [Fact]
+    public void SameOperand_MatchesVariablesAndEqualConstants()
+    {
+        Assert.True(PlaceIdentity.SameOperand(new LoadLocal(1, Int), new LoadLocal(1, Int)));
+        Assert.True(PlaceIdentity.SameOperand(new Constant(7, Int), new Constant(7, Int)));
+        Assert.True(PlaceIdentity.SameOperand(new Constant("k", Str), new Constant("k", Str)));
+    }
+
+    [Fact]
+    public void SameOperand_RejectsDifferentConstantsAndSideEffectingOperands()
+    {
+        Assert.False(PlaceIdentity.SameOperand(new Constant(1, Int), new Constant(2, Int)));
+        Assert.False(PlaceIdentity.SameOperand(new Constant(1, Int), new LoadLocal(1, Int)));
+        var getter = new MethodRef(Obj, "get_Value", Int, ImmutableArray<TypeRef>.Empty, HasThis: true);
+        var call = new Call(getter, isVirtual: false, [new LoadArgument(0, "this", Obj)]);
+        Assert.False(PlaceIdentity.SameOperand(call, call));
+    }
+
+    [Fact]
+    public void SameOperands_IsPairwiseAndLengthSensitive()
+    {
+        Assert.True(PlaceIdentity.SameOperands([], []));
+        Assert.True(PlaceIdentity.SameOperands(
+            [new LoadLocal(0, Int), new Constant(3, Int)],
+            [new LoadLocal(0, Int), new Constant(3, Int)]));
+        Assert.False(PlaceIdentity.SameOperands(
+            [new LoadLocal(0, Int)],
+            [new LoadLocal(0, Int), new Constant(3, Int)]));
+        Assert.False(PlaceIdentity.SameOperands(
+            [new LoadLocal(0, Int), new Constant(3, Int)],
+            [new LoadLocal(0, Int), new Constant(4, Int)]));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -859,7 +859,7 @@ public sealed partial class CSharpPrinter
         DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclaration ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
-        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, [], n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
+        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
         StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
@@ -879,12 +879,11 @@ public sealed partial class CSharpPrinter
         StoreProperty s => AssignmentText(
             PropertyTarget(s.Accessor, s.HasInstance ? s.Instance : null, s.IndexArguments, s.PropertyName, s.IsVirtual),
             s.Value,
-            left => s.IndexArguments.Count == 0
-                && left is LoadProperty load
-                && load.IndexArguments.Count == 0
+            left => left is LoadProperty load
                 && load.PropertyName == s.PropertyName
                 && Equals(load.Accessor.DeclaringType, s.Accessor.DeclaringType)
-                && SameLValue(load.Instance, s.Instance)),
+                && SameLValue(load.Instance, s.Instance)
+                && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments)),
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
             Deref(s.Address),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -728,22 +728,24 @@ public sealed class NullCoalescingFieldAssignment : IrNode
 
 /// <summary>
 /// A raised property null-coalescing assignment (<c>obj.Prop ??= fallback</c>, or
-/// <c>Type.Prop ??= fallback</c> for a static property). Produced from csc's
-/// property null-test diamond: <c>if (obj.Prop is null) obj.Prop = fallback;</c>,
-/// where the getter and setter are paired as one property and the receiver — when
-/// present — is re-evaluable (a local/argument/this), so collapsing the two
-/// accessor calls into one <c>??=</c> reorders nothing. Indexers are deferred to a
-/// later slice (their index arguments carry their own re-evaluation concern).
+/// <c>Type.Prop ??= fallback</c> for a static property), or an indexer form
+/// (<c>d[k] ??= fallback</c>). Produced from csc's property null-test diamond:
+/// <c>if (obj.Prop is null) obj.Prop = fallback;</c>, where the getter and setter
+/// are paired as one property and the receiver — when present — together with any
+/// index arguments are re-evaluable (a local/argument/this, or a constant index),
+/// so collapsing the two accessor calls into one <c>??=</c> reorders nothing.
 /// </summary>
 public sealed class NullCoalescingPropertyAssignment : IrNode
 {
-    public NullCoalescingPropertyAssignment(MethodRef setter, IrExpression? instance, IrExpression value, bool isVirtual)
+    public NullCoalescingPropertyAssignment(MethodRef setter, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, IrExpression value, bool isVirtual)
     {
         Setter = setter;
         IsVirtual = isVirtual;
         HasInstance = instance is not null;
         if (instance is not null)
             AddChild(instance);
+        foreach (var argument in indexArguments)
+            AddChild(argument);
         AddChild(value);
     }
 
@@ -755,7 +757,9 @@ public sealed class NullCoalescingPropertyAssignment : IrNode
     /// <summary>The property's type — the setter's value parameter.</summary>
     public TypeRef PropertyType => Setter.ParameterTypes[^1];
     public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
-    public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+    public IReadOnlyList<IrExpression> IndexArguments
+        => Children.Skip(HasInstance ? 1 : 0).Take(Children.Count - (HasInstance ? 1 : 0) - 1).Cast<IrExpression>().ToList();
+    public IrExpression Value => (IrExpression)Children[^1];
     public override IEnumerable<TypeRef> DirectTypes => Setter.ParameterTypes.Append(Setter.DeclaringType);
 
     public override string Describe()

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -55,7 +55,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass BreakStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call => default!;
     [Completeness(CompletenessLevel.Full)] public static InlineArrayCollectionPass CollectionExpression => new();
-    [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, and ref targets raised; checked-context and indexer/nested-struct compound not raised")]
+    [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, indexer, and ref targets raised; checked-context and nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static NullConditionalPass ConditionalAccess => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();
@@ -87,7 +87,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LocalDeclaration => default!;
     [Completeness(CompletenessLevel.Full)] public static LockSugarPass LockStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative MultipleLocalDeclarations => default!;
-    [Completeness(CompletenessLevel.Partial, "local-variable, field, and property (instance + static, re-evaluable receiver) ??=; indexers not raised")]
+    [Completeness(CompletenessLevel.Partial, "local-variable, field, property (instance + static, re-evaluable receiver), and indexer (re-evaluable place) ??= raised")]
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -12,8 +12,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// nothing. The property form (<c>obj.Prop ??= fallback</c>) pairs the getter and
 /// setter as one property and folds csc's value-spill (the setter takes the value
 /// through a temp so the assignment can also be the expression's result; in
-/// statement position that result is dead). Indexer <c>??=</c> is deferred — its
-/// index arguments carry their own re-evaluation concern.
+/// statement position that result is dead). The indexer form (<c>d[k] ??= fallback</c>)
+/// is the property form plus index arguments, accepted when the receiver and every
+/// index argument are pairwise re-evaluable (<see cref="PlaceIdentity.SameOperands"/>).
 /// </summary>
 public sealed class NullCoalescingAssignmentPass : IIrPass
 {
@@ -46,11 +47,14 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             if (TryMatchProperty(function, statement) is { } property)
             {
                 var instance = property.Store.Instance;
+                var indexArguments = property.Store.IndexArguments.ToList();
                 var value = property.Value;
                 instance?.Detach();
+                foreach (var argument in indexArguments)
+                    argument.Detach();
                 value.Detach();
                 var replacement = new NullCoalescingPropertyAssignment(
-                    property.Store.Accessor, instance, value, property.Store.IsVirtual);
+                    property.Store.Accessor, instance, indexArguments, value, property.Store.IsVirtual);
                 context.Stepper.StepOver("raise property null check assignment to ??=", statement);
                 statement.ReplaceWith(replacement);
             }
@@ -113,12 +117,11 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
     {
         if (statement.HasElse
             || NullTested(statement.Condition) is not LoadProperty getter
-            || getter.IndexArguments.Count != 0
             || statement.Then.Children is not [.., StoreProperty store]
-            || store.IndexArguments.Count != 0
             || store.PropertyName != getter.PropertyName
             || !Equals(store.Accessor.DeclaringType, getter.Accessor.DeclaringType)
-            || !SameReceiver(getter.Instance, store.Instance))
+            || !SameReceiver(getter.Instance, store.Instance)
+            || !PlaceIdentity.SameOperands(getter.IndexArguments, store.IndexArguments))
         {
             return null;
         }

--- a/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PlaceIdentity.cs
@@ -47,4 +47,40 @@ public static class PlaceIdentity
     /// </summary>
     public static bool SameStackSlot(IrExpression? left, IrExpression? right)
         => (left, right) is (LoadStackSlot a, LoadStackSlot b) && a.Slot == b.Slot;
+
+    /// <summary>
+    /// Two reads of the same re-evaluable operand: a variable
+    /// (<see cref="SameVariable"/>) or an identical literal. The leaf an indexer's
+    /// arguments take when a get and a set fold into one <c>d[i]</c> place — a bare
+    /// variable read or a constant has no side effect, so evaluating it once instead
+    /// of twice reorders nothing. A complex index (a call, arithmetic) is not
+    /// admitted here; csc spills such an index into a local, which then presents as
+    /// <see cref="SameVariable"/>.
+    /// </summary>
+    public static bool SameOperand(IrExpression? left, IrExpression? right)
+        => SameVariable(left, right)
+            || ((left, right) is (Constant a, Constant b) && Equals(a.Value, b.Value));
+
+    /// <summary>
+    /// Pairwise <see cref="SameOperand"/> over two argument lists — the index
+    /// arguments an indexer reads on one side of a fold and writes on the other.
+    /// Equal-length empty lists trivially match (a non-indexer property).
+    /// </summary>
+    public static bool SameOperands(IReadOnlyList<IrExpression> left, IReadOnlyList<IrExpression> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Count; i++)
+        {
+            if (!SameOperand(left[i], right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## What

Raises two indexer idioms the decompiler previously left expanded:

- **Indexer `??=`** — `d[k] ??= v` (was a `get`/`set` null-test diamond).
- **Indexer compound assignment** — `d[k] += v` (was `d[k] = d[k] + v`).

## The convergence

Both reduce to the property forms (already raised) plus one shared question: **are the indexer's index arguments the same re-evaluable place across the get and the set?** Two unrelated consumers — the `??=` pass and the printer's compound-assignment fold — independently needed that fact, so it lands as a shared `PlaceIdentity` atom rather than two hand-rolled loops. This is the "third occurrence builds the layer" rule from `docs/design/decompiler-substrate.md`, applied live.

## Changes

- **`PlaceIdentity`** gains `SameOperand` (a variable read or an identical literal) and its pairwise list form `SameOperands`. csc spills a complex index into a local (presents as `SameVariable`); a constant index re-loads and matches as an equal constant; a side-effecting index matches neither and stays expanded (conservative).
- **`NullCoalescingAssignmentPass`** accepts indexers: the property matcher drops its `IndexArguments.Count == 0` rejections and instead requires the getter/setter index lists to be pairwise `SameOperands`. `NullCoalescingPropertyAssignment` carries the index arguments through to `PropertyTarget` (which already renders `d[k]`). Value-spill recovery is unchanged.
- **Printer compound fold** (`StoreProperty`) likewise drops its indexer rejection and compares index lists with `SameOperands`, so `set(recv, idx, get(recv, idx) + v)` folds to `recv[idx] += v`. The receiver/index stay as csc's spill locals — folding them would drop the spill and change the IL.
- Ledger + substrate design doc updated.

## Validation

- 505 decompiler tests; the only failure is the pre-existing, unrelated `MixedSourceRendererTests.ClosureAndDelegateAllocations_BothInterleave`.
- New fixtures (reference-typed and numeric indexers, `Dictionary`, and a constant index) are pinned **opcode-exact** by the fidelity gate (decompile → recompile → compare opcodes).
- Product build clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
