### PR TITLE
Require generated iterator state machines

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -50,10 +50,36 @@ public class GeneratedCodeIdentityTests
             "UserAssembly",
             "Samples",
             "Outer+<>c__DisplayClass0_0")));
+        Assert.True(GeneratedCodeIdentity.IsIteratorStateMachineTypeName(TypeRef.GenericInstance(
+            TypeRef.Definition("UserAssembly", "Samples", "Outer+<M>d__0`1"),
+            [s_int])));
+    }
+
+    [Fact]
+    public void IteratorStateMachineConstructor_RequiresGeneratedDeclaringTypeAndCtor()
+    {
+        var constructor = IteratorConstructor(declaringTypeIsCompilerGenerated: true);
+
+        Assert.True(GeneratedCodeIdentity.IsIteratorStateMachineConstructor(constructor));
+        Assert.False(GeneratedCodeIdentity.IsIteratorStateMachineConstructor(constructor with
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.No,
+        }));
+        Assert.False(GeneratedCodeIdentity.IsIteratorStateMachineConstructor(constructor with { Name = "MoveNext" }));
+        Assert.False(GeneratedCodeIdentity.IsIteratorStateMachineConstructor(constructor with
+        {
+            DeclaringType = TypeRef.Definition("UserAssembly", "Samples", "Outer+Iterator"),
+        }));
     }
 
     static MethodRef LambdaMethod(bool declaringTypeIsCompilerGenerated)
         => new(s_closureHolder, "<M>b__0_0", s_int, [s_int], HasThis: true)
+        {
+            DeclaringTypeCompilerGenerated = declaringTypeIsCompilerGenerated ? MetadataFactState.Yes : MetadataFactState.No,
+        };
+
+    static MethodRef IteratorConstructor(bool declaringTypeIsCompilerGenerated)
+        => new(TypeRef.Definition("UserAssembly", "Samples", "Outer+<M>d__0"), ".ctor", TypeRef.CoreLib("System", "Void"), [s_int], HasThis: false)
         {
             DeclaringTypeCompilerGenerated = declaringTypeIsCompilerGenerated ? MetadataFactState.Yes : MetadataFactState.No,
         };

--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -69,4 +69,44 @@ public class IteratorAcknowledgmentPassTests
         Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
         Assert.Contains("source", Print(nameof(CfgSampleClass.NotAnIterator)));
     }
+
+    [Fact]
+    public void StateMachineNameLookalikeWithoutCompilerGeneratedMetadata_IsNotAcknowledged()
+    {
+        var function = BuildStateMachineNameLookalike();
+
+        IrPasses.Run(function);
+
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildStateMachineNameLookalike()
+    {
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [TypeRef.CoreLib("System", "Int32")]);
+        var lookalike = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var ctor = new MethodRef(
+            lookalike,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Int32")],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.No,
+        };
+
+        var block = new Block();
+        block.Add(new Return(new NewObject(ctor, [new Constant(-2, TypeRef.CoreLib("System", "Int32"))])));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
@@ -1,0 +1,17 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class IteratorRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.Yield)),
+            typeof(IteratorReconstructionPass),
+            [
+                new FactPrimitive("generated.iterator-state-machine", "GeneratedCodeIdentity.IsIteratorStateMachineConstructor"),
+            ],
+            PositiveCoverage: "IteratorReconstructionPassTests linear, empty, counting-loop, conditional, and multi-yield iterator fixtures",
+            AdversarialCoverage: "IteratorReconstructionPassTests nested/foreach-delegation negatives and IteratorAcknowledgmentPassTests state-machine-name lookalike",
+            MissingDiscriminator: "foreach-delegation, nested loops, captured iterators, and deeper state-machine/PDB correlation remain owed"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -42,6 +42,14 @@ public static class GeneratedCodeIdentity
         => method.CompilerGenerated == MetadataFactState.Yes
             && IsSynthesizedLocalFunctionName(method.Name);
 
+    public static bool IsIteratorStateMachineConstructor(MethodRef constructor)
+        => constructor.DeclaringTypeCompilerGenerated == MetadataFactState.Yes
+            && constructor.Name == ".ctor"
+            && IsIteratorStateMachineTypeName(constructor.DeclaringType);
+
+    public static bool IsIteratorStateMachineTypeName(TypeRef type)
+        => LeafTypeName(MetadataTypeName(type)).Contains(">d__", StringComparison.Ordinal);
+
     public static bool IsSynthesizedLocalFunctionName(string name)
         => name.StartsWith("<", StringComparison.Ordinal)
             && name.Contains(">g__", StringComparison.Ordinal);
@@ -51,4 +59,7 @@ public static class GeneratedCodeIdentity
         int plus = name.LastIndexOf('+');
         return plus < 0 ? name : name[(plus + 1)..];
     }
+
+    static string MetadataTypeName(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
@@ -21,7 +21,7 @@ internal static class IteratorShapes
             return false;
 
         var creation = function.Descendants.OfType<NewObject>()
-            .FirstOrDefault(n => IsStateMachineType(n.Constructor.DeclaringType));
+            .FirstOrDefault(n => GeneratedCodeIdentity.IsIteratorStateMachineConstructor(n.Constructor));
         if (creation is null)
             return false;
 
@@ -30,7 +30,7 @@ internal static class IteratorShapes
     }
 
     public static bool IsStateMachineType(TypeRef type)
-        => MetadataName(type).Contains(">d__", StringComparison.Ordinal);
+        => GeneratedCodeIdentity.IsIteratorStateMachineTypeName(type);
 
     public static string MetadataName(TypeRef type)
         => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;


### PR DESCRIPTION
## Summary
- require compiler-generated declaring-type evidence before iterator kickoff recognition trusts a >d__ state-machine name
- add GeneratedCodeIdentity iterator-state-machine predicates and adversarial name-lookalike coverage
- record the Yield lowering row's generated iterator state-machine predicate dependency in a sidecar

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal