### PR TITLE
Harden initializer raising: fold nested members inner-first

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1055,6 +1055,7 @@ public class CfgSampleClass
 
     public sealed class InitContainer
     {
+        public int Tag { get; set; }
         public InitTarget Inner { get; set; } = new();
         public System.Collections.Generic.List<int> Items { get; } = new();
     }
@@ -1064,6 +1065,32 @@ public class CfgSampleClass
 
     public static InitContainer MakeNestedCollection(int a, int b)
         => new InitContainer { Items = { a, b } };
+
+    // Adversarial: `Inner = new InitTarget { ... }` REASSIGNS Inner (a flat member
+    // store whose value is its own sub-initializer), so it must keep the `new` and
+    // never collapse to the nested-mutation form `Inner = { ... }`.
+    public static InitContainer MakeNestedReassign(int a, int b)
+        => new InitContainer { Inner = new InitTarget { X = a, Y = b } };
+
+    // Adversarial breadth: a flat scalar member interleaved with a nested block.
+    public static InitContainer MakeFlatAndNested(int a, int b, int c)
+        => new InitContainer { Tag = c, Inner = { X = a, Y = b } };
+
+    // Adversarial breadth: two distinct nested members (object + collection) — the
+    // pass must flush one block and open another on the member change.
+    public static InitContainer MakeTwoNestedMembers(int a, int b)
+        => new InitContainer { Inner = { X = a }, Items = { b } };
+
+    // Adversarial negative: a named-local nested mutation uses a real local, not the
+    // expression-position dup temp, so it must stay lowered (no initializer).
+    public static InitContainer MakeNamedLocalNestedMutation(int a, int b)
+    {
+        var c = new InitContainer();
+        c.Inner.X = a;
+        c.Inner.Y = b;
+        GC.KeepAlive(c);
+        return c;
+    }
 
     public static InitTarget MakePoint(int a, int b) => new InitTarget { X = a, Y = b };
 

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -164,4 +164,55 @@ public class ObjectInitializerPassTests
             "return new InitContainer { Items = { a, b } };",
             Print(nameof(CfgSampleClass.MakeNestedCollection)));
     }
+
+    [Fact]
+    public void NestedReassignment_KeepsTheNewAndDoesNotCollapseToMutation()
+    {
+        // `Inner = new InitTarget { ... }` reconstructs Inner (a flat member store
+        // whose value is its own sub-initializer); it must keep `new` and never
+        // render as the in-place nested-mutation form `Inner = { ... }`. The outer
+        // initializer only folds because seeds are raised inner-first.
+        var output = Print(nameof(CfgSampleClass.MakeNestedReassign));
+
+        Assert.Contains("return new InitContainer { Inner = new InitTarget { X = a, Y = b } };", output);
+        Assert.DoesNotContain("Inner = { ", output);
+    }
+
+    [Fact]
+    public void FlatAndNestedMembers_RaiseTogether()
+    {
+        var output = Print(nameof(CfgSampleClass.MakeFlatAndNested));
+
+        Assert.Contains("return new InitContainer { Tag = c, Inner = { X = a, Y = b } };", output);
+    }
+
+    [Fact]
+    public void TwoNestedMembers_RaiseAsSeparateBlocks()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeTwoNestedMembers));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(new string?[] { "Inner", "Items" }, initializer.Members);
+        var blocks = initializer.Entries
+            .Select(entry => Assert.IsType<InitializerBlock>(Assert.Single(entry.Arguments)))
+            .ToList();
+        Assert.False(blocks[0].IsCollection);  // Inner = { X = a }
+        Assert.True(blocks[1].IsCollection);   // Items = { b }
+        Assert.Contains("return new InitContainer { Inner = { X = a }, Items = { b } };", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void NamedLocalNestedMutation_StaysLowered()
+    {
+        // A nested mutation through a real local (used twice: KeepAlive + return) is
+        // not the expression-position dup form, so it must not fold to an initializer.
+        var function = Raised(nameof(CfgSampleClass.MakeNamedLocalNestedMutation));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".Inner.X = a;", output);
+        Assert.Contains("GC.KeepAlive", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
@@ -11,8 +11,8 @@ internal sealed class ObjectInitializerFacts : ILoweringFactProvider
                 new FactPrimitive("dataflow.stack-slot-dup-chain", "ObjectInitializerPass alias-slot tracking"),
                 new FactPrimitive("ir.initializer-entry-shape", "InitializerEntry member/indexer/Add argument model"),
             ],
-            PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, and dictionary initializer fixtures",
-            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat",
-            MissingDiscriminator: "named-local and nested initializer shapes are still owed"),
+            PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, dictionary, nested object/collection, and nested-reassign (Inner = new U { ... }, folded inner-first) fixtures",
+            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... })",
+            MissingDiscriminator: "named-local initializer shapes are still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -91,7 +91,7 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
-    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements, and nested initializers (Inner = { X = a } / Items = { e0, e1 }); named-local initializers not raised")]
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements, nested initializers (Inner = { X = a } / Items = { e0, e1 }), and nested members whose value is itself an initializer (Inner = new U { ... }, folded inner-first); named-local initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small exact BCL String.op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -91,7 +91,7 @@ internal static class LoweringCoverage
     public static NullCoalescingAssignmentPass NullCoalescingAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass NullCoalescingOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ObjectCreationExpression => default!;
