### PR TITLE
Unify a bitwise ulong/long operand pair on the unsigned type

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -309,6 +309,13 @@ public class CfgSampleClass
 
     public static void SetCharElement(char[] a, int v) => a[0] = (char)v;
 
+    // A bitwise AND of a ulong against a high-bit mask: `ldc.i8 0xC000…; and`. The
+    // mask's `ldc.i8` imports as a signed long, so the operand pair is ulong/long
+    // — which has no C# common type (`value & mask` is CS0019). The printer must
+    // unify on ulong (`value & unchecked((ulong)(-4611…))`), and the sign-agnostic
+    // `and` recompiles to the same opcode over the same bit pattern.
+    public static ulong MaskHighBits(ulong value) => value & 0xC000000000000000UL;
+
     // A comparison result returned from an int-returning method (`cgt.un; ret`,
     // as in byte.Sign / Convert.ToInt32(bool)): the bool flows into an integer
     // target. C# has no implicit bool→int, so it must spell `value > 0 ? 1 : 0`,

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -741,6 +741,20 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void BitwiseUlongLongMismatch_UnifiesOnUnsignedOperand()
+    {
+        // `ulong & <ldc.i8 high-bit>` imports as a ulong/long operand pair — no C#
+        // common type (CS0019). The printer must unify on ulong, spelling the
+        // out-of-range constant with `unchecked((ulong)(…))`, never a bare
+        // `value & -4611…`. The sign-agnostic `and` round-trips opcode-exact.
+        var function = ImportFixture(nameof(CfgSampleClass.MaskHighBits));
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("unchecked((ulong)(-4611686018427387904))", output);
+    }
+
+    [Fact]
     public void ElementAccess_ImportsTypedLoadAndStore()
     {
         var load = ImportFixture(nameof(CfgSampleClass.FirstElement));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -16,6 +16,20 @@ public sealed partial class CSharpPrinter
 {
     string BinaryText(Binary binary)
     {
+        // A bitwise And/Or/Xor on a {ulong/nuint} + {long/nint} pair: the IL op
+        // (and/or/xor) is sign-agnostic, but C# has no common type for the
+        // 64-bit/native signed+unsigned pair, so a bare `a & b` is CS0019. Unify
+        // on the unsigned operand's type — casting the signed side to it is a
+        // faithful bit reinterpret, and CastValue spells an out-of-range constant
+        // with the unchecked form (`_dateData & unchecked((ulong)(-4611…))`).
+        if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
+            && WideSignednessMismatch(binary.Left.ResultType, binary.Right.ResultType) is { } unifyType)
+        {
+            string unifiedLeft = Equals(binary.Left.ResultType, unifyType) ? Operand(binary.Left) : CastValue(binary.Left, unifyType);
+            string unifiedRight = Equals(binary.Right.ResultType, unifyType) ? Operand(binary.Right) : CastValue(binary.Right, unifyType);
+            string unified = $"{unifiedLeft} {BinaryOperator(binary)} {unifiedRight}";
+            return binary.IsChecked ? $"checked({unified})" : unified;
+        }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
         // float, where .un means unordered, not unsigned) print plain.
@@ -32,6 +46,19 @@ public sealed partial class CSharpPrinter
         // the recompiled IL keeps the .ovf opcode. A nested checked binary
         // re-wraps redundantly but emits the same opcode stream.
         return binary.IsChecked ? $"checked({text})" : text;
+    }
+
+    /// <summary>
+    /// The unsigned member of a <c>{UInt64/UIntPtr}</c> + <c>{Int64/IntPtr}</c>
+    /// operand pair (either order) — the no-common-type signed/unsigned 64-bit or
+    /// native combination C# rejects (CS0019) but a sign-agnostic bitwise IL op
+    /// permits; null when the operands are not that mismatch.
+    /// </summary>
+    static TypeRef? WideSignednessMismatch(TypeRef? a, TypeRef? b)
+    {
+        static bool Unsigned(TypeRef? t) => t is { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "UInt64" or "UIntPtr" };
+        static bool Signed(TypeRef? t) => t is { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "Int64" or "IntPtr" };
+        return Unsigned(a) && Signed(b) ? a : Signed(a) && Unsigned(b) ? b : null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

The `--validity-check` CS0019 bucket (operator not applicable) includes a clean, systematic family: a bitwise And/Or/Xor on a 64-bit/native signed+unsigned pair. `DateTime.get_InternalKind` decompiles to:

```csharp
return _dateData & -4611686018427387904;        // CS0019: operator & on ulong and long
```

`_dateData` is `ulong`; the mask's `ldc.i8` imports as a signed `long`. C# has no common type for `{ulong/nuint}` + `{long/nint}`, so the bare `a & b` doesn't bind.

## Fix

The IL op (`and`/`or`/`xor`) is sign-agnostic, so unifying on the unsigned operand's type is a faithful bit reinterpret. `BinaryText` now casts the signed side to the unsigned type via `CastValue`, which already spells an out-of-range constant with `unchecked`:

```csharp
return _dateData & unchecked((ulong)(-4611686018427387904));
```

Scoped to the no-common-type pair only (`UInt64`/`UIntPtr` × `Int64`/`IntPtr`); narrower mixes (`uint`/`int`) already promote to `long` and are untouched.

## Soundness

- **Faithful.** `and`/`or`/`xor` are bit-level and sign-neutral; the `unchecked((ulong)(-4611…))` constant is the same 64-bit pattern as `ldc.i8 -4611…`, so the recompiled `ldc.i8 … ; and` is identical. Verified by the new fixture round-tripping opcode-exact through the fidelity gate.
- **Printer-only.** No IR change, so `function.Fidelity` and the corpus Full-fidelity floor are untouched.
- **Bitwise only.** `&`/`|`/`^` are the operators where signedness is irrelevant to the opcode. Arithmetic and shifts (where it is not) keep their existing handling.

## Breadth & validation

- Corpus scan: **223 sites across 140 CoreLib methods** (DateTime bit fields, `Math.Abs`, `Enum.HasFlag`, the `Decimal`/`DecCalc` helpers, …).
- Same-base validity defect diff (`--diff-validity-defects`): bound methods lose CS0019, **zero regressions** (the rest are past the 4000-method bind cap; the IR scan confirms them).
- Decompiler suite green (**748**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests`.

## Tests

New `MaskHighBits` fixture (`value & 0xC000000000000000UL`) reproduces the ulong/long-`ldc.i8` shape; `IrImporterTests` asserts the operand renders as `unchecked((ulong)(-4611686018427387904))` at Full fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)