### PR TITLE
Reject custom-pattern foreach over-raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -242,4 +242,49 @@ public class ForeachStatementPassTests
         Assert.Single(function.Descendants.OfType<UsingStatement>());
         Assert.Single(function.Descendants.OfType<WhileLoop>());
     }
+
+    [Fact]
+    public void CustomPatternEnumeratorUsingWhile_StaysLowered()
+    {
+        var function = BuildCustomPatternEnumeratorUsingWhile();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildCustomPatternEnumeratorUsingWhile()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var collectionType = TypeRef.Definition("UserAssembly", "Samples", "CustomCollection");
+        var enumeratorType = TypeRef.Definition("UserAssembly", "Samples", "CustomEnumerator", ValueTypeHint.ReferenceType);
+        var getEnumerator = new MethodRef(collectionType, "GetEnumerator", enumeratorType, [], HasThis: true);
+        var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var loopBody = new Block();
+        loopBody.Add(new StoreLocal(1, intType, new LoadProperty(current, new LoadLocal(0, enumeratorType), [])));
+        var usingBody = new BlockContainer();
+        var usingBlock = new Block();
+        usingBlock.Add(new WhileLoop(new Call(moveNext, isVirtual: true, [new LoadLocal(0, enumeratorType)]), loopBody));
+        usingBody.Add(usingBlock);
+
+        var entry = new Block();
+        entry.Add(new UsingStatement(0, enumeratorType, new Call(getEnumerator, isVirtual: false, [new LoadArgument(0, "items", collectionType)]), usingBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("items", collectionType)], HasThis: false, GenericParameterCount: 0),
+            [enumeratorType, intType],
+            body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -150,6 +150,7 @@ public sealed class ForeachStatementPass : IIrPass
 
         if (usingStatement.Resource is not Call getEnumerator
             || !IsGetEnumerator(getEnumerator)
+            || !IsSupportedEnumeratorCollection(getEnumerator)
             || getEnumerator.Arguments is not [_])
         {
             return null;
@@ -357,6 +358,10 @@ public sealed class ForeachStatementPass : IIrPass
 
     static bool IsGetEnumerator(Call call)
         => call.Callee is { Name: "GetEnumerator", HasThis: true } && call.Arguments.Count == 1;
+
+    static bool IsSupportedEnumeratorCollection(Call getEnumerator)
+        => MemberIdentity.IsCoreLibraryType(getEnumerator.Callee.DeclaringType, "System.Collections", "IEnumerable")
+            || MemberIdentity.IsCoreLibraryType(getEnumerator.Callee.DeclaringType, "System.Collections.Generic", "IEnumerable`1");
 
     static bool IsMoveNextOn(IrExpression condition, int enumeratorIndex)
         => condition is Call call


### PR DESCRIPTION
## Summary
- gate enumerator foreach recovery to BCL IEnumerable/IEnumerable<T> collection shapes
- add a synthetic custom-pattern using/while near-miss that must stay lowered

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.ForeachStatementPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore
- dotnet build src/dotnet-inspect -c Release --no-restore --nologo