### PR TITLE
Raise `RuntimeHelpers.InitializeArray` RVA blob to a `new T[] { ... }` literal

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -70,6 +70,13 @@ public class CfgSampleClass
     // the CS0019 `styles & 16`.
     public static CfgStyles RefEnumMask(ref CfgStyles styles) => styles & CfgStyles.Gamma;
 
+    // A constant array with enough elements that csc bulk-initializes it from a
+    // <PrivateImplementationDetails> RVA blob via RuntimeHelpers.InitializeArray
+    // (rather than element-wise stelem). The printer must fold the blob back into
+    // `new int[] { ... }`; left raw the `ldtoken` of the angle-bracketed field name
+    // renders as a comment, leaving `InitializeArray(arr, )` — CS1525.
+    public static int[] RvaIntArray() => new int[] { 11, 22, 33, 44, 55, 66, 77, 88 };
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -117,6 +117,7 @@ public class FidelityGateTests
         "NegativeNativeInt",
         "OrLongIntoULong",
         "RefEnumMask",
+        "RvaIntArray",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler.Tests/InitializeArrayTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InitializeArrayTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A constant array is lowered to `new T[N]; RuntimeHelpers.InitializeArray(arr,
+// ldtoken <PrivateImplementationDetails>.blob)`. The `ldtoken` of the angle-bracketed
+// field renders as a comment, leaving `InitializeArray(arr, )` — CS1525. The pass
+// decodes the RVA blob and folds it back into `new T[] { ... }`.
+public class InitializeArrayTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void InitializeArray_FoldsBlobIntoArrayLiteral()
+    {
+        var output = Render(nameof(CfgSampleClass.RvaIntArray));
+
+        Assert.Contains("new int[] { 11, 22, 33, 44, 55, 66, 77, 88 }", output);
+        Assert.DoesNotContain("InitializeArray", output);
+        Assert.DoesNotContain("LoadToken", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1074,6 +1074,7 @@ public sealed partial class CSharpPrinter
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
         NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
+        ArrayLiteral a => $"new {TypeText(a.ElementType)}[] {{ {string.Join(", ", a.Elements.Select(Expression))} }}",
         CollectionExpression c => $"[{string.Join(", ", c.Elements.Select(Expression))}]",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
@@ -1201,7 +1202,7 @@ public sealed partial class CSharpPrinter
         bool atomic = node is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField
             or NewObject or ArrayLength or LoadElement or SliceExpression or RangeExpression or CaughtException or SizeOf or LoadToken
             or LoadProperty or TypeOf or DelegateCreation or InterpolatedStringExpression or TupleExpression or AnonymousObject or ObjectInitializerExpression or InitializerBlock or IndexFromEnd or CallIndirect or AddressOfMethod or NullConditional
-            or IncrementDecrement or SpanLiteral or CollectionExpression
+            or IncrementDecrement or SpanLiteral or ArrayLiteral or CollectionExpression
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2148,6 +2148,35 @@ public sealed class CollectionExpression : IrExpression
     public override string Describe() => $"CollectionExpression {ElementType.ToDisplayString()}[{Children.Count}]";
 }
 
+/// <summary>
+/// A constant array creation with an element initializer — <c>new T[] { e0, e1, ... }</c>
+/// — raised from the compiler's <c>RuntimeHelpers.InitializeArray</c> lowering: a
+/// <c>new T[N]</c> whose elements are bulk-loaded from a <c>&lt;PrivateImplementationDetails&gt;</c>
+/// field mapping the raw little-endian element bytes. Left as-is that renders as
+/// <c>RuntimeHelpers.InitializeArray(arr, /* LoadToken Field ... */)</c> — the
+/// unspellable <c>ldtoken</c> of a compiler-internal field — which never parses.
+/// The compiler re-lowers the reconstructed literal to the same content-addressed
+/// blob, so the round-trip is opcode-exact.
+/// </summary>
+public sealed class ArrayLiteral : IrExpression
+{
+    public ArrayLiteral(TypeRef elementType, TypeRef arrayType, IEnumerable<IrExpression> elements)
+    {
+        ElementType = elementType;
+        ArrayType = arrayType;
+        foreach (var element in elements)
+            AddChild(element);
+    }
+
+    public TypeRef ElementType { get; }
+    public TypeRef ArrayType { get; }
+    public IReadOnlyList<IrExpression> Elements => Children.Cast<IrExpression>().ToList();
+    public override TypeRef? ResultType => ArrayType;
+    public override IEnumerable<TypeRef> DirectTypes => [ElementType, ArrayType];
+
+    public override string Describe() => $"ArrayLiteral {ElementType.ToDisplayString()}[{Children.Count}]";
+}
+
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
 public sealed class LoadToken : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -314,6 +314,20 @@ public static class MemberIdentity
         && returnedElement.Equals(element);
     }
 
+    /// <summary><c>RuntimeHelpers.InitializeArray(Array, RuntimeFieldHandle)</c> — the
+    /// bulk array-initializer lowering that copies a <c>&lt;PrivateImplementationDetails&gt;</c>
+    /// RVA blob into a freshly-allocated array.</summary>
+    public static bool IsRuntimeHelpersInitializeArray(Call call)
+        => !call.IsVirtual
+            && IsStaticCoreLibraryMethod(
+                call.Callee,
+                "System.Runtime.CompilerServices",
+                "RuntimeHelpers",
+                "InitializeArray")
+            && call.Arguments.Count == 2
+            && call.Callee.ParameterTypes is [_, var handle]
+            && handle.Equals(s_runtimeFieldHandle);
+
     public static bool IsValueTupleType(TypeRef? type, out int arity)
     {
         arity = 0;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -71,6 +71,65 @@ public sealed class RvaSpanPass : IIrPass
             context.Stepper.StepOver("raise ReadOnlySpan RVA field to span literal", construction);
             construction.ReplaceWith(spanLiteral);
         }
+
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            // `new T[] { ... }` with constant elements lowers to `newarr T; dup;
+            // ldtoken <PrivateImplementationDetails>.blob; call InitializeArray` — the
+            // array creation feeds InitializeArray, whose RVA field name has angle
+            // brackets and never parses. Decode the blob and fold it back onto the
+            // array creation as an element initializer, then drop the InitializeArray
+            // statement (csc re-lowers the literal to the same blob, opcode-exact).
+            if (!MemberIdentity.IsRuntimeHelpersInitializeArray(call)
+                || call.Parent is not ExpressionStatement statement
+                || call.Arguments is not [{ } arrayArg, LoadToken { Kind: RuntimeTokenKind.Field, FieldRvaData: { } data }])
+            {
+                continue;
+            }
+            if (ResolveArrayCreation(arrayArg, function) is not { } creation)
+                continue;
+
+            var arrayElements = DecodeElements(creation.ElementType, data);
+            if (arrayElements is null)
+                continue;
+            // The blob length is the array's byte size; honour an explicit element
+            // count when the creation carries a constant length.
+            if (creation.Length is Constant { Value: int count } && count != arrayElements.Count)
+                continue;
+
+            var arrayLiteral = new ArrayLiteral(creation.ElementType, TypeRef.SzArray(creation.ElementType), arrayElements);
+            context.Stepper.StepOver("raise InitializeArray RVA blob to array literal", creation);
+            creation.ReplaceWith(arrayLiteral);
+            statement.Detach();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="NewArray"/> that initialized an InitializeArray target:
+    /// the argument inline, or the unique array-creating store of the slot/local it
+    /// loads. Null when the creation can't be pinned to a single array allocation.
+    /// </summary>
+    static NewArray? ResolveArrayCreation(IrExpression arrayArg, IrFunction function)
+    {
+        if (arrayArg is NewArray inline)
+            return inline;
+
+        IEnumerable<NewArray> defs = arrayArg switch
+        {
+            LoadStackSlot { Slot: var slot } => function.Descendants
+                .OfType<StoreStackSlot>()
+                .Where(store => store.Slot == slot)
+                .Select(store => store.Value)
+                .OfType<NewArray>(),
+            LoadLocal { Index: var index } => function.Descendants
+                .OfType<StoreLocal>()
+                .Where(store => store.Index == index)
+                .Select(store => store.Value)
+                .OfType<NewArray>(),
+            _ => [],
+        };
+
+        return defs.ToList() is [var single] ? single : null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

A constant array — `new byte[] { 0xEF, 0xBB, 0xBF }` — lowers to `newarr T; dup; ldtoken <PrivateImplementationDetails>.blob; call RuntimeHelpers.InitializeArray`, the array bytes mapped by an RVA field. Left as-is, the `ldtoken` of the angle-bracketed compiler-internal field name rendered as a comment, leaving:

```csharp
RuntimeHelpers.InitializeArray(S_256, /* LoadToken Field <PrivateImplementationDetails>.F1945... */);
```

→ **CS1525** *Invalid expression term ')'*. This was the majority of the Full malformed set (`UTF8Encoding.GetPreamble`, several `.cctor`s).

## Fix

`RvaSpanPass` already decodes `<PrivateImplementationDetails>` RVA blobs for the `CreateSpan`/`ReadOnlySpan` forms. Extend it to the `InitializeArray` form:

- Match `RuntimeHelpers.InitializeArray(arr, ldtoken Field{RvaData})` as a statement.
- Resolve the `NewArray` feeding the target — inline, or via the unique slot/local store that loads it.
- Decode the blob as the element type and fold it onto a new **`ArrayLiteral`** (`new T[] { ... }`), then drop the `InitializeArray` statement.

csc re-lowers the literal to the same content-addressed blob, so the round-trip is **opcode-exact**. Scoped to fixed-size primitive element types (the bytes decode unambiguously); enum/struct arrays (`VarEnum[]`, `HS[]`) are left untouched.

```csharp
// before:  RuntimeHelpers.InitializeArray(S_256, /* LoadToken Field ... */);   // CS1525
// after:   S_256 = new byte[] { 239, 187, 191 };
```

## Numbers

- Full malformed **11 → 9** (`OrdinalCasing..cctor`, `UTF8Encoding.GetPreamble`).
- **0 methods newly broken**; semantic-defect count flat (180); inventory flat **40234/41012**.
- New `ArrayLiteral` IR node + printer support; `RvaIntArray` fixture pinned opcode-exact; `InitializeArrayTests` added.
- 768 decompiler + 1174 product tests green.
