### PR TITLE
Raise capturing local functions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -731,6 +731,16 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    // Capturing local function: `n` is hoisted into a struct <>c__DisplayClass
+    // passed to the synthesized method by ref. LocalFunctionRaisingPass substitutes
+    // the captured field back and recovers the non-static `int Add(int v) => v + n;`.
+    public static int CapturingLocalFunction(int n)
+    {
+        return Add(5);
+
+        int Add(int v) => v + n;
+    }
+
     static void ThrowOverflow() => throw new OverflowException();
 
     // CoreLib Math.Abs(short) shape: the throw is an out-of-line call reached

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -64,6 +64,7 @@ public class FidelityGateTests
     {
         "SharedCaptureLambdas",
         "DoubleViaLocalFunction",
+        "CapturingLocalFunction",
         "CheckedAdd",
         "UnsignedShift",
         "Shadowed",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -57,6 +57,7 @@ public class IdiomShapeScorecardTests
         // Owed: a lambda body that keeps a local of its own (declined by the zero-local guard).
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.DoubleViaLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
+        new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CapturingLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -26,4 +26,15 @@ public class LocalFunctionRaisingPassTests
         Assert.DoesNotContain("g__", output);                          // no synthesized name
         Assert.DoesNotContain("CfgSampleClass.Twice", output);         // not the qualified mis-binding
     }
