### PR TITLE
Register ref/pointer enum pointee shape so `*styles & K` names the enum

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -49,11 +49,14 @@ public class CfgSampleClass
     // operand must be parenthesized: `(nint)(-1)`.
     public static nint NegativeNativeInt() => -1;
 
-    // A bitwise `|` between a ulong and a long: csc reinterprets the long with a
-    // no-op `(ulong)` cast that emits no conv, so the IL `or` carries a ulong and
-    // a long operand. C# rejects `mask | flag` across signed/unsigned (CS0019),
-    // so the printer must re-insert the unsigned reinterpret: `mask | (ulong)flag`.
     public static ulong OrLongIntoULong(ulong mask, long flag) => mask | (ulong)flag;
+
+    // A `ldind.i4` through a `ref` enum parameter is typed by the opcode width
+    // (int), not the pointee enum, so `styles & 16` reads as `int & int` in the
+    // IR. The importer must register the ref/pointer pointee's enum shape (and
+    // member names) so the constant retypes to the enum — `styles & Gamma`, not
+    // the CS0019 `styles & 16`.
+    public static CfgStyles RefEnumMask(ref CfgStyles styles) => styles & CfgStyles.Gamma;
 
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
@@ -2832,6 +2835,12 @@ public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
 // signed int -2147483648, the case the member-map key must agree on.
 [System.Flags]
 public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
+
+// A flags enum with a named member at a non-low bit (Gamma = 16): a `ref CfgStyles`
+// bitwise test reads the enum via `ldind.i4`, so the importer must register the
+// pointee's shape and member names for the int constant to name `Gamma`.
+[System.Flags]
+public enum CfgStyles { None = 0, Alpha = 1, Beta = 2, Gamma = 16 }
 
 // A value-type instance method whose `this` value is read directly: returning
 // `this` by value compiles to `ldarg.0; ldobj` (a load-indirect of the `this`

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -116,6 +116,7 @@ public class FidelityGateTests
         "LineSeparatorLiteral",
         "NegativeNativeInt",
         "OrLongIntoULong",
+        "RefEnumMask",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/RefEnumBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefEnumBitwiseTests.cs
@@ -1,0 +1,29 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A `ldind.i4` (and friends) through a `ref`/pointer enum is typed by the opcode
+// width (int), not the pointee enum — so the importer must register the pointee's
+// enum shape and member names, or an int constant beside it stays bare and the
+// bitwise idiom is CS0019 (`styles & 16`). The fix names the member: `styles & Gamma`.
+public class RefEnumBitwiseTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void RefEnumBitwise_NamesEnumMember()
+    {
+        var output = Render(nameof(CfgSampleClass.RefEnumMask));
+
+        Assert.Contains("CfgStyles.Gamma", output);
+        Assert.DoesNotContain("& 16", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -300,6 +300,12 @@ public static class IrImporter
 
         void Consider(TypeRef? type)
         {
+            // ByRef/pointer carry the real type in their element: a `ref Enum`
+            // parameter or `Enum*` only ever reaches the importer wrapped, so the
+            // pointee enum's shape (and member names) would never be registered —
+            // leaving `*styles & 64` as `int & 64` (CS0019). Unwrap to the pointee.
+            while (type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } element })
+                type = element;
             if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
                 return;
             var shape = source.ResolveShape(type);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -72,9 +72,19 @@ public sealed class TypedConstantsPass : IIrPass
         => type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } ? type.ElementType : null;
 
     static TypeRef? EnumOperandType(IrExpression operand, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
-        => operand is not Constant && operand.ResultType is { } type && shapes.GetValueOrDefault(type) == TypeShape.Enum
-            ? type
-            : null;
+    {
+        if (operand is Constant)
+            return null;
+        // A `ldind.i4`/`ldind.i1`/... through a `ref EnumType` (or `EnumType*`)
+        // yields a LoadIndirect typed by the opcode width (int/byte/...), not the
+        // pointee enum — so `styles & 64` reads as `int & int` in the IR but binds
+        // as `enum & int` in C# (CS0019). The declared type is the pointee enum;
+        // see through the load so the constant carries that enum's identity.
+        var type = operand is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } pointee } }
+            ? pointee
+            : operand.ResultType;
+        return type is { } && shapes.GetValueOrDefault(type) == TypeShape.Enum ? type : null;
+    }
 
     static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {


### PR DESCRIPTION
## Problem

A `ldind.i4`/`ldind.i1`/… through a `ref EnumType` (or `EnumType*`) yields a `LoadIndirect` typed by the **opcode width** (`int`/`byte`/…), not the pointee enum. The importer's shape resolver (`ResolveTypeInfo.Consider`) only registered `Definition` types, so a `ref Enum` parameter — which only ever reaches the importer wrapped in a `ByRef` — never had its enum **shape** or **member names** registered.

Consequently an int constant beside such a load stayed a bare `int`, and the bitwise-flag idiom bound as `enum & int` (**CS0019**). `System.DateTimeParse.GetDateTimeNow` rendered:

```csharp
if (((styles) & 64) != 0)   // CS0019: Operator '&' cannot be applied to 'DateTimeStyles' and 'int'
```

## Fix (two parts)

- **`IrImporter.ResolveTypeInfo`** — unwrap `ByRef`/pointer types in `Consider` so the pointee enum's shape and member names get registered.
- **`TypedConstantsPass.EnumOperandType`** — see through an opcode-typed `LoadIndirect` to its ref/pointer pointee enum, so the int constant beside it retypes to that enum. Scoped to the existing bitwise `And`/`Or`/`Xor` constant-retype path, so there is **no global type change** and no enum-arithmetic regression.

Now renders, faithful and opcode-exact (the named member *is* the constant `64`; `&` on the enum emits `and`):

```csharp
if ((styles & DateTimeStyles.AssumeUniversal) != 0)
```

## Numbers

- Semantic-defect methods **195 → 193** (CS0019 13 → 12, CS0266 225 → 223 — the same root cause also fixed `ModuleHandle.GetPEKind`'s out-enum CS0266).
- **0 methods newly broken** (method-level before/after diff).
- Inventory flat **40854/41012** opcode-exact.
- `RefEnumMask` fixture added + pinned opcode-exact; `RefEnumBitwiseTests` added.
- 756 decompiler + 1167 product tests green.
