### PR TITLE
Raise parameter-capturing local-bodied lambdas

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -127,9 +127,23 @@ public class CfgSampleClass
         => x => { System.Console.WriteLine(x); return x + 1; };
 
     // Local-bearing body: `y` is read twice, so inlining cannot fold it away and
-    // the body keeps a local of its own. A per-lambda local scope is owed.
+    // the recovered lambda needs a nested local scope of its own.
     public static System.Func<int, int> LocalBodyLambda()
         => x => { int y = x + 1; return y * y; };
+
+    // Capturing local-bearing body whose capture is an outer parameter. The
+    // parameter name is stable in the nested lambda print scope, so this is now
+    // recoverable.
+    public static System.Func<int, int> CapturingLocalBodyLambda(int n)
+        => x => { int y = x + n; return y * y; };
+
+    // Negative: the capture is an outer local, whose slot would be ambiguous when
+    // printing the lambda's own local scope.
+    public static System.Func<int, int> CapturingOuterLocalBodyLambda(int n)
+    {
+        int z = n + 1;
+        return x => { int y = x + z; return y * y; };
+    }
 
     public static int DoWhileSum(int n)
     {

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -61,6 +61,7 @@ public class IdiomShapeScorecardTests
         new("LambdaRaisingPass", nameof(CfgSampleClass.SharedCaptureLambdas), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.ClosureWithLinq), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.LocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLocalBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.DoubleViaLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CapturingLocalFunction), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LocalFunctionRaisingPass", nameof(CfgSampleClass.CaptureSecondParam), SyntaxKind.LocalFunctionStatement, [SyntaxKind.SimpleMemberAccessExpression]),

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -36,9 +36,21 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
-    public void CapturingLocalBearingBody_StaysLowered()
+    public void CapturingParameterLocalBearingBody_RaisesBlockLambdaWithNestedLocalScope()
     {
-        string output = PrintRaised(nameof(LambdaLocalBodyAdversarial.CapturingLocalBody), typeof(LambdaLocalBodyAdversarial));
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingLocalBodyLambda));
+
+        Assert.Contains("return x => {", output);
+        Assert.Contains(" = x + n;", output);
+        Assert.Contains("return ", output);
+        Assert.Contains(" * ", output);
+        Assert.DoesNotContain("new Func", output);
+    }
+
+    [Fact]
+    public void CapturingOuterLocalBearingBody_StaysLowered()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturingOuterLocalBodyLambda));
 
         Assert.DoesNotContain("=>", output);
         Assert.Contains("new Func", output);
@@ -138,10 +150,4 @@ public class LambdaRaisingPassTests
             [],
             body);
     }
-}
-
-public static class LambdaLocalBodyAdversarial
-{
-    public static System.Func<int, int> CapturingLocalBody(int n)
-        => x => { int y = x + n; return y * y; };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -11,9 +11,9 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated-type:lambda-holder", "GeneratedCodeIdentity.IsNonCapturingLambdaMethod"),
                 new FactPrimitive("generated-type:display-class", "GeneratedCodeIdentity.IsCapturingLambdaMethod"),
             ],
-            PositiveCoverage: "LambdaRaisingPassTests non-capturing, capturing, and non-capturing local-bodied fixtures",
-            AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata and capturing local-bodied guard",
-            MissingDiscriminator: "capturing local-bound bodies and expression trees need additional closure/state facts"),
+            PositiveCoverage: "LambdaRaisingPassTests non-capturing, capturing, non-capturing local-bodied, and parameter-capturing local-bodied fixtures",
+            AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata and outer-local capturing local-bodied guard",
+            MissingDiscriminator: "outer-local capturing local-bound bodies and expression trees need additional closure/state facts"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.CapturedClosure)),
@@ -22,9 +22,9 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated-type:display-class", "GeneratedCodeIdentity.IsCapturingLambdaMethod"),
                 new FactPrimitive("place.re-evaluable", "PlaceIdentity same-place atoms for safe environment substitution"),
             ],
