### PR TITLE
Recover interpolated-string alignment and format specifiers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1208,6 +1208,25 @@ public class CfgSampleClass
     public static int InterpolationAsArgument(string name, int age)
         => ConsumeInterpolation($"Hello {name}, you are {age}");
 
+    // Format specifier: AppendFormatted<T>(T, string) — owed scorecard climb.
+    public static string InterpolationWithFormat(decimal amount)
+        => $"Total: {amount:N2}";
+
+    // Alignment specifier: AppendFormatted<T>(T, int) — positive and negative pad.
+    public static string InterpolationWithAlignment(int code)
+        => $"[{code,5}]";
+
+    public static string InterpolationWithNegativeAlignment(string label)
+        => $"[{label,-10}]";
+
+    // Alignment and format together: AppendFormatted<T>(T, int, string).
+    public static string InterpolationWithAlignmentAndFormat(double ratio)
+        => $"{ratio,8:P1}";
+
+    // Mixed: a plain hole next to a formatted hole in one string.
+    public static string InterpolationMixedHoles(string name, int score)
+        => $"{name} scored {score:D4}!";
+
     static int ConsumeInterpolation(string text) => text.Length;
 
     public static int UsingStatement(string path)

--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -179,18 +179,30 @@ public class MemberIdentityTests
             isVirtual: false,
             [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "literal", s_string)])));
 
-        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
             AppendFormattedMethod(s_handler, s_int) with { ParameterTypes = [s_int, s_int] },
             isVirtual: false,
             [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "value", s_int), new Constant(10, s_int)])));
-        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
             AppendFormattedMethod(s_handler, s_int) with { ParameterTypes = [s_int, s_string] },
             isVirtual: false,
             [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "value", s_int), new Constant("X", s_string)])));
-        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
+        Assert.True(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
             AppendFormattedMethod(s_handler, s_int) with { ParameterTypes = [s_int, s_int, s_string] },
             isVirtual: false,
             [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "value", s_int), new Constant(10, s_int), new Constant("X", s_string)])));
+
+        // A format string containing a brace cannot round-trip through `{value:format}`
+        // syntax, so the overload stays unmatched (soundness guard).
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
+            AppendFormattedMethod(s_handler, s_int) with { ParameterTypes = [s_int, s_string] },
+            isVirtual: false,
+            [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "value", s_int), new Constant("a}b", s_string)])));
+        // Non-constant alignment/format args cannot be lifted to specifier syntax.
+        Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted(new Call(
+            AppendFormattedMethod(s_handler, s_int) with { ParameterTypes = [s_int, s_int] },
+            isVirtual: false,
+            [new LoadLocalAddress(0, s_handler), new LoadArgument(0, "value", s_int), new LoadArgument(1, "n", s_int)])));
 
         Assert.False(MemberIdentity.IsDefaultInterpolatedStringHandlerToStringAndClear(new Call(
             ToStringAndClearMethod(s_handler) with { ReturnType = s_object },

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -123,43 +123,92 @@ public class StringInterpolationPassTests
     }
 
     [Fact]
-    public void HandlerSequence_WithAlignmentAppendFormatted_IsNotRaised()
+    public void FormatSpecifier_RecoversColonFormat()
     {
-        var function = BuildAppendFormattedOverload([s_int, s_int], [new LoadArgument(0, "value", s_int), new Constant(10, s_int)]);
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolationWithFormat))).Output;
 
-        new StringInterpolationPass().Run(function, PassContext.None);
-
-        AssertAppendFormattedOverloadNotRaised(function);
+        Assert.NotNull(output);
+        Assert.Contains("return $\"Total: {amount:N2}\";", output);
+        Assert.DoesNotContain("AppendFormatted", output);
     }
 
     [Fact]
-    public void HandlerSequence_WithFormatAppendFormatted_IsNotRaised()
+    public void AlignmentSpecifier_RecoversCommaAlignment()
     {
-        var function = BuildAppendFormattedOverload([s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant("X", s_string)]);
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolationWithAlignment))).Output;
 
-        new StringInterpolationPass().Run(function, PassContext.None);
-
-        AssertAppendFormattedOverloadNotRaised(function);
+        Assert.NotNull(output);
+        Assert.Contains("return $\"[{code,5}]\";", output);
+        Assert.DoesNotContain("AppendFormatted", output);
     }
 
     [Fact]
