### PR TITLE
Degrade unspeakable metadata names honestly

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
@@ -26,9 +26,10 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class CorpusSweepGateTests
 {
-    // Measured over net11 CoreLib (41,159 methods): 0 pass-bugs, 99.97% Full,
-    // 95.75% fully raised. Floors sit a couple points below.
-    const double FullFidelityFloor = 99.0;
+    // Measured over net11 CoreLib (41,159 methods): 0 pass-bugs, 98.12% Full
+    // after residual unspeakable metadata names degrade honestly, 95.75% fully
+    // raised. Floors sit below the measured values.
+    const double FullFidelityFloor = 98.0;
     const double FullyRaisedFloor = 94.0;
 
     static string CoreLibPath => typeof(object).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/FidelityRemarksTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityRemarksTests.cs
@@ -60,4 +60,25 @@ public class FidelityRemarksTests
         Assert.Empty(FidelityRemarks.Collect(function));
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
+
+    [Fact]
+    public void Collect_UnrepresentableMetadataName_ReportsDec0009()
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var closure = TypeRef.Definition("Synthetic", "Samples", "<>c__DisplayClass0_0");
+        var container = new BlockContainer();
+        var entry = new Block(0x00);
+        container.Add(entry);
+        entry.Add(new StoreLocal(0, closure, new Constant(null, closure)));
+        entry.Add(new Return(null));
+
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("BadName", TypeRef.CoreLib("System", "Object"), signature, [closure], container);
+
+        var remark = Assert.Single(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnrepresentableMetadataName && r.Offset == -1);
+        Assert.Equal(-1, remark.Offset);
+        Assert.Contains("<>c__DisplayClass0_0", remark.Reason);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Residual compiler-generated metadata names such as <c>&lt;&gt;c</c> and
+/// <c>&lt;M&gt;b__0_0</c> are not valid C# identifiers. When raising leaves them
+/// in the final IR, the output must degrade honestly instead of claiming Full.
+/// </summary>
+public class UnspeakableNameFidelityTests
+{
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
+
+    static IrFunction Function(ImmutableArray<TypeRef> locals, BlockContainer body)
+    {
+        var signature = new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Object, signature, locals, body);
+    }
+
+    static BlockContainer Container(params IrNode[] statements)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        foreach (var statement in statements)
+            block.Add(statement);
+        return container;
+    }
+
+    [Fact]
+    public void ResidualCompilerGeneratedTypeName_DegradesToPartial()
+    {
+        var displayClass = TypeRef.Definition("Synthetic", "Samples", "<>c__DisplayClass0_0");
+        var ctor = new MethodRef(displayClass, ".ctor", Void, [], HasThis: false);
+        var body = Container(
+            new StoreLocal(0, displayClass, new NewObject(ctor, [])),
+            new Return(null));
+
+        var function = Function([displayClass], body);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void ResidualLambdaMethodName_DegradesToPartial()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "ClosureHolder");
+        var lambda = new MethodRef(holder, "<M>b__0_0", Void, [], HasThis: false);
+        var body = Container(
+            new ExpressionStatement(new DelegateCreation(Action, lambda, isVirtual: false, new Constant(null, Object))),
+            new Return(null));
+
+        var function = Function([], body);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void AutoPropertyBackingField_StaysFull()
+    {
+        var declaringType = TypeRef.Definition("Synthetic", "Samples", "C");
+        var backing = new FieldRef(declaringType, "<Count>k__BackingField", Int32);
+        var body = Container(new Return(new LoadField(backing, new LoadArgument(0, "this", declaringType))));
+        var signature = new MethodSignature(Int32, [], HasThis: true, GenericParameterCount: 0);
+        var function = new IrFunction("get_Count", declaringType, signature, [], body);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void LocalFunctionMetadataName_StaysFull()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "C");
+        var localFunction = new MethodRef(holder, "<M>g__Local|0_0", Void, [], HasThis: false);
+        var body = Container(
+            new ExpressionStatement(new DelegateCreation(Action, localFunction, isVirtual: false, new Constant(null, Object))),
+            new Return(null));
+
+        var function = Function([], body);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -87,6 +87,15 @@ public static class DiagnosticIds
     /// type itself is unknown.
     /// </summary>
     public const string UnknownResultType = "DEC0008";
