### PR TITLE
Render a pointer-vs-zero comparison as `ptr == null`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1696,6 +1696,19 @@ public class CfgSampleClass
         return (nuint)(&value);
     }
 
+    // A pointer compared to null: csc lowers `p == null` to `ldc.i4.0; conv.u;
+    // ceq`, so the zero arrives as a native-int constant. The branch must spell
+    // `p == null`, not the CS0019 `p == (nuint)0`.
+    public static unsafe int PointerNullBranch(byte* p)
+    {
+        if (p == null)
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+
     public static unsafe int UnsafeReadArrayElementAddress(int[] values)
     {
         fixed (int* p = &values[0])

--- a/src/ILInspector.Decompiler.Tests/PointerNullComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerNullComparisonTests.cs
@@ -1,0 +1,32 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// csc lowers a pointer `null` comparison (`p == null`) to `ldc.i4.0; conv.u;
+// ceq`, so the zero reaches the printer as a native-int constant (often through
+// a Convert). Comparing a pointer to that integer is CS0019; the printer must
+// recover the `p == null` form. C# forbids `is null` on pointer types (CS8521),
+// so the equality operator is required, not the is-pattern.
+public class PointerNullComparisonTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void PointerComparedToZero_RendersNullComparison()
+    {
+        var output = Render(nameof(CfgSampleClass.PointerNullBranch));
+
+        Assert.Contains("== null", output);
+        Assert.DoesNotContain("(nuint)0", output);
+        Assert.DoesNotContain("== 0", output);
+        Assert.DoesNotContain("is null", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -84,6 +84,25 @@ public sealed partial class CSharpPrinter
                 ? $"{Operand(operand)} is null"
                 : $"{Operand(operand)} is not null";
         }
+        // A pointer compared to a native-int zero is a null check: csc lowers
+        // `ptr == null` to `ldc.i4.0; conv.u; ceq`, so the zero arrives as an
+        // `int`/`nuint` 0 (often through a Convert). Comparing a pointer to that
+        // integer is CS0019; spell it `ptr == null`. C# forbids `is null` on
+        // pointer types (CS8521), so this uses the equality form, not is-null.
+        if (kind is ComparisonKind.Equal or ComparisonKind.NotEqual)
+        {
+            var pointer = left.ResultType is { Kind: TypeRefKind.Pointer } ? left
+                : right.ResultType is { Kind: TypeRefKind.Pointer } ? right
+                : null;
+            if (pointer is not null)
+            {
+                var other = ReferenceEquals(pointer, left) ? right : left;
+                if (other.ResultType is not { Kind: TypeRefKind.Pointer } && IsZeroConstant(other))
+                {
+                    return $"{Operand(pointer)} {ComparisonOperator(kind)} null";
+                }
+            }
+        }
         return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
@@ -91,6 +110,21 @@ public sealed partial class CSharpPrinter
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)
         => TypeFamilies.IsFloat(left.ResultType) || TypeFamilies.IsFloat(right.ResultType);
+
+    /// <summary>
+    /// True when an expression is an integer zero literal, peeling any native-int
+    /// reinterpret converts (`ldc.i4.0; conv.u`) the IL emits for a pointer
+    /// `null`. Used to spell a pointer-vs-zero comparison as `ptr == null`.
+    /// </summary>
+    static bool IsZeroConstant(IrExpression expression)
+    {
+        while (expression is Convert convert)
+        {
+            expression = convert.Operand;
+        }
+
+        return expression is Constant { Value: 0 or 0L or 0u or 0UL or (short)0 or (sbyte)0 or (byte)0 or (ushort)0 };
+    }
 
     /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
     string UnsignedOperand(IrExpression operand)


### PR DESCRIPTION
## Summary

A pointer compared to null rendered the invalid `if (p == (nuint)0)` (CS0019 —
`byte*`/`char*`/`void*` vs `nuint`). It now renders the idiomatic `if (p == null)`.

## Root cause

csc lowers a pointer null check (`p == null`) to `ldc.i4.0; conv.u; ceq`, so the
zero reaches the printer as an `int`/`nuint` constant (often wrapped in a
`Convert nuint`). `ComparisonText` compared the pointer operand directly against
that integer, which is CS0019.

## Fix

`ComparisonText` now recovers the null check: when one operand is pointer-typed
and the other is a zero constant (peeling the native-int reinterpret converts
via a new `IsZeroConstant` helper), it spells `ptr == null` / `ptr != null`. The
equality form is required because C# forbids `is null` on pointer types (CS8521).

Example: `Interop.Sys::StrError` went from `if (V_1 == ((nuint)0))` to
`if (V_1 == null)`.

## Numbers

- Semantic CS0019 **63 -> 33** (-30 methods)
- Full malformed flat
- Inventory flat (40987/41012 Full, 0 importer bugs)
- 609 decompiler + 1157 product tests green (new `PointerNullComparisonTests` +
  `CfgSampleClass.PointerNullBranch` fixture)
