### PR TITLE
Render address-of nodes in value positions without the invalid ref keyword

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
@@ -1,0 +1,45 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// An address-of node (ldloca/ldarga/ldflda/ldelema) leaves the IL as a managed
+// pointer. Used as a ref-argument, ref-local initializer, or ref-return it
+// spells `ref place`; in any other value position that `ref` is invalid C#
+// (CS1525/CS1612). These tests pin the two value-position shapes that were
+// rendering the bare `ref` form.
+public class AddressInValuePositionTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void ValueTypeArrayElementMemberAccess_DropsRefOnTheReceiver()
+    {
+        // `pairs[0].A` reads a field off a struct array element by address
+        // (ldelema; ldfld). The receiver is the element place, not `ref pairs[0]`
+        // — `(ref pairs[0]).A` is CS1525.
+        var output = Render(nameof(CfgSampleClass.FirstA));
+
+        Assert.Contains("return pairs[0].A;", output);
+        Assert.DoesNotContain("ref pairs[0]", output);
+    }
+
+    [Fact]
+    public void LocalAddressConvertedToNativeUInt_RendersAddressOf()
+    {
+        // `(nuint)(&value)` lowers to `ldloca; conv.u`. Converting the address to
+        // a native integer is C#'s address-of operator; `(nuint)(ref value)` is
+        // CS1525.
+        var output = Render(nameof(CfgSampleClass.AddressAsNativeUInt));
+
+        Assert.Contains("(nuint)(&value)", output);
+        Assert.DoesNotContain("ref value", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -63,6 +63,11 @@ public sealed partial class CSharpPrinter
         LoadLocalAddress a => $"{LocalName(a.Index)}",
         LoadArgumentAddress a => a.Name,
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
+        // A value-type array element accessed by address (ldelema; the receiver
+        // of a field/property/method on the element) spells the element place
+        // itself — C# auto-takes the address. The bare `ref pairs[0]` spelling
+        // would be CS1525 in this value position (`(ref pairs[0]).A`).
+        LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         _ => Operand(receiver),
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1336,6 +1336,16 @@ public sealed partial class CSharpPrinter
 
     string ConvertText(Convert convert)
     {
+        // An address-of node (ldloca/ldarga/ldflda/ldelema) converted to a
+        // pointer or native integer (conv.u/conv.i) is C#'s address-of operator,
+        // not a `ref` place: `(nuint)(ref x)` is CS1525 — the faithful unsafe
+        // spelling is `(nuint)(&x)`. The bare `ref` form is only valid in a
+        // ref-return/ref-argument/ref-local position, never as a cast operand.
+        if (convert.Operand is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress)
+        {
+            string addressCast = $"({TypeText(convert.Target)})(&{Deref(convert.Operand)})";
+            return convert.IsChecked ? $"checked({addressCast})" : addressCast;
+        }
         // Converting an out-of-range integer constant (conv.u8 of ldc.i4.m1 for
         // ulong.MaxValue) is CS0221 as a plain cast; reinterpret its bits with
         // unchecked, matching the constant handling at value boundaries.


### PR DESCRIPTION
## Problem

An address-of node (`ldloca`/`ldarga`/`ldflda`/`ldelema`) leaves the IL as a managed pointer. The bare `ref place` spelling is only valid C# in a **ref-return**, **ref-argument**, or **ref-local-initializer** position. In any other value position that `ref` is a syntax error (CS1525) or modifies a non-variable (CS1612).

Two value positions still emitted the bare `ref`, producing output that does not parse:

| Method | Before | After |
| --- | --- | --- |
| `FirstA(Pair[]) => pairs[0].A` | `return (ref pairs[0]).A;` | `return pairs[0].A;` |
| `AddressAsNativeUInt() => (nuint)(&value)` | `return (nuint)(ref value);` | `return (nuint)(&value);` |

## Fix

- **Member-access receiver** (`ReceiverText`): stripped the `ref` for local/argument/field addresses but was missing the `LoadElementAddress` case, so a struct array element receiver rendered `(ref pairs[0]).A`. Added the element-address case (covers fields, properties, method groups, and instance calls — they all share `ReceiverText`).
- **Address converted to pointer / native int** (`ConvertText`): `ldloca; conv.u` is the address-of operator; now renders `(nuint)(&x)` instead of `(nuint)(ref x)`.

The bare `ref` form is preserved where it is correct (ref-return via `CastValue`, ref-arguments via `RefArgument`, ref-local init), none of which route through the two changed paths.

## Impact

- Corpus syntactic validity: **Full malformed 995 -> 789 (-206 methods)**.
- Fidelity neutral: inventory 40984/41012 Full, 0 importer bugs; both new spellings re-lower opcode-exact (`ldelema; ldfld` and `ldloca; conv.u`).
- Pinned both shapes with `FirstA` / `AddressAsNativeUInt` render tests.
- 557 decompiler + 1157 product tests green.
