### PR TITLE
Add initializer and local-function fact sidecars

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -12,7 +12,9 @@ public class LoweringFactCatalogTests
 
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Await");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ObjectOrCollectionInitializerExpression");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");
+        Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.LocalFunction");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.CapturedClosure");
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -25,5 +25,16 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
             PositiveCoverage: "LambdaRaisingPassTests capturing lambda fixture",
             AdversarialCoverage: "LambdaRaisingPassTests guards for unsupported local/captured forms",
             MissingDiscriminator: "display classes spread across statements are still owed"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.LocalFunction)),
+            typeof(LocalFunctionRaisingPass),
+            [
+                new FactPrimitive("generated-method:local-function", "GeneratedCodeIdentity.IsLocalFunctionMethod"),
+                new FactPrimitive("cross-method-import", "PassContext.ImportMethodBody"),
+            ],
+            PositiveCoverage: "LocalFunctionRaisingPassTests static local function fixture",
+            AdversarialCoverage: "LocalFunctionRaisingPass guards reject capturing, recursive, nested, unsupported, or local-bodied forms",
+            MissingDiscriminator: "capturing, recursive, and nested local functions are still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class ObjectInitializerFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.ObjectOrCollectionInitializerExpression)),
+            typeof(ObjectInitializerPass),
+            [
+                new FactPrimitive("dataflow.stack-slot-dup-chain", "ObjectInitializerPass alias-slot tracking"),
+                new FactPrimitive("ir.initializer-entry-shape", "InitializerEntry member/indexer/Add argument model"),
+            ],
+            PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, and dictionary initializer fixtures",
+            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat",
+            MissingDiscriminator: "named-local and nested initializer shapes are still owed"),
+    ];
+}


### PR DESCRIPTION
## Summary
- add a sidecar fact-provider entry for `ObjectOrCollectionInitializerExpression` / `ObjectInitializerPass`
- add a `ClosureConversion.LocalFunction` sidecar entry for `LocalFunctionRaisingPass`
- extend catalog discovery assertions for both rows

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests
- dotnet build src/dotnet-inspect -c Release --no-restore
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore