### PR TITLE
[codex] Raise from-end open string ranges

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -210,21 +210,41 @@ public class RangeFromGetSubArrayPassTests
     }
 
     [Fact]
-    public void FromEndOpenStringRange_IsNotRaised()
+    public void FromEndOpenStringRange_RaisesToRangeIndexer()
     {
         var function = Raised(nameof(RangeAdversarialSamples.StringRangeFromEnd), typeof(RangeAdversarialSamples));
 
-        Assert.Empty(function.Descendants.OfType<SliceExpression>());
-        Assert.Contains("Substring", CSharpPrinter.Print(function).Output);
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.IsType<IndexFromEnd>(slice.Range.Start);
+        Assert.False(slice.Range.HasEnd);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return s[^i..];", output);
+        Assert.DoesNotContain("Substring", output);
     }
 
     [Fact]
-    public void FromEndOpenSpanRange_IsNotRaised()
+    public void FromEndOpenSpanRange_RaisesToRangeIndexer()
     {
         var function = Raised(nameof(RangeAdversarialSamples.SpanRangeFromEnd), typeof(RangeAdversarialSamples));
 
+        var slice = Assert.Single(function.Descendants.OfType<SliceExpression>());
+        Assert.IsType<IndexFromEnd>(slice.Range.Start);
+        Assert.False(slice.Range.HasEnd);
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return s[^i..];", output);
+        Assert.DoesNotContain(".Slice", output);
+    }
+
+    [Fact]
+    public void FromEndOpenRange_RequiresSameHiddenReceiver()
+    {
+        var function = BuildFromEndOpenWithMismatchedReceiver();
+
+        new RangeFromGetSubArrayPass().Run(function, PassContext.None);
+
         Assert.Empty(function.Descendants.OfType<SliceExpression>());
-        Assert.Contains(".Slice", CSharpPrinter.Print(function).Output);
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "Substring");
+        function.CheckInvariant();
     }
 
     [Fact]
@@ -290,6 +310,36 @@ public class RangeFromGetSubArrayPassTests
         var signature = new MethodSignature(
             s_string,
             [new Parameter("s", s_string), new Parameter("i", s_int), new Parameter("j", s_int), new Parameter("k", s_int)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [s_int], body);
+    }
+
+    static IrFunction BuildFromEndOpenWithMismatchedReceiver()
+    {
+        var substring = new MethodRef(s_string, "Substring", s_string, [s_int], HasThis: true);
+        var length = new MethodRef(s_string, "get_Length", s_int, [], HasThis: true);
+        var block = new Block();
+        block.Add(new StoreStackSlot(256, new LoadArgument(0, "s", s_string)));
+        block.Add(new StoreLocal(0, s_int, new LoadArgument(2, "i", s_int)));
+        block.Add(new StoreStackSlot(257, new LoadArgument(1, "t", s_string)));
+        block.Add(new Return(new Call(
+            substring,
+            isVirtual: true,
+            [
+                new LoadStackSlot(257, s_string),
+                new Binary(
+                    BinaryKind.Subtract,
+                    isChecked: false,
+                    isUnsigned: false,
+                    new LoadProperty(length, new LoadStackSlot(256, s_string), []),
+                    new LoadLocal(0, s_int)),
+            ])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            s_string,
+            [new Parameter("s", s_string), new Parameter("t", s_string), new Parameter("i", s_int)],
             HasThis: false,
             GenericParameterCount: 0);
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [s_int], body);

--- a/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
@@ -14,8 +14,8 @@ internal sealed class RangeRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:System.Range", "MemberIdentity.IsCoreLibraryType"),
                 new FactPrimitive("member.corelib-identity:System.Index", "MemberIdentity.IsCoreLibraryType"),
             ],
