### PR TITLE
Raise arity-2 tuple binary operators

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1008,6 +1008,10 @@ public class CfgSampleClass
 
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
+    public static bool TupleValueEquals((int Sum, int Product) left, (int Sum, int Product) right) => left == right;
+
+    public static bool TupleValueNotEquals((int Sum, int Product) left, (int Sum, int Product) right) => left != right;
+
     public static int DeconstructTuplePair((int Sum, int Product) pair)
     {
         (int sum, int product) = pair;

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -23,6 +23,8 @@ public class IdiomShapeScorecardTests
         new("SwitchRaisingPass", nameof(CfgSampleClass.SmallStringSwitch), SyntaxKind.SwitchStatement, [SyntaxKind.GotoStatement]),
         new("SwitchRaisingPass", nameof(CfgSampleClass.ClassifyMode), SyntaxKind.SwitchStatement, [SyntaxKind.IfStatement]),
         new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("TupleBinaryOperatorPass", nameof(CfgSampleClass.TupleValueEquals), SyntaxKind.EqualsExpression, [SyntaxKind.ConditionalExpression]),
+        new("TupleBinaryOperatorPass", nameof(CfgSampleClass.TupleValueNotEquals), SyntaxKind.NotEqualsExpression, [SyntaxKind.ConditionalExpression]),
         new("AnonymousObjectPass", nameof(CfgSampleClass.AnonShorthand), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),
         new("AwaitRecoveryPass", nameof(CfgSampleClass.AwaitOnce), SyntaxKind.AwaitExpression, [SyntaxKind.InvocationExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -1,0 +1,110 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TupleBinaryOperatorPassTests
+{
+    static IrFunction Raised(string methodName, Type? type = null)
+    {
+        type ??= typeof(CfgSampleClass);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void TupleValueEquality_RaisesToTupleBinaryExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleValueEquals));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.True(tupleBinary.IsEquality);
+        Assert.StartsWith("ValueTuple<", tupleBinary.TupleType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+    }
+
+    [Fact]
+    public void TupleValueInequality_RaisesToTupleBinaryExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleValueNotEquals));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.False(tupleBinary.IsEquality);
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersTupleEqualityOperator()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.TupleValueEquals))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return left == right;", output);
+        Assert.DoesNotContain(".Item", output);
+        Assert.DoesNotContain(" ? ", output);
+    }
+
+    [Fact]
+    public void PrintRaised_RendersTupleInequalityOperator()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.TupleValueNotEquals))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return left != right;", output);
+        Assert.DoesNotContain(".Item", output);
+        Assert.DoesNotContain(" ? ", output);
+    }
+
+    [Fact]
+    public void TupleLiteralComparison_IsNotRaised()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.TupleLiteralEquals), typeof(TupleBinaryAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("return a == c && b == d;", output);
+    }
+
+    [Fact]
+    public void DirectManualTupleFieldComparison_IsNotRaised()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.DirectManualTupleFields), typeof(TupleBinaryAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".Item1", output);
+        Assert.Contains(".Item2", output);
+    }
+
+    [Fact]
+    public void SourceNamedLocalTupleFieldComparison_IsNotRaised()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.SourceNamedLocalTupleFields), typeof(TupleBinaryAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".Item1", output);
+        Assert.Contains(".Item2", output);
+    }
+}
+
+public static class TupleBinaryAdversarialSamples
+{
+    public static bool TupleLiteralEquals(int a, int b, int c, int d) => (a, b) == (c, d);
+
+    public static bool DirectManualTupleFields((int Sum, int Product) left, (int Sum, int Product) right)
+        => left.Sum == right.Sum && left.Product == right.Product;
+
+    public static bool SourceNamedLocalTupleFields((int Sum, int Product) left, (int Sum, int Product) right)
+    {
+        var leftCopy = left;
+        var rightCopy = right;
+        return leftCopy.Sum == rightCopy.Sum && leftCopy.Product == rightCopy.Product;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -24,5 +24,16 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
             PositiveCoverage: "DeconstructionAssignmentPassTests ValueTuple field-store and Deconstruct-method fixtures",
             AdversarialCoverage: "DeconstructionAssignmentPassTests manual tuple field access and user ValueTuple lookalike",
             MissingDiscriminator: "nested/rest tuples, mixed declaration/assignment targets, and broader receiver forms still owed"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.TupleBinaryOperator)),
+            typeof(TupleBinaryOperatorPass),
+            [
+                new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
+                new FactPrimitive("pdb.hidden-local", "absence of source local names on operand spills"),
+            ],
+            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 tuple equality and inequality fixtures",
+            AdversarialCoverage: "TupleBinaryOperatorPassTests direct field comparison, source-named local comparison, and tuple-literal negatives",
+            MissingDiscriminator: "arity 3+, nested/rest tuples, tuple literals, and no-PDB source local comparisons still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -973,6 +973,7 @@ public sealed partial class CSharpPrinter
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
+        TupleBinaryExpression t => $"{Operand(t.Left)} {(t.IsEquality ? "==" : "!=")} {Operand(t.Right)}",
         AnonymousObject a => AnonymousObjectText(a),
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
         InitializerBlock ib => InitializerBodyText(ib.IsCollection, ib.Entries),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1254,6 +1254,30 @@ public sealed class TupleExpression : IrExpression
 }
 
 /// <summary>
+/// A raised C# tuple binary operator, produced from csc's hidden ValueTuple
+/// operand spills and element-wise comparison lowering.
+/// </summary>
+public sealed class TupleBinaryExpression : IrExpression
+{
+    public TupleBinaryExpression(bool isEquality, TypeRef tupleType, IrExpression left, IrExpression right)
+    {
+        IsEquality = isEquality;
+        TupleType = tupleType;
+        AddChild(left);
+        AddChild(right);
+    }
+
+    public bool IsEquality { get; }
+    public TypeRef TupleType { get; }
+    public IrExpression Left => (IrExpression)Children[0];
+    public IrExpression Right => (IrExpression)Children[1];
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+    public override IEnumerable<TypeRef> DirectTypes => [TupleType];
+
+    public override string Describe() => IsEquality ? "TupleBinary ==" : "TupleBinary !=";
+}
+
+/// <summary>
 /// A raised tuple deconstruction, produced by
 /// <see cref="DeconstructionAssignmentPass"/> from the compiler's
 /// <c>ValueTuple</c> receiver spill followed by sequential <c>ItemN</c> stores.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -105,6 +105,10 @@ public static class IrPasses
         new LockSugarPass(),
         new ForLoopPass(),
         new BooleanFoldingPass(),
+        // Raise csc's arity-2 tuple-valued ==/!= lowering after boolean folding
+        // has collapsed the element-comparison diamond into a ternary, and
+        // before inlining erases the result slot that marks the shape.
+        new TupleBinaryOperatorPass(),
         // Raise local `if (V is null) V = fallback;` diamonds into `V ??= fallback`.
         // Runs after structuring/boolean folding so the null test is a shaped
         // IfStatement, before later expression inlining reshapes local uses.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -110,7 +110,8 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass SwitchExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();
