### PR TITLE
Render the cgt.un against-null idiom as obj is not null

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -26,6 +26,12 @@ public class CfgSampleClass
     // Negative: a plain int count needs no cast — `1 << n` stays bare.
     public static int ShiftByInt(int n) => 1 << n;
 
+    // A reference inequality against null: csc lowers `o != null` to
+    // `ldnull; cgt.un` (an unsigned ordering), so the IR is GreaterThan-unsigned
+    // with a null operand. The printer must spell it `o is not null`, not the
+    // CS0019 `o > null`.
+    public static bool IsNotNullReference(object o) => o != null;
+
     // `a | b` of two bytes is `int` in C# (binary numeric promotion), so the
     // trailing conv.u1 is a real narrowing the language requires. The IR types the
     // `or` as byte (ECMA "wider operand wins"), so IdentityConvertPass must not drop

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -97,6 +97,7 @@ public class FidelityGateTests
         "NthCharFromEnd",
         "NullCoalescingAssignStaticField",
         "NullCoalescingAssignInstanceField",
+        "IsNotNullReference",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
@@ -1,0 +1,28 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// csc lowers a reference inequality (`o != null`) to `ldnull; cgt.un` — an
+// unsigned ordering with a null operand. Rendered literally that is the CS0019
+// `o > null`; the printer must recover the idiom as `o is not null`.
+public class ReferenceNullOrderingTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void ReferenceComparedToNullUnsigned_RendersIsNotNull()
+    {
+        var output = Render(nameof(CfgSampleClass.IsNotNullReference));
+
+        Assert.Contains("is not null", output);
+        Assert.DoesNotContain("> null", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -96,6 +96,21 @@ public sealed partial class CSharpPrinter
                 ? $"{Operand(operand)} is null"
                 : $"{Operand(operand)} is not null";
         }
+        // The `cgt.un`/`clt.un` against null idiom csc emits for a reference
+        // inequality (`ldnull; cgt.un` = `obj != null`): an unsigned ordering of a
+        // reference against null tests non-nullness (null is 0, so `x > 0` / `0 <
+        // x` unsigned is `x != 0`). There is no is-null ordering form, so this is
+        // always the not-null test; rendered literally `obj > null` is CS0019.
+        // Pointers forbid the is-pattern (CS8521), so spell those `!= null`.
+        if (isUnsigned
+            && ((kind == ComparisonKind.GreaterThan && right is Constant { Value: null })
+                || (kind == ComparisonKind.LessThan && left is Constant { Value: null })))
+        {
+            var operand = kind == ComparisonKind.GreaterThan ? left : right;
+            return operand.ResultType is { Kind: TypeRefKind.Pointer }
+                ? $"{Operand(operand)} != null"
+                : $"{Operand(operand)} is not null";
+        }
         // A pointer compared to a native-int zero is a null check: csc lowers
         // `ptr == null` to `ldc.i4.0; conv.u; ceq`, so the zero arrives as an
         // `int`/`nuint` 0 (often through a Convert). Comparing a pointer to that


### PR DESCRIPTION
## Problem

csc lowers a reference inequality (`obj != null`) to `ldnull; cgt.un` — an unsigned ordering of a reference against null. The importer types this as `Comparison.GreaterThan unsigned (ref, Constant null)`, and the printer spelled it literally as `obj > null` (CS0019: operator `>` is undefined for a reference type vs null).

Example, `System.MulticastDelegate::op_Inequality`, before:

```csharp
return d1 > null;
```

after:

```csharp
return d1 is not null;
```

## Fix

In `ComparisonText`, recognize the unsigned-ordering-against-null idiom: an unsigned greater-than with a null right operand (or less-than with a null left operand) tests non-nullness (null is 0, so unsigned `x > 0` is `x != 0`). Render it `obj is not null` for reference types, or `obj != null` for pointers (the is-pattern is forbidden on pointers, CS8521). This is always the not-null test — there is no is-null ordering form.

## Soundness

The idiom is unambiguous: `cgt.un`/`clt.un` against a null constant is csc's canonical reference-inequality lowering. Recompiles opcode-exact (`is not null` re-lowers to `cgt.un`).

## Corpus impact

- CS0019 validity defects 29 → 26 (−3 methods)
- Recompile inventory flat: 40987/41012 Full (99.94%)
- Added `IsNotNullReference` csc fixture (opcode-exact, pinned in the fidelity gate) + a render test
- 648 decompiler + 1157 product tests green
