### PR TITLE
Raise multi-property is patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -892,6 +892,26 @@ public class CfgSampleClass
         return 0;
     }
 
+    public sealed class PatternPoint
+    {
+        public int X { get; init; }
+        public int Y { get; init; }
+    }
+
+    public static bool IsPatternMultiProperty(object o) => o is PatternPoint { X: 1, Y: 2 };
+
+    public static bool IsPatternMultiPropertyMixed(object o) => o is PatternPoint { X: > 0, Y: 2 };
+
+    public static int IsPatternManualAsAndPropertiesWithUse(object o)
+    {
+        var point = o as PatternPoint;
+        if (point is not null && point.X == 1 && point.Y == 2)
+            return point.X + point.Y;
+        return 0;
+    }
+
+    public static bool IsPatternDuplicateProperty(object o) => o is PatternPoint { X: > 0, X: < 10 };
+
     // Genuine conjunction: the relational comparison is against a parameter, not
     // a constant, so it has no property sub-pattern form and stays a flat `&&`
     // with the pattern binding visible.

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -42,6 +42,7 @@ public class IdiomShapeScorecardTests
         new("BooleanFoldingPass", nameof(CfgSampleClass.NullCoalesce), SyntaxKind.CoalesceExpression, [SyntaxKind.IfStatement]),
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternPropertyGreater), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
+        new("IsPatternPass", nameof(CfgSampleClass.IsPatternMultiProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -104,6 +104,52 @@ public class IsPatternPassTests
     }
 
     [Fact]
+    public void MultiPropertyPattern_RendersSinglePropertyPatternClause()
+    {
+        var function = Raised(nameof(CfgSampleClass.IsPatternMultiProperty));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("o is PatternPoint { X: 1, Y: 2 }", output);
+        Assert.DoesNotContain("&&", output);
+        Assert.DoesNotContain(".X == 1", output);
+        Assert.DoesNotContain(".Y == 2", output);
+    }
+
+    [Fact]
+    public void MultiPropertyPattern_AllowsMixedRelationalAndEqualitySubpatterns()
+    {
+        var function = Raised(nameof(CfgSampleClass.IsPatternMultiPropertyMixed));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("o is PatternPoint { X: > 0, Y: 2 }", output);
+        Assert.DoesNotContain("&&", output);
+    }
+
+    [Fact]
+    public void ManualAsAndPropertyChecks_WithLocalUse_StaysFlatChain()
+    {
+        var function = Raised(nameof(CfgSampleClass.IsPatternManualAsAndPropertiesWithUse));
+
+        Assert.Empty(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("point is not null && point.X == 1 && point.Y == 2", output);
+        Assert.DoesNotContain("{ X: 1, Y: 2 }", output);
+    }
+
+    [Fact]
+    public void DuplicatePropertyPattern_StaysFlatChain()
+    {
+        var function = Raised(nameof(CfgSampleClass.IsPatternDuplicateProperty));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("o is PatternPoint", output);
+        Assert.DoesNotContain("{ X: > 0, X: < 10 }", output);
+    }
+
+    [Fact]
     public void PropertyPattern_WhenPatternLocalIsUsedInBody_StaysFlat()
     {
         var function = Raised(nameof(CfgSampleClass.IsPatternPropertyWithBindingUse));

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -13,6 +13,7 @@ public class LoweringFactCatalogTests
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Await");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ForEachStatement");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Index");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.IsPatternOperator");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ObjectOrCollectionInitializerExpression");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class IsPatternRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.IsPatternOperator)),
+            typeof(IsPatternPass),
+            [
+                new FactPrimitive("place.local-scope", "IsPatternPass.ReferencedOnlyWithin"),
+                new FactPrimitive("property-subpattern-comparison", "CSharpPrinter.TryPropertySubpattern"),
+            ],
+            PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures",
+            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, and duplicate-property negatives",
+            MissingDiscriminator: "positional/list sub-patterns and non-integral relational sub-patterns remain unraised"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1308,24 +1308,50 @@ public sealed partial class CSharpPrinter
 
     string? TryPropertyPatternText(LogicalBinary logical)
     {
-        if (logical.Kind != LogicalKind.And
-            || logical.Left is not IsPattern pattern
-            || !TryPropertySubpattern(logical.Right, pattern.LocalIndex, out var propertyName, out var subpattern))
+        if (logical.Kind != LogicalKind.And)
         {
             return null;
         }
 
-        return $"{Operand(pattern.Value)} is {TypeText(pattern.Type)} {{ {propertyName}: {subpattern} }}";
+        var conjuncts = new List<IrExpression>();
+        CollectConjuncts(logical, conjuncts);
+        if (conjuncts is not [IsPattern pattern, .. var rest])
+            return null;
+
+        var subpatterns = new List<(string PropertyName, string Subpattern)>();
+        foreach (var conjunct in rest)
+        {
+            if (!TryPropertySubpattern(conjunct, pattern.LocalIndex, out var propertyName, out var subpattern))
+                return null;
+            subpatterns.Add((propertyName, subpattern));
+        }
+        if (subpatterns.Count == 0
+            || subpatterns.Select(p => p.PropertyName).Distinct(StringComparer.Ordinal).Count() != subpatterns.Count)
+        {
+            return null;
+        }
+
+        return $"{Operand(pattern.Value)} is {TypeText(pattern.Type)} {{ {string.Join(", ", subpatterns.Select(p => $"{p.PropertyName}: {p.Subpattern}"))} }}";
+    }
+
+    static void CollectConjuncts(IrExpression expression, List<IrExpression> conjuncts)
+    {
+        if (expression is LogicalBinary { Kind: LogicalKind.And } logical)
+        {
+            CollectConjuncts(logical.Left, conjuncts);
+            CollectConjuncts(logical.Right, conjuncts);
+            return;
+        }
+
+        conjuncts.Add(expression);
     }
 
     /// <summary>
     /// Folds a single comparison of the pattern local's property against a
-    /// constant into a property sub-pattern: equality becomes the bare constant
+    /// constant into a property sub-pattern. Equality becomes the bare constant
     /// (<c>{ P: 5 }</c>); the four relational kinds become a relational pattern
-    /// (<c>{ P: &gt; 5 }</c>). Only fires for a lone comparison whose entire
-    /// other operand is the constant, so the pattern local is used exactly once
-    /// and dropping its binding is sound. Floats are excluded: their unordered
-    /// (NaN) comparison semantics are not reproduced by a relational pattern.
+    /// (<c>{ P: &gt; 5 }</c>). Floats are excluded: their unordered (NaN)
+    /// comparison semantics are not reproduced by a relational pattern.
     /// </summary>
     static bool TryPropertySubpattern(IrExpression expression, int patternLocal, out string propertyName, out string subpattern)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -82,13 +82,17 @@ public sealed class IsPatternPass : IIrPass
     /// </summary>
     static TestSite? FindTest(IrNode next, int index)
     {
-        // Short-circuit form: `t != null && rest` — the leading conjunct is the
-        // bare truthy load of the pattern local; the right operand is the scope
-        // entered only when the pattern matched.
+        // Short-circuit form: `t != null && rest` — the leading conjunct of the
+        // whole && chain is the bare truthy load of the pattern local; the full
+        // chain is the scope entered only when the pattern matched.
         foreach (var logical in next.Descendants.OfType<LogicalBinary>())
         {
-            if (logical.Kind == LogicalKind.And && logical.Left is LoadLocal andLoad && andLoad.Index == index)
-                return new TestSite(logical.Left, logical.Right);
+            if (logical.Kind == LogicalKind.And
+                && LeftmostConjunct(logical) is LoadLocal andLoad
+                && andLoad.Index == index)
+            {
+                return new TestSite(andLoad, logical);
+            }
         }
 
         // Statement-guard form: `if (t != null) { ...t... }` — the whole
@@ -97,6 +101,14 @@ public sealed class IsPatternPass : IIrPass
             return new TestSite(guard.Condition, guard.Then);
 
         return null;
+    }
+
+    static IrExpression LeftmostConjunct(LogicalBinary logical)
+    {
+        var current = logical.Left;
+        while (current is LogicalBinary { Kind: LogicalKind.And } nested)
+            current = nested.Left;
+        return current;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -80,7 +80,7 @@ internal static class LoweringCoverage
     public static IndexFromEndPass Index => new();
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and property-pattern equality and relational sub-patterns (`value is T { P: constant }`, `value is T { P: > constant }`); positional/list sub-patterns, multi-property patterns, and non-integral relational sub-patterns not raised")]
+    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and property-pattern equality/relational sub-patterns, including same-local multi-property conjunctions (`value is T { P: constant, Q: > constant }`); positional/list sub-patterns and non-integral relational sub-patterns not raised")]
     public static IsPatternPass IsPatternOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LabeledStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal => default!;


### PR DESCRIPTION
## Summary
- fold same-local property-check conjunctions into multi-property `is` patterns
- preserve local-use manual `as` + property checks and duplicate-property cases
- update IsPattern scorecard, ledger, and sidecar facts

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`