### PR TITLE
Add anonymous object metadata adversarial tests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
@@ -64,4 +64,85 @@ public class AnonymousObjectPassTests
         var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.AnonMemberShorthand))).Output;
         Assert.Contains("new { t.X, t.Y }", output);
     }
+
+    [Fact]
+    public void PropertyNameCountMismatch_IsNotRaised()
+    {
+        var function = FunctionWithAnonymousMetadata(["a"], [new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32")), new LoadArgument(1, "b", TypeRef.CoreLib("System", "String"))]);
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void EmptyPropertyNames_AreNotRaised()
+    {
+        var function = FunctionWithAnonymousMetadata([], [new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32"))]);
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DuplicatePropertyNames_AreNotRaisedToInvalidAnonymousObject()
+    {
+        var function = FunctionWithAnonymousMetadata(["a", "a"], [new LoadArgument(0, "a", TypeRef.CoreLib("System", "Int32")), new LoadArgument(1, "b", TypeRef.CoreLib("System", "String"))]);
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void GeneratedLookingTypeWithoutCapturedPropertyNames_IsNotRaised()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "<>f__AnonymousType0`1");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", TypeRef.CoreLib("System", "Void"), [intType], HasThis: true);
+        var function = FunctionReturning(new NewObject(ctor, [new LoadArgument(0, "a", intType)]));
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction FunctionWithAnonymousMetadata(string[] propertyNames, IrExpression[] arguments)
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "<>f__AnonymousType0`2");
+        var ctor = new MethodRef(
+            type,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [.. arguments.Select(argument => argument.ResultType ?? TypeRef.CoreLib("System", "Object"))],
+            HasThis: true);
+        return FunctionReturning(new NewObject(ctor, arguments)
+        {
+            AnonymousPropertyNames = [.. propertyNames],
+        });
+    }
+
+    static IrFunction FunctionReturning(IrExpression expression)
+    {
+        var returnType = expression.ResultType ?? TypeRef.CoreLib("System", "Object");
+        var block = new Block();
+        block.Add(new Return(expression));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(returnType, [new Parameter("a", TypeRef.CoreLib("System", "Int32")), new Parameter("b", TypeRef.CoreLib("System", "String"))], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
@@ -24,11 +24,22 @@ public sealed class AnonymousObjectPass : IIrPass
             var names = newObject.AnonymousPropertyNames;
             if (names.IsDefaultOrEmpty || names.Length != newObject.Arguments.Count)
                 continue;
+            if (HasDuplicateNames(names))
+                continue;
 
             var values = newObject.DetachChildren().Cast<IrExpression>().ToList();
             var anonymous = new AnonymousObject(newObject.Constructor.DeclaringType, names, values);
             context.Stepper.StepOver("raise anonymous-type constructor to anonymous object", newObject);
             newObject.ReplaceWith(anonymous);
         }
+    }
+
+    static bool HasDuplicateNames(IEnumerable<string> names)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in names)
+            if (!seen.Add(name))
+                return true;
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- add adversarial tests for anonymous-object metadata mismatches: count mismatch, empty property names, duplicate names, and generated-looking types without captured names
- add a small guard so duplicate anonymous-object property names do not raise to invalid C#

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.AnonymousObjectPassTests
- dotnet build src/dotnet-inspect -c Release --no-restore
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore