### PR TITLE
Reconstruct single counting-loop iterators

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1755,6 +1755,24 @@ public class CfgSampleClass
     {
         yield break;
     }
+
+    // Counting loop with a constant bound and an arithmetic yielded value: the
+    // single-yield loop shape reconstruction must map the hoisted loop field to a
+    // local and rebuild `i * i` over it (no parameter involved).
+    public static System.Collections.Generic.IEnumerable<int> YieldSquares()
+    {
+        for (int i = 0; i < 4; i++)
+            yield return i * i;
+    }
+
+    // Nested counting loops: two hoisted loop fields and more than two states, so
+    // the single-loop slice declines and honest acknowledgment stands.
+    public static System.Collections.Generic.IEnumerable<int> YieldGrid()
+    {
+        for (int i = 0; i < 2; i++)
+            for (int j = 0; j < 2; j++)
+                yield return i + j;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -54,12 +54,48 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
-    public void ParameterizedLoopIterator_FallsBackToAcknowledgment()
+    public void CountingLoopIterator_ReconstructsWhileLoop()
     {
         var function = Raised(nameof(CfgSampleClass.YieldRange));
 
-        // The captured-param + loop shape is outside the linear-constant slice, so
-        // reconstruction declines and the honest marker stands.
+        // The `for (int i = 0; i < n; i++) yield return i;` shape comes back as a
+        // structured loop with a single yield — not the acknowledgment fallback.
+        var yield = Assert.Single(function.Descendants.OfType<YieldReturn>());
+        Assert.IsType<LoadLocal>(yield.Value);
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void CountingLoopIterator_RendersLoopAndYield()
+    {
+        var output = Print(nameof(CfgSampleClass.YieldRange));
+
+        Assert.Contains("int i = 0;", output);
+        Assert.Contains("while (i < n)", output);
+        Assert.Contains("yield return i;", output);
+        Assert.DoesNotContain("not reconstructed", output);
+    }
+
+    [Fact]
+    public void CountingLoopIterator_ConstantBoundAndArithmeticElement()
+    {
+        // Constant bound, no parameter, and an arithmetic yielded value exercise the
+        // self-contained remap (hoisted loop field -> local) without a parameter.
+        var output = Print(nameof(CfgSampleClass.YieldSquares));
+
+        Assert.Contains("while (i < 4)", output);
+        Assert.Contains("yield return i * i;", output);
+    }
+
+    [Fact]
+    public void NestedLoopIterator_FallsBackToAcknowledgment()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldGrid));
+
+        // Two hoisted loop fields and more than two states are outside the
+        // single-loop slice, so reconstruction declines and the honest marker stands.
         Assert.Empty(function.Descendants.OfType<YieldReturn>());
         var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
         Assert.Equal("iterator", marker.Opcode);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -112,7 +112,25 @@ public sealed class IrFunction : IrNode
     public string Name { get; }
     public TypeRef DeclaringType { get; }
     public MethodSignature Signature { get; }
-    public ImmutableArray<TypeRef> Locals { get; }
+    public ImmutableArray<TypeRef> Locals { get; private set; }
+
+    /// <summary>
+    /// Appends a local slot (and its source name) and returns its index. Used by
+    /// raising passes that introduce a variable absent from the original IL — e.g.
+    /// <see cref="ILInspector.Decompiler.Pipeline.IteratorReconstructionPass"/>
+    /// materializing a hoisted iterator loop field back into a C# loop local. Keeps
+    /// <see cref="LocalNames"/> length-aligned with <see cref="Locals"/>.
+    /// </summary>
+    public int AddLocal(TypeRef type, string? name = null)
+    {
+        var index = Locals.Length;
+        Locals = Locals.Add(type);
+        var names = LocalNames;
+        while (names.Length < index)
+            names = names.Add(null);
+        LocalNames = names.Add(name);
+        return index;
+    }
 
     /// <summary>
     /// Source names for the entries in <see cref="Locals"/>, by slot index,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Reconstructs the single-yield <b>counting loop</b> iterator — the lowered form
