### PR TITLE
Render extension-method calls in instance syntax (xs.Where(p))

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
@@ -1,0 +1,56 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ExtensionMethodCallTests
+{
+    // Extension-ness is a cross-assembly fact (System.Linq lives in the shared
+    // framework, not beside the test assembly), so the default sibling locator
+    // cannot resolve it. Reach the running runtime directory, the same pattern
+    // AllocationClassifierTests uses for its corelib base-chain checks.
+    static readonly ILInspector.Metadata.AssemblyLocator RuntimeLocator = (name, trust) =>
+    {
+        string dir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        string path = System.IO.Path.Combine(dir, name + ".dll");
+        return System.IO.File.Exists(path) ? path : null;
+    };
+
+    static string PrintRaised(string methodName)
+    {
+        using var context = new MetadataContext(RuntimeLocator);
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeLocator, context);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void LinqCall_RendersAsInstanceExtensionSyntax()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateArgument));
+
+        // The static spelling Enumerable.Where(items, pred) is rendered as the
+        // instance form items.Where(pred) the source used.
+        Assert.Contains(".Where", output);
+        Assert.DoesNotContain("Enumerable.Where", output);
+    }
+
+    [Fact]
+    public void LinqChain_RendersAsFluentInstanceChain()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedDelegateChain));
+
+        Assert.Contains(".Where", output);
+        Assert.Contains(".Select", output);
+        Assert.DoesNotContain("Enumerable.Where", output);
+        Assert.DoesNotContain("Enumerable.Select", output);
+        // The first call is the receiver of the second: ...Where(...).Select(...).
+        int where = output.IndexOf(".Where", StringComparison.Ordinal);
+        int select = output.IndexOf(".Select", StringComparison.Ordinal);
+        Assert.True(where >= 0 && select > where, $"expected .Where(...).Select(...), got: {output}");
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -76,7 +76,8 @@ internal sealed class CrossAssemblyTypeResolver
         bool needsRefKinds = NeedsParameterRefKinds(callee);
         bool needsGenerated = NeedsGeneratedFacts(callee);
         bool needsUnsafe = resolveRequiresUnsafe && !callee.RequiresUnsafe;
-        if (!needsRefKinds && !needsGenerated && !needsUnsafe)
+        bool needsExtension = NeedsExtensionFacts(callee);
+        if (!needsRefKinds && !needsGenerated && !needsUnsafe && !needsExtension)
             return callee;
 
         var type = NamedDefinition(callee.DeclaringType);
@@ -106,6 +107,7 @@ internal sealed class CrossAssemblyTypeResolver
             RequiresUnsafe = callee.RequiresUnsafe || (needsUnsafe && resolved.RequiresUnsafe),
             CompilerGenerated = needsGenerated ? resolved.CompilerGenerated : callee.CompilerGenerated,
             DeclaringTypeCompilerGenerated = needsGenerated ? resolved.DeclaringTypeCompilerGenerated : callee.DeclaringTypeCompilerGenerated,
+            IsExtension = needsExtension ? resolved.IsExtension : callee.IsExtension,
         };
     }
 
@@ -138,7 +140,8 @@ internal sealed class CrossAssemblyTypeResolver
                     parameterRefKinds,
                     typeRequiresUnsafe || MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
                     FactState(methodCompilerGenerated),
-                    FactState(typeCompilerGenerated));
+                    FactState(typeCompilerGenerated),
+                    FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)));
             }
 
             return null;
@@ -309,11 +312,20 @@ internal sealed class CrossAssemblyTypeResolver
             || method.DeclaringType.Name.Contains('<', StringComparison.Ordinal)
             || method.DeclaringType.Name.Contains("__DisplayClass", StringComparison.Ordinal);
 
+    // An extension method is always static with at least one parameter (the
+    // receiver). That structural pre-filter keeps the cross-assembly resolution
+    // off instance calls and parameterless statics, the bulk of call sites.
+    static bool NeedsExtensionFacts(MethodRef method)
+        => method.IsExtension == MetadataFactState.Unknown
+            && !method.HasThis
+            && method.ParameterTypes.Length >= 1;
+
     static MetadataFactState FactState(bool value) => value ? MetadataFactState.Yes : MetadataFactState.No;
 
     readonly record struct ResolvedMethodFacts(
         ParameterRefKindResult ParameterRefKinds,
         bool RequiresUnsafe,
         MetadataFactState CompilerGenerated,
-        MetadataFactState DeclaringTypeCompilerGenerated);
+        MetadataFactState DeclaringTypeCompilerGenerated,
+        MetadataFactState IsExtension);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -116,6 +116,20 @@ public sealed partial class CSharpPrinter
             // operator spelling is the faithful inverse.
             if (IsOperatorCall(call))
                 return OperatorSpelling(call)!;
