### PR TITLE
Raise dictionary and indexer collection initializers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1060,6 +1060,12 @@ public class CfgSampleClass
     public static System.Collections.Generic.List<int> MakeList(int a, int b)
         => new System.Collections.Generic.List<int> { a, b, 42 };
 
+    public static System.Collections.Generic.Dictionary<string, int> MakeDictionaryByIndexer(int a, int b)
+        => new System.Collections.Generic.Dictionary<string, int> { ["x"] = a, ["y"] = b };
+
+    public static System.Collections.Generic.Dictionary<string, int> MakeDictionaryByAdd(int a, int b)
+        => new System.Collections.Generic.Dictionary<string, int> { { "x", a }, { "y", b } };
+
     public static InitTarget MakeEmpty() => new InitTarget();
 
     public static int InitTargetX(InitTarget target) => target.X;

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -47,7 +47,7 @@ public class ObjectInitializerPassTests
 
         var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
         Assert.True(initializer.IsCollection);
-        Assert.Equal(3, initializer.Values.Count);
+        Assert.Equal(3, initializer.Entries.Count);
         // No Add call survives as a standalone statement.
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
     }
@@ -92,5 +92,43 @@ public class ObjectInitializerPassTests
         Assert.Contains("return new InitTarget { X = a, Y = b };", Print(nameof(CfgSampleClass.MakePoint)));
         Assert.Contains("return new InitTarget { X = a, Z = b };", Print(nameof(CfgSampleClass.MakePointWithField)));
         Assert.Contains("return new List<int> { a, b, 42 };", Print(nameof(CfgSampleClass.MakeList)));