+/// of <c>for (T i = init; i &lt; bound; i += step) yield return f(i);</c> (and the
+/// equivalent <c>while</c>) — back to a structured loop with a real loop local.
+/// Unlike the linear-constant case (a clean <c>switch</c> chain), a looping
+/// iterator's <c>MoveNext</c> is an <em>irreducible</em> goto-dispatch CFG: the
+/// resume edge for state 1 jumps into the middle of the loop, so the generic
+/// structurer cannot form a natural loop. This recogniser matches that exact
+/// dispatch shape and synthesises the loop directly, mapping the state machine's
+/// hoisted loop field (<c>&lt;i&gt;5__2</c>) to a fresh local and its hoisted
+/// parameter fields back to the kickoff's parameters.
+///
+/// <para>Deliberately narrow (phase 1): exactly one loop, one yield, two states
+/// (entry + resume), and a body self-contained modulo the loop variable. Anything
+/// else — nested loops, multiple yields, captured locals, calls in the bound or
+/// yielded value — fails the match and falls through to honest acknowledgment.</para>
+/// </summary>
+internal static class CountingLoopReconstruction
+{
+    public static bool TryReconstruct(IrFunction moveNext, IrFunction kickoff, NewObject handoff, out List<IrNode> statements)
+    {
+        statements = [];
+        var blocks = moveNext.Body.Blocks;
+        if (blocks.Count != 8)
+            return false;  // the single counting-loop lowering is exactly eight blocks
+
+        var byOffset = new Dictionary<int, Block>();
+        foreach (var block in blocks)
+            byOffset[block.StartOffset] = block;
+
+        // ---- dispatch prologue: state local, then `state==0 -> init`, `state==1 -> resume`, else return false ----
+        if (blocks[0].Children is not [
+                StoreLocal { Value: LoadField { Field.Name: "<>1__state", Instance: LoadArgument { Index: 0 } } } stateStore,
+                ConditionalBranch entry])
+            return false;
+        var stateLocal = stateStore.Index;
+        if (!IsStateZero(entry.Condition, stateLocal))
+            return false;
+        var initOff = entry.TargetOffset;
+
+        if (blocks[1].Children is not [ConditionalBranch resumeDispatch]
+            || !IsStateEqual(resumeDispatch.Condition, stateLocal, 1))
+            return false;
+        var resumeOff = resumeDispatch.TargetOffset;
+
+        if (!IsReturnFalse(blocks[2]))
+            return false;
+
+        // ---- init block: `state = -1; <loopvar> = init; goto cond;` ----
+        if (!byOffset.TryGetValue(initOff, out var initBlock)
+            || initBlock.Children is not [
+                StoreField { Field.Name: "<>1__state" },
+                StoreField { Instance: LoadArgument { Index: 0 }, Field: var loopField } initStore,
+                Branch initBranch]
+            || !IsHoistedLocal(loopField.Name))
+            return false;
+        var initExpr = initStore.Value;
+        var condOff = initBranch.TargetOffset;
+
+        // ---- cond block: `if (<loopvar> < bound) goto yield;` falling through to a terminal `return false` ----
+        if (!byOffset.TryGetValue(condOff, out var condBlock)
+            || condBlock.Children is not [ConditionalBranch { Condition: Comparison comparison } condBranch]
+            || comparison.Left is not LoadField { Instance: LoadArgument { Index: 0 }, Field.Name: var condLeft }
+            || condLeft != loopField.Name)
+            return false;
+        var yieldOff = condBranch.TargetOffset;
+        var condIndex = blocks.ToList().IndexOf(condBlock);
+        if (condIndex + 1 >= blocks.Count || !IsReturnFalse(blocks[condIndex + 1]))
+            return false;
+        var terminalBlock = blocks[condIndex + 1];
+
+        // ---- yield block: `<>2__current = value; state = 1; return true;` ----
+        if (!byOffset.TryGetValue(yieldOff, out var yieldBlock)
+            || yieldBlock.Children is not [
+                StoreField { Field.Name: "<>2__current" } currentStore,
+                StoreField { Field.Name: "<>1__state" },
+                Return { Value: Constant { Value: true } }])
+            return false;
+        var yieldExpr = currentStore.Value;
+
+        // ---- resume block: `state = -1; [temp = <loopvar>;] <loopvar> = <loopvar> +/- step;` falling through to cond ----
+        if (!byOffset.TryGetValue(resumeOff, out var resumeBlock))
+            return false;
+        var resumeChildren = resumeBlock.Children;
+        if (resumeChildren.Count < 2
+            || resumeChildren[0] is not StoreField { Field.Name: "<>1__state" }
+            || resumeChildren[^1] is not StoreField { Instance: LoadArgument { Index: 0 }, Field.Name: var incName, Value: Binary increment }
+            || incName != loopField.Name
+            || increment.Right is not Constant stepConstant)
+            return false;
+        // Any statements between the state store and the increment are the `i++`
+        // temp copy (`temp = <loopvar>`); nothing else belongs in this slice.
+        for (var i = 1; i < resumeChildren.Count - 1; i++)
+            if (resumeChildren[i] is not StoreLocal)
+                return false;
+        var resumeIndex = blocks.ToList().IndexOf(resumeBlock);
+        if (resumeIndex + 1 >= blocks.Count || blocks[resumeIndex + 1] != condBlock)
+            return false;
+
+        // Every block must have a recognised role; an unexplained block means a
+        // richer shape than this slice handles.
+        var matched = new HashSet<Block> { blocks[0], blocks[1], blocks[2], initBlock, condBlock, terminalBlock, yieldBlock, resumeBlock };
+        if (matched.Count != blocks.Count)
+            return false;
+
+        // ---- synthesise: validate remap with the predicted local index, then commit ----
+        var loopType = loopField.Type;
+        var local = kickoff.Locals.Length;
+        if (Remap(initExpr, loopField.Name, local, loopType, kickoff) is not { } init
+            || Remap(comparison.Right, loopField.Name, local, loopType, kickoff) is not { } bound
+            || Remap(yieldExpr, loopField.Name, local, loopType, kickoff) is not { } element)
+            return false;
+
+        kickoff.AddLocal(loopType, ExtractSourceName(loopField.Name));
+
+        var body = new Block(0);
+        body.Add(new YieldReturn(element));
+        body.Add(new StoreLocal(local, loopType,
+            new Binary(increment.Kind, increment.IsChecked, increment.IsUnsigned,
+                new LoadLocal(local, loopType), new Constant(stepConstant.Value, stepConstant.Type))));
+
+        var loop = new WhileLoop(new Comparison(comparison.Kind, comparison.IsUnsigned, new LoadLocal(local, loopType), bound), body);
+        var declaration = new StoreLocal(local, loopType, init);
+
+        // Anchor to the kickoff's state-machine allocation, not a MoveNext offset
+        // (those live in a different method's offset space), so the allocation fact
+        // classified at import still lands on the reconstructed body.
+        if (handoff.SourceOffset >= 0)
+        {
+            declaration.SetSourceOffset(handoff.SourceOffset);
+            loop.SetSourceOffset(handoff.SourceOffset);
+        }
+
+        statements.Add(declaration);
+        statements.Add(loop);
+        return true;
+    }
+
+    // Rebuilds an expression in the kickoff's scope: the hoisted loop field becomes
+    // the loop local, hoisted parameter fields become the kickoff's parameters, and
+    // anything else (another field, a leaked `this`, a MoveNext temp, an unsupported
+    // node) returns null — the self-containment guard for this slice.
+    static IrExpression? Remap(IrExpression expr, string loopFieldName, int local, TypeRef loopType, IrFunction kickoff)
+    {
+        switch (expr)
+        {
+            case LoadField { Instance: LoadArgument { Index: 0 }, Field: var field }:
+                if (field.Name == loopFieldName)
+                    return new LoadLocal(local, loopType);
+                if (TryGetParameter(kickoff, field.Name, out var index, out var parameter))
+                    return new LoadArgument(index, parameter.Name, parameter.Type);
+                return null;
+            case Constant constant:
+                return new Constant(constant.Value, constant.Type);
+            case Comparison comparison:
+                if (Remap(comparison.Left, loopFieldName, local, loopType, kickoff) is not { } left
+                    || Remap(comparison.Right, loopFieldName, local, loopType, kickoff) is not { } right)
+                    return null;
+                return new Comparison(comparison.Kind, comparison.IsUnsigned, left, right);
+            case Binary binary:
+                if (Remap(binary.Left, loopFieldName, local, loopType, kickoff) is not { } bl
+                    || Remap(binary.Right, loopFieldName, local, loopType, kickoff) is not { } br)
+                    return null;
+                return new Binary(binary.Kind, binary.IsChecked, binary.IsUnsigned, bl, br);
+            default:
+                return null;
+        }
+    }
+
+    static bool TryGetParameter(IrFunction kickoff, string name, out int index, out Parameter parameter)
+    {
+        var parameters = kickoff.Signature.Parameters;
+        var argumentBase = kickoff.Signature.HasThis ? 1 : 0;
+        for (var i = 0; i < parameters.Length; i++)
+            if (parameters[i].Name == name)
+            {
+                index = argumentBase + i;
+                parameter = parameters[i];
+                return true;
+            }
+
+        index = -1;
+        parameter = null!;
+        return false;
+    }
+
+    // `state == 0` — csc emits `brfalse` on the state local, which raises to a
+    // logical-not; accept an explicit `== 0` comparison too.
+    static bool IsStateZero(IrExpression condition, int stateLocal) => condition switch
+    {
+        LogicalNot { Operand: LoadLocal load } => load.Index == stateLocal,
+        Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal load, Right: Constant { Value: 0 } } => load.Index == stateLocal,
+        _ => false,
+    };
+
+    static bool IsStateEqual(IrExpression condition, int stateLocal, int value)
+        => condition is Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal load, Right: Constant { Value: int v } }
+            && load.Index == stateLocal && v == value;
+
+    static bool IsReturnFalse(Block block)
+        => block.Children is [Return { Value: Constant { Value: false } }];
+
+    static bool IsHoistedLocal(string fieldName)
+        => fieldName.StartsWith("<", System.StringComparison.Ordinal)
+            && !fieldName.StartsWith("<>", System.StringComparison.Ordinal)
+            && fieldName.Contains(">5__", System.StringComparison.Ordinal);
+
+    static string ExtractSourceName(string fieldName)
+    {
+        var close = fieldName.IndexOf('>');
+        return close > 1 ? fieldName[1..close] : "i";
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -22,10 +22,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// An <b>empty</b> iterator — one whose <c>MoveNext</c> never stores
 /// <c>&lt;&gt;2__current</c> (so it yields nothing, e.g. a bare <c>yield break;</c>) —
 /// is reconstructed as <c>yield break;</c> regardless of dispatch shape (csc emits
-/// an <c>if</c> rather than a <c>switch</c> for a single state).
-/// Parameterized, captured, or looping iterators do not match and fall through to
-/// <see cref="IteratorAcknowledgmentPass"/>, which keeps the gap honest. A no-op
-/// when the seam is absent (stage dumps, the lowered/annotated views).</para>
+/// an <c>if</c> rather than a <c>switch</c> for a single state). A <b>counting
+/// loop</b> — a single <c>for</c>/<c>while</c> with one yield whose body is
+/// self-contained modulo the loop variable (e.g. <c>for (int i = 0; i &lt; n; i++)
+/// yield return i;</c>) — is reconstructed by
+/// <see cref="CountingLoopReconstruction"/> from the lowered goto-dispatch
+/// MoveNext.
+/// Nested loops, multiple yields, captured locals, or any other shape do not match
+/// and fall through to <see cref="IteratorAcknowledgmentPass"/>, which keeps the
+/// gap honest. A no-op when the seam is absent (stage dumps, the lowered/annotated
+/// views).</para>
 /// </summary>
 public sealed class IteratorReconstructionPass : IIrPass
 {
@@ -46,7 +52,7 @@ public sealed class IteratorReconstructionPass : IIrPass
         // lands at the altitude this pass recognizes.
         IrPasses.Run(moveNext, IrPasses.Default, context);
 
-        if (!TryReconstruct(moveNext, handoff, out var statements))
+        if (!TryReconstruct(moveNext, function, handoff, out var statements))
             return;  // leave for IteratorAcknowledgmentPass
 
         var stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
@@ -59,7 +65,7 @@ public sealed class IteratorReconstructionPass : IIrPass
         function.Body.Add(block);
     }
 
-    static bool TryReconstruct(IrFunction moveNext, NewObject handoff, out List<IrNode> statements)
+    static bool TryReconstruct(IrFunction moveNext, IrFunction kickoff, NewObject handoff, out List<IrNode> statements)
     {
         statements = [];
 
@@ -78,11 +84,19 @@ public sealed class IteratorReconstructionPass : IIrPass
             return true;
         }
 
-        if (!TryReconstructLinear(moveNext, out var yields))
-            return false;
+        if (TryReconstructLinear(moveNext, out var yields))
+        {
+            statements.AddRange(yields);
+            return true;
+        }
 
-        statements.AddRange(yields);
-        return true;
+        if (CountingLoopReconstruction.TryReconstruct(moveNext, kickoff, handoff, out var loop))
+        {
+            statements.AddRange(loop);
+            return true;
+        }
+
+        return false;
     }
 
     static bool TryReconstructLinear(IrFunction moveNext, out List<YieldReturn> yields)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -117,7 +117,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "reference-type exact BCL IDisposable null-guard and value-type constrained dispose; ref-struct pattern dispose and await using not raised")]
     public static UsingStatementPass UsingStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass WhileStatement => new();