-            PositiveCoverage: "RangeFromGetSubArrayPassTests array range endpoint matrix plus string/span two-bound fixtures",
-            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike and manual/one-sided Substring/Slice negatives",
-            MissingDiscriminator: "one-sided and from-end string/span forms plus broader manual Substring/Slice calls remain unraised"),
+            PositiveCoverage: "RangeFromGetSubArrayPassTests array range endpoint matrix plus string/span two-bound and from-end open fixtures",
+            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike, manual/one-sided Substring/Slice negatives, and mismatched receiver-spill negative",
+            MissingDiscriminator: "ordinary one-sided string/span forms plus broader manual Substring/Slice calls remain unraised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -100,7 +100,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess => new();
     [Completeness(CompletenessLevel.None, "declined, not owed: a query expression is translated to Enumerable.Where/Select/SelectMany/... calls during binding, before any lowering, so it leaves no IL anchor distinct from the equivalent fluent chain. It is recovered as that fluent method chain (the runtime-preferred form); re-sugaring to from..select would invent a distinction the IL does not make (taste rule case 3, no IL anchor)")]
     public static Unhandled Query => default!;
-    [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...), plus compiler-spilled string/span two-bound Substring/Slice forms (s[i..j]); one-sided and from-end string/span forms plus broader manual Substring/Slice calls not raised")]
+    [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...), plus compiler-spilled string/span two-bound Substring/Slice forms (s[i..j]) and from-end open forms (s[^i..]); ordinary one-sided string/span forms plus broader manual Substring/Slice calls not raised")]
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static StackAllocSpanPass StackAlloc => new();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -65,6 +65,8 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
             {
                 if (TryRaiseFromStartRange(function, block, i, stepper))
                     return true;
+                if (TryRaiseFromEndOpenRange(function, block, i, stepper))
+                    return true;
             }
         }
 
@@ -100,8 +102,48 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
         return true;
     }
 
+    static bool TryRaiseFromEndOpenRange(IrFunction function, Block block, int returnIndex, Stepper stepper)
+    {
+        if (returnIndex < 2
+            || block.Children[returnIndex - 2] is not StoreLocal offsetStore
+            || HasSourceLocalName(function, offsetStore.Index)
+            || !offsetStore.Type.Equals(TypeRef.CoreLib("System", "Int32"))
+            || block.Children[returnIndex - 1] is not StoreStackSlot receiverStore
+            || block.Children[returnIndex] is not Return { Value: Call call }
+            || !IsStringOrSpanRangeCall(call)
+            || call.Callee.ParameterTypes.Length != 1
+            || call.Arguments is not [var receiver, Binary { Kind: BinaryKind.Subtract } start]
+            || receiver is not LoadStackSlot receiverLoad
+            || receiverLoad.Slot != receiverStore.Slot
+            || LengthReceiver(start.Left) is not { } lengthReceiver
+            || !PlaceIdentity.SameStackSlot(receiver, lengthReceiver)
+            || start.Right is not LoadLocal offsetLoad
+            || offsetLoad.Index != offsetStore.Index)
+        {
+            return false;
+        }
+
+        var offset = (IrExpression)offsetStore.DetachChildren()[0];
+        var rangeStart = new IndexFromEnd(offset);
+        var sourceReceiver = (IrExpression)receiverStore.DetachChildren()[0];
+        var slice = new SliceExpression(sourceReceiver, new RangeExpression(rangeStart, end: null), call.ResultType);
+        slice.InheritSourceOffset(call);
+
+        stepper.StepOver("raise compiler-spilled string/span from-end Slice range to a[^n..] indexer", call);
+        call.ReplaceWith(slice);
+        offsetStore.Detach();
+        receiverStore.Detach();
+        return true;
+    }
+
     static bool IsStringOrSpanRangeCall(Call call)
         => MemberIdentity.IsStringSubstring(call) || MemberIdentity.IsSpanSlice(call);
+
+    static IrExpression? LengthReceiver(IrExpression expression) => expression switch
+    {
+        LoadProperty { HasInstance: true, PropertyName: "Length" } property => property.Instance,
+        _ => null,
+    };
 
     static bool HasSourceLocalName(IrFunction function, int index)
         => index >= 0


### PR DESCRIPTION
## Summary

- Raise compiler-spilled string/span from-end open range lowerings like `s[^i..]` from one-argument `Substring`/`Slice` calls.
- Keep ordinary one-sided `Substring`/`Slice` forms lowered unless the hidden offset and receiver-spill evidence proves the range lowering.
- Add a mismatched receiver-spill negative fixture and narrow the Range ledger/fact gap text.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*RangeFromGetSubArrayPassTests*" -method "*LoweringCoverageTests*" -method "*LoweringFactCatalogTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*FidelityGateTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `git diff --check origin/main...HEAD`
