### PR TITLE
Keep the explicit cast on a sub-int binary result flowing into a wider sibling

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SubIntBinaryCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubIntBinaryCastTests.cs
@@ -1,0 +1,51 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// C#'s binary numeric promotion never yields a sub-int type: a byte/sbyte/short/
+// ushort/char arithmetic, bitwise, or shift expression is typed `int`. The IR
+// keeps the ECMA stack type (the sub-int left operand), so a `char - n` result
+// flowing into a uint slot must still carry an explicit (uint) cast — otherwise
+// the printer treats it as the implicit char->uint conversion and drops the cast
+// (CS0266). A genuinely sub-int target the source widens to int keeps no cast.
+public class SubIntBinaryCastTests
+{
+    static readonly TypeRef Char = TypeRef.CoreLib("System", "Char");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef UInt32 = TypeRef.CoreLib("System", "UInt32");
+
+    static string RenderStore(TypeRef localType)
+    {
+        // V_0 = c - 56320; return V_0;  with c a char parameter.
+        var subtract = new Binary(BinaryKind.Subtract, isChecked: false, isUnsigned: false,
+            new LoadArgument(0, "c", Char), new Constant(56320, Int32));
+        var entry = new Block(0);
+        entry.Add(new StoreLocal(0, localType, subtract));
+        entry.Add(new Return(new LoadLocal(0, localType)));
+        var container = new BlockContainer();
+        container.Add(entry);
+
+        var signature = new MethodSignature(localType, [new Parameter("c", Char)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [], container);
+        return CSharpPrinter.Print(function).Output ?? "";
+    }
+
+    [Fact]
+    public void CharSubtractIntoUInt_KeepsExplicitCast()
+    {
+        var output = RenderStore(UInt32);
+
+        // `char - int` is int in C#; assigning int to uint needs an explicit cast.
+        Assert.Contains("(uint)(c - 56320)", output);
+    }
+
+    [Fact]
+    public void CharSubtractIntoInt_NeedsNoCast()
+    {
+        var output = RenderStore(Int32);
+
+        // `char - int` is already int; no cast, and certainly no `(uint)`.
+        Assert.DoesNotContain("(uint)", output);
+        Assert.Contains("c - 56320", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -261,10 +261,23 @@ public sealed partial class CSharpPrinter
     /// the matching unsigned type does not redundantly re-cast.
     /// </summary>
     static TypeRef? EffectiveType(IrExpression value)
-        => value is Binary { IsUnsigned: true, Kind: BinaryKind.Divide or BinaryKind.Remainder or BinaryKind.ShiftRight }
-            && TypeFamilies.UnsignedCounterpart(value.ResultType) is { } unsigned
-            ? unsigned
-            : value.ResultType;
+        => value switch
+        {
+            // An unsigned div/rem/shr renders with the operands cast to their
+            // unsigned type, so the result is unsigned even though the node's ECMA
+            // binary-promotion ResultType keeps the signed operand type.
+            Binary { IsUnsigned: true, Kind: BinaryKind.Divide or BinaryKind.Remainder or BinaryKind.ShiftRight }
+                when TypeFamilies.UnsignedCounterpart(value.ResultType) is { } unsigned => unsigned,
+            // C# binary numeric promotion never yields a sub-int type: a byte/
+            // sbyte/short/ushort/char arithmetic, bitwise, or shift expression is
+            // typed `int` in C#. The IR keeps the ECMA stack type (often the
+            // sub-int left operand), so reflect the promoted int for boundary-cast
+            // decisions — otherwise a `char - n` flowing into uint looks implicitly
+            // convertible (char→uint) and drops a required (uint) cast (CS0266).
+            Binary when TypeFamilies.IsSubInt32(value.ResultType)
+                => TypeRef.CoreLib("System", "Int32"),
+            _ => value.ResultType,
+        };
 
     static string BinaryOperator(Binary binary) => binary.Kind switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -115,6 +115,17 @@ public static class TypeFamilies
     public static bool IsIntegerLike(TypeRef type)
         => IsNumericPrimitive(type) && type.Name is not ("Single" or "Double");
 
+    /// <summary>
+    /// True for an integer primitive narrower than int — sbyte/byte/short/ushort/
+    /// char. C#'s binary numeric promotion never yields one of these: arithmetic,
+    /// bitwise, and shift operations on sub-int operands produce <c>int</c>. The IR
+    /// keeps the ECMA stack type (often the sub-int left operand), so a boundary
+    /// cast off a sub-int <c>Binary</c> result must reason about the promoted int.
+    /// </summary>
+    public static bool IsSubInt32(TypeRef? type)
+        => type is { } t && IsNumericPrimitive(t)
+            && t.Name is "SByte" or "Byte" or "Int16" or "UInt16" or "Char";
+
     /// <summary>Byte width of a fixed-width integer primitive; null for the platform-sized (nint/nuint) and float types.</summary>
     static int? Width(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
         ? type.Name switch


### PR DESCRIPTION
## Summary

**Bug hunt / correctness fix (CS0266).** C#'s binary numeric promotion never yields a sub-int type: an arithmetic, bitwise, or shift expression over `byte`/`sbyte`/`short`/`ushort`/`char` operands is typed `int`. The IR, following ECMA-335 stack typing, keeps the sub-int operand type as the `Binary` node's `ResultType` (e.g. `char - n` reports `Char`). The printer's boundary-cast decision read that IR type, so a `char - n` result stored into a `uint` slot looked like the *implicit* `char`→`uint` conversion and dropped the required cast — from `System.Char::IsSurrogatePair`:

```csharp
uint V_0 = lowSurrogate - 56320;        // CS0266: cannot implicitly convert int to uint
```

## Fix

`EffectiveType` — the helper that tells `CastValue` the C# type a rendered expression actually has — now promotes a sub-int `Binary` result to `Int32`, matching C#'s rules. The boundary then sees `int`→`uint`, which is *not* implicit, and keeps the cast:

```csharp
uint V_0 = (uint)(lowSurrogate - 56320);
```

A sub-int result flowing into `int` (its own promotion target) still needs no cast. Adds the `TypeFamilies.IsSubInt32` predicate.

## Validation

- Corpus semantic binding (harness `--validity-check`): **CS0266 occurrences 265 → 225** within the bound cap.
- Defect diff vs baseline: **zero regressions** (no method gained any code); CS0266 cleared from methods such as `Char.IsSurrogatePair`, `Char.ConvertToUtf32`, and `DateTimeParse.TryParseFormatO`/`R`.
- Syntactic-malformed count and corpus **Full fidelity (40845/41012, 0 importer bugs)** unchanged — this is a printer-only boundary-cast change.
- Adds `SubIntBinaryCastTests` (hand-built IR; the `uint` case verified to fail before the change).
- Full `ILInspector.Decompiler.Tests`: **732/732**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
