### PR TITLE
Render simple property patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -694,6 +694,15 @@ public class CfgSampleClass
         return 0;
     }
 
+    // Negative: the pattern local is read in the body, so folding the condition
+    // to a non-binding property pattern would make the local unavailable.
+    public static int IsPatternPropertyWithBindingUse(object o)
+    {
+        if (o is string s && s.Length == 5)
+            return s.Length;
+        return 0;
+    }
+
     // Negative: a plain `as` whose local is read on BOTH the matched and the
     // fall-through paths is not a pattern binding (the variable would not be
     // definitely assigned), so it must stay a flat `as` + null test.

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -38,6 +38,7 @@ public class IdiomShapeScorecardTests
         new("NullConditionalPass", nameof(CfgSampleClass.NullConditionalProperty), SyntaxKind.ConditionalAccessExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.TernaryInt), SyntaxKind.ConditionalExpression, [SyntaxKind.IfStatement]),
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),
+        new("IsPatternPass", nameof(CfgSampleClass.IsPatternProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -51,17 +51,30 @@ public class IsPatternPassTests
     }
 
     [Fact]
-    public void PropertyPattern_RecoversAsTypePatternConjunction()
+    public void PropertyPattern_RendersPropertyPatternClause()
     {
         // `o is string { Length: 5 }` lowers to the same as-store plus
-        // `s != null && s.Length == 5`; recovered as `o is string s && ...`.
+        // `s != null && s.Length == 5`; the printer folds the internal type
+        // pattern + equality back to the property-pattern altitude.
         var function = Raised(nameof(CfgSampleClass.IsPatternProperty));
 
         Assert.Single(function.Descendants.OfType<IsPattern>());
         var output = CSharpPrinter.Print(function).Output;
-        Assert.Contains("is string", output);
-        Assert.Contains("&& ", output);
-        Assert.Contains("== 5", output);
+        Assert.Contains("o is string { Length: 5 }", output);
+        Assert.DoesNotContain("&&", output);
+        Assert.DoesNotContain(".Length == 5", output);
+    }
+
+    [Fact]
+    public void PropertyPattern_WhenPatternLocalIsUsedInBody_StaysFlat()
+    {
+        var function = Raised(nameof(CfgSampleClass.IsPatternPropertyWithBindingUse));
+
+        Assert.Empty(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("{ Length: 5 }", output);
+        Assert.Contains(".Length", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1230,6 +1230,9 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string LogicalText(LogicalBinary logical)
     {
+        if (TryPropertyPatternText(logical) is { } propertyPattern)
+            return propertyPattern;
+
         // Sides are condition positions: Condition() owns truthiness (a
         // string operand spells 'is not null', never '!value') and the
         // negation folds. Same-kind chains associate bare; mixed kinds
@@ -1244,6 +1247,49 @@ public sealed partial class CSharpPrinter
         string op = logical.Kind == LogicalKind.And ? "&&" : "||";
         return $"{Side(logical.Left)} {op} {Side(logical.Right)}";
     }
+
+    string? TryPropertyPatternText(LogicalBinary logical)
+    {
+        if (logical.Kind != LogicalKind.And
+            || logical.Left is not IsPattern pattern
+            || !TryPropertyConstantEquality(logical.Right, pattern.LocalIndex, out var propertyName, out var constant))
+        {
+            return null;
+        }
+
+        return $"{Operand(pattern.Value)} is {TypeText(pattern.Type)} {{ {propertyName}: {ConstantText(constant)} }}";
+    }
+
+    static bool TryPropertyConstantEquality(IrExpression expression, int patternLocal, out string propertyName, out Constant constant)
+    {
+        propertyName = "";
+        constant = null!;
+
+        if (expression is not Comparison { Kind: ComparisonKind.Equal, Left: var left, Right: var right })
+            return false;
+
+        if (left is LoadProperty property && IsPatternLocalProperty(property, patternLocal) && right is Constant rightConstant)
+        {
+            propertyName = property.PropertyName;
+            constant = rightConstant;
+            return true;
+        }
+
+        if (right is LoadProperty reversedProperty && IsPatternLocalProperty(reversedProperty, patternLocal) && left is Constant leftConstant)
+        {
+            propertyName = reversedProperty.PropertyName;
+            constant = leftConstant;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsPatternLocalProperty(LoadProperty property, int patternLocal)
+        => property.HasInstance
+            && property.Instance is LoadLocal local
+            && local.Index == patternLocal
+            && property.IndexArguments.Count == 0;
 
     /// <summary>
     /// Assignment spelling with compound/increment sugar: when the value is

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -80,7 +80,7 @@ internal static class LoweringCoverage
     public static IndexFromEndPass Index => new();
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression); property/positional/list sub-patterns recover as `is T t && ...`, not the deconstructed syntax")]
+    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and simple property-pattern equality (`value is T { P: constant }`); positional/list sub-patterns and broader property sub-patterns not raised")]
     public static IsPatternPass IsPatternOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LabeledStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal => default!;


### PR DESCRIPTION
## Summary
- render simple property-pattern equality as `value is T { P: constant }` instead of `value is T t && t.P == constant`
- add scorecard coverage for `IsPatternProperty`
- keep binding-use near-misses flat so non-binding property-pattern syntax is not emitted when the pattern local is needed
- update the IsPattern ledger note

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal