### PR TITLE
Collapse the lazy delegate cache when the delegate is a call argument

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1117,6 +1117,19 @@ public class CfgSampleClass
         return items.Where(x => x > threshold).ToList();
     }
 
+    // A non-capturing lambda passed straight to a call. The compiler caches the
+    // delegate in a <>9__ field, but interleaves the receiver's evaluation
+    // between the cache load and the null guard, so the load is not adjacent to
+    // the guard. LambdaCachePass scans back to it and still collapses the dance.
+    public static IEnumerable<int> CachedDelegateArgument(IEnumerable<int> items)
+        => items.Where(x => x > 0);
+
+    // Two cached non-capturing delegates in a chain: the second call's receiver
+    // (the first call's result) interleaves ahead of the second guard, and reads
+    // the first delegate's result slot — both tolerated by the back-scan.
+    public static IEnumerable<int> CachedDelegateChain(IEnumerable<int> items)
+        => items.Where(x => x > 0).Select(x => x * 2);
+
     public static bool IsPositiveOrZero(int value)
     {
         return value >= 0;

--- a/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LambdaCachePassTests
+{
+    static string PrintRaised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    // The cache field name and the null guard are the two visible artifacts of an
+    // uncollapsed dance; a clean collapse leaves neither.
+    static void AssertCacheCollapsed(string output)
+    {
+        Assert.DoesNotContain("<>9__", output);
+        Assert.DoesNotContain("is null", output);
+    }
+
+    [Fact]
+    public void CachedDelegateArgument_CollapsesDespiteInterleavedReceiver()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateArgument));
+
+        AssertCacheCollapsed(output);
+        Assert.Contains("x => x > 0", output);
+        Assert.Contains("Where", output);
+    }
+
+    [Fact]
+    public void CachedDelegateChain_CollapsesBothGuards()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateChain));
+
+        AssertCacheCollapsed(output);
+        Assert.Contains("x => x > 0", output);
+        Assert.Contains("x => x * 2", output);
+        Assert.Contains("Where", output);
+        Assert.Contains("Select", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -10,6 +10,11 @@ namespace ILInspector.Decompiler.Pipeline;
 ///   if (s is null) { t = new D(&lt;&gt;9, &lt;Outer&gt;b__N_M); &lt;&gt;9__N_M = t; s = t; }
 ///   // ... use s
 /// </code>
+/// When the cached delegate is passed as a call argument, the compiler
+/// interleaves the receiver's evaluation between the load and the guard
+/// (<c>s = &lt;&gt;9__; recv = …; r = s; if (s is null) …</c>) — the shape every
+/// LINQ and <c>Array.FindAll</c>-style call site emits — so the load is found by
+/// scanning back to it, not at a fixed offset.
 /// This pass rewrites that whole dance to a single <c>s = new D(...)</c>,
 /// dropping the cache field, the null guard, and the carrier slots. The cache is
 /// a pure codegen artifact (re-emitting the C# restores an equivalent one), so
@@ -50,15 +55,34 @@ public sealed class LambdaCachePass : IIrPass
                 continue;
             int resultSlot = resultStore.Slot;
 
-            // The two statements ahead of the guard: cacheSlot = <>9__N_M; result = cacheSlot;
-            if (block.Children[ifStmt.ChildIndex - 2] is not
-                    StoreStackSlot { Value: LoadField { Field: { } loadedField, Instance: null } } cacheLoad
-                || block.Children[ifStmt.ChildIndex - 1] is not
+            // The seed (result = cacheSlot) sits immediately before the guard.
+            if (block.Children[ifStmt.ChildIndex - 1] is not
                     StoreStackSlot { Value: LoadStackSlot seedFrom } seedResult)
                 continue;
-            if (cacheLoad.Slot != cacheRead.Slot || loadedField != cacheField)
-                continue;
             if (seedResult.Slot != resultSlot || seedFrom.Slot != cacheRead.Slot)
+                continue;
+
+            // The cache load (cacheSlot = <>9__N_M) sits earlier in the same
+            // block, but not necessarily adjacent: when the cached delegate is an
+            // argument the compiler interleaves the call receiver's evaluation
+            // between the load and the guard — `s = <>9__; recv = xs; r = s; if (s
+            // is null) ...`, the shape every LINQ/`Array.FindAll`-style call emits.
+            // Scan back for the load rather than fixing its offset, stopping at any
+            // other statement that touches the cache slot (which would mean this is
+            // not the load we are erasing, so the whole-block precondition fails).
+            StoreStackSlot? cacheLoad = null;
+            for (int j = ifStmt.ChildIndex - 2; j >= 0; j--)
+            {
+                if (block.Children[j] is StoreStackSlot { Value: LoadField { Field: { } loadedField, Instance: null } } candidate
+                    && candidate.Slot == cacheRead.Slot && loadedField == cacheField)
+                {
+                    cacheLoad = candidate;
+                    break;
+                }
+                if (ReferencesSlot(block.Children[j], cacheRead.Slot))
+                    break;
+            }
+            if (cacheLoad is null)
                 continue;
 
             context.Stepper.StepOver($"collapse lazy delegate cache {cacheField.Name}", ifStmt);
@@ -73,4 +97,11 @@ public sealed class LambdaCachePass : IIrPass
     // closure holder); the name is the unique anchor for the whole idiom.
     static bool IsClosureCacheField(FieldRef field)
         => field.Name.StartsWith("<>9__", StringComparison.Ordinal);
+
+    // Whether the statement reads or writes the given stack slot anywhere in its
+    // subtree — the guard for what may be interleaved ahead of the cache load.
+    static bool ReferencesSlot(IrNode node, int slot)
+        => node.Descendants.Prepend(node).Any(n =>
+            n is LoadStackSlot { Slot: var read } && read == slot
+            || n is StoreStackSlot { Slot: var written } && written == slot);
 }


### PR DESCRIPTION
## What

`LambdaCachePass` collapses the compiler's lazy `<>9__N_M` delegate-cache dance back to a single `s = new D(...)`. It anchored the cache load at a **fixed offset** (`if.ChildIndex - 2`), immediately ahead of the null guard. But when the cached delegate is passed as a **call argument**, the compiler interleaves the receiver's evaluation between the load and the guard:

```
s = <>9__; recv = xs; r = s; if (s is null) { ... }
```

That is the shape **every LINQ chain and `Array.FindAll`-style call site emits**, so the load was never adjacent and the dance survived uncollapsed — `xs.Where(x => x > 0)` rendered as ~10 lines of exposed cache plumbing instead of the delegate.

## How

Find the cache load by **scanning back** from the guard instead of fixing its offset, stopping at any other statement that touches the cache slot (which would mean it is not the load being erased). Intervening statements that leave the cache slot alone are tolerated.

Before / after (real product path):

```csharp
// before
Func<int, bool> S_256 = <>c.<>9__0_0;
IEnumerable<int> S_0 = xs;
S_1 = S_256;
if (S_256 is null) { S_257 = x => x > 0; <>c.<>9__0_0 = S_257; S_1 = S_257; }
return Enumerable.Where<int>(S_0, S_1);

// after
IEnumerable<int> S_0 = xs;
Func<int, bool> S_1 = x => x > 0;
return Enumerable.Where<int>(S_0, S_1);
```

## Soundness

1. **Preconditions proved whole-block.** The back-scan stops at any reference to the cache slot, so a collapse fires only when the matched load is provably the one the guard and seed read. Reads of the *result* slot by an interleaved statement (e.g. a chain's prior call result) are reads of the pre-seed value, preserved because the collapse point stays at the guard's position.
2. **Semantics preserved.** Unchanged from the existing collapse — the cache is a pure codegen artifact; re-emitting the C# restores an equivalent one. Both new fixtures pass the **fidelity gate** (recompile to a matching opcode stream), so no `KnownDiffs` entry is needed.
3. **Per-item isolation.** No change to the pass's per-method structure.

## Class under the three-class rule

Case 1 (IL-anchored, adopt freely): the `<>9__` cache pattern is literally in the IL; erasing it is the inverse of a codegen lowering, not a fidelity-erasing choice.

## Tests & verification

- `CfgSampleClass.CachedDelegateArgument` (single call) and `CachedDelegateChain` (two-lambda chain) added; `LambdaCachePassTests` asserts the cache field and null guard are gone and the lambdas/calls remain.
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **512/512 pass** (incl. fidelity gate + corpus sweep gate over the new fixtures).
- `--pass-impact lambda-cache`: **14 → 74** changed methods over CoreLib (41,159), **0 pass bugs** — the bounded call-argument broadening.

## Context

This came out of scoping the owed `Query` ledger row. Query syntax has no IL anchor (it compiles byte-identical to the fluent chain, translated during binding before `LocalRewriter`), so it should not be raised; the real owed work it exposed is this cache collapse. Two follow-ups remain: (1) correct the `Query` ledger-row note to say it renders as the fluent chain; (2) inline the `S_0`/`S_1` intermediate temps into a single fluent `xs.Where(...).Select(...)` expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
