### PR TITLE
Render a by-ref call argument in a stack slot with its ref/out keyword

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RefArgumentRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefArgumentRenderingTests.cs
@@ -1,0 +1,53 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A by-ref call argument can arrive as a ref-typed stack slot: when a `ref`
+// argument (a field/local address) is evaluated before a later side-effecting
+// argument, the importer spills the managed pointer into a ref slot that survives
+// to the call. That slot still names a place, so the call must render with the
+// `ref`/`out` keyword the parameter demands — a bare `M(S_0, ...)` is CS1620.
+public class RefArgumentRenderingTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction BuildSlotByRefCall(ArgumentRefKind refKind)
+    {
+        var refInt = TypeRef.ByRef(Int32);
+        var callee = new MethodRef(
+            TypeRef.CoreLib("System", "Sample"),
+            "Exchange",
+            Int32,
+            [refInt, Int32],
+            HasThis: false)
+        {
+            ParameterRefKinds = [refKind, ArgumentRefKind.Value],
+        };
+        // Exchange(<ref slot>, 5)
+        var call = new Call(callee, isVirtual: false, [new LoadStackSlot(0, refInt), new Constant(5, Int32)]);
+        var block = new Block(0);
+        block.Add(new Return(call));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Holder"), signature, [], container);
+    }
+
+    [Fact]
+    public void RefArgumentInStackSlot_RendersWithRefKeyword()
+    {
+        var output = CSharpPrinter.Print(BuildSlotByRefCall(ArgumentRefKind.Ref)).Output;
+
+        Assert.Contains("Exchange(ref S_0, 5)", output);
+        Assert.DoesNotContain("Exchange(S_0", output);
+    }
+
+    [Fact]
+    public void OutArgumentInStackSlot_RendersWithOutKeyword()
+    {
+        var output = CSharpPrinter.Print(BuildSlotByRefCall(ArgumentRefKind.Out)).Output;
+
+        Assert.Contains("Exchange(out S_0, 5)", output);
+        Assert.DoesNotContain("Exchange(S_0", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -224,7 +224,7 @@ public sealed partial class CSharpPrinter
     {
         LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress => Deref(argument),
         Unbox u => $"({TypeText(u.Type)}){Operand(u.Operand)}",
-        LoadLocal or LoadArgument or LoadIndirect or Call or CallIndirect => Expression(argument),
+        LoadLocal or LoadArgument or LoadStackSlot or LoadIndirect or Call or CallIndirect => Expression(argument),
         _ => null,
     };
 
@@ -236,7 +236,11 @@ public sealed partial class CSharpPrinter
     string? ArgumentLvalue(IrExpression argument) => argument switch
     {
         LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress => Deref(argument),
-        LoadLocal or LoadArgument or LoadIndirect or Call or CallIndirect => Expression(argument),
+        // A ref-typed value already names a place: a ref local/parameter, a
+        // ref-returning call, or a ref slot the importer spilled the managed
+        // pointer into (a ref argument evaluated before a later side-effecting
+        // argument). Each renders as a bare name the ref/out keyword prefixes.
+        LoadLocal or LoadArgument or LoadStackSlot or LoadIndirect or Call or CallIndirect => Expression(argument),
         _ => null,
     };
 }


### PR DESCRIPTION
## Target

A **grounded validity bug**, found by a measured CoreLib validity sweep (per the #886 breadth-hunt-transition guidance — prefer validity/corpus bug hunts while the queue is busy). The sweep flagged CS1620 ("argument must be passed with the 'ref'/'out' keyword") on `Full`-fidelity methods — the "claimed good but doesn't compile" docket.

## Root cause

When a `ref` argument (a field/local address) is evaluated **before** a later side-effecting argument, the importer spills the managed pointer into a ref **stack slot** (`LoadStackSlot`) so it survives to the call. The printer's by-ref argument spelling (`RefArgument` → `ArgumentLvalue` / `ArgumentPlace`) listed every place form (`LoadLocal`, `LoadFieldAddress`, ref-returning `Call`, …) **except `LoadStackSlot`** — so the keyword was dropped and the call rendered the bare `M(S_0, …)`, which is CS1620.

## Fix

A ref-typed stack slot names a place exactly like a ref local, so add `LoadStackSlot` to both place switches. It renders as the bare slot name the `ref`/`out` keyword prefixes.

Concretely, `System.Environment::get_ProcessPath`:
```diff
- Interlocked.CompareExchange<string>(S_0, S_1, null);   // CS1620
+ Interlocked.CompareExchange<string>(ref S_0, S_1, null);
```

## Test

Pinned with `RefArgumentRenderingTests` (the `ref` and `out` forms over a ref-slot argument, built directly as IR). The end-to-end spill shape recompiles to a benign ref-local indirection (an opcode diff unrelated to the keyword), so a direct printer unit test pins the fix without growing the fidelity-gate docket.

## Verification

- **750/750** `ILInspector.Decompiler.Tests` — including `FidelityGateTests` (no regression in by-ref rendering) and the two new tests.
- Manually confirmed `get_ProcessPath` over CoreLib now emits the `ref` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)