### PR TITLE
Add foreach adversarial fact coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -14,6 +14,16 @@ public class ForeachStatementPassTests
         return function!;
     }
 
+    static IrFunction RaisedWithoutSymbols(string methodName)
+    {
+        using var source = MetadataSource.OpenWithoutSymbols(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
     [Fact]
     public void EnumeratorUsingLoop_RaisesToForeach()
     {
@@ -39,9 +49,31 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void ForeachLoop_WithoutSymbols_StillRaisesToForeach()
+    {
+        var function = RaisedWithoutSymbols(nameof(CfgSampleClass.ForeachLoop));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.DoesNotContain(function.Descendants.OfType<UsingStatement>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), _ => true);
+    }
+
+    [Fact]
     public void SourceNamedEnumeratorUsingLoop_StaysUsingWhile()
     {
         var function = Raised(nameof(CfgSampleClass.StructUsing));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void HandWrittenEnumeratorUsingLoop_WithoutSymbols_StaysUsingWhile()
+    {
+        var function = RaisedWithoutSymbols(nameof(CfgSampleClass.StructUsing));
 
         Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
         Assert.Single(function.Descendants.OfType<UsingStatement>());

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -11,6 +11,7 @@ public class LoweringFactCatalogTests
         var entries = DiscoverFactEntries().Cast<LoweringFactEntry>().ToList();
 
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Await");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ForEachStatement");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ObjectOrCollectionInitializerExpression");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
@@ -1,0 +1,19 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class ForeachRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.ForEachStatement)),
+            typeof(ForeachStatementPass),
+            [
+                new FactPrimitive("pdb.hidden-enumerator-local", "ForeachStatementPass HasSourceLocalName guard"),
+                new FactPrimitive("enumerator-call-shape", "ForeachStatementPass GetEnumerator/MoveNext/Current shape checks"),
+                new FactPrimitive("dataflow.enumerator-local-consumed", "ForeachStatementPass ReferencesEnumerator residual-use guard"),
+            ],
+            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols",
+            AdversarialCoverage: "ForeachStatementPassTests source-named and no-symbols hand-written enumerator using/while loop",
+            MissingDiscriminator: "array foreach, custom pattern enumerators, and broader collection/extension GetEnumerator shapes not raised"),
+    ];
+}


### PR DESCRIPTION
## Summary
- pin foreach recovery across the no-symbols boundary with a positive foreach fixture
- add a no-symbols hand-written enumerator using/while negative fixture
- add a ForeachRecoveryFacts sidecar entry for the ForEachStatement lowering row

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal