### PR TITLE
Document decompiler target priorities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,18 @@ Read this file first, then use the docs it points to:
 
 Keep this file as a resolver plus essential repo workflow rules. Put detailed architecture and taste guidance in docs instead of expanding `AGENTS.md`.
 
+## Current priorities
+
+For decompiler raise, scorecard, ledger, adversarial fixture, or predicate work,
+read `docs/decompiler-quality.md` first, then
+`docs/design/decompiler-substrate.md`.
+
+The current decompiler priority is high-value hardening: a near-full scorecard
+means more effort should go to adversarial passes over recent or broad raises and
+to sharpening `Partial` ledger rows, not to easy scorecard row inflation. Use
+**decompiler substrate** for shared pass-evidence layers and
+**identity predicates** for exact rewrite gates; avoid **fact substrate**.
+
 ## File-Based Apps
 
 Do NOT use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files. Always use file-based apps (new in .NET 10). Always prefer file-based apps over Python, unless a specific Python library is needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,13 @@ For decompiler raise, scorecard, ledger, adversarial fixture, or predicate work,
 read `docs/decompiler-quality.md` first, then
 `docs/design/decompiler-substrate.md`.
 
-The current decompiler priority is high-value hardening: a near-full scorecard
-means more effort should go to adversarial passes over recent or broad raises and
-to sharpening `Partial` ledger rows, not to easy scorecard row inflation. Use
-**decompiler substrate** for shared pass-evidence layers and
-**identity predicates** for exact rewrite gates; avoid **fact substrate**.
+The current decompiler priority is high-value hardening:
+
+- Treat a near-full scorecard as a signal to do more adversarial passes over
+  recent or broad raises.
+- Sharpen `Partial` ledger rows instead of adding easy scorecard rows.
+- Use **decompiler substrate** for shared pass-evidence layers and
+  **identity predicates** for exact rewrite gates; avoid **fact substrate**.
 
 ## File-Based Apps
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -90,37 +90,85 @@ that differs only in an important compiler discriminator such as a receiver spil
 Pin those in pass-level tests or the fidelity gate; the scorecard keeps the
 positive ratchet.
 
-Pick targets for value, not just availability. A high-value raise or substrate
-change has at least one of these signals:
+As the scorecard saturates, adversarial research becomes more valuable, not
+less. A high recovered ratio means the curated positives are mostly climbing; it
+does **not** mean the raises are sound around their edges. Do not add easy
+scorecard rows just to keep the number moving. Once the obvious positive climbs
+are recovered, shift more target selection toward adversarial passes over recent
+or broad raises and toward hardening `Partial` ledger rows.
 
-- It moves a scorecard or ledger row that users recognize in source (`await`,
-  `foreach`, tuple/deconstruction, interpolation, using/lock, switch/range).
+### Choosing high-value targets
+
+Pick targets for value, not just availability. Use this vocabulary in planning
+and PRs so the work stays tied to visible progress:
+
+| Target kind | What it means | Good signal |
+| --- | --- | --- |
+| **Scorecard climb** | Raise a visible source idiom to a higher C# altitude, or shrink an owed ledger row. | A scorecard/ledger row changes, a floor improves, or the output diff is source users recognize. |
+| **Bug hunt** | Fix demonstrated wrong, invalid, or fidelity-breaking output. | A negative fixture or corpus method fails before the change and passes after. |
+| **Adversarial pass** | Try to falsify a recent or fragile raise with near-miss negative fixtures. | A positive/negative pair differs by one compiler discriminator. |
+| **Predicate hardening** | Move exact rewrite-gate evidence into `MemberIdentity`, `GeneratedCodeIdentity`, or `PlaceIdentity`. | A concrete pass customer exists, a duplicated check is drifting, or fuzzy matching already caused a bug. |
+
+Terminology matters. Use **decompiler substrate** for the broad family of shared
+pass-evidence layers. Use **identity predicates** for the exact rewrite gates the
+passes call (`MemberIdentity`, `GeneratedCodeIdentity`, `PlaceIdentity`). Avoid
+**fact substrate** in quality docs: "facts" already names hidden-fact
+annotations and sidecar ledger metadata, while these predicates are private
+rewrite gates.
+
+A high-value target has at least one of these signals:
+
+- It is a scorecard climb users recognize in source (`await`, `foreach`,
+  tuple/deconstruction, interpolation, using/lock, switch/range).
 - It fixes a demonstrated false-positive or fidelity/validity failure, ideally
   with a negative fixture that fails before the change.
