### PR TITLE
Fold reconstructed for-loop increments to i++

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -101,5 +102,66 @@ public class IncrementDecrementPassTests
         var statements = Run(Function(TempStore(), update));
 
         Assert.Equal(2, statements.Count);
+    }
+
+    // Builds a `for (place = 0; place < 2; place = temp + 1) { ...head; temp = place; }`
+    // loop — the post-increment-through-spill shape iterator reconstruction leaves.
+    static ForLoop ForLoopWithTemp(int place, int temp, params IrNode[] bodyHead)
+    {
+        var init = new StoreLocal(place, Int32, new Constant(0, Int32));
+        var condition = new Comparison(ComparisonKind.LessThan, isUnsigned: false,
+            new LoadLocal(place, Int32), new Constant(2, Int32));
+        var increment = new StoreLocal(place, Int32,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(temp, Int32), new Constant(1, Int32)));
+        var body = new Block(0);
+        foreach (var statement in bodyHead)
+            body.Add(statement);
+        body.Add(new StoreLocal(temp, Int32, new LoadLocal(place, Int32)));
+        return new ForLoop(init, condition, increment, body);
+    }
+
+    static int IncrementOperandIndex(ForLoop loop) =>
+        ((LoadLocal)((Binary)((StoreLocal)loop.Increment).Value).Left).Index;
+
+    [Fact]
+    public void ForLoopTempIncrement_InlinesTempAndDropsCapture()
+    {
+        var loop = ForLoopWithTemp(place: 0, temp: 1, new StoreLocal(8, Int32, new Constant(5, Int32)));
+        new IncrementDecrementPass().Run(Function(loop), PassContext.None);
+
+        // The update reads the place itself now (self-referential `place = place + 1`,
+        // which the printer spells `place++`), and the capture statement is gone.
+        Assert.Equal(0, IncrementOperandIndex(loop));
+        Assert.DoesNotContain(loop.Body.Children.OfType<StoreLocal>(), s => s.Index == 1);
+        Assert.Single(loop.Body.Children);
+    }
+
+    [Fact]
+    public void SharedTempAcrossNestedForLoops_FoldsBothLoops()
+    {
+        // A single temp slot (1) serves both the outer (place 0) and inner
+        // (place 2) loops, as in the reconstructed YieldGrid nest. The fold proves
+        // the temp is used only in these dup idioms and inlines both.
+        var inner = ForLoopWithTemp(place: 2, temp: 1);
+        var outer = ForLoopWithTemp(place: 0, temp: 1, inner);
+        new IncrementDecrementPass().Run(Function(outer), PassContext.None);
+
+        Assert.Equal(0, IncrementOperandIndex(outer));
+        Assert.Equal(2, IncrementOperandIndex(inner));
+        Assert.DoesNotContain(outer.Body.Children.OfType<StoreLocal>(), s => s.Index == 1);
+        Assert.DoesNotContain(inner.Body.Children.OfType<StoreLocal>(), s => s.Index == 1);
+    }
+
+    [Fact]
+    public void ForLoopTemp_ReadElsewhere_IsNotFolded()
+    {
+        // The temp also feeds an unrelated read, so it is not purely the dup spill
+        // — inlining could drop an observed value, so the loop is left alone.
+        var loop = ForLoopWithTemp(place: 0, temp: 1, new StoreLocal(8, Int32, new Constant(5, Int32)));
+        var otherRead = new StoreLocal(9, Int32, new LoadLocal(1, Int32));
+        new IncrementDecrementPass().Run(Function(loop, otherRead), PassContext.None);
+
+        Assert.Equal(1, IncrementOperandIndex(loop));
+        Assert.Equal(2, loop.Body.Children.Count);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -116,6 +116,21 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void NestedLoopIterator_FoldsBothForUpdatesToOperator()
+    {
+        // Both loops' increments are rebuilt through a single shared spill slot
+        // (`V_1 = j; … V_1 = i;` captures with `j = V_1 + 1` / `i = V_1 + 1`
+        // updates); the post-reconstruction IncrementDecrementPass inlines the
+        // shared temp so both updates spell `i++` / `j++` and the temp disappears.
+        var output = Print(nameof(CfgSampleClass.YieldGrid));
+
+        Assert.Contains("for (int i = 0; i < 2; i++)", output);
+        Assert.Contains("for (int j = 0; j < 2; j++)", output);
+        Assert.DoesNotContain("V_1", output);
+        Assert.DoesNotContain("+ 1", output);
+    }
+
+    [Fact]
     public void NonIterator_IsUnaffected()
     {
         var function = Raised(nameof(CfgSampleClass.NotAnIterator));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -30,6 +30,8 @@ public sealed class IncrementDecrementPass : IIrPass
         while (FoldOnce(function, context.Stepper))
         {
         }
+
+        FoldForLoopIncrements(function, context.Stepper);
     }
 
     static bool FoldOnce(IrFunction function, Stepper stepper)
@@ -231,6 +233,82 @@ public sealed class IncrementDecrementPass : IIrPass
         tempStore.ReplaceWith(new ExpressionStatement(increment));
         block.Children[i + 1].Detach();
         return true;
+    }
+
+    readonly record struct ForLoopIncrement(ForLoop Loop, int TempIndex, PlaceRef Place, StoreLocal Capture, LoadLocal IncrementRead, BinaryKind Kind);
+
+    /// <summary>
+    /// Folds the for-loop post-increment temp form that iterator reconstruction
+    /// leaves in a rebuilt <c>for</c> loop:
+    ///
+    /// <code>
+    /// for (int j = 0; j &lt; n; j = V_1 + 1)   // update reads the temp
+    /// {
+    ///     ... body ...
+    ///     V_1 = j;                            // body's last statement captures j
+    /// }
+    /// </code>
+    ///
+    /// The hoisted loop variable's <c>j++</c> is rebuilt through a spill slot —
+    /// the body's last statement copies <c>j</c> into the temp, and the loop's
+    /// update reads the temp back as <c>j = V_1 + 1</c>. Inlining the temp turns
+    /// the update into the self-reading <c>j = j + 1</c>, which the printer already
+    /// spells <c>j++</c>, and drops the capture. A single temp slot is reused
+    /// across the loops of a nest (so the function-wide single-use guard of
+    /// <see cref="TryFoldStatementIncrement"/> does not apply); this fold instead
+    /// verifies the temp is used <em>only</em> in these dup idioms — every store of
+    /// it is one of the captures and every load one of the update reads — and folds
+    /// the whole group together, after which the temp is dead and undeclared.
+    /// </summary>
+    static void FoldForLoopIncrements(IrFunction function, Stepper stepper)
+    {
+        var candidates = new List<ForLoopIncrement>();
+        foreach (var loop in function.Descendants.OfType<ForLoop>())
+        {
+            if (PlaceOf(loop.Increment) is not { } place || StoreValue(loop.Increment) is not { } updateValue)
+                continue;
+            if (updateValue is not Binary { IsChecked: false, Kind: BinaryKind.Add or BinaryKind.Subtract } binary
+                || binary.Left is not LoadLocal tempRead
+                || binary.Right is not Constant { Value: 1 })
+            {
+                continue;
+            }
+            if (loop.Body.Children.Count == 0 || loop.Body.Children[^1] is not StoreLocal capture)
+                continue;
+            if (capture.Index != tempRead.Index || PlaceLoad(capture.Value) is not { } captured)
+                continue;
+            if (captured.IsLocal != place.IsLocal || captured.Index != place.Index)
+                continue;
+
+            candidates.Add(new ForLoopIncrement(loop, tempRead.Index, place, capture, tempRead, binary.Kind));
+        }
+
+        foreach (var group in candidates.GroupBy(c => c.TempIndex))
+        {
+            int temp = group.Key;
+            var folds = group.ToList();
+
+            // The temp must be exclusively the dup spill: every store of it is one
+            // of our captures, every load one of our update reads, and its address
+            // is never taken. Otherwise inlining would drop an observed value.
+            if (function.Descendants.OfType<LoadLocalAddress>().Any(a => a.Index == temp))
+                continue;
+            var captures = folds.Select(c => c.Capture).ToHashSet();
+            var reads = folds.Select(c => (LoadLocal)c.IncrementRead).ToHashSet();
+            var stores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == temp).ToList();
+            var loads = function.Descendants.OfType<LoadLocal>().Where(l => l.Index == temp).ToList();
+            if (stores.Count != captures.Count || !stores.All(captures.Contains))
+                continue;
+            if (loads.Count != reads.Count || !loads.All(reads.Contains))
+                continue;
+
+            foreach (var fold in folds)
+            {
+                stepper.StepOver($"inline for-loop post-increment temp into {(fold.Kind is BinaryKind.Add ? "++" : "--")} update", fold.Loop.Increment);
+                fold.IncrementRead.ReplaceWith(ClonePlace(fold.Place));
+                fold.Capture.Detach();
+            }
+        }
     }
 
     static PlaceRef? PlaceLoad(IrExpression expression) => expression switch


