### PR TITLE
Pin extension-method instance-syntax precision

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1560,6 +1560,17 @@ public class CfgSampleClass
     public static IEnumerable<int> CachedDelegateChain(IEnumerable<int> items)
         => items.Where(x => x > 0).Select(x => x * 2);
 
+    // A same-assembly user extension method, called in instance form. csc lowers it
+    // to the static call `ExtensionMethodSamples.Doubled(n)`; the [Extension] mark is
+    // read from the same-assembly MethodDef, so it should render back as `n.Doubled()`.
+    public static int CallsUserExtension(int n) => n.Doubled();
+
+    // Adversarial: a plain static method (NOT [Extension]) with a first parameter,
+    // called explicitly. It is byte-identical in shape to an extension call but
+    // carries no [Extension] mark, so it must keep the static `Combine(a, b)` form
+    // and never sugar to `a.Combine(b)`.
+    public static int CallsNonExtensionStatic(int a, int b) => ExtensionMethodSamples.Combine(a, b);
+
     public static bool IsPositiveOrZero(int value)
     {
         return value >= 0;
@@ -2470,4 +2481,14 @@ public sealed class LockFixtureSamples
     {
         lock (gate) { _value = 1; }
     }
+}
+
+// Same-assembly samples for extension-method rendering: one genuine [Extension]
+// method and one plain static of the same call shape, to exercise the IsExtension
+// gate that decides instance-vs-static spelling.
+public static class ExtensionMethodSamples
+{
+    public static int Doubled(this int value) => value * 2;
+
+    public static int Combine(int left, int right) => left + right;
 }

--- a/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
@@ -53,4 +53,27 @@ public class ExtensionMethodCallTests
         int select = output.IndexOf(".Select", StringComparison.Ordinal);
         Assert.True(where >= 0 && select > where, $"expected .Where(...).Select(...), got: {output}");
     }
+
+    [Fact]
+    public void SameAssemblyUserExtension_RendersAsInstanceSyntax()
+    {
+        // The [Extension] mark is read from the same-assembly MethodDef, so a user
+        // extension sugars the same way the cross-assembly LINQ ones do.
+        string output = PrintRaised(nameof(CfgSampleClass.CallsUserExtension));
+
+        Assert.Contains("n.Doubled()", output);
+        Assert.DoesNotContain("ExtensionMethodSamples.Doubled", output);
+    }
+
+    [Fact]
+    public void NonExtensionStatic_KeepsStaticSpelling()
+    {
+        // A plain static with a first parameter is byte-identical in shape to an
+        // extension call but carries no [Extension] mark, so it must NOT sugar to
+        // receiver syntax — the precision guard on the IsExtension gate.
+        string output = PrintRaised(nameof(CfgSampleClass.CallsNonExtensionStatic));
+
+        Assert.Contains("ExtensionMethodSamples.Combine(a, b)", output);
+        Assert.DoesNotContain("a.Combine", output);
+    }
 }


### PR DESCRIPTION
## Target

Adversarial coverage for the extension-method instance-syntax rendering (#828), a recent broad printer change. Its `ExtensionMethodCallTests` only exercised **cross-assembly LINQ positives** (`items.Where(...)`), leaving two boundaries untested:

| Gap | Fixture | Why it matters |
| --- | --- | --- |
| Same-assembly `[Extension]` read | `CallsUserExtension` → `n.Doubled()` | #828 reads the `[Extension]` mark from the same-assembly `MethodDef`, but only the cross-assembly (System.Linq) read had a test |
| Precision (no false sugaring) | `CallsNonExtensionStatic` → `ExtensionMethodSamples.Combine(a, b)` | A plain static of the same call shape carries no `[Extension]` mark and must **not** sugar to `a.Combine(b)`; #828's message claims this (`Array.FindAll`) but no test pinned it |

## Outcome

Both render correctly today — **pure coverage, no pass change**. The sharpest case is the non-extension static: it's byte-identical in IL shape to an extension call (a static call with a first argument), and the only thing keeping it from being mis-rendered as `a.Combine(b)` is the `IsExtension` metadata gate. This PR pins that gate.

The two new `CfgSampleClass` fixtures are also fidelity-gated (an extension call recompiles to the identical static call, so `FidelityGateTests` covers them).

## Verification

- **677/677** `ILInspector.Decompiler.Tests` — including `FidelityGateTests` and `CorpusSweepGateTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)