### PR TITLE
Raise multi-arg Add (dictionary) collection initializers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1060,6 +1060,9 @@ public class CfgSampleClass
     public static System.Collections.Generic.List<int> MakeList(int a, int b)
         => new System.Collections.Generic.List<int> { a, b, 42 };
 
+    public static System.Collections.Generic.Dictionary<int, string> MakeDictionary(string a, string b)
+        => new System.Collections.Generic.Dictionary<int, string> { { 1, a }, { 2, b } };
+
     public static InitTarget MakeEmpty() => new InitTarget();
 
     public static int InitTargetX(InitTarget target) => target.X;

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -41,6 +41,7 @@ public class IdiomShapeScorecardTests
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("ObjectInitializerPass", nameof(CfgSampleClass.MakeDictionary), SyntaxKind.ComplexElementInitializerExpression, [SyntaxKind.InvocationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.NthFromEnd), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -53,6 +53,19 @@ public class ObjectInitializerPassTests
     }
 
     [Fact]
+    public void DictionaryInitializer_RaisesMultiArgAddCalls()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeDictionary));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.True(initializer.IsCollection);
+        // Two { k, v } entries, each contributing a key and a value (4 values total).
+        Assert.Equal([2, 2], initializer.EntryArities);
+        Assert.Equal(4, initializer.Values.Count);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
+    }
+
+    [Fact]
     public void PlainConstruction_WithoutInitializer_StaysNewObject()
     {
         var function = Raised(nameof(CfgSampleClass.MakeEmpty));
@@ -92,5 +105,6 @@ public class ObjectInitializerPassTests
         Assert.Contains("return new InitTarget { X = a, Y = b };", Print(nameof(CfgSampleClass.MakePoint)));
         Assert.Contains("return new InitTarget { X = a, Z = b };", Print(nameof(CfgSampleClass.MakePointWithField)));
         Assert.Contains("return new List<int> { a, b, 42 };", Print(nameof(CfgSampleClass.MakeList)));
+        Assert.Contains("return new Dictionary<int, string> { { 1, a }, { 2, b } };", Print(nameof(CfgSampleClass.MakeDictionary)));
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -7,9 +7,10 @@ public sealed partial class CSharpPrinter
 {
     /// <summary>
     /// Renders a raised object/collection initializer: <c>new T(args) { ... }</c>
-    /// where the body is <c>Member = value</c> entries (object form) or bare
-    /// element expressions (collection form). Constructor parens are omitted when
-    /// the creation takes no arguments, matching idiomatic C#.
+    /// where the body is <c>Member = value</c> entries (object form), bare element
+    /// expressions, or braced multi-value <c>{ k, v }</c> dictionary elements
+    /// (collection form). Constructor parens are omitted when the creation takes no
+    /// arguments, matching idiomatic C#.
     /// </summary>
     string ObjectInitializerText(ObjectInitializerExpression initializer)
     {
@@ -18,9 +19,29 @@ public sealed partial class CSharpPrinter
             ? string.Empty
             : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
         var body = initializer.IsCollection
-            ? string.Join(", ", initializer.Values.Select(Expression))
+            ? CollectionInitializerBody(initializer)
             : string.Join(", ", initializer.Members.Zip(initializer.Values, (member, value) => $"{member} = {Expression(value)}"));
         return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+    }
+
+    /// <summary>
+    /// Renders collection elements, grouping the flat value list by
+    /// <see cref="ObjectInitializerExpression.EntryArities"/>: an arity-1 entry is a
+    /// bare element, a multi-value entry a braced <c>{ k, v }</c> (dictionary) element.
+    /// </summary>
+    string CollectionInitializerBody(ObjectInitializerExpression initializer)
+    {
+        var values = initializer.Values;
+        var parts = new List<string>(initializer.EntryArities.Length);
+        int next = 0;
+        foreach (var arity in initializer.EntryArities)
+        {
+            parts.Add(arity == 1
+                ? Expression(values[next])
+                : $"{{ {string.Join(", ", Enumerable.Range(next, arity).Select(k => Expression(values[k])))} }}");
+            next += arity;
+        }
+        return string.Join(", ", parts);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1262,17 +1262,23 @@ public sealed class DeconstructionAssignment : IrNode
 /// </summary>
 public sealed class ObjectInitializerExpression : IrExpression
 {
-    public ObjectInitializerExpression(NewObject creation, bool isCollection, IEnumerable<(string? Member, IrExpression Value)> entries)
+    public ObjectInitializerExpression(NewObject creation, bool isCollection, IEnumerable<(string? Member, IReadOnlyList<IrExpression> Values)> entries)
     {
         IsCollection = isCollection;
         AddChild(creation);
         var members = ImmutableArray.CreateBuilder<string?>();
-        foreach (var (member, value) in entries)
+        var arities = ImmutableArray.CreateBuilder<int>();
+        foreach (var (member, values) in entries)
         {
-            members.Add(member);
-            AddChild(value);
+            arities.Add(values.Count);
+            foreach (var value in values)
+            {
+                members.Add(member);
+                AddChild(value);
+            }
         }
         Members = members.ToImmutable();
+        EntryArities = arities.ToImmutable();
     }
 
     /// <summary>Collection-initializer (<c>{ e0, e1 }</c> via <c>Add</c>) vs object-initializer (<c>{ X = a }</c> via member stores).</summary>
@@ -1281,8 +1287,17 @@ public sealed class ObjectInitializerExpression : IrExpression
     /// <summary>The <c>new T(...)</c> creation the initializer decorates.</summary>
     public NewObject Creation => (NewObject)Children[0];
 
-    /// <summary>Target member name per entry value, parallel to <see cref="Values"/>; <c>null</c> for a collection element.</summary>
+    /// <summary>Target member name per entry value, parallel to <see cref="Values"/>; <c>null</c> for a collection element. A multi-value entry repeats the (null) member per value, so this stays 1:1 with <see cref="Values"/>.</summary>
     public ImmutableArray<string?> Members { get; }
+
+    /// <summary>
+    /// The number of <see cref="Values"/> contributed by each source entry, in
+    /// order; the values are this many consumed per entry and the arities sum to
+    /// <see cref="Values"/>.Count. An object member or a single collection element
+    /// has arity 1; a dictionary <c>{ k, v }</c> element (multi-argument <c>Add</c>)
+    /// has arity 2 or more.
+    /// </summary>
+    public ImmutableArray<int> EntryArities { get; }
 
     /// <summary>The entry values, in source order.</summary>
     public IReadOnlyList<IrExpression> Values => Children.Skip(1).Cast<IrExpression>().ToList();
@@ -1290,7 +1305,7 @@ public sealed class ObjectInitializerExpression : IrExpression
     public override TypeRef? ResultType => Creation.ResultType;
 
     public override string Describe()
-        => $"ObjectInitializer {Creation.Constructor.DeclaringType.ToDisplayString()} ({Members.Length} {(IsCollection ? "elements" : "members")})";
+        => $"ObjectInitializer {Creation.Constructor.DeclaringType.ToDisplayString()} ({EntryArities.Length} {(IsCollection ? "elements" : "members")})";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -91,7 +91,7 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
-    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position); named-local, indexer-element, nested, and multi-arg Add (dictionary) initializers not raised")]
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position), incl. multi-arg Add (dictionary) initializers; named-local, indexer-element, and nested initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -42,7 +42,7 @@ public sealed class ObjectInitializerPass : IIrPass
         IReadOnlyList<IrNode> Consumed,
         NewObject Creation,
         bool IsCollection,
-        IReadOnlyList<(string? Member, IrExpression Value)> Entries,
+        IReadOnlyList<(string? Member, IReadOnlyList<IrExpression> Values)> Entries,
         LoadStackSlot Use);
 
     static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation)
@@ -50,7 +50,7 @@ public sealed class ObjectInitializerPass : IIrPass
         var statements = seed.Parent!.Children;
         var aliasSlots = new HashSet<int> { seed.Slot };
         var consumed = new List<IrNode> { seed };
-        var entries = new List<(string? Member, IrExpression Value)>();
+        var entries = new List<(string? Member, IReadOnlyList<IrExpression> Values)>();
         bool? isCollection = null;
 
         for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
@@ -94,9 +94,10 @@ public sealed class ObjectInitializerPass : IIrPass
             return null;  // a bare `new T()` with no initializer — nothing to raise
 
         // A self-referential entry (t.Next = t) cannot fold into a single expression.
-        foreach (var (_, value) in entries)
-            if (ReferencesAnySlot(value, aliasSlots))
-                return null;
+        foreach (var (_, values) in entries)
+            foreach (var value in values)
+                if (ReferencesAnySlot(value, aliasSlots))
+                    return null;
 
         // The threaded reference must escape the run exactly once: that single
         // downstream load is where the initializer expression belongs.
@@ -110,26 +111,26 @@ public sealed class ObjectInitializerPass : IIrPass
         return new Plan(consumed, creation, isCollection ?? false, entries, outsideUses[0]);
     }
 
-    static (string? Member, IrExpression Value)? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    static (string? Member, IReadOnlyList<IrExpression> Values)? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
     {
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
-            => (property.PropertyName, property.Value),
+            => (property.PropertyName, (IReadOnlyList<IrExpression>)[property.Value]),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
-            => (field.Field.Name, field.Value),
+            => (field.Field.Name, (IReadOnlyList<IrExpression>)[field.Value]),
         _ => null,
     };
 
