### PR TITLE
Fold reconstructed iterator increments to x++

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -1,0 +1,105 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IncrementDecrementPassTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    // Builds `tempStore; placeUpdate;` as the two statements of a single block,
+    // declaring the place (slot 0) and the temporary (slot 1).
+    static IrFunction Function(params IrNode[] statements)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        foreach (var statement in statements)
+            block.Add(statement);
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+    }
+
+    static IReadOnlyList<IrNode> Run(IrFunction function)
+    {
+        new IncrementDecrementPass().Run(function, PassContext.None);
+        return function.Body.Blocks[0].Children;
+    }
+
+    static StoreLocal TempStore() => new(1, Int32, new LoadLocal(0, Int32));
+
+    static StoreLocal Update(BinaryKind kind) =>
+        new(0, Int32, new Binary(kind, isChecked: false, isUnsigned: false, new LoadLocal(1, Int32), new Constant(1, Int32)));
+
+    [Fact]
+    public void DeadTempPostIncrement_FoldsToOperator()
+    {
+        // V_1 = x; x = V_1 + 1;  ->  x++;
+        var statements = Run(Function(TempStore(), Update(BinaryKind.Add)));
+
+        var statement = Assert.Single(statements);
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(statement).Expression);
+        Assert.True(increment.IsIncrement);
+        Assert.False(increment.IsPrefix);
+        var target = Assert.IsType<LoadLocal>(increment.Target);
+        Assert.Equal(0, target.Index);
+    }
+
+    [Fact]
+    public void DeadTempPostDecrement_FoldsToOperator()
+    {
+        // V_1 = x; x = V_1 - 1;  ->  x--;
+        var statements = Run(Function(TempStore(), Update(BinaryKind.Subtract)));
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.False(increment.IsIncrement);
+    }
+
+    [Fact]
+    public void ReusedTemp_IsNotFolded()
+    {
+        // The temporary is written twice (V_1 also feeds an unrelated store), so
+        // it is not a single-use dead temp — folding would be unsound.
+        var statements = Run(Function(
+            TempStore(),
+            Update(BinaryKind.Add),
+            new StoreLocal(1, Int32, new Constant(7, Int32))));
+
+        Assert.Equal(3, statements.Count);
+        Assert.IsType<StoreLocal>(statements[0]);
+    }
+
+    [Fact]
+    public void NonUnitStep_IsNotFolded()
+    {
+        // V_1 = x; x = V_1 + 2; is a `+= 2`, not a post-increment.
+        var update = new StoreLocal(0, Int32,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, Int32), new Constant(2, Int32)));
+        var statements = Run(Function(TempStore(), update));
+
+        Assert.Equal(2, statements.Count);
+    }
+
+    [Fact]
+    public void MismatchedPlace_IsNotFolded()
+    {
+        // V_1 = x; y = V_1 + 1; updates a different place than it captured.
+        var temp = new StoreLocal(1, Int32, new LoadLocal(0, Int32));
+        var update = new StoreLocal(2, Int32,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, Int32), new Constant(1, Int32)));
+        var statements = Run(Function(temp, update));
+
+        Assert.Equal(2, statements.Count);
+    }
+
+    [Fact]
+    public void CheckedStep_IsNotFolded()
+    {
+        // A checked increment is left alone — the printer would not fold it and
+        // the operator would lose the overflow context.
+        var update = new StoreLocal(0, Int32,
+            new Binary(BinaryKind.Add, isChecked: true, isUnsigned: false, new LoadLocal(1, Int32), new Constant(1, Int32)));
+        var statements = Run(Function(TempStore(), update));
+
+        Assert.Equal(2, statements.Count);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -238,6 +238,19 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void MultiYieldLoopIterator_FoldsRebuiltIncrementToOperator()
+    {
+        // Reconstruction rebuilds the hoisted loop variable's increment through a
+        // spill slot (`V_1 = i; i = V_1 + 1;`); the post-reconstruction
+        // IncrementDecrementPass run folds that dead-temp shape back into `i++`.
+        var output = Print(nameof(CfgSampleClass.YieldPairs));
+
+        Assert.Contains("i++;", output);
+        Assert.DoesNotContain("= V_1 + 1", output);
+        Assert.DoesNotContain("V_1 = i;", output);
+    }
+
+    [Fact]
     public void SideEffectingEmptyIterator_PreservesSideEffectBeforeBreak()
     {
         var function = Raised(nameof(CfgSampleClass.BreakWithSideEffect));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -42,6 +42,8 @@ public sealed class IncrementDecrementPass : IIrPass
                     return true;
                 if (TryFoldAddressCompound(function, block, i, stepper))
                     return true;
+                if (TryFoldStatementIncrement(function, block, i, stepper))
+                    return true;
             }
         }
         return false;
@@ -175,6 +177,68 @@ public sealed class IncrementDecrementPass : IIrPass
         slotStore.Detach();
         return true;
     }
