### PR TITLE
Raise the array foreach lowering to foreach

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1224,6 +1224,47 @@ public class CfgSampleClass
         return result;
     }
 
+    // foreach over an array. The compiler lowers this to a hidden array-copy temp
+    // plus an indexed for loop over hidden index/length locals — no enumerator. The
+    // raise pass recovers the foreach from that indexed shape.
+    public static int ForeachArray(int[] numbers)
+    {
+        int sum = 0;
+        foreach (int n in numbers)
+            sum += n;
+        return sum;
+    }
+
+    // Adversarial: a hand-written indexed for loop over the same array. The index and
+    // the element local carry source names and the array is read directly with no
+    // copy temp, so this must stay a for loop and never raise to foreach.
+    public static int IndexedForOverArray(int[] numbers)
+    {
+        int sum = 0;
+        for (int i = 0; i < numbers.Length; i++)
+        {
+            int n = numbers[i];
+            sum += n;
+        }
+        return sum;
+    }
+
+    // Adversarial near-miss: the same indexed shape that copies the array first,
+    // matching the foreach lowering structurally. The copy and index carry source
+    // names (`copy`, `i`), so the hidden-scaffold discriminator must keep it a for
+    // loop even though the structure is identical to lowered foreach.
+    public static int CopyThenIndexedFor(int[] numbers)
+    {
+        int[] copy = numbers;
+        int sum = 0;
+        for (int i = 0; i < copy.Length; i++)
+        {
+            int n = copy[i];
+            sum += n;
+        }
+        return sum;
+    }
+
     public static Func<int, int> ClosureCapture(int offset)
     {
         return x => x + offset;

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -61,6 +61,47 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void ArrayLoop_RaisesToForeach()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachArray));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.DoesNotContain(function.Descendants.OfType<ForLoop>(), _ => true);
+    }
+
+    [Fact]
+    public void ArrayLoop_PrintRaised_RendersForeach()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ForeachArray))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("foreach (int n in numbers)", output);
+        Assert.Contains("sum += n;", output);
+        Assert.DoesNotContain(".Length", output);
+        Assert.DoesNotContain("for (", output);
+    }
+
+    [Fact]
+    public void HandWrittenIndexedForOverArray_StaysForLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.IndexedForOverArray));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
+    public void HandWrittenArrayCopyIndexedFor_StaysForLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.CopyThenIndexedFor));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
     public void SourceNamedEnumeratorUsingLoop_StaysUsingWhile()
     {
         var function = Raised(nameof(CfgSampleClass.StructUsing));

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -39,6 +39,7 @@ public class IdiomShapeScorecardTests
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
+        new("ForeachStatementPass", nameof(CfgSampleClass.ForeachArray), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -1,7 +1,10 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the narrow enumerator-lowering slice of <c>foreach</c>:
+/// Raises the compiler's two <c>foreach</c> lowerings back to a
+/// <see cref="ForeachStatement"/>.
+///
+/// <para><b>Enumerator form</b> — the general <c>IEnumerable</c> path:
 /// <code>
 /// using (var e = collection.GetEnumerator())
 /// {
@@ -12,9 +15,26 @@ namespace ILInspector.Decompiler.Pipeline;
 ///     }
 /// }
 /// </code>
-/// into <c>foreach (T item in collection) { BODY }</c>. The enumerator local must
-/// be compiler-hidden (no source local name) so hand-written using/while loops stay
-/// at their source altitude.
+/// The enumerator local must be compiler-hidden (no source local name) so
+/// hand-written using/while loops stay at their source altitude.</para>
+///
+/// <para><b>Array form</b> — a single-dimension array lowers to an indexed for
+/// loop over two hidden locals, an array copy and an index:
+/// <code>
+/// T[] a = collection;
+/// for (int i = 0; i &lt; a.Length; i++)
+/// {
+///     T item = a[i];
+///     BODY
+/// }
+/// </code>
+/// (structuring + <see cref="ForLoopPass"/> leave it a <see cref="ForLoop"/>).
+/// The array copy and index are the discriminator: a hand-written indexed for
+/// loop reads the array directly and names its index, so it never matches; even
+/// one that copies the array stays a for loop because its copy and index carry
+/// source names. Both slots must be referenced <em>only</em> by the lowered
+/// shape across the whole function — a reference anywhere else means the slots
+/// are not the hidden foreach scaffolding.</para>
 /// </summary>
 public sealed class ForeachStatementPass : IIrPass
 {
@@ -24,7 +44,7 @@ public sealed class ForeachStatementPass : IIrPass
     {
         foreach (var usingStatement in function.Descendants.OfType<UsingStatement>().ToList())
         {
-            if (TryMatch(function, usingStatement) is not { } match)
+            if (TryMatchEnumerator(function, usingStatement) is not { } match)
                 continue;
 
             var collection = match.Collection;
@@ -37,11 +57,28 @@ public sealed class ForeachStatementPass : IIrPass
             usingStatement.ReplaceWith(foreachStatement);
             return;
         }
+
+        foreach (var loop in function.Descendants.OfType<ForLoop>().ToList())
+        {
+            if (TryMatchArray(function, loop) is not { } match)
+                continue;
+
+            var collection = match.ArrayCopy.Value;
+            collection.Detach();
+            match.ItemStore.Detach();
+            var body = loop.Body;
+            body.Detach();
+            var foreachStatement = new ForeachStatement(match.ItemStore.Index, match.ItemStore.Type, collection, body);
+            context.Stepper.StepOver("raise indexed array loop to foreach", loop);
+            loop.ReplaceWith(foreachStatement);
+            match.ArrayCopy.Detach();
+            return;
+        }
     }
 
-    sealed record Match(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
+    sealed record EnumeratorMatch(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
 
-    static Match? TryMatch(IrFunction function, UsingStatement usingStatement)
+    static EnumeratorMatch? TryMatchEnumerator(IrFunction function, UsingStatement usingStatement)
     {
         int enumeratorIndex = usingStatement.LocalIndex;
         if (HasSourceLocalName(function, enumeratorIndex))
@@ -62,10 +99,73 @@ public sealed class ForeachStatementPass : IIrPass
             return null;
         }
 
-        if (loop.Body.Children.Skip(1).Any(child => ReferencesEnumerator(child, enumeratorIndex)))
+        if (loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
             return null;
 
-        return new Match(getEnumerator.Arguments[0], loop, currentStore);
+        return new EnumeratorMatch(getEnumerator.Arguments[0], loop, currentStore);
+    }
+
+    sealed record ArrayMatch(StoreLocal ArrayCopy, StoreLocal ItemStore);
+
+    static ArrayMatch? TryMatchArray(IrFunction function, ForLoop loop)
+    {
+        // The array copy is the statement immediately before the loop.
+        if (loop.Parent is not Block block || loop.ChildIndex == 0)
+            return null;
+        if (block.Children[loop.ChildIndex - 1] is not StoreLocal arrayCopy)
+            return null;
+        int arrayIndex = arrayCopy.Index;
+
+        // init: i = 0
+        if (loop.Initializer is not StoreLocal { Value: Constant { Value: 0 } } initStore)
+            return null;
+        int indexIndex = initStore.Index;
+        if (indexIndex == arrayIndex)
+            return null;
+
+        // condition: i < a.Length (signed)
+        if (loop.Condition is not Comparison { Kind: ComparisonKind.LessThan, IsUnsigned: false } comparison
+            || !IsLoad(comparison.Left, indexIndex)
+            || comparison.Right is not ArrayLength { Array: var lengthArray }
+            || !IsLoad(lengthArray, arrayIndex))
+        {
+            return null;
+        }
+
+        // increment: i = i + 1
+        if (loop.Increment is not StoreLocal { Index: var incIndex, Value: Binary { Kind: BinaryKind.Add, Left: var incLeft, Right: Constant { Value: 1 } } }
+            || incIndex != indexIndex
+            || !IsLoad(incLeft, indexIndex))
+        {
+            return null;
+        }
+
+        // body opens with: item = a[i]
+        if (loop.Body.Children is not [StoreLocal { Value: LoadElement { Array: var elementArray, Index: var elementIndex } } itemStore, ..]
+            || !IsLoad(elementArray, arrayIndex)
+            || !IsLoad(elementIndex, indexIndex))
+        {
+            return null;
+        }
+        if (itemStore.Index == arrayIndex || itemStore.Index == indexIndex)
+            return null;
+
+        // Both scaffold locals must be compiler-hidden; the item local may carry
+        // the source foreach-variable name, but the copy and index never do.
+        if (HasSourceLocalName(function, arrayIndex) || HasSourceLocalName(function, indexIndex))
+            return null;
+
+        // Whole-function safety: the copy and index slots are referenced only by
+        // the nodes this shape consumes. Anything else means they are not the
+        // hidden scaffolding (hand-written IL wearing the same shape, slot reuse).
+        var allowed = new HashSet<IrNode>(ReferenceEqualityComparer.Instance)
+        {
+            arrayCopy, initStore, comparison.Left, lengthArray, loop.Increment, incLeft, elementArray, elementIndex,
+        };
+        if (!ReferencedOnlyBy(function, arrayIndex, allowed) || !ReferencedOnlyBy(function, indexIndex, allowed))
+            return null;
+
+        return new ArrayMatch(arrayCopy, itemStore);
     }
 
     static bool HasSourceLocalName(IrFunction function, int index)
@@ -94,12 +194,32 @@ public sealed class ForeachStatementPass : IIrPass
         _ => false,
     };
 
-    static bool ReferencesEnumerator(IrNode node, int enumeratorIndex)
+    static bool IsLoad(IrExpression expression, int index)
+        => expression is LoadLocal load && load.Index == index;
+
+    static bool ReferencesLocal(IrNode node, int index)
         => node.Descendants.Prepend(node).Any(candidate => candidate switch
         {
-            LoadLocal load => load.Index == enumeratorIndex,
-            LoadLocalAddress address => address.Index == enumeratorIndex,
-            StoreLocal store => store.Index == enumeratorIndex,
+            LoadLocal load => load.Index == index,
+            LoadLocalAddress address => address.Index == index,
+            StoreLocal store => store.Index == index,
             _ => false,
         });
+
+    static bool ReferencedOnlyBy(IrFunction function, int index, HashSet<IrNode> allowed)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                StoreLocal store => store.Index == index,
+                _ => false,
+            };
+            if (references && !allowed.Contains(node))
+                return false;
+        }
+        return true;
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -164,7 +164,8 @@ public static class IrPasses
         // using statement. Runs after return sinking so a `return` from inside
         // the protected body stays inside the using body.
         new UsingStatementPass(),
-        // Raise compiler-hidden enumerator using/while/current loops to foreach.
+        // Raise compiler-hidden enumerator using/while/current loops and the
+        // indexed array lowering to foreach.
         new ForeachStatementPass(),
         // Raise the csc pin lowering (a pinned managed-ref local + derived
         // pointer + optional unpin store) into fixed (T* p = &place) { ... }.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -69,7 +69,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ExpressionStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field => default!;
     [Completeness(CompletenessLevel.Full)] public static FixedStatementPass FixedStatement => new();
-    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local; arrays and custom pattern enumerators not raised")]
+    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local, and the single-dimension array lowering (hidden array-copy + index for loop); string foreach, multidimensional arrays, and custom pattern enumerators not raised")]
     public static ForeachStatementPass ForEachStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static ForLoopPass ForStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative FunctionPointerInvocation => default!;


### PR DESCRIPTION
## Target

Sharpens the `ForEachStatement` `Partial` ledger row, whose note owed *"arrays and custom pattern enumerators not raised."* `foreach` over an array is one of the most common source shapes; it currently comes back as a raw indexed `for` loop. A scorecard climb users recognize in source, with a clean single discriminator.

## Change

Extends `ForeachStatementPass` to recover `foreach (T item in array)` from the compiler's indexed array lowering:

```
int[] a = collection;                          foreach (T item in collection)
for (int i = 0; i < a.Length; i++)     ─────►   { BODY }
{ T item = a[i]; BODY }
```

Folded into the existing pass (not a new one) so the single Roslyn `ForEachStatement` lowering keeps one ledger mechanism — `LoweringCoverageTests` requires every pipeline pass map to a ledger property.

## Discriminator & soundness

The two **compiler-hidden** scaffold locals (the array copy and the index) are the discriminator:

- A hand-written `for (int i = 0; i < arr.Length; i++) { var n = arr[i]; }` reads the array directly with a source-named index → stays a `for` loop.
- Even one that copies the array first (`int[] copy = arr; for (...)`) stays a `for` loop because `copy`/`i` carry source names.

Both slots are scanned **whole-function**: any reference outside the lowered shape (slot reuse, hand-written IL wearing the shape) declines the raise.

## Fixtures

| Fixture | Role |
| --- | --- |
| `ForeachArray` | positive — raises |
| `IndexedForOverArray` | negative — direct array read, source-named index |
| `CopyThenIndexedFor` | near-miss — **structurally identical** to the lowering, differs only by source-named locals |

Scorecard row added; ledger note updated to list string `foreach`, multidimensional arrays, and custom pattern enumerators as still owed.

## Verification

- **575/575** `ILInspector.Decompiler.Tests` — including `FidelityGateTests` (raised `foreach` recompiles to byte-identical IL) and `CorpusSweepGateTests` (CoreLib floors held).
- **1157/1157** `dotnet-inspect.Tests` (lowered-C# consumers unaffected).
- `--pass-impact foreach-statement` over CoreLib: **117/41159** methods now raise (e.g. `HashSet.UnionWith`, `CollectionHelpers.CopyTo`, `Contract.ForAll`), **0 pass bugs**.
- Fixture fidelity: the three new methods recompile exact; only the pre-existing `KnownDiffs` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)