### PR TITLE
Replace --files with first-class Files section and --path scoping (#875)

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -157,6 +157,7 @@ Use `package` for NuGet package structure and registry-backed signals. Use `libr
 ```bash
 dnx dotnet-inspect -y -- package System.Text.Json -S Signals
 dnx dotnet-inspect -y -- package System.Text.Json -S "Library Files"
+dnx dotnet-inspect -y -- package System.Text.Json --path "*.md" --jsonl
 dnx dotnet-inspect -y -- package Aspire.Azure.AI.OpenAI --library -S @Integrations
 dnx dotnet-inspect -y -- library System.Text.Json -S Signals
 dnx dotnet-inspect -y -- library System.Text.Json -S Switches
@@ -168,6 +169,8 @@ dnx dotnet-inspect -y -- library System.Diagnostics.DiagnosticSource -S OpenTele
 Use `package Foo --library` to inspect the package's primary DLL when it is unambiguous; add a DLL name when a package contains multiple libraries. Use `package Foo --all-libraries` when a package contains multiple relevant DLLs or a tool package carries libraries under `tools/`; aggregate Markdown sections such as `@Integrations` include library provenance when needed. For row modes such as `--tsv`/`--jsonl`, select one concrete section such as `Integrations` or `OpenTelemetry`, not a category like `@Integrations`. Use `-S Integrations` for the ecosystem roll-up, `-S @Integrations` for roll-up plus focused sections, or a focused section such as `OpenTelemetry`. Integration sections cover AI, ASP.NET Core, Aspire resources, Authentication, Configuration, Dependency Injection, Logging, Options, Hosting, Health Checks, HTTP Client, OpenAPI, and OpenTelemetry. Focused sections list package-owned starter APIs, support types, and telemetry controls, not raw assembly references.
 
 Use `-S Switches` when runtime feature switches or compatibility switches may affect behavior.
+
+List package contents with the opt-in `Files` section: `-S Files` for the whole package with uncompressed sizes, or `--path` to scope it. `--path /` lists root files only, `--path "lib/net8.0/"` a directory's immediate children, `--path "*.md"` globs across the package (handy for spotting oversized README/docs), and `--path README.md` a single file. Sizes are read from the package layout — no file contents are fetched.
 
 `library X -S Signals` resolves SourceLink by acquiring a missing PDB. Per-source-file reachability is opt-in: add `-S "SourceLink Availability"` and `-S "SourceLink Missing Files"` for HTTP HEAD checks, or `-S "SourceLink Integrity"` to download source files and compare checksums. For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -992,13 +992,13 @@ public class CommandLineTests
     }
 
     [Theory]
-    [InlineData(false, false, null, false)]  // --files
+    [InlineData(false, false, null, false)]  // scope none
     [InlineData(false, false, null, true)]   // --layout
-    [InlineData(true, false, null, false)]   // --files --lib
+    [InlineData(true, false, null, false)]   // --lib
     [InlineData(true, false, null, true)]    // --layout --lib
-    [InlineData(false, true, null, false)]   // --files --tools
+    [InlineData(false, true, null, false)]   // --tools
     [InlineData(false, true, null, true)]    // --layout --tools
