### PR TITLE
Raise two-bound string and span range slices

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -167,6 +167,10 @@ public class CfgSampleClass
 
     public static int[] ArrayRangeToFromEnd(int[] a) => a[..^1];
 
+    public static string StringRangeBoth(string s, int i, int j) => s[i..j];
+
+    public static System.ReadOnlySpan<int> SpanRangeBoth(System.ReadOnlySpan<int> s, int i, int j) => s[i..j];
+
     // Compound assignment over an array element: `a[i] += v` captures &a[i] in a
     // dup slot and stores back through it. The expanded `a[i] = a[i] + v` form
     // (no slot) must NOT fold, so both spellings are kept for contrast.

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -44,6 +44,8 @@ public class IdiomShapeScorecardTests
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
+        new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.StringRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
+        new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.SpanRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.LastElement), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("IndexFromEndPass", nameof(CfgSampleClass.NthFromEnd), SyntaxKind.IndexExpression, [SyntaxKind.SubtractExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructTuplePair), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),

--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -62,6 +62,70 @@ public class MemberIdentityTests
     }
 
     [Fact]
+    public void IsStringSubstring_RequiresExactBclInstanceSignature()
+    {
+        Assert.True(MemberIdentity.IsStringSubstring(StringSubstring(s_string, parameterCount: 1)));
+        Assert.True(MemberIdentity.IsStringSubstring(StringSubstring(s_string, parameterCount: 2)));
+
+        Assert.False(MemberIdentity.IsStringSubstring(StringSubstring(
+            TypeRef.Definition("UserAssembly", "System", "String"),
+            parameterCount: 2)));
+
+        Assert.False(MemberIdentity.IsStringSubstring(new Call(
+            StringSubstringMethod(s_string, parameterCount: 2) with { ReturnType = s_object },
+            isVirtual: true,
+            [new LoadArgument(0, "s", s_string), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsStringSubstring(new Call(
+            StringSubstringMethod(s_string, parameterCount: 2) with { ParameterTypes = [s_int, s_object] },
+            isVirtual: true,
+            [new LoadArgument(0, "s", s_string), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsStringSubstring(new Call(
+            StringSubstringMethod(s_string, parameterCount: 2),
+            isVirtual: false,
+            [new LoadArgument(0, "s", s_string), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsStringSubstring(new Call(
+            StringSubstringMethod(s_string, parameterCount: 2),
+            isVirtual: true,
+            [new LoadArgument(0, "s", s_string), new LoadArgument(1, "i", s_int)])));
+    }
+
+    [Fact]
+    public void IsSpanSlice_RequiresExactBclInstanceSignature()
+    {
+        Assert.True(MemberIdentity.IsSpanSlice(SpanSlice(s_readOnlySpanInt, parameterCount: 1)));
+        Assert.True(MemberIdentity.IsSpanSlice(SpanSlice(s_readOnlySpanInt, parameterCount: 2)));
+
+        var spanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [s_int]);
+        Assert.True(MemberIdentity.IsSpanSlice(SpanSlice(spanInt, parameterCount: 2)));
+
+        var userSpan = TypeRef.GenericInstance(TypeRef.Definition("UserAssembly", "System", "ReadOnlySpan`1"), [s_int]);
+        Assert.False(MemberIdentity.IsSpanSlice(SpanSlice(userSpan, parameterCount: 2)));
+
+        Assert.False(MemberIdentity.IsSpanSlice(new Call(
+            SpanSliceMethod(s_readOnlySpanInt, parameterCount: 2) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadArgumentAddress(0, "s", s_readOnlySpanInt), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsSpanSlice(new Call(
+            SpanSliceMethod(s_readOnlySpanInt, parameterCount: 2) with { ParameterTypes = [s_int, s_object] },
+            isVirtual: false,
+            [new LoadArgumentAddress(0, "s", s_readOnlySpanInt), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsSpanSlice(new Call(
+            SpanSliceMethod(s_readOnlySpanInt, parameterCount: 2),
+            isVirtual: true,
+            [new LoadArgumentAddress(0, "s", s_readOnlySpanInt), new LoadArgument(1, "i", s_int), new LoadArgument(2, "j", s_int)])));
+
+        Assert.False(MemberIdentity.IsSpanSlice(new Call(
+            SpanSliceMethod(s_readOnlySpanInt, parameterCount: 2),
+            isVirtual: false,
+            [new LoadArgumentAddress(0, "s", s_readOnlySpanInt), new LoadArgument(1, "i", s_int)])));
+    }
+
+    [Fact]
     public void IsAsyncHelpersAwait_RequiresExactBclStaticSingleArgument()
     {
         Assert.True(MemberIdentity.IsAsyncHelpersAwait(Await(TypeRef.CoreLib(
@@ -327,6 +391,24 @@ public class MemberIdentityTests
             GetSubArrayMethod(declaringType),
             isVirtual: false,
             [new LoadArgument(0, "a", s_intArray), new LoadArgument(1, "range", s_range)]);
+
+    static MethodRef StringSubstringMethod(TypeRef declaringType, int parameterCount)
+        => new(declaringType, "Substring", s_string, [.. Enumerable.Repeat(s_int, parameterCount)], HasThis: true);
+
+    static Call StringSubstring(TypeRef declaringType, int parameterCount)
+        => new(
+            StringSubstringMethod(declaringType, parameterCount),
+            isVirtual: true,
+            [(IrExpression)new LoadArgument(0, "s", s_string), .. Enumerable.Range(0, parameterCount).Select(i => new LoadArgument(i + 1, $"p{i}", s_int))]);
+
+    static MethodRef SpanSliceMethod(TypeRef declaringType, int parameterCount)
+        => new(declaringType, "Slice", declaringType, [.. Enumerable.Repeat(s_int, parameterCount)], HasThis: true);
+
+    static Call SpanSlice(TypeRef declaringType, int parameterCount)
+        => new(
+            SpanSliceMethod(declaringType, parameterCount),
+            isVirtual: false,
+            [(IrExpression)new LoadArgumentAddress(0, "s", declaringType), .. Enumerable.Range(0, parameterCount).Select(i => new LoadArgument(i + 1, $"p{i}", s_int))]);
 
     static MethodRef AwaitMethod(TypeRef declaringType)
         => new(declaringType, "Await", s_int, [s_int], HasThis: false);

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -10,10 +10,11 @@ public class RangeFromGetSubArrayPassTests
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
 
-    static IrFunction Raised(string methodName)
+    static IrFunction Raised(string methodName, Type? type = null)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        type ??= typeof(CfgSampleClass);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function.CheckInvariant();
@@ -136,6 +137,95 @@ public class RangeFromGetSubArrayPassTests
         Assert.Contains("return a[..^1];", CSharpPrinter.Print(function).Output);
     }
 
+    [Fact]
+    public void StringSubstring_TwoBounds_RaisesToRangeIndexer()
+    {
+        var function = Raised(nameof(CfgSampleClass.StringRangeBoth));
+
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.True(slice.Range.HasStart);
+        Assert.True(slice.Range.HasEnd);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return s[i..j];", output);
+        Assert.DoesNotContain("Substring", output);
+    }
+
+    [Fact]
+    public void SpanSlice_TwoBounds_RaisesToRangeIndexer()
+    {
+        var function = Raised(nameof(CfgSampleClass.SpanRangeBoth));
+
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.True(slice.Range.HasStart);
+        Assert.True(slice.Range.HasEnd);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return s[i..j];", output);
+        Assert.DoesNotContain(".Slice", output);
+    }
+
+    [Fact]
+    public void ManualSubstring_TwoBounds_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.ManualSubstringBoth), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Substring(i, j - i);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void ManualSlice_TwoBounds_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.ManualSliceBoth), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Slice(i, j - i);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void SourceNamedTempSubstring_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.SourceNamedTempSubstring), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("Substring", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void OneSidedStringRange_FromStart_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.StringRangeFromStart), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Substring(i);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void OneSidedStringRange_ToEnd_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.StringRangeToEnd), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Substring(0, j);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void FromEndOpenStringRange_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.StringRangeFromEnd), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("Substring", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void FromEndOpenSpanRange_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.SpanRangeFromEnd), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(".Slice", CSharpPrinter.Print(function).Output);
+    }
+
     static IrFunction BuildGetSubArrayLookalike()
     {
         var indexImplicit = new MethodRef(s_index, "op_Implicit", s_index, [s_int], HasThis: false);
@@ -163,4 +253,25 @@ public class RangeFromGetSubArrayPassTests
             GenericParameterCount: 0);
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
     }
+}
+
+public static class RangeAdversarialSamples
+{
+    public static string ManualSubstringBoth(string s, int i, int j) => s.Substring(i, j - i);
+
+    public static System.ReadOnlySpan<int> ManualSliceBoth(System.ReadOnlySpan<int> s, int i, int j) => s.Slice(i, j - i);
+
+    public static string SourceNamedTempSubstring(string s, int i, int j)
+    {
+        int start = i;
+        return s.Substring(start, j - start);
+    }
+
+    public static string StringRangeFromStart(string s, int i) => s[i..];
+
+    public static string StringRangeToEnd(string s, int j) => s[..j];
+
+    public static string StringRangeFromEnd(string s, int i) => s[^i..];
+
+    public static System.ReadOnlySpan<int> SpanRangeFromEnd(System.ReadOnlySpan<int> s, int i) => s[^i..];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
@@ -9,11 +9,13 @@ internal sealed class RangeRecoveryFacts : ILoweringFactProvider
             typeof(RangeFromGetSubArrayPass),
             [
                 new FactPrimitive("member.corelib-identity:RuntimeHelpers.GetSubArray", "MemberIdentity.IsRuntimeHelpersGetSubArray"),
+                new FactPrimitive("member.corelib-identity:string.Substring", "MemberIdentity.IsStringSubstring"),
+                new FactPrimitive("member.corelib-identity:Span.Slice", "MemberIdentity.IsSpanSlice"),
                 new FactPrimitive("member.corelib-identity:System.Range", "MemberIdentity.IsCoreLibraryType"),
                 new FactPrimitive("member.corelib-identity:System.Index", "MemberIdentity.IsCoreLibraryType"),
             ],
-            PositiveCoverage: "RangeFromGetSubArrayPassTests range endpoint matrix",
-            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike",
-            MissingDiscriminator: "string/span Slice and Substring forms are separate lowerings"),
+            PositiveCoverage: "RangeFromGetSubArrayPassTests array range endpoint matrix plus string/span two-bound fixtures",
+            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike and manual/one-sided Substring/Slice negatives",
+            MissingDiscriminator: "one-sided and from-end string/span forms plus broader manual Substring/Slice calls remain unraised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -986,7 +986,7 @@ public sealed partial class CSharpPrinter
         ObjectInitializerExpression oi => ObjectInitializerText(oi),
         InitializerBlock ib => InitializerBodyText(ib.IsCollection, ib.Entries),
         ArrayLength l => $"{Operand(l.Array)}.Length",
-        SliceExpression sl => $"{Operand(sl.Receiver)}[{Expression(sl.Range)}]",
+        SliceExpression sl => $"{ReceiverText(sl.Receiver)}[{Expression(sl.Range)}]",
         RangeExpression r => $"{(r.HasStart ? Expression(r.Start!) : "")}..{(r.HasEnd ? Expression(r.End!) : "")}",
         IndexFromEnd i => $"^{Operand(i.Offset)}",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -64,6 +64,43 @@ public static class MemberIdentity
             && rangeParameter.Equals(s_range);
     }
 
+    public static bool IsStringSubstring(Call call)
+        => call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: true,
+                Name: "Substring",
+                TypeArguments.IsEmpty: true,
+                ReturnType: var returnType,
+            }
+            && returnType.Equals(s_string)
+            && IsCoreLibraryType(call.Callee.DeclaringType, "System", "String")
+            && call.Callee.ParameterTypes.All(p => p.Equals(s_int))
+            && call.Callee.ParameterTypes.Length is 1 or 2
+            && call.Arguments.Count == call.Callee.ParameterTypes.Length + 1;
+
+    public static bool IsSpanSlice(Call call)
+    {
+        if (call.IsVirtual
+            || call.Callee is not
+            {
+                HasThis: true,
+                Name: "Slice",
+                TypeArguments.IsEmpty: true,
+                DeclaringType: var declaringType,
+                ReturnType: var returnType,
+            }
+            || !returnType.Equals(declaringType)
+            || !IsSpanLikeType(declaringType)
+            || call.Callee.ParameterTypes.Length is not (1 or 2)
+            || call.Arguments.Count != call.Callee.ParameterTypes.Length + 1)
+        {
+            return false;
+        }
+
+        return call.Callee.ParameterTypes.All(p => p.Equals(s_int));
+    }
+
     public static bool IsAsyncHelpersAwait(Call call)
         => !call.IsVirtual
             && IsStaticCoreLibraryMethod(
@@ -243,6 +280,10 @@ public static class MemberIdentity
 
     static TypeRef? NamedDefinition(TypeRef? type)
         => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
+
+    static bool IsSpanLikeType(TypeRef type)
+        => IsCoreLibraryType(type, "System", "Span`1")
+            || IsCoreLibraryType(type, "System", "ReadOnlySpan`1");
 
     static bool TryValueTupleArity(string name, out int arity)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -100,7 +100,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess => new();
     [Completeness(CompletenessLevel.None, "declined, not owed: a query expression is translated to Enumerable.Where/Select/SelectMany/... calls during binding, before any lowering, so it leaves no IL anchor distinct from the equivalent fluent chain. It is recovered as that fluent method chain (the runtime-preferred form); re-sugaring to from..select would invent a distinction the IL does not make (taste rule case 3, no IL anchor)")]
     public static Unhandled Query => default!;
-    [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...); string/span Substring/Slice forms not raised")]
+    [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...), plus compiler-spilled string/span two-bound Substring/Slice forms (s[i..j]); one-sided and from-end string/span forms plus broader manual Substring/Slice calls not raised")]
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -3,8 +3,8 @@ using System.Linq;
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the compiler's array range-slice lowering back into a C# range indexer:
-/// <c>RuntimeHelpers.GetSubArray(a, range)</c> becomes <c>a[range]</c>. The
+/// Raises the compiler's range-slice lowerings back into a C# range indexer.
+/// For arrays, <c>RuntimeHelpers.GetSubArray(a, range)</c> becomes <c>a[range]</c>. The
 /// <c>range</c> argument is one of the compiler's <see cref="System.Range"/>
 /// constructions — <c>new Range(lo, hi)</c>, <c>Range.StartAt</c>,
 /// <c>Range.EndAt</c>, or <c>Range.All</c> — which the pass rewrites into a
@@ -16,11 +16,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// via an <see cref="IndexFromEnd"/> node — so the whole space of array range
 /// slices (<c>a[i..^1]</c>, <c>a[^3..^1]</c>, <c>a[..^1]</c>, …) is recovered.</para>
 ///
-/// <para>The BCL <c>GetSubArray</c> is a compiler helper with no ordinary
-/// user-facing spelling in range syntax, so recognizing that exact helper is
-/// unambiguous and the round-trip is opcode-exact: the recovered
-/// <c>a[range]</c> re-lowers to the same call. The string/span <c>Substring</c>
-/// / <c>Slice</c> forms are a separate lowering and left untouched here.</para>
+/// <para>The string/span <c>Substring</c> / <c>Slice</c> forms share their
+/// methods with ordinary source calls, so those are raised only when csc's hidden
+/// start/receiver spills prove the range lowering.</para>
 /// </summary>
 public sealed class RangeFromGetSubArrayPass : IIrPass
 {
@@ -31,6 +29,10 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        while (TryRaiseStringOrSpanRange(function, context.Stepper))
+        {
+        }
+
         foreach (var call in function.Descendants.OfType<Call>().ToList())
         {
             if (!MemberIdentity.IsRuntimeHelpersGetSubArray(call))
@@ -54,6 +56,58 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
             call.ReplaceWith(slice);
         }
     }
+
+    static bool TryRaiseStringOrSpanRange(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            for (int i = 1; i < block.Children.Count; i++)
+            {
+                if (TryRaiseFromStartRange(function, block, i, stepper))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryRaiseFromStartRange(IrFunction function, Block block, int returnIndex, Stepper stepper)
+    {
+        if (block.Children[returnIndex - 1] is not StoreLocal startStore
+            || HasSourceLocalName(function, startStore.Index)
+            || !startStore.Type.Equals(TypeRef.CoreLib("System", "Int32"))
+            || block.Children[returnIndex] is not Return { Value: Call call }
+            || !IsStringOrSpanRangeCall(call)
+            || call.Callee.ParameterTypes.Length != 2
+            || call.Arguments is not [var receiver, LoadLocal start, Binary { Kind: BinaryKind.Subtract } length]
+            || start.Index != startStore.Index
+            || length.Right is not LoadLocal lengthStart
+            || lengthStart.Index != startStore.Index)
+        {
+            return false;
+        }
+
+        receiver.Detach();
+        var rangeStart = (IrExpression)startStore.DetachChildren()[0];
+        var rangeEnd = length.Left;
+        rangeEnd.Detach();
+        var slice = new SliceExpression(receiver, new RangeExpression(rangeStart, rangeEnd), call.ResultType);
+        slice.InheritSourceOffset(call);
+
+        stepper.StepOver("raise compiler-spilled string/span Slice range to a[..] indexer", call);
+        call.ReplaceWith(slice);
+        startStore.Detach();
+        return true;
+    }
+
+    static bool IsStringOrSpanRangeCall(Call call)
+        => MemberIdentity.IsStringSubstring(call) || MemberIdentity.IsSpanSlice(call);
+
+    static bool HasSourceLocalName(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && function.LocalNames[index] is { } name
+            && CSharpNaming.IsUsableIdentifier(name);
 
     /// <summary>
     /// Detaches the endpoint's inner index expression and wraps it in an


### PR DESCRIPTION
## Summary
- recover compiler-spilled string.Substring and Span/ReadOnlySpan Slice two-bound range lowerings as range indexers
- add exact member identity predicates for string.Substring and Span/ReadOnlySpan Slice
- update range ledger/facts/scorecard and add adversarial negatives for manual, one-sided, and from-end forms

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release