### PR TITLE
Keep narrowing casts to sub-int types over arithmetic expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -16,7 +16,18 @@ public class CfgSampleClass
 
     public static byte ToByte(int x) => (byte)x;
 
+    // `a | b` of two bytes is `int` in C# (binary numeric promotion), so the
+    // trailing conv.u1 is a real narrowing the language requires. The IR types the
+    // `or` as byte (ECMA "wider operand wins"), so IdentityConvertPass must not drop
+    // the conv as an identity — `return a | b;` would be CS0266.
+    public static byte OrTwoBytes(byte a, byte b) => (byte)(a | b);
+
     public static int LengthOf(string s) => s.Length;
+
+    // The canonical identity convert: `ldlen` yields a native int the importer
+    // models as int-typed ArrayLength, and the trailing conv.i4 is int -> int.
+    // IdentityConvertPass must still drop it — `a.Length`, no `(int)` cast.
+    public static int ArrayLen(int[] a) => a.Length;
 
     public static char LastChar(string s) => s[^1];
 

--- a/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
@@ -1,0 +1,52 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IdentityConvertPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void NarrowingBitwiseConvert_IsKept()
+    {
+        // `a | b` of two bytes is `int` in C#, so the trailing conv.u1 narrows a
+        // genuinely wider value. The IR types the `or` as byte (ECMA "wider operand
+        // wins"), which would look like an identity — but dropping it yields
+        // `return a | b;`, which is CS0266. The convert must survive.
+        var function = Raised(nameof(CfgSampleClass.OrTwoBytes));
+
+        var convert = Assert.Single(function.Descendants.OfType<Pipeline.Convert>());
+        Assert.Equal("Byte", convert.Target.Name);
+        Assert.IsType<Binary>(convert.Operand);
+    }
+
+    [Fact]
+    public void NarrowingBitwiseConvert_RendersCast()
+    {
+        var output = Print(nameof(CfgSampleClass.OrTwoBytes));
+
+        Assert.Contains("return (byte)(a | b);", output);
+    }
+
+    [Fact]
+    public void ArrayLengthIdentityConvert_IsStillDropped()
+    {
+        // The int -> int conv.i4 over an array length is a true no-op in C# too;
+        // the pass must keep dropping it so `a.Length` renders without a cast.
+        var function = Raised(nameof(CfgSampleClass.ArrayLen));
+
+        Assert.Empty(function.Descendants.OfType<Pipeline.Convert>());
+        Assert.Contains("return a.Length;", CSharpPrinter.Print(function).Output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
@@ -15,6 +15,15 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>int</c> is <c>Int32 → Int32</c>, but it reinterprets the source as
 /// unsigned and throws for negative bit patterns — the printer preserves that
 /// as <c>checked((int)(uint)x)</c>, which this pass must not erase.
+///
+/// <para>One more case is <em>not</em> identity despite equal IR types: a
+/// narrowing to a sub-<c>int</c> type (<c>byte</c>/<c>sbyte</c>/<c>short</c>/
+/// <c>ushort</c>/<c>char</c>) over an arithmetic or bitwise expression. IL models
+/// <c>byte | byte</c> as <c>byte</c> (ECMA-335 "wider operand wins"), so the
+/// trailing <c>conv.u1</c> is <c>Byte → Byte</c> here — but C# applies binary
+/// numeric promotion and types that same expression as <c>int</c>, so the cast
+/// is a real narrowing the language requires (<c>b = b | x;</c> is CS0266 without
+/// it). Keeping it is fidelity-neutral — the <c>conv</c> was in the original IL.</para>
 /// </summary>
 public sealed class IdentityConvertPass : IIrPass
 {
@@ -31,10 +40,22 @@ public sealed class IdentityConvertPass : IIrPass
             var operandType = convert.Operand.ResultType;
             if (operandType is not null && operandType.Equals(convert.Target))
             {
+                if (IsSubInt32Integer(convert.Target) && PromotesToInt32(convert.Operand))
+                    continue;  // C# promotes the operand to int; the narrowing cast is real
                 var operand = (IrExpression)convert.DetachChildren()[0];
                 context.Stepper.StepOver($"drop identity conversion to {convert.Target.Name}", convert);
                 convert.ReplaceWith(operand);
             }
         }
     }
+
+    // C# binary numeric promotion widens sub-int operands to int, so an arithmetic,
+    // bitwise, shift (Binary), or unary negate/complement expression over them is
+    // int-typed in C# even when the IR models it narrower. Comparisons are a
+    // separate node (bool-typed), so every Binary/Unary here is a promoting op.
+    static bool PromotesToInt32(IrExpression operand) => operand is Binary or Unary;
+
+    static bool IsSubInt32Integer(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && type.Name is "Byte" or "SByte" or "Int16" or "UInt16" or "Char";
 }


### PR DESCRIPTION
## Problem

Next cluster down the `--validity-check` semantic docket (issue #622): **CS0266** (implicit-conversion, the largest semantic bucket). A representative case:

```csharp
// System.Buffers.IndexOfAnyAsciiSearcher::SetBitmapBit
*bitmap = (*bitmap) | (1 << n);   // CS0266: cannot convert 'int' to 'byte'
```

The raw importer renders this correctly — `StoreIndirect sbyte <- Convert byte <- Binary.Or` — but `IdentityConvertPass` then **strips the `Convert byte`**. It drops a `conv` whose target equals its operand's IR result type, and the IR types `byte | byte` as `byte` (ECMA-335 III.1.5, *"the wider operand wins"*). So `conv.u1` over a byte-typed `or` looks like a `Byte → Byte` identity.

But **C# applies binary numeric promotion** and types `byte | byte` as `int`, so that cast is a real narrowing the language requires. Stripping it yields invalid C#.

## Fix

Keep a `conv` to a sub-`int` type (`byte`/`sbyte`/`short`/`ushort`/`char`) when its operand is an arithmetic / bitwise / shift (`Binary`) or unary negate/complement (`Unary`) expression — exactly the node kinds C# promotes to `int`. Comparisons are a separate bool-typed node, so every `Binary`/`Unary` reaching the guard is a promoting op.

The array-length identity (`int → int` `conv.i4` over `ArrayLength`) is **unaffected** — its target is `int`, not a sub-int type.

| Method | Before | After |
| --- | --- | --- |
| `SetBitmapBit` | `*p = (*p) \| (1 << n);` | `*p = (byte)((*p) \| (byte)(1 << n));` |
| `OrTwoBytes(a, b)` | `return a \| b;` (CS0266) | `return (byte)(a \| b);` |

## Fidelity

**Neutral** — the `conv` was in the original IL, so the restored cast recompiles to the same opcode stream. Verified by the fixture `FidelityGate` round-tripping the new `OrTwoBytes` body exactly.

## Impact

Over .NET 11 preview CoreLib (full-corpus `--emit-validity-defects` diff):

- **78 methods** cleared from the validity docket, **zero** new defects.
- CS0266: **422 → 375** (plus knock-on CS0019 / CS0034 drops on the same bodies).

## Tests

New `IdentityConvertPassTests`: narrowing convert kept + rendered as a cast (`OrTwoBytes`), and the array-length identity still dropped (`ArrayLen`). 577 decompiler tests green incl. `FidelityGateTests` and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)