### PR TITLE
Raise every array foreach in a method, not just the first

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1312,6 +1312,32 @@ public class CfgSampleClass
         return sum;
     }
 
+    // Two array foreach loops in one method: the pass must raise BOTH, not just
+    // the first — passes run once, so a single-match-then-return leaves the second
+    // a for loop.
+    public static int TwoForeachArrays(int[] a, int[] b)
+    {
+        int sum = 0;
+        foreach (int n in a)
+            sum += n;
+        foreach (int m in b)
+            sum -= m;
+        return sum;
+    }
+
+    // An enumerator foreach followed by an array foreach in one method. The
+    // enumerator phase must raise all its matches AND fall through to the array
+    // phase so both forms recover in a single pass.
+    public static int EnumeratorThenArrayForeach(IEnumerable<int> items, int[] more)
+    {
+        int sum = 0;
+        foreach (int item in items)
+            sum += item;
+        foreach (int n in more)
+            sum += n;
+        return sum;
+    }
+
     public static Func<int, int> ClosureCapture(int offset)
     {
         return x => x + offset;

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -102,6 +102,26 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void TwoArrayForeachLoops_RaiseBoth()
+    {
+        var function = Raised(nameof(CfgSampleClass.TwoForeachArrays));
+
+        Assert.Equal(2, function.Descendants.OfType<ForeachStatement>().Count());
+        Assert.DoesNotContain(function.Descendants.OfType<ForLoop>(), _ => true);
+    }
+
+    [Fact]
+    public void EnumeratorThenArrayForeach_RaisesBothForms()
+    {
+        var function = Raised(nameof(CfgSampleClass.EnumeratorThenArrayForeach));
+
+        Assert.Equal(2, function.Descendants.OfType<ForeachStatement>().Count());
+        Assert.DoesNotContain(function.Descendants.OfType<ForLoop>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<UsingStatement>(), _ => true);
+        Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), _ => true);
+    }
+
+    [Fact]
     public void SourceNamedEnumeratorUsingLoop_StaysUsingWhile()
     {
         var function = Raised(nameof(CfgSampleClass.StructUsing));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -35,6 +35,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// source names. Both slots must be referenced <em>only</em> by the lowered
 /// shape across the whole function — a reference anywhere else means the slots
 /// are not the hidden foreach scaffolding.</para>
+///
+/// <para>The compiler may reuse one array-copy/index pair across several sibling
+/// <c>foreach</c> loops in a method. The array phase therefore collects every
+/// structural candidate first and pools the scaffold nodes per slot across all
+/// of them before the whole-function uniqueness check, so each loop's reference
+/// to the shared slots reads as scaffolding rather than a stray use. Every clean
+/// candidate is raised; passes run once, so neither phase may stop after the
+/// first match, and the enumerator phase falls through to the array phase.</para>
 /// </summary>
 public sealed class ForeachStatementPass : IIrPass
 {
@@ -55,25 +63,53 @@ public sealed class ForeachStatementPass : IIrPass
             var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
             context.Stepper.StepOver("raise enumerator loop to foreach", usingStatement);
             usingStatement.ReplaceWith(foreachStatement);
-            return;
         }
 
+        // Collect every structural array-foreach candidate first, then admit a
+        // candidate only if its two scaffold slots are referenced solely by
+        // recognized foreach scaffolding. Pooling the allowed nodes per slot
+        // tolerates the compiler reusing one array-copy/index pair across several
+        // foreach loops in the same method (which would otherwise make each loop
+        // look like it has stray references to the others' nodes).
+        var candidates = new List<ArrayCandidate>();
         foreach (var loop in function.Descendants.OfType<ForLoop>().ToList())
         {
-            if (TryMatchArray(function, loop) is not { } match)
-                continue;
+            if (TryMatchArray(function, loop) is { } candidate)
+                candidates.Add(candidate);
+        }
 
-            var collection = match.ArrayCopy.Value;
+        var allowedBySlot = new Dictionary<int, HashSet<IrNode>>();
+        foreach (var candidate in candidates)
+        {
+            Pool(allowedBySlot, candidate.ArrayIndex, candidate.Allowed);
+            Pool(allowedBySlot, candidate.IndexIndex, candidate.Allowed);
+        }
+
+        var clean = candidates
+            .Where(c => ReferencedOnlyBy(function, c.ArrayIndex, allowedBySlot[c.ArrayIndex])
+                && ReferencedOnlyBy(function, c.IndexIndex, allowedBySlot[c.IndexIndex]))
+            .ToList();
+
+        foreach (var candidate in clean)
+        {
+            var loop = candidate.Loop;
+            var collection = candidate.ArrayCopy.Value;
             collection.Detach();
-            match.ItemStore.Detach();
+            candidate.ItemStore.Detach();
             var body = loop.Body;
             body.Detach();
-            var foreachStatement = new ForeachStatement(match.ItemStore.Index, match.ItemStore.Type, collection, body);
+            var foreachStatement = new ForeachStatement(candidate.ItemStore.Index, candidate.ItemStore.Type, collection, body);
             context.Stepper.StepOver("raise indexed array loop to foreach", loop);
             loop.ReplaceWith(foreachStatement);
-            match.ArrayCopy.Detach();
-            return;
+            candidate.ArrayCopy.Detach();
         }
+    }
+
+    static void Pool(Dictionary<int, HashSet<IrNode>> allowedBySlot, int slot, IReadOnlyCollection<IrNode> allowed)
+    {
+        if (!allowedBySlot.TryGetValue(slot, out var set))
+            allowedBySlot[slot] = set = new HashSet<IrNode>(ReferenceEqualityComparer.Instance);
+        set.UnionWith(allowed);
     }
 
     sealed record EnumeratorMatch(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
@@ -105,9 +141,10 @@ public sealed class ForeachStatementPass : IIrPass
         return new EnumeratorMatch(getEnumerator.Arguments[0], loop, currentStore);
     }
 
-    sealed record ArrayMatch(StoreLocal ArrayCopy, StoreLocal ItemStore);
+    sealed record ArrayCandidate(
+        ForLoop Loop, StoreLocal ArrayCopy, StoreLocal ItemStore, int ArrayIndex, int IndexIndex, IReadOnlyCollection<IrNode> Allowed);
 
-    static ArrayMatch? TryMatchArray(IrFunction function, ForLoop loop)
+    static ArrayCandidate? TryMatchArray(IrFunction function, ForLoop loop)
     {
         // The array copy is the statement immediately before the loop.
         if (loop.Parent is not Block block || loop.ChildIndex == 0)
@@ -155,17 +192,17 @@ public sealed class ForeachStatementPass : IIrPass
         if (HasSourceLocalName(function, arrayIndex) || HasSourceLocalName(function, indexIndex))
             return null;
 
-        // Whole-function safety: the copy and index slots are referenced only by
-        // the nodes this shape consumes. Anything else means they are not the
-        // hidden scaffolding (hand-written IL wearing the same shape, slot reuse).
+        // The nodes that legitimately reference the scaffold slots for this loop.
+        // Run pools these across every candidate so reuse of one slot pair by
+        // several foreach loops still counts as pure scaffolding; a reference
+        // outside the pool (hand-written IL wearing the shape, slot reuse by user
+        // code) means the slots are not the hidden foreach scaffolding.
         var allowed = new HashSet<IrNode>(ReferenceEqualityComparer.Instance)
         {
             arrayCopy, initStore, comparison.Left, lengthArray, loop.Increment, incLeft, elementArray, elementIndex,
         };
-        if (!ReferencedOnlyBy(function, arrayIndex, allowed) || !ReferencedOnlyBy(function, indexIndex, allowed))
-            return null;
 
-        return new ArrayMatch(arrayCopy, itemStore);
+        return new ArrayCandidate(loop, arrayCopy, itemStore, arrayIndex, indexIndex, allowed);
     }
 
     static bool HasSourceLocalName(IrFunction function, int index)


### PR DESCRIPTION
## Problem

The array-`foreach` raise (#820) recovered only one loop per method. A method
with two array `foreach` loops raised **zero** of them.

Two causes:

1. The C# compiler reuses the hidden array-copy/index scaffold slots across
   sibling `foreach` loops. The pass's whole-function uniqueness check
   (`ReferencedOnlyBy`) then saw each loop's references to the shared slots as
   stray uses and declined every candidate.
2. Each phase `return`ed after its first match, and the enumerator phase
   `return`ed before the array phase ran — so even with distinct slots only one
   loop raised, and a method couldn't mix enumerator + array foreach.

## Fix

The array phase now:

- collects **all** structural candidates (structural match split out from the
  uniqueness check),
- pools the allowed scaffold nodes **per slot** across all candidates,
- admits each candidate whose two slots are referenced only by that pool, and
- raises every clean candidate.

A genuine stray use of a scaffold slot is in no candidate's pool, so that
candidate honestly declines — the existing negatives (`IndexedForOverArray`,
`CopyThenIndexedFor`) still stay `for` loops. The enumerator phase raises all
matches and falls through to the array phase.

## Fixtures / tests

- `TwoForeachArrays` — two array foreach loops, both must raise.
- `EnumeratorThenArrayForeach` — enumerator + array foreach in one method, both
  must raise.
- New pass tests assert both raise to 2 `foreach`/0 `for`; negatives unchanged.

## Validation

- Full decompiler suite: 611 tests pass.
- Corpus inventory: full raises **40984 → 40987**, importer bugs **0**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
