### PR TITLE
Escape reserved-keyword identifiers in the decompiler body

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -26,6 +26,11 @@ public class CfgSampleClass
     // Negative: a plain int count needs no cast — `1 << n` stays bare.
     public static int ShiftByInt(int n) => 1 << n;
 
+    // A parameter named with a C# keyword (`delegate`): the metadata name is the
+    // bare keyword, so every reference must be @-escaped (`@delegate`) or it is
+    // CS1001 "Identifier expected". Exercises the LoadArgument render path.
+    public static int KeywordParam(int @delegate) => @delegate + 1;
+
     // A reference inequality against null: csc lowers `o != null` to
     // `ldnull; cgt.un` (an unsigned ordering), so the IR is GreaterThan-unsigned
     // with a null operand. The printer must spell it `o is not null`, not the

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -101,6 +101,7 @@ public class FidelityGateTests
         "NullCoalescingAssignInstanceField",
         "WhileTrueWithReturns",
         "WhileTrueWithBreak",
+        "KeywordParam",
         "IsNotNullReference",
         "LineSeparatorLiteral",
     };

--- a/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
@@ -1,0 +1,29 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A parameter (or any metadata identifier) whose name is a C# reserved keyword
+// must be @-escaped in the rendered body — a bare `delegate` is CS1001
+// "Identifier expected". Locals are already synthetic (V_0/S_0) or keyword-
+// filtered, so the live case is parameter names.
+public class KeywordIdentifierTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void KeywordParameter_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.KeywordParam));
+
+        Assert.Contains("@delegate + 1", output);
+        Assert.DoesNotContain(" delegate", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -22,6 +22,12 @@ internal static class CSharpNaming
         return !ReservedKeywords.Contains(name);
     }
 
+    /// <summary>An identifier safe to emit in C# source: a reserved keyword is
+    /// <c>@</c>-escaped (a parameter named <c>delegate</c> becomes <c>@delegate</c>,
+    /// which would otherwise be CS1001); any other name is returned unchanged.</summary>
+    public static string EscapeIdentifier(string name)
+        => ReservedKeywords.Contains(name) ? "@" + name : name;
+
     static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
     {
         "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -89,8 +89,8 @@ public sealed partial class CSharpPrinter
     string LambdaText(Lambda lambda)
     {
         string parameters = lambda.Parameters is [var single]
-            ? single.Name
-            : $"({string.Join(", ", lambda.Parameters.Select(p => p.Name))})";
+            ? CSharpNaming.EscapeIdentifier(single.Name)
+            : $"({string.Join(", ", lambda.Parameters.Select(p => CSharpNaming.EscapeIdentifier(p.Name)))})";
 
         if (lambda.ExpressionBody is { } expr)
             return $"{parameters} => {Expression(expr)}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -557,7 +557,7 @@ public sealed partial class CSharpPrinter
         if (node is LocalFunctionStatement localFunction)
         {
             string modifier = localFunction.IsStatic ? "static " : "";
-            string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{TypeText(p.Type)} {p.Name}"));
+            string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{TypeText(p.Type)} {CSharpNaming.EscapeIdentifier(p.Name)}"));
             string header = $"{modifier}{TypeText(localFunction.ReturnType)} {localFunction.Name}({parameters})";
             if (localFunction.ExpressionBody is { } body)
             {
@@ -937,7 +937,7 @@ public sealed partial class CSharpPrinter
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
         NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
-        StoreArgument s => AssignmentText(s.Name, s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
+        StoreArgument s => AssignmentText(CSharpNaming.EscapeIdentifier(s.Name), s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
         StoreStackSlot { Value.ResultType.Kind: TypeRefKind.ByRef } s => _declaringStores.Contains(s)
@@ -972,7 +972,7 @@ public sealed partial class CSharpPrinter
         InitObject { Address: LoadLocalAddress local } init => _declaringStores.Contains(init)
             ? $"{TypeText(init.Type)} {LocalName(local.Index)} = default;"
             : $"{LocalName(local.Index)} = default;",
-        InitObject { Address: LoadArgumentAddress argument } => $"{argument.Name} = default;",
+        InitObject { Address: LoadArgumentAddress argument } => $"{CSharpNaming.EscapeIdentifier(argument.Name)} = default;",
         InitObject { Address: LoadFieldAddress field } o2 => $"{FieldTarget(field.Field, field.Instance)} = default;",
         InitObject o => $"{Deref(o.Address)} = default({TypeText(o.Type)});",
         Return { Value: { } value } => $"return {CastValue(value, _function.Signature.ReturnType)};",
@@ -994,7 +994,8 @@ public sealed partial class CSharpPrinter
 
     string Expression(IrExpression node) => node switch
     {
-        LoadArgument a => a.Name,
+        LoadArgument { Index: 0, Name: "this" } => "this",
+        LoadArgument a => CSharpNaming.EscapeIdentifier(a.Name),
         LoadLocal l => $"{LocalName(l.Index)}",
         LoadStackSlot s => $"S_{s.Slot}",
         Constant { Value: int } c when EnumMemberName(c) is { } named => named,
@@ -1053,7 +1054,7 @@ public sealed partial class CSharpPrinter
         UnboxAny u => $"({TypeText(u.Type)}){UnboxAnyOperand(u.Operand)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
         LoadLocalAddress a => $"ref {LocalName(a.Index)}",
-        LoadArgumentAddress a => $"ref {a.Name}",
+        LoadArgumentAddress a => $"ref {CSharpNaming.EscapeIdentifier(a.Name)}",
         LoadFieldAddress f => $"ref {FieldTarget(f.Field, f.Instance)}",
         LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
         LoadIndirect l => DerefLoad(l),
@@ -1191,7 +1192,7 @@ public sealed partial class CSharpPrinter
         // which is CS0193 (DeclaringType is never an unmanaged pointer).
         LoadArgument { Index: 0, Name: "this" } => "this",
         LoadLocalAddress a => $"{LocalName(a.Index)}",
-        LoadArgumentAddress a => a.Name,
+        LoadArgumentAddress a => CSharpNaming.EscapeIdentifier(a.Name),
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
         LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         { ResultType.Kind: TypeRefKind.Pointer } => $"*{Operand(address)}",

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -314,8 +314,8 @@ static class ValidityCheck
 
     static string ParameterText(Parameter parameter)
         => parameter.Type.Kind == TypeRefKind.ByRef
-            ? $"ref {TypeText(parameter.Type.ElementType!)} {parameter.Name}"
-            : $"{TypeText(parameter.Type)} {parameter.Name}";
+            ? $"ref {TypeText(parameter.Type.ElementType!)} {CSharpNaming.EscapeIdentifier(parameter.Name)}"
+            : $"{TypeText(parameter.Type)} {CSharpNaming.EscapeIdentifier(parameter.Name)}";
 
     static string TypeText(TypeRef type)
     {


### PR DESCRIPTION
## Problem

A parameter whose metadata name is a C# reserved keyword (e.g. `delegate`) was rendered **bare** in the decompiled body, producing CS1001 "Identifier expected". Synthetic locals (`V_0`/`S_0`) and keyword-named locals are already filtered to a safe spelling, so the live case is parameter names, which flow straight from metadata.

`System.Diagnostics.DiagnosticMethodInfo::Create` (parameter `delegate`), before:

```csharp
ArgumentNullException.ThrowIfNull(delegate, "@delegate");
return new DiagnosticMethodInfo(delegate.Method);
```

after:

```csharp
ArgumentNullException.ThrowIfNull(@delegate, "@delegate");
return new DiagnosticMethodInfo(@delegate.Method);
```

## Fix

Add `CSharpNaming.EscapeIdentifier` (prefix a reserved keyword with `@`) and apply it at every parameter-name emission site: `LoadArgument` / `StoreArgument` / `LoadArgumentAddress` / `InitObject`, plus lambda and local-function parameter declarations. The synthesized instance receiver (`LoadArgument { Index: 0, Name: "this" }`) keeps rendering as the `this` keyword, not `@this`.

Also escape parameter names in the validity harness's reconstruction shell so its measured signature matches the body (the `FidelityCheck` reconstructor already escaped via Roslyn `SyntaxFacts`).

## Soundness

`@delegate` denotes the same identifier as `delegate`; recompiles opcode-exact.

## Corpus impact

- Full malformed 334 → 331 (−3 methods: `DiagnosticMethodInfo::Create`, `LoggingExtensions::GetMethodName`, `Condition::.ctor`)
- Recompile inventory flat: 40845/41012 Full
- Added `KeywordParam` fixture (opcode-exact, pinned in the fidelity gate) + a render test
- 693 decompiler + 1157 product tests green

## Follow-up (not in this PR)

The product's `--decompile` **declaration** line is rendered by the `ILInspector.Metadata` signature layer (which cannot reference the decompiler's `CSharpNaming`), so `Create(System.Delegate delegate)` still needs the same escaping. That is a separate change in the metadata API-surface formatter with a broader blast radius.
