### PR TITLE
[codex] Raise static local function local bodies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -751,6 +751,19 @@ public class CfgSampleClass
         static int Twice(int v) => v * 2;
     }
 
+    // Local-bodied static local function: Release uses a stack slot for `y`, so
+    // recovery needs a nested local-function scope, not the host method scope.
+    public static int StaticLocalFunctionWithLocal(int x)
+    {
+        return SquarePlusOne(x);
+
+        static int SquarePlusOne(int v)
+        {
+            int y = v + 1;
+            return y * y;
+        }
+    }
+
     // Capturing local function: `n` is hoisted into a struct <>c__DisplayClass
     // passed to the synthesized method by ref. LocalFunctionRaisingPass substitutes
     // the captured field back and recovers the non-static `int Add(int v) => v + n;`.
@@ -769,6 +782,20 @@ public class CfgSampleClass
         return Add(5) + Add(7);
 
         int Add(int v) => v + n;
+    }
+
+    // Capturing local-bodied local functions still stay lowered: capture
+    // substitution prints in the host scope, so local-bodied capture recovery
+    // needs an additional nested-scope representation.
+    public static int CapturingLocalFunctionWithLocal(int n)
+    {
+        return AddSquare(5);
+
+        int AddSquare(int v)
+        {
+            int y = v + n;
+            return y * y;
+        }
     }
 
     // Adversarial soundness probe: the captured parameter is mutated before the

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -32,6 +32,20 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
+    public void StaticLocalFunctionWithLocal_RaisesWithNestedLocalScope()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.StaticLocalFunctionWithLocal));
+
+        Assert.Contains("return SquarePlusOne(x);", output);
+        Assert.Contains("static int SquarePlusOne(int v)", output);
+        Assert.Contains(" = v + 1;", output);
+        Assert.Contains("return ", output);
+        Assert.Contains(" * ", output);
+        Assert.DoesNotContain("g__", output);
+        Assert.DoesNotContain("CfgSampleClass.SquarePlusOne", output);
+    }
+
+    [Fact]
     public void CapturingLocalFunctionCalledTwice_RecoversSingleDeclarationAcrossBothCalls()
     {
         string output = PrintRaised(nameof(CfgSampleClass.CapturingCalledTwice));
@@ -42,6 +56,15 @@ public class LocalFunctionRaisingPassTests
         Assert.Equal(1, CountOccurrences(output, "int Add(int v)"));
         Assert.DoesNotContain("static int Add", output);         // capturing local function is not static (CS8421)
         Assert.DoesNotContain("DisplayClass", output);           // environment elided
+    }
+
+    [Fact]
+    public void CapturingLocalFunctionWithLocal_StaysLowered()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingLocalFunctionWithLocal));
+
+        Assert.Contains("DisplayClass", output);
+        Assert.DoesNotContain("int AddSquare(int v)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -33,8 +33,8 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated-method:local-function", "GeneratedCodeIdentity.IsLocalFunctionMethod"),
                 new FactPrimitive("cross-method-import", "PassContext.ImportMethodBody"),
             ],
