### PR TITLE
Document worktree-per-feature branching off upstream main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@ Never amend commits. Always create new commits instead of using `git commit --am
 
 The `main` branch is protected. All work must be done on a feature branch.
 
+Development should always happen in a worktree. Create a new worktree for each
+new feature, and start every new feature/worktree level with upstream `main`
+(fetch and base off the latest `upstream/main`).
+
 Create feature branches with descriptive names, e.g.:
 - `feature/issue-3-assembly-references`
 - `fix/null-reference-in-parser`


### PR DESCRIPTION
## Summary

Clarifies the Branching guidance in `AGENTS.md`:

- Development should always happen in a git **worktree**.
- Create a **new worktree per feature**.
- Each new feature/worktree should **start level with the latest `upstream/main`**.

## Why

The previous Branching section only stated that `main` is protected and that work must happen on a feature branch. It did not capture the worktree-per-feature convention or the requirement to base new work on the latest upstream `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>