### PR TITLE
Parenthesize a negative cast operand against a contextual-keyword type

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -42,6 +42,13 @@ public class CfgSampleClass
     // across source lines (CS1010 "Newline in constant").
     public static string LineSeparatorLiteral() => "a\u2028b\u2029c";
 
+    // A negative integer cast to a contextual-keyword type (`nint`): csc lowers
+    // `nint x = -1` to `ldc.i4.m1; conv.i`, which the printer spells `(nint)-1`.
+    // C# parses `(nint)-1` as binary subtraction (CS0075) because `nint` is a
+    // contextual keyword, not a cast-disambiguating predefined type — so the
+    // operand must be parenthesized: `(nint)(-1)`.
+    public static nint NegativeNativeInt() => -1;
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -111,6 +111,7 @@ public class FidelityGateTests
         "KeywordParam",
         "IsNotNullReference",
         "LineSeparatorLiteral",
+        "NegativeNativeInt",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/NegativeCastParenthesizationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NegativeCastParenthesizationTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A cast whose operand begins with a unary `-`/`+` is parsed as binary
+// subtraction/addition (CS0075) unless the cast target is a predefined keyword
+// type the parser treats as cast-disambiguating. `nint`/`nuint` are contextual
+// keywords (and named types are not), so `(nint)-1` misparses — the printer must
+// parenthesize the operand: `(nint)(-1)`.
+public class NegativeCastParenthesizationTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void NegativeNativeIntCast_ParenthesizesOperand()
+    {
+        var output = Render(nameof(CfgSampleClass.NegativeNativeInt));
+
+        Assert.Contains("(nint)(-1)", output);
+        Assert.DoesNotContain("(nint)-1", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1561,9 +1561,26 @@ public sealed partial class CSharpPrinter
         // conv.r.un and conv.ovf.*.un interpret the SOURCE as unsigned —
         // a signed operand needs its unsigned cast or the value is wrong.
         string operand = convert.IsUnsigned ? UnsignedOperand(convert.Operand) : Operand(convert.Operand);
-        string cast = $"({TypeText(convert.Target)}){operand}";
+        string targetText = TypeText(convert.Target);
+        // A cast whose operand begins with a unary `-`/`+` is parsed as binary
+        // subtraction/addition (CS0075) unless the target spelling is a predefined
+        // keyword type the parser treats as cast-disambiguating. `nint`/`nuint`
+        // are contextual keywords and named types are not, so `(nint)-1` misparses
+        // — wrap the operand: `(nint)(-1)`. The parens are opcode-identical.
+        if (operand.Length > 0 && operand[0] is '-' or '+' && !s_castDisambiguatingKeywords.Contains(targetText))
+            operand = $"({operand})";
+        string cast = $"({targetText}){operand}";
         return convert.IsChecked ? $"checked({cast})" : cast;
     }
+
+    // The predefined-type keyword spellings the C# parser treats as
+    // cast-disambiguating: `(int)-1` is a cast, but `(nint)-1` (a contextual
+    // keyword) or `(MyEnum)-1` (a named type) parses as subtraction (CS0075).
+    static readonly HashSet<string> s_castDisambiguatingKeywords = new(StringComparer.Ordinal)
+    {
+        "bool", "byte", "sbyte", "char", "short", "ushort", "int", "uint",
+        "long", "ulong", "float", "double", "decimal", "string", "object", "void",
+    };
 
     /// <summary>
     /// A retyped enum constant renders <c>EnumType.Member</c> when its value


### PR DESCRIPTION
## Problem

`--validity-check` flags three CoreLib methods (`System.ArrayEnumerator::Reset`,
`System.ArrayEnumerator::.ctor`, `System.MulticastDelegate::IsUnmanagedFunctionPtr`)
with **CS0075 "To cast a negative value, you must enclose the value in parentheses."**

The printer rendered `(nint)-1`. C# parses `(nint)-1` as binary subtraction, not a
cast, because `nint`/`nuint` are *contextual* keywords — the parser only treats a
cast as unary-disambiguating when the target is a predefined keyword type
(`int`, `long`, …). Named types (enums/structs) have the same problem.

## Fix

`ConvertText` now wraps a cast operand that begins with a unary `-`/`+` when the
target spelling is not a cast-disambiguating predefined keyword: `(nint)(-1)`.
The parentheses are opcode-identical on recompile. The enum-cast path in
`CastValue` already did this for negative enum literals; this generalizes it to
the conversion printer.

## Soundness

Parenthesizing a unary-signed operand never changes meaning or IL; it only
removes the parse ambiguity. Predefined keyword targets (`(int)-1`) are left
untouched, so there is no churn on the already-valid cases.

## Numbers

- Semantic-defect methods **226 → 223 (−3)**; CS0075 **→ 0**.
- Full malformed flat (221); recompile inventory flat (40854/41012).
- `NegativeNativeInt` fixture pinned opcode-exact in the fidelity gate.
- 725 decompiler + 1157 product tests green.

Found via `--validity-check`.
