### PR TITLE
Curate adversarial fact classifications

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
@@ -10,8 +10,8 @@ internal sealed class IteratorRecoveryFacts : ILoweringFactProvider
             [
                 new FactPrimitive("generated.iterator-state-machine", "GeneratedCodeIdentity.IsIteratorStateMachineConstructor"),
             ],
-            PositiveCoverage: "IteratorReconstructionPassTests linear, empty, counting-loop, conditional, and multi-yield iterator fixtures",
-            AdversarialCoverage: "IteratorReconstructionPassTests nested/foreach-delegation negatives and IteratorAcknowledgmentPassTests state-machine-name lookalike",
-            MissingDiscriminator: "foreach-delegation, nested loops, captured iterators, and deeper state-machine/PDB correlation remain owed"),
+            PositiveCoverage: "IteratorReconstructionPassTests linear, yield-nothing, counting-loop, conditional, multi-yield, nested-loop, and foreach-delegation iterator fixtures",
+            AdversarialCoverage: "IteratorReconstructionPassTests parameter-referencing empty iterator and IteratorAcknowledgmentPassTests state-machine-name lookalike",
+            MissingDiscriminator: "captured iterator shapes and deeper state-machine/PDB correlation remain owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -32,8 +32,8 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
                 new FactPrimitive("pdb.hidden-local", "absence of source local names on operand spills"),
             ],
-            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 tuple equality and inequality fixtures",
-            AdversarialCoverage: "TupleBinaryOperatorPassTests direct field comparison, source-named local comparison, and tuple-literal negatives",
-            MissingDiscriminator: "arity 3+, nested/rest tuples, tuple literals, and no-PDB source local comparisons still owed"),
+            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 whole-tuple equality/inequality and tuple-literal equality/inequality fixtures, including arity 3 literals",
+            AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, direct manual field comparison, and source-named local field comparison",
+            MissingDiscriminator: "whole-tuple arity 3+, nested/rest tuples, mixed literal-vs-variable operands, and no-PDB source-local comparisons still owed"),
     ];
 }


### PR DESCRIPTION
## Summary
- update iterator recovery sidecar notes after nested-loop and foreach-delegation raises landed
- reclassify tuple-literal tuple binary fixtures as positive coverage rather than adversarial negatives
- narrow remaining missing-discriminator notes to the current owed shapes

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.TupleBinaryOperatorPassTests -class ILInspector.Decompiler.Tests.IteratorReconstructionPassTests