### PR TITLE
Raise static non-capturing local functions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -63,6 +63,7 @@ public class FidelityGateTests
     static readonly string[] PinnedExact =
     {
         "SharedCaptureLambdas",
+        "DoubleViaLocalFunction",
         "CheckedAdd",
         "UnsignedShift",
         "Shadowed",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -56,6 +56,7 @@ public class IdiomShapeScorecardTests
         new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         // Owed: a lambda body that keeps a local of its own (declined by the zero-local guard).
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LocalFunctionRaisingPass", nameof(CfgSampleClass.DoubleViaLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -1,0 +1,29 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LocalFunctionRaisingPassTests
+{
+    static string PrintRaised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void StaticLocalFunction_RecoveredAsDeclarationAndUnqualifiedCall()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.DoubleViaLocalFunction));
+
+        Assert.Contains("return Twice(x);", output);                  // call rendered unqualified
+        Assert.Contains("static int Twice(int v) => v * 2;", output); // declaration emitted
+        Assert.DoesNotContain("g__", output);                          // no synthesized name
+        Assert.DoesNotContain("CfgSampleClass.Twice", output);         // not the qualified mis-binding
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -32,6 +32,20 @@ public static class GeneratedCodeIdentity
         => name.StartsWith("<", StringComparison.Ordinal)
             && name.Contains(">b__", StringComparison.Ordinal);
 
+    /// <summary>
+    /// A synthesized local-function method: <c>&lt;Enclosing&gt;g__Name|N_M</c>,
+    /// emitted directly on the enclosing type (not a closure holder), so it is
+    /// the method's own <c>[CompilerGenerated]</c> evidence — not the declaring
+    /// type's — that gates the name pattern.
+    /// </summary>
+    public static bool IsLocalFunctionMethod(MethodRef method)
+        => method.CompilerGenerated == MetadataFactState.Yes
+            && IsSynthesizedLocalFunctionName(method.Name);
+
+    public static bool IsSynthesizedLocalFunctionName(string name)
+        => name.StartsWith("<", StringComparison.Ordinal)
+            && name.Contains(">g__", StringComparison.Ordinal);
+
     static string LeafTypeName(string name)
     {
         int plus = name.LastIndexOf('+');

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -506,6 +506,24 @@ public sealed partial class CSharpPrinter
             _statementLines.TryAdd(node, startLine);
         }
         string pad = new(' ', indent * 4);
+        if (node is LocalFunctionStatement localFunction)
+        {
+            string modifier = localFunction.IsStatic ? "static " : "";
+            string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{TypeText(p.Type)} {p.Name}"));
+            string header = $"{modifier}{TypeText(localFunction.ReturnType)} {localFunction.Name}({parameters})";
+            if (localFunction.ExpressionBody is { } body)
+            {
+                sb.Append(pad).Append(header).Append(" => ").Append(Expression(body)).AppendLine(";");
+            }
+            else
+            {
+                sb.Append(pad).AppendLine(header);
+                sb.Append(pad).AppendLine("{");
+                AppendContainer(sb, localFunction.Body, indent + 1);
+                sb.Append(pad).AppendLine("}");
+            }
+            return;
+        }
         if (node is Return { Value: SwitchExpression returnedSwitch })
         {
             // A switch expression returned spans several lines, one arm per line,
@@ -950,6 +968,7 @@ public sealed partial class CSharpPrinter
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),
+        LocalFunctionInvocation inv => $"{inv.Name}({Arguments(inv.Arguments)})",
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1412,6 +1412,63 @@ public sealed class Lambda : IrExpression
         => $"Lambda {DelegateType.ToDisplayString()} ({Parameters.Length} params)";
 }
 
