### PR TITLE
[codex] Raise noncapturing lambda local bodies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -54,8 +54,7 @@ public class IdiomShapeScorecardTests
         new("LambdaRaisingPass", nameof(CfgSampleClass.InvokeLocalCapture), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.SharedCaptureLambdas), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
-        // Owed: a lambda body that keeps a local of its own (declined by the zero-local guard).
-        new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression], CurrentlyRecovered: false),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.DoubleViaLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CapturingLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
     ];

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -7,10 +7,11 @@ public class LambdaRaisingPassTests
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_func = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`2"), [s_int, s_int]);
 
-    static string PrintRaised(string methodName)
+    static string PrintRaised(string methodName, Type? fixtureType = null)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        var type = fixtureType ?? typeof(CfgSampleClass);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
         Assert.NotNull(function);
 
         var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
@@ -35,6 +36,15 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
+    public void CapturingLocalBearingBody_StaysLowered()
+    {
+        string output = PrintRaised(nameof(LambdaLocalBodyAdversarial.CapturingLocalBody), typeof(LambdaLocalBodyAdversarial));
+
+        Assert.DoesNotContain("=>", output);
+        Assert.Contains("new Func", output);
+    }
+
+    [Fact]
     public void CapturingExpressionBody_SubstitutesCaptureAndRaisesLambda()
         => Assert.Equal("return x => x + n;", PrintRaised(nameof(CfgSampleClass.CapturingLambda)));
 
@@ -43,12 +53,15 @@ public class LambdaRaisingPassTests
         => Assert.Equal("return x => (x + a) - b;", PrintRaised(nameof(CfgSampleClass.TwoCaptureLambda)));
 
     [Fact]
-    public void LocalBearingBody_IsNotRaised()
+    public void LocalBearingBody_RaisesBlockLambdaWithNestedLocalScope()
     {
         string output = PrintRaised(nameof(CfgSampleClass.LocalBodyLambda));
 
-        Assert.DoesNotContain("=>", output);
-        Assert.Contains("new Func", output);
+        Assert.Contains("return x => {", output);
+        Assert.Contains(" = x + 1;", output);
+        Assert.Contains("return ", output);
+        Assert.Contains(" * ", output);
+        Assert.DoesNotContain("new Func", output);
     }
 
     [Fact]
@@ -125,4 +138,10 @@ public class LambdaRaisingPassTests
             [],
             body);
     }
+}
+
+public static class LambdaLocalBodyAdversarial
+{
+    public static System.Func<int, int> CapturingLocalBody(int n)
+        => x => { int y = x + n; return y * y; };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -11,9 +11,9 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated-type:lambda-holder", "GeneratedCodeIdentity.IsNonCapturingLambdaMethod"),
                 new FactPrimitive("generated-type:display-class", "GeneratedCodeIdentity.IsCapturingLambdaMethod"),
             ],
-            PositiveCoverage: "LambdaRaisingPassTests non-capturing and capturing fixtures",
-            AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata",
-            MissingDiscriminator: "local-bound bodies and expression trees need additional closure/state facts"),
+            PositiveCoverage: "LambdaRaisingPassTests non-capturing, capturing, and non-capturing local-bodied fixtures",
+            AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata and capturing local-bodied guard",
+            MissingDiscriminator: "capturing local-bound bodies and expression trees need additional closure/state facts"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.CapturedClosure)),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -82,9 +82,9 @@ public sealed partial class CSharpPrinter
     /// Renders a recovered lambda: parameter names (the delegate type supplies
     /// their types, so they stay unannotated), then <c>=&gt; expr</c> for an
     /// expression body or <c>=&gt; { ... }</c> otherwise. A single parameter
-    /// drops the parentheses. The body's arguments are self-naming on their
-    /// nodes, so this reuses the outer printer with no scope switch — sound only
-    /// because the raising pass admits only non-capturing, zero-local bodies.
+    /// drops the parentheses. Zero-local bodies reuse the current printer so
+    /// capture substitutions still bind to the outer scope; local-bearing bodies
+    /// are non-capturing and print through an isolated lambda scope.
     /// </summary>
     string LambdaText(Lambda lambda)
     {
@@ -95,11 +95,45 @@ public sealed partial class CSharpPrinter
         if (lambda.ExpressionBody is { } expr)
             return $"{parameters} => {Expression(expr)}";
 
+        if (NeedsNestedLambdaScope(lambda))
+            return $"{parameters} => {{ {LambdaBodyWithLocalScope(lambda)} }}";
+
         var statements = lambda.Body.Blocks
             .SelectMany(b => b.Children)
             .Select(LambdaStatement)
             .Where(s => s is not null);
         return $"{parameters} => {{ {string.Join(" ", statements)} }}";
+    }
+
+    static bool NeedsNestedLambdaScope(Lambda lambda)
+        => !lambda.Locals.IsEmpty
+            || lambda.Body.Descendants.Any(node => node is LoadStackSlot or StoreStackSlot);
+
+    string LambdaBodyWithLocalScope(Lambda lambda)
+    {
+        var body = lambda.Body;
+        body.Detach();
+        try
+        {
+            var function = new IrFunction(
+                "<lambda>",
+                _function.DeclaringType,
+                new MethodSignature(TypeRef.CoreLib("System", "Void"), lambda.Parameters, HasThis: false, GenericParameterCount: 0),
+                lambda.Locals,
+                body)
+            {
+                LocalNames = lambda.LocalNames,
+                UsesUpdatedMemorySafetyRules = lambda.UsesUpdatedMemorySafetyRules,
+                SkipLocalsInit = lambda.SkipLocalsInit,
+            };
+            var text = new CSharpPrinter(function).PrintBody(function).Trim();
+            return string.Join(" ", text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
+        }
+        finally
+        {
+            body.Detach();
+            lambda.ResetBody(body);
+        }
     }
 
     string? LambdaStatement(IrNode node) => node switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -210,15 +210,15 @@ public sealed partial class CSharpPrinter
     {
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
-        foreach (var fixedNode in function.Descendants.OfType<Fixed>())
+        foreach (var fixedNode in DescendantsOutsideLambdas(function).OfType<Fixed>())
             _fixedLocals.Add(fixedNode.LocalIndex);
-        foreach (var usingNode in function.Descendants.OfType<UsingStatement>())
+        foreach (var usingNode in DescendantsOutsideLambdas(function).OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
-        foreach (var foreachNode in function.Descendants.OfType<ForeachStatement>())
+        foreach (var foreachNode in DescendantsOutsideLambdas(function).OfType<ForeachStatement>())
             _foreachLocals.Add(foreachNode.LocalIndex);
-        foreach (var pattern in function.Descendants.OfType<IsPattern>())
+        foreach (var pattern in DescendantsOutsideLambdas(function).OfType<IsPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
-        foreach (var deconstruction in function.Descendants.OfType<DeconstructionAssignment>())
+        foreach (var deconstruction in DescendantsOutsideLambdas(function).OfType<DeconstructionAssignment>())
             if (deconstruction.IsDeclaration)
                 foreach (int index in deconstruction.LocalIndices)
                     _deconstructionLocals.Add(index);
@@ -293,7 +293,7 @@ public sealed partial class CSharpPrinter
     static HashSet<int> CollectBranchTargets(IrFunction function)
     {
         var targets = new HashSet<int>();
-        foreach (var node in function.Descendants)
+        foreach (var node in DescendantsOutsideLambdas(function))
         {
             switch (node)
             {
@@ -317,7 +317,7 @@ public sealed partial class CSharpPrinter
             .Where(clause => clause.VariableIndex is not null)
             .Select(clause => clause.VariableIndex!.Value)
             .ToHashSet();
-        foreach (var node in function.Descendants)
+        foreach (var node in DescendantsOutsideLambdas(function))
         {
             switch (node)
             {
@@ -404,9 +404,9 @@ public sealed partial class CSharpPrinter
         // once, up front, with its merged type — declaring it at one store would
         // type it from that branch's value and strand the other branch's store.
         var slotStoreCounts = new Dictionary<int, int>();
-        foreach (var store in function.Descendants.OfType<StoreStackSlot>())
+        foreach (var store in DescendantsOutsideLambdas(function).OfType<StoreStackSlot>())
             slotStoreCounts[store.Slot] = slotStoreCounts.GetValueOrDefault(store.Slot) + 1;
-        foreach (var node in function.Descendants)
+        foreach (var node in DescendantsOutsideLambdas(function))
         {
             switch (node)
             {
@@ -469,7 +469,7 @@ public sealed partial class CSharpPrinter
 
     /// <summary>True when the local slot is read (loaded by value or address) anywhere in the body.</summary>
     static bool LocalIsRead(IrFunction function, int index)
-        => function.Descendants.Any(n =>
+        => DescendantsOutsideLambdas(function).Any(n =>
             (n is LoadLocal load && load.Index == index)
             || (n is LoadLocalAddress address && address.Index == index));
 
@@ -477,7 +477,7 @@ public sealed partial class CSharpPrinter
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
     {
         IrNode? last = null;
-        foreach (var node in function.Descendants)
+        foreach (var node in DescendantsOutsideLambdas(function))
         {
             if (node is LoadLocal load && load.Index == localIndex
                 || node is StoreLocal store && store.Index == localIndex
@@ -492,6 +492,18 @@ public sealed partial class CSharpPrinter
                 return true;
         }
         return false;
+    }
+
+    static IEnumerable<IrNode> DescendantsOutsideLambdas(IrNode node)
+    {
+        foreach (var child in node.Children)
+        {
+            yield return child;
+            if (child is Lambda)
+                continue;
+            foreach (var descendant in DescendantsOutsideLambdas(child))
+                yield return descendant;
+        }
     }
 
     /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -56,7 +56,7 @@ static class DefiniteAssignment
         {
             if (node is null)
                 return;
-            foreach (var n in node.Descendants.Prepend(node))
+            foreach (var n in SelfAndDescendantsOutsideLambdas(node))
             {
                 int? read = n switch
                 {
@@ -67,6 +67,16 @@ static class DefiniteAssignment
                 if (read is { } index && !assigned.Contains(index))
                     readEarly.Add(index);
             }
+        }
+
+        static IEnumerable<IrNode> SelfAndDescendantsOutsideLambdas(IrNode node)
+        {
+            yield return node;
+            if (node is Lambda)
+                yield break;
+            foreach (var child in node.Children)
+                foreach (var descendant in SelfAndDescendantsOutsideLambdas(child))
+                    yield return descendant;
         }
 
         // assigned is the set definitely assigned on entry; it is mutated to the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1509,27 +1509,46 @@ public sealed class DelegateCreation : IrExpression
 /// (the synthesized method's block container, imported and run through the
 /// pipeline). The result type is the delegate type the lambda is converted to.
 ///
-/// <para>Non-capturing, zero-local bodies only for now: the body reads no
-/// display-class state and declares no locals, so it prints inside the outer
-/// function's scope without a local context of its own (arguments are
-/// self-naming on the node). A capturing body, or one with its own locals, needs
-/// the printer to switch scope when it descends here — a later increment.</para>
+/// <para>Non-capturing bodies may carry their own locals; the printer switches
+/// to this nested scope when needed. Capturing bodies still print in the outer
+/// function scope after capture substitution.</para>
 /// </summary>
 public sealed class Lambda : IrExpression
 {
-    public Lambda(TypeRef delegateType, ImmutableArray<Parameter> parameters, BlockContainer body)
+    public Lambda(
+        TypeRef delegateType,
+        ImmutableArray<Parameter> parameters,
+        ImmutableArray<TypeRef> locals,
+        ImmutableArray<string?> localNames,
+        bool usesUpdatedMemorySafetyRules,
+        bool skipLocalsInit,
+        BlockContainer body)
     {
         DelegateType = delegateType;
         Parameters = parameters;
+        Locals = locals;
+        LocalNames = localNames;
+        UsesUpdatedMemorySafetyRules = usesUpdatedMemorySafetyRules;
+        SkipLocalsInit = skipLocalsInit;
         AddChild(body);
     }
 
     public TypeRef DelegateType { get; }
     public ImmutableArray<Parameter> Parameters { get; }
+    public ImmutableArray<TypeRef> Locals { get; }
+    public ImmutableArray<string?> LocalNames { get; }
+    public bool UsesUpdatedMemorySafetyRules { get; }
+    public bool SkipLocalsInit { get; }
     public BlockContainer Body => (BlockContainer)Children[0];
     public override TypeRef? ResultType => DelegateType;
     public override IEnumerable<TypeRef> DirectTypes
         => Parameters.Select(p => p.Type).Append(DelegateType);
+
+    public void ResetBody(BlockContainer body)
+    {
+        DetachChildren();
+        AddChild(body);
+    }
 
     /// <summary>
     /// The single returned expression when the body is one block ending in a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -13,13 +13,14 @@ namespace ILInspector.Decompiler.Pipeline;
 ///
 /// <para><see cref="DelegateConstructionPass"/> raises a method-group delegate —
 /// but that is a LocalRewriter <c>DelegateCreationExpression</c> (already Full),
-/// not a closure. <see cref="LambdaRaisingPass"/> recovers zero-local lambdas,
-/// non-capturing (on the <c>&lt;&gt;c</c> holder, after <see cref="LambdaCachePass"/>
-/// strips its lazy cache) and capturing (a folded <c>&lt;&gt;c__DisplayClass</c>
+/// not a closure. <see cref="LambdaRaisingPass"/> recovers non-capturing
+/// lambdas, including local/stack-slot body temporaries (on the <c>&lt;&gt;c</c>
+/// holder, after <see cref="LambdaCachePass"/> strips its lazy cache), plus
+/// zero-local capturing lambdas (a folded <c>&lt;&gt;c__DisplayClass</c>
 /// environment whose hoisted fields are substituted back into the body), and
 /// <see cref="LocalFunctionRaisingPass"/> recovers static non-capturing local
-/// functions. Capturing local functions, local-bound lambda bodies, and
-/// expression trees are still owed, so they render as synthesized
+/// functions. Capturing local-bound lambda bodies and expression trees are
+/// still owed, so they render as synthesized
 /// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — an inferior-form gap
 /// the LocalRewriter register cannot show.</para>
 ///
@@ -28,7 +29,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.Partial, "zero-local expression or simple block bodies, capturing or not; local-bound bodies still owed")]
+    [Completeness(CompletenessLevel.Partial, "expression, simple block, and non-capturing local-bound bodies; capturing local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.Partial, "static and capturing (ref struct display-class env, substituted back) local functions with a zero-local body, declared back into the host method and called by their source name; recursive, nested, and shared-environment local functions still owed")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -10,10 +10,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// synthesized method through the pass context's cross-method seam, re-presents
 /// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
 ///
-/// <para>Current slice — <b>zero-local</b> lambdas, capturing or not:</para>
+/// <para>Current slice — non-capturing lambdas may carry body locals/slots;
+/// capturing lambdas remain zero-local after capture substitution:</para>
 /// <list type="bullet">
 /// <item><b>Non-capturing</b> — the target runs on the static <c>&lt;&gt;c</c>
-/// singleton and reads no <c>this</c>.</item>
+/// singleton and reads no <c>this</c>. The lambda node carries its own
+/// local table when the body needs a nested print scope.</item>
 /// <item><b>Capturing</b> — captured variables are hoisted into a
 /// <c>&lt;&gt;c__DisplayClass</c> environment; the body's <c>this.f</c> reads are
 /// substituted with the captured values, which then print in the outer scope.
@@ -24,11 +26,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// display class read in any way other than its capture stores and lambda
 /// delegate targets is left as-is.</item>
 /// </list>
-/// <para>In both cases the body must carry compiler-generated metadata evidence,
-/// declare no locals of its own, and be a single <c>return expr;</c> or a simple
-/// block ending in a return — bodies that print correctly inside the outer
-/// function's scope (arguments are self-naming). A no-op when the seam is absent
-/// (stage dumps, the lowered/annotated views).</para>
+/// <para>In all cases the body must carry compiler-generated metadata evidence
+/// and be a single <c>return expr;</c> or a simple block ending in a return.
+/// Capturing bodies still need to print in the outer function scope, so they
+/// keep the zero-local guard. A no-op when the seam is absent (stage dumps, the
+/// lowered/annotated views).</para>
 /// </summary>
 public sealed class LambdaRaisingPass : IIrPass
 {
@@ -70,7 +72,7 @@ public sealed class LambdaRaisingPass : IIrPass
         if (body.Descendants.OfType<LoadArgument>().Any(a => a.Index == 0))
             return null;
 
-        return Finish(creation, body, creation);
+        return Finish(creation, body, creation, allowLocals: true);
     }
 
     static Lambda? RaiseCapturing(DelegateCreation creation, PassContext context)
@@ -202,7 +204,7 @@ public sealed class LambdaRaisingPass : IIrPass
                 load.ReplaceWith(value.Clone());
         }
 
-        return Finish(creation, body, provenance);
+        return Finish(creation, body, provenance, allowLocals: false);
     }
 
     // A hoisted capture binds a variable, not an expression: a parameter/this load
@@ -234,15 +236,17 @@ public sealed class LambdaRaisingPass : IIrPass
         return body;
     }
 
-    // Shared finisher: admit only a body that prints soundly in the outer scope —
-    // no locals of its own, nothing unsupported, and a single printable block.
-    static Lambda? Finish(DelegateCreation creation, IrFunction body, IrNode provenance)
+    // Shared finisher: admit only a body that prints soundly in the target scope.
+    // Capturing lambdas still print in the outer scope after substitution, so
+    // they keep the zero-local restriction. Non-capturing bodies can carry their
+    // own local table and print in a nested lambda scope.
+    static Lambda? Finish(DelegateCreation creation, IrFunction body, IrNode provenance, bool allowLocals)
     {
-        if (!body.Locals.IsEmpty)
+        if (!allowLocals && !body.Locals.IsEmpty)
             return null;
         if (body.Descendants.OfType<UnsupportedNode>().Any())
             return null;
-        if (!IsPrintableBody(body))
+        if (!IsPrintableBody(body, allowLocals))
             return null;
 
         var container = body.Body;
@@ -258,7 +262,14 @@ public sealed class LambdaRaisingPass : IIrPass
         // allocation) anchor to this statement.
         foreach (var node in Self(container))
             node.SetSourceOffset(-1);
-        var lambda = new Lambda(creation.DelegateType, body.Signature.Parameters, container);
+        var lambda = new Lambda(
+            creation.DelegateType,
+            body.Signature.Parameters,
+            body.Locals,
+            body.LocalNames,
+            body.UsesUpdatedMemorySafetyRules,
+            body.SkipLocalsInit,
+            container);
         lambda.InheritSourceOffset(provenance);
         return lambda;
     }
@@ -270,7 +281,7 @@ public sealed class LambdaRaisingPass : IIrPass
             yield return descendant;
     }
 
-    static bool IsPrintableBody(IrFunction body)
+    static bool IsPrintableBody(IrFunction body, bool allowLocalStatements = false)
     {
         if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
             return false;
@@ -280,6 +291,12 @@ public sealed class LambdaRaisingPass : IIrPass
             var statement = statements[i];
             if (statement is Return { Value: not null })
                 return i == statements.Count - 1;
+            if (statement is ExpressionStatement)
+                continue;
+            if (allowLocalStatements && statement is StoreLocal)
+                continue;
+            if (allowLocalStatements && statement is StoreStackSlot)
+                continue;
             if (statement is not ExpressionStatement)
                 return false;
         }


### PR DESCRIPTION
## Summary

- Raise non-capturing lambda bodies that need their own local/stack-slot scope back to block lambdas.
- Keep capturing local-bodied lambdas lowered as an adversarial boundary until capture substitution has a safe nested-scope representation.
- Prevent nested lambda locals/slots from leaking into enclosing printer declaration and definite-assignment analysis.
- Move the lambda scorecard row forward and narrow the closure ledger/fact notes to the remaining capturing local-bodied gap.

## Why

`CfgSampleClass.LocalBodyLambda` was the remaining unrecovered lambda scorecard row. The existing raise stopped at the delegate-cache form because lambda bodies with local/slot temporaries could not print in an isolated nested scope.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*LambdaRaisingPassTests*" -method "*IdiomShapeScorecardTests*" -method "*LoweringFactCatalogTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*FidelityGateTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `git diff --check`
