### PR TITLE
Retype bool/char constants stored through a ref or pointer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -1,0 +1,42 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TypedConstantsPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void BoolStoredThroughByRef_RetypesConstantToBool()
+    {
+        // `out bool flag = true` lowers to `stind.i1` over a `ref bool`, whose opcode
+        // width is sbyte. Retyping by the address's pointee type (bool), not the
+        // opcode type, recovers the boolean literal — otherwise the output is
+        // `flag = 1;`, which is not valid C# (CS0029).
+        var function = Raised(nameof(CfgSampleClass.SetFlag));
+        var store = Assert.Single(function.Descendants.OfType<StoreIndirect>());
+
+        var constant = Assert.IsType<Constant>(store.Value);
+        Assert.IsType<bool>(constant.Value);
+        Assert.Equal(true, constant.Value);
+    }
+
+    [Fact]
+    public void BoolStoredThroughByRef_RendersBooleanLiteral()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.SetFlag))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("flag = true;", output);
+        Assert.DoesNotContain("flag = 1;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -46,7 +46,12 @@ public sealed class TypedConstantsPass : IIrPass
                 case StoreElement { Value: Constant constant, ElementType: { } elementType }:
                     Retype(constant, elementType, shapes, stepper);
                     break;
-                case StoreIndirect { Value: Constant constant, Type: { } indirectType }:
+                // `stind.i1`/`stind.i2` carry only a storage width (sbyte/short), so a
+                // `bool`/`char` location stored through a managed ref or pointer keeps
+                // the opcode's integer type. The address's pointee type is the real
+                // target — `ref bool wasSymlink = 0` is `wasSymlink = false`.
+                case StoreIndirect { Value: Constant constant } store
+                    when (PointeeType(store.Address.ResultType) ?? store.Type) is { } indirectType:
                     Retype(constant, indirectType, shapes, stepper);
                     break;
                 // `flags & 16` is `BindingFlags & int` — CS0019. The bitwise
@@ -62,6 +67,9 @@ public sealed class TypedConstantsPass : IIrPass
             }
         }
     }
+
+    static TypeRef? PointeeType(TypeRef? type)
+        => type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } ? type.ElementType : null;
 
     static TypeRef? EnumOperandType(IrExpression operand, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
         => operand is not Constant && operand.ResultType is { } type && shapes.GetValueOrDefault(type) == TypeShape.Enum


### PR DESCRIPTION
## Problem

From the `--validity-check` semantic-defect docket (the "claimed Full but won't compile" set, issue #622): `out bool` parameters set to a literal rendered as an integer assignment that does not compile.

`stind.i1` / `stind.i2` carry only a **storage width** (sbyte / short), shared across bool/sbyte/byte and char/short. `TypedConstantsPass` keyed its `StoreIndirect` retype off the opcode type, so a constant written to a `bool`/`char` location through a managed ref or pointer stayed an int:

```csharp
// Microsoft.Win32.SafeHandles.SafeFileHandle::Open
wasSymlink = 0;   // CS0029: cannot implicitly convert 'int' to 'bool'
```

The IR confirms it: `StoreIndirect sbyte` over `LoadArgument (ref bool wasSymlink)` with `Constant 0 (int)` — the `sbyte` is the opcode width, but the address's pointee type is `bool`.

## Fix

Retype by the **address's pointee type** (the ByRef/Pointer element) when present, falling back to the opcode type otherwise — so the change is never worse than before.

| Method | Before | After |
| --- | --- | --- |
| `SafeFileHandle::Open` | `wasSymlink = 0;` | `wasSymlink = false;` |
| `Sys.Fcntl::GetIsNonBlocking` | `isNonBlocking = 0;` | `isNonBlocking = false;` |

This also covers `char` locations written through `stind.i2` and pointer (`bool*`/`char*`) stores, not just `ref`/`out`.

## Impact

Over .NET 11 preview CoreLib (`--validity-check`):

- CS0029 (int→bool): **267 → 232**
- Total semantically-defective `Full` methods: **566 → 543**

## Tests

Pins the `out bool` path with the previously-untested `SetFlag` fixture (`flag = true;`, not `flag = 1;`). 573 decompiler tests green, including `FidelityGateTests` and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)