### PR TITLE
Bind a stranded trailing label to an empty statement

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StrandedLabelRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StrandedLabelRenderingTests.cs
@@ -1,0 +1,52 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A label binds to the statement that follows it, so a labeled block that is the
+// last thing in a container — with no statement after the label — strands the
+// label as `IL_XXXX:` directly before a `}` (or end of method). That is invalid
+// C# (CS1525/CS1002). The printer must bind such a trailing label to an empty
+// statement (`IL_XXXX: ;`) so the output still parses. This shape is common: a
+// forward branch whose fall-through target is the empty tail of a try block.
+public class StrandedLabelRenderingTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+
+    static IrFunction BuildWithTrailingLabel(int targetOffset)
+    {
+        // Block 0: if (flag) goto IL_<target>; return 1;
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(0, "flag", Boolean), targetOffset));
+        entry.Add(new Return(new Constant(1, Int32)));
+        // The branch target is an empty block at the very end of the container,
+        // so its label has no following statement.
+        var tail = new Block(targetOffset);
+
+        var container = new BlockContainer();
+        container.Add(entry);
+        container.Add(tail);
+
+        var signature = new MethodSignature(Int32, [new Parameter("flag", Boolean)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [], container);
+    }
+
+    [Fact]
+    public void TrailingEmptyLabeledBlock_BindsLabelToEmptyStatement()
+    {
+        var result = CSharpPrinter.Print(BuildWithTrailingLabel(0x10));
+
+        var lines = (result.Output ?? "")
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+
+        int labelIndex = lines.IndexOf("IL_0010:");
+        Assert.True(labelIndex >= 0, $"expected a stranded label in:\n{result.Output}");
+        // The label must not be the last token, and what follows it is the empty
+        // statement that keeps the label legal.
+        Assert.True(labelIndex + 1 < lines.Count, "label is the last token — it is stranded");
+        Assert.Equal(";", lines[labelIndex + 1]);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -267,11 +267,19 @@ public sealed partial class CSharpPrinter
     {
         string pad = new(' ', indent * 4);
         var blocks = container.Blocks;
+        // A label binds to the next statement, even one in a following block, so
+        // an empty labeled block is fine mid-container. It only strands when the
+        // container ends with no statement after the label; track that and emit a
+        // labeled empty statement (';') to keep the C# valid.
+        bool labelPendingStatement = false;
         for (int i = 0; i < blocks.Count; i++)
         {
             var block = blocks[i];
             if (_labelTargets.Contains(block.StartOffset))
+            {
                 sb.Append(pad).AppendLine($"IL_{block.StartOffset:X4}:");
+                labelPendingStatement = true;
+            }
             // The trailing 'return;' trims, current-style — unless it is a
             // labeled block's only statement, where trimming would strand
             // the label as invalid C#.
@@ -286,8 +294,12 @@ public sealed partial class CSharpPrinter
                     break;
                 emit.Add(statement);
             }
+            if (emit.Count > 0)
+                labelPendingStatement = false;
             AppendStatements(sb, emit, indent);
         }
+        if (labelPendingStatement)
+            sb.Append(pad).AppendLine(";");
     }
 
     static HashSet<int> CollectBranchTargets(IrFunction function)


### PR DESCRIPTION
## Summary

**Bug hunt / validity fix.** A C# label binds to the statement that follows it. The printer emits an `IL_XXXX:` label for every block that is a branch target, but a labeled block that is the **last thing in a container** — with no statement after the label — left the label dangling directly before a `}` (or end of method). That is invalid C# (CS1525 "invalid expression term", CS1002 "; expected", CS0201).

It is a common shape: a forward branch whose fall-through target is the empty tail of a `try` block. From `System.AppContextConfigHelper::GetInt32Config`:

```csharp
    if (!(allowNegative || V_1 >= 0)) goto IL_0055;
    return V_1;
    IL_0055:
    }            // <- label stranded before the brace
```

## Fix

`AppendContainer` now tracks whether the most recent label has been followed by a statement. A label may legally bind to a statement in a *later* block, so a label is only stranded when the container ends with no statement after it. In that case the printer emits a labeled empty statement so the label stays legal:

```csharp
    IL_0055:
    ;
```

The existing `labeledReturnOnly` carve-out (keep a labeled block's only `return;` rather than trimming it) still applies and composes with this general guard.

## Validation

- Corpus syntactic validity (harness `--validity-check`): **Full malformed 334 → 309 (25 methods)**; Full count (38037) and the Partial set (142) unchanged.
- Adds `StrandedLabelRenderingTests` (hand-built IR; verified to fail before the change, pass after).
- Full `ILInspector.Decompiler.Tests`: **695/695**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
