### PR TITLE
Use exact ValueTuple identity for tuple raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -93,6 +93,39 @@ public class DeconstructionAssignmentPassTests
         Assert.Contains(".Item", output);
         Assert.DoesNotContain("(int sum, int product) = pair;", output);
     }
+
+    [Fact]
+    public void UserValueTupleLookalike_FieldStoresAreNotRaised()
+    {
+        var function = BuildUserValueTupleFieldStores();
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item1");
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item2");
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildUserValueTupleFieldStores()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var tupleType = TypeRef.GenericInstance(
+            TypeRef.Definition("UserAssembly", "System", "ValueTuple`2"),
+            [intType, intType]);
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "pair", tupleType)));
+        block.Add(new StoreLocal(0, intType, new LoadField(new FieldRef(tupleType, "Item1", intType), new LoadStackSlot(0, tupleType))));
+        block.Add(new StoreLocal(1, intType, new LoadField(new FieldRef(tupleType, "Item2", intType), new LoadStackSlot(0, tupleType))));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("pair", tupleType)], HasThis: false, GenericParameterCount: 0),
+            [intType, intType],
+            body);
+    }
 }
 
 public static class DeconstructionAdversarialSamples

--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -214,6 +214,59 @@ public class MemberIdentityTests
             [new LoadLocal(0, disposable)])));
     }
 
+    [Fact]
+    public void IsValueTupleType_RequiresExactBclGenericDefinitionAndMatchingArity()
+    {
+        var tuple2 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`2"), s_int, s_string);
+        Assert.True(MemberIdentity.IsValueTupleType(tuple2, out var arity2));
+        Assert.Equal(2, arity2);
+        Assert.True(MemberIdentity.IsSupportedValueTupleType(tuple2, out _));
+
+        Assert.True(MemberIdentity.IsValueTupleType(
+            ValueTupleType(TypeRef.Definition("System.Runtime", "System", "ValueTuple`2"), s_int, s_string),
+            out _));
+
+        Assert.False(MemberIdentity.IsValueTupleType(
+            ValueTupleType(TypeRef.Definition("UserAssembly", "System", "ValueTuple`2"), s_int, s_string),
+            out _));
+
+        Assert.False(MemberIdentity.IsValueTupleType(
+            ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`2"), s_int),
+            out _));
+
+        var tuple1 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`1"), s_int);
+        Assert.True(MemberIdentity.IsValueTupleType(tuple1, out var arity1));
+        Assert.Equal(1, arity1);
+        Assert.False(MemberIdentity.IsSupportedValueTupleType(tuple1, out _));
+
+        var tuple8 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`8"),
+            s_int, s_int, s_int, s_int, s_int, s_int, s_int, s_int);
+        Assert.True(MemberIdentity.IsValueTupleType(tuple8, out var arity8));
+        Assert.Equal(8, arity8);
+        Assert.False(MemberIdentity.IsSupportedValueTupleType(tuple8, out _));
+    }
+
+    [Fact]
+    public void IsValueTupleConstructor_RequiresExactBclSupportedArityAndSignature()
+    {
+        var tuple2 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`2"), s_int, s_string);
+        Assert.True(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(tuple2), out var arity));
+        Assert.Equal(2, arity);
+
+        Assert.False(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(
+            ValueTupleType(TypeRef.Definition("UserAssembly", "System", "ValueTuple`2"), s_int, s_string)), out _));
+
+        Assert.False(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(
+            ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`1"), s_int)), out _));
+
+        var tuple8 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`8"),
+            s_int, s_int, s_int, s_int, s_int, s_int, s_int, s_int);
+        Assert.False(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(tuple8), out _));
+
+        Assert.False(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(tuple2, [s_int, s_int]), out _));
+        Assert.False(MemberIdentity.IsValueTupleConstructor(ValueTupleNew(tuple2, argumentCount: 1), out _));
+    }
+
     static MethodRef GetSubArrayMethod(TypeRef declaringType)
         => new(declaringType, "GetSubArray", s_intArray, [s_intArray, s_range], HasThis: false);
 
@@ -294,4 +347,19 @@ public class MemberIdentityTests
 
     static Call Dispose(TypeRef declaringType)
         => new(DisposeMethod(declaringType), isVirtual: true, [new LoadLocal(0, declaringType)]);
+
+    static TypeRef ValueTupleType(TypeRef definition, params TypeRef[] arguments)
+        => TypeRef.GenericInstance(definition, [.. arguments]);
+
+    static NewObject ValueTupleNew(TypeRef tupleType, TypeRef[]? parameterTypes = null, int? argumentCount = null)
+    {
+        parameterTypes ??= [.. tupleType.TypeArguments];
+        int count = argumentCount ?? parameterTypes.Length;
+        var arguments = Enumerable.Range(0, count)
+            .Select(index => (IrExpression)new Constant(index, parameterTypes[Math.Min(index, parameterTypes.Length - 1)]))
+            .ToArray();
+        return new NewObject(
+            new MethodRef(tupleType, ".ctor", s_void, [.. parameterTypes], HasThis: false),
+            arguments);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
@@ -61,4 +61,30 @@ public class TupleCreationPassTests
         Assert.Empty(function.Descendants.OfType<TupleExpression>());
         Assert.Single(function.Descendants.OfType<NewObject>());
     }
+
+    [Fact]
+    public void UserValueTupleLookalike_IsNotRaised()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var tupleType = TypeRef.GenericInstance(
+            TypeRef.Definition("UserAssembly", "System", "ValueTuple`2"),
+            [intType, intType]);
+        var ctor = new MethodRef(tupleType, ".ctor", TypeRef.CoreLib("System", "Void"), [intType, intType], HasThis: false);
+        var newObject = new NewObject(ctor, [new Constant(1, intType), new Constant(2, intType)]);
+        var block = new Block();
+        block.Add(new Return(newObject));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(tupleType, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new TupleCreationPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<TupleExpression>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -1,0 +1,28 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class TupleRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.TupleCreationExpression)),
+            typeof(TupleCreationPass),
+            [
+                new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsValueTupleConstructor"),
+            ],
+            PositiveCoverage: "TupleCreationPassTests ValueTuple constructor fixture",
+            AdversarialCoverage: "TupleCreationPassTests user ValueTuple lookalike and expression-statement negative fixtures",
+            MissingDiscriminator: "nested/rest tuples and tuple element names not recovered"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.DeconstructionAssignmentOperator)),
+            typeof(DeconstructionAssignmentPass),
+            [
+                new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
+                new FactPrimitive("place.stack-slot", "PlaceIdentity.SameStackSlot-equivalent slot ownership checks"),
+            ],
+            PositiveCoverage: "DeconstructionAssignmentPassTests ValueTuple field-store and Deconstruct-method fixtures",
+            AdversarialCoverage: "DeconstructionAssignmentPassTests manual tuple field access and user ValueTuple lookalike",
+            MissingDiscriminator: "nested/rest tuples, mixed declaration/assignment targets, and broader receiver forms still owed"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -143,8 +143,61 @@ public static class MemberIdentity
         && returnedElement.Equals(element);
     }
 
+    public static bool IsValueTupleType(TypeRef? type, out int arity)
+    {
+        arity = 0;
+        if (type is not { Kind: TypeRefKind.GenericInstance, ElementType: { } definition })
+            return false;
+        if (definition is not
+            {
+                Kind: TypeRefKind.Definition,
+                Assembly: TypeRef.CoreLibrary or "System.Runtime",
+                Namespace: "System",
+                Name: var name,
+            } || !TryValueTupleArity(name, out arity))
+        {
+            return false;
+        }
+
+        return arity == type.TypeArguments.Length;
+    }
+
+    public static bool IsSupportedValueTupleType(TypeRef? type, out int arity)
+        => IsValueTupleType(type, out arity) && arity is >= 2 and <= 7;
+
+    public static bool IsValueTupleConstructor(NewObject newObject, out int arity)
+    {
+        arity = 0;
+        var ctor = newObject.Constructor;
+        if (ctor.Name != ".ctor"
+            || !IsSupportedValueTupleType(ctor.DeclaringType, out arity)
+            || ctor.ParameterTypes.Length != arity
+            || newObject.Arguments.Count != arity)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < arity; i++)
+            if (!ctor.ParameterTypes[i].Equals(ctor.DeclaringType.TypeArguments[i]))
+                return false;
+
+        return true;
+    }
+
     static TypeRef? NamedDefinition(TypeRef? type)
         => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
+
+    static bool TryValueTupleArity(string name, out int arity)
+    {
+        const string prefix = "ValueTuple`";
+        if (!name.StartsWith(prefix, StringComparison.Ordinal)
+            || !int.TryParse(name[prefix.Length..], out arity))
+        {
+            arity = 0;
+            return false;
+        }
+        return arity > 0;
+    }
 
     static bool IsMonitorMethod(Call call, string methodName)
         => !call.IsVirtual

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -45,8 +45,7 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         var children = block.Children;
         if (children[i] is not StoreStackSlot seed
             || seed.Value.ResultType is not { } tupleType
-            || ValueTupleArity(tupleType) is not { } arity
-            || arity is < 2 or > 7
+            || !MemberIdentity.IsSupportedValueTupleType(tupleType, out var arity)
             || i + arity >= children.Count)
         {
             return false;
@@ -170,18 +169,6 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         }
 
         return ([.. resolved.Select(target => target.index)], [.. resolved.Select(target => target.type)]);
-    }
-
-    static int? ValueTupleArity(TypeRef type)
-    {
-        if (type is not { Kind: TypeRefKind.GenericInstance, ElementType: { } definition })
-            return null;
-        if (definition is not { Namespace: "System", Assembly: TypeRef.CoreLibrary or "System.Runtime" }
-            || !definition.Name.StartsWith("ValueTuple`", StringComparison.Ordinal))
-        {
-            return null;
-        }
-        return type.TypeArguments.Length;
     }
 
     static bool ReferencedOnlyWithin(IrFunction function, int slot, IReadOnlyList<StoreLocal> stores)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -61,7 +61,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass ContinueStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion => default!;
-    [Completeness(CompletenessLevel.Partial, "local ValueTuple deconstruction (arities 2-7) as a fresh-local declaration or existing-local assignment, plus Deconstruct-method calls with a local/parameter receiver; mixed declaration/assignment and the temp-then-copy receiver forms not raised")]
+    [Completeness(CompletenessLevel.Partial, "local exact BCL ValueTuple deconstruction (arities 2-7) as a fresh-local declaration or existing-local assignment, plus Deconstruct-method calls with a local/parameter receiver; mixed declaration/assignment and the temp-then-copy receiver forms not raised")]
     public static DeconstructionAssignmentPass DeconstructionAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static DelegateConstructionPass DelegateCreationExpression => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static DoWhileLoopPass DoStatement => new();
@@ -111,7 +111,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();
     [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")] public static Unhandled TupleBinaryOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
+    [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative UnaryOperator => default!;
     [Completeness(CompletenessLevel.Partial, "reference-type exact BCL IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
@@ -15,7 +15,7 @@ public sealed class TupleCreationPass : IIrPass
     {
         foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
         {
-            if (!IsTupleConstructor(newObject))
+            if (!MemberIdentity.IsValueTupleConstructor(newObject, out _))
                 continue;
             if (newObject.Parent is ExpressionStatement)
                 continue;
@@ -27,25 +27,4 @@ public sealed class TupleCreationPass : IIrPass
         }
     }
 
-    static bool IsTupleConstructor(NewObject newObject)
-    {
-        var ctor = newObject.Constructor;
-        if (ctor.Name != ".ctor" || ctor.DeclaringType is not { Kind: TypeRefKind.GenericInstance } tupleType)
-            return false;
-
-        var definition = tupleType.ElementType;
-        if (definition is not
-            {
-                Namespace: "System",
-                Assembly: TypeRef.CoreLibrary or "System.Runtime",
-            } || !definition.Name.StartsWith("ValueTuple`", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        int arity = tupleType.TypeArguments.Length;
-        return arity is >= 2 and <= 7
-            && ctor.ParameterTypes.Length == arity
-            && newObject.Arguments.Count == arity;
-    }
 }


### PR DESCRIPTION
## Summary
- add `MemberIdentity` predicates for exact BCL `System.ValueTuple` type and constructor identity
- migrate `TupleCreationPass` and `DeconstructionAssignmentPass` to the shared predicates
- add direct identity tests plus user-defined `System.ValueTuple` lookalike negatives for tuple creation and field-store deconstruction
- add sidecar fact metadata for tuple creation and deconstruction ledger rows
- update ledger notes to call out exact BCL `ValueTuple` identity

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.TupleCreationPassTests -class ILInspector.Decompiler.Tests.DeconstructionAssignmentPassTests -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal