### PR TITLE
Degrade residual runtime tokens honestly

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoadTokenFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoadTokenFidelityTests.cs
@@ -1,0 +1,55 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Type tokens raise to <c>typeof(T)</c>; method and field tokens have no C#
+/// expression spelling unless a pass consumes them. Left flat, the printer can
+/// only emit a comment, which is invalid in expression positions.
+/// </summary>
+public class LoadTokenFidelityTests
+{
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    static IrFunction Function(IrExpression expression)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ExpressionStatement(expression));
+        block.Add(new Return(null));
+
+        var signature = new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Object, signature, [], container);
+    }
+
+    [Fact]
+    public void FieldToken_DegradesToPartialAndReportsRemark()
+    {
+        var function = Function(new LoadToken(RuntimeTokenKind.Field, null, "C.F"));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var remark = Assert.Single(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnsupportedRuntimeToken);
+        Assert.Contains("ldtoken", remark.Reason);
+    }
+
+    [Fact]
+    public void MethodToken_DegradesToPartial()
+    {
+        var function = Function(new LoadToken(RuntimeTokenKind.Method, null, "C.M"));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void TypeToken_StaysFull()
+    {
+        var function = Function(new LoadToken(RuntimeTokenKind.Type, Object, Object.ToDisplayString()));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -97,6 +97,14 @@ public static class DiagnosticIds
     /// shape is raised or given a legal spelling.
     /// </summary>
     public const string UnrepresentableMetadataName = "DEC0009";
+
+    /// <summary>
+    /// A runtime token load (<c>ldtoken</c>) survived raising in a value position
+    /// where C# has no expression spelling. Type tokens can render as
+    /// <c>typeof(T)</c>; residual method and field tokens render only as comments
+    /// and therefore cap fidelity until a pass consumes them.
+    /// </summary>
+    public const string UnsupportedRuntimeToken = "DEC0010";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -39,6 +39,10 @@ public static class FidelityRemarks
                     Add(remarks, DiagnosticIds.UnverifiedByRefArgument, OffsetOf(node), node,
                         "by-ref argument rendered against an unknown call-site ref-kind (out/in cannot be distinguished from ref)");
                     break;
+                case LoadToken { Kind: not RuntimeTokenKind.Type }:
+                    Add(remarks, DiagnosticIds.UnsupportedRuntimeToken, OffsetOf(node), node,
+                        "runtime method/field token load (ldtoken) with no C# expression spelling");
+                    break;
             }
 
             var unsupportedType = node.DirectTypes.FirstOrDefault(t => t.ContainsUnsupported)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -228,10 +228,11 @@ public sealed class IrFunction : IrNode
     /// <summary>
     /// Computed from the tree, never asserted: any unsupported node, any
     /// unsupported type referenced anywhere, any metadata name the printer would
-    /// have to emit with no C# spelling, any expression whose result type the
-    /// pipeline does not know (null — e.g. a join slot merged from conflicting
-    /// types), or an un-raised <c>pinned T&amp;</c> local (no faithful C# spelling)
-    /// ⇒ at most <see cref="DecompilationFidelity.Partial"/>.
+    /// have to emit with no C# spelling, any residual runtime token with no C#
+    /// expression spelling, any expression whose result type the pipeline does
+    /// not know (null — e.g. a join slot merged from conflicting types), or an
+    /// un-raised <c>pinned T&amp;</c> local (no faithful C# spelling) ⇒ at most
+    /// <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
         => Descendants.Prepend(this).Any(n =>
@@ -239,6 +240,7 @@ public sealed class IrFunction : IrNode
             || n is LoadFunctionPointer
             || n is Call { HasUnverifiedByRefArgument: true }
             || n is NewObject { HasUnverifiedByRefArgument: true }
+            || n is LoadToken { Kind: not RuntimeTokenKind.Type }
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || CSharpSpellability.HasUnrepresentableMetadataName(n)
             || n is IrExpression { ResultType: null }


### PR DESCRIPTION
## Summary

Residual field and method `ldtoken` nodes have no valid C# expression spelling. The printer can only emit them as comments, which becomes malformed C# when the token is used as an argument, for example:

```csharp
RuntimeHelpers.InitializeArray(S_256, /* LoadToken Field <PrivateImplementationDetails>... */);
```

Before this change those methods could still report `Full` with no fidelity remarks. This PR caps residual non-type `LoadToken` nodes at `Partial` and reports them as `DEC0010`. Type tokens are unchanged because they already render as `typeof(T)`.

## Measured impact

On `ILInspector.Decompiler.Tests.dll`, `--validity-check` now reports:

- Before: `Full malformed: 9`
- After: `Full malformed: 0`

The defect diff had no regressed codes.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*LoadTokenFidelityTests*" -method "*FidelityRemarksTests*" -reporter quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check --diff-validity-defects /tmp/target-hunt-next-defects.tsv`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*CorpusSweepGateTests.CoreLibSweep_MeetsHealthFloors" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