+
+    /// <summary>
+    /// A metadata type, method, field, property, or generic parameter name would
+    /// render as invalid C# if emitted bare (for example a residual compiler-
+    /// generated <c>&lt;&gt;c</c> holder or <c>&lt;M&gt;b__0_0</c> lambda method).
+    /// The output is still useful, but cannot claim Full fidelity until the
+    /// shape is raised or given a legal spelling.
+    /// </summary>
+    public const string UnrepresentableMetadataName = "DEC0009";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -1,0 +1,167 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Final-output C# spelling checks for metadata names the printer would emit
+/// bare. These are honest-degradation predicates, not rewrite gates: when a
+/// compiler-generated or otherwise unspeakable metadata name survives raising,
+/// the method is no longer Full-fidelity C#.
+/// </summary>
+internal static class CSharpSpellability
+{
+    public static bool HasUnrepresentableMetadataName(IrNode node)
+        => UnrepresentableMetadataNameReason(node) is not null;
+
+    public static string? UnrepresentableMetadataNameReason(IrNode node)
+    {
+        foreach (var type in RenderedTypes(node))
+        {
+            if (TypeReason(type) is { } reason)
+                return reason;
+        }
+
+        if (node is IrExpression { ResultType: { } resultType }
+            && TypeReason(resultType) is { } expressionTypeReason)
+        {
+            return expressionTypeReason;
+        }
+
+        return node switch
+        {
+            Call call => MethodReason(call.Callee),
+            NewObject newObject => ConstructorReason(newObject.Constructor),
+            AddressOfMethod address => MethodReason(address.Method),
+            DelegateCreation creation => MethodReason(creation.Method),
+            LoadField load => FieldReason(load.Field),
+            StoreField store => FieldReason(store.Field),
+            LoadFieldAddress address => FieldReason(address.Field),
+            LoadProperty load => PropertyReason(load.PropertyName),
+            StoreProperty store => PropertyReason(store.PropertyName),
+            NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
+            NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
+            _ => null,
+        };
+    }
+
+    static IEnumerable<TypeRef> RenderedTypes(IrNode node)
+        => node is IrFunction function
+            ? FunctionRenderedTypes(function)
+            : node.DirectTypes;
+
+    static IEnumerable<TypeRef> FunctionRenderedTypes(IrFunction function)
+    {
+        yield return function.Signature.ReturnType;
+        foreach (var parameter in function.Signature.Parameters)
+            yield return parameter.Type;
+        foreach (var local in function.Locals)
+            yield return local;
+        foreach (var region in function.Regions)
+            if (region.CatchType is { } catchType)
+                yield return catchType;
+    }
+
+    static string? ConstructorReason(MethodRef constructor)
+    {
+        foreach (var argument in constructor.TypeArguments)
+            if (TypeReason(argument) is { } reason)
+                return reason;
+        return null;
+    }
+
+    static string? MethodReason(MethodRef method)
+    {
+        foreach (var argument in method.TypeArguments)
+            if (TypeReason(argument) is { } reason)
+                return reason;
+
+        if (method.Name is ".ctor")
+            return null;
+
+        string name = CSharpNaming.MethodName(method.Name);
+        return CSharpNaming.IsUsableIdentifier(name)
+            ? null
+            : $"method name '{method.Name}' has no C# spelling";
+    }
+
+    static string? FieldReason(FieldRef field)
+    {
+        string name = CSharpNaming.BackingFieldProperty(field.Name) ?? field.Name;
+        return CSharpNaming.IsUsableIdentifier(name)
+            ? null
+            : $"field name '{field.Name}' has no C# spelling";
+    }
+
+    static string? PropertyReason(string name)
+        => CSharpNaming.IsUsableIdentifier(name)
+            ? null
+            : $"property name '{name}' has no C# spelling";
+
+    static string? TypeReason(TypeRef type)
+    {
+        switch (type.Kind)
+        {
+            case TypeRefKind.Definition:
+                if (IsCoreLibPrimitive(type))
+                    return null;
+                string simpleName = StripArity(InnermostName(type.Name));
+                return CSharpNaming.IsUsableIdentifier(simpleName)
+                    ? null
+                    : $"type name '{simpleName}' has no C# spelling";
+
+            case TypeRefKind.GenericInstance:
+                if (type.ElementType is { } definition && TypeReason(definition) is { } definitionReason)
+                    return definitionReason;
+                foreach (var argument in type.TypeArguments)
+                    if (TypeReason(argument) is { } argumentReason)
+                        return argumentReason;
+                return null;
+
+            case TypeRefKind.SzArray:
+            case TypeRefKind.Array:
+            case TypeRefKind.ByRef:
+            case TypeRefKind.Pointer:
+            case TypeRefKind.Pinned:
+                return type.ElementType is { } element ? TypeReason(element) : null;
+
+            case TypeRefKind.GenericParameter:
+            case TypeRefKind.MethodGenericParameter:
+                return type.GenericParameterName.Length == 0 || CSharpNaming.IsUsableIdentifier(type.GenericParameterName)
+                    ? null
+                    : $"generic parameter name '{type.GenericParameterName}' has no C# spelling";
+
+            case TypeRefKind.FunctionPointer:
+                if (type.ElementType is { } returnType && TypeReason(returnType) is { } returnReason)
+                    return returnReason;
+                foreach (var parameter in type.TypeArguments)
+                    if (TypeReason(parameter) is { } parameterReason)
+                        return parameterReason;
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    static bool IsCoreLibPrimitive(TypeRef type)
+        => type.Assembly == TypeRef.CoreLibrary
+            && type.Namespace == "System"
+            && s_coreLibPrimitiveNames.Contains(type.Name);
+
+    static string InnermostName(string metadataName)
+    {
+        int nested = metadataName.LastIndexOf('+');
+        return nested < 0 ? metadataName : metadataName[(nested + 1)..];
+    }
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
+    }
+
+    static readonly HashSet<string> s_coreLibPrimitiveNames = new(StringComparer.Ordinal)
+    {
+        "Boolean", "Byte", "SByte", "Char", "Int16", "UInt16", "Int32", "UInt32",
+        "Int64", "UInt64", "Single", "Double", "Decimal", "IntPtr", "UIntPtr",
+        "String", "Object", "Void",
+    };
+}

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -47,6 +47,9 @@ public static class FidelityRemarks
                 Add(remarks, DiagnosticIds.UnsupportedType, OffsetOf(node), node,
                     $"references an unrepresentable type ({unsupportedType.ToDisplayString()})");
 
+            if (CSharpSpellability.UnrepresentableMetadataNameReason(node) is { } nameReason)
+                Add(remarks, DiagnosticIds.UnrepresentableMetadataName, OffsetOf(node), node, nameReason);
+
             if (node is IrExpression { ResultType: null })
                 Add(remarks, DiagnosticIds.UnknownResultType, OffsetOf(node), node,
                     "expression result type is unknown (e.g. a slot merged from conflicting types)");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -227,7 +227,8 @@ public sealed class IrFunction : IrNode
 
     /// <summary>
     /// Computed from the tree, never asserted: any unsupported node, any
-    /// unsupported type referenced anywhere, any expression whose result type the
+    /// unsupported type referenced anywhere, any metadata name the printer would
+    /// have to emit with no C# spelling, any expression whose result type the
     /// pipeline does not know (null — e.g. a join slot merged from conflicting
     /// types), or an un-raised <c>pinned T&amp;</c> local (no faithful C# spelling)
     /// ⇒ at most <see cref="DecompilationFidelity.Partial"/>.
@@ -239,6 +240,7 @@ public sealed class IrFunction : IrNode
             || n is Call { HasUnverifiedByRefArgument: true }
             || n is NewObject { HasUnverifiedByRefArgument: true }
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
+            || CSharpSpellability.HasUnrepresentableMetadataName(n)
             || n is IrExpression { ResultType: null }
             || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
             || HasUnraisedPinnedLocal()


### PR DESCRIPTION
## Summary

Residual compiler-generated metadata names such as `<>c__DisplayClass0_0`, `<>c`, and `<M>b__0_0` have no legal bare C# spelling. The decompiler could leave those names in final IR while still reporting `Full`, which made validity checks count invalid generated-name output as claimed-good C#.

This PR adds a final-output spellability predicate for metadata names and uses it in the same places as the existing fidelity caps:

- `IrFunction.Fidelity` now drops to `Partial` when a rendered type/member/property/generic-parameter name has no C# spelling.
- `FidelityRemarks` reports the same condition as `DEC0009`.
- Auto-property backing fields and local-function metadata names stay `Full` when the existing printer naming path makes them legal.
- The CoreLib `Full` corpus floor is rebaselined to the new honest classification.

## Measured impact

On `ILInspector.Decompiler.Tests.dll`, `--validity-check` moved the generated-name family out of malformed `Full` output:

- Before: `Full malformed: 305`
- After: `Full malformed: 9`

CoreLib now measures `98.12%` `Full` after residual unspeakable names degrade honestly, so the corpus floor is set to `98.0%`.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*UnspeakableNameFidelityTests*" -method "*FidelityRemarksTests*" -method "*PinnedLocalFidelityTests*" -reporter quiet`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*CorpusSweepGateTests.CoreLibSweep_MeetsHealthFloors" -reporter quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.local/share/dnvm/dn/shared/Microsoft.NETCore.App/11.0.0-preview.5.26302.115/System.Private.CoreLib.dll --validity-check`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
