### PR TITLE
Raise nested object/collection initializers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1053,6 +1053,18 @@ public class CfgSampleClass
         public int Z;
     }
 
+    public sealed class InitContainer
+    {
+        public InitTarget Inner { get; set; } = new();
+        public System.Collections.Generic.List<int> Items { get; } = new();
+    }
+
+    public static InitContainer MakeNestedObject(int a, int b)
+        => new InitContainer { Inner = { X = a, Y = b } };
+
+    public static InitContainer MakeNestedCollection(int a, int b)
+        => new InitContainer { Items = { a, b } };
+
     public static InitTarget MakePoint(int a, int b) => new InitTarget { X = a, Y = b };
 
     public static InitTarget MakePointWithField(int a, int b) => new InitTarget { X = a, Z = b };

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -122,13 +122,46 @@ public class ObjectInitializerPassTests
     }
 
     [Fact]
-    public void PrintRaised_RendersDictionaryInitializers()
+    public void NestedObjectInitializer_RaisesMemberStoresIntoAnInitializerBlock()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeNestedObject));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        // The single top-level entry is the nested member; its value is the block.
+        var entry = Assert.Single(initializer.Entries);
+        Assert.Equal("Inner", entry.Member);
+        var block = Assert.IsType<InitializerBlock>(Assert.Single(entry.Arguments));
+        Assert.False(block.IsCollection);
+        Assert.Equal(new string?[] { "X", "Y" }, block.Members);
+        // The nested member reads are folded away — no residual stores/loads of Inner.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+    }
+
+    [Fact]
+    public void NestedCollectionInitializer_RaisesAddsIntoACollectionBlock()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeNestedCollection));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);  // top level assigns Items via `=`
+        var entry = Assert.Single(initializer.Entries);
+        Assert.Equal("Items", entry.Member);
+        var block = Assert.IsType<InitializerBlock>(Assert.Single(entry.Arguments));
+        Assert.True(block.IsCollection);
+        Assert.Equal(2, block.Entries.Count);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
+    }
+
+    [Fact]
+    public void PrintRaised_RendersNestedInitializers()
     {
         Assert.Contains(
-            "return new Dictionary<string, int> { [\"x\"] = a, [\"y\"] = b };",
-            Print(nameof(CfgSampleClass.MakeDictionaryByIndexer)));
+            "return new InitContainer { Inner = { X = a, Y = b } };",
+            Print(nameof(CfgSampleClass.MakeNestedObject)));
         Assert.Contains(
-            "return new Dictionary<string, int> { { \"x\", a }, { \"y\", b } };",
-            Print(nameof(CfgSampleClass.MakeDictionaryByAdd)));
+            "return new InitContainer { Items = { a, b } };",
+            Print(nameof(CfgSampleClass.MakeNestedCollection)));
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -18,9 +18,12 @@ public sealed partial class CSharpPrinter
         var arguments = creation.Arguments.Count == 0
             ? string.Empty
             : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
-        var body = string.Join(", ", initializer.Entries.Select(entry => InitializerEntryText(initializer.IsCollection, entry)));
-        return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {{ {body} }}";
+        return $"new {TypeText(creation.Constructor.DeclaringType)}{arguments} {InitializerBodyText(initializer.IsCollection, initializer.Entries)}";
     }
+
+    /// <summary>Renders the brace body shared by a top-level initializer and a nested <see cref="InitializerBlock"/>.</summary>
+    string InitializerBodyText(bool isCollection, IReadOnlyList<InitializerEntry> entries)
+        => $"{{ {string.Join(", ", entries.Select(entry => InitializerEntryText(isCollection, entry)))} }}";
 
     /// <summary>Renders one initializer entry per the parent's collection/object form (see <see cref="InitializerEntry"/>).</summary>
     string InitializerEntryText(bool isCollection, InitializerEntry entry)
@@ -34,12 +37,19 @@ public sealed partial class CSharpPrinter
                 : $"{{ {string.Join(", ", entry.Arguments.Select(Expression))} }}";
         }
 
