### PR TITLE
Reconcile signedness in a mixed signed/unsigned bitwise operator

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -49,6 +49,12 @@ public class CfgSampleClass
     // operand must be parenthesized: `(nint)(-1)`.
     public static nint NegativeNativeInt() => -1;
 
+    // A bitwise `|` between a ulong and a long: csc reinterprets the long with a
+    // no-op `(ulong)` cast that emits no conv, so the IL `or` carries a ulong and
+    // a long operand. C# rejects `mask | flag` across signed/unsigned (CS0019),
+    // so the printer must re-insert the unsigned reinterpret: `mask | (ulong)flag`.
+    public static ulong OrLongIntoULong(ulong mask, long flag) => mask | (ulong)flag;
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -115,6 +115,7 @@ public class FidelityGateTests
         "IsNotNullReference",
         "LineSeparatorLiteral",
         "NegativeNativeInt",
+        "OrLongIntoULong",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
@@ -1,0 +1,29 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A bitwise `&`/`|`/`^` between a signed and an unsigned integer of the same
+// stack width (e.g. `ulong | long`) is CS0019 — neither operand converts to the
+// other — but the bit result is identical under either interpretation, so the
+// printer reinterprets the signed operand as unsigned (`mask | (ulong)flag`),
+// which emits no opcode.
+public class MixedSignBitwiseTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void ULongOrLong_ReinterpretsSignedOperandAsUnsigned()
+    {
+        var output = Render(nameof(CfgSampleClass.OrLongIntoULong));
+
+        Assert.Contains("mask | (ulong)flag", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -21,9 +21,18 @@ public sealed partial class CSharpPrinter
         // float, where .un means unordered, not unsigned) print plain.
         bool castBoth = binary.IsUnsigned && binary.Kind is BinaryKind.Divide or BinaryKind.Remainder;
         bool castLeft = castBoth || (binary.IsUnsigned && binary.Kind is BinaryKind.ShiftRight);
-        string left = castLeft ? UnsignedOperand(binary.Left) : Operand(binary.Left);
+        // A bitwise &/|/^ between a signed and an unsigned integer of the same
+        // stack width is CS0019 (no implicit signed<->unsigned conversion), but
+        // the bit result is identical under either interpretation. Reinterpret
+        // the signed operand as unsigned — `S_0 | (ulong)S_1` — which is a no-op
+        // (same-width) reinterpret, so the `or`/`and`/`xor` opcode is unchanged.
+        bool mixedSignBitwise = MixedSignBitwise(binary);
+        string left = mixedSignBitwise ? BitwiseUnsignedOperand(binary.Left)
+            : castLeft ? UnsignedOperand(binary.Left)
+            : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
+            : mixedSignBitwise ? BitwiseUnsignedOperand(binary.Right)
             : castBoth ? UnsignedOperand(binary.Right)
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
@@ -32,6 +41,69 @@ public sealed partial class CSharpPrinter
         // the recompiled IL keeps the .ovf opcode. A nested checked binary
         // re-wraps redundantly but emits the same opcode stream.
         return binary.IsChecked ? $"checked({text})" : text;
+    }
+
+    /// <summary>
+    /// True when a bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> has one signed and one
+    /// unsigned integer operand of the same stack width (e.g. <c>ulong | long</c>).
+    /// C# rejects that pair (CS0019) because neither converts to the other, yet
+    /// the bit result is the same under either interpretation, so the printer
+    /// reinterprets the signed operand as unsigned. Restricted to same-width
+    /// signed/unsigned integer pairs — bool/char are excluded by
+    /// <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
+    /// </summary>
+    bool MixedSignBitwise(Binary binary)
+    {
+        if (binary.Kind is not (BinaryKind.And or BinaryKind.Or or BinaryKind.Xor))
+            return false;
+        var left = EffectiveType(binary.Left);
+        var right = EffectiveType(binary.Right);
+        var family = TypeFamilies.Of(left);
+        if (family is not (StackFamily.I4 or StackFamily.I8 or StackFamily.I) || family != TypeFamilies.Of(right))
+            return false;
+        bool leftSigned = TypeFamilies.UnsignedCastKeyword(left) is not null;
+        bool rightSigned = TypeFamilies.UnsignedCastKeyword(right) is not null;
+        return (leftSigned && TypeFamilies.IsUnsignedIntegerPrimitive(right))
+            || (rightSigned && TypeFamilies.IsUnsignedIntegerPrimitive(left));
+    }
+
+    /// <summary>
+    /// Reinterprets a bitwise operand as its unsigned counterpart for the
+    /// signed/unsigned reconciliation in <see cref="MixedSignBitwise"/>. An
+    /// already-unsigned operand prints plain; an operand that reduces to a
+    /// negative constant (possibly behind conv nodes) gets the
+    /// <c>unchecked((uint)(-x))</c> bit spelling so the out-of-range cast is
+    /// legal (CS0221); any other signed operand takes the same-width reinterpret
+    /// cast, which emits no opcode.
+    /// </summary>
+    string BitwiseUnsignedOperand(IrExpression operand)
+    {
+        var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
+        if (unsigned is null)
+            return Operand(operand);
+        string cast = $"({TypeText(unsigned)}){Operand(operand)}";
+        return TryGetIntegerConstant(operand, out long value) && !TypeFamilies.ConstantFits(value, unsigned)
+            ? $"unchecked({cast})"
+            : cast;
+    }
+
+    /// <summary>The integer value an expression reduces to, peeling unchecked conv nodes; false when it is not a constant.</summary>
+    static bool TryGetIntegerConstant(IrExpression expression, out long value)
+    {
+        while (expression is Convert { IsChecked: false } convert)
+            expression = convert.Operand;
+        switch (expression)
+        {
+            case Constant { Value: int i }:
+                value = i;
+                return true;
+            case Constant { Value: long l }:
+                value = l;
+                return true;
+            default:
+                value = 0;
+                return false;
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -190,6 +190,16 @@ public static class TypeFamilies
                 _ => null,
             }
             : null;
+
+    /// <summary>
+    /// True for the unsigned fixed/native integer primitives (byte, ushort,
+    /// uint, ulong, nuint). Excludes bool and char, which are unsigned in
+    /// representation but are not the integers a signed/unsigned bitwise
+    /// reconciliation should treat as the unsigned partner.
+    /// </summary>
+    public static bool IsUnsignedIntegerPrimitive(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && type.Name is "Byte" or "UInt16" or "UInt32" or "UInt64" or "UIntPtr";
 }
 
 /// <summary>


### PR DESCRIPTION
## Problem

`--validity-check` flags a recurring **CS0019** cluster: `Operator '|'/'&'/'^'
cannot be applied to operands of type 'long' and 'ulong'` (and the mirror).
Examples: `Double::get_Significand`, `Double::Hypot`, `Double::TanForIntervalPiBy4`,
`DateTime::.ctor`. The printer rendered `S_0 | S_1` where one operand is `ulong`
and the other `long` — C# rejects that pair because neither converts to the other.

## Fix

For a bitwise `&`/`|`/`^` whose operands are a signed and an unsigned integer of
the **same stack width**, the printer reinterprets the signed operand as its
unsigned counterpart: `S_0 | (ulong)S_1`. The bit result is identical under
either interpretation, and the same-width cast emits no opcode, so the
`or`/`and`/`xor` instruction is unchanged.

A signed operand that reduces to a **negative constant** (possibly behind `conv`
nodes) gets the `unchecked((uint)(-x))` bit spelling instead of a bare cast, so
the out-of-range reinterpret is legal (avoids CS0221).

## Soundness

Restricted to same-width signed/unsigned integer pairs; `bool`/`char` are
excluded. For bitwise operators signedness never changes the result bits, so the
reinterpret is faithful — confirmed by the opcode-exact `OrLongIntoULong` pin.

## Numbers

- Semantic-defect methods **221 → 213 (−8)**.
- **0 methods newly broken** (verified by a method-level diff of the failing set);
  newly passing include `get_Significand`, `Hypot`, `TanForIntervalPiBy4`,
  `DateTime::.ctor`, `DecCalc::GetHashCode`.
- Full malformed flat (218); recompile inventory flat (40854/41012).
- 747 decompiler + 1157 product tests green.

Found via `--validity-check`.
