### PR TITLE
Curate tuple binary coverage metadata

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -198,6 +198,19 @@ public class TupleBinaryOperatorPassTests
     }
 
     [Fact]
+    public void HandWrittenMixedTupleFieldComparison_IsNotRaised()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.LazyMixedLiteralVariableComparison), typeof(TupleBinaryAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("pair.Item1", output);
+        Assert.Contains("pair.Item2", output);
+        Assert.Contains("&&", output);
+    }
+
+    [Fact]
     public void DirectManualTupleFieldComparison_IsNotRaised()
     {
         var function = Raised(nameof(TupleBinaryAdversarialSamples.DirectManualTupleFields), typeof(TupleBinaryAdversarialSamples));
@@ -234,6 +247,11 @@ public static class TupleBinaryAdversarialSamples
     // Hand-written arity-3 short-circuit chain: still lazy, still no spills, so the
     // N-ary literal matcher must not mistake it for `(a, b, e) == (c, d, f)`.
     public static bool LazyAndComparison3(int a, int b, int c, int d, int e, int f) => a == c && b == d && e == f;
+
+    // Hand-written mixed literal-vs-variable spelling: source-like `a,b` on one
+    // side and tuple fields on the other, but no eager hidden operand spills.
+    public static bool LazyMixedLiteralVariableComparison(int a, int b, (int Sum, int Product) pair)
+        => a == pair.Sum && b == pair.Product;
 
     public static bool DirectManualTupleFields((int Sum, int Product) left, (int Sum, int Product) right)
         => left.Sum == right.Sum && left.Product == right.Product;

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -32,8 +32,8 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
                 new FactPrimitive("pdb.hidden-local", "absence of source local names on operand spills"),
             ],
-            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 whole-tuple equality/inequality and tuple-literal equality/inequality fixtures, including arity 3 literals",
-            AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, direct manual field comparison, and source-named local field comparison",
-            MissingDiscriminator: "whole-tuple arity 3+, nested/rest tuples, mixed literal-vs-variable operands, and no-PDB source-local comparisons still owed"),
+            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 whole-tuple equality/inequality, tuple-literal equality/inequality (including arity 3), mixed literal-vs-variable, side-effect-order, and const-element fixtures",
+            AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, hand-written mixed tuple-field comparison, direct manual field comparison, and source-named local field comparison",
+            MissingDiscriminator: "whole-tuple arity 3+, nested/rest tuples, and no-PDB source-local comparisons still owed"),
     ];
 }


### PR DESCRIPTION
## Summary
- move mixed literal-vs-variable tuple binary coverage out of the missing-discriminator note
- add a hand-written mixed tuple-field short-circuit negative guardrail
- update TupleRecoveryFacts to distinguish current positives from true adversarial coverage

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TupleBinaryOperatorPassTests -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests