### PR TITLE
Raise the `ReadOnlySpan<byte>` RVA-field ctor to a byte[] literal

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1915,6 +1915,14 @@ public class CfgSampleClass
     // same field — opcode-exact.
     public static System.ReadOnlySpan<uint> ConstantUIntSpan() => new uint[] { 1, 10, 100, 1000, 10000 };
 
+    // A constant byte-array initializer in a ReadOnlySpan<byte> context: csc's
+    // 1-byte-element optimization builds the span directly as
+    // `new ReadOnlySpan<byte>(ref <PrivateImplementationDetails>.HASH, length)`
+    // (a ref to the mapped RVA blob plus its length) rather than through
+    // CreateSpan. RvaSpanPass decodes the blob and raises it back to the array
+    // literal, which csc re-lowers to the same field — opcode-exact.
+    public static System.ReadOnlySpan<byte> ConstantByteSpan() => new byte[] { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
     static int SumSpan(System.ReadOnlySpan<int> s) => s.Length;
 
     // A collection expression with NON-constant elements in a ReadOnlySpan<T>

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -78,6 +78,7 @@ public class FidelityGateTests
         "SumPinnedArray",
         "SumTwoPinned",
         "ConstantUIntSpan",
+        "ConstantByteSpan",
         "InlineArraySpan",
         "IsPatternGuard",
         "IsPatternConjunction",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -356,6 +356,26 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void ConstantByteSpan_RaisesToArrayLiteral()
+    {
+        // A constant byte-array initializer in a ReadOnlySpan<byte> context uses
+        // csc's 1-byte-element optimization, building the span directly as
+        // `new ReadOnlySpan<byte>(ref <PrivateImplementationDetails>.HASH, length)`
+        // rather than through CreateSpan. The field name has angle brackets, so
+        // left flat it never parses. RvaSpanPass decodes the field's mapped RVA
+        // bytes and raises the construction back to the `new byte[] { ... }`
+        // literal csc re-lowers to the same content-addressed field — opcode-exact.
+        var function = ImportFixture(nameof(CfgSampleClass.ConstantByteSpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains("new byte[] { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+    [Fact]
     public void InlineArraySpan_RaisesToCollectionExpression()
     {
         // A collection expression with non-constant elements in a ReadOnlySpan<T>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -731,8 +731,15 @@ public static class IrImporter
 
                 case ILOpCode.Ldflda or ILOpCode.Ldsflda:
                 {
-                    var field = ResolveField(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
-                    stack.Push(new LoadFieldAddress(field, opcode == ILOpCode.Ldflda ? Pop(stack) : null));
+                    var fieldHandle = MetadataTokens.EntityHandle(reader.ReadILToken());
+                    var field = ResolveField(source.Reader, fieldHandle, callerScope);
+                    var rvaData = opcode == ILOpCode.Ldsflda && fieldHandle.Kind == HandleKind.FieldDefinition
+                        ? TryReadFieldRvaData(source, (FieldDefinitionHandle)fieldHandle)
+                        : null;
+                    stack.Push(new LoadFieldAddress(field, opcode == ILOpCode.Ldflda ? Pop(stack) : null)
+                    {
+                        FieldRvaData = rvaData,
+                    });
                     break;
                 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2268,6 +2268,16 @@ public sealed class LoadFieldAddress : IrExpression
     public override TypeRef? ResultType => TypeRef.ByRef(Field.Type);
     public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
 
+    /// <summary>
+    /// For a <c>ldsflda</c> of a field with mapped RVA data — the
+    /// <c>&lt;PrivateImplementationDetails&gt;</c> blob a constant
+    /// <c>ReadOnlySpan&lt;byte&gt;</c> initializer points at (csc's 1-byte-element
+    /// optimization constructs the span as <c>new ReadOnlySpan&lt;byte&gt;(ref
+    /// field, length)</c>) — the raw little-endian bytes. Lets the span-literal
+    /// raising reconstruct <c>new byte[] { ... }</c>. Null for every other field.
+    /// </summary>
+    public byte[]? FieldRvaData { get; init; }
+
     public override string Describe() => $"LoadFieldAddress {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -46,6 +46,31 @@ public sealed class RvaSpanPass : IIrPass
             context.Stepper.StepOver("raise CreateSpan RVA blob to span literal", call);
             call.ReplaceWith(literal);
         }
+
+        foreach (var construction in function.Descendants.OfType<NewObject>().ToList())
+        {
+            // csc's 1-byte-element optimization builds a constant
+            // `ReadOnlySpan<byte>` directly as `new ReadOnlySpan<byte>(ref
+            // <PrivateImplementationDetails>.HASH, length)` — a ref to the mapped
+            // RVA blob plus its length — rather than through CreateSpan. The field
+            // name has angle brackets, so left as-is it never parses; decode the
+            // blob and rebuild the `new byte[] { ... }` literal the optimization
+            // came from (csc re-lowers it to the same content-addressed blob, so
+            // the round-trip is opcode-exact).
+            if (construction.Constructor.DeclaringType is not
+                { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: "ReadOnlySpan`1" }, TypeArguments: [var spanElement] } spanInstance)
+                continue;
+            if (construction.Arguments is not [LoadFieldAddress { FieldRvaData: { } rvaData }, Constant { Value: int rvaLength }])
+                continue;
+
+            var spanElements = DecodeElements(spanElement, rvaData);
+            if (spanElements is null || spanElements.Count != rvaLength)
+                continue;
+
+            var spanLiteral = new SpanLiteral(spanElement, spanInstance, spanElements);
+            context.Stepper.StepOver("raise ReadOnlySpan RVA field to span literal", construction);
+            construction.ReplaceWith(spanLiteral);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

A constant `ReadOnlySpan<byte>` rendered the unparseable
`new ReadOnlySpan<byte>(ref <PrivateImplementationDetails>.HASH, 12)` (CS1525 —
the `<` in the compiler-internal field name). It now raises to the
`new byte[] { ... }` literal it came from. This was the **single biggest
malformed driver** in the corpus.

## Root cause

csc's 1-byte-element optimization builds a constant `ReadOnlySpan<byte>` directly
as `new ReadOnlySpan<byte>(ref <PrivateImplementationDetails>.HASH, length)` — a
ref to the mapped RVA blob plus its length — rather than through
`RuntimeHelpers.CreateSpan<T>` (which `RvaSpanPass` already handled in #647). The
`<PrivateImplementationDetails>` field name has angle brackets, so the
construction never parses.

## Fix

- `LoadFieldAddress` now captures the field's mapped RVA bytes at import (for
  `ldsflda` of a `FieldDefinition`), mirroring `LoadToken.FieldRvaData`.
- `RvaSpanPass` gains a second arm that recognizes the
  `ReadOnlySpan<byte>(ref RVA-field, length)` construction, decodes the blob with
  the existing `DecodeElements`, and rebuilds the `new byte[] { ... }` literal.

csc re-lowers the literal to the same content-addressed field, so the round-trip
is opcode-exact. Example: `DateTime::get_DaysInMonth365` now renders
`return new byte[] { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };`.

## Numbers

- Full malformed **530 -> 488** (-42 methods)
- Inventory flat (40987/41012 Full, 0 importer bugs)
- 638 decompiler + 1157 product tests green
- `ConstantByteSpan` fixture pinned opcode-exact in the FidelityGate, plus a new
  `ConstantByteSpan_RaisesToArrayLiteral` importer test
