### PR TITLE
Degrade un-raised pinned locals below Full fidelity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// A <c>pinned T&amp;</c> local has no faithful C# spelling on its own — left
+/// flat it renders as the IL-only <c>pinned ref T name;</c> declaration, which is
+/// not legal C# (CS1585/CS1002, the dominant malformed-Full family the validity
+/// check surfaces over CoreLib's <c>[LibraryImport]</c> marshalling stubs).
+/// <see cref="FixedStatementPass"/> raises the shapes it can prove into a real
+/// <c>fixed</c> statement; the ones it cannot prove are deliberately left flat,
+/// and those must degrade honestly to <see cref="DecompilationFidelity.Partial"/>
+/// rather than claim <see cref="DecompilationFidelity.Full"/>. These tests pin the
+/// fidelity rule directly so they stay meaningful regardless of which concrete
+/// shapes the pass happens to raise.
+/// </summary>
+public class PinnedLocalFidelityTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef PinnedRefInt = TypeRef.Pinned(TypeRef.ByRef(Int32));
+
+    static IrFunction Function(ImmutableArray<TypeRef> locals, BlockContainer body)
+    {
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, locals, body);
+    }
+
+    static BlockContainer Container(params IrNode[] statements)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        foreach (var statement in statements)
+            block.Add(statement);
+        return container;
+    }
+
+    [Fact]
+    public void UnraisedPinnedLocal_StillReferenced_DegradesToPartial()
+    {
+        // A pinned slot referenced by a store/load with no owning `fixed` is the
+        // flat, un-raised shape: it would render `pinned ref int V_0;`, invalid C#.
+        var body = Container(
+            new StoreLocal(0, Int32, new Constant(0, Int32)),
+            new ExpressionStatement(new LoadLocal(0, Int32)));
+
+        var function = Function([PinnedRefInt], body);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void PinnedLocal_OwnedByFixedStatement_StaysFull()
+    {
+        // The raised shape: the pinned slot IS the `fixed` pointer variable, so a
+        // body load of it is spellable. It must not trip the honest-degradation
+        // rule even though the slot is still referenced and still typed `pinned`.
+        var fixedBody = Container(new ExpressionStatement(new LoadLocal(0, Int32)));
+        var body = Container(new Fixed(Int32, localIndex: 0, new Constant(0, Int32), fixedBody));
+
+        var function = Function([PinnedRefInt], body);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void PinnedLocal_Unreferenced_StaysFull()
+    {
+        // The folded raise leaves the pinned slot unreferenced (the derived
+        // pointer became the `fixed` variable). An unreferenced pinned slot is
+        // never declared, so it has nothing to render and must not degrade.
+        var body = Container(new ExpressionStatement(new LoadLocal(1, Int32)));
+
+        var function = Function([PinnedRefInt, Int32], body);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -227,9 +227,10 @@ public sealed class IrFunction : IrNode
 
     /// <summary>
     /// Computed from the tree, never asserted: any unsupported node, any
-    /// unsupported type referenced anywhere, or any expression whose result
-    /// type the pipeline does not know (null — e.g. a join slot merged from
-    /// conflicting types) ⇒ at most <see cref="DecompilationFidelity.Partial"/>.
+    /// unsupported type referenced anywhere, any expression whose result type the
+    /// pipeline does not know (null — e.g. a join slot merged from conflicting
+    /// types), or an un-raised <c>pinned T&amp;</c> local (no faithful C# spelling)
+    /// ⇒ at most <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
         => Descendants.Prepend(this).Any(n =>
@@ -240,8 +241,47 @@ public sealed class IrFunction : IrNode
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || n is IrExpression { ResultType: null }
             || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
+            || HasUnraisedPinnedLocal()
             ? DecompilationFidelity.Partial
             : DecompilationFidelity.Full;
+
+    /// <summary>
+    /// True when a <c>pinned</c> local survives un-raised: still referenced by a
+    /// load/store/address yet owned by no <see cref="Fixed"/> statement. Such a
+    /// slot renders as the IL-only <c>pinned ref T name;</c> declaration, which is
+    /// not legal C# (CS1585) — so the method must degrade honestly rather than
+    /// claim <see cref="DecompilationFidelity.Full"/>. <see cref="FixedStatementPass"/>
+    /// raises the provable shapes (the marshalling-stub forms it cannot prove are
+    /// deliberately left flat); a raised pin is either its owning <c>fixed</c>
+    /// variable or, when the derived pointer is folded, left unreferenced — both
+    /// excluded here, so only the genuinely flat pin trips this.
+    /// </summary>
+    bool HasUnraisedPinnedLocal()
+    {
+        HashSet<int>? pinned = null;
+        for (int i = 0; i < Locals.Length; i++)
+        {
+            if (Locals[i].Kind == TypeRefKind.Pinned)
+                (pinned ??= []).Add(i);
+        }
+        if (pinned is null)
+            return false;
+
+        var fixedOwned = Descendants.OfType<Fixed>().Select(f => f.LocalIndex).ToHashSet();
+        foreach (var node in Descendants)
+        {
+            int slot = node switch
+            {
+                LoadLocal load => load.Index,
+                StoreLocal store => store.Index,
+                LoadLocalAddress address => address.Index,
+                _ => -1,
+            };
+            if (slot >= 0 && pinned.Contains(slot) && !fixedOwned.Contains(slot))
+                return true;
+        }
+        return false;
+    }
 
     public override string Describe()
         => $"Function {Signature.ReturnType.ToDisplayString()} {Name}({string.Join(", ", Signature.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})";


### PR DESCRIPTION
## Problem

Running the harness's `--validity-check` over CoreLib surfaces a docket of methods reported at `Full` fidelity that **do not even parse** — the largest "claimed good but isn't" family. Every method in the cluster (`Interop.Sys::FStat`, `Interop.Globalization::GetSortHandle`, `Interop.Sys::GetCwd`, …) renders an IL-only local declaration:

```csharp
pinned ref FileStatus V_4;   // CS1585 — not legal C#
```

`FixedStatementPass` raises the *provable* pinned-local shapes into real `fixed` statements, but deliberately leaves the harder `[LibraryImport]` marshalling-stub forms (pin in a `try`, unpin in a `finally`) flat. The defect is that those flat methods still emitted the unspellable `pinned ref T` **and were reported as `Full`** — violating the by-construction honest-degradation contract ("output never pretends to be more faithful than it is").

## Fix

One self-contained rule in `IrFunction.Fidelity`: a `pinned` local still referenced by a load/store/address but owned by no `Fixed` node is the genuinely un-raised case ⇒ cap fidelity at `Partial`. Raised pins are excluded — a raised pin is either the owning `fixed` pointer variable or, when the derived pointer is folded, left unreferenced. The check short-circuits on the common no-pinned-local case after a cheap `Locals` scan, so it adds no cost to the overwhelming majority of methods.

This is honest degradation, not recovery: the un-raised stubs now report `Partial` (where invalid fragments are expected) instead of a false `Full`. Teaching `FixedStatementPass` the try/finally marshalling-stub shape to actually raise these to `fixed` is the natural follow-up scorecard climb.

## Soundness

- **Preconditions proven whole-function.** Pinned slots are collected from `Locals`; the owning-`Fixed` set and every referencing node are scanned across the whole tree, not a local neighbourhood.
- **Raised pins unaffected.** Unfolded raise: the pinned slot *is* the `Fixed.LocalIndex` → excluded. Folded raise: the pinned slot is left unreferenced → never trips. Verified by the unchanged fixture/lowered fidelity gates staying green.

## Results

- **143 methods move out of the false-`Full` bucket** — `--validity-check` Full-malformed **579 → 436** — into honest `Partial`.
- The corpus `Full`-fidelity floor still holds (≈99.56% over CoreLib, floor 99.0%).
- Full decompiler suite green (**640**, +3 new), including `FidelityGateTests`, `LoweredFidelityGateTests`, the idiom scorecard, `LoweringCoverageTests`, and `CorpusSweepGateTests`.

## Tests

New `PinnedLocalFidelityTests` pins the rule directly with hand-built IR so it stays meaningful regardless of which concrete shapes the pass raises:

- un-raised pinned local still referenced ⇒ `Partial`
- pinned local owned by a `fixed` statement ⇒ `Full`
- pinned local left unreferenced (folded raise) ⇒ `Full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)