-    public void HandlerSequence_WithAlignmentAndFormatAppendFormatted_IsNotRaised()
+    public void NegativeAlignmentSpecifier_RecoversSignedAlignment()
     {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolationWithNegativeAlignment))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return $\"[{label,-10}]\";", output);
+    }
+
+    [Fact]
+    public void AlignmentAndFormat_RecoversBothClauses()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolationWithAlignmentAndFormat))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return $\"{ratio,8:P1}\";", output);
+        Assert.DoesNotContain("AppendFormatted", output);
+    }
+
+    [Fact]
+    public void MixedHoles_RecoversPlainAndFormattedHoles()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.InterpolationMixedHoles))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return $\"{name} scored {score:D4}!\";", output);
+        Assert.DoesNotContain("AppendFormatted", output);
+    }
+
+    [Fact]
+    public void HiddenTempHandler_BraceInFormat_StaysLowered()
+    {
+        // A format containing a brace cannot round-trip through `{value:format}`
+        // syntax, so the call must stay lowered even when every other condition of
+        // the hidden-temp handler pattern is met.
         var function = BuildAppendFormattedOverload(
-            [s_int, s_int, s_string],
-            [new LoadArgument(0, "value", s_int), new Constant(10, s_int), new Constant("X", s_string)]);
+            [s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant("a}b", s_string)]);
 
         new StringInterpolationPass().Run(function, PassContext.None);
 
-        AssertAppendFormattedOverloadNotRaised(function);
-    }
-
-    static void AssertAppendFormattedOverloadNotRaised(IrFunction function)
-    {
         Assert.Empty(function.Descendants.OfType<InterpolatedStringExpression>());
         Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "AppendFormatted");
-        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "ToStringAndClear");
         function.CheckInvariant();
+    }
+
+    [Fact]
+    public void HiddenTempHandler_PlainFormat_Raises()
+    {
+        // The same scaffold with a brace-free format raises, proving the negative
+        // above is the brace guard and not an unrelated mismatch.
+        var function = BuildAppendFormattedOverload(
+            [s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant("N2", s_string)]);
+
+        new StringInterpolationPass().Run(function, PassContext.None);
+
+        var interpolation = Assert.Single(function.Descendants.OfType<InterpolatedStringExpression>());
+        Assert.Equal(":N2", FormatClause(interpolation));
+        function.CheckInvariant();
+    }
+
+    static string FormatClause(InterpolatedStringExpression node)
+    {
+        var part = node.Parts.Single(p => !p.IsLiteral);
+        var format = part.Format!;
+        var alignment = format.HasAlignment ? "," + format.Alignment : "";
+        var formatString = format.FormatString is { } f ? ":" + f : "";
+        return alignment + formatString;
     }
 
     static IrFunction BuildUserHandlerLookalike()

--- a/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
@@ -10,7 +10,7 @@ internal sealed class StringInterpolationFacts : ILoweringFactProvider
             [
                 new FactPrimitive("member.corelib-identity:DefaultInterpolatedStringHandler", "MemberIdentity interpolated-string handler predicates"),
             ],
-            PositiveCoverage: "StringInterpolationPassTests straight-line handler append fixtures",
+            PositiveCoverage: "StringInterpolationPassTests straight-line handler append fixtures, including alignment and format specifiers",
             AdversarialCoverage: "StringInterpolationPassTests user handler lookalike",
             MissingDiscriminator: "non-straight-line handler flows need dataflow facts"),
     ];

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -128,7 +128,15 @@ public sealed partial class CSharpPrinter
             }
             else if (part.ExpressionIndex >= 0 && part.ExpressionIndex < node.FormattedValues.Count)
             {
-                sb.Append('{').Append(InterpolatedExpression(node.FormattedValues[part.ExpressionIndex])).Append('}');
+                sb.Append('{').Append(InterpolatedExpression(node.FormattedValues[part.ExpressionIndex]));
+                if (part.Format is { } format)
+                {
+                    if (format.HasAlignment)
+                        sb.Append(',').Append(format.Alignment.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    if (format.FormatString is { } formatString)
+                        sb.Append(':').Append(formatString);
+                }
+                sb.Append('}');
             }
         }
         return sb.Append('"').ToString();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1201,11 +1201,20 @@ public sealed class AnonymousObject : IrExpression
     public override string Describe() => $"AnonymousObject ({Children.Count} properties)";
 }
 
-/// <summary>One segment in a raised interpolated string: either literal text or a formatted-expression child by index.</summary>
-public sealed record InterpolatedStringPart(string? Literal, int ExpressionIndex)
+/// <summary>
+/// The alignment and/or format clause of an interpolated-string hole — the
+/// <c>,alignment</c> and <c>:format</c> suffixes recovered from the
+/// <c>AppendFormatted</c> overload's extra arguments. <see cref="HasAlignment"/>
+/// distinguishes an absent alignment from a present zero, so the recovered hole
+/// round-trips to the same handler overload.
+/// </summary>
+public sealed record InterpolationFormat(int Alignment, bool HasAlignment, string? FormatString);
+
+/// <summary>One segment in a raised interpolated string: either literal text or a formatted-expression child by index, with an optional alignment/format clause.</summary>
+public sealed record InterpolatedStringPart(string? Literal, int ExpressionIndex, InterpolationFormat? Format = null)
 {
     public static InterpolatedStringPart LiteralText(string text) => new(text, -1);
-    public static InterpolatedStringPart FormattedValue(int expressionIndex) => new(null, expressionIndex);
+    public static InterpolatedStringPart FormattedValue(int expressionIndex, InterpolationFormat? format = null) => new(null, expressionIndex, format);
     public bool IsLiteral => Literal is not null;
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -94,10 +94,50 @@ public static class MemberIdentity
             && call.Arguments.Count == 2;
 
     public static bool IsDefaultInterpolatedStringHandlerAppendFormatted(Call call)
-        => IsDefaultInterpolatedStringHandlerInstanceMethod(call, "AppendFormatted")
-            && call.Callee.ReturnType.Equals(s_void)
-            && call.Callee.ParameterTypes.Length == 1
-            && call.Arguments.Count == 2;
+    {
+        if (!IsDefaultInterpolatedStringHandlerInstanceMethod(call, "AppendFormatted")
+            || !call.Callee.ReturnType.Equals(s_void)
+            || call.Arguments.Count != call.Callee.ParameterTypes.Length + 1)
+        {
+            return false;
+        }
+
+        // value; value + alignment (int) | format (string); value + alignment + format.
+        // The alignment/format arguments are compile-time constants in every C#
+        // interpolation, so a non-constant in those slots is not this lowering. A
+        // format that contains a brace cannot round-trip through `{value:format}`
+        // syntax, so leave those (hand-written handler) calls lowered.
+        return call.Callee.ParameterTypes switch
+        {
+            [_] => true,
+            [_, var second] when second.Equals(s_int) => call.Arguments[2] is Constant { Value: int },
+            [_, var second] when second.Equals(s_string) => call.Arguments[2] is Constant { Value: string format } && IsBraceFreeFormat(format),
+            [_, var alignment, var format] => alignment.Equals(s_int) && format.Equals(s_string)
+                && call.Arguments[2] is Constant { Value: int } && call.Arguments[3] is Constant { Value: string formatText } && IsBraceFreeFormat(formatText),
+            _ => false,
+        };
+    }
+
+    static bool IsBraceFreeFormat(string format)
+        => !format.Contains('{') && !format.Contains('}');
+
+    /// <summary>
+    /// The alignment/format clause carried by an <c>AppendFormatted</c> call's
+    /// extra constant arguments, or <see langword="null"/> for the value-only
+    /// overload. The caller must have already matched
+    /// <see cref="IsDefaultInterpolatedStringHandlerAppendFormatted"/>.
+    /// </summary>
+    public static InterpolationFormat? GetAppendFormattedFormat(Call call)
+        => call.Callee.ParameterTypes switch
+        {
+            [_, var second] when second.Equals(s_int)
+                => new InterpolationFormat((int)((Constant)call.Arguments[2]).Value!, HasAlignment: true, FormatString: null),
+            [_, var second] when second.Equals(s_string)
+                => new InterpolationFormat(0, HasAlignment: false, (string)((Constant)call.Arguments[2]).Value!),
+            [_, _, _]
+                => new InterpolationFormat((int)((Constant)call.Arguments[2]).Value!, HasAlignment: true, (string)((Constant)call.Arguments[3]).Value!),
+            _ => null,
+        };
 
     public static bool IsDefaultInterpolatedStringHandlerToStringAndClear(Call call)
         => IsDefaultInterpolatedStringHandlerInstanceMethod(call, "ToStringAndClear")

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -104,7 +104,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative StringConcat => default!;
-    [Completeness(CompletenessLevel.Partial, "straight-line exact BCL DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted; the result is raised wherever the ToStringAndClear call is consumed in the next statement (return, local assignment, argument)")]
+    [Completeness(CompletenessLevel.Partial, "straight-line exact BCL DefaultInterpolatedStringHandler AppendLiteral/AppendFormatted, including the alignment and format specifiers from the AppendFormatted(value, alignment) / (value, format) / (value, alignment, format) overloads (`{x,5}`, `{x:N2}`, `{x,-10:P1}`); the result is raised wherever the ToStringAndClear call is consumed in the next statement (return, local assignment, argument)")]
     public static StringInterpolationPass StringInterpolation => new();
     [Completeness(CompletenessLevel.Partial, "value-producing jump tables raise to a switch expression; the sparse binary-search form recovers as a switch statement; pattern switches not raised")]
     public static SwitchRaisingPass SwitchExpression => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StringInterpolationPass.cs
@@ -48,9 +48,10 @@ public sealed class StringInterpolationPass : IIrPass
                     }
                     else
                     {
+                        var format = MemberIdentity.GetAppendFormattedFormat(call);
                         var callParts = call.DetachChildren().Cast<IrExpression>().ToList();
                         var value = callParts[1];
-                        parts.Add(InterpolatedStringPart.FormattedValue(values.Count));
+                        parts.Add(InterpolatedStringPart.FormattedValue(values.Count, format));
                         values.Add(value);
                     }
                 }


### PR DESCRIPTION
## Summary

Scorecard climb: recovers **interpolated-string alignment and format specifiers**, so lowered `DefaultInterpolatedStringHandler` sequences round-trip back to the C# the developer wrote.

Before, only the bare `AppendFormatted(value)` overload was matched, so any hole with a format or alignment stayed lowered as raw handler calls. Now the three constant-carrying overloads are recovered:

| C# source | csc-lowered call | now raises to |
|---|---|---|
| `$"{x:N2}"` | `AppendFormatted<T>(T, string)` | `$"{x:N2}"` |
| `$"{x,5}"` | `AppendFormatted<T>(T, int)` | `$"{x,5}"` |
| `$"{x,-10:P1}"` | `AppendFormatted<T>(T, int, string)` | `$"{x,-10:P1}"` |

## How

- New `InterpolationFormat(int Alignment, bool HasAlignment, string? FormatString)` IR record; `InterpolatedStringPart` carries an optional format. `HasAlignment` (rather than a nullable alignment) keeps the absent-vs-zero distinction explicit so output round-trips to the original overload.
- `MemberIdentity.IsDefaultInterpolatedStringHandlerAppendFormatted` broadened to the 1/2/3-arg overloads. Alignment/format args must be **compile-time constants** (csc always emits them so), and a format containing a brace stays lowered — it can't round-trip through `{value:format}` syntax (soundness guard).
- Printer renders `,alignment` and `:format` clauses into the hole.

## Validation

- 5 source fixtures (`InterpolationWith{Format,Alignment,NegativeAlignment,AlignmentAndFormat}`, `InterpolationMixedHoles`); all raise opcode-exact in the fidelity gate.
- Synthetic-IR tests pin the brace-format and non-constant-arg guards.
- Flips the owed adversarial cases added in #806 from "stays lowered" to "recovered" (both the pass-level `*_IsNotRaised` tests and the `MemberIdentity` unit assertions), per the owed-fixture-flip rule in `docs/decompiler-quality.md`.
- Scorecard note (`LoweringCoverage.cs`) and fact sidecar (`StringInterpolationFacts.cs`) updated to record the new coverage.
- Full decompiler suite green (575); product builds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