-            PositiveCoverage: "LambdaRaisingPassTests capturing lambda fixture",
-            AdversarialCoverage: "LambdaRaisingPassTests guards for unsupported local/captured forms",
-            MissingDiscriminator: "display classes spread across statements are still owed"),
+            PositiveCoverage: "LambdaRaisingPassTests folded captures, local display-class environments, shared captures, and parameter-capturing local-bodied fixtures",
+            AdversarialCoverage: "LambdaRaisingPassTests guards for unsupported outer-local local-bodied and generated-name lookalike forms",
+            MissingDiscriminator: "nested display-class environments and display classes captured by local functions remain owed"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.LocalFunction)),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -29,7 +29,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.Partial, "expression, simple block, and non-capturing local-bound bodies; capturing local-bound bodies still owed")]
+    [Completeness(CompletenessLevel.Partial, "expression, simple block, non-capturing local-bound bodies, and parameter-capturing local-bound bodies; outer-local capturing local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.Partial, "static local functions with expression/simple block/local-bodied forms, plus capturing (ref struct display-class env, substituted back) zero-local local functions, declared back into the host method and called by their source name; capturing local-bodied, recursive, nested, and shared-environment local functions still owed")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -11,7 +11,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// its body as <c>(params) =&gt; body</c>, and replaces the delegate creation.
 ///
 /// <para>Current slice — non-capturing lambdas may carry body locals/slots;
-/// capturing lambdas remain zero-local after capture substitution:</para>
+/// capturing lambdas may also carry body locals when every substituted
+/// capture is an outer argument/<c>this</c> load:</para>
 /// <list type="bullet">
 /// <item><b>Non-capturing</b> — the target runs on the static <c>&lt;&gt;c</c>
 /// singleton and reads no <c>this</c>. The lambda node carries its own
@@ -28,8 +29,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </list>
 /// <para>In all cases the body must carry compiler-generated metadata evidence
 /// and be a single <c>return expr;</c> or a simple block ending in a return.
-/// Capturing bodies still need to print in the outer function scope, so they
-/// keep the zero-local guard. A no-op when the seam is absent (stage dumps, the
+/// Captured outer locals still keep the zero-local guard: local-bearing lambda
+/// bodies print in a nested lambda scope, where an outer local slot would be
+/// ambiguous. A no-op when the seam is absent (stage dumps, the
 /// lowered/annotated views).</para>
 /// </summary>
 public sealed class LambdaRaisingPass : IIrPass
@@ -204,7 +206,7 @@ public sealed class LambdaRaisingPass : IIrPass
                 load.ReplaceWith(value.Clone());
         }
 
-        return Finish(creation, body, provenance, allowLocals: false);
+        return Finish(creation, body, provenance, allowLocals: CapturesAreArgumentOnly(captures.Values));
     }
 
     // A hoisted capture binds a variable, not an expression: a parameter/this load
@@ -216,6 +218,9 @@ public sealed class LambdaRaisingPass : IIrPass
         LoadLocal local => !GeneratedCodeIdentity.IsDisplayClassName(function.Locals[local.Index]),
         _ => false,
     };
+
+    static bool CapturesAreArgumentOnly(IEnumerable<IrExpression> values)
+        => values.All(value => value is LoadArgument);
 
     static IrFunction RootFunction(IrNode node)
     {
@@ -237,9 +242,10 @@ public sealed class LambdaRaisingPass : IIrPass
     }
 
     // Shared finisher: admit only a body that prints soundly in the target scope.
-    // Capturing lambdas still print in the outer scope after substitution, so
-    // they keep the zero-local restriction. Non-capturing bodies can carry their
-    // own local table and print in a nested lambda scope.
+    // When locals are allowed, the lambda carries its own local table and prints
+    // through a nested lambda scope. Capturing callers enable that only when all
+    // substituted captures are argument/this loads, whose names are stable across
+    // the nested print scope.
     static Lambda? Finish(DelegateCreation creation, IrFunction body, IrNode provenance, bool allowLocals)
     {
         if (!allowLocals && !body.Locals.IsEmpty)


### PR DESCRIPTION
## Summary
- raise capturing lambdas with local-bearing bodies when captures are outer parameters/this loads
- add a scorecard case for parameter-capturing local-bodied lambdas
- keep outer-local capturing local-bodied lambdas lowered as an adversarial guardrail
- update ClosureCoverage and LambdaRecoveryFacts classification

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal