### PR TITLE
Render box; unbox.any as (U)(object)x instead of collapsing the box

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -614,6 +614,12 @@ public class CfgSampleClass
 
     public static bool IsValueTypeOf<T>() => typeof(T).IsValueType;
 
+    // The generic-math `(U)(object)x` idiom: a type parameter cast to a concrete
+    // type through object lowers to `box T; unbox.any byte`. The box is an explicit
+    // (object) cast the printer must keep — `(byte)left` over a generic T is CS0030.
+    public static bool GreaterAsByte<T>(T left, T right) where T : struct
+        => (byte)(object)left > (byte)(object)right;
+
     public struct Pair { public int A; public int B; }
 
     public static int FirstA(Pair[] pairs) => pairs[0].A;

--- a/src/ILInspector.Decompiler.Tests/UnboxAnyRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnboxAnyRenderingTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class UnboxAnyRenderingTests
+{
+    static string Print(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function!).Output!;
+    }
+
+    [Fact]
+    public void UnboxOverBox_KeepsObjectIntermediary()
+    {
+        // `box T; unbox.any byte` is `(byte)(object)x`. Collapsing the box to a plain
+        // `(byte)x` over a generic type parameter is CS0030 (no direct conversion).
+        var output = Print(nameof(CfgSampleClass.GreaterAsByte));
+
+        Assert.Contains("(byte)(object)", output);
+        // The bare `(byte)left`/`(byte)right` form (no object cast) must not appear.
+        Assert.DoesNotContain("(byte)(left)", output);
+        Assert.DoesNotContain("(byte)(right)", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1011,7 +1011,7 @@ public sealed partial class CSharpPrinter
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
-        UnboxAny u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
+        UnboxAny u => $"({TypeText(u.Type)}){UnboxAnyOperand(u.Operand)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
         LoadLocalAddress a => $"ref {LocalName(a.Index)}",
         LoadArgumentAddress a => $"ref {a.Name}",
@@ -1094,6 +1094,14 @@ public sealed partial class CSharpPrinter
             _ => null,   // a struct cannot be a branch operand; unknown stays raw
         };
     }
+
+    // `box T; unbox.any U` is the generic-math `(U)(object)x` idiom: the box is an
+    // explicit (object) cast, not the transparent implicit boxing of a value into an
+    // object slot. `(U)x` over a generic type parameter has no direct conversion and
+    // is CS0030 — and even for a concrete type, collapsing box+unbox.any to a plain
+    // `(U)x` drops the round-trip the IL actually performs. Keep the intermediary.
+    string UnboxAnyOperand(IrExpression operand)
+        => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)


### PR DESCRIPTION
## Problem

Next cluster down the `--validity-check` docket (issue #622): **CS0030** ("cannot convert type"), concentrated in the generic-math helpers (`TryConvertFrom*`, `GreaterThan`/`LessThan`, …).

The printer rendered `Box` transparently and `UnboxAny U` as `(U)operand`, so a `box T; unbox.any U` chain collapsed to `(U)x`. Over a generic type parameter that conversion does not exist:

```csharp
// System.Collections.Generic.GenericArraySortHelper<T>::GreaterThan
return (byte)left > (byte)right;   // CS0030: cannot convert 'T' to 'byte'
```

The source is the generic-math idiom `(byte)(object)left` — `box T; unbox.any byte`. The decompiler dropped the `(object)` intermediary.

## Fix

When an `UnboxAny`'s operand is a `Box`, keep the `(object)` cast: `(U)(object)x`. This matches the IL and is legal C#. Transparent boxing **elsewhere** (a value flowing into an `object` slot, where C# boxes implicitly) is unchanged — only the box-feeding-`unbox.any` position gets the explicit cast.

| Method | Before | After |
| --- | --- | --- |
| `GenericArraySortHelper<T>::GreaterThan` | `(byte)left > (byte)right` | `(byte)(object)left > (byte)(object)right` |
| `Int32::TryConvertFromTruncating` | `V_0 = (double)value;` | `V_0 = (double)(object)value;` |

## Fidelity

**Neutral** — the `box` and `unbox.any` were both in the original IL, so the restored cast recompiles to the same opcode stream. Verified by the fixture `FidelityGate` round-tripping the new `GreaterAsByte<T>` body.

## Impact

Over .NET 11 preview CoreLib (full-corpus `--emit-validity-defects` diff):

- **61 methods** cleared from the validity docket, **zero** new defects.
- CS0030: **173 → 16**.

## Tests

New `UnboxAnyRenderingTests` (the `(object)` intermediary is kept) + the `GreaterAsByte<T>` fixture. 609 decompiler tests green incl. `FidelityGateTests` and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)