### PR TITLE
Escape U+2028/U+2029 line separators in string and char literals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -31,6 +31,11 @@ public class CfgSampleClass
     // with a null operand. The printer must spell it `o is not null`, not the
     // CS0019 `o > null`.
     public static bool IsNotNullReference(object o) => o != null;
+    // A string literal containing the C# line terminators that are not
+    // `char.IsControl`: U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR.
+    // The printer must escape them (\u2028/\u2029) or the emitted literal splits
+    // across source lines (CS1010 "Newline in constant").
+    public static string LineSeparatorLiteral() => "a\u2028b\u2029c";
 
     // `a | b` of two bytes is `int` in C# (binary numeric promotion), so the
     // trailing conv.u1 is a real narrowing the language requires. The IR types the

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -98,6 +98,7 @@ public class FidelityGateTests
         "NullCoalescingAssignStaticField",
         "NullCoalescingAssignInstanceField",
         "IsNotNullReference",
+        "LineSeparatorLiteral",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/StringLiteralEscapingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringLiteralEscapingTests.cs
@@ -1,0 +1,32 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// C# defines five line-terminator characters (ECMA-334 §6.3.1): CR, LF, NEL
+// (U+0085), LINE SEPARATOR (U+2028), and PARAGRAPH SEPARATOR (U+2029). The first
+// three are `char.IsControl` and were already escaped; U+2028/U+2029 are not, so
+// a raw emit splits the string literal across source lines (CS1010). The printer
+// must escape them.
+public class StringLiteralEscapingTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void LineAndParagraphSeparators_AreEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.LineSeparatorLiteral));
+
+        Assert.Contains("\\u2028", output);
+        Assert.Contains("\\u2029", output);
+        Assert.DoesNotContain("\u2028", output);
+        Assert.DoesNotContain("\u2029", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1504,6 +1504,12 @@ public sealed partial class CSharpPrinter
         '\r' => "\\r",
         '\t' => "\\t",
         '\v' => "\\v",
+        // U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are C# line
+        // terminators (ECMA-334 §6.3.1) but are not `char.IsControl`, so a raw
+        // emit splits the literal across source lines (CS1010 "Newline in
+        // constant"). Escape them explicitly.
+        '\u2028' => "\\u2028",
+        '\u2029' => "\\u2029",
         _ when char.IsControl(c) => $"\\u{(int)c:x4}",
         _ => c.ToString(),
     };


### PR DESCRIPTION
## Problem

C# defines five line-terminator characters (ECMA-334 §6.3.1): CR, LF, NEL (U+0085), LINE SEPARATOR (U+2028), and PARAGRAPH SEPARATOR (U+2029). The printer's `EscapeChar` handled the first three (CR/LF directly, NEL via the `char.IsControl` fallback), but **U+2028/U+2029 are not control characters**, so they fell through to a raw emit. A raw line separator inside a literal splits it across source lines — CS1010 "Newline in constant".

`System.String::ReplaceLineEndingsWithLineFeed` and `System.String.SearchValuesStorage::.cctor` both embed the line-ending search set containing U+2028/U+2029, e.g. before:

```csharp
... .IndexOfAny<char>((ReadOnlySpan<char>)"\r\f\u0085<raw LS><raw PS>");
```

after:

```csharp
... .IndexOfAny<char>((ReadOnlySpan<char>)"\r\f\u0085\u2028\u2029");
```

## Fix

Add explicit `'\u2028' => "\\u2028"` and `'\u2029' => "\\u2029"` cases to `EscapeChar`. This covers both string and char literals (they share the escaper).

## Soundness

Escaping a character is purely a spelling change — the literal denotes the same string and recompiles opcode-exact (same `ldstr`).

## Corpus impact

- Full malformed 478 → 476 (−2 methods)
- Recompile inventory flat: 40987/41012 Full (99.94%)
- Added `LineSeparatorLiteral` fixture (opcode-exact, pinned in the fidelity gate) + a render test
- 660 decompiler + 1157 product tests green