-    static (string? Member, IrExpression Value)? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
+    static (string? Member, IReadOnlyList<IrExpression> Values)? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
     {
         if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
             return null;
-        if (call.Callee.Name != "Add" || call.Arguments.Count != 2)
-            return null;  // single-element Add only (receiver + one value); dictionary Add(k, v) is a later slice
+        if (call.Callee.Name != "Add" || call.Arguments.Count < 2)
+            return null;  // receiver + one-or-more element values (Add(v) collection, Add(k, v) dictionary)
         if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
             return null;
-        return (null, call.Arguments[1]);
+        return (null, call.Arguments.Skip(1).ToList());
     }
 
     static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
@@ -152,11 +153,12 @@ public sealed class ObjectInitializerPass : IIrPass
             statement.Detach();
 
         plan.Creation.Detach();
-        var entries = new List<(string?, IrExpression)>(plan.Entries.Count);
-        foreach (var (member, value) in plan.Entries)
+        var entries = new List<(string?, IReadOnlyList<IrExpression>)>(plan.Entries.Count);
+        foreach (var (member, values) in plan.Entries)
         {
-            value.Detach();
-            entries.Add((member, value));
+            foreach (var value in values)
+                value.Detach();
+            entries.Add((member, values));
         }
 
         var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);


### PR DESCRIPTION
## Summary

Generalizes `ObjectInitializerPass` to recover **dictionary collection initializers** — `new Dictionary<K,V> { {k, v}, ... }` — which the C# compiler lowers to a stack-slot dup chain threaded through multi-argument `Add(receiver, k, v)` calls. Previously only single-element collection `Add(receiver, value)` and object member initializers were raised; multi-arg `Add` fell through to bare statements.

## Changes

- **`ObjectInitializerExpression` node** now carries per-entry value lists. A new `EntryArities` array records how many values each source entry contributed; `Members`/`Values` stay 1:1 (the member is padded per value) so existing consumers (e.g. `LambdaRaisingPass`) are unaffected.
- **`ObjectInitializerPass`** accepts `Add` with `>= 2` arguments (receiver + N element values); the self-reference guard and `Apply` iterate each value per entry.
- **`CSharpPrinter`** partitions the flat value list by `EntryArities`: arity 1 → bare element, arity ≥ 2 → braced `{ k, v }` element.
- Ledger note updated; new fixture (`MakeDictionary`), pass/render tests, and a scorecard row added.

## Faithfulness

Re-lowering the raised syntax produces **identical IL** (opcode-exact); `FidelityGate` confirms the fixture round-trips. The dup/stack-slot discriminator already excludes hand-written `d.Add(k, v)` (named local, not a stack slot).

## Validation

- Decompiler tests: **516/516** green (incl. FidelityGate).
- Product tests: **1157** green.
- Corpus **fidelity/validity neutral**: 40984/41012 Full, 995 malformed at both merge-base and HEAD.
- `--pass-impact object-initializer`: **+70 methods, 0 pass bugs**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>