### PR TITLE
Raise mixed-target tuple deconstruction over locals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1310,6 +1310,17 @@ public class CfgSampleClass
         return first + second;
     }
 
+    // Mixed deconstruction over locals: `sum` is declared by the deconstruction,
+    // `product` is a pre-existing local assigned into. csc stores Item1 to the fresh
+    // slot and Item2 to the existing slot, both StoreLocal — recovered as the mixed
+    // `(int sum, product) = pair`.
+    public static int DeconstructMixedLocal((int Sum, int Product) pair, bool flag)
+    {
+        int product = flag ? 10 : 20;
+        (int sum, product) = pair;
+        return sum + product;
+    }
+
     public static object AnonShorthand(int a, string b) => new { a, b };
 
     public static object AnonNamed(int x, string y) => new { Id = x, Name = y };

--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -60,6 +60,29 @@ public class DeconstructionAssignmentPassTests
     }
 
     [Fact]
+    public void MixedLocalTargets_RaiseToMixedDeconstruction()
+    {
+        var function = Raised(nameof(CfgSampleClass.DeconstructMixedLocal));
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.False(deconstruction.IsDeclaration);
+        // `sum` is declared here, `product` pre-exists.
+        Assert.Equal([true, false], deconstruction.IsDeclared);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), f => f.Field.Name is "Item1" or "Item2");
+    }
+
+    [Fact]
+    public void PrintRaised_RendersMixedDeconstruction_DeclaresOnlyTheFreshTarget()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.DeconstructMixedLocal))).Output;
+
+        Assert.NotNull(output);
+        // `sum` declared inline, `product` (pre-existing) assigned bare.
+        Assert.Contains("(int sum, product) = pair;", output);
+        Assert.DoesNotContain(".Item", output);
+    }
+
+    [Fact]
     public void DeconstructMethodCall_RaisesToDeconstructionDeclaration()
     {
         var function = Raised(nameof(CfgSampleClass.DeconstructViaMethod));
@@ -108,15 +131,17 @@ public class DeconstructionAssignmentPassTests
     }
 
     [Fact]
-    public void MixedFreshAndExistingValueTupleTargets_AreNotRaised()
+    public void MixedFreshAndExistingValueTupleTargets_RaiseToMixedDeconstruction()
     {
         var function = BuildMixedValueTupleTargets();
 
         new DeconstructionAssignmentPass().Run(function, PassContext.None);
 
-        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
-        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item1");
-        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item2");
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        // Local 0 is fresh (declared here); local 1 pre-exists (assigned).
+        Assert.Equal([true, false], deconstruction.IsDeclared);
+        Assert.False(deconstruction.IsDeclaration);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), field => field.Field.Name.StartsWith("Item"));
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -54,6 +54,7 @@ public class IdiomShapeScorecardTests
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructTuplePair), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructIntoExistingLocals), SyntaxKind.TupleExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructViaMethod), SyntaxKind.DeclarationExpression, [SyntaxKind.InvocationExpression]),
+        new("DeconstructionAssignmentPass", nameof(CfgSampleClass.DeconstructMixedLocal), SyntaxKind.DeclarationExpression, [SyntaxKind.SimpleMemberAccessExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.NonCapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.CapturingLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),
         new("LambdaRaisingPass", nameof(CfgSampleClass.StatementBodyLambda), SyntaxKind.SimpleLambdaExpression, [SyntaxKind.ObjectCreationExpression]),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -219,9 +219,9 @@ public sealed partial class CSharpPrinter
         foreach (var pattern in DescendantsOutsideNestedFunctions(function).OfType<IsPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
         foreach (var deconstruction in DescendantsOutsideNestedFunctions(function).OfType<DeconstructionAssignment>())
-            if (deconstruction.IsDeclaration)
-                foreach (int index in deconstruction.LocalIndices)
-                    _deconstructionLocals.Add(index);
+            for (int i = 0; i < deconstruction.LocalIndices.Length; i++)
+                if (deconstruction.IsDeclared[i])
+                    _deconstructionLocals.Add(deconstruction.LocalIndices[i]);
         CollectDeclaringStores(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
@@ -921,7 +921,7 @@ public sealed partial class CSharpPrinter
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
-        DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclaration ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
+        DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclared[i] ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
         NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1348,11 +1348,11 @@ public sealed class TupleBinaryExpression : IrExpression
 /// </summary>
 public sealed class DeconstructionAssignment : IrNode
 {
-    public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source, bool isDeclaration = true)
+    public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source, ImmutableArray<bool> isDeclared)
     {
         LocalIndices = localIndices;
         LocalTypes = localTypes;
-        IsDeclaration = isDeclaration;
+        IsDeclared = isDeclared;
         AddChild(source);
     }
 
@@ -1360,16 +1360,26 @@ public sealed class DeconstructionAssignment : IrNode
     public ImmutableArray<TypeRef> LocalTypes { get; }
 
     /// <summary>
-    /// True when the targets are fresh locals introduced by this deconstruction
-    /// (rendered with their declared types); false when assigning into existing
-    /// locals (rendered as bare names).
+    /// Per-target declaration flags, parallel to <see cref="LocalIndices"/>: a
+    /// target is <c>true</c> when it is a fresh local introduced here (rendered
+    /// with its declared type) and <c>false</c> when it assigns into a pre-existing
+    /// local (rendered as a bare name). A run may mix the two — <c>(int x, y) =</c>.
     /// </summary>
-    public bool IsDeclaration { get; }
+    public ImmutableArray<bool> IsDeclared { get; }
+
+    /// <summary>True when every target is a fresh declaration (the uniform-declaration form).</summary>
+    public bool IsDeclaration => IsDeclared.All(declared => declared);
 
     public IrExpression Source => (IrExpression)Children[0];
     public override IEnumerable<TypeRef> DirectTypes => LocalTypes;
 
-    public override string Describe() => $"DeconstructionAssignment ({LocalIndices.Length} locals, {(IsDeclaration ? "declaration" : "assignment")})";
+    public override string Describe()
+    {
+        string shape = IsDeclared.All(d => d) ? "declaration"
+            : IsDeclared.Any(d => d) ? "mixed"
+            : "assignment";
+        return $"DeconstructionAssignment ({LocalIndices.Length} locals, {shape})";
+    }
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -10,11 +10,13 @@ namespace ILInspector.Decompiler.Pipeline;
 /// T2 b = S.Item2;
 /// </code>
 /// into <c>(T1 a, T2 b) = tuple;</c> when the targets are fresh locals declared
-/// here, or <c>(a, b) = tuple;</c> when they assign into pre-existing locals.
-/// Scoped to direct <c>System.ValueTuple</c> fields, arities 2-7, with every
-/// target uniformly a declaration or uniformly an existing local (no mixed
-/// deconstruction). Nested/rest tuples and user-defined <c>Deconstruct</c> calls
-/// are later slices.
+/// here, <c>(a, b) = tuple;</c> when they assign into pre-existing locals, or a
+/// mix such as <c>(T1 a, b) = tuple;</c> — each target is classified independently
+/// as a declaration or an assignment. Scoped to direct <c>System.ValueTuple</c>
+/// fields, arities 2-7, with every target a local (parameter and field targets,
+/// which the importer spells as <c>StoreArgument</c>/<c>StoreField</c> rather than
+/// <c>StoreLocal</c>, fall outside the match). Nested/rest tuples and user-defined
+/// <c>Deconstruct</c> calls are later slices.
 /// </summary>
 public sealed class DeconstructionAssignmentPass : IIrPass
 {
@@ -78,11 +80,11 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         }
 
         var targets = stores.Select(store => (store.Index, store.Type, (IrNode)store));
-        if (ClassifyTargets(function, targets, out bool isDeclaration) is not { } resolved)
+        if (ClassifyTargets(function, targets) is not { } resolved)
             return false;
 
         var source = (IrExpression)seed.DetachChildren()[0];
-        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, isDeclaration);
+        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared);
         context.Stepper.StepOver("raise ValueTuple field stores to deconstruction", seed);
         seed.ReplaceWith(deconstruction);
         foreach (var store in stores)
@@ -127,10 +129,10 @@ public sealed class DeconstructionAssignmentPass : IIrPass
             return false;
         }
 
-        if (ClassifyTargets(function, targets, out bool isDeclaration) is not { } resolved)
+        if (ClassifyTargets(function, targets) is not { } resolved)
             return false;
 
-        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, isDeclaration);
+        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared);
         context.Stepper.StepOver("raise Deconstruct-method call to deconstruction", statement);
         statement.ReplaceWith(deconstruction);
         return true;
@@ -147,28 +149,24 @@ public sealed class DeconstructionAssignmentPass : IIrPass
     };
 
     /// <summary>
-    /// Resolves the deconstruction targets: every target must be uniformly a
-    /// fresh local (a declaration) or uniformly a pre-existing local (an
-    /// assignment) — C# has no spelling for a run that mixes the two here — and
-    /// the existing-local form additionally requires distinct targets, since
-    /// <c>(a, a) = ...</c> is not a valid deconstruction. Returns null to decline.
+    /// Resolves the deconstruction targets, classifying each independently as a
+    /// fresh local introduced here (a declaration, its first reference is this
+    /// store) or a pre-existing local (an assignment). A run may mix the two —
+    /// <c>(int x, y) = …</c> — so the per-target flags are returned parallel to the
+    /// indices. Distinct targets are required since <c>(a, a) = …</c> is not a
+    /// valid deconstruction; the all-fresh form is inherently distinct. Returns
+    /// null to decline.
     /// </summary>
-    static (ImmutableArray<int> indices, ImmutableArray<TypeRef> types)? ClassifyTargets(
+    static (ImmutableArray<int> indices, ImmutableArray<TypeRef> types, ImmutableArray<bool> isDeclared)? ClassifyTargets(
         IrFunction function,
-        IEnumerable<(int index, TypeRef type, IrNode reference)> targets,
-        out bool isDeclaration)
+        IEnumerable<(int index, TypeRef type, IrNode reference)> targets)
     {
-        isDeclaration = false;
         var resolved = targets.ToList();
-        int firstRefCount = resolved.Count(target => IsFirstReference(function, target.reference, target.index));
-        isDeclaration = firstRefCount == resolved.Count;
-        if (!isDeclaration
-            && (firstRefCount != 0 || resolved.Select(target => target.index).Distinct().Count() != resolved.Count))
-        {
+        if (resolved.Select(target => target.index).Distinct().Count() != resolved.Count)
             return null;
-        }
 
-        return ([.. resolved.Select(target => target.index)], [.. resolved.Select(target => target.type)]);
+        var isDeclared = resolved.Select(target => IsFirstReference(function, target.reference, target.index)).ToImmutableArray();
+        return ([.. resolved.Select(target => target.index)], [.. resolved.Select(target => target.type)], isDeclared);
     }
 
     static bool ReferencedOnlyWithin(IrFunction function, int slot, IReadOnlyList<StoreLocal> stores)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -61,7 +61,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass ContinueStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion => default!;
-    [Completeness(CompletenessLevel.Partial, "local exact BCL ValueTuple deconstruction (arities 2-7) as a fresh-local declaration or existing-local assignment, plus Deconstruct-method calls with a local/parameter receiver; mixed declaration/assignment and the temp-then-copy receiver forms not raised")]
+    [Completeness(CompletenessLevel.Partial, "local exact BCL ValueTuple deconstruction (arities 2-7) as a fresh-local declaration, existing-local assignment, or a mix of the two over locals ((int x, y) = ...), plus Deconstruct-method calls with a local/parameter receiver; non-local existing targets (parameters/fields) and the temp-then-copy receiver forms not raised")]
     public static DeconstructionAssignmentPass DeconstructionAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static DelegateConstructionPass DelegateCreationExpression => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static DoWhileLoopPass DoStatement => new();


### PR DESCRIPTION
## Target

A genuine **climb** that flips a pinned negative and narrows a `Partial` ledger row. `DeconstructionAssignmentPass` raised tuple deconstruction only when every target was *uniformly* a fresh declaration or *uniformly* an existing local; the mixed form `(int x, y) = tuple` was declined (`MixedFreshAndExisting...` was pinned as not-raised). It now classifies each target independently.

```
int product = …;
(int sum, product) = pair;   // sum declared here, product pre-exists
```
previously came back as the lowered `S = pair; sum = S.Item1; product = S.Item2;` — now recovers the source shape.

## Change

- `DeconstructionAssignment` carries a per-target `IsDeclared` array instead of a single `IsDeclaration` flag (kept as a convenience = all-declared). The printer declares only the fresh targets inline and spells existing ones bare.
- `ClassifyTargets` returns the per-target flags and no longer rejects the mixed shape, keeping the distinct-targets guard.

**Scope**: every target must be a local. Parameter/field existing-targets are spelled `StoreArgument`/`StoreField` by the importer (not `StoreLocal`), so they fall outside the structural match and stay owed — the ledger note is updated to say so.

## Soundness

Declaration-vs-assignment is purely a C# **spelling** — `int x = …` and `x = …` emit the same store to the same slot — so admitting the mixed spelling **cannot change emitted IL**. The structural match (ValueTuple stack-slot seed + in-order `ItemN` stores + whole-function slot-use check) is unchanged; only the per-element decl/assign classification is relaxed.

## Verification

- **688/688** `ILInspector.Decompiler.Tests` — including `FidelityGateTests` (the mixed fixture recompiles **opcode-exact**), `CorpusSweepGateTests` (corpus fidelity floor held), the idiom scorecard (new mixed row recovered), and regression on the all-fresh / all-existing forms.
- `--pass-impact deconstruction-assignment` over CoreLib: **100/41159** methods, **0 pass bugs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)