### PR TITLE
Deref a reinterpreted-address read as its own pointer type, not nuint

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1966,6 +1966,16 @@ public class CfgSampleClass
         }
     }
 
+    // The generic reinterpret-then-read idiom (Enum.IsDefinedPrimitive et al.):
+    // take the address of a generic value, reinterpret it as a primitive pointer,
+    // and deref — `ldarga; conv.u; ldind.<T>`. The conv to a native int is what
+    // makes the naive deref `*((nuint)(&value))` (CS0193); the read must spell its
+    // own pointer type: `*(byte*)(&value)`.
+    public static unsafe byte ReinterpretFirstByte<T>(T value) where T : unmanaged
+    {
+        return *(byte*)&value;
+    }
+
     // A function-pointer parameter is a representable type: delegate*<int, int>
     // imports at Full fidelity and renders in C# function-pointer syntax (return
     // type last). It carries no node-level stop.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -677,6 +677,21 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void ReinterpretRead_DerefsAsItsOwnPointerType_NotNativeInt()
+    {
+        // `ldarga; conv.u; ldind.u1` (reinterpret a generic value as a primitive
+        // and read it). Deref-ing the native-int address — `*((nuint)(&value))` —
+        // is CS0193; the read must spell its own pointer type: `*(byte*)(&value)`.
+        var function = ImportFixture(nameof(CfgSampleClass.ReinterpretFirstByte));
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("*(byte*)(&value)", output);
+        Assert.DoesNotContain("*((nuint)", output);
+        Assert.DoesNotContain("*((nint)", output);
+    }
+
+    [Fact]
     public void ElementAccess_ImportsTypedLoadAndStore()
     {
         var load = ImportFixture(nameof(CfgSampleClass.FirstElement));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1044,7 +1044,7 @@ public sealed partial class CSharpPrinter
         LoadArgumentAddress a => $"ref {a.Name}",
         LoadFieldAddress f => $"ref {FieldTarget(f.Field, f.Instance)}",
         LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
-        LoadIndirect l => Deref(l.Address),
+        LoadIndirect l => DerefLoad(l),
         SizeOf s => $"sizeof({TypeText(s.Type)})",
         TypeOf t => $"typeof({TypeText(t.Type)})",
         LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
@@ -1199,6 +1199,32 @@ public sealed partial class CSharpPrinter
         { ResultType.Kind: TypeRefKind.ByRef } => Operand(address),
         _ => $"*{Operand(address)}",
     };
+
+    /// <summary>
+    /// Renders a <c>ldind.&lt;T&gt;</c> read. Most addresses go through
+    /// <see cref="Deref"/>, but when the address was reinterpreted to a native
+    /// integer (<c>ldarga; conv.u; ldind.u1</c> — the generic
+    /// reinterpret-then-read idiom, e.g. <c>Enum.IsDefinedPrimitive&lt;byte&gt;</c>),
+    /// <see cref="Deref"/> would render <c>*((nuint)(&amp;value))</c> — a deref of
+    /// an integer, CS0193. The faithful unsafe spelling reinterprets the address
+    /// as the read's own pointer type and derefs it: <c>*(T*)(&amp;value)</c>. The
+    /// <c>(T*)</c> cast subsumes the <c>conv.u</c>, so the read recompiles to the
+    /// same <c>ldind</c>.
+    /// </summary>
+    string DerefLoad(LoadIndirect load)
+    {
+        if (load.Type is { } element
+            && load.Address is Convert { Target: { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "IntPtr" or "UIntPtr" } } conv)
+        {
+            // An address-of operand keeps its `&place` unsafe spelling (mirroring
+            // ConvertText); any other operand is already a pointer/integer value.
+            string addr = conv.Operand is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress
+                ? $"(&{Deref(conv.Operand)})"
+                : Operand(conv.Operand);
+            return $"*({TypeText(element)}*){addr}";
+        }
+        return Deref(load.Address);
+    }
 
     /// <summary>
     /// The C# type a store-indirect writes through. A primitive <c>stind</c>


### PR DESCRIPTION
## Problem

Mining the `--validity-check` CS0193 bucket (`*`/`->` on a non-pointer) surfaced a systematic mis-render of the generic reinterpret-then-read idiom. `Enum.IsDefined<TEnum>` decompiles to:

```csharp
return Enum.IsDefinedPrimitive<byte>(rt, *((nuint)(&value)));   // CS0193
```

The IL is `ldarga value; conv.u; ldind.u1` — take the address of a generic value, reinterpret it to a native int, read it as a primitive. It imports as a `LoadIndirect` over a `Convert` to `nuint`. `Deref` renders the address without consulting the read's element type, so the native-int reinterpret prints literally and the `*` derefs a `nuint`.

## Fix

When a `LoadIndirect` reads through a `Convert` to `IntPtr`/`UIntPtr`, reinterpret the address as the read's **own** pointer type and deref that: `*(byte*)(&value)`. The `(T*)` cast subsumes the `conv.u`, so the read recompiles to the same `ldind`. One printer helper, `DerefLoad`; every other deref still goes through `Deref` unchanged.

`Enum.IsDefined` now renders the faithful `*(byte*)(&value)`, `*(ushort*)(&value)`, …

## Soundness

- **Semantics preserved.** The `(T*)` cast is the same reinterpret the `conv.u` performed; the recompiled read is the same `ldind.<T>`. Verified by the new fixture round-tripping opcode-exact through the fidelity gate.
- **Printer-only.** No IR change, so `function.Fidelity` and the corpus Full-fidelity floor are untouched.
- **Tightly scoped.** Only a `LoadIndirect` over a native-int `Convert` is intercepted; genuine pointer derefs and `ref` reads keep their `Deref` spelling. An address-of operand keeps `&place` (mirroring `ConvertText`); any other operand is already a pointer/integer value.

## Breadth & validation

- Corpus scan: **131 read sites across 18 CoreLib methods** (Enum, `Buffers.Any{1..5}SearchValues`, `Task.FromResult`, `MdConstant.GetValue`, `EventSource.ObjectIDForEvents`).
- Same-base validity defect diff (`--diff-validity-defects`): the bound methods lose CS0193, **zero regressions** (the rest are past the 4000-method bind cap but the IR scan confirms them).
- Decompiler suite green (**677**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests`.

## Tests

New `ReinterpretFirstByte<T>` fixture (`*(byte*)&value`, `where T : unmanaged`) reproduces the `ldarga; conv.u; ldind` shape; `IrImporterTests` asserts the read renders `*(byte*)(&value)` and never `*((nuint)`/`*((nint)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)