### PR TITLE
Spell a copied-this .ctor call as this()/base(), never `recv..ctor()`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstructorChainRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorChainRenderingTests.cs
@@ -1,0 +1,57 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A `call` (not `newobj`) to a constructor is only ever a this(...)/base(...)
+// chain, so its receiver is always `this`. The import sometimes routes `this`
+// through a copied temp (`MyType V_0 = this; V_0..ctor(...)`) instead of a bare
+// ldarg.0; the printer must still spell the chain by keyword and never leak the
+// `.ctor` member name (which is never valid C#).
+public class ConstructorChainRenderingTests
+{
+    static readonly TypeRef Derived = TypeRef.CoreLib("System", "MyDerived");
+    static readonly TypeRef Base = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    static DecompilerResult RenderConstructor(TypeRef chainDeclaringType, IrExpression receiver)
+    {
+        var ctor = new MethodRef(chainDeclaringType, ".ctor", Void, [Int32], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [receiver, new Constant(5, Int32)]);
+        var entry = new Block(0);
+        entry.Add(new ExpressionStatement(call));
+        entry.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var signature = new MethodSignature(Void, [new Parameter("value", Int32)], HasThis: true, GenericParameterCount: 0);
+        var function = new IrFunction(".ctor", Derived, signature, [Derived], container);
+        return CSharpPrinter.Print(function);
+    }
+
+    [Fact]
+    public void CopiedThisReceiver_RendersBaseChain()
+    {
+        var result = RenderConstructor(Base, new LoadLocal(0, Derived));
+
+        Assert.Equal("base(5)", result.ConstructorChain);
+        Assert.DoesNotContain(".ctor", result.Output);
+    }
+
+    [Fact]
+    public void CopiedThisReceiver_RendersThisChain()
+    {
+        var result = RenderConstructor(Derived, new LoadLocal(0, Derived));
+
+        Assert.Equal("this(5)", result.ConstructorChain);
+        Assert.DoesNotContain(".ctor", result.Output);
+    }
+
+    [Fact]
+    public void DirectThisReceiver_StillRendersBaseChain()
+    {
+        var result = RenderConstructor(Base, new LoadArgument(0, "this", Derived));
+
+        Assert.Equal("base(5)", result.ConstructorChain);
+        Assert.DoesNotContain(".ctor", result.Output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -134,9 +134,13 @@ public sealed partial class CSharpPrinter
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
-        if (call.Callee.Name == ".ctor" && receiver is LoadArgument { Index: 0, Name: "this" })
+        if (call.Callee.Name == ".ctor")
         {
-            // A this-receiver constructor call is C#'s base(...)/this(...).
+            // A call (not newobj) to a constructor is only ever a this(...)/base(...)
+            // chain — IL exposes no other way to invoke .ctor — so the receiver is
+            // always `this`, however the import spelled it (a copied-this temp
+            // included). Spell the chain keyword and drop the receiver; the
+            // `receiver..ctor(...)` fallback would never be valid C#.
             string keyword = Equals(call.Callee.DeclaringType, _function.DeclaringType) ? "this" : "base";
             return $"{keyword}({rest})";
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -855,7 +855,7 @@ public sealed partial class CSharpPrinter
         for (int i = 0; i < entry.Children.Count; i++)
         {
             if (entry.Children[i] is ExpressionStatement { Expression: Call { Callee: { Name: ".ctor", HasThis: true } } call }
-                && call.Arguments is [LoadArgument { Index: 0 }, ..])
+                && call.Arguments is [_, ..])
             {
                 return i;
             }
@@ -897,7 +897,7 @@ public sealed partial class CSharpPrinter
         ExpressionStatement
         {
             Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call,
-        } when call.Arguments is [LoadArgument { Index: 0 }, ..]
+        } when call.Arguments is [_, ..]
             => ConstructorChainText(callee, call),
         ExpressionStatement e => e.Expression switch
         {


### PR DESCRIPTION
## Problem

A `call` (not `newobj`) to a constructor is only ever a `this(...)`/`base(...)`
chain — IL exposes no other way to invoke `.ctor` — so its receiver is always
`this`. But the import sometimes routes `this` through a copied temp:

```
MyType V_0 = this;
...
V_0..ctor(args);
```

The printer's chain recognizers keyed on the literal `LoadArgument { Index: 0 }`
receiver, so a copied-`this` chain fell through to the generic member-call
spelling and rendered `V_0..ctor(args)` — and `.ctor` is never a valid C#
identifier. This shows up in the corpus on real BCL constructors (e.g.
`System.AggregateException::.ctor`) as **CS0201** / **CS1002**.

## Fix

Recognize a `.ctor` call by its callee alone, regardless of how the receiver was
spelled:

- `CallText` spells the chain keyword (`this`/`base` per declaring type) and
  drops the receiver.
- The prologue lift (`ChainCallIndex` and the constructor-initializer
  `Statement` case) no longer requires the literal `this` argument, so the chain
  is hoisted onto the signature as `: base(...)` / `: this(...)` where it
  belongs.

This is sound by IL semantics: object creation is a separate `NewObject` node,
so any `Call` to `.ctor` is a chain on `this`.

## Validation

- Corpus syntactic-malformed methods: **530 → 520** (10 constructors now parse).
- Fidelity unchanged: 40987/41012 Full, 0 importer bugs.
- Full decompiler suite: 636 tests pass.
- New `ConstructorChainRenderingTests` cover the copied-`this` `base`/`this`
  cases plus a direct-`this` regression guard.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