+
+    [Fact]
+    public void CapturingLocalFunction_SubstitutesEnvironmentAndDropsRefParameter()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingLocalFunction));
+
+        Assert.Contains("return Add(5);", output);              // call drops the ref-env argument
+        Assert.Contains("int Add(int v) => v + n;", output);    // captured `n` substituted; env param gone
+        Assert.DoesNotContain("static int Add", output);        // capturing local function is not static (CS8421)
+        Assert.DoesNotContain("DisplayClass", output);          // environment elided
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -31,7 +31,7 @@ internal static class ClosureCoverage
     [Completeness(CompletenessLevel.Partial, "zero-local expression or simple block bodies, capturing or not; local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
-    [Completeness(CompletenessLevel.Partial, "static, non-capturing local functions with a zero-local body, declared back into the host method and called by their source name; capturing (ref display-class env), recursive, and nested local functions still owed")]
+    [Completeness(CompletenessLevel.Partial, "static and capturing (ref struct display-class env, substituted back) local functions with a zero-local body, declared back into the host method and called by their source name; recursive, nested, and shared-environment local functions still owed")]
     public static LocalFunctionRaisingPass LocalFunction => new();
 
     [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from its <>c__DisplayClass environment — folded onto the delegate, or a local set up and shared across statements (allocation/stores elided); a class captured by a local function, or nested environments, still owed")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -10,12 +12,17 @@ namespace ILInspector.Decompiler.Pipeline;
 /// unqualified <c>Name(args)</c> (the source spelling, replacing the
 /// otherwise-unspeakable <c>Enclosing.&lt;Outer&gt;g__Name|N_M(args)</c>).
 ///
-/// <para>Current slice — <b>static, non-capturing</b> local functions with a
-/// zero-local body that prints in the host scope (arguments are self-naming).
-/// Excluded, and left as-is: a capturing local function (it takes its
-/// <c>&lt;&gt;c__DisplayClass</c> environment by <c>ref</c>), and a body that
-/// itself calls a local function (recursion or nesting), which keeps the import
-/// non-recursive. A no-op when the seam is absent.</para>
+/// <para>Slice — <b>static</b> local functions with a zero-local body that prints
+/// in the host scope (arguments are self-naming), <b>non-capturing or
+/// capturing</b>. A capturing local function takes its <c>&lt;&gt;c__DisplayClass</c>
+/// environment (a struct) by <c>ref</c> as its last parameter; the host sets the
+/// captured fields directly on a local and passes <c>ref env</c>. This recovers
+/// it by substituting each <c>env.f</c> read in the body with the captured value,
+/// dropping the environment parameter from the declaration and the <c>ref env</c>
+/// argument from each call, and eliding the capture stores. Left as-is: an
+/// environment shared with another local function or read any other way, and a
+/// body that itself calls a local function (recursion / nesting), which keeps the
+/// import non-recursive. A no-op when the seam is absent.</para>
 /// </summary>
 public sealed class LocalFunctionRaisingPass : IIrPass
 {
@@ -26,18 +33,23 @@ public sealed class LocalFunctionRaisingPass : IIrPass
         if (context.ImportMethodBody is null)
             return;
 
-        var byMethod = function.Descendants.OfType<Call>()
+        var groups = function.Descendants.OfType<Call>()
             .Where(c => c.Parent is not null && GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee))
             .GroupBy(c => c.Callee)
             .ToList();
 
         var declarations = new List<LocalFunctionStatement>();
-        foreach (var group in byMethod)
+        foreach (var group in groups)
         {
             var method = group.Key;
-            // Static value-parameter signature only: an instance receiver or a
-            // display-class (by-ref) parameter means a capturing local function.
-            if (method.HasThis || method.ParameterTypes.Any(IsDisplayClassParameter))
+            if (method.HasThis)
+                continue;  // instance receiver — out of this slice
+
+            var calls = group.ToList();
+            var environment = ResolveEnvironment(method, calls, function);
+            // A display-class parameter we could not resolve to a clean, single-use
+            // environment (shared, or read another way) is out of this slice.
+            if (environment is null && method.ParameterTypes.Any(IsDisplayClassParameter))
                 continue;
 
             var body = context.ImportMethodBody(method);
@@ -49,28 +61,41 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                 continue;
 
             IrPasses.Run(body, IrPasses.Default, context);
+
+            if (environment is not null && !SubstituteEnvironment(body, environment))
+                continue;
             if (!body.Locals.IsEmpty
                 || body.Descendants.OfType<UnsupportedNode>().Any()
                 || !IsPrintableBody(body))
                 continue;
 
             string name = CSharpNaming.MethodName(method.Name);
+            // The environment parameter is the last one; drop it from the source signature.
+            var parameters = environment is null
+                ? body.Signature.Parameters
+                : body.Signature.Parameters.RemoveAt(body.Signature.Parameters.Length - 1);
+
             var container = body.Body;
             container.Detach();
-            // The body is another method's; clear its offsets so they cannot
-            // collide with the host's offset-keyed annotations and interleaved IL
-            // (the local function is rendered inline; its own IL is not projected).
+            // The body is another method's; clear its offsets so they cannot collide
+            // with the host's offset-keyed annotations and interleaved IL.
             foreach (var node in Self(container))
                 node.SetSourceOffset(-1);
 
-            foreach (var call in group.ToList())
+            foreach (var call in calls)
             {
                 context.Stepper.StepOver($"raise local function {name}", call);
-                var arguments = call.DetachChildren().Cast<IrExpression>();
+                var arguments = call.DetachChildren().Cast<IrExpression>().ToList();
+                if (environment is not null)
+                    arguments.RemoveAt(arguments.Count - 1);   // drop the ref-env argument
                 call.ReplaceWith(new LocalFunctionInvocation(name, method.ReturnType, arguments));
             }
+            // A capturing local function cannot be `static` (CS8421); the
+            // synthesized method is static only because the environment is passed
+            // explicitly by ref, which the recovered source form does not show.
             declarations.Add(new LocalFunctionStatement(
-                name, method.ReturnType, body.Signature.Parameters, isStatic: true, container));
+                name, method.ReturnType, parameters, isStatic: environment is null, container));
+            environment?.Elide();
         }
 
         if (declarations.Count == 0)
@@ -82,6 +107,77 @@ public sealed class LocalFunctionRaisingPass : IIrPass
         foreach (var declaration in declarations)
             block.Add(declaration);
     }
