### PR TITLE
Collapse multi-call local functions to one declaration (#794 follow-up)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -731,6 +731,15 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    // Adversarial breadth: a static local function called more than once. The call
+    // sites must collapse to a single recovered declaration, not one per call.
+    public static int StaticLocalFunctionCalledTwice(int x)
+    {
+        return Twice(x) + Twice(x + 1);
+
+        static int Twice(int v) => v * 2;
+    }
+
     // Capturing local function: `n` is hoisted into a struct <>c__DisplayClass
     // passed to the synthesized method by ref. LocalFunctionRaisingPass substitutes
     // the captured field back and recovers the non-static `int Add(int v) => v + n;`.
@@ -739,6 +748,48 @@ public class CfgSampleClass
         return Add(5);
 
         int Add(int v) => v + n;
+    }
+
+    // Adversarial breadth: one capturing local function called twice. Both calls
+    // pass `ref env` for the same environment local; the pass must drop the ref-env
+    // argument from each and recover a single declaration.
+    public static int CapturingCalledTwice(int n)
+    {
+        return Add(5) + Add(7);
+
+        int Add(int v) => v + n;
+    }
+
+    // Adversarial soundness probe: the captured parameter is mutated before the
+    // call, so the environment field is filled with the post-mutation value. The
+    // recovered `v + n` reads the (reassigned) parameter — the fidelity gate proves
+    // whether the substitution stays opcode-exact.
+    public static int CapturingAfterMutation(int n)
+    {
+        n += 1;
+        return Add(5);
+
+        int Add(int v) => v + n;
+    }
+
+    // Adversarial negative: two local functions sharing one environment (both
+    // capture `n`). The shared display-class local is referenced by both call sites,
+    // so neither resolves to a clean single-use environment — must stay lowered.
+    public static int SharedEnvironmentLocalFunctions(int n)
+    {
+        return Add(5) + Mul(3);
+
+        int Add(int v) => v + n;
+        int Mul(int v) => v * n;
+    }
+
+    // Adversarial negative: a recursive local function (its body calls itself), which
+    // keeps the import non-recursive — must stay lowered.
+    public static int RecursiveLocalFunction(int n)
+    {
+        return Fact(n);
+
+        int Fact(int v) => v <= 1 ? 1 : v * Fact(v - 1);
     }
 
     static void ThrowOverflow() => throw new OverflowException();

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -17,6 +17,78 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
+    public void StaticLocalFunctionCalledTwice_CollapsesToOneDeclaration()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.StaticLocalFunctionCalledTwice));
+
+        Assert.Contains("Twice(x)", output);                              // both calls rendered unqualified
+        Assert.Contains("Twice(x + 1)", output);
+        Assert.Contains("static int Twice(int v) => v * 2;", output);     // declaration emitted
+        // Each call site carries its own (reference-unequal) MethodRef, so a per-Callee
+        // grouping would emit one declaration per call. Recovery must collapse to one.
+        Assert.Equal(1, CountOccurrences(output, "int Twice(int v)"));
+        Assert.DoesNotContain("g__", output);
+        Assert.DoesNotContain("CfgSampleClass.Twice", output);
+    }
+
+    [Fact]
+    public void CapturingLocalFunctionCalledTwice_RecoversSingleDeclarationAcrossBothCalls()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingCalledTwice));
+
+        Assert.Contains("Add(5)", output);                       // both calls drop the ref-env argument
+        Assert.Contains("Add(7)", output);
+        Assert.Contains("int Add(int v) => v + n;", output);     // captured `n` substituted; env param gone
+        Assert.Equal(1, CountOccurrences(output, "int Add(int v)"));
+        Assert.DoesNotContain("static int Add", output);         // capturing local function is not static (CS8421)
+        Assert.DoesNotContain("DisplayClass", output);           // environment elided
+    }
+
+    [Fact]
+    public void SharedEnvironmentLocalFunctions_StayLowered()
+    {
+        // Two local functions share one display-class environment, so neither
+        // resolves to a clean single-use environment — recovery must not fire.
+        string output = PrintRaised(nameof(CfgSampleClass.SharedEnvironmentLocalFunctions));
+
+        Assert.Contains("DisplayClass", output);                 // environment not elided
+        Assert.DoesNotContain("int Add(int v) =>", output);      // no recovered declaration
+        Assert.DoesNotContain("int Mul(int v) =>", output);
+    }
+
+    [Fact]
+    public void RecursiveLocalFunction_StaysLowered()
+    {
+        // The body calls itself; keeping the import non-recursive bars recovery.
+        string output = PrintRaised(nameof(CfgSampleClass.RecursiveLocalFunction));
+
+        Assert.DoesNotContain("int Fact(int v) =>", output);     // no recovered declaration
+        Assert.Contains("Fact(n)", output);                      // call left as the lowered invocation
+    }
+
+    [Fact]
+    public void CapturingAfterMutation_StaysLowered()
+    {
+        // The captured local is mutated, so the environment field is written from a
+        // read of itself (not a clean capture value) — recovery must not fire.
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingAfterMutation));
+
+        Assert.Contains("DisplayClass", output);                 // environment not elided
+        Assert.DoesNotContain("int Add(int v) =>", output);      // no recovered declaration
+    }
+
+    static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, System.StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    [Fact]
     public void StaticLocalFunction_RecoveredAsDeclarationAndUnqualifiedCall()
     {
         string output = PrintRaised(nameof(CfgSampleClass.DoubleViaLocalFunction));

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -33,8 +33,8 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated-method:local-function", "GeneratedCodeIdentity.IsLocalFunctionMethod"),
                 new FactPrimitive("cross-method-import", "PassContext.ImportMethodBody"),
             ],
