### PR TITLE
Recover checked-context compound assignment as a checked block

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -309,6 +309,28 @@ public class CfgSampleClass
 
     public static void RefAdd(ref int p, int v) => p += v;
 
+    // Checked-context compound assignment: `checked(x += v)` lowers to
+    // `x = checked(x + v)` (add.ovf). The compound sugar can only be recovered
+    // inside a `checked { ... }` block, since `checked(x += v);` is not a valid
+    // statement expression.
+    public static int CheckedCompoundAdd(int x, int v)
+    {
+        checked { x += v; }
+        return x;
+    }
+
+    public static int CheckedCompoundMul(int x, int v)
+    {
+        checked { x *= v; }
+        return x;
+    }
+
+    public static int CheckedCompoundInc(int x)
+    {
+        checked { x++; }
+        return x;
+    }
+
     public static int TryFinallyAdd(int x)
     {
         try { return x + 1; }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -397,6 +397,41 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void CheckedCompound_RendersCheckedBlockWithCompoundSugar()
+    {
+        // `checked(x += v)` lowers to add.ovf; `checked(x += v);` is not a legal
+        // statement (CS0201), so the overflow context is restored with a
+        // single-statement checked block that keeps the compound sugar.
+        var function = ImportFixture(nameof(CfgSampleClass.CheckedCompoundAdd));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Contains("checked { x += v; }", output);
+        Assert.DoesNotContain("x = checked(", output);
+    }
+
+    [Fact]
+    public void CheckedCompoundMultiply_RendersCheckedBlock()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.CheckedCompoundMul));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("checked { x *= v; }", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
+    public void CheckedCompoundIncrement_RendersCheckedBlockWithOperator()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.CheckedCompoundInc));
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("checked { x++; }", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
     public void CheckedAdd_RendersCheckedExpression()
     {
         // add.ovf carries an overflow check the default (unchecked) C# context

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1336,22 +1336,35 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string AssignmentText(string target, IrExpression value, Func<IrExpression, bool> readsTarget, TypeRef? targetType = null)
     {
-        if (value is Binary { IsChecked: false } binary && readsTarget(binary.Left))
+        if (value is Binary binary && readsTarget(binary.Left))
         {
             // A compound assignment only forms when the value reads the target
             // in same-type arithmetic, so the result already matches the target
             // — no conversion is involved on this path.
-            if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
-                return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
-            // A shift count carries the compiler's implicit width mask; strip it
-            // exactly as the expression form does so `x <<= n` does not re-mask on
-            // recompile (see ShiftCount).
-            string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
-                ? ShiftCount(binary)
-                : Operand(binary.Right);
-            return $"{target} {BinaryOperator(binary)}= {rightText};";
+            string statement = CompoundStatement(target, binary);
+            // A checked compound (add.ovf/sub.ovf/mul.ovf) cannot be spelled as a
+            // statement-level `checked(x += v)` (CS0201), so the overflow context
+            // is restored with a single-statement checked block. Only the
+            // overflow-honoring operators ever carry IsChecked here.
+            return binary.IsChecked ? $"checked {{ {statement} }}" : statement;
         }
         return $"{target} = {CastValue(value, targetType)};";
+    }
+
+    /// <summary>
+    /// Spells a compound assignment whose value reads the target: <c>x++</c>/
+    /// <c>x--</c> for a ±1 step, <c>x op= rest</c> otherwise. A shift count carries
+    /// the compiler's implicit width mask; strip it exactly as the expression form
+    /// does so <c>x &lt;&lt;= n</c> does not re-mask on recompile (see ShiftCount).
+    /// </summary>
+    string CompoundStatement(string target, Binary binary)
+    {
+        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
+            return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
+        string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
+            ? ShiftCount(binary)
+            : Operand(binary.Right);
+        return $"{target} {BinaryOperator(binary)}= {rightText};";
     }
 
     /// <summary>Structural same-place check for compound-assignment receivers; conservative (this/locals/arguments/static only).</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -55,7 +55,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass BreakStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call => default!;
     [Completeness(CompletenessLevel.Full)] public static InlineArrayCollectionPass CollectionExpression => new();
-    [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, indexer, and ref targets raised; checked-context and nested-struct compound not raised")]
+    [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, indexer, and ref targets raised, including the checked-context form (`checked(x += v)` recovered as a `checked { x += v; }` block); nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static NullConditionalPass ConditionalAccess => new();
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();


### PR DESCRIPTION
## Target

Narrows the `CompoundAssignmentOperator` `Partial` ledger row, which listed
**checked-context compound not raised**. A compound assignment in a checked
context (`checked(x += v)`) lowers to `x = checked(x + v)`
(`add.ovf`/`sub.ovf`/`mul.ovf`). The printer recovered the compound sugar only
for unchecked binaries; for a checked binary it fell back to the long form:

```csharp
x = checked(x + v);   // before — correct IL, but not the source shape
```

The compound sugar could not simply be emitted inline because a statement-level
`checked(x += v);` is **not legal C#** (CS0201 — only assignment/call/increment/
decrement/await/new can be statements).

## Change

Restore the overflow context with a single-statement **checked block**, which is
a legal statement and keeps the compound sugar:

```csharp
checked { x += v; }   // after
checked { x *= v; }
checked { x++; }      // the ±1 step still folds to the operator
```

The change is confined to the printer's `AssignmentText` (now factored into a
shared `CompoundStatement` helper). The IR is unchanged — only the rendering of
an existing `StoreX(Binary { IsChecked: true })` that reads its own target — so
the **compile-back gate confirms** `checked { x += v; }` recompiles to the same
`.ovf` opcode as the input.

Only the overflow-honoring operators (`+`, `-`, `*`) ever carry `IsChecked`
here, and the compound path only forms in same-type arithmetic (a narrowing
compound goes through a `Convert` and never reaches it), so the wrap is sound.

## Tests

- `CfgSampleClass`: `CheckedCompoundAdd`, `CheckedCompoundMul`,
  `CheckedCompoundInc` fixtures.
- `IrImporterTests`: three render assertions (checked block + compound/operator
  sugar; no `x = checked(` long form).
- Decompiler suite 714 green (incl. compile-back gate), product suite 1157 (9
  skip).

**Scope**: nested-struct compound (`obj.Field.X += v` over a struct field) stays
owed; the ledger note is updated accordingly.