+
+    /// <summary>The captured environment of a capturing local function: the host's struct display-class local, its field bindings, and the body argument that names it.</summary>
+    sealed record Environment(
+        TypeRef Type, int ArgIndex, Dictionary<string, IrExpression> Captures, List<StoreField> Stores)
+    {
+        public void Elide()
+        {
+            foreach (var store in Stores)
+                store.Detach();
+        }
+    }
+
+    // A capturing local function takes its struct <>c__DisplayClass environment by
+    // ref as the last parameter; the host fills it via field stores through a
+    // local address and passes ref env to each call. Resolve that to a capture map
+    // when the environment is used only for those stores and these calls.
+    static Environment? ResolveEnvironment(MethodRef method, List<Call> calls, IrFunction function)
+    {
+        if (method.ParameterTypes is not [.., { Kind: TypeRefKind.ByRef } byRef]
+            || !GeneratedCodeIdentity.IsDisplayClassName(byRef.ElementType!))
+            return null;
+        var envType = byRef.ElementType!;
+
+        // Every call passes ref <sameLocal> as its last argument.
+        if (calls[0].Arguments[^1] is not LoadLocalAddress { Index: var slot })
+            return null;
+        if (calls.Any(c => c.Arguments[^1] is not LoadLocalAddress address || address.Index != slot))
+            return null;
+
+        var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
+        var stores = new List<StoreField>();
+        foreach (var store in function.Descendants.OfType<StoreField>())
+        {
+            if (store.Instance is LoadLocalAddress { Index: var s } && s == slot && Equals(store.Field.DeclaringType, envType))
+            {
+                if (!IsCaptureValue(store.Value, function))
+                    return null;
+                captures[store.Field.Name] = store.Value;
+                stores.Add(store);
+            }
+        }
+
+        // The environment local must be touched only by those capture stores and
+        // these calls' ref arguments — any other read means it outlives this setup.
+        int addressUses = function.Descendants.OfType<LoadLocalAddress>().Count(a => a.Index == slot);
+        if (function.Descendants.OfType<LoadLocal>().Any(l => l.Index == slot)
+            || addressUses != stores.Count + calls.Count)
+            return null;
+
+        return new Environment(envType, method.ParameterTypes.Length - 1, captures, stores);
+    }
+
+    static bool SubstituteEnvironment(IrFunction body, Environment environment)
+    {
+        foreach (var load in body.Descendants.OfType<LoadField>().ToList())
+        {
+            if (load.Instance is LoadArgument arg && arg.Index == environment.ArgIndex
+                && Equals(load.Field.DeclaringType, environment.Type)
+                && environment.Captures.TryGetValue(load.Field.Name, out var value))
+                load.ReplaceWith(value.Clone());
+        }
+        // No bare read of the environment parameter may survive substitution.
+        return !body.Descendants.OfType<LoadArgument>().Any(a => a.Index == environment.ArgIndex);
+    }
+
+    static bool IsCaptureValue(IrExpression value, IrFunction function) => value switch
+    {
+        LoadArgument => true,
+        LoadLocal local => !GeneratedCodeIdentity.IsDisplayClassName(function.Locals[local.Index]),
+        _ => false,
+    };
 
     static bool IsDisplayClassParameter(TypeRef type)
         => GeneratedCodeIdentity.IsDisplayClassName(type.Kind == TypeRefKind.ByRef ? type.ElementType! : type);


### PR DESCRIPTION
## What

Extends `LocalFunctionRaisingPass` (#786) past **static** local functions to the **capturing** form:

```csharp
int CapturingLocalFunction(int n)
{
    return Add(5);
    int Add(int v) => v + n;   // captures n
}
```
…now recovers `return Add(5); int Add(int v) => v + n;` (previously the unspeakable `<…>g__Add|N_M` shape).

## How

A capturing local function takes its struct `<>c__DisplayClass` environment **by ref as its last parameter**; the host fills the captured fields on a local and passes `ref env` to each call, and the body reads `env.f` through that ref param.

The pass resolves the environment — one local, used *only* for its capture stores and these calls' ref arguments — then:
1. substitutes each `env.f` read in the imported body with the captured value,
2. drops the environment parameter from the recovered declaration,
3. drops the `ref env` argument from each call site,
4. elides the capture stores (the now-unreferenced struct local prints nothing).

The declaration is emitted **non-`static`**: a static local function can't capture (CS8421), so the `static` modifier is kept only for the non-capturing form, even though the synthesized method is always static (the env is passed explicitly).

## Tests

- `ClosureCoverage.LocalFunction` note widened (it already pointed at this pass).
- Scorecard: `CapturingLocalFunction` recovers `LocalFunctionStatement`, rejects the `SimpleMemberAccessExpression` mis-binding.
- **Pinned opcode-exact** in the fidelity gate (the `static`-modifier bug was caught exactly here — CS8421 — before pinning).
- Unit test asserting the substituted body, dropped ref-env, non-static modifier, and elided environment.
- 547/547 decompiler tests green; no new opcode diffs in the gate or BCL corpus sweep.

## Follow-ups

Recursive, nested, and shared-environment local functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
