### PR TITLE
[codex] Raise whole-tuple equality arity 3

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1272,6 +1272,8 @@ public class CfgSampleClass
 
     public static bool TupleValueNotEquals((int Sum, int Product) left, (int Sum, int Product) right) => left != right;
 
+    public static bool TupleValueEquals3((int A, int B, int C) left, (int A, int B, int C) right) => left == right;
+
     // Element-literal tuple equality: `(a, b) == (c, d)`. csc eagerly spills the
     // operands (unnamed temps) then compares element-wise — TupleLiteralBinaryPass
     // raises that back to the tuple operator.

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -59,6 +59,21 @@ public class TupleBinaryOperatorPassTests
     }
 
     [Fact]
+    public void WholeTupleArity3Equality_RaisesToTupleBinaryExpression()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleValueEquals3));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.True(tupleBinary.IsEquality);
+        Assert.StartsWith("ValueTuple<", tupleBinary.TupleType.ToDisplayString());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return left == right;", output);
+        Assert.DoesNotContain(".Item", output);
+        Assert.DoesNotContain("&&", output);
+    }
+
+    [Fact]
     public void TupleLiteralEquality_RaisesToTupleBinaryExpression()
     {
         var function = Raised(nameof(CfgSampleClass.TupleLiteralEquals));

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -32,8 +32,8 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
                 new FactPrimitive("pdb.hidden-local", "absence of source local names on operand spills"),
             ],
-            PositiveCoverage: "TupleBinaryOperatorPassTests arity-2 whole-tuple equality/inequality, tuple-literal equality/inequality (including arity 3), mixed literal-vs-variable, side-effect-order, and const-element fixtures",
+            PositiveCoverage: "TupleBinaryOperatorPassTests whole-tuple equality fixtures including arity 3, arity-2 whole-tuple inequality, tuple-literal equality/inequality (including arity 3), mixed literal-vs-variable, side-effect-order, and const-element fixtures",
             AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, hand-written mixed tuple-field comparison, direct manual field comparison, and source-named local field comparison",
-            MissingDiscriminator: "whole-tuple arity 3+, nested/rest tuples, and no-PDB source-local comparisons still owed"),
+            MissingDiscriminator: "whole-tuple inequality arity 3+ control-flow forms, nested/rest tuples, and no-PDB source-local comparisons still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -111,7 +111,7 @@ internal static class LoweringCoverage
     public static SwitchRaisingPass SwitchExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ThrowStatement => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();
-    [Completeness(CompletenessLevel.Partial, "tuple-valued `==`/`!=` with hidden ValueTuple operand spills: the whole-tuple form (`left == right`, arity 2), the element-literal form (`(a, b) == (c, d)`, any arity, recovered from csc's eager operand spills), and the mixed literal-vs-variable form (`(a, b) == pair`); nested/rest tuples and source-named local field comparisons not raised")]
+    [Completeness(CompletenessLevel.Partial, "tuple-valued `==`/`!=` with hidden ValueTuple operand spills: whole-tuple equality (`left == right`, supported arities 2-7) and arity-2 whole-tuple inequality, the element-literal form (`(a, b) == (c, d)`, any arity, recovered from csc's eager operand spills), and the mixed literal-vs-variable form (`(a, b) == pair`); whole-tuple inequality arity 3+ control-flow forms, nested/rest tuples, and source-named local field comparisons not raised")]
     public static TupleBinaryOperatorPass TupleBinaryOperator => new();
     [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
@@ -8,7 +8,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <list type="bullet">
 /// <item>The <em>whole-tuple</em> form (<c>left == right</c>, both operands
 /// <c>ValueTuple</c> locals): the proof is the pair of hidden ValueTuple operand
-/// spills feeding ordered <c>Item1</c>/<c>Item2</c> comparisons.</item>
+/// spills feeding ordered <c>ItemN</c> comparisons.</item>
 /// <item>The <em>element-literal</em> form (<c>(a, b) == (c, d)</c>, any arity):
 /// the proof is csc's <em>eager</em> operand evaluation — every element except
 /// the first is spilled to an unnamed temporary <em>before</em> the first test,
@@ -53,7 +53,7 @@ public sealed class TupleBinaryOperatorPass : IIrPass
     {
         if (!TryGetOperandSpills(function, block, returnIndex, out var leftStore, out var rightStore, out var tupleType)
             || block.Children[returnIndex] is not Return { Value: LogicalBinary logical }
-            || !TryMatchArity2Logical(logical, leftStore.Index, rightStore.Index, tupleType, out bool isEquality))
+            || !TryMatchLogical(logical, leftStore.Index, rightStore.Index, tupleType, out bool isEquality))
         {
             return false;
         }
@@ -73,6 +73,8 @@ public sealed class TupleBinaryOperatorPass : IIrPass
             || block.Children[resultIndex] is not StoreStackSlot { Value: Conditional conditional } resultStore
             || block.Children[resultIndex + 1] is not Return { Value: LoadStackSlot returned }
             || returned.Slot != resultStore.Slot
+            || !MemberIdentity.IsSupportedValueTupleType(tupleType, out var arity)
+            || arity != 2
             || !TryMatchArity2Conditional(conditional, leftStore.Index, rightStore.Index, tupleType, out bool isEquality))
         {
             return false;
@@ -103,8 +105,7 @@ public sealed class TupleBinaryOperatorPass : IIrPass
             || HasSourceLocalName(function, left.Index)
             || HasSourceLocalName(function, right.Index)
             || !left.Type.Equals(right.Type)
-            || !MemberIdentity.IsSupportedValueTupleType(left.Type, out var arity)
-            || arity != 2)
+            || !MemberIdentity.IsSupportedValueTupleType(left.Type, out _))
         {
             return false;
         }
@@ -155,7 +156,7 @@ public sealed class TupleBinaryOperatorPass : IIrPass
             && conditional.WhenFalse is Constant { Value: true };
     }
 
-    static bool TryMatchArity2Logical(
+    static bool TryMatchLogical(
         LogicalBinary logical,
         int leftLocal,
         int rightLocal,
@@ -175,11 +176,19 @@ public sealed class TupleBinaryOperatorPass : IIrPass
             default:
                 return false;
         }
-        if (!IsItemComparison(logical.Left, comparisonKind, leftLocal, rightLocal, tupleType, item: 1)
-            || !IsItemComparison(logical.Right, comparisonKind, leftLocal, rightLocal, tupleType, item: 2))
+        if (!MemberIdentity.IsSupportedValueTupleType(tupleType, out var arity))
+            return false;
+
+        var comparisons = new List<Comparison>();
+        if (!TryFlatten(logical, logical.Kind, comparisonKind, comparisons)
+            || comparisons.Count != arity)
         {
             return false;
         }
+
+        for (int i = 0; i < comparisons.Count; i++)
+            if (!IsItemComparison(comparisons[i], comparisonKind, leftLocal, rightLocal, tupleType, i + 1))
+                return false;
 
         isEquality = logical.Kind == LogicalKind.And;
         return true;


### PR DESCRIPTION
## Summary

- Raise whole-tuple `left == right` equality for supported `ValueTuple` arities beyond arity 2 by generalizing the hidden-spill `ItemN` logical matcher.
- Add an arity-3 whole-tuple equality fixture/test.
- Narrow tuple binary coverage/fact text so whole-tuple `!=` arity 3+ remains documented as a control-flow-shaped gap.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*TupleBinaryOperatorPassTests*" -method "*LoweringCoverageTests*" -method "*LoweringFactCatalogTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*FidelityGateTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `git diff --check origin/main...HEAD`
