### PR TITLE
Raise event add_/remove_ accessor calls to += / -= subscriptions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -26,6 +26,18 @@ public class CfgSampleClass
     // Negative: a plain int count needs no cast — `1 << n` stays bare.
     public static int ShiftByInt(int n) => 1 << n;
 
+    // Event subscription/unsubscription. Subscribing to an event declared on
+    // ANOTHER type lowers to a call to its compiler-generated add_/remove_
+    // accessor, which is SpecialName and void. Calling such an accessor directly
+    // is CS0571; the printer must raise it back to `e += h` / `e -= h`.
+    // Static event (null receiver): Console.CancelKeyPress is a static event.
+    public static void HookConsoleCancel(System.ConsoleCancelEventHandler h)
+        => System.Console.CancelKeyPress += h;
+
+    // Instance event on a passed-in receiver, unsubscribe form.
+    public static void UnhookProcessExit(System.AppDomain domain, System.EventHandler h)
+        => domain.ProcessExit -= h;
+
     // A parameter named with a C# keyword (`delegate`): the metadata name is the
     // bare keyword, so every reference must be @-escaped (`@delegate`) or it is
     // CS1001 "Identifier expected". Exercises the LoadArgument render path.

--- a/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
@@ -1,0 +1,53 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// An IL call to an event's compiler-generated add_/remove_ accessor cannot be
+// spelled as a direct method call in C# — `e.add_X(h)` is CS0571 "cannot
+// explicitly call operator or accessor". The PropertySugarPass must raise such
+// calls to an EventSubscription, which the printer renders as `e += h` / `e -= h`.
+public class EventSubscriptionRenderingTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    [Fact]
+    public void StaticEventAdd_RaisesToPlusEquals()
+    {
+        var function = Raised(nameof(CfgSampleClass.HookConsoleCancel));
+
+        var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
+        Assert.True(subscription.IsAdd);
+        Assert.Equal("CancelKeyPress", subscription.EventName);
+        // The lowered add_ accessor call is gone.
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "add_CancelKeyPress");
+
+        var output = Print(nameof(CfgSampleClass.HookConsoleCancel));
+        Assert.Contains("Console.CancelKeyPress += h;", output);
+        Assert.DoesNotContain("add_CancelKeyPress", output);
+    }
+
+    [Fact]
+    public void InstanceEventRemove_RaisesToMinusEquals()
+    {
+        var function = Raised(nameof(CfgSampleClass.UnhookProcessExit));
+
+        var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
+        Assert.False(subscription.IsAdd);
+        Assert.Equal("ProcessExit", subscription.EventName);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "remove_ProcessExit");
+
+        var output = Print(nameof(CfgSampleClass.UnhookProcessExit));
+        Assert.Contains("domain.ProcessExit -= h;", output);
+        Assert.DoesNotContain("remove_ProcessExit", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -980,6 +980,7 @@ public sealed partial class CSharpPrinter
                 && Equals(load.Accessor.DeclaringType, s.Accessor.DeclaringType)
                 && SameLValue(load.Instance, s.Instance)
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments)),
+        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
             Deref(s.Address),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1522,6 +1522,8 @@ public static class IrImporter
                     // strongest local evidence without assembly resolution.
                     IsSpecialName = memberName.StartsWith("get_", StringComparison.Ordinal)
                         || memberName.StartsWith("set_", StringComparison.Ordinal)
+                        || memberName.StartsWith("add_", StringComparison.Ordinal)
+                        || memberName.StartsWith("remove_", StringComparison.Ordinal)
                         || memberName.StartsWith("op_", StringComparison.Ordinal)
                         || memberName is ".ctor" or ".cctor",
                     // A same-assembly call on a generic type instance is a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2241,6 +2241,38 @@ public sealed class StoreProperty : IrNode
     public override string Describe() => $"StoreProperty {Accessor.DeclaringType.ToDisplayString()}.{PropertyName}";
 }
 
+/// <summary>A raised event subscription or unsubscription (from an add_/remove_ accessor call) — C#'s <c>e += h</c> / <c>e -= h</c>.</summary>
+public sealed class EventSubscription : IrNode
+{
+    public EventSubscription(MethodRef accessor, bool isAdd, IrExpression? instance, IrExpression value)
+    {
+        Accessor = accessor;
+        IsAdd = isAdd;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        AddChild(value);
+    }
+
+    public MethodRef Accessor { get; }
+
+    /// <summary>true for add_ (+=); false for remove_ (-=).</summary>
+    public bool IsAdd { get; }
+
+    /// <summary>Whether the accessor call was virtual; non-virtual cross-type this-receiver access spells base.</summary>
+    public bool IsVirtual { get; init; }
+    public bool HasInstance { get; }
+
+    // Both "add_" and "remove_" prefixes are stripped to the event name.
+    public string EventName => Accessor.Name[(IsAdd ? "add_".Length : "remove_".Length)..];
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[^1];
+    public override IEnumerable<TypeRef> DirectTypes
+        => Accessor.ParameterTypes.Append(Accessor.DeclaringType);
+
+    public override string Describe() => $"EventSubscription {Accessor.DeclaringType.ToDisplayString()}.{EventName} {(IsAdd ? "+=" : "-=")}";
+}
+
 /// <summary>The exception value the CLR pushes on entry to a catch or filter handler.</summary>
 public sealed class CaughtException : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -4,7 +4,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// Raises accessor calls to property and indexer nodes — the inverse of the
 /// compiler's property lowering. The get_/set_ naming plus matching arity is
 /// the same evidence the current emitter uses; the result is typed nodes,
