### PR TITLE
Degrade PrivateImplementationDetails type references

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UnspellableTypeFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspellableTypeFidelityTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class UnspellableTypeFidelityTests
+{
+    [Fact]
+    public void PrivateImplementationDetailsType_DegradesToPartial()
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var hiddenType = TypeRef.Definition("System.Private.CoreLib", "", "<PrivateImplementationDetails>");
+        var helper = new MethodRef(hiddenType, "Helper", voidType, [], HasThis: false);
+
+        var block = new Block();
+        block.Add(new ExpressionStatement(new Call(helper, isVirtual: false, [])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Object"),
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var remark = Assert.Single(FidelityRemarks.Collect(function), r => r.Code == DiagnosticIds.UnsupportedType);
+        Assert.Contains("<PrivateImplementationDetails>", remark.Reason);
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -49,8 +49,9 @@ public static class DiagnosticIds
     public const string UnsupportedConstruct = "DEC0004";
 
     /// <summary>
-    /// A type the slice cannot represent (a function pointer, a custom modifier)
-    /// appears in a signature, local, or node — lowering fidelity. Distinct from
+    /// A type the slice cannot represent (a function pointer, a custom modifier,
+    /// or an unspellable implementation-detail type) appears in a signature,
+    /// local, or node — lowering fidelity. Distinct from
     /// <see cref="UnsupportedConstruct"/> (an opcode in a body): the cause is the
     /// type surface, not the instruction stream, and it otherwise carries no
     /// node-level diagnostic of its own.

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -210,15 +210,16 @@ public sealed class TypeRef : IEquatable<TypeRef>
         }
     }
 
-    /// <summary>True if this type or any constituent shape is <see cref="TypeRefKind.Unsupported"/> (feeds the fidelity computation).</summary>
+    /// <summary>True if this type or any constituent shape cannot be represented as valid C# (feeds the fidelity computation).</summary>
     public bool ContainsUnsupported =>
         Kind == TypeRefKind.Unsupported
+        || IsPrivateImplementationDetails
         || ElementType?.ContainsUnsupported == true
         || TypeArguments.Any(a => a.ContainsUnsupported);
 
     /// <summary>
-    /// The reasons of every <see cref="TypeRefKind.Unsupported"/> shape reachable
-    /// from this type (element types and type arguments included), in pre-order.
+    /// The reasons of every unsupported shape or unspellable implementation-detail
+    /// type reachable from this type (element types and type arguments included), in pre-order.
     /// Drives the importer's type-level diagnostics so a signature the slice
     /// cannot represent (a function pointer, a custom modifier) reports *why* it
     /// lowered fidelity instead of sinking it silently.
@@ -227,6 +228,8 @@ public sealed class TypeRef : IEquatable<TypeRef>
     {
         if (Kind == TypeRefKind.Unsupported)
             yield return UnsupportedReason;
+        if (IsPrivateImplementationDetails)
+            yield return $"unspellable C# type name '{ToDisplayString()}'";
         if (ElementType is { } element)
             foreach (var reason in element.UnsupportedReasons())
                 yield return reason;
@@ -299,6 +302,11 @@ public sealed class TypeRef : IEquatable<TypeRef>
     };
 
     public override string ToString() => ToDisplayString();
+
+    bool IsPrivateImplementationDetails
+        => Kind == TypeRefKind.Definition
+            && (Name == "<PrivateImplementationDetails>"
+                || Name.StartsWith("<PrivateImplementationDetails>+", StringComparison.Ordinal));
 
     string DisplayName()
     {


### PR DESCRIPTION
## Summary
- treat <PrivateImplementationDetails> type references as unsupported type surfaces
- add a focused fidelity test proving those implementation-detail references cap output below Full
- keep the measured corpus witness (System.Array::FindAll) out of malformed Full output by reporting DEC0005

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.UnspellableTypeFidelityTests
- dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 500 --max-examples 8
- dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --dump 'System.Array::FindAll' --index 0 --remarks\n- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore\n- dotnet build src/dotnet-inspect -c Release --no-restore --nologo