### PR TITLE
Render an unraised IL switch jump table as a valid lowered switch

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// An IL `switch` opcode the switch-raising pass could not lift into a structured
+// `switch` stays in the tree as a SwitchBranch jump table. The printer must
+// render it as valid lowered C# — a `switch` block with one `case i: goto
+// IL_xxxx;` per target — not the placeholder `switch (...) goto [..]` form, which
+// is not legal C# (CS1513/CS1514). Out-of-range values fall through, matching the
+// opcode.
+public class SwitchBranchRenderingTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    static DecompilerResult RenderSwitch(params int[] targets)
+    {
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [.. targets]));
+        entry.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(entry);
+        // Each target needs a labeled landing block so the labels are emitted.
+        foreach (int target in targets.Distinct().OrderBy(t => t))
+        {
+            var block = new Block(target);
+            block.Add(new Return(null));
+            container.Add(block);
+        }
+
+        var signature = new MethodSignature(Void, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [], container);
+        return CSharpPrinter.Print(function);
+    }
+
+    [Fact]
+    public void JumpTable_RendersValidCaseGotoBlock()
+    {
+        var result = RenderSwitch(0x10, 0x20, 0x30);
+        var output = result.Output ?? "";
+
+        Assert.DoesNotContain("goto [", output);
+        Assert.Contains("switch (x)", output);
+        Assert.Contains("case 0: goto IL_0010;", output);
+        Assert.Contains("case 1: goto IL_0020;", output);
+        Assert.Contains("case 2: goto IL_0030;", output);
+    }
+
+    [Fact]
+    public void DuplicateTargets_EmitOnePerCaseIndex()
+    {
+        // IL switch tables routinely repeat a target (a shared fall-through); each
+        // case index still needs its own arm.
+        var result = RenderSwitch(0x10, 0x20, 0x10);
+        var output = result.Output ?? "";
+
+        Assert.Contains("case 0: goto IL_0010;", output);
+        Assert.Contains("case 1: goto IL_0020;", output);
+        Assert.Contains("case 2: goto IL_0010;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -703,6 +703,22 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             return;
         }
+        if (node is SwitchBranch switchBranch)
+        {
+            // The IL switch opcode is a jump table: it branches to
+            // targets[value] when 0 <= value < targets.Length and falls through
+            // otherwise. Render it as a valid lowered switch — one
+            // `case i: goto IL_xxxx;` per target — rather than the placeholder
+            // `switch (...) goto [..]` form, which is not legal C#. Fall-through
+            // (no default) preserves the opcode's out-of-range behavior.
+            sb.Append(pad).Append("switch (").Append(Expression(switchBranch.Value)).AppendLine(")");
+            sb.Append(pad).AppendLine("{");
+            string casePad = pad + "    ";
+            for (int t = 0; t < switchBranch.TargetOffsets.Length; t++)
+                sb.Append(casePad).AppendLine($"case {t}: goto IL_{switchBranch.TargetOffsets[t]:X4};");
+            sb.Append(pad).AppendLine("}");
+            return;
+        }
         if (Statement(node) is { } line)
             sb.Append(pad).AppendLine(line);
     }


### PR DESCRIPTION
## Summary

**Bug hunt / validity fix.** The IL `switch` opcode is a jump table: it branches to `targets[value]` when `0 <= value < targets.Length` and falls through otherwise. When the switch-raising pass cannot lift one into a structured `switch` (e.g. a string-length dispatch with nested character comparisons, as in `System.Collections.Hashtable::OnDeserialization`), it stays in the tree as a `SwitchBranch`. The printer rendered it as a placeholder that is **not legal C#** (CS1513 `}` expected, CS1514 `{` expected, CS1001/CS1002):

```csharp
switch (V_8 - 4) goto [IL_0111, IL_01FA, IL_0127, ...];
```

## Fix

`AppendStatement` now lowers a `SwitchBranch` to a valid `switch` block — one `case i: goto IL_xxxx;` per target, with no `default:` so out-of-range values fall through exactly as the opcode does:

```csharp
switch (V_8 - 4)
{
    case 0: goto IL_0111;
    case 1: goto IL_01FA;
    case 2: goto IL_0127;
    ...
}
```

Duplicate targets (a shared fall-through repeated in the table) each get their own case arm. This is the lowered-altitude fallback for switches the structuring pass leaves unraised; it does not change which methods reach Full fidelity (the IR pipeline is unaffected).

## Validation

- Corpus syntactic validity (harness `--validity-check`): **Full malformed 334 → 247 (87 methods)**; Full count (38037) and the Partial set (142) unchanged.
- Adds `SwitchBranchRenderingTests` (hand-built IR; both cases verified to fail before the change, pass after) covering the case/goto lowering and duplicate targets.
- Full `ILInspector.Decompiler.Tests`: **714/714**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
