### PR TITLE
Type a typed stelem store from the array element, not the opcode sign

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -173,6 +173,15 @@ public class CfgSampleClass
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
+    // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into
+    // short[], ushort[], and char[]. The store must be typed from the array's
+    // element (byte/char), not the opcode's signed default (sbyte/short): typing
+    // it from the opcode makes the element store render a `(sbyte)`/`(short)`
+    // cast, which is CS0266 against a byte[]/char[] element.
+    public static void SetByteElement(byte[] a, int v) => a[0] = (byte)v;
+
+    public static void SetCharElement(char[] a, int v) => a[0] = (char)v;
+
     // Array range slices: the compiler lowers these to
     // RuntimeHelpers.GetSubArray(a, <Range>); the decompiler raises them back to
     // the a[i..j] indexer (RangeFromGetSubArrayPass). Both from-start endpoints

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -688,6 +688,27 @@ public class IrImporterTests
         Assert.Single(store.Descendants.OfType<StoreElement>());
     }
 
+    [Theory]
+    [InlineData(nameof(CfgSampleClass.SetByteElement), "byte", "(byte)")]
+    [InlineData(nameof(CfgSampleClass.SetCharElement), "char", "(char)")]
+    public void TypedStelem_TakesElementTypeFromArray_NotOpcodeSign(string method, string element, string expectedCast)
+    {
+        // stelem.i1/i2 encode width and a default sign (sbyte/short), but the
+        // array's element type is authoritative: a `byte[]`/`char[]` store typed
+        // from the opcode renders an `(sbyte)`/`(short)` cast that is CS0266
+        // against the element. The store must take the array's element type.
+        var function = ImportFixture(method);
+
+        var store = Assert.Single(function.Descendants.OfType<StoreElement>());
+        Assert.Equal(element, store.ElementType?.ToDisplayString());
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains(expectedCast, output);
+        Assert.DoesNotContain("(sbyte)", output);
+        Assert.DoesNotContain("(short)", output);
+    }
+
     [Fact]
     public void Switch_ImportsWithTargetsAsLeaders()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -842,7 +842,7 @@ public static class IrImporter
                     var index = Pop(stack);
                     var array = Pop(stack);
                     SpillUnstableBeforeSideEffect(body, stack, state);
-                    body.Add(new StoreElement(ElementTypeOf(opcode), array, index, value));
+                    body.Add(new StoreElement(StelemElementType(opcode, array), array, index, value));
                     break;
                 }
 
@@ -1398,6 +1398,26 @@ public static class IrImporter
         ILOpCode.Ldind_i or ILOpCode.Stind_i => TypeRef.CoreLib("System", "IntPtr"),
         _ => null,  // ldind.ref / stind.ref
     };
+
+    /// <summary>
+    /// Element type for a typed <c>stelem</c>, preferring the array's own element
+    /// type over the opcode's default signedness. <c>stelem.i1</c> stores into
+    /// <c>sbyte[]</c>, <c>byte[]</c>, and <c>bool[]</c> alike; typing the store
+    /// from the opcode (always <c>sbyte</c>) makes the printer cast the value to
+    /// <c>(sbyte)</c>, which is CS0266 against a <c>byte[]</c> element. When the
+    /// array's static element type is a same-width integer sibling
+    /// (byte/sbyte, short/ushort/char, int/uint, long/ulong), it is authoritative —
+    /// the C# store goes through it — so use it; otherwise fall back to the opcode.
+    /// </summary>
+    static TypeRef? StelemElementType(ILOpCode opcode, IrExpression array)
+    {
+        var fromOpcode = ElementTypeOf(opcode);
+        return fromOpcode is not null
+            && array.ResultType is { Kind: TypeRefKind.SzArray, ElementType: { } element }
+            && TypeFamilies.SameWidth(element, fromOpcode)
+            ? element
+            : fromOpcode;
+    }
 
     static TypeRef? ElementTypeOf(ILOpCode opcode) => opcode switch
     {


### PR DESCRIPTION
## Problem

Mining the harness's `--validity-check` semantic docket (the CS0266 bucket) surfaced a clean conversion bug. `BitConverter.GetBytes(bool)` decompiles to:

```csharp
byte[] S_256 = new byte[1];
S_256[0] = (sbyte)(value ? 1 : 0);   // CS0266: cannot implicitly convert sbyte to byte
return S_256;
```

Root cause: the width-typed `stelem` opcodes encode a default signedness — `stelem.i1` → sbyte, `stelem.i2` → short — but there is **no unsigned form**. `byte[]`, `sbyte[]`, and `bool[]` all store through `stelem.i1`; `char[]`/`ushort[]`/`short[]` through `stelem.i2`. The importer typed `StoreElement` straight from the opcode, so a store into a `byte[]` became `StoreElement sbyte`, and the printer faithfully cast the value to `(sbyte)` — invalid against the `byte[]` element.

## Fix

The array's own element type is authoritative — the C# store goes through it. Type the store from the array's element type when it is a same-width integer sibling of the opcode default (byte/sbyte, short/ushort/char, int/uint, long/ulong); fall back to the opcode otherwise (generic `T[]`, ref arrays, width mismatch). One importer helper, `StelemElementType`.

`BitConverter.GetBytes(bool)` now renders the faithful, valid `S_256[0] = (byte)(value ? 1 : 0);`.

## Soundness

- **Semantics preserved exactly.** The substitution is *same-width only* (`TypeFamilies.SameWidth`), so the byte-width truncation the opcode performs is unchanged. The recompiled store is the same `stelem.i*` — fidelity is preserved; it now compiles where it previously raised CS0266.
- **Scope is the store only.** Loads already disambiguate (`ldelem.u1` byte vs `ldelem.i1` sbyte), so only the store opcode is signedness-ambiguous. `stelem` (token form) and `stelem.ref` are untouched.
- **Fall-through is safe.** `Width(bool)`/`Width(float)`/`Width(nint)` are null, so `SameWidth` excludes them — a `bool[]` store keeps its prior typing, no behavior change.

## Breadth & validation

- Corpus scan: **153 store sites across 69 CoreLib methods** corrected (118 sbyte→byte, 32 short→char, 2 long→ulong, 1 int→uint).
- Same-base validity defect diff (`--diff-validity-defects`): the bound methods lose CS0266, **zero regressions**.
- Decompiler suite green (**659**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests` — the new `byte[]`/`char[]` element-store fixtures round-trip opcode-exact.

## Tests

New theory in `IrImporterTests` over `SetByteElement`/`SetCharElement` fixtures: asserts the `StoreElement` element type is taken from the array (`byte`/`char`), the rendered cast matches (`(byte)`/`(char)`), and no `(sbyte)`/`(short)` leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)