### PR TITLE
Negate a branch over a `ref bool` deref instead of comparing it to 0

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -26,6 +26,19 @@ public class CfgSampleClass
 
     public static int Twice(int x) { var t = x + x; return t; }
 
+    // Branch over a `ref bool` deref: csc emits `ldarg; ldind.u1; brtrue`, so the
+    // condition's IR ResultType is `byte`, but it renders as the C# bool place.
+    // The branch must spell `!flag`, not the CS0019 `flag == 0`.
+    public static int RefBoolGuard(ref bool flag)
+    {
+        if (!flag)
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+
     public static int Reused(int x) { var n = x + 1; return n * n; }
 
     public static bool BothPositive(int a, int b)

--- a/src/ILInspector.Decompiler.Tests/RefBoolBranchTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefBoolBranchTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A `ref bool`/`bool*` deref loads via `ldind.u1`, so the branch condition's IR
+// ResultType is `byte`. The printer's truthiness speller must still treat it as
+// a boolean (it renders as the bool place), spelling `!flag` rather than the
+// CS0019 integer comparison `flag == 0`.
+public class RefBoolBranchTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void BranchOverRefBoolDeref_NegatesRatherThanComparesToZero()
+    {
+        var output = Render(nameof(CfgSampleClass.RefBoolGuard));
+
+        Assert.DoesNotContain("== 0", output);
+        Assert.DoesNotContain("!= 0", output);
+        Assert.Contains("!", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1063,6 +1063,13 @@ public sealed partial class CSharpPrinter
         if (operand is IsInstance ii && IsValueTypeTarget(ii.Type))
             return ($"{Operand(operand)}", $"!({Operand(operand)})");
 
+        // A `ref bool`/`bool*` deref loads via `ldind.u1`, so its IR ResultType is
+        // `byte`, but it renders as the C# bool place (`flag`/`*p`). Spelling it
+        // `flag != 0`/`flag == 0` is `bool != int` (CS0019); it is its own truth
+        // value, so let it render bare/negated like any other boolean.
+        if (RendersAsBoolean(operand))
+            return null;
+
         var type = operand.ResultType;
         if (type is null || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
             return null;
@@ -1094,6 +1101,15 @@ public sealed partial class CSharpPrinter
             _ => null,   // a struct cannot be a branch operand; unknown stays raw
         };
     }
+
+    /// <summary>
+    /// True when an expression renders as a C# <c>bool</c> regardless of its IR
+    /// ResultType. A <c>ref bool</c>/<c>bool*</c> deref loads via <c>ldind.u1</c>
+    /// (ResultType <c>byte</c>) but the printer spells it as the underlying bool
+    /// place, so a branch over it must negate rather than compare to 0.
+    /// </summary>
+    static bool RendersAsBoolean(IrExpression operand)
+        => operand is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary } } };
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)


### PR DESCRIPTION
## Summary

A branch over a `ref bool`/`bool*` deref was rendering the invalid
`if ((flag) == 0)` (CS0019 — comparing a `bool` to the integer literal `0`).
It now renders the negated bool: `if (!flag)`.

## Root cause

A `ref bool`/`bool*` deref loads via `ldind.u1`, so the importer types the
branch condition's IR `ResultType` as `byte`. The printer's `Truthiness`
speller keyed off that byte type and emitted the integer truthiness form
(`flag != 0` / `flag == 0`), but the deref renders as the underlying C# bool
place (`flag` / `*p`). Comparing that `bool` to `0` is CS0019.

## Fix

A new `RendersAsBoolean` predicate recognizes a `LoadIndirect` through a
`ref bool`/`bool*`, and `Truthiness` returns `null` for it so a brtrue/brfalse
over it spells the bare/negated bool (`flag` / `!flag`) like any other boolean
operand. Tight: only fires when the address element type is `System.Boolean`.

Example: `Microsoft.Win32.SafeHandles.SafeFileHandle::FStatCheckIO` went from
`if ((statusHasValue) == 0)` to `if (!(statusHasValue))`.

## Numbers

- Semantic CS0019 **63 → 60** (−3 methods)
- Full malformed flat (530)
- Inventory flat (40987/41012 Full, 0 importer bugs)
- 594 decompiler + 1157 product tests green (new `RefBoolBranchTests` +
  `CfgSampleClass.RefBoolGuard` fixture)
