### PR TITLE
Spell a by-ref return with the ref keyword (return ref place)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RefArgumentRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefArgumentRenderingTests.cs
@@ -50,4 +50,26 @@ public class RefArgumentRenderingTests
         Assert.Contains("Exchange(out S_0, 5)", output);
         Assert.DoesNotContain("Exchange(S_0", output);
     }
+
+    static IrFunction BuildRefReturn()
+    {
+        var refInt = TypeRef.ByRef(Int32);
+        // ref int M() { return <ref local>; }  — the ref local names a place, so the
+        // by-ref return must spell `return ref V_0;` (a bare `return V_0;` is CS8150).
+        var block = new Block(0);
+        block.Add(new Return(new LoadLocal(0, refInt)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(refInt, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Holder"), signature, [refInt], container);
+    }
+
+    [Fact]
+    public void ByRefReturn_RendersReturnRef()
+    {
+        var output = CSharpPrinter.Print(BuildRefReturn()).Output;
+
+        Assert.Contains("return ref V_0;", output);
+        Assert.DoesNotContain("return V_0;", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1005,7 +1005,7 @@ public sealed partial class CSharpPrinter
         InitObject { Address: LoadArgumentAddress argument } => $"{CSharpNaming.EscapeIdentifier(argument.Name)} = default;",
         InitObject { Address: LoadFieldAddress field } o2 => $"{FieldTarget(field.Field, field.Instance)} = default;",
         InitObject o => $"{Deref(o.Address)} = default({TypeText(o.Type)});",
-        Return { Value: { } value } => $"return {CastValue(value, _function.Signature.ReturnType)};",
+        Return { Value: { } value } => ReturnText(value),
         Return => "return;",
         YieldReturn y => $"yield return {Expression(y.Value)};",
         YieldBreak => "yield break;",
@@ -1424,6 +1424,18 @@ public sealed partial class CSharpPrinter
             && property.Instance is LoadLocal local
             && local.Index == patternLocal
             && property.IndexArguments.Count == 0;
+
+    /// <summary>
+    /// A return statement. A method that returns by reference (<c>ref T</c>) ends
+    /// in <c>return ref place;</c> — the IL <c>ret</c> yields a managed pointer, so
+    /// the keyword is required (a bare <c>return place;</c> is CS8150). Falls back
+    /// to the by-value spelling for value returns and for the rare ref return whose
+    /// value is not a single place (a ref ternary binds <c>ref</c> per arm).
+    /// </summary>
+    string ReturnText(IrExpression value)
+        => _function.Signature.ReturnType is { Kind: TypeRefKind.ByRef } && ArgumentLvalue(value) is { } place
+            ? $"return ref {place};"
+            : $"return {CastValue(value, _function.Signature.ReturnType)};";
 
     /// <summary>
     /// Assignment spelling with compound/increment sugar: when the value is


### PR DESCRIPTION
## Target

Another **grounded validity bug** from a measured CoreLib validity sweep (the #886-preferred mode). The sweep flagged **CS8150** ("by-value returns may only be used in methods that return by value") on `Full`-fidelity **ref-returning** methods. This is the return-position analog of the by-ref *argument* keyword fix (#895).

## Root cause

The `Return` renderer always spelled `return {value};` via `CastValue`, never emitting the `ref` keyword a `ref T` return demands. The IL `ret` of a ref-returning method yields a managed pointer, so a bare `return place;` is invalid C#.

## Fix

When the method's return type is by-ref **and** the returned value names a place (reusing the same `ArgumentLvalue` place logic the by-ref *call arguments* already use), spell it `return ref place;`.

```diff
- return Unsafe.As<decimal, DecCalc>(ref d);    // CS8150
+ return ref Unsafe.As<decimal, DecCalc>(ref d);
```

Fixes the common ref-returning-call / ref-local shape across the cluster: `Decimal::AsMutable`, `String::GetRawStringDataAsUInt16` / `…UInt8`, `Enum.EnumInfo::GetStorageRef`.

**Scoped:** the exotic ref-*field* return (`return ref obj.refField;` — a `ref byte` field loaded by `LoadField`, as in `TypedReference::GetRefAny`) is a distinct shape `ArgumentLvalue` doesn't cover and stays owed.

## Test

`RefArgumentRenderingTests.ByRefReturn_RendersReturnRef` (a `ref int` method returning a ref local, built directly as IR).

## Verification

- **768/768** `ILInspector.Decompiler.Tests` — `FidelityGateTests` and the new test included; no regression in return rendering.
- Confirmed the four cluster methods over CoreLib now emit `return ref …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)