### PR TITLE
Pin the cgt.un not-null idiom against unsigned-comparison near-misses

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -32,6 +32,15 @@ public class CfgSampleClass
     // CS0019 `o > null`.
     public static bool IsNotNullReference(object o) => o != null;
 
+    // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
+    // `cgt.un` against a zero constant, but the zero is an integer literal, not a
+    // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.
+    public static bool UnsignedGreaterThanZero(uint x) => x > 0;
+
+    // A genuine unsigned ordering between two values: `cgt.un` with no null/zero
+    // operand at all, so the not-null recovery must leave it as `a > b`.
+    public static bool UnsignedGreaterThan(uint a, uint b) => a > b;
+
     // `a | b` of two bytes is `int` in C# (binary numeric promotion), so the
     // trailing conv.u1 is a real narrowing the language requires. The IR types the
     // `or` as byte (ECMA "wider operand wins"), so IdentityConvertPass must not drop

--- a/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
@@ -25,4 +25,27 @@ public class ReferenceNullOrderingTests
         Assert.Contains("is not null", output);
         Assert.DoesNotContain("> null", output);
     }
+
+    [Fact]
+    public void UnsignedGreaterThanZero_StaysComparison_NotNullCheck()
+    {
+        // `x > 0` on a uint emits the same `cgt.un` opcode against a zero constant,
+        // but the zero is an integer literal, not a reference null — the not-null
+        // recovery keys on a null operand, so this must stay a `>` comparison.
+        var output = Render(nameof(CfgSampleClass.UnsignedGreaterThanZero));
+
+        Assert.Contains("x >", output);
+        Assert.DoesNotContain("is not null", output);
+    }
+
+    [Fact]
+    public void UnsignedComparisonBetweenValues_StaysComparison()
+    {
+        // A genuine unsigned ordering (`cgt.un` with no null/zero operand) must be
+        // left untouched by the not-null recovery.
+        var output = Render(nameof(CfgSampleClass.UnsignedGreaterThan));
+
+        Assert.Contains("a > b", output);
+        Assert.DoesNotContain("is not null", output);
+    }
 }


### PR DESCRIPTION
## Target

Adversarial coverage for the reference not-null recovery (#845), which renders an unsigned `cgt.un`/`clt.un` against a null operand as `obj is not null`. The opcode is **overloaded** — `cgt.un` is also the unsigned greater-than opcode — so the recovery keys on the operand being a *reference null*, not on the opcode alone. #845 shipped only the positive fixture; nothing pinned that genuine unsigned integer comparisons survive.

## Findings

| Fixture | Probe | Result |
| --- | --- | --- |
| `UnsignedGreaterThanZero` | `x > 0` on a `uint` — same `cgt.un`, but against an integer-zero constant, not a reference null | Stays `x > 0` ✓ |
| `UnsignedGreaterThan` | `a > b` — unsigned ordering with no null/zero operand | Stays `a > b` ✓ |

The sharp case is `x > 0`: structurally it's `cgt.un` against a zero-valued constant, identical in opcode to the not-null idiom — the only thing keeping it from rendering as `is not null` is the discriminator checking `Constant { Value: null }` (a reference null) rather than integer 0. This PR pins that distinction.

Both render correctly today — **pure coverage, no printer change**.

## Verification

- **678/678** `ILInspector.Decompiler.Tests` (rebased on current `main`) — including `FidelityGateTests` and `CorpusSweepGateTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)