### PR TITLE
Spell a bool value flowing into an integer target as cond ? 1 : 0

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -213,6 +213,12 @@ public class CfgSampleClass
 
     public static void SetCharElement(char[] a, int v) => a[0] = (char)v;
 
+    // A comparison result returned from an int-returning method (`cgt.un; ret`,
+    // as in byte.Sign / Convert.ToInt32(bool)): the bool flows into an integer
+    // target. C# has no implicit bool→int, so it must spell `value > 0 ? 1 : 0`,
+    // which Roslyn folds back to the bare `cgt.un` — opcode-exact.
+    public static int IsPositiveAsInt(uint value) => value > 0 ? 1 : 0;
+
     // Array range slices: the compiler lowers these to
     // RuntimeHelpers.GetSubArray(a, <Range>); the decompiler raises them back to
     // the a[i..j] indexer (RangeFromGetSubArrayPass). Both from-start endpoints

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -677,6 +677,20 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void BoolValueIntoIntegerReturn_SpellsConditionalOneZero()
+    {
+        // `cgt.un; ret` from an int-returning method: a comparison result consumed
+        // as a number. C# has no implicit bool->int, so the read must spell
+        // `value > 0 ? 1 : 0` — not a bare `value > 0` (CS0029) — and Roslyn folds
+        // that back to the bare comparison opcode.
+        var function = ImportFixture(nameof(CfgSampleClass.IsPositiveAsInt));
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("? 1 : 0", output);
+    }
+
+    [Fact]
     public void ElementAccess_ImportsTypedLoadAndStore()
     {
         var load = ImportFixture(nameof(CfgSampleClass.FirstElement));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -201,6 +201,16 @@ public sealed partial class CSharpPrinter
                 || value is Constant { Value: long lv } && lv < 0;
             return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
         }
+        // A bool-valued expression flowing into an integer target is IL's
+        // comparison/test result consumed as a number — `cgt.un; ret` from an int
+        // method (e.g. byte.Sign, Convert.ToInt32(bool)). C# has no implicit
+        // bool→int, so spell it as the faithful `cond ? 1 : 0`; Roslyn folds that
+        // back to the bare comparison opcode, so it recompiles exactly. Runs
+        // before the merge-node bail so a bool ternary/coalesce into int is wrapped
+        // too (its arms are bool, the wrap is legal).
+        if (target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
+            && EffectiveType(value) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
+            return $"{Condition(value)} ? 1 : 0";
         // Cast only off a value whose rendered C# type reliably equals its IR
         // result type. A merge node (ternary/coalesce) reports a merged type the
         // arms may not actually share, and a stack slot's type is the join of


### PR DESCRIPTION
## Problem

Mining the `--validity-check` CS0029 bucket (no implicit conversion) surfaced the comparison-result-as-number family. `byte.Sign` decompiles to:

```csharp
return value > (uint)0;   // CS0029: cannot implicitly convert bool to int
```

The IL is `cgt.un; ret` from an `int`-returning method — the unsigned comparison's `0`/`1` result is returned as the int. The importer correctly models the `cgt.un` as a bool-valued `Comparison` (a genuine unsigned test, not a bool→int marshalling shape, so `BoolToIntNormalizationPass` rightly leaves it), but the printer rendered it bare into the integer return context.

## Fix

`CastValue` now spells a bool value flowing into an integer target as the faithful `cond ? 1 : 0`. Roslyn folds `x > 0 ? 1 : 0` back to the bare comparison opcode, so it recompiles to the same stream.

`byte.Sign` now renders `return value > (uint)0 ? 1 : 0;`.

## Soundness

- **Faithful.** `value > 0 ? 1 : 0` recompiles to exactly `ldarg.0; ldc.i4.0; cgt.un; ret` (`02 16 fe 02 2a`) — Roslyn folds the constant-arm ternary. Verified by the new fixture round-tripping opcode-exact through the fidelity gate.
- **Printer-only.** No IR change, so `function.Fidelity` and the corpus Full-fidelity floor are untouched.
- **Tightly scoped.** Fires only when the value's effective type is `System.Boolean` (CoreLib) and the target is an integer primitive. A narrow/char/nint integer never carries a *bare* bool value (those go through a `conv`, leaving a `Convert` node, not a bare `Comparison`), so only the genuine `cgt.un`-as-int width is wrapped. Runs before the merge-node bail so a bool ternary/coalesce into int is also wrapped (its arms are bool, the wrap is legal).

## Breadth & validation

- Corpus scan: **46 sites across 41 CoreLib methods** — the `Sign` family (`Byte`/`UInt16`/`UInt32`/`UInt64`/`UInt128`/`Half`), `Convert.ToInt32`/`ToUInt32`, `Boolean.GetHashCode`, and several interop bool returns.
- Same-base validity defect diff (`--diff-validity-defects`): the bound methods lose CS0029, **zero regressions** (the rest are past the 4000-method bind cap; the IR scan confirms them).
- Decompiler suite green (**693**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests`.

## Tests

New `IsPositiveAsInt` fixture (`value > 0 ? 1 : 0`) reproduces the `cgt.un; ret` shape; `IrImporterTests` asserts the read renders `? 1 : 0` at Full fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)