### PR TITLE
Type a ref/pointer-to-bool/char load by its pointee (bool == int)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -50,6 +50,12 @@ public class CfgSampleClass
         return 2;
     }
 
+    // The `ref bool` deref compared to a constant, materialized as a value:
+    // `ldarg; ldind.u1; ldc.i4.0; ceq`. The comparison's IR ResultType is `byte`,
+    // so `flag == 0` is CS0019 unless the load recovers its bool pointee type — then
+    // the constant retypes to `false` and folds to `!flag`.
+    public static bool RefBoolIsClear(ref bool flag) => !flag;
+
     public static int Reused(int x) { var n = x + 1; return n * n; }
 
     public static bool BothPositive(int a, int b)

--- a/src/ILInspector.Decompiler.Tests/LoadIndirectBoolTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoadIndirectBoolTests.cs
@@ -1,0 +1,44 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LoadIndirectBoolTests
+{
+    static IrFunction Imported(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return function!;
+    }
+
+    static string Print(string methodName)
+    {
+        var function = Imported(methodName);
+        IrPasses.Run(function);
+        function.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void LoadIndirectOverRefBool_TypesAsBool()
+    {
+        // `ldind.u1` carries a byte storage width; the address is `ref bool`, so the
+        // loaded value's type is the bool pointee, not byte.
+        var load = Imported(nameof(CfgSampleClass.RefBoolIsClear))
+            .Descendants.OfType<LoadIndirect>().First();
+
+        Assert.Equal("Boolean", load.ResultType?.Name);
+    }
+
+    [Fact]
+    public void RefBoolComparedToConstant_RecoversBoolNotInt()
+    {
+        // `flag == 0` is CS0019; the bool pointee lets the constant retype and fold.
+        var output = Print(nameof(CfgSampleClass.RefBoolIsClear));
+
+        Assert.Contains("!(flag)", output);
+        Assert.DoesNotContain("== 0", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2305,7 +2305,22 @@ public sealed class LoadIndirect : IrExpression
     public bool IsVolatile { get; init; }
     public IrExpression Address => (IrExpression)Children[0];
     public override TypeRef? ResultType
-        => Type ?? (Address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null);
+    {
+        get
+        {
+            var pointee = Address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect
+                ? indirect.ElementType
+                : null;
+            // ldind.u1/ldind.u2 carry only a storage width (byte/ushort), shared by
+            // bool/byte and char/ushort. A bool/char location read through a ref or
+            // pointer is really that type — without it `*pBool == 0` types as
+            // `byte == int`, never recovering the bool constant (CS0019). Prefer the
+            // pointee for those two; otherwise the opcode type is authoritative.
+            if (pointee is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Boolean" or "Char" })
+                return pointee;
+            return Type ?? pointee;
+        }
+    }
     public override IEnumerable<TypeRef> DirectTypes => Type is null ? [] : [Type];
 
     public override string Describe() => $"LoadIndirect {ResultType?.ToDisplayString() ?? "?"}{(IsVolatile ? " volatile" : "")}";


### PR DESCRIPTION
## Problem

The `bool == int` root of the `--validity-check` **CS0019** cluster (issue #622), and the load-side twin of #810.

`LoadIndirect.ResultType` returned the opcode width. `ldind.u1`/`ldind.u2` carry only a storage width (byte/ushort), shared by bool/byte and char/ushort — so a `bool` read through a ref or pointer typed as `byte`. A comparison to a constant then typed as `byte == int`, and the constant never recovered:

```csharp
// Microsoft.Win32.SafeHandles.SafeFileHandle::FStatCheckIO  (statusHasValue is ref bool)
if (statusHasValue == 0) { ... }   // CS0019: operator '==' on 'bool' and 'int'
```

## Fix

Prefer the address's pointee type when it is `bool` or `char`; otherwise the opcode type stays authoritative (mirrors #810's store-side pointee fix). With the load typed `bool`, `TypedConstantsPass` retypes the constant to `false` and `BooleanFoldingPass` folds `flag == false` into `!flag`.

| Method | Before | After |
| --- | --- | --- |
| `SafeFileHandle::FStatCheckIO` | `if (statusHasValue == 0)` | `if (!statusHasValue)` |
| `RefBoolIsClear(ref bool flag)` | `return flag == 0;` | `return !flag;` |

## Fidelity

**Neutral** — `!flag` and `flag == false` both recompile to the `ldind.u1; ldc.i4.0; ceq` the original carried. Verified by the fixture `FidelityGate` round-tripping the new `RefBoolIsClear` body.

## Impact

Over .NET 11 preview CoreLib (full-corpus `--emit-validity-defects` diff): **7 methods** cleared from the validity docket, **zero** new defects. With #810 (store side), `ref`/`out bool` and `bool*` now round-trip on both read and write.

## Tests

New `LoadIndirectBoolTests` (the load types as `bool`; `flag == 0` becomes `!flag`) + the `RefBoolIsClear` fixture. 639 decompiler tests green incl. `FidelityGateTests` and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)