### PR TITLE
Raise the array-pin form of fixed (T* p = array)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2004,6 +2004,21 @@ public class CfgSampleClass
         return sum;
     }
 
+    // The array-pin form `fixed (T* p = array)`: the whole array is pinned, so the
+    // language inserts the null/empty guard diamond (FixedArrayStatementPass).
+    // Distinct from SumPinnedArray's `&values[0]` managed-reference pin.
+    public static unsafe void FixedWholeArray(byte[] data)
+    {
+        fixed (byte* p = data)
+        {
+            ConsumePointer(p);
+        }
+    }
+
+    static unsafe void ConsumePointer(byte* p)
+    {
+    }
+
     public static unsafe nuint AddressAsNativeUInt()
     {
         int value = 42;

--- a/src/ILInspector.Decompiler.Tests/FixedArrayStatementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedArrayStatementTests.cs
@@ -1,0 +1,40 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class FixedArrayStatementTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void ArrayPin_RaisesToFixedStatement()
+    {
+        var function = Raised(nameof(CfgSampleClass.FixedWholeArray));
+
+        // The null/empty guard diamond and the pin/unpin scaffolding collapse into a
+        // single array-form fixed statement (source rendered as-is, not `&place`).
+        var fixedStatement = Assert.Single(function.Descendants.OfType<Fixed>());
+        Assert.False(fixedStatement.SourceIsAddress);
+        Assert.Equal("Byte", fixedStatement.ElementType.Name);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
+    public void ArrayPin_RendersValidFixed()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.FixedWholeArray))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("fixed (byte* p = ", output);
+        Assert.DoesNotContain("pinned", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -631,8 +631,11 @@ public sealed partial class CSharpPrinter
         {
             sb.Append(pad)
                 .Append("fixed (").Append(TypeText(fixedStatement.ElementType)).Append("* ")
-                .Append(LocalName(fixedStatement.LocalIndex)).Append(" = &")
-                .Append(Deref(fixedStatement.PinSource)).AppendLine(")");
+                .Append(LocalName(fixedStatement.LocalIndex)).Append(" = ")
+                .Append(fixedStatement.SourceIsAddress
+                    ? "&" + Deref(fixedStatement.PinSource)
+                    : Expression(fixedStatement.PinSource))
+                .AppendLine(")");
             sb.Append(pad).AppendLine("{");
             AppendContainer(sb, fixedStatement.Body, indent + 1);
             sb.Append(pad).AppendLine("}");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -590,10 +590,11 @@ public sealed class Lock : IrNode
 /// </summary>
 public sealed class Fixed : IrNode
 {
-    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body)
+    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true)
     {
         ElementType = elementType;
         LocalIndex = localIndex;
+        SourceIsAddress = sourceIsAddress;
         AddChild(pinSource);
         AddChild(body);
     }
@@ -603,6 +604,14 @@ public sealed class Fixed : IrNode
 
     /// <summary>The pinned local slot that becomes the <c>fixed</c> pointer variable.</summary>
     public int LocalIndex { get; }
+
+    /// <summary>
+    /// True for the managed-reference pin (<c>fixed (T* p = &amp;place)</c>), where the
+    /// source renders as <c>&amp;</c> applied to a place. False for the array/string pin
+    /// (<c>fixed (T* p = array)</c>), where the source is a pinnable expression rendered
+    /// as-is — the language inserts the element-address and null/empty guard itself.
+    /// </summary>
+    public bool SourceIsAddress { get; }
 
     /// <summary>The managed reference being pinned; rendered as <c>&amp;</c> applied to the place it refers to.</summary>
     public IrExpression PinSource => (IrExpression)Children[0];

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the csc pin lowering for <c>fixed (T* p = array)</c> — the array/string
+/// form, where the pinned local is the whole array (a <c>pinned T[]</c>), not a
+/// managed reference. The byref form (<c>fixed (T* p = &amp;place)</c>) is the
+/// flat-statement shape <see cref="FixedStatementPass"/> handles directly; this is
+/// the same Roslyn <c>FixedStatement</c> lowering's array variant, invoked from
+/// that pass rather than registered separately.
+///
+/// <para>Pinning an array carries the language's null/empty guard: a null or
+/// zero-length array pins to a null pointer, anything else to <c>&amp;array[0]</c>.
+/// csc lowers <c>fixed (byte* p = a) { ... }</c> to
+/// <code>
+///   pinned byte[] V_pin = a;                       // pin
+///   if (a == null || a.Length == 0) p = (byte*)0;  // empty -> null pointer
+///   else                            p = &amp;V_pin[0]; // else  -> first element
+///   ... use p ...
+///   V_pin = null;                                  // unpin
+/// </code>
+/// Left flat the pinned local renders as the non-C# <c>pinned T[]</c> and the
+/// guard diamond never structures, so the whole method is malformed. This pass
+/// recognizes the diamond, drops it together with the pin/unpin scaffolding, and
+/// wraps the body in <c>fixed (T* p = a) { ... }</c> — the language regenerates the
+/// guard on recompile, so the rewrite is opcode-faithful.</para>
+///
+/// <para>Scoped to a single pinned-array slot whose region is one entry-block
+/// guard diamond: the pin is assigned once, the derived pointer is written only by
+/// the diamond's two arms (one <c>= (T*)0</c>, one <c>= &amp;pin[0]</c>), the array
+/// is unpinned by a single later <c>pin = null</c> store, and every read of the
+/// pinned slot lives inside the diamond (its length guard and element address).
+/// Anything else leaves the method flat.</para>
+/// </summary>
+internal static class FixedArrayRaising
+{
+    public static void RaiseAll(IrFunction function, PassContext context)
+    {
+        var pinnedArraySlots = Enumerable.Range(0, function.Locals.Length)
+            .Where(i => function.Locals[i].Kind == TypeRefKind.Pinned
+                && function.Locals[i].ElementType is { Kind: TypeRefKind.SzArray })
+            .ToList();
+
+        foreach (var slot in pinnedArraySlots)
+            TryRaise(function, slot, context);
+    }
+
+    static void TryRaise(IrFunction function, int pin, PassContext context)
+    {
+        // The pinned slot is assigned exactly twice: the defining pin store and a
+        // later `pin = null` unpin, both in the same block.
+        var stores = function.Descendants.OfType<StoreLocal>().Where(s => s.Index == pin).ToList();
+        if (stores is not [var defStore, var unpin]
+            || !IsNullStore(unpin)
+            || defStore.Parent is not Block block
+            || !ReferenceEquals(unpin.Parent, block))
+        {
+            return;
+        }
+
+        // The guard diamond is an if/else immediately after the pin store; each arm
+        // assigns the same derived-pointer slot — one to a null pointer, the other to
+        // the address of the pinned array's first element.
+        if (block.Children.ElementAtOrDefault(defStore.ChildIndex + 1) is not IfStatement { HasElse: true } guard)
+            return;
+        if (ArmStore(guard.Then) is not { } thenStore || ArmStore(guard.Else!) is not { } elseStore)
+            return;
+        if (thenStore.Index != elseStore.Index)
+            return;
+
+        var (zeroStore, addressStore) =
+            IsNullPointer(thenStore.Value) && ElementAddressType(addressValue: elseStore.Value, pin) is not null
+                ? (thenStore, elseStore)
+                : IsNullPointer(elseStore.Value) && ElementAddressType(addressValue: thenStore.Value, pin) is not null
+                    ? (elseStore, thenStore)
+                    : (null, null);
+        if (zeroStore is null || addressStore is null)
+            return;
+        if (ElementAddressType(addressStore.Value, pin) is not { } elementType)
+            return;
+
+        int pointerSlot = thenStore.Index;
+
+        // The pinned slot is consumed only inside the diamond (its length guard and
+        // the element-address arm) — never the body — so dropping it orphans nothing.
+        foreach (var load in function.Descendants.OfType<LoadLocal>())
+        {
+            if (load.Index == pin && !IsInside(load, guard))
+                return;
+        }
+
+        // The body runs from after the diamond to just before the unpin; every
+        // statement there belongs under the fixed. A use of the pointer after the
+        // unpin would be out of scope, so require the unpin to follow the diamond.
+        if (unpin.ChildIndex <= guard.ChildIndex)
+            return;
+        var bodyStmts = block.Children
+            .Where(c => c.ChildIndex > guard.ChildIndex && c.ChildIndex < unpin.ChildIndex)
+            .ToList();
+
+        // The derived pointer is written only by the diamond's arms; a body write
+        // would mean the slot outlives the fixed region.
+        foreach (var node in function.Descendants)
+        {
+            if (node is StoreLocal s && s.Index == pointerSlot && s != zeroStore && s != addressStore)
+                return;
+        }
+
+        // Shape proven. Lift the array source out of the pin store, detach the body,
+        // and replace the diamond with `fixed (T* ptr = array) { body }`. The pin
+        // store and the unpin are dropped — the language re-emits them.
+        var source = (IrExpression)defStore.DetachChildren()[0];
+        foreach (var stmt in bodyStmts)
+            stmt.Detach();
+
+        var body = new BlockContainer();
+        var bodyBlock = new Block(block.StartOffset);
+        foreach (var stmt in bodyStmts)
+            bodyBlock.Add(stmt);
+        body.Add(bodyBlock);
+
+        var fixedStatement = new Fixed(elementType, pointerSlot, source, body, sourceIsAddress: false);
+        context.Stepper.StepOver("raise pinned array to fixed statement", defStore);
+        guard.ReplaceWith(fixedStatement);
+        defStore.Detach();
+        unpin.Detach();
+    }
+
+    /// <summary>The single store an if-arm makes, or null when the arm is not exactly one StoreLocal.</summary>
+    static StoreLocal? ArmStore(Block arm)
+        => arm.Children is [StoreLocal store] ? store : null;
+
+    /// <summary>The element type when <paramref name="addressValue"/> is <c>&amp;pin[0]</c> (through pointer converts); otherwise null.</summary>
+    static TypeRef? ElementAddressType(IrExpression addressValue, int pin)
+        => StripConverts(addressValue) is LoadElementAddress
+        {
+            Array: LoadLocal arrayLoad,
+            Index: Constant { Value: 0 },
+            ElementType: { } elementType,
+        } && arrayLoad.Index == pin
+            ? elementType
+            : null;
+
+    static bool IsNullPointer(IrExpression value)
+        => StripConverts(value) is Constant { Value: null or 0 or 0L };
+
+    static bool IsNullStore(StoreLocal store)
+        => StripConverts(store.Value) is Constant { Value: null or 0 or 0L };
+
+    static IrExpression StripConverts(IrExpression value)
+    {
+        while (value is Convert convert)
+            value = convert.Operand;
+        return value;
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, root))
+                return true;
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
@@ -51,8 +51,14 @@ public sealed class FixedStatementPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        // Every pinned local pins a managed reference (`pinned T&`). A pinned
-        // array/string (a non-byref pinned element) is out of scope.
+        // The array/string pin form — `fixed (T* p = array)` — is the same Roslyn
+        // FixedStatement lowering, but its pinned local is the whole array and the
+        // null/empty guard is an if/else diamond, not a flat statement run. Raise it
+        // first (independent locals), then handle the managed-reference form below.
+        FixedArrayRaising.RaiseAll(function, context);
+
+        // The rest handles the managed-reference pin (`pinned T&`). A pinned
+        // array/string (a non-byref pinned element) is out of scope here.
         var pinnedSlots = Enumerable.Range(0, function.Locals.Length)
             .Where(i => function.Locals[i].Kind == TypeRefKind.Pinned
                 && function.Locals[i].ElementType is { Kind: TypeRefKind.ByRef })


### PR DESCRIPTION
## Problem

The dominant remaining `--validity-check` parse-error cluster (issue #622): `fixed (T* p = array)`. Pinning a whole array emits a `pinned T[]` local plus the language's null/empty guard as an if/else diamond:

```csharp
// Internal.Console.Error::Write
pinned byte[] V_2 = S_256;                       // non-C# `pinned T[]`
if (...) V_1 = (nuint)0; else V_1 = (nuint)(&V_2[0]);   // empty/null guard diamond
Sys.LogError(V_1, V_0.Length);
V_2 = null;                                      // unpin
```

`FixedStatementPass` handled only the managed-reference form (`fixed (T* p = &place)`); the array form fell through, rendering the non-C# `pinned T[]` and a diamond the structurer left as gaps — so every such method was both **malformed** and **unstructured**, contributing no validity or fidelity signal.

## Fix

Add `FixedArrayRaising`, invoked from `FixedStatementPass` (it inverts the *same* Roslyn `FixedStatement` lowering, so it shares that pass's coverage row rather than registering separately). It recognizes the guard diamond, drops it with the pin/unpin scaffolding, and wraps the body in a single array-form fixed statement. The `Fixed` node gains a `SourceIsAddress` flag so the array source renders as-is (no `&`).

```csharp
byte[] S_256 = V_0;
fixed (byte* V_1 = S_256)
{
    Sys.LogError(V_1, V_0.Length);
}
```

## Fidelity

**Neutral** — the language regenerates the pin, guard, and unpin on recompile, so the rewrite is opcode-faithful. Verified by the fixture `FidelityGate` round-tripping the new `FixedWholeArray` body.

## Impact

Over .NET 11 preview CoreLib (`--pass-impact`): **15 malformed methods** raised to valid `fixed`, **0 pass bugs**. ~13 become fully clean; 2 (`GetStringForSmallInput`, `NameInfo::GetOrCreateEventHandle`) now expose pre-existing latent semantic defects (`ref`-arg / narrowing) that the `pinned T[]` parse error had hidden — exactly the malformed-set-first leverage #622 calls for.

## Tests

New `FixedArrayStatementTests` (diamond collapses to an array-form `Fixed`; renders `fixed (byte* p = ...)`, no `pinned`) + the `FixedWholeArray` fixture. 694 decompiler tests green incl. `FidelityGateTests`, `LoweringCoverageTests`, and the corpus floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)