### PR TITLE
Inline spilled call-chain temporaries into a single expression

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ExpressionInliningPassTests
+{
+    static string PrintRaised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    // The collapsed cache leaves the chain spilled across reused stack slots
+    // (`S_0 = xs; S_1 = x => ...; S_0 = Where(S_0, S_1); ...`). Live-range
+    // inlining folds those temps into the call arguments, leaving one statement.
+    [Fact]
+    public void CachedDelegateArgument_InlinesToSingleCall()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateArgument));
+
+        Assert.Equal(1, output.Count(c => c == ';'));
+        Assert.StartsWith("return ", output);
+        Assert.Contains("Where", output);
+        Assert.Contains("x => x > 0", output);
+    }
+
+    [Fact]
+    public void CachedDelegateChain_InlinesToSingleNestedExpression()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateChain));
+
+        Assert.Equal(1, output.Count(c => c == ';'));
+        Assert.StartsWith("return ", output);
+        // The first call's result feeds the second as its receiver argument.
+        int where = output.IndexOf("Where", StringComparison.Ordinal);
+        int select = output.IndexOf("Select", StringComparison.Ordinal);
+        Assert.True(where >= 0 && select >= 0 && select < where,
+            $"expected Select(Where(...), ...) nesting, got: {output}");
+        Assert.Contains("x => x > 0", output);
+        Assert.Contains("x => x * 2", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -8,6 +8,19 @@ namespace ILInspector.Decompiler.Pipeline;
 /// following statement either as its first-evaluated leaf (the stored value
 /// still evaluates first) or with a pure stored value (evaluation order
 /// cannot matter). Runs to fixpoint so spill chains collapse.
+///
+/// <para>A second mode, <see cref="InlineLiveRangeOnce"/>, collapses the
+/// spilled-call-chain shape the simple mode cannot: a fluent call chain
+/// (<c>xs.Where(p).Select(f)</c>) spills its receiver, each lambda, and every
+/// intermediate result into reused stack slots — so a slot has several stores
+/// and several loads function-wide (defeating the single-store/single-load
+/// keys), and a store's use sits past an interleaved statement (defeating the
+/// adjacency rule). This mode reasons per-store over its live range: a movable
+/// value (an effect-free read or a non-capturing delegate creation) inlines
+/// into the one load it reaches before the slot is rewritten, provided nothing
+/// in between writes what the value reads. Effect-free values reorder freely;
+/// the interference scan keeps a value that reads a place from crossing a write
+/// to it.</para>
 /// </summary>
 public sealed class ExpressionInliningPass : IIrPass
 {
@@ -15,7 +28,7 @@ public sealed class ExpressionInliningPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (InlineOnce(function, context))
+        while (InlineOnce(function, context) || InlineLiveRangeOnce(function, context))
         {
         }
     }
@@ -88,6 +101,201 @@ public sealed class ExpressionInliningPass : IIrPass
         }
         return false;
     }
