### PR TITLE
Correct the Query ledger row: declined (no IL anchor), not owed

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -47,6 +47,8 @@ Conflicts between class 1 and class 2 are rare by construction — most fixer su
 
 **3. No IL anchor — follow the oracle as a tiebreaker.** Conventions with no IL consequence at all (`var` policy, explicit types on declarations, brace style) follow the runtime `.editorconfig`, purely for corpus coherence.
 
+- LINQ query syntax (`from x in xs select f`) compiles to the *same* `Enumerable.Where/Select/...` calls as the fluent chain — query expressions are translated during binding, before any lowering, so the two forms are IL-identical. With no anchor to choose between them, the oracle decides: the runtime writes fluent method chains, so that is what we render. We do not re-sugar back to `from..select`. (This is why the `Query` row in the lowering ledger is `None`/declined, not owed.)
+
 ## Names
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -98,7 +98,8 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess => new();
-    [Completeness(CompletenessLevel.None, "from x in xs select ...")] public static Unhandled Query => default!;
+    [Completeness(CompletenessLevel.None, "declined, not owed: a query expression is translated to Enumerable.Where/Select/SelectMany/... calls during binding, before any lowering, so it leaves no IL anchor distinct from the equivalent fluent chain. It is recovered as that fluent method chain (the runtime-preferred form); re-sugaring to from..select would invent a distinction the IL does not make (taste rule case 3, no IL anchor)")]
+    public static Unhandled Query => default!;
     [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...); string/span Substring/Slice forms not raised")]
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
@@ -134,5 +135,9 @@ internal sealed class CompletenessAttribute(CompletenessLevel level, string? not
 /// <summary>Mechanism marker: the importer builds this construct directly out of the stack simulation — no raising pass, no idiom to recover.</summary>
 internal sealed class ImporterNative;
 
-/// <summary>Mechanism marker: no mechanism yet — the lowered form is emitted as-is. The owed roadmap.</summary>
+/// <summary>Mechanism marker: no raising pass. Usually the owed roadmap — the
+/// lowered form is emitted as-is until a pass recovers the idiom. The exception
+/// is a construct with no IL anchor (e.g. a query expression, translated to
+/// method calls during binding): it is rendered faithfully as its lower-sugar
+/// equivalent and is deliberately declined, not owed — the note says which.</summary>
 internal sealed class Unhandled;


### PR DESCRIPTION
## What

The `Query` row in `LoweringCoverage` read `None` / `Unhandled` with the note `"from x in xs select ..."` — which reads as **owed work**, a `from..select` raise waiting to be written. It is not, and a prior scoping pass nearly fell into building a `QueryPass` because of it.

A query expression is translated to `Enumerable.Where/Select/...` calls **during binding**, before any lowering, so it leaves **no IL anchor** distinct from the equivalent fluent chain — `from x in xs where p select f` and `xs.Where(x => p).Select(x => f)` compile byte-identically. Under the taste doc's three-class rule that is **case 3 (no IL anchor → follow the oracle)**, and the runtime writes fluent method chains, so that is the faithful rendering. Re-sugaring to `from..select` would invent a distinction the IL does not make.

## Changes (docs only)

- Rewrite the `Query` row note to say it is **declined, not owed**, and why.
- Extend the `Unhandled` marker doc to cover the no-IL-anchor decline case, so the marker isn't self-contradictory (usually the owed roadmap; a no-anchor construct rendered as its lower-sugar equivalent is declined — the note says which).
- Add LINQ query syntax as the worked **case-3 example** in `docs/decompiler-taste.md`, where the rule lives.

No mechanism or completeness change: the ledger framework forces `None ⟺ Unhandled` (ImporterNative must be Full, a pass can't be None), and we genuinely do not recover the `from..select` idiom. The correction is the documentation that says the gap is intentional.

## Verification

- `dotnet run --project src/ILInspector.Decompiler.Tests` — 566/566 (incl. `LoweringCoverageTests` consistency guard).
- `markdownlint` clean on `docs/decompiler-taste.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)