+/// <summary>
+/// A recovered local-function declaration — the inverse of the compiler lowering
+/// a <c>Name(...) { ... }</c> local function to a synthesized
+/// <c>&lt;Enclosing&gt;g__Name|N_M</c> method. Holds the source name, signature,
+/// and raised body; the printer emits it as a nested method declaration in the
+/// host body (call sites become <see cref="LocalFunctionInvocation"/>).
+/// </summary>
+public sealed class LocalFunctionStatement : IrNode
+{
+    public LocalFunctionStatement(
+        string name, TypeRef returnType, ImmutableArray<Parameter> parameters, bool isStatic, BlockContainer body)
+    {
+        Name = name;
+        ReturnType = returnType;
+        Parameters = parameters;
+        IsStatic = isStatic;
+        AddChild(body);
+    }
+
+    public string Name { get; }
+    public TypeRef ReturnType { get; }
+    public ImmutableArray<Parameter> Parameters { get; }
+    public bool IsStatic { get; }
+    public BlockContainer Body => (BlockContainer)Children[0];
+    public override IEnumerable<TypeRef> DirectTypes => Parameters.Select(p => p.Type).Append(ReturnType);
+
+    /// <summary>The single returned expression when the body is one block ending in a bare <c>return expr;</c>.</summary>
+    public IrExpression? ExpressionBody
+        => Body.Blocks is [{ Children: [Return { Value: { } value }] }] ? value : null;
+
+    public override string Describe() => $"LocalFunctionStatement {Name} ({Parameters.Length} params)";
+}
+
+/// <summary>
+/// A call to a recovered local function — rendered as the unqualified
+/// <c>Name(args)</c>, the source spelling, rather than the synthesized
+/// <c>Enclosing.&lt;Outer&gt;g__Name|N_M(args)</c> the call site lowered to.
+/// </summary>
+public sealed class LocalFunctionInvocation : IrExpression
+{
+    public LocalFunctionInvocation(string name, TypeRef returnType, IEnumerable<IrExpression> arguments)
+    {
+        Name = name;
+        ReturnType = returnType;
+        foreach (var argument in arguments)
+            AddChild(argument);
+    }
+
+    public string Name { get; }
+    public TypeRef ReturnType { get; }
+    public IReadOnlyList<IrExpression> Arguments => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => ReturnType;
+    public override IEnumerable<TypeRef> DirectTypes => [ReturnType];
+
+    public override string Describe() => $"LocalFunctionInvocation {Name}";
+}
+
 public sealed class Throw : IrNode
 {
     public Throw(IrExpression value) => AddChild(value);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -16,10 +16,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// not a closure. <see cref="LambdaRaisingPass"/> recovers zero-local lambdas,
 /// non-capturing (on the <c>&lt;&gt;c</c> holder, after <see cref="LambdaCachePass"/>
 /// strips its lazy cache) and capturing (a folded <c>&lt;&gt;c__DisplayClass</c>
-/// environment whose hoisted fields are substituted back into the body). Local
-/// functions, local-bound lambda bodies, and expression trees are still owed, so
-/// they render as synthesized <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c>
-/// shapes — an inferior-form gap the LocalRewriter register cannot show.</para>
+/// environment whose hoisted fields are substituted back into the body), and
+/// <see cref="LocalFunctionRaisingPass"/> recovers static non-capturing local
+/// functions. Capturing local functions, local-bound lambda bodies, and
+/// expression trees are still owed, so they render as synthesized
+/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — an inferior-form gap
+/// the LocalRewriter register cannot show.</para>
 ///
 /// <para>Synced against dotnet/roslyn
 /// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
@@ -29,8 +31,8 @@ internal static class ClosureCoverage
     [Completeness(CompletenessLevel.Partial, "zero-local expression or simple block bodies, capturing or not; local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
-    [Completeness(CompletenessLevel.None, "void Local() { } — synthesized g__Local| method (+ ref-struct env if capturing)")]
-    public static Unhandled LocalFunction => default!;
+    [Completeness(CompletenessLevel.Partial, "static, non-capturing local functions with a zero-local body, declared back into the host method and called by their source name; capturing (ref display-class env), recursive, and nested local functions still owed")]
+    public static LocalFunctionRaisingPass LocalFunction => new();
 
     [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from its <>c__DisplayClass environment — folded onto the delegate, or a local set up and shared across statements (allocation/stores elided); a class captured by a local function, or nested environments, still owed")]
     public static LambdaRaisingPass CapturedClosure => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -126,6 +126,10 @@ public static class IrPasses
         // it as `(params) => body`. Needs the cross-method import seam on the
         // pass context; a no-op when that seam is absent.
         new LambdaRaisingPass(),
+        // Raise a direct call to a synthesized local-function method into the
+        // local function: import the body, emit a nested declaration, and rewrite
+        // call sites to the unqualified name. Also needs the import seam.
+        new LocalFunctionRaisingPass(),
         // Raise the csc type-pattern lowering (a `value as T` store gating a
         // null test that scopes the narrowed local) into `value is T t`. Runs
         // after structuring and boolean folding so the `if` guard and the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -1,0 +1,112 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a call to a compiler-synthesized local-function method back to the
+/// local function itself — the inverse of ClosureConversion lowering a
+/// <c>Name(...) { ... }</c> local function to a <c>&lt;Enclosing&gt;g__Name|N_M</c>
+/// method invoked directly. The synthesized body is imported through the pass
+/// context's cross-method seam, emitted as a nested local-function declaration
+/// at the end of the host body, and every call site is rewritten to the
+/// unqualified <c>Name(args)</c> (the source spelling, replacing the
+/// otherwise-unspeakable <c>Enclosing.&lt;Outer&gt;g__Name|N_M(args)</c>).
+///
+/// <para>Current slice — <b>static, non-capturing</b> local functions with a
+/// zero-local body that prints in the host scope (arguments are self-naming).
+/// Excluded, and left as-is: a capturing local function (it takes its
+/// <c>&lt;&gt;c__DisplayClass</c> environment by <c>ref</c>), and a body that
+/// itself calls a local function (recursion or nesting), which keeps the import
+/// non-recursive. A no-op when the seam is absent.</para>
+/// </summary>
+public sealed class LocalFunctionRaisingPass : IIrPass
+{
+    public string Name => "local-function-raising";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (context.ImportMethodBody is null)
+            return;
+
+        var byMethod = function.Descendants.OfType<Call>()
+            .Where(c => c.Parent is not null && GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee))
+            .GroupBy(c => c.Callee)
+            .ToList();
+
+        var declarations = new List<LocalFunctionStatement>();
+        foreach (var group in byMethod)
+        {
+            var method = group.Key;
+            // Static value-parameter signature only: an instance receiver or a
+            // display-class (by-ref) parameter means a capturing local function.
+            if (method.HasThis || method.ParameterTypes.Any(IsDisplayClassParameter))
+                continue;
+
+            var body = context.ImportMethodBody(method);
+            if (body is null)
+                continue;
+            // Keep the import non-recursive: a body that calls a local function
+            // (itself, mutually, or nested) is out of this slice.
+            if (body.Descendants.OfType<Call>().Any(c => GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee)))
+                continue;
+
+            IrPasses.Run(body, IrPasses.Default, context);
+            if (!body.Locals.IsEmpty
+                || body.Descendants.OfType<UnsupportedNode>().Any()
+                || !IsPrintableBody(body))
+                continue;
+
+            string name = CSharpNaming.MethodName(method.Name);
+            var container = body.Body;
+            container.Detach();
+            // The body is another method's; clear its offsets so they cannot
+            // collide with the host's offset-keyed annotations and interleaved IL
+            // (the local function is rendered inline; its own IL is not projected).
+            foreach (var node in Self(container))
+                node.SetSourceOffset(-1);
+
+            foreach (var call in group.ToList())
+            {
+                context.Stepper.StepOver($"raise local function {name}", call);
+                var arguments = call.DetachChildren().Cast<IrExpression>();
+                call.ReplaceWith(new LocalFunctionInvocation(name, method.ReturnType, arguments));
+            }
+            declarations.Add(new LocalFunctionStatement(
+                name, method.ReturnType, body.Signature.Parameters, isStatic: true, container));
+        }
+
+        if (declarations.Count == 0)
+            return;
+
+        // Local functions are declarations, valid even after a return, so they
+        // append to the last top-level block — the idiomatic trailing placement.
+        var block = function.Body.Blocks[^1];
+        foreach (var declaration in declarations)
+            block.Add(declaration);
+    }
+
+    static bool IsDisplayClassParameter(TypeRef type)
+        => GeneratedCodeIdentity.IsDisplayClassName(type.Kind == TypeRefKind.ByRef ? type.ElementType! : type);
+
+    static bool IsPrintableBody(IrFunction body)
+    {
+        if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
+            return false;
+
+        for (int i = 0; i < statements.Count; i++)
+        {
+            var statement = statements[i];
+            if (statement is Return { Value: not null })
+                return i == statements.Count - 1;
+            if (statement is not ExpressionStatement)
+                return false;
+        }
+
+        return false;
+    }
+
+    static IEnumerable<IrNode> Self(IrNode node)
+    {
+        yield return node;
+        foreach (var descendant in node.Descendants)
+            yield return descendant;
+    }
+}


### PR DESCRIPTION
## What

Recovers a **static local function** from its lowered form. The compiler emits `Name(...) { ... }` as a synthesized `<Enclosing>g__Name|N_M` method invoked directly. Today the decompiler renders that call as `Enclosing.Name(args)` — which is a **correctness bug**, not just low altitude:

```csharp
public static int DoubleViaLocalFunction(int x)
{
    return Twice(x);
    static int Twice(int v) => v * 2;
}
```
…renders as `return CfgSampleClass.Twice(x);` — silently **binding to the unrelated public `CfgSampleClass.Twice(int)`** that happens to exist. When no same-named member exists, it doesn't compile at all.

Now it recovers:
```csharp
return Twice(x);
static int Twice(int v) => v * 2;
```

## How

`LocalFunctionRaisingPass` imports the synthesized body through the cross-method seam, emits a nested local-function **declaration** at the end of the host body (declarations are valid after a `return`), and rewrites each call site to the unqualified source name — via two new nodes (`LocalFunctionStatement`, `LocalFunctionInvocation`). Recognition is the method's own `[CompilerGenerated]` plus the `<Enclosing>g__Name|N_M` name (the declaring type is the real type, not a closure holder, so it's the *method's* attribute that gates the name).

## Scope

Static, non-capturing local functions with a zero-local body that prints in the host scope (arguments self-name). Explicitly excluded and left as-is:
- **capturing** local functions (they take a `ref <>c__DisplayClass` environment),
- bodies that themselves **call a local function** (recursion / mutual recursion / nesting) — this keeps the import non-recursive.

## Tests

- `ClosureCoverage.LocalFunction`: `None → Partial` (the third ClosureConversion leg, after lambda + captured-closure).
- Scorecard: `DoubleViaLocalFunction` recovers `LocalFunctionStatement`, rejects the `SimpleMemberAccessExpression` mis-binding.
- **Pinned opcode-exact** in the fidelity gate.
- Unit test asserting the declaration + unqualified call.
- 520/520 decompiler tests green; no new opcode diffs in the gate or BCL corpus sweep (local functions are common there).

## Follow-ups

Capturing local functions (ref display-class env), then recursive / nested local functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