### PR DESCRIPTION
## Summary

Follow-up to #844. Reconstructed nested-loop iterators still rendered their
loop-variable increments through a spill slot instead of `i++`:

```csharp
// before
for (int i = 0; i < 2; i = V_1 + 1)
{
    for (int j = 0; j < 2; j = V_1 + 1)
    {
        yield return i + j;
        V_1 = j;
    }
    V_1 = i;
}
```

```csharp
// after — an exact reconstruction of the source
for (int i = 0; i < 2; i++)
    for (int j = 0; j < 2; j++)
        yield return i + j;
```

## Cause

Iterator reconstruction rebuilds the hoisted loop variable's `i++` inside the
rebuilt `for` loop: the body's last statement copies the loop variable into a
temp (`V_1 = j;`) and the loop update reads it back (`j = V_1 + 1`). A nest
**reuses a single temp slot** across all its loops, so the function-wide
single-use guard from #844's statement-form fold does not apply.

## Fix

Add `FoldForLoopIncrements` to `IncrementDecrementPass`: collect every `for`
loop whose update is `place = temp + 1` and whose body's last statement captures
`temp = place`, group them by temp slot, and — once it proves the temp is used
**only** in these dup idioms (every store of it is one of the captures, every
load one of the update reads, address never taken) — inline the temp into each
update (`place = place + 1`, which the printer's existing `AssignmentText`
already spells `place++`) and drop the captures. The temp is then dead and
undeclared.

Soundness: because the temp is exclusively the dup spill and each capture is its
loop's last body statement (executed immediately before that loop's update), the
captured value is observed only by the update being redirected; the whole group
folds together. A `checked` binary or non-unit step is left alone. The shape
does not arise from csc directly, so the fold is iterator-cleanup only and does
not change non-reconstructed output.

## Validation

- `IncrementDecrementPassTests`: +3 (single loop inline, shared temp across a
  nest folds both, temp read elsewhere declines).
- `IteratorReconstructionPassTests`: `YieldGrid` now renders `for … i++` /
  `for … j++` with no `V_1` temp.
- Decompiler suite 679 green (compile-back + corpus-sweep + annotate-check gates
  included); product suite 1157 (9 skip) green.
