### PR TITLE
Raise string foreach indexed loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1323,6 +1323,55 @@ public class CfgSampleClass
         return sum;
     }
 
+    // foreach over a string lowers like an array foreach, but with string.Length
+    // and string.Chars over a hidden string-copy temp and hidden index local.
+    public static int ForeachString(string text)
+    {
+        int sum = 0;
+        foreach (char ch in text)
+            sum += ch;
+        return sum;
+    }
+
+    public static int ForeachStringWithBreak(string text)
+    {
+        int sum = 0;
+        foreach (char ch in text)
+        {
+            if (ch == ',')
+                break;
+            sum += ch;
+        }
+        return sum;
+    }
+
+    // Adversarial: direct hand-written string indexed loop. No hidden string copy,
+    // so this must stay a for loop.
+    public static int IndexedForOverString(string text)
+    {
+        int sum = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char ch = text[i];
+            sum += ch;
+        }
+        return sum;
+    }
+
+    // Adversarial near-miss: structurally matches the string foreach lowering, but
+    // source names on the copy and index locals keep it a for loop.
+    public static int CopyThenIndexedForString(string text)
+    {
+        string copy = text;
+        int sum = 0;
+        for (int i = 0; i < copy.Length; i++)
+        {
+            char ch = copy[i];
+            sum += ch;
+        }
+        return sum;
+    }
+
     public static Func<int, int> ClosureCapture(int offset)
     {
         return x => x + offset;

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -102,6 +102,58 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void StringLoop_RaisesToForeach()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachString));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("char", foreachStatement.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.DoesNotContain(function.Descendants.OfType<ForLoop>(), _ => true);
+    }
+
+    [Fact]
+    public void StringLoop_PrintRaised_RendersForeach()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ForeachString))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("foreach (char ch in text)", output);
+        Assert.Contains("sum += ch;", output);
+        Assert.DoesNotContain(".Length", output);
+        Assert.DoesNotContain("for (", output);
+    }
+
+    [Fact]
+    public void StringLoop_WithBreak_RaisesToForeach()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ForeachStringWithBreak))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("foreach (char ch in text)", output);
+        Assert.Contains("break;", output);
+        Assert.DoesNotContain("for (", output);
+    }
+
+    [Fact]
+    public void HandWrittenIndexedForOverString_StaysForLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.IndexedForOverString));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
+    public void HandWrittenStringCopyIndexedFor_StaysForLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.CopyThenIndexedForString));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
     public void SourceNamedEnumeratorUsingLoop_StaysUsingWhile()
     {
         var function = Raised(nameof(CfgSampleClass.StructUsing));

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -42,6 +42,7 @@ public class IdiomShapeScorecardTests
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachArray), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
+        new("ForeachStatementPass", nameof(CfgSampleClass.ForeachString), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
@@ -11,9 +11,10 @@ internal sealed class ForeachRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("pdb.hidden-enumerator-local", "ForeachStatementPass HasSourceLocalName guard"),
                 new FactPrimitive("enumerator-call-shape", "ForeachStatementPass GetEnumerator/MoveNext/Current shape checks"),
                 new FactPrimitive("dataflow.enumerator-local-consumed", "ForeachStatementPass ReferencesEnumerator residual-use guard"),
+                new FactPrimitive("member.corelib-identity:string.Length/string.Chars", "MemberIdentity.IsStringLengthGetter/IsStringCharsGetter"),
             ],
-            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols",
-            AdversarialCoverage: "ForeachStatementPassTests source-named and no-symbols hand-written enumerator using/while loop",
-            MissingDiscriminator: "array foreach, custom pattern enumerators, and broader collection/extension GetEnumerator shapes not raised"),
+            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, and strings",
+            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop and hand-written indexed array/string for loops",
+            MissingDiscriminator: "custom pattern enumerators, multidimensional arrays, and broader collection/extension GetEnumerator shapes not raised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -1,7 +1,7 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the compiler's two <c>foreach</c> lowerings back to a
+/// Raises supported compiler <c>foreach</c> lowerings back to a
 /// <see cref="ForeachStatement"/>.
 ///
 /// <para><b>Enumerator form</b> — the general <c>IEnumerable</c> path:
@@ -35,6 +35,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// source names. Both slots must be referenced <em>only</em> by the lowered
 /// shape across the whole function — a reference anywhere else means the slots
 /// are not the hidden foreach scaffolding.</para>
+///
+/// <para><b>String form</b> mirrors the array form, but indexes through
+/// <c>string.Length</c> and <c>string.Chars</c> over hidden string-copy and index
+/// locals.</para>
 /// </summary>
 public sealed class ForeachStatementPass : IIrPass
 {
@@ -61,19 +65,30 @@ public sealed class ForeachStatementPass : IIrPass
         foreach (var loop in function.Descendants.OfType<ForLoop>().ToList())
         {
             if (TryMatchArray(function, loop) is not { } match)
-                continue;
+            {
+                if (TryMatchString(function, loop) is not { } stringMatch)
+                    continue;
 
-            var collection = match.ArrayCopy.Value;
-            collection.Detach();
-            match.ItemStore.Detach();
-            var body = loop.Body;
-            body.Detach();
-            var foreachStatement = new ForeachStatement(match.ItemStore.Index, match.ItemStore.Type, collection, body);
-            context.Stepper.StepOver("raise indexed array loop to foreach", loop);
-            loop.ReplaceWith(foreachStatement);
-            match.ArrayCopy.Detach();
+                RaiseIndexedLoop(loop, stringMatch.StringCopy, stringMatch.ItemStore, "raise indexed string loop to foreach", context);
+                return;
+            }
+
+            RaiseIndexedLoop(loop, match.ArrayCopy, match.ItemStore, "raise indexed array loop to foreach", context);
             return;
         }
+    }
+
+    static void RaiseIndexedLoop(ForLoop loop, StoreLocal collectionCopy, StoreLocal itemStore, string message, PassContext context)
+    {
+        var collection = collectionCopy.Value;
+        collection.Detach();
+        itemStore.Detach();
+        var body = loop.Body;
+        body.Detach();
+        var foreachStatement = new ForeachStatement(itemStore.Index, itemStore.Type, collection, body);
+        context.Stepper.StepOver(message, loop);
+        loop.ReplaceWith(foreachStatement);
+        collectionCopy.Detach();
     }
 
     sealed record EnumeratorMatch(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
@@ -166,6 +181,67 @@ public sealed class ForeachStatementPass : IIrPass
             return null;
 
         return new ArrayMatch(arrayCopy, itemStore);
+    }
+
+    sealed record StringMatch(StoreLocal StringCopy, StoreLocal ItemStore);
+
+    static StringMatch? TryMatchString(IrFunction function, ForLoop loop)
+    {
+        if (loop.Parent is not Block block || loop.ChildIndex == 0)
+            return null;
+        if (block.Children[loop.ChildIndex - 1] is not StoreLocal stringCopy
+            || !stringCopy.Type.Equals(TypeRef.CoreLib("System", "String")))
+        {
+            return null;
+        }
+
+        int stringIndex = stringCopy.Index;
+        if (loop.Initializer is not StoreLocal { Value: Constant { Value: 0 } } initStore)
+            return null;
+        int indexIndex = initStore.Index;
+        if (indexIndex == stringIndex)
+            return null;
+
+        if (loop.Condition is not Comparison { Kind: ComparisonKind.LessThan, IsUnsigned: false } comparison
+            || !IsLoad(comparison.Left, indexIndex)
+            || comparison.Right is not LoadProperty length
+            || !MemberIdentity.IsStringLengthGetter(length)
+            || length.Instance is not LoadLocal lengthReceiver
+            || lengthReceiver.Index != stringIndex)
+        {
+            return null;
+        }
+
+        if (loop.Increment is not StoreLocal { Index: var incIndex, Value: Binary { Kind: BinaryKind.Add, Left: var incLeft, Right: Constant { Value: 1 } } }
+            || incIndex != indexIndex
+            || !IsLoad(incLeft, indexIndex))
+        {
+            return null;
+        }
+
+        if (loop.Body.Children is not [StoreLocal { Value: LoadProperty chars } itemStore, ..]
+            || !MemberIdentity.IsStringCharsGetter(chars)
+            || chars.Instance is not LoadLocal charsReceiver
+            || charsReceiver.Index != stringIndex
+            || chars.IndexArguments is not [LoadLocal charsIndex]
+            || charsIndex.Index != indexIndex)
+        {
+            return null;
+        }
+        if (itemStore.Index == stringIndex || itemStore.Index == indexIndex)
+            return null;
+
+        if (HasSourceLocalName(function, stringIndex) || HasSourceLocalName(function, indexIndex))
+            return null;
+
+        var allowed = new HashSet<IrNode>(ReferenceEqualityComparer.Instance)
+        {
+            stringCopy, initStore, comparison.Left, lengthReceiver, loop.Increment, incLeft, charsReceiver, charsIndex,
+        };
+        if (!ReferencedOnlyBy(function, stringIndex, allowed) || !ReferencedOnlyBy(function, indexIndex, allowed))
+            return null;
+
+        return new StringMatch(stringCopy, itemStore);
     }
 
     static bool HasSourceLocalName(IrFunction function, int index)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -69,7 +69,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ExpressionStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field => default!;
     [Completeness(CompletenessLevel.Full)] public static FixedStatementPass FixedStatement => new();
-    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local, and the single-dimension array lowering (hidden array-copy + index for loop); string foreach, multidimensional arrays, and custom pattern enumerators not raised")]
+    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local, the single-dimension array lowering (hidden array-copy + index for loop), and string foreach lowering (hidden string-copy + index for loop); multidimensional arrays and custom pattern enumerators not raised")]
     public static ForeachStatementPass ForEachStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static ForLoopPass ForStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative FunctionPointerInvocation => default!;


### PR DESCRIPTION
## Summary
- recover compiler-lowered string foreach loops from hidden string-copy and index scaffolding
- share indexed foreach raising for array and string forms
- add positive and adversarial tests plus scorecard, ledger, and foreach fact updates

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release