### PR TITLE
Fix capturing local-function raise for non-first-parameter captures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -772,6 +772,28 @@ public class CfgSampleClass
         int Add(int v) => v + n;
     }
 
+    // Capturing the host's SECOND parameter (index 1). The substituted capture
+    // value is host arg 1, which shares the numeric index of the synthesized env
+    // parameter (also the last/only ref parameter) — a raise that detects leftover
+    // environment reads by raw argument index would mistake the substituted value
+    // for an unresolved environment read and decline.
+    public static int CaptureSecondParam(int x, int n)
+    {
+        return Add(5);
+
+        int Add(int v) => v + n;
+    }
+
+    // Two distinct captured variables read by the local function — exercises
+    // multi-field environment substitution; `b` again lands on the env parameter
+    // index.
+    public static int CaptureTwoVariables(int a, int b)
+    {
+        return Add(5);
+
+        int Add(int v) => v + a - b;
+    }
+
     // Adversarial negative: two local functions sharing one environment (both
     // capture `n`). The shared display-class local is referenced by both call sites,
     // so neither resolves to a clean single-use environment — must stay lowered.
@@ -790,6 +812,31 @@ public class CfgSampleClass
         return Fact(n);
 
         int Fact(int v) => v <= 1 ? 1 : v * Fact(v - 1);
+    }
+
+    // Adversarial negative: the captured variable `n` is reassigned AFTER the only
+    // call. The compiler hoists `n` into the display class, so env.n gets an
+    // initial-capture store and a post-call store. Substituting the post-call value
+    // at the body read would change the program (at the call site `n` was still its
+    // initial value), so the raise must decline.
+    public static int CaptureReassignedAfterCall(int n, int m)
+    {
+        int r = Add(5);
+        n = m;
+        return r;
+
+        int Add(int v) => v + n;
+    }
+
+    // Adversarial negative: the captured variable is reassigned before the call.
+    // Two stores to env.n mean a single substituted value is not obviously the live
+    // one; the raise stays conservative and declines.
+    public static int CaptureReassignedBeforeCall(int n, int m)
+    {
+        n = m;
+        return Add(5);
+
+        int Add(int v) => v + n;
     }
 
     static void ThrowOverflow() => throw new OverflowException();

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -59,6 +59,8 @@ public class IdiomShapeScorecardTests
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.DoubleViaLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CapturingLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
+        new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CaptureSecondParam), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
+        new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CaptureTwoVariables), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
     ];
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -169,4 +169,50 @@ public class LocalFunctionRaisingPassTests
             [],
             body);
     }
