### PR TITLE
Raise custom pattern foreach loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1501,6 +1501,46 @@ public class CfgSampleClass
         return sum;
     }
 
+    public readonly struct PatternEnumerable
+    {
+        public PatternEnumerator GetEnumerator() => new();
+    }
+
+    public struct PatternEnumerator
+    {
+        int _current;
+
+        public int Current => _current;
+
+        public bool MoveNext()
+        {
+            if (_current == 3)
+                return false;
+            _current++;
+            return true;
+        }
+    }
+
+    public static int ForeachPatternEnumerable(PatternEnumerable source)
+    {
+        int sum = 0;
+        foreach (int value in source)
+            sum += value;
+        return sum;
+    }
+
+    public static int ManualPatternEnumeratorLoop(PatternEnumerable source)
+    {
+        int sum = 0;
+        PatternEnumerator e = source.GetEnumerator();
+        while (e.MoveNext())
+        {
+            int value = e.Current;
+            sum += value;
+        }
+        return sum;
+    }
+
     public static Func<int, int> ClosureCapture(int offset)
     {
         return x => x + offset;

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -163,6 +163,56 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void PatternEnumeratorLoop_RaisesToForeach()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachPatternEnumerable));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
+        Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), _ => true);
+    }
+
+    [Fact]
+    public void PatternEnumeratorLoop_PrintRaised_RendersForeach()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.ForeachPatternEnumerable))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("foreach (int value in source)", output);
+        Assert.Contains("sum += value;", output);
+        Assert.DoesNotContain("GetEnumerator", output);
+        Assert.DoesNotContain("MoveNext", output);
+    }
+
+    [Fact]
+    public void PatternEnumeratorLoop_WithoutSymbols_StaysWhile()
+    {
+        var function = RaisedWithoutSymbols(nameof(CfgSampleClass.ForeachPatternEnumerable));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void HandWrittenPatternEnumeratorLoop_StaysWhile()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualPatternEnumeratorLoop));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void HandWrittenPatternEnumeratorLoop_WithoutSymbols_StaysWhile()
+    {
+        var function = RaisedWithoutSymbols(nameof(CfgSampleClass.ManualPatternEnumeratorLoop));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
     public void EnumeratorThenArrayForeach_RaisesBothForms()
     {
         var function = Raised(nameof(CfgSampleClass.EnumeratorThenArrayForeach));

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -43,6 +43,7 @@ public class IdiomShapeScorecardTests
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachArray), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachString), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
+        new("ForeachStatementPass", nameof(CfgSampleClass.ForeachPatternEnumerable), SyntaxKind.ForEachStatement, [SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
@@ -12,9 +12,10 @@ internal sealed class ForeachRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("enumerator-call-shape", "ForeachStatementPass GetEnumerator/MoveNext/Current shape checks"),
                 new FactPrimitive("dataflow.enumerator-local-consumed", "ForeachStatementPass ReferencesEnumerator residual-use guard"),
                 new FactPrimitive("member.corelib-identity:string.Length/string.Chars", "MemberIdentity.IsStringLengthGetter/IsStringCharsGetter"),
+                new FactPrimitive("pdb.hidden-pattern-enumerator-local", "ForeachStatementPass HasLocalNameSlot + HasSourceLocalName guard"),
             ],
-            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, and strings",
-            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop and hand-written indexed array/string for loops",
-            MissingDiscriminator: "custom pattern enumerators, multidimensional arrays, and broader collection/extension GetEnumerator shapes not raised"),
+            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, strings, and PDB-discriminated custom pattern enumerators",
+            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop, hand-written indexed array/string for loops, and no-symbols/manual pattern enumerator loops",
+            MissingDiscriminator: "multidimensional arrays, no-symbol custom pattern enumerators, and broader collection/extension GetEnumerator shapes not raised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -513,9 +513,10 @@ public sealed class MetadataSource : IDisposable
 
     /// <summary>
     /// Source local-variable names for a method from its portable PDB, indexed
-    /// by IL local slot. Absent entries — no PDB, no recorded name, a
-    /// compiler-generated (debugger-hidden) local, or a name that is not a
-    /// usable identifier — stay null, and the printer renders <c>V_index</c>.
+    /// by IL local slot. No PDB returns an empty array. Present PDB entries with
+    /// no recorded name, a compiler-generated (debugger-hidden) local, or a name
+    /// that is not a usable identifier stay null, and the printer renders
+    /// <c>V_index</c>.
     /// </summary>
     internal ImmutableArray<string?> LocalNames(MethodDefinitionHandle methodHandle, int localCount)
     {
@@ -523,7 +524,7 @@ public sealed class MetadataSource : IDisposable
             return [];
         var pdb = PdbReader();
         if (pdb is null)
-            return [.. Enumerable.Repeat<string?>(null, localCount)];
+            return [];
 
         var names = new string?[localCount];
         try

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -61,13 +61,31 @@ public sealed class ForeachStatementPass : IIrPass
                 continue;
 
             var collection = match.Collection;
-            collection.Detach();
+            if (collection.Parent is not null)
+                collection.Detach();
             match.CurrentStore.Detach();
             var body = match.Loop.Body;
             body.Detach();
             var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
             context.Stepper.StepOver("raise enumerator loop to foreach", usingStatement);
             usingStatement.ReplaceWith(foreachStatement);
+        }
+
+        foreach (var loop in function.Descendants.OfType<WhileLoop>().ToList())
+        {
+            if (TryMatchPattern(function, loop) is not { } match)
+                continue;
+
+            var collection = match.Collection;
+            if (collection.Parent is not null)
+                collection.Detach();
+            match.CurrentStore.Detach();
+            var body = loop.Body;
+            body.Detach();
+            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
+            context.Stepper.StepOver("raise pattern enumerator loop to foreach", loop);
+            loop.ReplaceWith(foreachStatement);
+            match.EnumeratorStore.Detach();
         }
 
         // Collect every structural indexed-foreach candidate first, then admit a
@@ -150,6 +168,57 @@ public sealed class ForeachStatementPass : IIrPass
 
         return new EnumeratorMatch(getEnumerator.Arguments[0], loop, currentStore);
     }
+
+    sealed record PatternMatch(IrExpression Collection, StoreLocal EnumeratorStore, WhileLoop Loop, StoreLocal CurrentStore);
+
+    static PatternMatch? TryMatchPattern(IrFunction function, WhileLoop loop)
+    {
+        if (loop.Parent is not Block block || loop.ChildIndex == 0)
+            return null;
+        if (block.Children[loop.ChildIndex - 1] is not StoreLocal { Value: Call getEnumerator } enumeratorStore
+            || !IsGetEnumerator(getEnumerator)
+            || getEnumerator.Arguments is not [_])
+        {
+            return null;
+        }
+
+        int enumeratorIndex = enumeratorStore.Index;
+        if (!HasLocalNameSlot(function, enumeratorIndex)
+            || HasSourceLocalName(function, enumeratorIndex))
+        {
+            return null;
+        }
+
+        if (loop.Condition is not Call moveNext
+            || !IsMoveNextCall(moveNext)
+            || moveNext.Arguments is not [var moveNextReceiver]
+            || !IsEnumeratorReceiver(moveNextReceiver, enumeratorIndex)
+            || loop.Body.Children is not [StoreLocal { Value: LoadProperty current } currentStore, ..]
+            || !IsCurrentOn(current, enumeratorIndex))
+        {
+            return null;
+        }
+
+        if (loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
+            return null;
+
+        var currentReceiver = current.Instance!;
+        var allowed = new HashSet<IrNode>(ReferenceEqualityComparer.Instance)
+        {
+            enumeratorStore, moveNextReceiver, currentReceiver,
+        };
+        if (!ReferencedOnlyBy(function, enumeratorIndex, allowed))
+            return null;
+
+        return new PatternMatch(CollectionValue(getEnumerator.Arguments[0]), enumeratorStore, loop, currentStore);
+    }
+
+    static IrExpression CollectionValue(IrExpression expression) => expression switch
+    {
+        LoadArgumentAddress address => new LoadArgument(address.Index, address.Name, address.Type),
+        LoadLocalAddress address => new LoadLocal(address.Index, address.Type),
+        _ => expression,
+    };
 
     sealed record IndexedCandidate(
         ForLoop Loop,
@@ -283,15 +352,23 @@ public sealed class ForeachStatementPass : IIrPass
             && index < function.LocalNames.Length
             && !string.IsNullOrWhiteSpace(function.LocalNames[index]);
 
+    static bool HasLocalNameSlot(IrFunction function, int index)
+        => index >= 0 && index < function.LocalNames.Length;
+
     static bool IsGetEnumerator(Call call)
         => call.Callee is { Name: "GetEnumerator", HasThis: true } && call.Arguments.Count == 1;
 
     static bool IsMoveNextOn(IrExpression condition, int enumeratorIndex)
-        => condition is Call
+        => condition is Call call
+            && IsMoveNextCall(call)
+            && call.Arguments is [var receiver]
+            && IsEnumeratorReceiver(receiver, enumeratorIndex);
+
+    static bool IsMoveNextCall(Call call)
+        => call is
         {
             Callee: { Name: "MoveNext", HasThis: true, ReturnType: { Namespace: "System", Name: "Boolean" } },
-            Arguments: [var receiver],
-        } && IsEnumeratorReceiver(receiver, enumeratorIndex);
+        };
 
     static bool IsCurrentOn(LoadProperty property, int enumeratorIndex)
         => property is { HasInstance: true, PropertyName: "Current", Instance: { } receiver }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -69,7 +69,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ExpressionStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Field => default!;
     [Completeness(CompletenessLevel.Full)] public static FixedStatementPass FixedStatement => new();
-    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local, the single-dimension array lowering (hidden array-copy + index for loop), and string foreach lowering (hidden string-copy + index for loop); multidimensional arrays and custom pattern enumerators not raised")]
+    [Completeness(CompletenessLevel.Partial, "enumerator using/while/current lowering with hidden enumerator local, the single-dimension array lowering (hidden array-copy + index for loop), string foreach lowering (hidden string-copy + index for loop), and PDB-discriminated custom pattern enumerators without Dispose; multidimensional arrays and no-symbol custom pattern enumerators not raised")]
     public static ForeachStatementPass ForEachStatement => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static ForLoopPass ForStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative FunctionPointerInvocation => default!;


### PR DESCRIPTION
## Summary
- recover PDB-discriminated custom pattern enumerator foreach loops
- preserve no-symbol and hand-written pattern enumerator loops as lowered while loops
- update foreach scorecard, ledger, and sidecar facts

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release