### PR TITLE
Reconcile signedness in a mixed signed/unsigned arithmetic operator

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -63,6 +63,14 @@ public class CfgSampleClass
 
     public static ulong OrLongIntoULong(ulong mask, long flag) => mask | (ulong)flag;
 
+    // The arithmetic sibling of OrLongIntoULong: `a * (ulong)b` over a ulong and a
+    // long. The `(ulong)` is a same-width no-op (no conv in IL), so the importer
+    // sees `mul(ulong, long)` — a mixed-sign 64-bit pair with no C# common type
+    // (CS0019). add/sub/mul are sign-neutral at the same width, so the printer
+    // reinterprets the signed operand as unsigned (`a * (ulong)b`), keeping the
+    // same `mul` opcode.
+    public static ulong MulLongIntoULong(ulong a, long b) => a * (ulong)b;
+
     // A `ldind.i4` through a `ref` enum parameter is typed by the opcode width
     // (int), not the pointee enum, so `styles & 16` reads as `int & int` in the
     // IR. The importer must register the ref/pointer pointee's enum shape (and

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -116,6 +116,7 @@ public class FidelityGateTests
         "LineSeparatorLiteral",
         "NegativeNativeInt",
         "OrLongIntoULong",
+        "MulLongIntoULong",
         "RefEnumMask",
     };
 

--- a/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
@@ -26,4 +26,15 @@ public class MixedSignBitwiseTests
 
         Assert.Contains("mask | (ulong)flag", output);
     }
+
+    [Fact]
+    public void ULongMulLong_ReinterpretsSignedOperandAsUnsigned()
+    {
+        // The arithmetic sibling: an unchecked `*` over a ulong/long pair has no
+        // C# common type either, and `mul` is sign-neutral at this width, so the
+        // signed operand reinterprets the same way — `a * (ulong)b`, same opcode.
+        var output = Render(nameof(CfgSampleClass.MulLongIntoULong));
+
+        Assert.Contains("a * (ulong)b", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -39,18 +39,19 @@ public sealed partial class CSharpPrinter
         // float, where .un means unordered, not unsigned) print plain.
         bool castBoth = binary.IsUnsigned && binary.Kind is BinaryKind.Divide or BinaryKind.Remainder;
         bool castLeft = castBoth || (binary.IsUnsigned && binary.Kind is BinaryKind.ShiftRight);
-        // A bitwise &/|/^ between a signed and an unsigned integer of the same
-        // stack width is CS0019 (no implicit signed<->unsigned conversion), but
-        // the bit result is identical under either interpretation. Reinterpret
-        // the signed operand as unsigned — `S_0 | (ulong)S_1` — which is a no-op
-        // (same-width) reinterpret, so the `or`/`and`/`xor` opcode is unchanged.
-        bool mixedSignBitwise = MixedSignBitwise(binary);
-        string left = mixedSignBitwise ? BitwiseUnsignedOperand(binary.Left)
+        // A bitwise &/|/^ — or an unchecked +/-/* at 64-bit/native width — between
+        // a signed and an unsigned integer of the same stack width has no C#
+        // common type (CS0019/CS0034), even though the IL op is sign-neutral at
+        // that width. Reinterpret the signed operand as unsigned — `S_0 | (ulong)S_1`,
+        // `count * (nuint)stride` — a no-op same-width cast, so the opcode and its
+        // stack width are unchanged.
+        bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary);
+        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left)
             : castLeft ? UnsignedOperand(binary.Left)
             : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
-            : mixedSignBitwise ? BitwiseUnsignedOperand(binary.Right)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Right)
             : castBoth ? UnsignedOperand(binary.Right)
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
@@ -71,9 +72,39 @@ public sealed partial class CSharpPrinter
     /// <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
     /// </summary>
     bool MixedSignBitwise(Binary binary)
+        => binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
+            && MixedSignSameWidthIntegers(binary);
+
+    /// <summary>
+    /// True when an <em>unchecked</em> <c>+</c>/<c>-</c>/<c>*</c> has one signed
+    /// and one unsigned <em>64-bit or native</em> integer operand (e.g.
+    /// <c>nuint * nint</c>, <c>ulong - long</c>). Same reinterpret rationale as
+    /// <see cref="MixedSignBitwise"/>: <c>add</c>/<c>sub</c>/<c>mul</c> are
+    /// bit-identical for two's-complement signed and unsigned operands, so casting
+    /// the signed side to unsigned reuses the same opcode — and at this width the
+    /// pair has <em>no</em> C# common type (CS0034/CS0019), so the fix is
+    /// self-contained: the result is unsigned and stays unsigned to its parent.
+    /// <para><c>int</c>/<c>uint</c> (32-bit) is deliberately excluded: there the
+    /// bare form binds to <c>long</c>, so the operand cast must also propagate the
+    /// rendered type to nested parents (<c>1 + (uint)…</c>) — a separate concern
+    /// from this same-width reinterpret. Checked operations are excluded too:
+    /// <c>add.ovf</c> vs <c>add.ovf.un</c> differ by signedness.</para>
+    /// </summary>
+    bool MixedSignArithmetic(Binary binary)
+        => !binary.IsChecked
+            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+            && MixedSignSameWidthIntegers(binary)
+            && TypeFamilies.Of(EffectiveType(binary.Left)) is StackFamily.I8 or StackFamily.I;
+
+    /// <summary>
+    /// The operand-type test shared by <see cref="MixedSignBitwise"/> and
+    /// <see cref="MixedSignArithmetic"/>: one signed and one unsigned integer of
+    /// the same stack width (e.g. <c>ulong</c>/<c>long</c>, <c>uint</c>/<c>int</c>),
+    /// the pair C# rejects (or silently widens) but a sign-neutral IL op permits.
+    /// bool/char are excluded by <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
+    /// </summary>
+    bool MixedSignSameWidthIntegers(Binary binary)
     {
-        if (binary.Kind is not (BinaryKind.And or BinaryKind.Or or BinaryKind.Xor))
-            return false;
         var left = EffectiveType(binary.Left);
         var right = EffectiveType(binary.Right);
         var family = TypeFamilies.Of(left);


### PR DESCRIPTION
## Problem

The arithmetic sibling of #888 (which did bitwise). An unchecked `+`/`-`/`*` between a signed and an unsigned 64-bit or native integer has no C# common type, even though the IL op is sign-neutral at that width. `Buffer.Memmove` decompiles to:

```csharp
SpanHelpers.Memmove(..., elementCount * (nint)sizeof(T));   // CS0034: operator * is ambiguous on nuint and nint
```

`elementCount` is `nuint`, `(nint)sizeof(T)` is `nint`; neither converts to the other.

## Fix

`add`/`sub`/`mul` are bit-identical for two's-complement signed and unsigned operands, so reinterpret the signed side as unsigned — reusing the exact mechanism #888 built for bitwise. Factor the operand-type test out of `MixedSignBitwise` into a shared `MixedSignSameWidthIntegers`, and add `MixedSignArithmetic` that composes it with the same `BitwiseUnsignedOperand`:

```csharp
SpanHelpers.Memmove(..., elementCount * (nuint)((nint)sizeof(T)));
```

The `(nuint)` is a same-width no-op, so the `mul` opcode is unchanged.

## Scope (deliberately narrow)

- **64-bit/native only.** `int`/`uint` (32-bit) is excluded: there the bare form binds to `long` (not CS0019), so folding the operand cast in leaves the result rendering as the wider type to nested parents (`1 + (uint)…`), which *relocates* the mismatch rather than fixing it — measured to regress `get_Month` and `Decimal.Round`. At 64-bit/native there is no common type, so the result is unsigned and stays unsigned to its parent: self-contained. The 32-bit case needs rendered-type propagation, a separate change.
- **Unchecked only.** `add.ovf` vs `add.ovf.un` differ by signedness, so reinterpreting an operand there would change the opcode.

## Validation

- Same-base validity defect diff (`--diff-validity-defects`): **8 methods lose CS0034** (`Buffer.Memmove`, `Math.BigMul`, the `Array.CopyImpl*` helpers, `Double.CreateDouble`, …), **zero regressions** (the i4 cases that would regress are excluded; verified by re-diffing).
- Decompiler suite green (**768**); the new `MulLongIntoULong` fixture is pinned **opcode-exact** in `FidelityGateTests` (the arithmetic analog of `OrLongIntoULong`).

## Tests

`MulLongIntoULong(ulong a, long b) => a * (ulong)b` reproduces the `mul(ulong, long)` shape (the `(ulong)` is a no-op the importer re-derives); `MixedSignBitwiseTests` asserts it renders `a * (ulong)b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)