+        // A nested member (Inner = { ... }) carries an InitializerBlock value, which
+        // prints as its own brace body rather than a `new`-rooted expression.
+        var value = entry.Arguments[^1];
+        string valueText = value is InitializerBlock block
+            ? InitializerBodyText(block.IsCollection, block.Entries)
+            : Expression(value);
+
         if (entry.Member is { } member)
-            return $"{member} = {Expression(entry.Arguments[^1])}";
+            return $"{member} = {valueText}";
 
         // An indexer member: the trailing argument is the value, the rest are keys.
         var keys = entry.Arguments.Take(entry.Arguments.Count - 1).Select(Expression);
-        return $"[{string.Join(", ", keys)}] = {Expression(entry.Arguments[^1])}";
+        return $"[{string.Join(", ", keys)}] = {valueText}";
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -975,6 +975,7 @@ public sealed partial class CSharpPrinter
         TupleExpression t => $"({Arguments(t.Elements)})",
         AnonymousObject a => AnonymousObjectText(a),
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
+        InitializerBlock ib => InitializerBodyText(ib.IsCollection, ib.Entries),
         ArrayLength l => $"{Operand(l.Array)}.Length",
         SliceExpression sl => $"{Operand(sl.Receiver)}[{Expression(sl.Range)}]",
         RangeExpression r => $"{(r.HasStart ? Expression(r.Start!) : "")}..{(r.HasEnd ? Expression(r.End!) : "")}",
@@ -1084,7 +1085,7 @@ public sealed partial class CSharpPrinter
         // misbinds to its first operand (e.g. `!a != b`, CS0023).
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or SliceExpression or RangeExpression or CaughtException or SizeOf or LoadToken
-            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or AnonymousObject or ObjectInitializerExpression or IndexFromEnd or CallIndirect or AddressOfMethod or NullConditional
+            or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or AnonymousObject or ObjectInitializerExpression or InitializerBlock or IndexFromEnd or CallIndirect or AddressOfMethod or NullConditional
             or IncrementDecrement or SpanLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1314,29 +1314,59 @@ public sealed class ObjectInitializerExpression : IrExpression
     public ImmutableArray<int> ArgumentCounts { get; }
 
     /// <summary>The entries, in source order, each carrying its own argument expressions.</summary>
-    public IReadOnlyList<InitializerEntry> Entries
-    {
-        get
-        {
-            var entries = new List<InitializerEntry>(Members.Length);
-            int index = 1;  // skip the creation child
-            for (int e = 0; e < Members.Length; e++)
-            {
-                int count = ArgumentCounts[e];
-                var arguments = new IrExpression[count];
-                for (int j = 0; j < count; j++)
-                    arguments[j] = (IrExpression)Children[index + j];
-                index += count;
-                entries.Add(new InitializerEntry(Members[e], arguments));
-            }
-            return entries;
-        }
-    }
+    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 1, Members, ArgumentCounts);
 
     public override TypeRef? ResultType => Creation.ResultType;
 
     public override string Describe()
         => $"ObjectInitializer {Creation.Constructor.DeclaringType.ToDisplayString()} ({Members.Length} {(IsCollection ? "elements" : "members")})";