+
+    // A place the dataflow tracks: a method argument, a local, or a stack slot.
+    enum PlaceKind { Argument, Local, Slot }
+
+    /// <summary>
+    /// One inline of a movable value into the single load it reaches within its
+    /// live range — the spilled-call-chain collapse. Unlike <see cref="InlineOnce"/>
+    /// this tolerates a slot that is reused (several stores/loads function-wide)
+    /// and a use that sits past interleaved statements, by reasoning over the
+    /// store's live range instead of function-wide counts.
+    /// </summary>
+    static bool InlineLiveRangeOnce(IrFunction function, PassContext context)
+    {
+        var argumentAddresses = new HashSet<int>();
+        var addressTakenLocals = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case LoadArgumentAddress a: argumentAddresses.Add(a.Index); break;
+                case StoreArgument s: argumentAddresses.Add(s.Index); break;
+                case LoadLocalAddress a: addressTakenLocals.Add(a.Index); break;
+            }
+        }
+
+        foreach (var block in function.Descendants.OfType<Block>())
+        {
+            for (int si = 0; si < block.Children.Count; si++)
+            {
+                // Only stack slots — the compiler's spill scratch — are inlined
+                // here. A user local carries source meaning and the structuring
+                // passes shape constructs (??=, deconstruction) around it; moving
+                // those reshapes already-raised code into a different opcode stream.
+                if (block.Children[si] is not StoreStackSlot store)
+                    continue;
+                var (targetKind, targetIndex, value) = (PlaceKind.Slot, store.Slot, store.Value);
+                if (!TryMovableReads(value, out var reads))
+                    continue;
+                if (reads.Any(r => !ReadIsStable(r, argumentAddresses, addressTakenLocals, function)))
+                    continue;
+                // Confine to a slot whose every store and load lives in this one
+                // block. Reaching-definition analysis across blocks is what the
+                // simple mode's function-wide single-load key stands in for; a
+                // block-local slot makes the forward scan below exact, so a store
+                // in a successor block (or read back across a loop edge) can never
+                // be the definition we silently drop. The spilled call chain is
+                // block-local by construction.
+                if (!IsConfinedToBlock(function, targetKind, targetIndex, block))
+                    continue;
+
+                // Walk forward to the one load this store reaches: the first
+                // statement that loads the slot is its use (even if that statement
+                // also rewrites the slot — the load on the right evaluates first).
+                // Bail on a write to anything the value reads before the use, and
+                // require the definition to be dead after that single use (a second
+                // load before the slot is rewritten would read a value we moved).
+                IrNode? use = null;
+                IrNode? useStatement = null;
+                bool blocked = false;
+                for (int k = si + 1; k < block.Children.Count; k++)
+                {
+                    var stmt = block.Children[k];
+                    var uses = LoadsOf(stmt, targetKind, targetIndex);
+                    bool rewritesTarget = Writes(stmt, targetKind, targetIndex);
+                    if (uses.Count > 0)
+                    {
+                        if (use is not null || uses.Count > 1)
+                        {
+                            blocked = true;       // a second use of this definition
+                            break;
+                        }
+                        use = uses[0];
+                        useStatement = stmt;
+                        if (rewritesTarget)
+                            break;                // redefined in the same statement, after the use
+                        continue;
+                    }
+                    if (rewritesTarget)
+                    {
+                        blocked = use is null;    // dead before use ⇒ leave it alone
+                        break;
+                    }
+                    if (use is null && reads.Any(r => Writes(stmt, r.Kind, r.Index)))
+                    {
+                        blocked = true;
+                        break;
+                    }
+                }
+                if (blocked || use is null || useStatement is null)
+                    continue;
+
+                // A value that reads places must still evaluate first at the use
+                // site; an effect-free value that reads nothing can land anywhere.
+                if (reads.Count > 0 && !IsFirstEvaluatedLeaf(use, useStatement))
+                    continue;
+
+                var inlined = (IrExpression)block.Children[si].DetachChildren()[0];
+                context.Stepper.StepOver(
+                    $"inline {(targetKind == PlaceKind.Slot ? "stack slot" : "local")} {targetIndex} into its live-range use",
+                    use);
+                block.Children[si].Detach();
+                use.ReplaceWith(inlined);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// A value safe to recompute at a later point: it produces no observable
+    /// effect, so reordering it is invisible as long as the places it reads are
+    /// unchanged in between (the caller's interference scan). A non-capturing
+    /// delegate creation qualifies — its target is the static <c>&lt;&gt;c.&lt;&gt;9</c>
+    /// singleton, so it reads nothing the method can mutate.
+    /// </summary>
+    static bool TryMovableReads(IrExpression value, out List<(PlaceKind Kind, int Index)> reads)
+    {
+        reads = [];
+        switch (value)
+        {
+            case Constant or SizeOf or LoadToken:
+                return true;
+            case LoadArgument argument:
+                reads.Add((PlaceKind.Argument, argument.Index));
+                return true;
+            case LoadLocal load:
+                reads.Add((PlaceKind.Local, load.Index));
+                return true;
+            case LoadStackSlot load:
+                reads.Add((PlaceKind.Slot, load.Slot));
+                return true;
+            case DelegateCreation { Target: LoadField { Instance: null } }:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // A read is stable to move only if no escaped address could let an
+    // intervening call mutate it: arg whose address is never taken (and not the
+    // possibly-byref `this` of an instance method), or a local never addressed.
+    static bool ReadIsStable(
+        (PlaceKind Kind, int Index) read, HashSet<int> argumentAddresses, HashSet<int> addressTakenLocals, IrFunction function)
+        => read.Kind switch
+        {
+            PlaceKind.Argument => !argumentAddresses.Contains(read.Index)
+                && !(function.Signature.HasThis && read.Index == 0),
+            PlaceKind.Local => !addressTakenLocals.Contains(read.Index),
+            _ => true,
+        };
+
+    // True when every load and store of the place sits inside one block, so its
+    // whole live range is the straight-line statements the forward scan reads.
+    static bool IsConfinedToBlock(IrFunction function, PlaceKind kind, int index, Block block)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool touches = kind switch
+            {
+                PlaceKind.Slot => node is LoadStackSlot ls && ls.Slot == index || node is StoreStackSlot ss && ss.Slot == index,
+                PlaceKind.Local => node is LoadLocal ll && ll.Index == index || node is StoreLocal sl && sl.Index == index,
+                _ => false,
+            };
+            if (touches && !ReferenceEquals(EnclosingBlock(node), block))
+                return false;
+        }
+        return true;
+    }
+
+    static Block? EnclosingBlock(IrNode node)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (current is Block block)
+                return block;
+        }
+        return null;
+    }
+
+    static List<IrNode> LoadsOf(IrNode statement, PlaceKind kind, int index)
+        => [.. statement.Descendants.Prepend(statement).Where(n => kind switch
+        {
+            PlaceKind.Slot => n is LoadStackSlot s && s.Slot == index,
+            PlaceKind.Local => n is LoadLocal l && l.Index == index,
+            _ => false,
+        })];
+
+    static bool Writes(IrNode statement, PlaceKind kind, int index)
+        => statement.Descendants.Prepend(statement).Any(n => kind switch
+        {
+            PlaceKind.Slot => n is StoreStackSlot s && s.Slot == index,
+            PlaceKind.Local => n is StoreLocal l && l.Index == index,
+            PlaceKind.Argument => n is StoreArgument a && a.Index == index,
+            _ => false,
+        });
 
     /// <summary>
     /// The first statement of the block after <paramref name="block"/>, when


