### PR TITLE
Drop the ref prefix on an unbox receiver of a member access

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2872,6 +2872,17 @@ public struct CfgSelf
     public CfgSelf Identity() => this;
 }
 
+// A value-type Equals(object) that reads a field off the unboxed argument:
+// `((CfgBoxed)other).Value` compiles to `unbox` (a managed pointer into the
+// box) + `ldfld`, so the field receiver is an Unbox node. The printer must
+// spell the access `((CfgBoxed)other).Value`, NOT `(ref (CfgBoxed)other).Value`
+// — the `ref` form is CS1525 "Invalid expression term 'ref'".
+public struct CfgBoxed
+{
+    public int Value;
+    public bool FieldEquals(object other) => Value == ((CfgBoxed)other).Value;
+}
+
 public sealed class CfgNullableTarget
 {
     public int Value;

--- a/src/ILInspector.Decompiler.Tests/UnboxReceiverRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnboxReceiverRenderingTests.cs
@@ -1,0 +1,35 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// An `unbox` opcode yields a managed pointer to the value inside a box; when it
+// is the receiver of a field/property/method access, C# spells it as the cast
+// itself — `((T)x).Member` — because the compiler auto-takes the address. The
+// by-ref argument spelling `ref (T)x` is CS1525 "Invalid expression term 'ref'"
+// in that value position, so the printer must drop the `ref` for receivers.
+public class UnboxReceiverRenderingTests
+{
+    static IrFunction Raised(string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void UnboxFieldReceiver_DropsRefPrefix()
+    {
+        var function = Raised(typeof(CfgBoxed).FullName!, nameof(CfgBoxed.FieldEquals));
+        // The field-off-unbox pattern must import as an Unbox receiver (the read
+        // off a box uses `unbox` + `ldfld`, not a copying `unbox.any`).
+        Assert.Single(function.Descendants.OfType<Unbox>());
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        // The unbox-into-field-access must read as a parenthesized cast, never `ref`.
+        Assert.Contains("((CfgBoxed)other).Value", output);
+        Assert.DoesNotContain("ref (", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -68,6 +68,11 @@ public sealed partial class CSharpPrinter
         // itself — C# auto-takes the address. The bare `ref pairs[0]` spelling
         // would be CS1525 in this value position (`(ref pairs[0]).A`).
         LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        // An unbox yields a managed pointer to the value inside the box; a
+        // member access on it spells the cast itself ((T)x), since C# auto-takes
+        // the address. The `ref (T)x` form (the by-ref argument spelling) is
+        // CS1525 "Invalid expression term 'ref'" in this value position.
+        Unbox u => $"(({TypeText(u.Type)}){Operand(u.Operand)})",
         _ => Operand(receiver),
     };
 


### PR DESCRIPTION
## Target
A member access whose receiver is an `unbox` (a managed pointer into a box) rendered the receiver with the by-ref *argument* spelling. `System.Index::Equals` came out as:

```csharp
return (value is Index) && _value == (ref (Index)value)._value;
```

The `ref` is **CS1525** "Invalid expression term 'ref'" — invalid in a value position. C# auto-takes the address for member access on a value, so the faithful spelling is `((Index)value)._value`.

## Fix
`ReceiverText` already spells the place (not its `ref` address) for `LoadLocalAddress`/`LoadArgumentAddress`/`LoadFieldAddress`/`LoadElementAddress` receivers. Added the matching **`Unbox`** case, rendering the parenthesized cast `((T)x)` so the member access binds correctly.

## Result
- Clears the last Full-malformed CS1525 `ref` case (`System.Index::Equals`): **Full malformed 11 → 10**.
- **Zero validity regressions** (defect diff).
- Full fidelity unchanged: 40234/41012, 0 importer bugs.
- 768/768 decompiler tests pass.

## Tests
`UnboxReceiverRenderingTests` + a `CfgBoxed` struct fixture whose `FieldEquals(object)` reads a field off the unboxed argument (`((CfgBoxed)other).Value`), which compiles to `unbox`+`ldfld`. Asserts the IR carries an `Unbox` node, the output reads `((CfgBoxed)other).Value`, and no `ref (` survives.