### PR TITLE
Collapse a nested checked() into the enclosing checked context

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2057,6 +2057,15 @@ public class CfgSampleClass
         return checked((short)value);
     }
 
+    // A checked conversion over a checked add (`add.ovf; conv.ovf.u1`). Both the
+    // convert and the binary are checked, but one `checked(...)` already covers
+    // the whole expression — the printer must collapse the redundant nesting to
+    // `checked((byte)(left + right))`, not `checked((byte)(checked(left + right)))`.
+    public static byte CheckedAddToByte(int left, int right)
+    {
+        return checked((byte)(left + right));
+    }
+
     public static string NullCoalesce(string? a, string b)
     {
         return a ?? b;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -445,6 +445,22 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void CheckedConversionOverCheckedAdd_CollapsesNestedChecked()
+    {
+        // Both the conversion (conv.ovf.u1) and the add (add.ovf) are checked, but
+        // one checked(...) already covers the whole expression. The printer must
+        // collapse the redundant nesting to checked((byte)(left + right)), never
+        // checked((byte)(checked(left + right))). Roslyn keeps both .ovf opcodes.
+        var function = ImportFixture(nameof(CfgSampleClass.CheckedAddToByte));
+        IrPasses.Run(function);
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("checked((byte)(left + right))", output);
+        Assert.DoesNotContain("checked(left + right)", output);
+    }
+
+    [Fact]
     public void StaleFieldRead_PinsFieldReadTakenBeforeStore()
     {
         // `int v = h.Value; h.Value = 99; return v + h.Value;` carries the first

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -16,6 +16,24 @@ public sealed partial class CSharpPrinter
 {
     string BinaryText(Binary binary)
     {
+        // A checked binary already inside a checked context drops its own wrapper
+        // (the enclosing checked covers it); only the outermost one wraps. Set the
+        // context around the operands so nested checked nodes collapse into ours.
+        bool enclosingChecked = _checkedContext;
+        if (binary.IsChecked)
+            _checkedContext = true;
+        try
+        {
+            return BinaryBody(binary, wrap: binary.IsChecked && !enclosingChecked);
+        }
+        finally
+        {
+            _checkedContext = enclosingChecked;
+        }
+    }
+
+    string BinaryBody(Binary binary, bool wrap)
+    {
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
         // float, where .un means unordered, not unsigned) print plain.
@@ -38,9 +56,9 @@ public sealed partial class CSharpPrinter
         string text = $"{left} {BinaryOperator(binary)} {right}";
         // add.ovf/sub.ovf/mul.ovf (and their .un forms) carry an overflow check
         // the default (unchecked) C# context would drop — spell it explicitly so
-        // the recompiled IL keeps the .ovf opcode. A nested checked binary
-        // re-wraps redundantly but emits the same opcode stream.
-        return binary.IsChecked ? $"checked({text})" : text;
+        // the recompiled IL keeps the .ovf opcode. Wrap only the outermost checked
+        // node (wrap); a nested one is already covered by the enclosing context.
+        return wrap ? $"checked({text})" : text;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -177,6 +177,16 @@ public sealed partial class CSharpPrinter
     /// <summary>Offsets some surviving goto targets — labels print wherever the block lives, top-level or inside a flat EH body.</summary>
     HashSet<int> _labelTargets = [];
 
+    /// <summary>
+    /// True while rendering inside an emitted <c>checked(...)</c> expression. A
+    /// checked operation (overflow binary or conversion) nested in this context
+    /// needs no <c>checked</c> wrapper of its own — the enclosing one already
+    /// establishes the overflow context, and Roslyn keeps the same <c>.ovf</c>
+    /// opcodes — so the printer collapses <c>checked((byte)(checked(a + b)))</c>
+    /// to <c>checked((byte)(a + b))</c>. Saved/restored around each checked node.
+    /// </summary>
+    bool _checkedContext;
+
     /// <summary>An explicit base/this chain call lifted out of a constructor body to its signature initializer (base/this calls are invalid as body statements).</summary>
     string? _constructorChain;
     IrNode? _chainStatement;
@@ -1577,6 +1587,23 @@ public sealed partial class CSharpPrinter
 
     string ConvertText(Convert convert)
     {
+        // A checked conversion already inside a checked context drops its own
+        // wrapper (the enclosing checked covers it); only the outermost one wraps.
+        bool enclosingChecked = _checkedContext;
+        if (convert.IsChecked)
+            _checkedContext = true;
+        try
+        {
+            return ConvertBody(convert, wrap: convert.IsChecked && !enclosingChecked);
+        }
+        finally
+        {
+            _checkedContext = enclosingChecked;
+        }
+    }
+
+    string ConvertBody(Convert convert, bool wrap)
+    {
         // An address-of node (ldloca/ldarga/ldflda/ldelema) converted to a
         // pointer or native integer (conv.u/conv.i) is C#'s address-of operator,
         // not a `ref` place: `(nuint)(ref x)` is CS1525 — the faithful unsafe
@@ -1585,7 +1612,7 @@ public sealed partial class CSharpPrinter
         if (convert.Operand is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress)
         {
             string addressCast = $"({TypeText(convert.Target)})(&{Deref(convert.Operand)})";
-            return convert.IsChecked ? $"checked({addressCast})" : addressCast;
+            return wrap ? $"checked({addressCast})" : addressCast;
         }
         // Converting an out-of-range integer constant (conv.u8 of ldc.i4.m1 for
         // ulong.MaxValue) is CS0221 as a plain cast; reinterpret its bits with
@@ -1609,7 +1636,7 @@ public sealed partial class CSharpPrinter
         if (operand.Length > 0 && operand[0] is '-' or '+' && !s_castDisambiguatingKeywords.Contains(targetText))
             operand = $"({operand})";
         string cast = $"({targetText}){operand}";
-        return convert.IsChecked ? $"checked({cast})" : cast;
+        return wrap ? $"checked({cast})" : cast;
     }
 
     // The predefined-type keyword spellings the C# parser treats as


### PR DESCRIPTION
## Problem

A checked conversion over a checked binary renders each checked node with its own `checked(...)` wrapper, producing redundant nesting across the generic-math checked operators, the ETW metadata collectors, and the decimal helpers:

```csharp
return checked((byte)(checked(left + right)));
dataCount = checked((sbyte)(checked(dataCount + 1)));
```

The inner `checked(...)` is dead — the outer one already establishes the overflow context for the whole expression.

## Fix

Thread a `_checkedContext` flag through `BinaryText`/`ConvertText`, saved/restored around each checked node, so only the **outermost** checked node emits a wrapper; nested checked operations render bare:

```csharp
return checked((byte)(left + right));
dataCount = checked((sbyte)(dataCount + 1));
```

## Soundness

- **Faithful.** Roslyn compiles `checked((byte)(left + right))` to the same `add.ovf; conv.ovf.u1` as the nested form — the overflow context covers the whole expression. Verified by the new fixture round-tripping opcode-exact through the fidelity gate.
- **Printer-only.** No IR change, so `function.Fidelity`, the corpus Full-fidelity floor, and the `.ovf` opcode stream are untouched.
- **Outermost-only.** The flag wraps only the first checked node entered; a checked node already inside the context renders bare, and the flag is restored on exit so sibling expressions are unaffected.

## Breadth & validation

- Corpus scan: the redundant nesting is removed from **54 CoreLib methods** (the remaining lines with two `checked(`-like tokens are independent sibling expressions or `unchecked(...)`, not parent-child nesting).
- Same-base validity defect diff (`--diff-validity-defects`): **zero regressions, zero new defects** — the collapsed form is exactly as valid, just cleaner (this is a readability/altitude change, not a validity fix).
- Decompiler suite green (**752**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests`.

## Tests

New `CheckedAddToByte` fixture (`checked((byte)(left + right))`, from `add.ovf; conv.ovf.u1`) — both nodes checked; `IrImporterTests` asserts the output is `checked((byte)(left + right))` and contains no nested `checked(left + right)`, at Full fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)