-            PositiveCoverage: "LocalFunctionRaisingPassTests static and capturing fixtures, each called once and more than once",
-            AdversarialCoverage: "LocalFunctionRaisingPass guards reject shared-environment, recursive, nested, post-mutation capture, unsupported, or local-bodied forms",
-            MissingDiscriminator: "nested local functions and environments spread across statements are still owed"),
+            PositiveCoverage: "LocalFunctionRaisingPassTests static, static local-bodied, and capturing fixtures, each called once and more than once where applicable",
+            AdversarialCoverage: "LocalFunctionRaisingPass guards reject shared-environment, recursive, nested, post-mutation capture, unsupported, and capturing local-bodied forms",
+            MissingDiscriminator: "capturing local-bodied forms, nested local functions, and environments spread across statements are still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -210,15 +210,15 @@ public sealed partial class CSharpPrinter
     {
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
-        foreach (var fixedNode in DescendantsOutsideLambdas(function).OfType<Fixed>())
+        foreach (var fixedNode in DescendantsOutsideNestedFunctions(function).OfType<Fixed>())
             _fixedLocals.Add(fixedNode.LocalIndex);
-        foreach (var usingNode in DescendantsOutsideLambdas(function).OfType<UsingStatement>())
+        foreach (var usingNode in DescendantsOutsideNestedFunctions(function).OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
-        foreach (var foreachNode in DescendantsOutsideLambdas(function).OfType<ForeachStatement>())
+        foreach (var foreachNode in DescendantsOutsideNestedFunctions(function).OfType<ForeachStatement>())
             _foreachLocals.Add(foreachNode.LocalIndex);
-        foreach (var pattern in DescendantsOutsideLambdas(function).OfType<IsPattern>())
+        foreach (var pattern in DescendantsOutsideNestedFunctions(function).OfType<IsPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
-        foreach (var deconstruction in DescendantsOutsideLambdas(function).OfType<DeconstructionAssignment>())
+        foreach (var deconstruction in DescendantsOutsideNestedFunctions(function).OfType<DeconstructionAssignment>())
             if (deconstruction.IsDeclaration)
                 foreach (int index in deconstruction.LocalIndices)
                     _deconstructionLocals.Add(index);
@@ -293,7 +293,7 @@ public sealed partial class CSharpPrinter
     static HashSet<int> CollectBranchTargets(IrFunction function)
     {
         var targets = new HashSet<int>();
-        foreach (var node in DescendantsOutsideLambdas(function))
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
             switch (node)
             {
@@ -317,7 +317,7 @@ public sealed partial class CSharpPrinter
             .Where(clause => clause.VariableIndex is not null)
             .Select(clause => clause.VariableIndex!.Value)
             .ToHashSet();
-        foreach (var node in DescendantsOutsideLambdas(function))
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
             switch (node)
             {
@@ -404,9 +404,9 @@ public sealed partial class CSharpPrinter
         // once, up front, with its merged type — declaring it at one store would
         // type it from that branch's value and strand the other branch's store.
         var slotStoreCounts = new Dictionary<int, int>();
-        foreach (var store in DescendantsOutsideLambdas(function).OfType<StoreStackSlot>())
+        foreach (var store in DescendantsOutsideNestedFunctions(function).OfType<StoreStackSlot>())
             slotStoreCounts[store.Slot] = slotStoreCounts.GetValueOrDefault(store.Slot) + 1;
-        foreach (var node in DescendantsOutsideLambdas(function))
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
             switch (node)
             {
@@ -469,7 +469,7 @@ public sealed partial class CSharpPrinter
 
     /// <summary>True when the local slot is read (loaded by value or address) anywhere in the body.</summary>
     static bool LocalIsRead(IrFunction function, int index)
-        => DescendantsOutsideLambdas(function).Any(n =>
+        => DescendantsOutsideNestedFunctions(function).Any(n =>
             (n is LoadLocal load && load.Index == index)
             || (n is LoadLocalAddress address && address.Index == index));
 
@@ -477,7 +477,7 @@ public sealed partial class CSharpPrinter
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
     {
         IrNode? last = null;
-        foreach (var node in DescendantsOutsideLambdas(function))
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
             if (node is LoadLocal load && load.Index == localIndex
                 || node is StoreLocal store && store.Index == localIndex
@@ -494,16 +494,40 @@ public sealed partial class CSharpPrinter
         return false;
     }
 
-    static IEnumerable<IrNode> DescendantsOutsideLambdas(IrNode node)
+    static IEnumerable<IrNode> DescendantsOutsideNestedFunctions(IrNode node)
     {
         foreach (var child in node.Children)
         {
             yield return child;
-            if (child is Lambda)
+            if (child is Lambda or LocalFunctionStatement)
                 continue;
-            foreach (var descendant in DescendantsOutsideLambdas(child))
+            foreach (var descendant in DescendantsOutsideNestedFunctions(child))
                 yield return descendant;
         }
+    }
+
+    static bool NeedsNestedLocalFunctionScope(LocalFunctionStatement localFunction)
+        => !localFunction.Locals.IsEmpty
+            || localFunction.Body.Descendants.Any(node => node is LoadStackSlot or StoreStackSlot);
+
+    void AppendNestedLocalFunctionBody(StringBuilder sb, LocalFunctionStatement localFunction, int indent)
+    {
+        var body = (BlockContainer)localFunction.Body.Clone();
+        var function = new IrFunction(
+            localFunction.Name,
+            _function.DeclaringType,
+            new MethodSignature(localFunction.ReturnType, localFunction.Parameters, HasThis: false, GenericParameterCount: 0),
+            localFunction.Locals,
+            body)
+        {
+            LocalNames = localFunction.LocalNames,
+            UsesUpdatedMemorySafetyRules = localFunction.UsesUpdatedMemorySafetyRules,
+            SkipLocalsInit = localFunction.SkipLocalsInit,
+        };
+
+        string pad = new(' ', indent * 4);
+        foreach (var line in new CSharpPrinter(function).PrintBody(function).TrimEnd().Split(Environment.NewLine))
+            sb.Append(pad).AppendLine(line);
     }
 
     /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
@@ -531,7 +555,10 @@ public sealed partial class CSharpPrinter
             {
                 sb.Append(pad).AppendLine(header);
                 sb.Append(pad).AppendLine("{");
-                AppendContainer(sb, localFunction.Body, indent + 1);
+                if (NeedsNestedLocalFunctionScope(localFunction))
+                    AppendNestedLocalFunctionBody(sb, localFunction, indent + 1);
+                else
+                    AppendContainer(sb, localFunction.Body, indent + 1);
                 sb.Append(pad).AppendLine("}");
             }
             return;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -56,7 +56,7 @@ static class DefiniteAssignment
         {
             if (node is null)
                 return;
-            foreach (var n in SelfAndDescendantsOutsideLambdas(node))
+            foreach (var n in SelfAndDescendantsOutsideNestedFunctions(node))
             {
                 int? read = n switch
                 {
@@ -69,13 +69,13 @@ static class DefiniteAssignment
             }
         }
 
-        static IEnumerable<IrNode> SelfAndDescendantsOutsideLambdas(IrNode node)
+        static IEnumerable<IrNode> SelfAndDescendantsOutsideNestedFunctions(IrNode node)
         {
             yield return node;
-            if (node is Lambda)
+            if (node is Lambda or LocalFunctionStatement)
                 yield break;
             foreach (var child in node.Children)
-                foreach (var descendant in SelfAndDescendantsOutsideLambdas(child))
+                foreach (var descendant in SelfAndDescendantsOutsideNestedFunctions(child))
                     yield return descendant;
         }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1605,12 +1605,24 @@ public sealed class Lambda : IrExpression
 public sealed class LocalFunctionStatement : IrNode
 {
     public LocalFunctionStatement(
-        string name, TypeRef returnType, ImmutableArray<Parameter> parameters, bool isStatic, BlockContainer body)
+        string name,
+        TypeRef returnType,
+        ImmutableArray<Parameter> parameters,
+        bool isStatic,
+        ImmutableArray<TypeRef> locals,
+        ImmutableArray<string?> localNames,
+        bool usesUpdatedMemorySafetyRules,
+        bool skipLocalsInit,
+        BlockContainer body)
     {
         Name = name;
         ReturnType = returnType;
         Parameters = parameters;
         IsStatic = isStatic;
+        Locals = locals;
+        LocalNames = localNames;
+        UsesUpdatedMemorySafetyRules = usesUpdatedMemorySafetyRules;
+        SkipLocalsInit = skipLocalsInit;
         AddChild(body);
     }
 
@@ -1618,6 +1630,10 @@ public sealed class LocalFunctionStatement : IrNode
     public TypeRef ReturnType { get; }
     public ImmutableArray<Parameter> Parameters { get; }
     public bool IsStatic { get; }
+    public ImmutableArray<TypeRef> Locals { get; }
+    public ImmutableArray<string?> LocalNames { get; }
+    public bool UsesUpdatedMemorySafetyRules { get; }
+    public bool SkipLocalsInit { get; }
     public BlockContainer Body => (BlockContainer)Children[0];
     public override IEnumerable<TypeRef> DirectTypes => Parameters.Select(p => p.Type).Append(ReturnType);
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -32,7 +32,7 @@ internal static class ClosureCoverage
     [Completeness(CompletenessLevel.Partial, "expression, simple block, and non-capturing local-bound bodies; capturing local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
-    [Completeness(CompletenessLevel.Partial, "static and capturing (ref struct display-class env, substituted back) local functions with a zero-local body, declared back into the host method and called by their source name; recursive, nested, and shared-environment local functions still owed")]
+    [Completeness(CompletenessLevel.Partial, "static local functions with expression/simple block/local-bodied forms, plus capturing (ref struct display-class env, substituted back) zero-local local functions, declared back into the host method and called by their source name; capturing local-bodied, recursive, nested, and shared-environment local functions still owed")]
     public static LocalFunctionRaisingPass LocalFunction => new();
 
     [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from its <>c__DisplayClass environment — folded onto the delegate, or a local set up and shared across statements (allocation/stores elided); a class captured by a local function, or nested environments, still owed")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -12,9 +12,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// unqualified <c>Name(args)</c> (the source spelling, replacing the
 /// otherwise-unspeakable <c>Enclosing.&lt;Outer&gt;g__Name|N_M(args)</c>).
 ///
-/// <para>Slice — <b>static</b> local functions with a zero-local body that prints
-/// in the host scope (arguments are self-naming), <b>non-capturing or
-/// capturing</b>. A capturing local function takes its <c>&lt;&gt;c__DisplayClass</c>
+/// <para>Slice — <b>static</b> local functions may carry body locals/slots and
+/// print in a nested scope. Capturing local functions remain zero-local after
+/// capture substitution because their substituted captures print in the host
+/// scope. A capturing local function takes its <c>&lt;&gt;c__DisplayClass</c>
 /// environment (a struct) by <c>ref</c> as its last parameter; the host sets the
 /// captured fields directly on a local and passes <c>ref env</c>. This recovers
 /// it by substituting each <c>env.f</c> read in the body with the captured value,
@@ -69,9 +70,10 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
             if (environment is not null && !SubstituteEnvironment(body, environment))
                 continue;
-            if (!body.Locals.IsEmpty
+            bool allowLocals = environment is null;
+            if (!allowLocals && !body.Locals.IsEmpty
                 || body.Descendants.OfType<UnsupportedNode>().Any()
-                || !IsPrintableBody(body))
+                || !IsPrintableBody(body, allowLocals))
                 continue;
 
             string name = CSharpNaming.MethodName(method.Name);
@@ -99,7 +101,15 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             // synthesized method is static only because the environment is passed
             // explicitly by ref, which the recovered source form does not show.
             declarations.Add(new LocalFunctionStatement(
-                name, method.ReturnType, parameters, isStatic: environment is null, container));
+                name,
+                method.ReturnType,
+                parameters,
+                isStatic: environment is null,
+                body.Locals,
+                body.LocalNames,
+                body.UsesUpdatedMemorySafetyRules,
+                body.SkipLocalsInit,
+                container));
             environment?.Elide();
         }
 
@@ -187,7 +197,7 @@ public sealed class LocalFunctionRaisingPass : IIrPass
     static bool IsDisplayClassParameter(TypeRef type)
         => GeneratedCodeIdentity.IsDisplayClassName(type.Kind == TypeRefKind.ByRef ? type.ElementType! : type);
 
-    static bool IsPrintableBody(IrFunction body)
+    static bool IsPrintableBody(IrFunction body, bool allowLocalStatements = false)
     {
         if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
             return false;
@@ -197,6 +207,12 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             var statement = statements[i];
             if (statement is Return { Value: not null })
                 return i == statements.Count - 1;
+            if (statement is ExpressionStatement)
+                continue;
+            if (allowLocalStatements && statement is StoreLocal)
+                continue;
+            if (allowLocalStatements && statement is StoreStackSlot)
+                continue;
             if (statement is not ExpressionStatement)
                 return false;
         }


### PR DESCRIPTION
## Summary

- Raise static/noncapturing local functions with body-local and stack-slot temporaries back to local-function declarations.
- Keep capturing local functions with body locals lowered as the adversarial boundary.
- Prevent nested local-function locals/slots from leaking into enclosing declaration and definite-assignment analysis.
- Update local-function ledger and fact wording to reflect the narrowed support boundary.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*LocalFunctionRaisingPassTests*" -method "*LoweringFactCatalogTests*" -method "*LoweringCoverageTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*FidelityGateTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `git diff --check`
