### PR TITLE
Cast non-int shift counts to int (uint/enum CS0019)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -16,6 +16,16 @@ public class CfgSampleClass
 
     public static byte ToByte(int x) => (byte)x;
 
+    // Shift counts whose type is not `int`: C# requires `int`, so the source `(int)`
+    // cast is mandatory — but uint->int and enum->int are no-op reinterprets that
+    // emit no conv, so the IL shift count carries the original (uint/enum) type. The
+    // printer must re-insert `(int)`; `1 << n` over a uint/enum is CS0019.
+    public static int ShiftByUInt(uint n) => 1 << (int)n;
+    public static int ShiftByEnum(CfgPriority d) => 1 << (int)d;
+
+    // Negative: a plain int count needs no cast — `1 << n` stays bare.
+    public static int ShiftByInt(int n) => 1 << n;
+
     // `a | b` of two bytes is `int` in C# (binary numeric promotion), so the
     // trailing conv.u1 is a real narrowing the language requires. The IR types the
     // `or` as byte (ECMA "wider operand wins"), so IdentityConvertPass must not drop

--- a/src/ILInspector.Decompiler.Tests/ShiftCountRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShiftCountRenderingTests.cs
@@ -1,0 +1,39 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ShiftCountRenderingTests
+{
+    static string Print(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function!).Output!;
+    }
+
+    [Fact]
+    public void UIntShiftCount_IsCastToInt()
+    {
+        // `1 << n` over a uint count is CS0019; C# requires an int count.
+        Assert.Contains("1 << (int)n", Print(nameof(CfgSampleClass.ShiftByUInt)));
+    }
+
+    [Fact]
+    public void EnumShiftCount_IsCastToInt()
+    {
+        Assert.Contains("1 << (int)d", Print(nameof(CfgSampleClass.ShiftByEnum)));
+    }
+
+    [Fact]
+    public void IntShiftCount_StaysBare()
+    {
+        // A plain int count already binds; no redundant cast.
+        var output = Print(nameof(CfgSampleClass.ShiftByInt));
+        Assert.Contains("1 << n", output);
+        Assert.DoesNotContain("(int)n", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -47,9 +47,21 @@ public sealed partial class CSharpPrinter
     {
         if (shift.Right is Binary { Kind: BinaryKind.And, Right: Constant { Value: int mask } } masked
             && ShiftWidthMask(EffectiveType(shift.Left)) is { } width && mask == width)
-            return Operand(masked.Left);
-        return Operand(shift.Right);
+            return IntShiftCount(masked.Left);
+        return IntShiftCount(shift.Right);
     }
+
+    // C#'s shift operators take an `int` count; a `uint` or enum count is CS0019.
+    // IL's shl/shr take an int32 count, so reinterpreting a uint or a 32-bit enum as
+    // int emits no conv — the cast is fidelity-neutral. A long/native-int count
+    // already carries its own narrowing Convert (int32-typed by the time it lands
+    // here), and small ints widen to int implicitly, so neither needs a cast.
+    string IntShiftCount(IrExpression count)
+        => NeedsIntShiftCast(EffectiveType(count)) ? $"(int){Operand(count)}" : Operand(count);
+
+    bool NeedsIntShiftCast(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "UInt32" }
+            || (type is not null && _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum);
 
     static int? ShiftWidthMask(TypeRef? leftOperand) => TypeFamilies.Of(leftOperand) switch
     {


### PR DESCRIPTION
## Problem

Continuing down the `--validity-check` docket (issue #622): the shift-count sub-cluster of **CS0019**. C#'s shift operators take an `int` count — a `uint` or enum count is CS0019. The source `(int)` cast is mandatory, but `uint -> int` and 32-bit-`enum -> int` are no-op reinterprets that emit no `conv`, so the IL shift count carries the original type and the printer rendered it bare:

```csharp
// System.Collections.BitArray::Get  (pos is uint)
return (_array[i] & (1 << pos)) > 0u;   // CS0019: operator '<<' on 'int' and 'uint'
// System.Char::CheckLetterOrDigit  (uc is UnicodeCategory)
return (uint)(287 & (1 << uc)) > 0u;    // CS0019: operator '<<' on 'int' and enum
```

## Fix

Re-insert `(int)` on a shift count whose type is `uint` or an enum (in `ShiftCount`, including the width-mask-strip path). A `long`/native-int count already carries its own narrowing `Convert` (int32-typed by the time it reaches here), and small ints widen to `int` implicitly — so neither needs, nor wrongly gets, a cast.

| Method | Before | After |
| --- | --- | --- |
| `BitArray::Get` | `1 << V_1` | `1 << (int)V_1` |
| `Char::CheckLetterOrDigit` | `1 << uc` | `1 << (int)uc` |

## Fidelity

**Neutral** — `(int)` over a `uint` or 32-bit enum reinterprets the same stack bits with no `conv`, so the recompiled IL is unchanged. Verified by the fixture `FidelityGate` round-tripping the new `ShiftByUInt`/`ShiftByEnum` bodies.

## Impact

Over .NET 11 preview CoreLib (full-corpus `--emit-validity-defects` diff): **11 methods** cleared from the validity docket (12 lose CS0019), **zero** new defects — bit-manipulation helpers (`BitArray`, `BitHelper`, ...). The remaining CS0019 is other roots (pointer `==` nuint, bool `==` int, uint-vs-negative-constant), each a separate follow-up.

## Tests

New `ShiftCountRenderingTests` — `uint`/enum counts cast, plain `int` count stays bare — plus the `ShiftBy*` fixtures. 628 decompiler tests green incl. `FidelityGateTests` and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)