+}
+
+/// <summary>
+/// A nested initializer body — the brace group on the right of a nested member
+/// entry (<c>Inner = { X = a }</c> / <c>Items = { e0, e1 }</c>), produced by
+/// <see cref="ObjectInitializerPass"/> from member/<c>Add</c> stores rooted at a
+/// member read off the threaded reference rather than the reference itself. It is
+/// an <see cref="ObjectInitializerExpression"/> without the <c>new T(...)</c>
+/// creation: the member is initialized in place, not reconstructed. It only
+/// appears as the value of a parent <see cref="InitializerEntry"/>, so the IR tree
+/// carries arbitrary nesting depth without any special-casing here.
+/// </summary>
+public sealed class InitializerBlock : IrExpression
+{
+    public InitializerBlock(bool isCollection, IEnumerable<InitializerEntry> entries)
+    {
+        IsCollection = isCollection;
+        var members = ImmutableArray.CreateBuilder<string?>();
+        var argumentCounts = ImmutableArray.CreateBuilder<int>();
+        foreach (var entry in entries)
+        {
+            members.Add(entry.Member);
+            argumentCounts.Add(entry.Arguments.Count);
+            foreach (var argument in entry.Arguments)
+                AddChild(argument);
+        }
+        Members = members.ToImmutable();
+        ArgumentCounts = argumentCounts.ToImmutable();
+    }
+
+    /// <summary>Collection body (<c>{ e0, e1 }</c> via <c>Add</c>) vs object body (<c>{ X = a }</c> via member stores).</summary>
+    public bool IsCollection { get; }
+
+    /// <summary>Target member name per entry; <c>null</c> for a collection element or an indexer member.</summary>
+    public ImmutableArray<string?> Members { get; }
+
+    /// <summary>The number of child expressions each entry owns, parallel to <see cref="Members"/>.</summary>
+    public ImmutableArray<int> ArgumentCounts { get; }
+
+    /// <summary>The entries, in source order, each carrying its own argument expressions.</summary>
+    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 0, Members, ArgumentCounts);
+
+    /// <summary>A nested body initializes an existing member in place; it has no standalone result type.</summary>
+    public override TypeRef? ResultType => null;
+
+    public override string Describe()
+        => $"InitializerBlock ({Members.Length} {(IsCollection ? "elements" : "members")})";
 }
 
 /// <summary>
@@ -1348,8 +1378,35 @@ public sealed class ObjectInitializerExpression : IrExpression
 /// <item>object form, indexer member (<c>[k0, k1] = v</c>): <see cref="Member"/> null, the trailing argument is the value and the rest are the index keys;</item>
 /// <item>collection form (<c>v</c> or <c>{ k, v }</c>): <see cref="Member"/> null, the arguments are the <c>Add</c> call's value arguments.</item>
 /// </list>
+/// A nested member entry (<c>Inner = { ... }</c>) is a named member whose single
+/// argument is an <see cref="InitializerBlock"/>.
 /// </summary>
-public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression> Arguments);
+public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression> Arguments)
+{
+    /// <summary>
+    /// Reconstructs the entries from a node's flat children: the run starting at
+    /// <paramref name="start"/> is partitioned by <paramref name="argumentCounts"/>,
+    /// each slice paired with its <paramref name="members"/> name. Shared by
+    /// <see cref="ObjectInitializerExpression"/> (start 1, after the creation) and
+    /// <see cref="InitializerBlock"/> (start 0).
+    /// </summary>
+    internal static IReadOnlyList<InitializerEntry> Slice(
+        IReadOnlyList<IrNode> children, int start, ImmutableArray<string?> members, ImmutableArray<int> argumentCounts)
+    {
+        var entries = new List<InitializerEntry>(members.Length);
+        int index = start;
+        for (int e = 0; e < members.Length; e++)
+        {
+            int count = argumentCounts[e];
+            var arguments = new IrExpression[count];
+            for (int j = 0; j < count; j++)
+                arguments[j] = (IrExpression)children[index + j];
+            index += count;
+            entries.Add(new InitializerEntry(members[e], arguments));
+        }
+        return entries;
+    }
+}
 
 /// <summary>
 /// <c>ldftn</c>/<c>ldvirtftn</c>: a method's entry-point address as a native

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -91,7 +91,7 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
-    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements; named-local and nested initializers not raised")]
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements, and nested initializers (Inner = { X = a } / Items = { e0, e1 }); named-local initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -13,8 +13,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// in expression position (a <c>return</c>/argument initializer). It covers named
 /// members (<c>X = a</c>), indexer members (<c>[k] = v</c>), single-element
 /// collection <c>Add</c>s, and multi-argument <c>Add</c>s (the dictionary