### PR DESCRIPTION
## What

#784 (the cache collapse this builds on) has merged. Once the delegate cache is collapsed, a fluent call chain is a flat run of stores into reused stack slots feeding the final call:

```csharp
S_0 = xs;
S_1 = x => x > 0;
S_0 = Enumerable.Where<int>(S_0, S_1);
S_1 = x => x * 2;
return Enumerable.Select<int, int>(S_0, S_1);
```

`ExpressionInliningPass`'s simple mode cannot fold these: a reused slot has several stores/loads function-wide (defeating its single-store/single-load key), and a store's use sits past an interleaved statement (defeating its adjacency rule). The temps stay exposed.

## How

A second mode reasons **per-store over its live range**. A *movable* value — an effect-free read or a non-capturing delegate creation (target on the static `<>c.<>9` singleton) — inlines into the one load it reaches before the slot is rewritten. Result:

```csharp
return Enumerable.Select<int, int>(Enumerable.Where<int>(xs, x => x > 0), x => x * 2);
```

(Rendering this as the fully-fluent `xs.Where(...).Select(...)` is a further slice: extension-method-receiver sugar.)

## Soundness

1. **Preconditions proved whole-block.** The mode fires only on a slot whose every store and load is **confined to one block**, making the straight-line forward scan exact reaching-definition analysis — a use in a successor block or across a loop edge can never be the definition silently dropped. (An early per-block-only version without this guard regressed 29 fixtures; confinement + dead-after-use checks brought it to 0.)
2. **Semantics preserved.** A movable value produces no effect, so reordering it is invisible as long as nothing between the store and the use writes a place it reads (interference scan), and it still evaluates first at the use when it reads anything (first-leaf rule).
3. **Stack slots only — never user locals.** Locals carry source meaning and the structuring passes shape `??=`/deconstruction around them; moving those reshapes already-raised code into a different opcode stream (this was the last regression class, now excluded by construction).

## Tests & verification

- `ExpressionInliningPassTests` (new) pins the chain to a single nested expression; `CachedDelegate*` fixtures (from #784) reused.
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **514/514 pass**, including `FidelityGateTests` (exact opcode round-trip over loops, `??=`, deconstruction, pinned, and the LINQ fixtures) and `CorpusSweepGateTests` floors.
- `--pass-impact expression-inlining`: **1144 → 1502** changed methods over CoreLib (41,159), **0 pass bugs** — the intended live-range broadening.
- Note: the standalone `--fidelity-check` CLI cannot recompile in this environment (CS0518, missing core refs) regardless of this change, so fidelity is gated by the in-host `FidelityGateTests` (the CI gate), not the CLI.

## Merge order

Stacked on the cache collapse (#784), now merged; rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
