### PR TITLE
Pin index-from-end string property identity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -147,6 +147,18 @@ public class IndexFromEndPassTests
     }
 
     [Fact]
+    public void UserCharsAndLengthProperties_AreNotStringIndexFromEnd()
+    {
+        var function = BuildUserCharsLengthIndexFromEndShape();
+
+        new IndexFromEndPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<IndexFromEnd>());
+        Assert.Single(function.Descendants.OfType<Binary>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void HandWrittenLengthMinusConstant_IsNotRaised()
     {
         // `a[a.Length - 1]` re-loads the array directly (no receiver spill), so
@@ -157,5 +169,39 @@ public class IndexFromEndPassTests
         Assert.Empty(function.Descendants.OfType<IndexFromEnd>());
         var output = CSharpPrinter.Print(function).Output;
         Assert.Equal("return a[a.Length - 1];", output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    static IrFunction BuildUserCharsLengthIndexFromEndShape()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var userStringType = TypeRef.Definition("UserAssembly", "System", "String");
+        var lengthGetter = new MethodRef(userStringType, "get_Length", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var charsGetter = new MethodRef(userStringType, "get_Chars", charType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var receiverSlot = StoreStackSlot.DupSlotBase;
+        var index = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadProperty(lengthGetter, new LoadStackSlot(receiverSlot, userStringType), []),
+            new Constant(1, intType));
+        var chars = new LoadProperty(charsGetter, new LoadStackSlot(receiverSlot, userStringType), [index]);
+        var block = new Block();
+        block.Add(new Return(chars));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(charType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -122,6 +122,25 @@ public static class MemberIdentity
         && declaringType.TypeArguments is [var spanElement]
         && element.Equals(spanElement);
 
+    public static bool IsSpanLengthGetter(LoadProperty property)
+        => property is
+        {
+            HasInstance: true,
+            PropertyName: "Length",
+            Accessor:
+            {
+                HasThis: true,
+                Name: "get_Length",
+                TypeArguments.IsEmpty: true,
+                DeclaringType: var declaringType,
+                ParameterTypes.IsEmpty: true,
+                ReturnType: var returnType,
+            },
+            IndexArguments.Count: 0,
+        }
+        && IsSpanLikeType(declaringType)
+        && returnType.Equals(s_int);
+
     public static bool IsAsyncHelpersAwait(Call call)
         => !call.IsVirtual
             && IsStaticCoreLibraryMethod(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IndexFromEndPass.cs
@@ -28,7 +28,7 @@ public sealed class IndexFromEndPass : IIrPass
                 case StoreElement store:
                     TryRewrite(store.Array, store.Index, context.Stepper);
                     break;
-                case LoadProperty property when property is { HasInstance: true, PropertyName: "Chars", IndexArguments.Count: 1 }:
+                case LoadProperty property when MemberIdentity.IsStringCharsGetter(property):
                     TryRewrite(property.Instance!, property.IndexArguments[0], context.Stepper);
                     break;
                 case LoadProperty property when MemberIdentity.IsSpanIndexerGetter(property):
@@ -63,7 +63,8 @@ public sealed class IndexFromEndPass : IIrPass
     static IrExpression? LengthReceiver(IrExpression expression) => expression switch
     {
         ArrayLength length => length.Array,
-        LoadProperty { HasInstance: true, PropertyName: "Length" } property => property.Instance,
+        LoadProperty property when MemberIdentity.IsStringLengthGetter(property)
+            || MemberIdentity.IsSpanLengthGetter(property) => property.Instance,
         _ => null,
     };
 


### PR DESCRIPTION
## Summary
- gate string index-from-end recovery on exact corelib string Chars/Length identity
- add exact span Length identity for span index-from-end recovery
- add a synthetic user-type System.String lookalike near-miss that must stay lowered

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.IndexFromEndPassTests
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore
- dotnet build src/dotnet-inspect -c Release --no-restore --nologo