-/// <c>{ k, v }</c> form). Named-local initializers and nested initializers are
-/// left for a later slice — those shapes simply fail to match and stay lowered.</para>
+/// <c>{ k, v }</c> form). It also covers <em>nested</em> initializers
+/// (<c>Inner = { X = a }</c> / <c>Items = { e0, e1 }</c>): stores/Adds rooted at a
+/// member <em>read</em> off the threaded reference rather than the reference
+/// itself, contiguous runs on the same member folded into one
+/// <see cref="InitializerBlock"/>. Named-local initializers are left for a later
+/// slice — those shapes simply fail to match and stay lowered.</para>
 ///
 /// <para>Runs after <see cref="PropertySugarPass"/> so property setters are
 /// already <see cref="StoreProperty"/> nodes, uniform with field stores.</para>
@@ -43,26 +47,78 @@ public sealed class ObjectInitializerPass : IIrPass
         IReadOnlyList<IrNode> Consumed,
         NewObject Creation,
         bool IsCollection,
-        IReadOnlyList<InitializerEntry> Entries,
+        IReadOnlyList<EntryPlan> Entries,
         LoadStackSlot Use);
+
+    /// <summary>
+    /// A planned initializer entry. A flat entry carries its leaf <see cref="Arguments"/>
+    /// directly (<see cref="Block"/> null); a nested entry (<c>Member = { ... }</c>)
+    /// carries a <see cref="BlockPlan"/> and no direct arguments. Block construction
+    /// is deferred to <see cref="Apply"/> so its leaf arguments are detached from
+    /// their lowered statements before being reparented into the new IR.
+    /// </summary>
+    sealed record EntryPlan(string? Member, IReadOnlyList<IrExpression> Arguments, BlockPlan? Block);
+
+    /// <summary>A nested initializer body: an object/collection brace group with no creation.</summary>
+    sealed record BlockPlan(bool IsCollection, IReadOnlyList<EntryPlan> Entries);
 
     static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation)
     {
         var statements = seed.Parent!.Children;
         var aliasSlots = new HashSet<int> { seed.Slot };
         var consumed = new List<IrNode> { seed };
-        var entries = new List<InitializerEntry>();
+        var entries = new List<EntryPlan>();
         bool? isCollection = null;
+
+        // A run of nested ops on the same member folds into one InitializerBlock
+        // entry; this holds the run currently being accumulated.
+        string? pendingMember = null;
+        bool pendingBlockIsCollection = false;
+        List<EntryPlan>? pendingInner = null;
+
+        void FlushPending()
+        {
+            if (pendingInner is null)
+                return;
+            entries.Add(new EntryPlan(pendingMember, [], new BlockPlan(pendingBlockIsCollection, pendingInner)));
+            pendingMember = null;
+            pendingInner = null;
+        }
 
         for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
         {
             var statement = statements[i];
 
-            // A dup of the threaded reference: sNew = LoadStackSlot(sKnown).
+            // A dup of the threaded reference: sNew = LoadStackSlot(sKnown). These
+            // interleave nested ops, so they do not break a pending nested run.
             if (statement is StoreStackSlot { Value: LoadStackSlot source } copy && aliasSlots.Contains(source.Slot))
             {
                 aliasSlots.Add(copy.Slot);
                 consumed.Add(copy);
+                continue;
+            }
+
+            // A nested initializer op: a store/Add rooted at a member read off the
+            // threaded reference (Inner = { ... } / Items = { ... }). Top level is
+            // object form (the member is assigned via `=`), never collection.
+            if (TryNestedOp(statement, aliasSlots) is { } nested)
+            {
+                if (isCollection == true)
+                    break;
+                isCollection = false;
+
+                bool sameRun = pendingInner is not null
+                    && pendingMember == nested.OuterMember
+                    && pendingBlockIsCollection == nested.IsCollection;
+                if (!sameRun)
+                {
+                    FlushPending();
+                    pendingMember = nested.OuterMember;
+                    pendingBlockIsCollection = nested.IsCollection;
+                    pendingInner = [];
+                }
+                pendingInner!.Add(nested.Inner);
+                consumed.Add(statement);
                 continue;
             }
 
@@ -72,6 +128,7 @@ public sealed class ObjectInitializerPass : IIrPass
             {
                 if (isCollection == true)
                     break;  // C# initializers are member-only or element-only, never mixed
+                FlushPending();
                 isCollection = false;
                 entries.Add(member);
                 consumed.Add(statement);
@@ -83,6 +140,7 @@ public sealed class ObjectInitializerPass : IIrPass
             {
                 if (isCollection == false)
                     break;
+                FlushPending();
                 isCollection = true;
                 entries.Add(element);
                 consumed.Add(statement);
@@ -92,14 +150,15 @@ public sealed class ObjectInitializerPass : IIrPass
             break;
         }
 
+        FlushPending();
+
         if (entries.Count == 0)
             return null;  // a bare `new T()` with no initializer — nothing to raise
 
         // A self-referential entry (t.Next = t) cannot fold into a single expression.
-        foreach (var entry in entries)
-            foreach (var argument in entry.Arguments)
-                if (ReferencesAnySlot(argument, aliasSlots))
-                    return null;
+        foreach (var leaf in LeafArguments(entries))
+            if (ReferencesAnySlot(leaf, aliasSlots))
+                return null;
 
         // The threaded reference must escape the run exactly once: that single
         // downstream load is where the initializer expression belongs.
@@ -113,22 +172,69 @@ public sealed class ObjectInitializerPass : IIrPass
         return new Plan(consumed, creation, isCollection ?? false, entries, outsideUses[0]);
     }
 
-    static InitializerEntry? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    sealed record NestedOp(string OuterMember, bool IsCollection, EntryPlan Inner);
+
+    /// <summary>
+    /// Matches a store/Add whose target reads a member off the threaded reference
+    /// (the nested-initializer shape), returning the outer member name and the
+    /// inner entry to accumulate. A plain property/field read distinguishes a
+    /// nested op from a flat one (which targets the reference directly).
+    /// </summary>
+    static NestedOp? TryNestedOp(IrNode statement, HashSet<int> aliasSlots)
+    {
+        switch (statement)
+        {
+            // Nested object member store: outer.Member.X = v / outer.Member[k] = v.
+            case StoreProperty { HasInstance: true } property
+                when OuterMemberOffSlot(property.Instance, aliasSlots) is { } outer:
+                var objectInner = property.IndexArguments.Count != 0
+                    ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null)
+                    : new EntryPlan(property.PropertyName, [property.Value], null);
+                return new NestedOp(outer, IsCollection: false, objectInner);
+
+            case StoreField { HasInstance: true } field
+                when OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
+                return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
+
+            // Nested collection element: outer.Member.Add(v, ...).
+            case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
+                when call.Callee.Name == "Add" && call.Arguments.Count >= 2
+                    && OuterMemberOffSlot(call.Arguments[0], aliasSlots) is { } outer:
+                return new NestedOp(outer, IsCollection: true, new EntryPlan(null, [.. call.Arguments.Skip(1)], null));
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>The member name when <paramref name="instance"/> reads a plain property/field off a threaded slot; otherwise null.</summary>
+    static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
+    {
+        LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
+            => property.PropertyName,
+        LoadField { Instance: LoadStackSlot slot } field
+            when aliasSlots.Contains(slot.Slot)
+            => field.Field.Name,
+        _ => null,
+    };
+
+    static EntryPlan? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
     {
         // An indexer member `[k0, k1] = v`: the keys precede the value.
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count != 0
-            => new InitializerEntry(null, [.. property.IndexArguments, property.Value]),
+            => new EntryPlan(null, [.. property.IndexArguments, property.Value], null),
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot)
-            => new InitializerEntry(property.PropertyName, [property.Value]),
+            => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
-            => new InitializerEntry(field.Field.Name, [field.Value]),
+            => new EntryPlan(field.Field.Name, [field.Value], null),
         _ => null,
     };
 
-    static InitializerEntry? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
+    static EntryPlan? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
     {
         if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
             return null;
@@ -136,7 +242,25 @@ public sealed class ObjectInitializerPass : IIrPass
             return null;  // receiver + at least one value; multi-value Add is the dictionary form
         if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
             return null;
-        return new InitializerEntry(null, [.. call.Arguments.Skip(1)]);
+        return new EntryPlan(null, [.. call.Arguments.Skip(1)], null);
+    }
+
+    /// <summary>Every leaf argument expression across the entry tree, flattening nested blocks.</summary>
+    static IEnumerable<IrExpression> LeafArguments(IEnumerable<EntryPlan> entries)
+    {
+        foreach (var entry in entries)
+        {
+            if (entry.Block is { } block)
+            {
+                foreach (var leaf in LeafArguments(block.Entries))
+                    yield return leaf;
+            }
+            else
+            {
+                foreach (var argument in entry.Arguments)
+                    yield return argument;
+            }
+        }
     }
 
     static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
@@ -153,22 +277,27 @@ public sealed class ObjectInitializerPass : IIrPass
 
     static void Apply(Plan plan)
     {
-        // Drop the lowered run from the block, then lift the creation and entry
-        // arguments out of those now-detached statements into the initializer.
+        // Drop the lowered run from the block, then lift the creation and leaf
+        // arguments out of those now-detached statements before reparenting them
+        // into the new initializer tree.
         foreach (var statement in plan.Consumed)
             statement.Detach();
 
         plan.Creation.Detach();
-        var entries = new List<InitializerEntry>(plan.Entries.Count);
-        foreach (var entry in plan.Entries)
-        {
-            foreach (var argument in entry.Arguments)
-                argument.Detach();
-            entries.Add(entry);
-        }
+        foreach (var leaf in LeafArguments(plan.Entries))
+            leaf.Detach();
 
+        var entries = plan.Entries.Select(BuildEntry).ToList();
         var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);
         initializer.InheritSourceOffset(plan.Creation);
         plan.Use.ReplaceWith(initializer);
     }
+
+    static InitializerEntry BuildEntry(EntryPlan entry)
+        => entry.Block is { } block
+            ? new InitializerEntry(entry.Member, [BuildBlock(block)])
+            : new InitializerEntry(entry.Member, entry.Arguments);
+
+    static InitializerBlock BuildBlock(BlockPlan block)
+        => new(block.IsCollection, block.Entries.Select(BuildEntry).ToList());
 }


### PR DESCRIPTION
## What

Extend `ObjectInitializerPass` to recover **nested object/collection initializers**, completing the initializer family begun in #787:

```csharp
new InitContainer { Inner = { X = a, Y = b } }   // nested object
new InitContainer { Items = { a, b } }           // nested collection
```

## How

The compiler lowers a nested initializer as member stores / `Add` calls rooted at a member **read** off the dup-threaded reference (`LoadProperty/LoadField(slot)`), rather than at the reference itself. That read-vs-target distinction is the discriminator: a nested member is initialized *in place* (never reconstructed), and hand-written code uses named locals, not the expression-position dup temp — so the shape is unambiguous.

- **`InitializerBlock`** — a new IR node: a creation-less initializer body (the brace group on the right of `Member = { ... }`). A nested entry is just an ordinary `InitializerEntry` whose value is an `InitializerBlock`, so the tree nests naturally with no new entry fields. A shared `InitializerEntry.Slice` helper backs both `ObjectInitializerExpression` and `InitializerBlock`.
- **Pass** — contiguous runs of nested ops on the same member fold into one block; the top level stays object-form (`Member =`). Block construction is deferred to `Apply` so leaf arguments are detached before reparenting. Self-reference and single-escape guards flatten nested leaves. Any ungroupable shape bails (returns null) and stays lowered.
- **Printer** — renders `Member = { block-body }` (the `=` form, no `new`) for both nested object and nested collection members.

## Validation

- New unit tests assert raised IR shape + printed text for `MakeNestedObject` / `MakeNestedCollection`.
- The **fidelity gate** decompiles + recompiles both fixtures and proves opcode-exact round-trip.
- 539 decompiler tests green; product builds clean. Ledger line updated.