-- It removes duplicated pass-local evidence checks that gate rewrites
-  (`MemberIdentity`, `GeneratedCodeIdentity`, `PlaceIdentity`), especially after
+- It strengthens an adversarial pass for an active or recently changed raise.
+- It consolidates identity predicates with a concrete consumer, especially after
   an adversarial review found the same category of bug.
-- It unlocks several future raises by adding shared metadata facts, without
-  pulling Roslyn, assembly loading, or broad runtime type-system machinery into
-  the product path.
 - It improves a CI gate or measured corpus floor, not just formatting of an
   already-correct shape.
 
-Prefer work in this order: correctness bug > validity failure > scorecard/ledger
-idiom > shared substrate with concrete consumers > adversarial coverage for an
-active raise > cosmetic readability. Avoid speculative helpers, one-off cleanup,
-or broad rewrites that do not move a measured signal. When choosing among
-similar targets, pick the one with the clearest discriminator and the smallest
-adversarial fixture pair.
+Prefer work in this order: correctness bug > validity failure > scorecard climb
+> predicate hardening with a concrete consumer > adversarial pass for an active
+raise > cosmetic readability. After a burst of obvious predicate wins, bias back
+toward scorecard climbs and adversarial passes. Avoid speculative helpers,
+one-off cleanup, or broad rewrites that do not move a measured signal. When
+choosing among similar targets, pick the one with the clearest discriminator and
+the smallest adversarial fixture pair.
+
+Read progress as **leverage**, not elapsed time. The ledger gives breadth: `None`
+rows are owed mechanisms, `Partial` rows are the live frontier, and `Full` rows
+are solved enough for the current lowering category. The scorecard gives
+altitude on curated fixtures: a climb means a recognizable source idiom is back,
+not that soundness has been proven for every nearby lowering. A strong progress
+review asks whether a row moved from `None` to `Partial`/`Full`, a `Partial` note
+got narrower, a scorecard fixture climbed, an adversarial pass added a useful
+near-miss, predicate hardening removed a fuzzy rewrite gate, or a corpus floor
+improved without losing fidelity.
+
+Use the ledger and scorecard together, but do not optimize either one in
+isolation. The ledger selects terrain; the scorecard pins a visible altitude
+target; adversarial passes, fidelity/validity checks, and corpus floors prove
+the climb did not over-match. Do not add easy scorecard cases just to inflate the
+ratio, and do not mark a ledger row `Full` until fixtures and adversarial shapes
+cover the meaningful variants of that lowering. A `Partial` row with a sharper
+note, stronger fixtures, and safer predicates is real progress even if the raw
+bucket count does not change.
+
+Treat a near-full scorecard as a mode switch. The default question changes from
+"can we recover this idiom at all?" to "where could this recovered idiom
+over-match?" Good follow-up targets are recent broad raises, pass families with
+many `Partial` notes, and places where a single missing discriminator could turn
+source-like output into different IL.
 
 The intended pass-improvement loop is:
 
-1. Pick one of the three raise tasks:
-   **new raise** (an owed ledger entry with no mechanism),
-   **improve a raise** (a pass with known unrecovered fixtures or partial
-   coverage), or **adversarial discovery** (try to falsify an existing raise).
-   Apply the high-value filter above before starting; do not spend a PR on a
-   target that lacks a measurable signal or a concrete consumer.
+1. Pick one high-value target type: a **scorecard climb** (new or improved raise
+   for an owed/recoverable idiom), a **bug hunt** (demonstrated wrong output), an
+   **adversarial pass** (try to falsify an existing raise), or an
+   **predicate hardening** task (shared exact evidence with a concrete pass
+   customer). Apply the high-value filter above before starting; do not spend a
+   PR on a target that lacks a measurable signal or a concrete consumer.
 2. Create a dedicated feature worktree for the raise task. Raise work touches
    common hotspots, so do not work directly in the main checkout or share one
    worktree across unrelated raise/adversarial/doc tasks.
@@ -141,14 +189,14 @@ The intended pass-improvement loop is:
    branch state, not just the pre-merge local state, stayed
    semantic, valid C#.
 
-After a raise looks good, use an adversarial fixture pass before merge. Give an
-agent the pass, its intended discriminator, the positive fixtures, and the
-soundness checklist below; ask it to add or update fixtures that try to falsify
-the match without changing the pass first. The useful output is concrete: a
-source-shaped negative fixture, the exact discriminator it toggles, and the test
-that proves the pass does not raise it. When the pass is too broad, add the
-negative fixture first so it fails for the current implementation, then narrow
-the matcher.
+After a raise looks good, run an **adversarial pass** before merge. This is a
+review pass, not an IR pipeline pass: give an agent the raise pass, its intended
+discriminator, the positive fixtures, and the soundness checklist below; ask it
+to add or update fixtures that try to falsify the match without changing the
+implementation first. The useful output is concrete: a source-shaped negative
+fixture, the exact discriminator it toggles, and the test that proves the pass
+does not raise it. When the pass is too broad, add the negative fixture first so
+it fails for the current implementation, then narrow the matcher.
 
 Good adversarial fixtures are usually positive/negative pairs that differ by
 one compiler discriminator. Examples: the real `^1` lowering spills the receiver

--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -1,8 +1,12 @@
 # Decompiler Substrate Layers
 
-How shared *facts* are factored out from the raising passes, and how we notice
-when several passes have independently grown the same need. This is a design
-note about a recurring shape, not a tour of every helper. See
+How shared rewrite-gate predicates are factored out from the raising passes, and
+how we notice when several passes have independently grown the same need. This
+is a design note about a recurring shape, not a tour of every helper. Use
+**decompiler substrate** for the broad shared layer and **identity predicates**
+for the exact gates that decide whether a rewrite may fire; avoid **fact
+substrate**, because "facts" already names hidden-fact annotations and sidecar
+ledger metadata. See
 [decompiler.md](../decompiler.md) for the IR pipeline the passes run over,
 [decompiler-quality.md](../decompiler-quality.md) for the correctness oracle the
 passes are held to, and [hidden-fact-annotations.md](hidden-fact-annotations.md)
@@ -13,20 +17,20 @@ for the read-only fact layer modelled on the same instinct.
 A raising pass turns an IL idiom back into its C# spelling. To do that safely it
 must keep asking the same small questions: *is this the BCL member I think it
 is?* *is this type compiler-generated?* *are these two expressions the same
-re-evaluable place?* Each question is a **fact** about the IR — structural,
-side-effect-free, answerable without rewriting anything.
+re-evaluable place?* Each question is a predicate over IR evidence —
+structural, side-effect-free, answerable without rewriting anything.
 
-When a fact is answered inline inside one pass, the next pass that needs it
+When a predicate is answered inline inside one pass, the next pass that needs it
 copies the code. The copies drift: one matches a member on namespace and name,
 another on assembly identity and exact signature; one admits a local read where
-another must not. Drift in a fact check is a soundness bug waiting to happen,
+another must not. Drift in a rewrite gate is a soundness bug waiting to happen,
 because the whole point of the check is to gate a rewrite.
 
 The fix is a **substrate layer**: a thin `public static class` in
-`Pipeline/` that owns one fact category, exposed as small composable atoms the
-passes call. Three exist today:
+`Pipeline/` that owns one predicate category, exposed as small composable atoms
+the passes call. Three exist today:
 
-| Layer | Fact category | Example question |
+| Layer | Predicate category | Example question |
 | --- | --- | --- |
 | `MemberIdentity` | Exact BCL member / type identity | Is this `RuntimeHelpers.GetSubArray`? |
 | `GeneratedCodeIdentity` | Compiler-generated shape (attribute-gated) | Is this a non-capturing lambda holder? |
@@ -91,11 +95,11 @@ reactive:
 `LocalRewriter` lowering, recording the mechanism (which pass) and completeness.
 It already makes the *dedicated-vs-shared* gradient derivable — a pass type used
 by one row is dedicated, by several is shared. The substrate extension is for
-sidecar fact providers to name the **fact primitives** their rows depend on,
-keyed by the stable ledger row name. When three or more rows cite the same
+sidecar fact providers to name the **predicate primitives** their rows depend
+on, keyed by the stable ledger row name. When three or more rows cite the same
 primitive, that is the signal to promote it to a substrate layer before the
 fourth copy is written — the ledger turns "we keep needing this" from tribal
-memory into a queryable fact.
+memory into queryable metadata.
 
 The fact metadata deliberately stays out of the central ledger rows. This keeps
 the conflict-reduction shape from PRs such as the stable ledger and printer


### PR DESCRIPTION
## Summary
- add a Current priorities router to AGENTS.md for decompiler raise/scorecard/ledger/adversarial/predicate work
- clarify that a near-full scorecard shifts effort toward adversarial passes and Partial ledger hardening
- settle terminology: decompiler substrate for shared pass-evidence layers, identity predicates for exact rewrite gates

## Validation
- npx markdownlint-cli AGENTS.md docs/decompiler-quality.md docs/design/decompiler-substrate.md