### PR TITLE
Flag the declared README in the Files section + --path @readme (#889)

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -158,6 +158,7 @@ Use `package` for NuGet package structure and registry-backed signals. Use `libr
 dnx dotnet-inspect -y -- package System.Text.Json -S Signals
 dnx dotnet-inspect -y -- package System.Text.Json -S "Library Files"
 dnx dotnet-inspect -y -- package System.Text.Json --path "*.md" --jsonl
+dnx dotnet-inspect -y -- package System.Text.Json --path @readme --json
 dnx dotnet-inspect -y -- package Aspire.Azure.AI.OpenAI --library -S @Integrations
 dnx dotnet-inspect -y -- library System.Text.Json -S Signals
 dnx dotnet-inspect -y -- library System.Text.Json -S Switches
@@ -170,7 +171,7 @@ Use `package Foo --library` to inspect the package's primary DLL when it is unam
 
 Use `-S Switches` when runtime feature switches or compatibility switches may affect behavior.
 
-List package contents with the opt-in `Files` section: `-S Files` for the whole package with uncompressed sizes, or `--path` to scope it. `--path /` lists root files only, `--path "lib/net8.0/"` a directory's immediate children, `--path "*.md"` globs across the package (handy for spotting oversized README/docs), and `--path README.md` a single file. Sizes are read from the package layout — no file contents are fetched.
+List package contents with the opt-in `Files` section: `-S Files` for the whole package with uncompressed sizes, or `--path` to scope it. `--path /` lists root files only, `--path "lib/net8.0/"` a directory's immediate children, `--path "*.md"` globs across the package (handy for spotting oversized README/docs), `--path README.md` a single file, and `--path @readme` the package's declared readme whatever its filename (e.g. `PACKAGE.md`, `package-readme.md`). Sizes are read from the package layout — no file contents are fetched. Use `--json` for a lossless row (numeric `size`, boolean `is_readme`); `--jsonl`/`--tsv` stringify those fields.
 
 `library X -S Signals` resolves SourceLink by acquiring a missing PDB. Per-source-file reachability is opt-in: add `-S "SourceLink Availability"` and `-S "SourceLink Missing Files"` for HTTP HEAD checks, or `-S "SourceLink Integrity"` to download source files and compare checksums. For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -435,6 +435,23 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PreprocessArgs_EscapesAtReadmePathValue_ToDodgeResponseFiles()
+    {
+        // A leading '@' on --path would otherwise be consumed by System.CommandLine
+        // as a response-file token, so it is escaped during preprocessing.
+        var result = CommandLineBuilder.PreprocessArgs(["package", "Foo", "--path", "@readme"]);
+
+        Assert.Equal(["package", "Foo", "--path", "__dotnet_inspect_at__readme"], result);
+    }
+
+    [Fact]
+    public void PreprocessArgs_DoesNotEscapeNonAtPathValue()
+    {
+        var args = new[] { "package", "Foo", "--path", "lib/" };
+        Assert.Equal(args, CommandLineBuilder.PreprocessArgs(args));
+    }
+
+    [Fact]
     public void PreprocessArgs_WithDllFile_PrependsLibrary()
     {
         var args = new[] { "artifacts/bin/Foo/debug/Foo.dll", "--json" };

--- a/src/dotnet-inspect.Tests/PackageFileListerTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFileListerTests.cs
@@ -123,4 +123,73 @@ public class PackageFileListerTests
         Assert.Single(result);
         Assert.Equal("lib/net6.0/Foo.dll", result[0].Path);
     }
+
+    [Fact]
+    public void ListAll_MarksDeclaredReadme_RegardlessOfName()
+    {
+        var root = CreateExtractDir("PACKAGE.md", "README.md", "lib/net8.0/Foo.dll");
+        try
+        {
+            var files = PackageFileLister.ListAll(root, declaredReadme: "PACKAGE.md");
+            var readmes = files.Where(f => f.IsReadme).Select(f => f.Path).ToList();
+            Assert.Equal(new[] { "PACKAGE.md" }, readmes);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ListAll_MarksDeclaredReadme_InSubdirectory()
+    {
+        var root = CreateExtractDir("docs/package-readme.md", "README.md");
+        try
+        {
+            var files = PackageFileLister.ListAll(root, declaredReadme: "docs/package-readme.md");
+            Assert.Single(files.Where(f => f.IsReadme), f => f.Path == "docs/package-readme.md");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ListAll_NoDeclaredReadme_MarksNothing()
+    {
+        var root = CreateExtractDir("README.md", "lib/net8.0/Foo.dll");
+        try
+        {
+            var files = PackageFileLister.ListAll(root);
+            Assert.DoesNotContain(files, f => f.IsReadme);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Filter_AtReadme_ReturnsTheDeclaredReadmeOnly()
+    {
+        List<PackageFile> files =
+        [
+            new("README.md", 10, IsReadme: false),
+            new("PACKAGE.md", 20, IsReadme: true),
+            new("lib/net8.0/Foo.dll", 30),
+        ];
+
+        var result = PackageFileLister.Filter(files, "@readme");
+        Assert.Single(result);
+        Assert.Equal("PACKAGE.md", result[0].Path);
+        Assert.True(result[0].IsReadme);
+    }
+
+    [Fact]
+    public void Filter_AtReadme_IsCaseInsensitive()
+    {
+        List<PackageFile> files = [new("PACKAGE.md", 20, IsReadme: true)];
+        Assert.Single(PackageFileLister.Filter(files, "@README"));
+    }
 }

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -28,7 +28,7 @@ public static class PackageCommandDefinitions
         layoutOption.Aliases.Add("--tree");
         var pathOption = new Option<string?>("--path")
         {
-            Description = "List package files with sizes (the Files section), scoped to a file, a directory (e.g. lib/), the root (/), or a glob (e.g. *.md). Pass --path with no value for the whole package.",
+            Description = "List package files with sizes (the Files section), scoped to a file, a directory (e.g. lib/), the root (/), a glob (e.g. *.md), or @readme for the declared readme. Pass --path with no value for the whole package.",
             Arity = ArgumentArity.ZeroOrOne
         };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -52,7 +52,7 @@ public static class ArgumentPreprocessor
         args = MergeRepeatedListOption(args, SelectAliases, "-S");
         args = MergeRepeatedListOption(args, ["--columns"], "--columns");
         args = MergeRepeatedListOption(args, ["--fields"], "--fields");
-        args = EscapeAtCategoryOptionValues(args, [.. SelectAliases, "-D", "--discover"]);
+        args = EscapeAtCategoryOptionValues(args, [.. SelectAliases, "-D", "--discover", "--path"]);
 
         // Expand -NN shorthand (e.g., -30) into -n 30, like head -30
         for (int i = 0; i < args.Length; i++)
@@ -152,6 +152,15 @@ public static class ArgumentPreprocessor
     private static string EscapeAtCategoryValue(string value)
         => value.StartsWith("@", StringComparison.Ordinal)
             ? EscapedAtCategoryPrefix + value[1..]
+            : value;
+
+    /// <summary>
+    /// Reverses <see cref="EscapeAtCategoryValue"/>, restoring a leading <c>@</c> that was
+    /// escaped to dodge System.CommandLine response-file token processing.
+    /// </summary>
+    internal static string UnescapeAtCategoryValue(string value)
+        => value.StartsWith(EscapedAtCategoryPrefix, StringComparison.Ordinal)
+            ? "@" + value[EscapedAtCategoryPrefix.Length..]
             : value;
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using DotnetInspector.CommandLine;
 using DotnetInspector.Options;
 using DotnetInspector.Services;
 
@@ -86,7 +87,9 @@ public static class PackageOptionsParser
         if (parseResult.GetResult(args.PathOption) is { Implicit: false })
         {
             var value = parseResult.GetValue(args.PathOption);
-            pathFilter = string.IsNullOrEmpty(value) ? "**" : value;
+            pathFilter = string.IsNullOrEmpty(value)
+                ? "**"
+                : ArgumentPreprocessor.UnescapeAtCategoryValue(value);
         }
 
         var options = new InspectionOptions

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -378,7 +378,8 @@ public class PackageCommand
                 || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
             if (wantsFilesSection)
             {
-                var files = PackageFileLister.ListAll(extractPath);
+                string declaredReadme = result.ReadmeFile ?? "README.md";
+                var files = PackageFileLister.ListAll(extractPath, declaredReadme);
                 result.Files = PackageFileLister.Filter(files, options.PathFilter);
             }
 

--- a/src/dotnet-inspect/Inspectors/PackageFileLister.cs
+++ b/src/dotnet-inspect/Inspectors/PackageFileLister.cs
@@ -14,16 +14,21 @@ public static class PackageFileLister
     /// <summary>
     /// Enumerates every package file (excluding zip plumbing) with its size,
     /// ordered by path. Paths are package-relative with forward slashes.
+    /// <paramref name="declaredReadme"/> is the package-relative path the
+    /// <c>.nuspec</c> declares as its readme (e.g. <c>PACKAGE.md</c>); the
+    /// matching row is flagged <see cref="PackageFile.IsReadme"/>.
     /// </summary>
-    public static List<PackageFile> ListAll(string extractPath)
+    public static List<PackageFile> ListAll(string extractPath, string? declaredReadme = null)
     {
+        string? readme = declaredReadme?.Replace('\\', '/').Trim();
         var files = new List<PackageFile>();
         foreach (var full in Directory.EnumerateFiles(extractPath, "*", SearchOption.AllDirectories))
         {
             string rel = System.IO.Path.GetRelativePath(extractPath, full).Replace('\\', '/');
             if (IsPlumbing(rel))
                 continue;
-            files.Add(new PackageFile(rel, new FileInfo(full).Length));
+            bool isReadme = readme is not null && string.Equals(rel, readme, StringComparison.OrdinalIgnoreCase);
+            files.Add(new PackageFile(rel, new FileInfo(full).Length, isReadme));
         }
 
         files.Sort(static (a, b) => string.CompareOrdinal(a.Path, b.Path));
@@ -33,6 +38,8 @@ public static class PackageFileLister
     /// <summary>
     /// Restricts a listing to the <c>--path</c> pattern. Semantics:
     /// <list type="bullet">
+    /// <item><c>@readme</c>: the file the package declares as its readme,
+    /// regardless of filename (resolved via <see cref="PackageFile.IsReadme"/>).</item>
     /// <item>Root (<c>/</c>, <c>.</c>, or empty): files directly at the package root.</item>
     /// <item>Directory (trailing <c>/</c>, e.g. <c>lib/</c>): files directly in that directory.</item>
     /// <item>Glob (contains <c>*</c> or <c>?</c>, e.g. <c>*.md</c>): matched against the full
@@ -48,6 +55,10 @@ public static class PackageFileLister
             return files.ToList();
 
         string p = pattern.Replace('\\', '/');
+
+        // Declared-readme selector: the nuspec-declared readme, whatever its name.
+        if (p.Equals("@readme", StringComparison.OrdinalIgnoreCase))
+            return files.Where(f => f.IsReadme).ToList();
 
         // Root selector: top-level files only.
         if (p is "/" or "." or "./")

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -206,6 +206,7 @@ public record class PackageBinarySignals
 /// <summary>
 /// A single file in a NuGet package: its package-relative path (forward slashes)
 /// and uncompressed size in bytes (read from the already-extracted package, so
-/// no extra download is required).
+/// no extra download is required). <paramref name="IsReadme"/> marks the file the
+/// package's <c>.nuspec</c> declares as its readme (not always <c>README.md</c>).
 /// </summary>
-public sealed record PackageFile(string Path, long Size);
+public sealed record PackageFile(string Path, long Size, bool IsReadme = false);

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -385,7 +385,5 @@ public class SharedOptions
     }
 
     private static string UnescapeAtCategory(string value)
-        => value.StartsWith(ArgumentPreprocessor.EscapedAtCategoryPrefix, StringComparison.Ordinal)
-            ? "@" + value[ArgumentPreprocessor.EscapedAtCategoryPrefix.Length..]
-            : value;
+        => ArgumentPreprocessor.UnescapeAtCategoryValue(value);
 }

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -69,7 +69,7 @@ public class InspectionResultView
 
     [MarkoutSection(Name = PackageSections.Files)]
     public List<PackageFileRow>? Files => _data.Files?
-        .Select(f => new PackageFileRow(f.Path, f.Size))
+        .Select(f => new PackageFileRow(f.Path, f.Size, f.IsReadme))
         .ToList();
 
     [MarkoutSection(Name = PackageSections.LibraryFiles)]
@@ -397,7 +397,9 @@ public record LibraryFileRow(
 [MarkoutSerializable]
 public record PackageFileRow(
     [property: MarkoutPropertyName("Path")] string Path,
-    [property: MarkoutPropertyName("Size")] long Size);
+    [property: MarkoutPropertyName("Size")] long Size,
+    [property: MarkoutPropertyName("Readme")]
+    [property: MarkoutBoolFormat("readme", "")] bool IsReadme);
 
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(InspectionResultView))]


### PR DESCRIPTION
Addresses #889 (follow-up to #875 / #882).

Makes the Files section's output directly consumable for the motivating use case — surveying packages for large in-package READMEs.

## 1. Flag (and target) the declared README ✅

The in-package readme is whatever the `.nuspec` `<readme>` element points at, and it is **not always `README.md`**:

| Package | Declared readme |
| --- | --- |
| `System.Text.Json` | `PACKAGE.md` |
| `Polly` | `package-readme.md` |
| `Newtonsoft.Json` | `README.md` |

This PR adds:

- **`PackageFile.IsReadme`** — marks the declared-readme row (resolved from the nuspec, falling back to `README.md`). Surfaces as a `Readme` marker column in `--table`/`--tsv`/`--jsonl` and a real boolean `is_readme` in lossless `--json`.
- **`--path @readme`** — resolves to the declared readme regardless of filename, so you get *name + size of the displayed readme in one shot*:

```
$ dotnet-inspect package System.Text.Json --path @readme --json
{ "path": "PACKAGE.md", "size": 8582, "is_readme": true }

$ dotnet-inspect package Polly --path @readme --tsv
path             	size	is_readme
package-readme.md	1265	readme
```

The `@` prefix is escaped during arg preprocessing (reusing the existing `-S @All` category-escape) so System.CommandLine doesn't treat `@readme` as a response-file token.

## 2. Numeric `size` ✅ for `--json`, ⏳ for `--jsonl`

The lossless **`--json`** path already emits `"size": 8582` (number) and `"is_readme": true` (boolean) — see above. This is the recommended path for downstream sort/math.

Row modes (**`--jsonl`/`--tsv`**) still stringify every cell (`"size":"8582"`), because that serialization is owned by the **Markout** table serializer (pinned package, shared by every section) — it flattens all cells to strings before writing. Emitting unquoted numbers there is an opt-in Markout feature (source-generator + writer plumbing) and a separate Markout release; happy to open that PR next if you'd like. For now `--json` covers the lossless need.

## Tests

- `PackageFileListerTests`: declared-readme marking (root / subdirectory / none), `@readme` filter incl. case-insensitivity.
- `CommandLineTests`: `--path @readme` arg-escaping (and non-`@` values pass through).
- Full suite green: **1174 passed, 0 failed, 9 skipped** (ilasm-dependent).

## Docs

`SKILL.md` documents `--path @readme` and the lossless `--json` row.

## Minor (not addressed here, per the issue)

The issue also mentions a contributor-docs note about running a local build (RID-specific installed tool vs framework-dependent `dotnet pack` output). The issue says "not asking for action here", so it's left out of this PR.