+    }
+
+    [Fact]
+    public void IndexerInitializer_RaisesToObjectInitializerWithIndexerMembers()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeDictionaryByIndexer));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        // An indexer member is an object-form entry ([k] = v uses `=`), not a collection Add.
+        Assert.False(initializer.IsCollection);
+        // Each entry carries its key(s) plus the value, and no member name.
+        Assert.All(initializer.Entries, entry => Assert.Null(entry.Member));
+        Assert.All(initializer.Entries, entry => Assert.Equal(2, entry.Arguments.Count));
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+    }
+
+    [Fact]
+    public void DictionaryAddInitializer_RaisesToCollectionInitializerWithMultiArgElements()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeDictionaryByAdd));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.True(initializer.IsCollection);
+        // Each dictionary Add element keeps both arguments (key, value).
+        Assert.All(initializer.Entries, entry => Assert.Equal(2, entry.Arguments.Count));
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
+    }
+
+    [Fact]
+    public void PrintRaised_RendersDictionaryInitializers()
+    {
+        Assert.Contains(
+            "return new Dictionary<string, int> { [\"x\"] = a, [\"y\"] = b };",
+            Print(nameof(CfgSampleClass.MakeDictionaryByIndexer)));
+        Assert.Contains(
+            "return new Dictionary<string, int> { { \"x\", a }, { \"y\", b } };",
+            Print(nameof(CfgSampleClass.MakeDictionaryByAdd)));
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -7,9 +7,10 @@ public sealed partial class CSharpPrinter
 {
     /// <summary>
     /// Renders a raised object/collection initializer: <c>new T(args) { ... }</c>
-    /// where the body is <c>Member = value</c> entries (object form) or bare
-    /// element expressions (collection form). Constructor parens are omitted when
-    /// the creation takes no arguments, matching idiomatic C#.
+    /// where the body is <c>Member = value</c> / <c>[k] = value</c> entries (object
+    /// form) or bare element / <c>{ k, v }</c> entries (collection form).
+    /// Constructor parens are omitted when the creation takes no arguments,
+    /// matching idiomatic C#.
     /// </summary>
     string ObjectInitializerText(ObjectInitializerExpression initializer)
     {
@@ -17,10 +18,28 @@ public sealed partial class CSharpPrinter
         var arguments = creation.Arguments.Count == 0
             ? string.Empty
             : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
-        var body = initializer.IsCollection
-            ? string.Join(", ", initializer.Values.Select(Expression))
-            : string.Join(", ", initializer.Members.Zip(initializer.Values, (member, value) => $"{member} = {Expression(value)}"));
+        var body = string.Join(", ", initializer.Entries.Select(entry => InitializerEntryText(initializer.IsCollection, entry)));
         return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+    }
+
+    /// <summary>Renders one initializer entry per the parent's collection/object form (see <see cref="InitializerEntry"/>).</summary>
+    string InitializerEntryText(bool isCollection, InitializerEntry entry)
+    {
+        if (isCollection)
+        {
+            // A single-argument Add is a bare element; a multi-argument Add (a
+            // dictionary `{ k, v }`) keeps its brace-wrapped argument list.
+            return entry.Arguments.Count == 1
+                ? Expression(entry.Arguments[0])
+                : $"{{ {string.Join(", ", entry.Arguments.Select(Expression))} }}";
+        }
+
+        if (entry.Member is { } member)
+            return $"{member} = {Expression(entry.Arguments[^1])}";
+
+        // An indexer member: the trailing argument is the value, the rest are keys.
+        var keys = entry.Arguments.Take(entry.Arguments.Count - 1).Select(Expression);
+        return $"[{string.Join(", ", keys)}] = {Expression(entry.Arguments[^1])}";
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1262,36 +1262,72 @@ public sealed class DeconstructionAssignment : IrNode
 /// </summary>
 public sealed class ObjectInitializerExpression : IrExpression
 {
-    public ObjectInitializerExpression(NewObject creation, bool isCollection, IEnumerable<(string? Member, IrExpression Value)> entries)
+    public ObjectInitializerExpression(NewObject creation, bool isCollection, IEnumerable<InitializerEntry> entries)
     {
         IsCollection = isCollection;
         AddChild(creation);
         var members = ImmutableArray.CreateBuilder<string?>();
-        foreach (var (member, value) in entries)
+        var argumentCounts = ImmutableArray.CreateBuilder<int>();
+        foreach (var entry in entries)
         {
-            members.Add(member);
-            AddChild(value);
+            members.Add(entry.Member);
+            argumentCounts.Add(entry.Arguments.Count);
+            foreach (var argument in entry.Arguments)
+                AddChild(argument);
         }
         Members = members.ToImmutable();
+        ArgumentCounts = argumentCounts.ToImmutable();
     }
 
-    /// <summary>Collection-initializer (<c>{ e0, e1 }</c> via <c>Add</c>) vs object-initializer (<c>{ X = a }</c> via member stores).</summary>
+    /// <summary>Collection-initializer (<c>{ e0, e1 }</c> / <c>{ {k, v} }</c> via <c>Add</c>) vs object-initializer (<c>{ X = a }</c> / <c>{ [k] = v }</c> via member or indexer stores).</summary>
     public bool IsCollection { get; }
 
     /// <summary>The <c>new T(...)</c> creation the initializer decorates.</summary>
     public NewObject Creation => (NewObject)Children[0];
 
-    /// <summary>Target member name per entry value, parallel to <see cref="Values"/>; <c>null</c> for a collection element.</summary>
+    /// <summary>Target member name per entry; <c>null</c> for a collection element or an indexer member (<c>[k] = v</c>).</summary>
     public ImmutableArray<string?> Members { get; }
 
-    /// <summary>The entry values, in source order.</summary>
-    public IReadOnlyList<IrExpression> Values => Children.Skip(1).Cast<IrExpression>().ToList();
+    /// <summary>The number of child expressions each entry owns, parallel to <see cref="Members"/>.</summary>
+    public ImmutableArray<int> ArgumentCounts { get; }
+
+    /// <summary>The entries, in source order, each carrying its own argument expressions.</summary>
+    public IReadOnlyList<InitializerEntry> Entries
+    {
+        get
+        {
+            var entries = new List<InitializerEntry>(Members.Length);
+            int index = 1;  // skip the creation child
+            for (int e = 0; e < Members.Length; e++)
+            {
+                int count = ArgumentCounts[e];
+                var arguments = new IrExpression[count];
+                for (int j = 0; j < count; j++)
+                    arguments[j] = (IrExpression)Children[index + j];
+                index += count;
+                entries.Add(new InitializerEntry(Members[e], arguments));
+            }
+            return entries;
+        }
+    }
 
     public override TypeRef? ResultType => Creation.ResultType;
 
     public override string Describe()
         => $"ObjectInitializer {Creation.Constructor.DeclaringType.ToDisplayString()} ({Members.Length} {(IsCollection ? "elements" : "members")})";
 }
+
+/// <summary>
+/// One entry of a raised object/collection initializer. The interpretation of
+/// <see cref="Arguments"/> depends on the parent's <see cref="ObjectInitializerExpression.IsCollection"/>
+/// flag and <see cref="Member"/>:
+/// <list type="bullet">
+/// <item>object form, named member (<c>X = v</c>): <see cref="Member"/> set, one argument (the value);</item>
+/// <item>object form, indexer member (<c>[k0, k1] = v</c>): <see cref="Member"/> null, the trailing argument is the value and the rest are the index keys;</item>
+/// <item>collection form (<c>v</c> or <c>{ k, v }</c>): <see cref="Member"/> null, the arguments are the <c>Add</c> call's value arguments.</item>
+/// </list>
+/// </summary>
+public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression> Arguments);
 
 /// <summary>
 /// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -85,12 +85,12 @@ public sealed class LambdaRaisingPass : IIrPass
 
         var outer = RootFunction(creation);
         var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
-        var values = env.Values;
-        for (int i = 0; i < values.Count; i++)
+        foreach (var entry in env.Entries)
         {
-            if (env.Members[i] is not { } field || !IsCaptureValue(values[i], outer))
+            var value = entry.Arguments[^1];
+            if (entry.Member is not { } field || !IsCaptureValue(value, outer))
                 return null;
-            captures[field] = values[i];
+            captures[field] = value;
         }
 
         // Anchor to the folded environment's allocation (new <>c__DisplayClass)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -91,7 +91,7 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
-    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position); named-local, indexer-element, nested, and multi-arg Add (dictionary) initializers not raised")]
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements; named-local and nested initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -10,10 +10,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// initializer at the single use site and removes the now-dead chain.
 ///
 /// <para>Slice scope: the stack-slot dup form, which is what the compiler emits
-/// in expression position (a <c>return</c>/argument initializer). Named-local
-/// initializers, indexer-element initializers, nested initializers, and
-/// multi-argument <c>Add</c> (dictionary) initializers are left for a later
-/// slice — those shapes simply fail to match and stay lowered.</para>
+/// in expression position (a <c>return</c>/argument initializer). It covers named
+/// members (<c>X = a</c>), indexer members (<c>[k] = v</c>), single-element
+/// collection <c>Add</c>s, and multi-argument <c>Add</c>s (the dictionary
+/// <c>{ k, v }</c> form). Named-local initializers and nested initializers are
+/// left for a later slice — those shapes simply fail to match and stay lowered.</para>
 ///
 /// <para>Runs after <see cref="PropertySugarPass"/> so property setters are
 /// already <see cref="StoreProperty"/> nodes, uniform with field stores.</para>
@@ -42,7 +43,7 @@ public sealed class ObjectInitializerPass : IIrPass
         IReadOnlyList<IrNode> Consumed,
         NewObject Creation,
         bool IsCollection,
-        IReadOnlyList<(string? Member, IrExpression Value)> Entries,
+        IReadOnlyList<InitializerEntry> Entries,
         LoadStackSlot Use);
 
     static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation)
@@ -50,7 +51,7 @@ public sealed class ObjectInitializerPass : IIrPass
         var statements = seed.Parent!.Children;
         var aliasSlots = new HashSet<int> { seed.Slot };
         var consumed = new List<IrNode> { seed };
-        var entries = new List<(string? Member, IrExpression Value)>();
+        var entries = new List<InitializerEntry>();
         bool? isCollection = null;
 
         for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
@@ -65,7 +66,8 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
-            // An object-initializer member store on the threaded reference.
+            // An object-initializer member store on the threaded reference — a named
+            // member (X = v) or an indexer member ([k] = v).
             if (TryMemberStore(statement, aliasSlots) is { } member)
             {
                 if (isCollection == true)
@@ -76,7 +78,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
-            // A collection-initializer element: receiver.Add(value) on the reference.
+            // A collection-initializer element: receiver.Add(value, ...) on the reference.
             if (TryCollectionAdd(statement, aliasSlots) is { } element)
             {
                 if (isCollection == false)
@@ -94,9 +96,10 @@ public sealed class ObjectInitializerPass : IIrPass
             return null;  // a bare `new T()` with no initializer — nothing to raise
 
         // A self-referential entry (t.Next = t) cannot fold into a single expression.
-        foreach (var (_, value) in entries)
-            if (ReferencesAnySlot(value, aliasSlots))
-                return null;
+        foreach (var entry in entries)
+            foreach (var argument in entry.Arguments)
+                if (ReferencesAnySlot(argument, aliasSlots))
+                    return null;
 
         // The threaded reference must escape the run exactly once: that single
         // downstream load is where the initializer expression belongs.
@@ -110,26 +113,30 @@ public sealed class ObjectInitializerPass : IIrPass
         return new Plan(consumed, creation, isCollection ?? false, entries, outsideUses[0]);
     }
 
-    static (string? Member, IrExpression Value)? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    static InitializerEntry? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
     {
+        // An indexer member `[k0, k1] = v`: the keys precede the value.
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
-            => (property.PropertyName, property.Value),
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count != 0
+            => new InitializerEntry(null, [.. property.IndexArguments, property.Value]),
+        StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
+            when aliasSlots.Contains(slot.Slot)
+            => new InitializerEntry(property.PropertyName, [property.Value]),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
-            => (field.Field.Name, field.Value),
+            => new InitializerEntry(field.Field.Name, [field.Value]),
         _ => null,
     };
 
-    static (string? Member, IrExpression Value)? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
+    static InitializerEntry? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
     {
         if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
             return null;
-        if (call.Callee.Name != "Add" || call.Arguments.Count != 2)
-            return null;  // single-element Add only (receiver + one value); dictionary Add(k, v) is a later slice
+        if (call.Callee.Name != "Add" || call.Arguments.Count < 2)
+            return null;  // receiver + at least one value; multi-value Add is the dictionary form
         if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
             return null;
-        return (null, call.Arguments[1]);
+        return new InitializerEntry(null, [.. call.Arguments.Skip(1)]);
     }
 
     static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
@@ -147,16 +154,17 @@ public sealed class ObjectInitializerPass : IIrPass
     static void Apply(Plan plan)
     {
         // Drop the lowered run from the block, then lift the creation and entry
-        // values out of those now-detached statements into the initializer.
+        // arguments out of those now-detached statements into the initializer.
         foreach (var statement in plan.Consumed)
             statement.Detach();
 
         plan.Creation.Detach();
-        var entries = new List<(string?, IrExpression)>(plan.Entries.Count);
-        foreach (var (member, value) in plan.Entries)
+        var entries = new List<InitializerEntry>(plan.Entries.Count);
+        foreach (var entry in plan.Entries)
         {
-            value.Detach();
-            entries.Add((member, value));
+            foreach (var argument in entry.Arguments)
+                argument.Detach();
+            entries.Add(entry);
         }
 
         var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);


### PR DESCRIPTION
## What

Raises both deferred dictionary-initializer syntaxes back to source:

- **Indexer members** — `new T { [k] = v }`
- **Multi-argument (dictionary) `Add`** — `new T { {k, v} }`

```csharp
// before
Dictionary<string, int> d = new Dictionary<string, int>();
d["x"] = a;
Dictionary<string, int> t = d;
t["y"] = b;
return t;
// after
return new Dictionary<string, int> { ["x"] = a, ["y"] = b };
```

## Why this is sound

`ObjectInitializerPass` already folds csc's **dup-threaded temp** form (a fresh reference threaded through stack slots in expression position and consumed exactly once) for named members and single-element `Add`. Both dictionary forms ride that **same** fingerprint — they are just different statement kinds on the threaded slot — so this extends the existing discriminator rather than inventing a new one. A hand-written `var d = new(); d[k] = v;` uses a named local, not the threaded temp, so it stays lowered.

## Changes

- **Entry model.** `ObjectInitializerExpression`'s entry becomes `InitializerEntry(string? Member, IReadOnlyList<IrExpression> Arguments)` with a per-entry argument count, replacing the single-value tuple — so an entry can carry index keys plus a value, or a multi-argument `Add`.
- **Pass.** `TryMemberStore` accepts an indexer `StoreProperty` (`IndexArguments.Count != 0`), recording the keys ahead of the value (an object-form entry — it assigns with `=`). `TryCollectionAdd` accepts a receiver plus one *or more* value arguments.
- **Printer.** Renders `[keys] = value` for an indexer member and `{ a, b }` for a multi-argument `Add`; bare-element and `Member = value` forms are unchanged.
- **`LambdaRaisingPass`** (reads a display-class environment initializer) moves to the new `Entries` accessor.
- Ledger updated.

## Validation

- 522 decompiler tests, **0 failures**.
- New fixtures (`MakeDictionaryByIndexer`, `MakeDictionaryByAdd`) pinned **opcode-exact** by the fidelity gate (decompile → recompile → compare opcodes).
- Product build clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