-            PositiveCoverage: "LocalFunctionRaisingPassTests static local function fixture",
-            AdversarialCoverage: "LocalFunctionRaisingPass guards reject capturing, recursive, nested, unsupported, or local-bodied forms",
-            MissingDiscriminator: "capturing, recursive, and nested local functions are still owed"),
+            PositiveCoverage: "LocalFunctionRaisingPassTests static and capturing fixtures, each called once and more than once",
+            AdversarialCoverage: "LocalFunctionRaisingPass guards reject shared-environment, recursive, nested, post-mutation capture, unsupported, or local-bodied forms",
+            MissingDiscriminator: "nested local functions and environments spread across statements are still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -35,17 +35,22 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
         var groups = function.Descendants.OfType<Call>()
             .Where(c => c.Parent is not null && GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee))
-            .GroupBy(c => c.Callee)
+            // Group by the callee's stable identity, not the MethodRef record:
+            // ParameterTypes is an ImmutableArray, whose Equals is reference (not
+            // structural), so two call sites to the same local function carry
+            // non-equal MethodRef instances and would split into separate groups.
+            // Local-function mangled names are unique within a type.
+            .GroupBy(c => (c.Callee.DeclaringType.ToDisplayString(), c.Callee.Name))
             .ToList();
 
         var declarations = new List<LocalFunctionStatement>();
         foreach (var group in groups)
         {
-            var method = group.Key;
+            var calls = group.ToList();
+            var method = calls[0].Callee;
             if (method.HasThis)
                 continue;  // instance receiver — out of this slice
 
-            var calls = group.ToList();
             var environment = ResolveEnvironment(method, calls, function);
             // A display-class parameter we could not resolve to a clean, single-use
             // environment (shared, or read another way) is out of this slice.


### PR DESCRIPTION
## Summary

A **Memory-adversarial** pass over the capturing-local-function recovery shipped in #794 surfaced a grouping bug that affects **every local function called more than once**.

`LocalFunctionRaisingPass` grouped call sites with `GroupBy(c => c.Callee)`. `MethodRef` is a `record` whose `ParameterTypes` is an `ImmutableArray<TypeRef>`, and `ImmutableArray<T>.Equals` is **reference** (not structural) equality. So two call sites to the same local function carry non-equal `MethodRef` instances and split into separate single-call groups.

### Symptoms

- **Static multi-call** — each split group raised independently and appended its own declaration, emitting a **duplicate** `static int Twice(...)` (invalid C#, CS0128).
- **Capturing multi-call** — each split group saw `calls.Count == 1`, so the environment count check `addressUses != stores.Count + calls.Count` (`3 != 1 + 1`) bailed and the call **stayed fully lowered**.

### Fix

Group by the callee's stable identity `(DeclaringType, Name)` — local-function mangled names are unique within a type — so all call sites collapse to one group, one declaration, and the environment check counts every `ref env` argument.

## Adversarial fixture matrix

Positives (raise, opcode-exact in the fidelity gate):
- `StaticLocalFunctionCalledTwice` → `Twice(x) + Twice(x + 1)` with a single `static int Twice(...)`.
- `CapturingCalledTwice` → `Add(5) + Add(7)` with a single `int Add(int v) => v + n;`.

Negatives (soundly stay lowered):
- `SharedEnvironmentLocalFunctions` — two functions share one display-class environment.
- `RecursiveLocalFunction` — body calls itself (import stays non-recursive).
- `CapturingAfterMutation` — captured local mutated, so the env field is written from a read of itself.

## Validation

- 552 decompiler tests green (fidelity gate opcode-exact for both new positives).
- `LoweringFactCatalogTests` green; `LambdaRecoveryFacts` sidecar updated to record capturing + multi-call support (central `ClosureCoverage.cs` untouched, per the fact-sidecar convention).
- Product builds clean.