+
+    [Fact]
+    public void CapturingSecondParameter_SubstitutesDespiteIndexCollision()
+    {
+        // The captured value is host argument 1, which shares the numeric index of
+        // the synthesized env parameter; the substituted value must not be mistaken
+        // for an unresolved environment read.
+        string output = PrintRaised(nameof(CfgSampleClass.CaptureSecondParam));
+
+        Assert.Contains("return Add(5);", output);
+        Assert.Contains("int Add(int v) => v + n;", output);
+        Assert.DoesNotContain("DisplayClass", output);
+        Assert.DoesNotContain("ref ", output);
+    }
+
+    [Fact]
+    public void CapturingTwoVariables_SubstitutesEveryCapturedField()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CaptureTwoVariables));
+
+        Assert.Contains("return Add(5);", output);
+        Assert.Contains("v + a", output);
+        Assert.Contains("b", output);
+        Assert.DoesNotContain("DisplayClass", output);
+        Assert.DoesNotContain("ref ", output);
+    }
+
+    [Fact]
+    public void CaptureReassignedAfterCall_DeclinesToRaise()
+    {
+        // Reassigning the captured variable after the call means no single
+        // substituted value is live at the call site — the raise must stay honest.
+        string output = PrintRaised(nameof(CfgSampleClass.CaptureReassignedAfterCall));
+
+        Assert.DoesNotContain("int Add(int v) =>", output);     // not raised to a local function
+        Assert.Contains("DisplayClass", output);                // honest fallback to the lowered form
+    }
+
+    [Fact]
+    public void CaptureReassignedBeforeCall_DeclinesToRaise()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CaptureReassignedBeforeCall));
+
+        Assert.DoesNotContain("int Add(int v) =>", output);
+        Assert.Contains("DisplayClass", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -20,9 +20,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// it by substituting each <c>env.f</c> read in the body with the captured value,
 /// dropping the environment parameter from the declaration and the <c>ref env</c>
 /// argument from each call, and eliding the capture stores. Left as-is: an
-/// environment shared with another local function or read any other way, and a
-/// body that itself calls a local function (recursion / nesting), which keeps the
-/// import non-recursive. A no-op when the seam is absent.</para>
+/// environment shared with another local function or read any other way, a
+/// captured variable stored more than once (reassigned, so no single value is
+/// live at every call site), and a body that itself calls a local function
+/// (recursion / nesting), which keeps the import non-recursive. A no-op when the
+/// seam is absent.</para>
 /// </summary>
 public sealed class LocalFunctionRaisingPass : IIrPass
 {
@@ -149,7 +151,12 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             {
                 if (!IsCaptureValue(store.Value, function))
                     return null;
-                captures[store.Field.Name] = store.Value;
+                // Exactly one store per captured field: a second store means the
+                // captured variable is reassigned, so no single substituted value
+                // is live at every call site (the reassignment may even follow the
+                // call). Leave those to the honest fallback.
+                if (!captures.TryAdd(store.Field.Name, store.Value))
+                    return null;
                 stores.Add(store);
             }
         }
@@ -166,6 +173,22 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
     static bool SubstituteEnvironment(IrFunction body, Environment environment)
     {
+        // Every use of the environment parameter must be the receiver of a
+        // LoadField we can substitute. Check that on the original body, before
+        // substitution: the captured values cloned in below are themselves
+        // host LoadArguments, so a post-substitution index test cannot tell a
+        // leftover environment read from a substituted host argument that
+        // happens to share the same index.
+        foreach (var arg in body.Descendants.OfType<LoadArgument>())
+        {
+            if (arg.Index != environment.ArgIndex)
+                continue;
+            if (arg.Parent is not LoadField load
+                || !Equals(load.Field.DeclaringType, environment.Type)
+                || !environment.Captures.ContainsKey(load.Field.Name))
+                return false;
+        }
+
         foreach (var load in body.Descendants.OfType<LoadField>().ToList())
         {
             if (load.Instance is LoadArgument arg && arg.Index == environment.ArgIndex
@@ -173,8 +196,7 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                 && environment.Captures.TryGetValue(load.Field.Name, out var value))
                 load.ReplaceWith(value.Clone());
         }
-        // No bare read of the environment parameter may survive substitution.
-        return !body.Descendants.OfType<LoadArgument>().Any(a => a.Index == environment.ArgIndex);
+        return true;
     }
 
     static bool IsCaptureValue(IrExpression value, IrFunction function) => value switch


### PR DESCRIPTION
## Target

Bug hunt on the most recent raise (#794, capturing local functions). The idiom
scorecard is near-saturated, so per `docs/decompiler-quality.md` this is
doc-prescribed work: an adversarial/bug pass on a recent broad raise.

## Bug

`LocalFunctionRaisingPass` silently declined to raise a capturing local function
whenever a captured variable's host argument index matched the synthesized
environment parameter index, falling back to the unspeakable
`Enclosing.<Outer>g__Name|N_M(ref env)` form. `SubstituteEnvironment` replaced
each `env.field` read with a clone of the host capture value (itself a
`LoadArgument`), then detected leftover environment reads by raw argument index —
so a substituted host argument sharing that index looked like an unresolved env
read and the raise bailed. This hit two common shapes:

- capturing any non-first parameter (single capture)
- capturing two or more variables

## Fix

Detect non-substitutable environment uses on the original body *before*
substitution, instead of by post-substitution index.

Removing that accidental guard exposed a latent unsoundness:
`ResolveEnvironment` accepted a captured field stored more than once (a
reassigned variable) and substituted an arbitrary last value, which is wrong when
the reassignment does not dominate every call site (e.g. a reassignment that
follows the call). Require exactly one store per captured field so reassignment
shapes stay an honest fallback.

## Tests

- Positive fixtures `CaptureSecondParam`, `CaptureTwoVariables` with idiom
  scorecard entries — both now raise with correctly-named captures.
- Adversarial negatives `CaptureReassignedBeforeCall`, `CaptureReassignedAfterCall`
  that must not raise.
- All 551 decompiler tests pass (including the fixture fidelity gate).
- Corpus inventory identical to baseline: 40984/41012 Full, 0 importer bugs.