-/// not name surgery at print time.
+/// not name surgery at print time. Event add_/remove_ accessor calls are
+/// raised the same way to <c>e += h</c> / <c>e -= h</c> subscriptions.
 /// </summary>
 public sealed class PropertySugarPass : IIrPass
 {
@@ -38,6 +39,15 @@ public sealed class PropertySugarPass : IIrPass
                     statement.ReplaceWith(new StoreProperty(call.Callee, instance, indexArguments, value) { IsVirtual = call.IsVirtual });
                     break;
                 }
+                case ExpressionStatement { Expression: Call call } statement when IsEventAccessor(call.Callee, out bool isAdd):
+                {
+                    var children = call.DetachChildren().Cast<IrExpression>().ToList();
+                    var instance = call.Callee.HasThis ? children[0] : null;
+                    var value = children[^1];
+                    context.Stepper.StepOver($"raise {call.Callee.Name} call to event {(isAdd ? "+=" : "-=")}", statement);
+                    statement.ReplaceWith(new EventSubscription(call.Callee, isAdd, instance, value) { IsVirtual = call.IsVirtual });
+                    break;
+                }
             }
         }
     }
@@ -54,4 +64,19 @@ public sealed class PropertySugarPass : IIrPass
             && callee.Name.Length > "set_".Length
             && callee.ParameterTypes.Length >= 1
             && callee.ReturnType is { Namespace: "System", Name: "Void" };
+
+    // An event accessor is a void add_X/remove_X special-name method taking the
+    // handler delegate — exactly one explicit parameter (the receiver, if any,
+    // is the this-pointer). Calling it directly is CS0571; C# spells it += / -=.
+    static bool IsEventAccessor(MethodRef callee, out bool isAdd)
+    {
+        isAdd = callee.Name.StartsWith("add_", StringComparison.Ordinal);
+        bool isRemove = callee.Name.StartsWith("remove_", StringComparison.Ordinal);
+        if (!callee.IsSpecialName || (!isAdd && !isRemove))
+            return false;
+        int prefix = isAdd ? "add_".Length : "remove_".Length;
+        return callee.Name.Length > prefix
+            && callee.ParameterTypes.Length == 1
+            && callee.ReturnType is { Namespace: "System", Name: "Void" };
+    }
 }


### PR DESCRIPTION
## Target
A direct call to an event's compiler-generated `add_`/`remove_` accessor cannot be spelled as a method call in C# — `AppContext.add_FirstChanceException(value)` is **CS0571** "cannot explicitly call operator or accessor". The decompiler emitted exactly that for the four `AppDomain` event accessors, which delegate to `AppContext`'s static events.

## Fix
Event accessors are the same accessor shape `PropertySugarPass` already raises for `get_`/`set_`. This adds:

- A new **`EventSubscription`** IR node (add/remove, optional instance, value).
- A `PropertySugarPass` case raising void `add_X`/`remove_X` special-name calls to it.
- A printer case rendering `receiver.Event += handler;` / `-= handler;` (reusing `PropertyTarget` for static/instance/base receiver spelling).
- Extends the importer's cross-assembly **MemberRef** special-name heuristic to recognize `add_`/`remove_` (alongside `get_`/`set_`/`op_`), so subscriptions to events declared in other assemblies raise too (MemberRefs carry no SpecialName flag).

## Result
- **CS0571 cleared on 4 corpus methods** (`add_`/`remove_` `FirstChanceException`/`UnhandledException`); **zero validity regressions**.
- Full fidelity unchanged: 40854/41012 (99.61%), 0 importer bugs.
- 753/753 decompiler tests pass.

## Tests
`EventSubscriptionRenderingTests` with two real-IL fixtures in `CfgSampleClass`: a static event `+=` (`Console.CancelKeyPress`, null receiver) and an instance event `-=` (`AppDomain.ProcessExit`, receiver-qualified) — both assert the `EventSubscription` raise and the rendered `+=`/`-=` text, and that no `add_`/`remove_` call survives.