-    [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences and empty (`yield break;`) iterators reconstructed (IteratorReconstructionPass), parameterized/captured/looping iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();
+    [Completeness(CompletenessLevel.Partial, "yield return — iterator state machine; linear self-contained `yield return <const>;` sequences, empty (`yield break;`) iterators, and single counting loops (`for (T i = init; i < bound; i++) yield return f(i);` self-contained modulo the loop variable) reconstructed (IteratorReconstructionPass); nested loops, multiple yields, and captured/parameterized non-loop iterators fall back to honest acknowledgment (IteratorAcknowledgmentPass)")] public static IteratorReconstructionPass Yield => new();
 }
 
 /// <summary>How much of a lowered construct comes back as the idiom.</summary>


### PR DESCRIPTION
## Summary

Extends iterator `yield` recovery from linear/empty sequences to the **single counting loop** — the lowered form of `for (T i = init; i < bound; i++) yield return f(i);` and the equivalent `while`.

Unlike the linear case (a clean `switch` chain), a looping iterator's `MoveNext` is an **irreducible goto-dispatch CFG**: the state-1 resume edge jumps into the middle of the loop, so the generic structurer cannot form a natural loop, and the kickoff previously fell back to acknowledgment.

`CountingLoopReconstruction` matches that exact dispatch shape (entry + resume states, one loop, one yield) and synthesises the loop directly:

- the hoisted loop field (`<i>5__2`) becomes a fresh local (`IrFunction.AddLocal`),
- hoisted parameter fields map back to the kickoff's parameters,
- the body is rebuilt as `T i = init; while (i < bound) { yield return f(i); i = i + step; }`.

Example — `YieldRange(int n)` now reconstructs to:

```csharp
int i = 0;
while (i < n)
{
    yield return i;
    i++;
}
```

## Self-containment guard

The expression remap **is** the guard: a bound or yielded value referencing anything beyond the loop variable, the kickoff's parameters, and constants declines the match. Nested loops, multiple yields, and captured locals fall through to honest acknowledgment (`IteratorAcknowledgmentPass`).

## Notes

- Reconstructed statements anchor to the state-machine allocation offset, not a `MoveNext` offset (those belong to a different method's offset space).
- This is **phase 1** of looping-yield recovery; nested loops / multiple yields / `foreach`-delegation remain follow-ups.

## Tests

- New: counting-loop reconstruction (while-loop shape, render, constant-bound + arithmetic element), nested-loop fall-back.
- Flipped the former `YieldRange` acknowledgment expectation to reconstruction.
- Full decompiler suite (518) and product suite (1157 / 9 skip) green.