+            // An extension method's static call C.M(receiver, args) renders as the
+            // instance form receiver.M(args) the source used. No IL anchor chooses
+            // between the two forms (taste rule case 3), and the runtime writes the
+            // instance form; only sugar on confirmed [Extension] evidence, and drop
+            // the receiver from the parameter pairing (it is parameter 0).
+            if (call.Callee.IsExtension == MetadataFactState.Yes && arguments.Count >= 1)
+            {
+                IReadOnlyList<TypeRef> restTypes = [.. call.Callee.ParameterTypes.Skip(1)];
+                var restRefKinds = call.Callee.ParameterRefKinds.IsDefaultOrEmpty
+                    ? call.Callee.ParameterRefKinds
+                    : [.. call.Callee.ParameterRefKinds.Skip(1)];
+                string extensionArgs = Arguments(arguments.Skip(1), restTypes, restRefKinds);
+                return $"{ReceiverText(arguments[0])}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
+            }
             return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
         }
         var receiver = arguments[0];

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1469,6 +1469,7 @@ public static class IrImporter
                     RequiresUnsafe = MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
                     CompilerGenerated = FactState(methodCompilerGenerated),
                     DeclaringTypeCompilerGenerated = FactState(typeCompilerGenerated),
+                    IsExtension = FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)),
                 };
             }
             case HandleKind.MemberReference:

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -72,6 +72,17 @@ public sealed record MethodRef(
     public MetadataFactState DeclaringTypeCompilerGenerated { get; init; } = MetadataFactState.Unknown;
 
     /// <summary>
+    /// Metadata <c>[Extension]</c> evidence on this method: it is an extension
+    /// method, so a static call <c>C.M(receiver, args)</c> can render as the
+    /// instance form <c>receiver.M(args)</c> the source almost certainly used.
+    /// <see cref="MetadataFactState.Unknown"/> until the defining MethodDef is
+    /// read (same-assembly at import, cross-assembly through the resolver); the
+    /// printer sugars only on <see cref="MetadataFactState.Yes"/>, so an
+    /// unresolved callee keeps the explicit static spelling — never a wrong one.
+    /// </summary>
+    public MetadataFactState IsExtension { get; init; } = MetadataFactState.Unknown;
+
+    /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
     /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
     /// resolved as a MemberReference (cross-assembly, or a same-assembly call on

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -43,6 +43,11 @@ internal static class MethodDefinitionFacts
     internal static bool HasCompilerGeneratedAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 
+    // The compiler stamps ExtensionAttribute on an extension method (and on its
+    // declaring class and module). The method-level mark is the precise signal.
+    internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)
+        => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices", "ExtensionAttribute");
+
     internal static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
     {
         if (handles.Count == 0)


### PR DESCRIPTION
## What

An extension method compiles to a static call — `xs.Where(p)` and `Enumerable.Where(xs, p)` are **byte-identical IL** (the instance form is translated to the static one during binding). With no IL anchor to choose between them (**taste rule case 3 — no IL anchor → follow the oracle**), and the runtime writing the instance form, that is what we render.

Combined with the delegate-cache collapse (#784) and call-chain inlining (#805), a LINQ chain now comes back as the source shape:

```csharp
// before
return Enumerable.Select<int, int>(Enumerable.Where<int>(xs, x => x > 0), x => x * 2);
// after
return xs.Where<int>(x => x > 0).Select<int, int>(x => x * 2);
```

## How

- Add an `IsExtension` metadata fact to `MethodRef` (the `[Extension]` mark on the method), read from the MethodDef **same-assembly at import** and **cross-assembly through `CrossAssemblyTypeResolver`** (where `System.Linq` resolves). A structural pre-filter (static, ≥ 1 parameter) keeps the resolution off instance calls and parameterless statics — the bulk of call sites — mirroring the existing `LooksCompilerGenerated` discipline.
- `CallText` sugars a static call to `receiver.Method(rest)` only on **confirmed `[Extension]` evidence** (`MetadataFactState.Yes`); an unresolved callee keeps the explicit `Type.Method(...)` spelling, never a guessed one.

## Precision

`Array.FindAll` (a plain static, not an extension) keeps its static form — only `[Extension]`-marked methods are sugared. The instance form requires `System.Linq` in scope, but the output already emits the short name `Enumerable` (same using requirement), so validity is unchanged — confirmed by the fidelity gate binding + recompiling.

## Verification

- `ExtensionMethodCallTests` (new) renders the LINQ fixtures via a runtime-dir locator (the `AllocationClassifierTests` pattern) and asserts the instance/fluent form.
- `dotnet run --project src/ILInspector.Decompiler.Tests` — **576/576**, including `FidelityGateTests` (`xs.Where(...)` recompiles to the identical static call — no IL change) and `CorpusSweepGateTests`. Suite time unchanged (~110s), so the added cross-assembly resolution stays within budget.

## Series

Completes the LINQ readability series: #784 (cache collapse) → #805 (chain inlining) → this (extension sugar). Independent of the ledger-note correction (#815).

🤖 Generated with [Claude Code](https://claude.com/claude-code)