### PR TITLE
Document breadth-hunt transition guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ The current decompiler priority is high-value hardening:
 
 - Treat a near-full scorecard as a signal to do more adversarial passes over
   recent or broad raises.
+- When the obvious breadth-hunt queue dries up, switch to stabilization,
+  curation, measured validity/corpus bugs, or one explicitly scoped large climb;
+  do not keep opening tiny overlapping raise PRs for motion.
 - Sharpen `Partial` ledger rows instead of adding easy scorecard rows.
 - Run curator passes when uncoordinated agents land raises: keep scorecard
   entries positive-only, sidecar coverage current, and adversarial fixtures

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -136,6 +136,24 @@ one-off cleanup, or broad rewrites that do not move a measured signal. When
 choosing among similar targets, pick the one with the clearest discriminator and
 the smallest adversarial fixture pair.
 
+When the obvious target queue dries up, stop the random breadth hunt. A run that
+mostly finds stale ledger wording, tiny pins, or overlapping branch ideas has
+crossed from discovery into coordination overhead. At that point, pick one of
+three modes deliberately:
+
+| Mode | Use when | Good output |
+| --- | --- | --- |
+| **Stabilization** | Several PRs are open or recently merged in adjacent pass families. | Merge-conflict fixes, CI follow-through, and no new feature overlap. |
+| **Curation** | Recent raises changed the truth of sidecars, ledger notes, or test intent. | Small PRs that update scorecard/ledger/sidecar/test classification only. |
+| **Scoped climb** | The next target is a large frontier item rather than a one-PR slice. | A short design plan and ownership of one area, not drive-by broad edits. |
+
+Prefer validity/corpus bug hunts while the PR queue is busy; they are usually
+independent and grounded by failing methods. Do not start another small raise in
+a pass family that already has active branches unless it directly fixes one of
+them. If choosing a large climb — classic async state machines,
+positional/list patterns, deeper state-machine/PDB work, or checked-block
+synthesis — write down the slice and expected discriminators before coding.
+
 Read progress as **leverage**, not elapsed time. The ledger gives breadth: `None`
 rows are owed mechanisms, `Partial` rows are the live frontier, and `Full` rows
 are solved enough for the current lowering category. The scorecard gives
@@ -160,6 +178,12 @@ Treat a near-full scorecard as a mode switch. The default question changes from
 over-match?" Good follow-up targets are recent broad raises, pass families with
 many `Partial` notes, and places where a single missing discriminator could turn
 source-like output into different IL.
+
+When the scorecard is fully recovered, the default mode changes again: do not add
+more easy positives just to keep motion visible. Either stabilize/curate the
+recent wave, take validity/fidelity bugs from measured signals, or explicitly
+scope a larger climb. A new scorecard row should represent a meaningful frontier,
+not a small variant of an already-recovered shape.
 
 ### Curating uncoordinated raise work
 


### PR DESCRIPTION
## Summary
- add guidance for ending random breadth-hunt target selection when small targets dry up
- define stabilization, curation, and scoped-climb modes
- update AGENTS.md current priorities to discourage tiny overlapping raise PRs for motion

## Validation
- npx markdownlint-cli AGENTS.md docs/decompiler-quality.md