-    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements, nested initializers (Inner = { X = a } / Items = { e0, e1 }), and nested members whose value is itself an initializer (Inner = new U { ... }, folded inner-first); named-local initializers not raised")]
+    [Completeness(CompletenessLevel.Partial, "stack-slot dup form (expression position): named members, indexer members ([k] = v), single-element and multi-argument (dictionary { k, v }) Add elements, and nested initializers (Inner = { X = a } / Items = { e0, e1 }); named-local initializers not raised")]
     public static ObjectInitializerPass ObjectOrCollectionInitializerExpression => new();
     [Completeness(CompletenessLevel.Partial, "jump-table and sparse binary-search switch statements + the small exact BCL String.op_Equality-chain switch-on-string; pattern switches and the hash-bucket string form not raised")]
     public static SwitchRaisingPass PatternSwitchStatement => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -29,7 +29,12 @@ public sealed class ObjectInitializerPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        foreach (var seed in function.Descendants.OfType<StoreStackSlot>().ToList())
+        // Process seeds inner-first. The compiler emits the outer `new T(...)`
+        // before any nested `new U(...)` that feeds one of its members, so reverse
+        // document order folds sub-initializers before their enclosing initializer
+        // — letting a nested member's value (`Inner = new U { ... }`) be a raised
+        // initializer by the time the outer run inspects that member store.
+        foreach (var seed in function.Descendants.OfType<StoreStackSlot>().Reverse().ToList())
         {
             if (seed.Parent is not Block || seed.Value is not NewObject creation)
                 continue;


### PR DESCRIPTION
## What

A **Memory-adversarial** hardening pass (per the new `docs/decompiler-quality.md` adversarial-modes guidance from #795) over the recently-broadened object/collection-initializer family (#787, #789). The synthetic fixture matrix surfaced a real partial-coverage gap, now fixed.

## The gap

A nested member whose value is *itself* an initializer did not raise the outer initializer:

```csharp
new InitContainer { Inner = new InitTarget { X = a, Y = b } }
```

raised only the inner sub-initializer, leaving the outer lowered (`S.Inner = new InitTarget {...}; return S;`).

**Cause:** the pass visited seeds in document order. The compiler emits the outer `new T(...)` before any nested `new U(...)`, so the outer seed was inspected *before* the inner sub-initializer folded; the outer run then hit the un-foldable inner `NewObject` and bailed.

## Fix

Process seeds in **reverse document order** so sub-initializers raise before their enclosing initializer — bottom-up folding in a single pass at arbitrary nesting depth. One-line change in `ObjectInitializerPass.Run`.

## Adversarial fixtures (pinned)

| Fixture | Shape | Expectation |
| --- | --- | --- |
| `MakeNestedReassign` | `Inner = new InitTarget { ... }` | **now raises** outer, keeps `new` |
| `MakeNestedObject` | `Inner = { ... }` | mutate-in-place — the pair proves reconstruct vs mutate stay **distinct** |
| `MakeFlatAndNested` | `{ Tag = c, Inner = { ... } }` | flat + nested interleaved |
| `MakeTwoNestedMembers` | `{ Inner = { X = a }, Items = { b } }` | two separate blocks (object + collection) |
| `MakeNamedLocalNestedMutation` | `var c = new(); c.Inner.X = a; ...` | **must not fold** (real local) — stays lowered |

## Coverage recording

Follows the fact-sidecar convention (#792): the coverage delta is recorded in `ObjectInitializerFacts` (positive/adversarial coverage updated; `MissingDiscriminator` narrowed to the still-owed named-local form) **without churning the central `LoweringCoverage` ledger** — which #792 had left stale on nested anyway.

## Validation

- The **fidelity gate** decompiles + recompiles all five fixtures and proves opcode-exact round-trip.
- 550 decompiler tests green (incl. `LoweringFactCatalogTests`); product builds clean. Rebased on current `origin/main`.
