### PR TITLE
Use exact string equality identity for switch raising

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -215,6 +215,33 @@ public class MemberIdentityTests
     }
 
     [Fact]
+    public void IsStringEquality_RequiresExactBclStaticSignature()
+    {
+        Assert.True(MemberIdentity.IsStringEquality(StringEquality(s_string)));
+        Assert.False(MemberIdentity.IsStringEquality(StringEquality(TypeRef.Definition("UserAssembly", "System", "String"))));
+
+        Assert.False(MemberIdentity.IsStringEquality(new Call(
+            StringEqualityMethod(s_string) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringEquality(new Call(
+            StringEqualityMethod(s_string) with { ParameterTypes = [s_string, s_object] },
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringEquality(new Call(
+            StringEqualityMethod(s_string),
+            isVirtual: true,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringEquality(new Call(
+            StringEqualityMethod(s_string),
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string)])));
+    }
+
+    [Fact]
     public void IsValueTupleType_RequiresExactBclGenericDefinitionAndMatchingArity()
     {
         var tuple2 = ValueTupleType(TypeRef.CoreLib("System", "ValueTuple`2"), s_int, s_string);
@@ -347,6 +374,15 @@ public class MemberIdentityTests
 
     static Call Dispose(TypeRef declaringType)
         => new(DisposeMethod(declaringType), isVirtual: true, [new LoadLocal(0, declaringType)]);
+
+    static MethodRef StringEqualityMethod(TypeRef declaringType)
+        => new(declaringType, "op_Equality", TypeRef.CoreLib("System", "Boolean"), [s_string, s_string], HasThis: false);
+
+    static Call StringEquality(TypeRef declaringType)
+        => new(
+            StringEqualityMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)]);
 
     static TypeRef ValueTupleType(TypeRef definition, params TypeRef[] arguments)
         => TypeRef.GenericInstance(definition, [.. arguments]);

--- a/src/ILInspector.Decompiler.Tests/StringSwitchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringSwitchRaisingTests.cs
@@ -4,6 +4,9 @@ namespace ILInspector.Decompiler.Tests;
 
 public class StringSwitchRaisingTests
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+
     static IrFunction Raised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -91,4 +94,60 @@ public class StringSwitchRaisingTests
 
         Assert.Empty(function.Descendants.OfType<Switch>());
     }
+
+    [Fact]
+    public void UserStringEqualityLookalikeChain_IsNotRaised()
+    {
+        var function = BuildUserStringEqualityChain();
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Equal(2, function.Descendants.OfType<ConditionalBranch>().Count());
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildUserStringEqualityChain()
+    {
+        var userString = TypeRef.Definition("UserAssembly", "System", "String");
+        var eq = new MethodRef(userString, "op_Equality", s_bool, [userString, userString], HasThis: false);
+        var body = new BlockContainer();
+
+        var first = new Block(0);
+        first.Add(new ConditionalBranch(StringEq(eq, userString, "a"), targetOffset: 30));
+        body.Add(first);
+
+        var second = new Block(10);
+        second.Add(new ConditionalBranch(StringEq(eq, userString, "b"), targetOffset: 40));
+        body.Add(second);
+
+        var dispatchDefault = new Block(20);
+        dispatchDefault.Add(new Branch(50));
+        body.Add(dispatchDefault);
+
+        var caseA = new Block(30);
+        caseA.Add(new Return(new Constant(1, s_int)));
+        body.Add(caseA);
+
+        var caseB = new Block(40);
+        caseB.Add(new Return(new Constant(2, s_int)));
+        body.Add(caseB);
+
+        var defaultBlock = new Block(50);
+        defaultBlock.Add(new Return(new Constant(0, s_int)));
+        body.Add(defaultBlock);
+
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(s_int, [new Parameter("s", userString)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static Call StringEq(MethodRef eq, TypeRef stringType, string value)
+        => new(
+            eq,
+            isVirtual: false,
+            [new LoadArgument(0, "s", stringType), new Constant(value, stringType)]);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/SwitchRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/SwitchRecoveryFacts.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class SwitchRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.PatternSwitchStatement)),
+            typeof(SwitchRaisingPass),
+            [
+                new FactPrimitive("member.corelib-identity:String.op_Equality", "MemberIdentity.IsStringEquality"),
+                new FactPrimitive("place.variable", "PlaceIdentity.SameVariable"),
+            ],
+            PositiveCoverage: "StringSwitchRaisingTests small op_Equality-chain string switch fixtures",
+            AdversarialCoverage: "StringSwitchRaisingTests single equality and user String.op_Equality lookalikes",
+            MissingDiscriminator: "hash-bucket string switch form and pattern switches are still owed"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -7,6 +7,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class MemberIdentity
 {
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
@@ -116,6 +117,22 @@ public static class MemberIdentity
             }
             && returnType.Equals(s_void)
             && IsCoreLibraryOrFacadeType(call.Callee.DeclaringType, "System", "IDisposable", "System.Runtime");
+
+    public static bool IsStringEquality(Call call)
+        => !call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: false,
+                Name: "op_Equality",
+                TypeArguments.IsEmpty: true,
+                ParameterTypes: [var left, var right],
+                ReturnType: var returnType,
+            }
+            && returnType.Equals(s_bool)
+            && left.Equals(s_string)
+            && right.Equals(s_string)
+            && call.Arguments.Count == 2
+            && IsCoreLibraryType(call.Callee.DeclaringType, "System", "String");
 
     public static bool IsRuntimeHelpersCreateSpan(Call call)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -93,7 +93,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
     [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements; named-local and nested initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
-    [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
+    [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small exact BCL String.op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -982,8 +982,8 @@ public sealed class SwitchRaisingPass : IIrPass
     {
         value = null!;
         literal = null!;
-        if (condition is Call { Callee: { Name: "op_Equality", DeclaringType: { Namespace: "System", Name: "String" } }, Arguments: var args }
-            && args.Count == 2)
+        if (condition is Call { Arguments: var args } call
+            && MemberIdentity.IsStringEquality(call))
         {
             if (args[1] is Constant { Value: string right })
             {


### PR DESCRIPTION
## Summary
- add `MemberIdentity.IsStringEquality` for exact BCL `System.String.op_Equality`
- migrate `SwitchRaisingPass` string-switch detection to the shared predicate
- add direct identity tests and a synthetic user-defined `System.String.op_Equality` switch-chain negative
- add sidecar fact metadata for the string-switch lowering row
- update the ledger note to call out exact BCL `String.op_Equality` identity

## Validation
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity minimal
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.StringSwitchRaisingTests -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal