### PR TITLE
Spell a discarded value statement with the _ = discard, not a bare value

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DiscardedExpressionStatementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiscardedExpressionStatementTests.cs
@@ -1,0 +1,63 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// C# requires an expression statement to be an invocation, object creation,
+// await, or inc/decrement. A bare value left as a statement — a stack slot
+// discarded by an IL `pop`, the caught exception, a comparison — is CS0201.
+// The printer must spell such a discard with `_ =` (always valid), never as the
+// bare `value;`. A genuine statement-expression (a call) stays bare so a
+// void-returning call is not turned into the illegal `_ = VoidCall();` (CS0815).
+public class DiscardedExpressionStatementTests
+{
+    static readonly TypeRef Owner = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static string Print(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var entry = new Block(0x00);
+        entry.Add(statement);
+        entry.Add(new Return(null));
+        container.Add(entry);
+
+        var signature = new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Owner, signature, [], container);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void DiscardedStackSlot_RendersAsDiscardAssignment()
+    {
+        // An IL `pop` of a stored slot surfaces as `ExpressionStatement(LoadStackSlot)`.
+        var output = Print(new ExpressionStatement(new LoadStackSlot(0, Int32)));
+
+        Assert.Contains("_ = S_0;", output);
+    }
+
+    [Fact]
+    public void DiscardedComparison_RendersAsDiscardAssignment()
+    {
+        var comparison = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false,
+            new LoadStackSlot(0, Int32), new Constant(0, Int32));
+        var output = Print(new ExpressionStatement(comparison));
+
+        Assert.Contains("_ = ", output);
+        Assert.DoesNotContain("\nS_0 == 0;", output);
+    }
+
+    [Fact]
+    public void DiscardedVoidCall_StaysBareStatement()
+    {
+        // A call is a legal statement-expression; wrapping a void call with `_ =`
+        // would be CS0815, so it must stay the bare invocation statement.
+        var callee = new MethodRef(Owner, "DoWork", Void, [], HasThis: false);
+        var output = Print(new ExpressionStatement(new Call(callee, isVirtual: false, [])));
+
+        Assert.Contains("DoWork();", output);
+        Assert.DoesNotContain("_ =", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -860,9 +860,17 @@ public sealed partial class CSharpPrinter
             Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call,
         } when call.Arguments is [LoadArgument { Index: 0 }, ..]
             => ConstructorChainText(callee, call),
-        ExpressionStatement e => e.Expression is UnsupportedNode u
-            ? $"/* {u.Describe()} */"
-            : $"{Expression(e.Expression)};",
+        ExpressionStatement e => e.Expression switch
+        {
+            UnsupportedNode u => $"/* {u.Describe()} */",
+            // C# requires an expression statement to be an invocation, object
+            // creation, await, or inc/decrement. A bare value — a stack slot
+            // discarded by an IL `pop`, a comparison, the caught exception, an
+            // operator-spelled call (`a != b`) — is CS0201 as a statement, so
+            // spell the discard explicitly with `_ =`, which is always valid.
+            { } expr when !IsStatementExpression(expr) => $"_ = {Expression(expr)};",
+            { } expr => $"{Expression(expr)};",
+        },
         // Storing into a ref-typed local rebinds the reference itself (stloc of
         // a managed pointer), not a write-through — that is C#'s ref
         // (re)assignment, which takes `= ref <place>` on both the initial
@@ -1232,6 +1240,19 @@ public sealed partial class CSharpPrinter
 
     /// <summary>True when a non-instance call renders as a C# operator (`a != b`, `-x`) rather than a method invocation — the compound form that must parenthesize as an operand.</summary>
     bool IsOperatorCall(Call call) => !call.Callee.HasThis && call.Callee.IsSpecialName && OperatorSpelling(call) is not null;
+
+    /// <summary>
+    /// True when an expression is legal as a C# expression statement: an
+    /// invocation, object creation, await, or inc/decrement. An operator-spelled
+    /// call (`a != b`) renders as a value, not a statement, so it is excluded.
+    /// Any other value is CS0201 as a statement and must be discarded with `_ =`.
+    /// </summary>
+    bool IsStatementExpression(IrExpression expression) => expression switch
+    {
+        Call call => !IsOperatorCall(call),
+        CallIndirect or NewObject or IncrementDecrement or AwaitExpression or LocalFunctionInvocation => true,
+        _ => false,
+    };
 
     /// <summary>
     /// True when <paramref name="type"/> is a value type, so an <c>isinst</c>


### PR DESCRIPTION
## Problem

An expression statement whose expression is a pure value renders as the bare `value;` — which is **CS0201**: C# only accepts an invocation, object creation, `await`, or increment/decrement as an expression statement. This was the largest remaining syntactic-validity cluster.

It surfaces from several shapes, e.g. a stack slot discarded by an IL `pop` (the `as ... ?? throw` / validate-and-reuse idiom in `System.Delegate::CreateDelegate`):

```csharp
if (S_256 is null)
{
    S_0;                       // CS0201 — bare discarded slot
    throw new ArgumentException(...);
}
```

Other instances: the caught exception (`__exception;`), a discarded comparison (`typeof(T) == typeof(nint);`).

## Fix

The discard now spells `_ = value;`, which is always valid and preserves the "a value was computed and dropped here" intent:

```csharp
if (S_256 is null)
{
    _ = S_0;
    throw new ArgumentException(...);
}
```

A genuine statement-expression (a call) stays bare, so a **void-returning** call is not turned into the illegal `_ = VoidCall();` (CS0815). The new `IsStatementExpression` predicate draws that line and excludes operator-spelled calls (`a != b` is not a statement).

## Impact

- Corpus syntactic validity: **Full malformed 792 -> 530 (-262 methods)**; Partial malformed 4 -> 0.
- Fidelity neutral: inventory 40987/41012 Full, 0 importer bugs (these methods could not parse before, so none were recompile-Full; the count is unchanged).
- Pinned the discard rendering, the comparison case, and the void-call negative with `DiscardedExpressionStatementTests` (built directly from IR).
- 572 decompiler + 1157 product tests green.