-    [InlineData(false, false, "net8.0", false)] // --files --tfm net8.0
+    [InlineData(false, false, "net8.0", false)] // --tfm net8.0
     [InlineData(false, false, "net8.0", true)]  // --layout --tfm net8.0
     public void WriteFileLayoutTips_NeverWritesTips(bool scopeLib, bool scopeTools, string? tfm, bool isLayout)
     {

--- a/src/dotnet-inspect.Tests/PackageFileListerTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFileListerTests.cs
@@ -1,0 +1,126 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+
+namespace DotnetInspector.Tests;
+
+public class PackageFileListerTests
+{
+    private static string CreateExtractDir(params string[] relativePaths)
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(root);
+        foreach (var rel in relativePaths)
+        {
+            var full = Path.Combine(root, rel.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, rel); // size = byte length of the path string
+        }
+        return root;
+    }
+
+    [Fact]
+    public void ListAll_ExcludesZipAndRestorePlumbing()
+    {
+        var root = CreateExtractDir(
+            "README.md",
+            "LICENSE.md",
+            "lib/net8.0/Foo.dll",
+            "Foo.nuspec",
+            "_rels/.rels",
+            "[Content_Types].xml",
+            "package/services/metadata/core-properties/abc.psmdcp",
+            ".signature.p7s",
+            ".nupkg.metadata",
+            "foo.1.0.0.nupkg",
+            "foo.1.0.0.nupkg.sha512");
+        try
+        {
+            var files = PackageFileLister.ListAll(root);
+            var paths = files.Select(f => f.Path).ToList();
+
+            Assert.Equal(new[] { "LICENSE.md", "README.md", "lib/net8.0/Foo.dll" }.OrderBy(x => x, StringComparer.Ordinal),
+                paths.OrderBy(x => x, StringComparer.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ListAll_ReportsUncompressedSizeAndSortsByPath()
+    {
+        var root = CreateExtractDir("b.txt", "a.txt", "lib/c.txt");
+        try
+        {
+            var files = PackageFileLister.ListAll(root);
+
+            Assert.Equal(new[] { "a.txt", "b.txt", "lib/c.txt" }, files.Select(f => f.Path).ToArray());
+            Assert.All(files, f => Assert.Equal(f.Path.Length, f.Size));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static List<PackageFile> Sample() =>
+    [
+        new("README.md", 10),
+        new("LICENSE.md", 20),
+        new("lib/net8.0/Foo.dll", 30),
+        new("lib/net8.0/Foo.xml", 40),
+        new("lib/net6.0/Foo.dll", 50),
+        new("docs/guide.md", 60),
+    ];
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData(".")]
+    [InlineData("./")]
+    public void Filter_Root_ReturnsTopLevelFilesOnly(string pattern)
+    {
+        var result = PackageFileLister.Filter(Sample(), pattern);
+        Assert.Equal(new[] { "README.md", "LICENSE.md" }.OrderBy(x => x, StringComparer.Ordinal),
+            result.Select(f => f.Path).OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Filter_NullOrEmpty_ReturnsEverything()
+    {
+        Assert.Equal(6, PackageFileLister.Filter(Sample(), null).Count);
+        Assert.Equal(6, PackageFileLister.Filter(Sample(), "").Count);
+    }
+
+    [Fact]
+    public void Filter_GlobMd_MatchesMarkdownAnywhere()
+    {
+        var result = PackageFileLister.Filter(Sample(), "*.md");
+        Assert.Equal(new[] { "README.md", "LICENSE.md", "docs/guide.md" }.OrderBy(x => x, StringComparer.Ordinal),
+            result.Select(f => f.Path).OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Filter_DirectoryTrailingSlash_ReturnsImmediateChildren()
+    {
+        var result = PackageFileLister.Filter(Sample(), "lib/net8.0/");
+        Assert.Equal(new[] { "lib/net8.0/Foo.dll", "lib/net8.0/Foo.xml" }.OrderBy(x => x, StringComparer.Ordinal),
+            result.Select(f => f.Path).OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Filter_ExactFile_ReturnsSingleRow()
+    {
+        var result = PackageFileLister.Filter(Sample(), "README.md");
+        Assert.Single(result);
+        Assert.Equal("README.md", result[0].Path);
+    }
+
+    [Fact]
+    public void Filter_BareDirectory_TreatedAsDirectory()
+    {
+        var result = PackageFileLister.Filter(Sample(), "lib/net6.0");
+        Assert.Single(result);
+        Assert.Equal("lib/net6.0/Foo.dll", result[0].Path);
+    }
+}

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1026,7 +1026,7 @@ public class SectionPipelineTests
             RuntimeIdentifierPackages = [new RidPackageReference { RuntimeIdentifier = "win-x64", PackageId = "Test.win-x64" }],
             RuntimeDependencies = [new PackageDependency { Id = "Dep2", Version = "2.0" }],
             LibraryFiles = ["lib/net8.0/test.dll"],
-            Files = ["lib/net8.0/test.dll"],
+            Files = [new PackageFile("lib/net8.0/test.dll", 1234)],
             SignatureResult = new DotnetInspector.Services.SignatureVerificationResult { RepositoryVerified = true, Repository = "nuget.org" },
             AuditSignals = [new AuditSignal("Package", "Assemblies", "1", "test")]
         };

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -26,10 +26,14 @@ public static class PackageCommandDefinitions
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree (tip: use 'depends --package' instead)" };
         var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
         layoutOption.Aliases.Add("--tree");
-        var filesOption = new Option<bool>("--files") { Description = "List files in the package (flat list, filterable with --tfm)" };
+        var pathOption = new Option<string?>("--path")
+        {
+            Description = "List package files with sizes (the Files section), scoped to a file, a directory (e.g. lib/), the root (/), or a glob (e.g. *.md). Pass --path with no value for the whole package.",
+            Arity = ArgumentArity.ZeroOrOne
+        };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };
-        var libOption = new Option<bool>("--lib") { Description = "Scope to lib/ folder (use with --files or --layout)" };
-        var toolsOption = new Option<bool>("--tools") { Description = "Scope to tools/ folder (use with --files or --layout)" };
+        var libOption = new Option<bool>("--lib") { Description = "Scope to lib/ folder (use with --layout)" };
+        var toolsOption = new Option<bool>("--tools") { Description = "Scope to tools/ folder (use with --layout)" };
         var libraryOption = new Option<string?>("--library")
         {
             Description = "Inspect a library from this package; omit value to select the primary library when unambiguous",
@@ -51,7 +55,7 @@ public static class PackageCommandDefinitions
         packageCommand.Arguments.Add(packageNameArg);
         packageCommand.Options.Add(dependenciesOption);
         packageCommand.Options.Add(layoutOption);
-        packageCommand.Options.Add(filesOption);
+        packageCommand.Options.Add(pathOption);
         packageCommand.Options.Add(tfmsOption);
         packageCommand.Options.Add(libOption);
         packageCommand.Options.Add(toolsOption);
@@ -78,7 +82,7 @@ public static class PackageCommandDefinitions
         packageCommand.Subcommands.Add(searchCommand);
 
         var commandArgs = new PackageOptionsParser.PackageCommandArgs(
-            packageNameArg, dependenciesOption, layoutOption, filesOption, tfmsOption,
+            packageNameArg, dependenciesOption, layoutOption, pathOption, tfmsOption,
             libOption, toolsOption, libraryOption, allLibrariesOption, versionsOption, prereleaseOption, readmeOption,
             tfmOption, versionOption, latestVersionOption, outOption, opts.OneLine, opts.NoHeaders);
 

--- a/src/dotnet-inspect/CommandLine/Helpers/TipWriter.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/TipWriter.cs
@@ -38,7 +38,7 @@ public static class TipWriter
         tips.Add(new(FindCommand.Name, $"<pattern> --package {packageName}", "search for types"));
         tips.Add(new(DiffCommand.Name, $"--package {packageName}@<prev>..<cur>", "diff versions"));
         tips.Add(new(PackageCommand.Name, $"{packageName} --readme", "view README"));
-        tips.Add(new(PackageCommand.Name, $"{packageName} --files", "list package files"));
+        tips.Add(new(PackageCommand.Name, $"{packageName} --path /", "list package files"));
         tips.Add(new(PackageCommand.Name, $"{packageName} --layout", "show file tree"));
 
         Hints.WriteTips(tipLevel, [.. tips]);

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -18,7 +18,7 @@ public static class PackageOptionsParser
         Argument<string[]> PackageNameArg,
         Option<bool> DependenciesOption,
         Option<bool> LayoutOption,
-        Option<bool> FilesOption,
+        Option<string?> PathOption,
         Option<bool> TfmsOption,
         Option<bool> LibOption,
         Option<bool> ToolsOption,
@@ -79,6 +79,16 @@ public static class PackageOptionsParser
 
         var verbosity = opts.ParseVerbosity(parseResult);
 
+        // --path scopes the file listing and selects the Files section. A bare
+        // --path (present without a value) means the whole package (root and below);
+        // an explicit /, directory, file, or glob narrows it.
+        string? pathFilter = null;
+        if (parseResult.GetResult(args.PathOption) is { Implicit: false })
+        {
+            var value = parseResult.GetValue(args.PathOption);
+            pathFilter = string.IsNullOrEmpty(value) ? "**" : value;
+        }
+
         var options = new InspectionOptions
         {
             PackageArgs = packageArgs,
@@ -88,7 +98,7 @@ public static class PackageOptionsParser
             PackageLibrary = packageLibrary,
             AllLibraries = parseResult.GetValue(args.AllLibrariesOption),
             ListLayout = parseResult.GetValue(args.LayoutOption),
-            ListFiles = parseResult.GetValue(args.FilesOption),
+            PathFilter = pathFilter,
             ListTfms = parseResult.GetValue(args.TfmsOption),
             ScopeLib = parseResult.GetValue(args.LibOption),
             ScopeTools = parseResult.GetValue(args.ToolsOption),
@@ -117,6 +127,10 @@ public static class PackageOptionsParser
             Rows = opts.ParseRows(parseResult),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
         };
+
+        // --path is sugar for selecting the Files section (which carries path + size).
+        if (pathFilter != null)
+            options = options with { Select = [.. options.Select ?? [], Views.PackageSections.Files] };
 
         var tipLevel = options.FormatExplicitlySet || options.IsRawOutput || verbosity != Verbosity.Minimal || options.Select != null || options.Discover != null || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null || options.Limit != null
             ? TipLevel.Quiet : opts.ParseTipLevel(parseResult);

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -615,7 +615,7 @@ public class LibraryCommand
         if (matchedAssembly == null)
         {
             Console.Error.WriteLine($"Error: Library '{assemblyName}' not found in package.");
-            Console.Error.WriteLine("Use 'dotnet-inspect package <name> --files' to list available libraries.");
+            Console.Error.WriteLine("Use 'dotnet-inspect package <name> --path \"lib/\"' to list available libraries.");
             DeleteTempDir(tempDir);
             return null;
         }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -288,13 +288,6 @@ public class PackageCommand
                 return 0;
             }
 
-            // Handle --files mode: list files and exit early
-            if (options.ListFiles)
-            {
-                ListPackageFiles(extractPath, options, packageName, options.TipLevel);
-                return 0;
-            }
-
             // Handle --tfms mode: list target frameworks and exit early
             if (options.ListTfms)
             {
@@ -377,6 +370,17 @@ public class PackageCommand
             }
 
             result.Source = isLocalFile ? SourceKind.File : SourceKind.NuGet;
+
+            // Populate the Files section from the already-extracted package (sizes
+            // come from FileInfo, so no extra download). Scoped by --path when given.
+            // The section is opt-in (-S Files / --path), so this stays cheap.
+            bool wantsFilesSection = options.IncludeSections?.Contains(PackageSections.Files) == true
+                || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
+            if (wantsFilesSection)
+            {
+                var files = PackageFileLister.ListAll(extractPath);
+                result.Files = PackageFileLister.Filter(files, options.PathFilter);
+            }
 
             // Filter output based on options
             FilterResultForOutput(result, options);
@@ -532,7 +536,7 @@ public class PackageCommand
         List<string> conflicts = [];
         if (options.AllLibraries) conflicts.Add("--all-libraries");
         if (options.ListLayout) conflicts.Add("--layout");
-        if (options.ListFiles) conflicts.Add("--files");
+        if (options.PathFilter != null) conflicts.Add("--path");
         if (options.ListTfms) conflicts.Add("--tfms");
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");
@@ -551,7 +555,7 @@ public class PackageCommand
         List<string> conflicts = [];
         if (options.PackageLibrary != null) conflicts.Add("--library");
         if (options.ListLayout) conflicts.Add("--layout");
-        if (options.ListFiles) conflicts.Add("--files");
+        if (options.PathFilter != null) conflicts.Add("--path");
         if (options.ListTfms) conflicts.Add("--tfms");
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");
@@ -1458,64 +1462,9 @@ public class PackageCommand
         WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: true);
     }
 
-    private static void ListPackageFiles(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel)
-    {
-        string searchPath;
-        bool useFileNameOnly = false;
-
-        // Scope to a specific TFM if requested
-        if (!string.IsNullOrEmpty(options.Tfm))
-        {
-            string libDir = Path.Combine(extractPath, "lib", options.Tfm);
-            string toolsDir = Path.Combine(extractPath, "tools", options.Tfm);
-
-            if (Directory.Exists(libDir))
-                searchPath = libDir;
-            else if (Directory.Exists(toolsDir))
-                searchPath = toolsDir;
-            else
-            {
-                Console.Error.WriteLine($"Error: TFM '{options.Tfm}' not found. Use --tfms to list available frameworks.");
-                return;
-            }
-            useFileNameOnly = true;
-        }
-        else
-        {
-            var (resolved, error) = ResolveScopedPath(extractPath, options);
-            if (error != null)
-            {
-                Console.Error.WriteLine(error);
-                return;
-            }
-            searchPath = resolved;
-        }
-
-        string[] files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
-
-        // Use bare filenames when scoped to a specific TFM, relative paths otherwise
-        var fileNames = files
-            .Select(f => useFileNameOnly
-                ? Path.GetFileName(f)
-                : Path.GetRelativePath(extractPath, f).Replace('\\', '/'))
-            .Where(p => !p.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.StartsWith("_rels", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(p => p);
-
-        var results = options.Limit.HasValue
-            ? fileNames.Take(options.Limit.Value)
-            : fileNames;
-
-        OutputFormatter.WriteStringList(results, "Path", "Path", options.Tsv, options.Jsonl, Console.Out);
-        WriteFileLayoutTips(extractPath, options, packageName, tipLevel, isLayout: false);
-    }
-
     internal static void WriteFileLayoutTips(string extractPath, InspectionOptions options, string packageName, TipLevel tipLevel, bool isLayout)
     {
-        // Tips are not shown for --files / --layout modes
+        // Tips are not shown for --layout mode
     }
 
     private static (string path, string? error) ResolveScopedPath(string extractPath, InspectionOptions options)

--- a/src/dotnet-inspect/Inspectors/PackageFileLister.cs
+++ b/src/dotnet-inspect/Inspectors/PackageFileLister.cs
@@ -1,0 +1,101 @@
+using System.IO.Enumeration;
+using DotnetInspector.Models;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Lists the files of an extracted NuGet package with their uncompressed sizes,
+/// and scopes that listing with the <c>--path</c> pattern. Pure and filesystem-
+/// light: the package is already extracted, so sizes come from <see cref="FileInfo.Length"/>
+/// and no content is read.
+/// </summary>
+public static class PackageFileLister
+{
+    /// <summary>
+    /// Enumerates every package file (excluding zip plumbing) with its size,
+    /// ordered by path. Paths are package-relative with forward slashes.
+    /// </summary>
+    public static List<PackageFile> ListAll(string extractPath)
+    {
+        var files = new List<PackageFile>();
+        foreach (var full in Directory.EnumerateFiles(extractPath, "*", SearchOption.AllDirectories))
+        {
+            string rel = System.IO.Path.GetRelativePath(extractPath, full).Replace('\\', '/');
+            if (IsPlumbing(rel))
+                continue;
+            files.Add(new PackageFile(rel, new FileInfo(full).Length));
+        }
+
+        files.Sort(static (a, b) => string.CompareOrdinal(a.Path, b.Path));
+        return files;
+    }
+
+    /// <summary>
+    /// Restricts a listing to the <c>--path</c> pattern. Semantics:
+    /// <list type="bullet">
+    /// <item>Root (<c>/</c>, <c>.</c>, or empty): files directly at the package root.</item>
+    /// <item>Directory (trailing <c>/</c>, e.g. <c>lib/</c>): files directly in that directory.</item>
+    /// <item>Glob (contains <c>*</c> or <c>?</c>, e.g. <c>*.md</c>): matched against the full
+    /// relative path, where <c>*</c> spans directory separators — so <c>*.md</c> finds every
+    /// <c>.md</c> file anywhere in the package.</item>
+    /// <item>Exact path (<c>README.md</c>): that one file; if it names a directory, that
+    /// directory's immediate files.</item>
+    /// </list>
+    /// </summary>
+    public static List<PackageFile> Filter(IEnumerable<PackageFile> files, string? pattern)
+    {
+        if (string.IsNullOrEmpty(pattern))
+            return files.ToList();
+
+        string p = pattern.Replace('\\', '/');
+
+        // Root selector: top-level files only.
+        if (p is "/" or "." or "./")
+            return files.Where(f => !f.Path.Contains('/')).ToList();
+
+        // Glob: match across the whole relative path, '*' spanning separators.
+        if (p.Contains('*') || p.Contains('?'))
+        {
+            return files
+                .Where(f => FileSystemName.MatchesSimpleExpression(p, f.Path, ignoreCase: true))
+                .ToList();
+        }
+
+        // Directory selector (trailing slash): immediate files in that directory.
+        if (p.EndsWith('/'))
+        {
+            string dir = p.TrimEnd('/');
+            return files.Where(f => IsImmediateChild(f.Path, dir)).ToList();
+        }
+
+        // Exact file match.
+        var exact = files
+            .Where(f => string.Equals(f.Path, p, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exact.Count > 0)
+            return exact;
+
+        // Not an exact file — treat as a directory and list its immediate files.
+        return files.Where(f => IsImmediateChild(f.Path, p)).ToList();
+    }
+
+    private static bool IsImmediateChild(string path, string dir)
+    {
+        if (!path.StartsWith(dir + "/", StringComparison.OrdinalIgnoreCase))
+            return false;
+        // No further separator after the directory prefix => immediate child.
+        return path.IndexOf('/', dir.Length + 1) < 0;
+    }
+
+    private static bool IsPlumbing(string rel)
+        // Zip plumbing (OPC packaging artifacts inside the .nupkg).
+        => rel.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
+            || rel.StartsWith("_rels/", StringComparison.OrdinalIgnoreCase)
+            || rel.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase)
+            || rel.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase)
+            || rel.Equals(".signature.p7s", StringComparison.OrdinalIgnoreCase)
+            // Restore-folder artifacts added by the NuGet client (not zip content).
+            || rel.Equals(".nupkg.metadata", StringComparison.OrdinalIgnoreCase)
+            || rel.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
+            || rel.EndsWith(".nupkg.sha512", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -300,41 +300,6 @@ internal static class PackageInspector
         result.Vulnerabilities = metadata.Vulnerabilities;
     }
 
-    /// <summary>
-    /// Populates the Files list for detailed verbosity output.
-    /// </summary>
-    private static void PopulateFilesForDetailedView(string extractPath, InspectionResult result)
-    {
-        // Get DLLs from tools or lib directory
-        string toolsDir = Path.Combine(extractPath, "tools");
-        string libDir = Path.Combine(extractPath, "lib");
-
-        string searchPath;
-        if (Directory.Exists(toolsDir))
-        {
-            searchPath = toolsDir;
-        }
-        else if (Directory.Exists(libDir))
-        {
-            searchPath = libDir;
-        }
-        else
-        {
-            return;
-        }
-
-        var files = Directory.GetFiles(searchPath, "*.dll", SearchOption.AllDirectories)
-            .Select(f => Path.GetRelativePath(extractPath, f))
-            .Where(p => !p.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .OrderBy(p => p)
-            .ToList();
-
-        if (files.Count > 0)
-        {
-            result.Files = files;
-        }
-    }
-
     private static void PopulateLibraryFiles(string extractPath, InspectionResult result)
     {
         var libDir = Path.Combine(extractPath, "lib");

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -158,9 +158,10 @@ public class InspectionResult
     public List<PackageDependency>? RuntimeDependencies { get; set; }
 
     /// <summary>
-    /// List of files in the package (DLLs from lib/tools, or all files with --all).
+    /// All files in the package (excluding zip plumbing), each with its
+    /// uncompressed size in bytes. Populated on demand for the Files section.
     /// </summary>
-    public List<string>? Files { get; set; }
+    public List<PackageFile>? Files { get; set; }
 
     /// <summary>
     /// Result of NuGet package signature verification.
@@ -201,3 +202,10 @@ public record class PackageBinarySignals
     public int MsdlSourceLinkPdbs { get; init; }
     public int OtherSourceLinkPdbs { get; init; }
 }
+
+/// <summary>
+/// A single file in a NuGet package: its package-relative path (forward slashes)
+/// and uncompressed size in bytes (read from the already-extracted package, so
+/// no extra download is required).
+/// </summary>
+public sealed record PackageFile(string Path, long Size);

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -44,17 +44,18 @@ public record InspectionOptions
     public bool ListLayout { get; init; }
 
     /// <summary>
-    /// List files in the package (flat list, filterable with --tfm).
+    /// Scope the file listing to a path: a file, a directory (trailing slash), the
+    /// package root (<c>/</c>), or a glob (<c>*.md</c>). Selects the Files section.
     /// </summary>
-    public bool ListFiles { get; init; }
+    public string? PathFilter { get; init; }
 
     /// <summary>
-    /// Scope to lib/ folder (use with --files or --layout).
+    /// Scope to lib/ folder (use with --layout).
     /// </summary>
     public bool ScopeLib { get; init; }
 
     /// <summary>
-    /// Scope to tools/ folder (use with --files or --layout).
+    /// Scope to tools/ folder (use with --layout).
     /// </summary>
     public bool ScopeTools { get; init; }
 
@@ -84,7 +85,7 @@ public record InspectionOptions
     public string? OutputPath { get; init; }
 
     /// <summary>
-    /// Limit the number of results (for --versions, --files).
+    /// Limit the number of results (for --versions).
     /// </summary>
     public int? Limit { get; init; }
 
@@ -200,7 +201,7 @@ public record InspectionOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ListLayout || ListFiles || ListTfms || ListVersions || ShowReadme || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
+    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
 
     /// <summary>
     /// All inspection features enabled.

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -141,6 +141,7 @@ public static class PackageSectionDescriptors
     {
         public static string Name => PackageSections.Files;
         public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model)
             => model.Files is { Count: > 0 };

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -68,7 +68,9 @@ public class InspectionResultView
     }
 
     [MarkoutSection(Name = PackageSections.Files)]
-    public List<string>? Files => _data.Files;
+    public List<PackageFileRow>? Files => _data.Files?
+        .Select(f => new PackageFileRow(f.Path, f.Size))
+        .ToList();
 
     [MarkoutSection(Name = PackageSections.LibraryFiles)]
     public List<LibraryFileRow>? LibraryFiles => _data.LibraryFiles?
@@ -392,6 +394,11 @@ public record LibraryFileRow(
     [property: MarkoutPropertyName("TFM")] string Tfm,
     [property: MarkoutPropertyName("File")] string File);
 
+[MarkoutSerializable]
+public record PackageFileRow(
+    [property: MarkoutPropertyName("Path")] string Path,
+    [property: MarkoutPropertyName("Size")] long Size);
+
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(InspectionResultView))]
 [MarkoutContext(typeof(LibraryInspectionView))]
@@ -414,6 +421,7 @@ public record LibraryFileRow(
 [MarkoutContext(typeof(FlatDependency))]
 [MarkoutContext(typeof(TargetFrameworkRow))]
 [MarkoutContext(typeof(LibraryFileRow))]
+[MarkoutContext(typeof(PackageFileRow))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]


### PR DESCRIPTION
Closes #875.

Converts package file listing from the bolt-on `--files` flag (path-only, early-exit) into a first-class, opt-in **`Files` section** that reports each file's uncompressed **size**, plus a new **`--path`** flag for scoping the listing. The motivating use case: surveying packages for oversized README/docs that become a token liability for agents — sizes come straight from the package layout, so no file contents are fetched.

## What changed

`--files` is **removed**. Compat is low; the new workflow is documented in `SKILL.md` as the compat story.

List package contents with:

| Command | Result |
| --- | --- |
| `package Foo -S Files` | whole package, with sizes |
| `package Foo --path /` | root files only |
| `package Foo --path "lib/net8.0/"` | a directory's immediate children |
| `package Foo --path "*.md"` | glob across the whole package |
| `package Foo --path README.md` | a single file |
| `package Foo --path` | whole package (bare flag) |

### Demo

```
$ dotnet-inspect package Newtonsoft.Json --path / --jsonl
{"path":"LICENSE.md","size":"1104"}
{"path":"README.md","size":"1963"}
{"path":"packageIcon.png","size":"8956"}

$ dotnet-inspect package Newtonsoft.Json --path "lib/net6.0/" --jsonl
{"path":"lib/net6.0/Newtonsoft.Json.dll","size":"723368"}
{"path":"lib/net6.0/Newtonsoft.Json.xml","size":"718249"}
```

## Notes

- New `PackageFileLister` (pure/testable) enumerates the already-extracted package and reports sizes via `FileInfo.Length`. It excludes zip plumbing (`.nuspec`, `_rels`, `[Content_Types]`, `.psmdcp`, `.signature.p7s`) and NuGet restore artifacts (`.nupkg`, `.nupkg.metadata`, `.nupkg.sha512`) so the listing reflects package **content**.
- `Files` is an opt-in (`ExplicitOnly`) section, so it never appears in the default view, per the verbosity contract. `--path` is sugar for `-S Files`.
- Sizes are **numeric** in lossless `--json`; row modes (`--jsonl`/`--tsv`) stringify per Markout convention.
- Removed dead `PopulateFilesForDetailedView` and the old `ListPackageFiles` early-exit. Updated tips and the library not-found hint to point at `--path`.

## Tests

- New `PackageFileListerTests` cover plumbing/restore-artifact exclusion, size reporting, sort order, and every `--path` semantic (root, glob, directory, exact file, bare directory).
- Full suite green: **1167 passed, 0 failed, 9 skipped** (ilasm-dependent).