+
+    /// <summary>
+    /// Folds the dead-temp post-increment statement form — a value-less
+    /// <c>x++</c>/<c>x--</c> that a spill left behind as
+    ///
+    /// <code>
+    /// V = x;   x = V ± 1;        ≡   x++ / x--   (V never read again)
+    /// </code>
+    ///
+    /// — back into the operator statement. The temporary captures the old value
+    /// and is immediately dead, so the pair is exactly a discarded post-increment.
+    /// This shape does not arise from csc directly (a statement <c>x++</c> lowers
+    /// to <c>ldloc; ldc.i4.1; add; stloc</c> with no temp); it surfaces from the
+    /// decompiler's own iterator/state-machine reconstruction, where the hoisted
+    /// loop variable's increment is rebuilt through a spill slot. The fold only
+    /// fires when the temporary is written once and read exactly once (the
+    /// update), so removing it reorders nothing.
+    /// </summary>
+    static bool TryFoldStatementIncrement(IrFunction function, Block block, int i, Stepper stepper)
+    {
+        if (block.Children[i] is not StoreLocal { } tempStore)
+            return false;
+        if (PlaceLoad(tempStore.Value) is not { } readPlace)
+            return false;
+        if (PlaceOf(block.Children[i + 1]) is not { } writePlace || StoreValue(block.Children[i + 1]) is not { } updateValue)
+            return false;
+
+        // The captured place and the updated place must be the same local or
+        // argument, and must not be the temporary itself.
+        if (readPlace.IsLocal != writePlace.IsLocal || readPlace.Index != writePlace.Index)
+            return false;
+        if (writePlace.IsLocal && writePlace.Index == tempStore.Index)
+            return false;
+
+        if (updateValue is not Binary { IsChecked: false, Kind: var kind } binary
+            || binary.Left is not LoadLocal load || load.Index != tempStore.Index
+            || binary.Right is not Constant { Value: 1 }
+            || kind is not (BinaryKind.Add or BinaryKind.Subtract))
+        {
+            return false;
+        }
+
+        // The temporary must be written once and read exactly once across the
+        // whole function — the increment we are folding — so it is genuinely dead.
+        if (function.Descendants.OfType<StoreLocal>().Count(s => s.Index == tempStore.Index) != 1)
+            return false;
+        if (function.Descendants.OfType<LoadLocal>().Count(l => l.Index == tempStore.Index) != 1)
+            return false;
+
+        var increment = new IncrementDecrement(ClonePlace(writePlace), kind is BinaryKind.Add, isPrefix: false);
+        stepper.StepOver($"fold dead-temp {(kind is BinaryKind.Add ? "++" : "--")} statement into operator", tempStore);
+        tempStore.ReplaceWith(new ExpressionStatement(increment));
+        block.Children[i + 1].Detach();
+        return true;
+    }
+
+    static PlaceRef? PlaceLoad(IrExpression expression) => expression switch
+    {
+        LoadLocal { ResultType: { } t } l => new PlaceRef(true, l.Index, "", t),
+        LoadArgument { ResultType: { } t } a => new PlaceRef(false, a.Index, a.Name, t),
+        _ => null,
+    };
 
     static PlaceRef? PlaceOf(IrNode store) => store switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -206,6 +206,11 @@ public static class IrPasses
         // before the acknowledgment pass: reconstruction raises when it can; the
         // acknowledgment is the honest fallback for shapes it declines.
         new IteratorReconstructionPass(),
+        // Reconstruction rebuilds the hoisted loop variable's increment through a
+        // spill slot (`V = i; i = V + 1;`), the dead-temp post-increment shape the
+        // earlier IncrementDecrementPass run (before reconstruction) never saw.
+        // Re-run it to fold those back into `i++`/`i--` on the rebuilt body.
+        new IncrementDecrementPass(),
         // Recognize a compiler-generated iterator kickoff and replace its
         // misleading `return new <X>d__N(-2);` handoff with an honest marker
         // (the yield body in MoveNext is not yet reconstructed). Runs late with


### PR DESCRIPTION
## Summary

Reconstructed iterators rendered their loop-variable increment as a dead-temp
post-increment instead of `i++`:

```csharp
while (i < n)
{
    yield return i;
    yield return -i;
    V_1 = i;        // before
    i = V_1 + 1;    // before
}
```

```csharp
while (i < n)
{
    yield return i;
    yield return -i;
    i++;            // after
}
```

## Cause

Iterator/state-machine reconstruction rebuilds the hoisted loop variable's
increment through a spill slot, leaving `V_1 = i; i = V_1 + 1;` (the temporary
captures the old value and is never read again). `IncrementDecrementPass` runs
**before** `IteratorReconstructionPass`, so its existing dup-idiom fold never
sees these rebuilt increments.

## Fix

- Add `TryFoldStatementIncrement` to `IncrementDecrementPass`: recognize the
  adjacent dead-temp `V = x; x = V ± 1;` statement pair and collapse it to
  `x++` / `x--`.
- Re-run `IncrementDecrementPass` once after `IteratorReconstructionPass` to
  clean up the rebuilt bodies (the ledger classifies passes by type via a
  HashSet, so a second run of the same pass is fine).

Soundness: the fold only fires when the temporary is **written once and read
exactly once** (genuinely dead) and the captured and updated places are the
**same** local or argument, so nothing reorders. A `checked` binary or a
non-unit step (`+= 2`) is left alone. The shape does not arise from csc directly
(a statement `x++` lowers to `ldloc; ldc.i4.1; add; stloc` with no temp), so the
fold is iterator-cleanup only and does not change non-reconstructed output.

The reused-temp case (e.g. `YieldGrid`, where one temp serves the inner loop's
update slot and a separate increment) correctly declines, since the temp is
written more than once.

## Validation

- New `IncrementDecrementPassTests` (6): positive `++`/`--`, plus negatives for
  reused temp, non-unit step, mismatched place, and `checked`.
- `IteratorReconstructionPassTests`: `YieldPairs` now renders `i++;` and no
  longer the `V_1 = i; i = V_1 + 1;` temp form.
- Decompiler suite 648 green (compile-back + annotate-check + corpus-sweep gates
  included); product suite 1157 (9 skip) green.