-    [Completeness(CompletenessLevel.None, "(a, b) == (c, d)")] public static Unhandled TupleBinaryOperator => default!;
+    [Completeness(CompletenessLevel.Partial, "arity-2 tuple-valued `==`/`!=` with hidden ValueTuple operand spills; tuple literals, arity 3+, nested/rest tuples, and source-named local field comparisons not raised")]
+    public static TupleBinaryOperatorPass TupleBinaryOperator => new();
     [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative UnaryOperator => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
@@ -1,0 +1,201 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises csc's arity-2 tuple-valued <c>==</c>/<c>!=</c> lowering back into the
+/// tuple binary operator. The proof is the pair of hidden ValueTuple operand
+/// spills feeding ordered <c>Item1</c>/<c>Item2</c> comparisons.
+/// </summary>
+public sealed class TupleBinaryOperatorPass : IIrPass
+{
+    public string Name => "tuple-binary-operator";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (RaiseOnce(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool RaiseOnce(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            for (int i = 2; i < block.Children.Count; i++)
+            {
+                if (TryRaiseReturnAt(function, block, i, stepper)
+                    || i < block.Children.Count - 1 && TryRaiseSlotAt(function, block, i, stepper))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static bool TryRaiseReturnAt(IrFunction function, Block block, int returnIndex, Stepper stepper)
+    {
+        if (!TryGetOperandSpills(function, block, returnIndex, out var leftStore, out var rightStore, out var tupleType)
+            || block.Children[returnIndex] is not Return { Value: LogicalBinary logical }
+            || !TryMatchArity2Logical(logical, leftStore.Index, rightStore.Index, tupleType, out bool isEquality))
+        {
+            return false;
+        }
+
+        var tupleBinary = BuildTupleBinary(leftStore, rightStore, tupleType, isEquality, logical);
+
+        stepper.StepOver("raise ValueTuple element comparisons to tuple binary operator", logical);
+        logical.ReplaceWith(tupleBinary);
+        leftStore.Detach();
+        rightStore.Detach();
+        return true;
+    }
+
+    static bool TryRaiseSlotAt(IrFunction function, Block block, int resultIndex, Stepper stepper)
+    {
+        if (!TryGetOperandSpills(function, block, resultIndex, out var leftStore, out var rightStore, out var tupleType)
+            || block.Children[resultIndex] is not StoreStackSlot { Value: Conditional conditional } resultStore
+            || block.Children[resultIndex + 1] is not Return { Value: LoadStackSlot returned }
+            || returned.Slot != resultStore.Slot
+            || !TryMatchArity2Conditional(conditional, leftStore.Index, rightStore.Index, tupleType, out bool isEquality))
+        {
+            return false;
+        }
+
+        var tupleBinary = BuildTupleBinary(leftStore, rightStore, tupleType, isEquality, conditional);
+
+        stepper.StepOver("raise ValueTuple element comparisons to tuple binary operator", conditional);
+        conditional.ReplaceWith(tupleBinary);
+        leftStore.Detach();
+        rightStore.Detach();
+        return true;
+    }
+
+    static bool TryGetOperandSpills(
+        IrFunction function,
+        Block block,
+        int consumerIndex,
+        out StoreLocal leftStore,
+        out StoreLocal rightStore,
+        out TypeRef tupleType)
+    {
+        leftStore = null!;
+        rightStore = null!;
+        tupleType = null!;
+        if (block.Children[consumerIndex - 2] is not StoreLocal left
+            || block.Children[consumerIndex - 1] is not StoreLocal right
+            || HasSourceLocalName(function, left.Index)
+            || HasSourceLocalName(function, right.Index)
+            || !left.Type.Equals(right.Type)
+            || !MemberIdentity.IsSupportedValueTupleType(left.Type, out var arity)
+            || arity != 2)
+        {
+            return false;
+        }
+
+        leftStore = left;
+        rightStore = right;
+        tupleType = left.Type;
+        return true;
+    }
+
+    static TupleBinaryExpression BuildTupleBinary(
+        StoreLocal leftStore,
+        StoreLocal rightStore,
+        TypeRef tupleType,
+        bool isEquality,
+        IrNode source)
+    {
+        var left = (IrExpression)leftStore.DetachChildren()[0];
+        var right = (IrExpression)rightStore.DetachChildren()[0];
+        var tupleBinary = new TupleBinaryExpression(isEquality, tupleType, left, right);
+        tupleBinary.InheritSourceOffset(source);
+        return tupleBinary;
+    }
+
+    static bool TryMatchArity2Conditional(
+        Conditional conditional,
+        int leftLocal,
+        int rightLocal,
+        TypeRef tupleType,
+        out bool isEquality)
+    {
+        isEquality = false;
+        if (!IsItemComparison(conditional.Condition, ComparisonKind.Equal, leftLocal, rightLocal, tupleType, item: 1))
+            return false;
+        if (conditional.WhenTrue is not Comparison finalComparison)
+            return false;
+        if (!IsItemComparison(finalComparison, finalComparison.Kind, leftLocal, rightLocal, tupleType, item: 2))
+            return false;
+
+        if (finalComparison.Kind == ComparisonKind.Equal
+            && conditional.WhenFalse is Constant { Value: false })
+        {
+            isEquality = true;
+            return true;
+        }
+
+        return finalComparison.Kind == ComparisonKind.NotEqual
+            && conditional.WhenFalse is Constant { Value: true };
+    }
+
+    static bool TryMatchArity2Logical(
+        LogicalBinary logical,
+        int leftLocal,
+        int rightLocal,
+        TypeRef tupleType,
+        out bool isEquality)
+    {
+        isEquality = false;
+        ComparisonKind comparisonKind;
+        switch (logical.Kind)
+        {
+            case LogicalKind.And:
+                comparisonKind = ComparisonKind.Equal;
+                break;
+            case LogicalKind.Or:
+                comparisonKind = ComparisonKind.NotEqual;
+                break;
+            default:
+                return false;
+        }
+        if (!IsItemComparison(logical.Left, comparisonKind, leftLocal, rightLocal, tupleType, item: 1)
+            || !IsItemComparison(logical.Right, comparisonKind, leftLocal, rightLocal, tupleType, item: 2))
+        {
+            return false;
+        }
+
+        isEquality = logical.Kind == LogicalKind.And;
+        return true;
+    }
+
+    static bool IsItemComparison(
+        IrExpression expression,
+        ComparisonKind kind,
+        int leftLocal,
+        int rightLocal,
+        TypeRef tupleType,
+        int item)
+        => expression is Comparison comparison
+            && !comparison.IsUnsigned
+            && comparison.Kind == kind
+            && IsTupleItemLoad(comparison.Left, leftLocal, tupleType, item)
+            && IsTupleItemLoad(comparison.Right, rightLocal, tupleType, item);
+
+    static bool IsTupleItemLoad(IrExpression expression, int local, TypeRef tupleType, int item)
+        => expression is LoadField
+        {
+            IsVolatile: false,
+            Field: { Name: var name, DeclaringType: var declaringType, Type: var fieldType },
+            Instance: LoadLocal receiver,
+        }
+        && receiver.Index == local
+        && name == $"Item{item}"
+        && declaringType.Equals(tupleType)
+        && fieldType.Equals(tupleType.TypeArguments[item - 1]);
+
+    static bool HasSourceLocalName(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && function.LocalNames[index] is { } name
+            && CSharpNaming.IsUsableIdentifier(name);
+}


### PR DESCRIPTION
## Summary
- add TupleBinaryOperatorPass and TupleBinaryExpression for arity-2 ValueTuple ==/!= recovery
- render tuple-valued comparisons as left == right / left != right
- update lowering ledger, tuple recovery facts, scorecard, and adversarial fixtures

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release