### PR TITLE
Raise the element-literal tuple binary operator form

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1063,6 +1063,17 @@ public class CfgSampleClass
 
     public static bool TupleValueNotEquals((int Sum, int Product) left, (int Sum, int Product) right) => left != right;
 
+    // Element-literal tuple equality: `(a, b) == (c, d)`. csc eagerly spills the
+    // operands (unnamed temps) then compares element-wise — TupleLiteralBinaryPass
+    // raises that back to the tuple operator.
+    public static bool TupleLiteralEquals(int a, int b, int c, int d) => (a, b) == (c, d);
+
+    public static bool TupleLiteralNotEquals(int a, int b, int c, int d) => (a, b) != (c, d);
+
+    // Arity-3 element-literal tuple equality, to exercise the general N-ary chain.
+    public static bool TupleLiteralEquals3(int a, int b, int c, int d, int e, int f) => (a, b, c) == (d, e, f);
+
+
     public static int DeconstructTuplePair((int Sum, int Product) pair)
     {
         (int sum, int product) = pair;

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -59,9 +59,47 @@ public class TupleBinaryOperatorPassTests
     }
 
     [Fact]
-    public void TupleLiteralComparison_IsNotRaised()
+    public void TupleLiteralEquality_RaisesToTupleBinaryExpression()
     {
-        var function = Raised(nameof(TupleBinaryAdversarialSamples.TupleLiteralEquals), typeof(TupleBinaryAdversarialSamples));
+        var function = Raised(nameof(CfgSampleClass.TupleLiteralEquals));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.True(tupleBinary.IsEquality);
+        Assert.IsType<TupleExpression>(tupleBinary.Left);
+        Assert.IsType<TupleExpression>(tupleBinary.Right);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return (a, b) == (c, d);", output);
+        Assert.DoesNotContain("&&", output);
+    }
+
+    [Fact]
+    public void TupleLiteralInequality_RaisesToTupleBinaryExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleLiteralNotEquals));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.False(tupleBinary.IsEquality);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return (a, b) != (c, d);", output);
+        Assert.DoesNotContain("||", output);
+    }
+
+    [Fact]
+    public void TupleLiteralEqualityArity3_RaisesAllElements()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleLiteralEquals3));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.Equal(3, ((TupleExpression)tupleBinary.Left).Elements.Count);
+        Assert.Equal(3, ((TupleExpression)tupleBinary.Right).Elements.Count);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return (a, b, c) == (d, e, f);", output);
+    }
+
+    [Fact]
+    public void LazyShortCircuitComparison_IsNotRaised()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.LazyAndComparison), typeof(TupleBinaryAdversarialSamples));
 
         Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
         var output = CSharpPrinter.Print(function).Output;
@@ -96,7 +134,9 @@ public class TupleBinaryOperatorPassTests
 
 public static class TupleBinaryAdversarialSamples
 {
-    public static bool TupleLiteralEquals(int a, int b, int c, int d) => (a, b) == (c, d);
+    // Genuine hand-written short-circuit `&&` over bare parameters: csc lowers it
+    // lazily (no eager operand spills), so it must NOT raise to a tuple operator.
+    public static bool LazyAndComparison(int a, int b, int c, int d) => a == c && b == d;
 
     public static bool DirectManualTupleFields((int Sum, int Product) left, (int Sum, int Product) right)
         => left.Sum == right.Sum && left.Product == right.Product;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -111,7 +111,7 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass SwitchExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();
-    [Completeness(CompletenessLevel.Partial, "arity-2 tuple-valued `==`/`!=` with hidden ValueTuple operand spills; tuple literals, arity 3+, nested/rest tuples, and source-named local field comparisons not raised")]
+    [Completeness(CompletenessLevel.Partial, "tuple-valued `==`/`!=` with hidden ValueTuple operand spills: the whole-tuple form (`left == right`, arity 2) and the element-literal form (`(a, b) == (c, d)`, any arity, recovered from csc's eager operand spills); nested/rest tuples, mixed literal-vs-variable operands, and source-named local field comparisons not raised")]
     public static TupleBinaryOperatorPass TupleBinaryOperator => new();
     [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
@@ -1,9 +1,21 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// Raises csc's arity-2 tuple-valued <c>==</c>/<c>!=</c> lowering back into the
-/// tuple binary operator. The proof is the pair of hidden ValueTuple operand
-/// spills feeding ordered <c>Item1</c>/<c>Item2</c> comparisons.
+/// tuple binary operator. Two shapes are recovered:
+/// <list type="bullet">
+/// <item>The <em>whole-tuple</em> form (<c>left == right</c>, both operands
+/// <c>ValueTuple</c> locals): the proof is the pair of hidden ValueTuple operand
+/// spills feeding ordered <c>Item1</c>/<c>Item2</c> comparisons.</item>
+/// <item>The <em>element-literal</em> form (<c>(a, b) == (c, d)</c>, any arity):
+/// the proof is csc's <em>eager</em> operand evaluation — every element except
+/// the first is spilled to an unnamed temporary <em>before</em> the first test,
+/// then compared element-wise. Hand-written <c>a == c &amp;&amp; b == d</c>
+/// evaluates lazily and leaves no such spill prologue, so the eager spills are a
+/// reliable signature that does not collide with ordinary short-circuit code.</item>
+/// </list>
 /// </summary>
 public sealed class TupleBinaryOperatorPass : IIrPass
 {
@@ -20,10 +32,11 @@ public sealed class TupleBinaryOperatorPass : IIrPass
     {
         foreach (var block in function.Descendants.OfType<Block>().ToList())
         {
-            for (int i = 2; i < block.Children.Count; i++)
+            for (int i = 1; i < block.Children.Count; i++)
             {
-                if (TryRaiseReturnAt(function, block, i, stepper)
-                    || i < block.Children.Count - 1 && TryRaiseSlotAt(function, block, i, stepper))
+                if (i >= 2 && (TryRaiseReturnAt(function, block, i, stepper)
+                        || i < block.Children.Count - 1 && TryRaiseSlotAt(function, block, i, stepper))
+                    || TryRaiseLiteralAt(function, block, i, stepper))
                 {
                     return true;
                 }
@@ -192,6 +205,149 @@ public sealed class TupleBinaryOperatorPass : IIrPass
         && name == $"Item{item}"
         && declaringType.Equals(tupleType)
         && fieldType.Equals(tupleType.TypeArguments[item - 1]);
+
+    // ---- Element-literal form: `(a, b) == (c, d)` of any arity. ----
+
+    static bool TryRaiseLiteralAt(IrFunction function, Block block, int consumerIndex, Stepper stepper)
+    {
+        if (GetLiteralLogical(block.Children[consumerIndex]) is not { } logical
+            || !TryGetLiteralKind(logical.Kind, out var comparisonKind, out bool isEquality))
+        {
+            return false;
+        }
+
+        // Flatten the left-nested logical chain into element comparisons.
+        var comparisons = new List<Comparison>();
+        if (!TryFlatten(logical, logical.Kind, comparisonKind, comparisons) || comparisons.Count < 2)
+            return false;
+
+        // Collect the eager spill prologue: consecutive unnamed StoreLocals
+        // immediately preceding the consumer.
+        var spills = new Dictionary<int, StoreLocal>();
+        for (int j = consumerIndex - 1; j >= 0; j--)
+        {
+            if (block.Children[j] is not StoreLocal store
+                || HasSourceLocalName(function, store.Index)
+                || !spills.TryAdd(store.Index, store))
+            {
+                break;
+            }
+        }
+        if (spills.Count == 0)
+            return false;
+
+        // Resolve every comparison operand: a load of a spilled temp inlines the
+        // stored element; anything else stays as-is. Track spill consumption.
+        var leftRefs = new List<IrExpression>(comparisons.Count);
+        var rightRefs = new List<IrExpression>(comparisons.Count);
+        var used = new Dictionary<int, int>();
+        foreach (var comparison in comparisons)
+        {
+            leftRefs.Add(ResolveLiteralOperand(comparison.Left, spills, used));
+            rightRefs.Add(ResolveLiteralOperand(comparison.Right, spills, used));
+        }
+
+        // Clean shape: every spilled temp consumed exactly once. A dangling or
+        // multiply-used spill means this is not a tuple literal comparison.
+        if (used.Count != spills.Count || used.Values.Any(count => count != 1))
+            return false;
+
+        // Element result types must be known to synthesize the ValueTuple type.
+        var leftTypes = LiteralElementTypes(leftRefs);
+        var rightTypes = LiteralElementTypes(rightRefs);
+        if (leftTypes is null || rightTypes is null)
+            return false;
+
+        var leftTuple = new TupleExpression(MakeTupleType(leftTypes.Value), DetachAll(leftRefs));
+        var rightTuple = new TupleExpression(MakeTupleType(rightTypes.Value), DetachAll(rightRefs));
+        var tupleBinary = new TupleBinaryExpression(isEquality, leftTuple.TupleType, leftTuple, rightTuple);
+        tupleBinary.InheritSourceOffset(logical);
+
+        stepper.StepOver("raise element-literal tuple comparison to tuple binary operator", logical);
+        logical.ReplaceWith(tupleBinary);
+        foreach (var spill in spills.Values)
+            spill.Detach();
+        return true;
+    }
+
+    static LogicalBinary? GetLiteralLogical(IrNode statement) => statement switch
+    {
+        Return { Value: LogicalBinary logical } => logical,
+        StoreStackSlot { Value: LogicalBinary logical } => logical,
+        StoreLocal { Value: LogicalBinary logical } => logical,
+        _ => null,
+    };
+
+    static bool TryGetLiteralKind(LogicalKind kind, out ComparisonKind comparisonKind, out bool isEquality)
+    {
+        switch (kind)
+        {
+            case LogicalKind.And:
+                comparisonKind = ComparisonKind.Equal;
+                isEquality = true;
+                return true;
+            case LogicalKind.Or:
+                comparisonKind = ComparisonKind.NotEqual;
+                isEquality = false;
+                return true;
+            default:
+                comparisonKind = default;
+                isEquality = false;
+                return false;
+        }
+    }
+
+    // A `(a, b, c) == ...` lowering is a left-nested chain of the same logical
+    // kind whose leaves are element comparisons, in tuple element order.
+    static bool TryFlatten(IrExpression node, LogicalKind kind, ComparisonKind comparisonKind, List<Comparison> comparisons)
+    {
+        if (node is LogicalBinary logical)
+        {
+            return logical.Kind == kind
+                && TryFlatten(logical.Left, kind, comparisonKind, comparisons)
+                && TryFlatten(logical.Right, kind, comparisonKind, comparisons);
+        }
+
+        if (node is Comparison comparison && comparison.Kind == comparisonKind && !comparison.IsUnsigned)
+        {
+            comparisons.Add(comparison);
+            return true;
+        }
+
+        return false;
+    }
+
+    static IrExpression ResolveLiteralOperand(IrExpression operand, Dictionary<int, StoreLocal> spills, Dictionary<int, int> used)
+    {
+        if (operand is LoadLocal load && spills.TryGetValue(load.Index, out var store))
+        {
+            used[load.Index] = used.GetValueOrDefault(load.Index) + 1;
+            return store.Value;
+        }
+        return operand;
+    }
+
+    static ImmutableArray<TypeRef>? LiteralElementTypes(List<IrExpression> elements)
+    {
+        var builder = ImmutableArray.CreateBuilder<TypeRef>(elements.Count);
+        foreach (var element in elements)
+        {
+            if (element.ResultType is not { } type)
+                return null;
+            builder.Add(type);
+        }
+        return builder.MoveToImmutable();
+    }
+
+    static TypeRef MakeTupleType(ImmutableArray<TypeRef> elementTypes)
+        => TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple"), elementTypes);
+
+    static List<IrExpression> DetachAll(List<IrExpression> refs)
+    {
+        foreach (var node in refs)
+            node.Detach();
+        return refs;
+    }
 
     static bool HasSourceLocalName(IrFunction function, int index)
         => index >= 0


### PR DESCRIPTION
## What

Extends `TupleBinaryOperatorPass` to recover the **element-literal** tuple comparison form `(a, b) == (c, d)` (and `!=`), of any arity — the counterpart of the whole-tuple `left == right` form added in #813.

Before, `(a, b) == (c, d)` fell through to copy-prop and printed as `return a == c && b == d;` — observably correct, but not the source idiom and (for side-effecting elements) misleadingly lazy-looking.

## How — the proof

csc lowers a tuple-literal comparison by **eagerly** spilling every operand (except the first, which stays on the stack) to an unnamed temporary *before* the first element test, then comparing element-wise:

```
V0 = b; V1 = c; V2 = d;          // eager unnamed spills
return a == V1 && V0 == V2;       // a==c && b==d
```

Hand-written `a == c && b == d` evaluates **lazily** and leaves no such spill prologue. The eager unnamed spills are therefore a reliable signature that does not collide with ordinary short-circuit code.

The matcher:
- flattens the left-nested `&&`/`||` chain into element comparisons (any arity);
- collects the consecutive unnamed-spill prologue immediately preceding the consumer (`Return`/slot/local store);
- inlines each single-use spill back into its comparison operand;
- requires **every** spill consumed exactly once (a dangling or reused spill ⇒ bail);
- rebuilds two tuple literals under a `TupleBinaryExpression`.

Folded into the existing pass (not a sibling) so the lowering ledger's one-Roslyn-construct-to-one-pass invariant holds.

## Tests & ledger

- Fixtures `TupleLiteralEquals`/`TupleLiteralNotEquals` (arity 2) + `TupleLiteralEquals3` (arity 3).
- Flipped the old "literal is not raised" adversarial test to a positive; added a genuine lazy-`&&` negative (`LazyAndComparison`) to pin the precision boundary.
- `LoweringCoverage` `TupleBinaryOperator` note updated — still **Partial** (nested/rest tuples, mixed literal-vs-variable operands, and source-named field comparisons stay out of scope).

## Validation

- Compile-back gate confirms the recovered `(a, b) == (c, d)` recompiles to equivalent IL.
- Decompiler suite **596** green; product suite **1157** green (9 skip).
