### PR TITLE
Add decompiler library report harness

### DIFF
--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -1,0 +1,307 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Per-assembly portfolio view: combines the cheap IR residual classifier with
+/// the Roslyn-backed validity oracle so a directory of libraries becomes a
+/// prioritized unsupported-pattern report.
+/// </summary>
+internal static class LibraryReport
+{
+    public static int Run(IReadOnlyList<string> assemblies, int compileCap, int maxExamples, bool json)
+    {
+        var reports = new List<AssemblyReport>();
+        using var metadata = CorpusMetadata.Create(assemblies);
+        var references = ValidityCheck.RuntimeReferences();
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compileOptions = new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            allowUnsafe: true,
+            nullableContextOptions: NullableContextOptions.Disable)
+            .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
+            .WithMetadataImportOptions(MetadataImportOptions.Internal);
+
+        foreach (var assembly in assemblies)
+        {
+            reports.Add(AnalyzeAssembly(assembly, metadata, references, parseOptions, compileOptions, compileCap, maxExamples));
+        }
+
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(reports, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        else
+        {
+            PrintMarkdown(reports);
+        }
+
+        return reports.Any(r => r.PassBugs > 0) ? 1 : 0;
+    }
+
+    static AssemblyReport AnalyzeAssembly(
+        string path,
+        MetadataContext metadata,
+        ImmutableArray<MetadataReference> references,
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions compileOptions,
+        int compileCap,
+        int maxExamples)
+    {
+        var buckets = new Dictionary<string, Bucket>(StringComparer.Ordinal);
+        var report = new MutableReport(Path.GetFileName(path), path);
+
+        try
+        {
+            using var source = MetadataSource.Open(path, context: metadata);
+            report.Assembly = source.AssemblyName;
+            var constraints = ShellConstraints.Build(source);
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                report.TotalMethods++;
+                var id = $"{typeName}::{methodName}";
+                try
+                {
+                    IrPasses.Run(function);
+                }
+                catch (Exception ex)
+                {
+                    report.PassBugs++;
+                    Record(buckets, $"pass-bug: {ex.GetType().Name}", id, maxExamples);
+                    continue;
+                }
+
+                bool full = function.Fidelity == DecompilationFidelity.Full;
+                if (full)
+                {
+                    report.FullMethods++;
+                }
+                else
+                {
+                    report.PartialMethods++;
+                }
+
+                string? residual = Completeness.Residual(function)
+                    ?? (!full ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}" : null);
+                if (residual is null)
+                {
+                    report.FullyRaisedMethods++;
+                }
+                else
+                {
+                    Record(buckets, residual, id, maxExamples);
+                }
+
+                if (typeName.Contains('<', StringComparison.Ordinal) || methodName.Contains('<', StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string? rendered;
+                try
+                {
+                    rendered = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method)).Output;
+                }
+                catch (Exception ex)
+                {
+                    if (full)
+                    {
+                        Record(buckets, $"validity: render-exception:{ex.GetType().Name}", id, maxExamples);
+                    }
+                    continue;
+                }
+
+                if (rendered is null)
+                {
+                    continue;
+                }
+                report.RenderedMethods++;
+
+                string shell = ValidityCheck.Shell(function, rendered, typeName, methodName, constraints);
+                var tree = CSharpSyntaxTree.ParseText(shell, parseOptions);
+                var syntaxErrors = tree.GetDiagnostics().Where(ValidityCheck.IsError).ToList();
+                var illegal = ValidityCheck.IllegalStatements(tree);
+                if (syntaxErrors.Count > 0 || illegal.Count > 0)
+                {
+                    if (full)
+                    {
+                        report.FullMalformed++;
+                        string code = syntaxErrors.Count > 0 ? syntaxErrors[0].Id : "CS0201";
+                        Record(buckets, $"validity: malformed:{code}", id, maxExamples);
+                    }
+                    else
+                    {
+                        report.PartialMalformed++;
+                    }
+                    continue;
+                }
+
+                if (!full || report.SemanticChecked >= compileCap)
+                {
+                    continue;
+                }
+                report.SemanticChecked++;
+
+                var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
+                var defects = compilation.GetDiagnostics()
+                    .Where(ValidityCheck.IsError)
+                    .Where(d => !ValidityCheck.BindingNoise.Contains(d.Id))
+                    .Where(d => !ValidityCheck.IsShellArtifact(d))
+                    .ToList();
+                if (defects.Count == 0)
+                {
+                    continue;
+                }
+
+                report.SemanticDefectMethods++;
+                foreach (var defect in defects)
+                {
+                    Record(buckets, $"validity: {defect.Id}", id, maxExamples);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            report.PassBugs++;
+            Record(buckets, $"assembly-open: {ex.GetType().Name}", report.Assembly, maxExamples);
+        }
+
+        return report.ToReport(buckets);
+    }
+
+    static string BucketFor(DecompilerDiagnostic diagnostic)
+    {
+        if (diagnostic.Id is null)
+        {
+            return "(typed)";
+        }
+        if (diagnostic.Id == DiagnosticIds.UnsupportedType)
+        {
+            var message = diagnostic.Message ?? "(typed)";
+            int detail = message.IndexOf('(');
+            return detail < 0 ? message : message[..detail].TrimEnd();
+        }
+        return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
+    }
+
+    static void Record(Dictionary<string, Bucket> buckets, string key, string example, int maxExamples)
+    {
+        if (!buckets.TryGetValue(key, out var bucket))
+        {
+            buckets[key] = bucket = new Bucket(key);
+        }
+        bucket.Count++;
+        if (bucket.Examples.Count < maxExamples)
+        {
+            bucket.Examples.Add(example);
+        }
+    }
+
+    static void PrintMarkdown(IReadOnlyList<AssemblyReport> reports)
+    {
+        Console.WriteLine("# Decompiler library report");
+        Console.WriteLine();
+        Console.WriteLine("| Assembly | Methods | Full | Fully raised | Full malformed | Bound Full defects | Pass bugs | Top patterns |");
+        Console.WriteLine("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
+        foreach (var report in reports)
+        {
+            var top = report.Patterns.Take(3)
+                .Select(p => $"{p.Count} {Escape(p.Name)}");
+            Console.WriteLine($"| {Escape(report.Assembly)} | {report.TotalMethods} | {CountPercent(report.FullMethods, report.TotalMethods)} | {CountPercent(report.FullyRaisedMethods, report.TotalMethods)} | {report.FullMalformed} | {report.SemanticDefectMethods}/{report.SemanticChecked} | {report.PassBugs} | {string.Join("<br>", top)} |");
+        }
+
+        foreach (var report in reports)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"## {report.Assembly}");
+            Console.WriteLine();
+            Console.WriteLine($"Path: `{report.Path}`");
+            Console.WriteLine();
+            Console.WriteLine("Top unsupported patterns:");
+            if (report.Patterns.Count == 0)
+            {
+                Console.WriteLine("- (none)");
+                continue;
+            }
+
+            foreach (var pattern in report.Patterns.Take(10))
+            {
+                Console.WriteLine($"- **{pattern.Name}**: {pattern.Count}");
+                foreach (var example in pattern.Examples.Take(3))
+                {
+                    Console.WriteLine($"  - `{example}`");
+                }
+            }
+        }
+    }
+
+    static string CountPercent(int part, int whole)
+        => whole == 0 ? "0/0" : $"{part}/{whole} ({100.0 * part / whole:F2}%)";
+
+    static string Escape(string value)
+        => value.Replace("|", "\\|").Replace("\n", " ");
+
+    sealed class MutableReport(string assembly, string path)
+    {
+        public string Assembly { get; set; } = assembly;
+        public string Path { get; } = path;
+        public int TotalMethods { get; set; }
+        public int FullMethods { get; set; }
+        public int PartialMethods { get; set; }
+        public int FullyRaisedMethods { get; set; }
+        public int RenderedMethods { get; set; }
+        public int FullMalformed { get; set; }
+        public int PartialMalformed { get; set; }
+        public int SemanticChecked { get; set; }
+        public int SemanticDefectMethods { get; set; }
+        public int PassBugs { get; set; }
+
+        public AssemblyReport ToReport(Dictionary<string, Bucket> buckets)
+            => new(
+                Assembly,
+                Path,
+                TotalMethods,
+                FullMethods,
+                PartialMethods,
+                FullyRaisedMethods,
+                RenderedMethods,
+                FullMalformed,
+                PartialMalformed,
+                SemanticChecked,
+                SemanticDefectMethods,
+                PassBugs,
+                [.. buckets.Values
+                    .OrderByDescending(b => b.Count)
+                    .ThenBy(b => b.Name, StringComparer.Ordinal)
+                    .Select(b => new PatternReport(b.Name, b.Count, [.. b.Examples]))]);
+    }
+
+    sealed class Bucket(string name)
+    {
+        public string Name { get; } = name;
+        public int Count { get; set; }
+        public List<string> Examples { get; } = [];
+    }
+}
+
+internal sealed record AssemblyReport(
+    string Assembly,
+    string Path,
+    int TotalMethods,
+    int FullMethods,
+    int PartialMethods,
+    int FullyRaisedMethods,
+    int RenderedMethods,
+    int FullMalformed,
+    int PartialMalformed,
+    int SemanticChecked,
+    int SemanticDefectMethods,
+    int PassBugs,
+    IReadOnlyList<PatternReport> Patterns);
+
+internal sealed record PatternReport(string Name, int Count, IReadOnlyList<string> Examples);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -50,6 +50,8 @@ static class Program
         string? passImpactPass = null;
         bool showDiff = false;
         bool structuringStops = false;
+        bool libraryReport = false;
+        bool json = false;
         int cap = int.MaxValue;
 
         for (int i = 0; i < args.Length; i++)
@@ -90,6 +92,8 @@ static class Program
                     break;
                 case "--show-diff": showDiff = true; break;
                 case "--structuring-stops": structuringStops = true; break;
+                case "--library-report": libraryReport = true; break;
+                case "--json": json = true; break;
                 case "--cap": cap = int.Parse(args[++i]); break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
@@ -111,6 +115,9 @@ static class Program
 
         if (annotationCheck)
             return AnnotationCheck.Run(assemblies, maxExamples);
+
+        if (libraryReport)
+            return LibraryReport.Run(assemblies, compileCap, maxExamples, json);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -996,6 +1003,9 @@ static class Program
                                 (every unambiguous witness opcode — box/newarr/
                                 localloc/calli — produced its annotation). Exits
                                 non-zero on any precision violation.
+          --library-report       per-assembly summary: Full %, fully-raised %,
+                                validity defects, residual pattern buckets, and
+                                examples. Use --json for machine-readable output.
           --pass-impact [pass]  blast-radius sweep — the inverse of --dump --diff.
                                 With no pass: histogram of how many corpus methods
                                 each pass changes. With a pass name (e.g.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,6 +8,13 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Gaps** (`--gaps`): the completeness view — see below.
 
+**Library report** (`--library-report`): a portfolio view, one row per assembly.
+It combines the IR residual buckets from `--gaps` with the Roslyn-backed validity
+oracle from `--validity-check`, then prints the top unsupported patterns and
+example methods for each library. Use this for the direct
+"which patterns are unsupported in which library?" loop. `--json` emits the same
+data as structured JSON.
+
 **Validity check** (`--validity-check`): the *validity* check — `--gaps` is *completeness*, `--fidelity-check` is *fidelity*, this is *does it even compile*. The pipeline guarantees by construction only that it never crashes and never silently fabricates (unrepresentable IL becomes a visible `/* … */` comment and drops fidelity to `Partial`) — **not** that the rendered text is valid C#. This mode measures the gap: each body is wrapped in a method shell carrying its real signature (return type, generic parameters with their `where` constraints reconstructed from metadata, parameters, so locals/params/type-params and `this` all bind — without the constraints a constrained generic-math call like `byte.TryConvertFromTruncating<TOther>` spuriously fails CS0314), then (1) parsed — a parse error is unambiguously a decompiler defect; (2) checked for statement legality (the CS0201 rule — a bare cast/expression statement parses but isn't valid); (3) bound against the runtime references. Diagnostics are bucketed by code with the member/type-**visibility** codes (the shell can't see the real declaring type's fields/methods) filtered as noise, so genuine defects stand out — `CS0193` (`*`-deref of a managed ref), `CS0175` (`base(...)` rendered as a statement), `CS1620` (an `out` argument not marked `out`), `CS0165` (a local used before the decompiler assigned it). Reported split by fidelity: a `Partial` method is *expected* to carry invalid fragments; a **`Full` method that fails to compile is the real "claimed good but isn't" signal** and the prioritized fix docket. Compiler-generated members are excluded (their metadata names aren't valid identifiers). `--compile-cap N` bounds the (slow) semantic-binding pass.
 
 *Defect tracking — prove a fix regressed nothing.* A raw count (e.g. "CS0266: 263") tells you a bucket shrank but not *which* methods changed, so it cannot distinguish a real fix from a fix that also broke something else. `--emit-validity-defects <file>` writes the per-method defect map (one `Type::Method<TAB>CODE,CODE` row per method) before your change; after the change, `--diff-validity-defects <file>` re-runs the check and prints the differential against that baseline — **REGRESSED** (methods that gained a code) and **IMPROVED** (methods that lost one), per code. A clean fix shows entries only under IMPROVED with an empty REGRESSED; any REGRESSED row is a method your change broke. Only methods checked in *both* runs are compared (cap-boundary methods are excluded), so keep `--compile-cap` identical across the baseline and diff runs. This is the regression-proof loop behind a "N→M occurrences, 0 regressions" claim.
@@ -43,6 +50,12 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 ```bash
 # CoreLib of the running runtime (default input)
 dotnet run --project tools/DecompilerHarness -c Release
+
+# Per-assembly unsupported-pattern report for a product or shared framework folder
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --library-report
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/shared/Microsoft.NETCore.App/11.0.0 --library-report --json
 
 # Whole shared framework: fidelity histogram + stop-reason roadmap
 dotnet run --project tools/DecompilerHarness -c Release -- \

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -52,7 +52,7 @@ static class ValidityCheck
     // an interface-constrained type parameter the external shell cannot see. The
     // call IS the correct spelling (it round-trips to the same constrained call);
     // the diagnostic is an artifact of the constraint-free shell.
-    static readonly HashSet<string> BindingNoise =
+    internal static readonly HashSet<string> BindingNoise =
     [
         "CS0103", "CS0117", "CS1061", "CS0246", "CS0234", "CS0122",
         "CS0119", "CS1955", "CS0021", "CS0070", "CS0118", "CS1501",
@@ -291,7 +291,7 @@ static class ValidityCheck
     }
 
     /// <summary>Wraps a body in a generic instance method on a class so locals, params, type params, and `this` all bind; member access on `this` becomes filtered binding noise.</summary>
-    static string Shell(IrFunction function, string body, string typeName, string methodName,
+    internal static string Shell(IrFunction function, string body, string typeName, string methodName,
         IReadOnlyDictionary<string, Dictionary<string, string>> constraints)
     {
         var generics = GenericParameterNames(function);
@@ -372,7 +372,7 @@ static class ValidityCheck
     }
 
     /// <summary>Expression statements whose expression is not a legal statement (the CS0201 rule), checkable without binding.</summary>
-    static List<ExpressionStatementSyntax> IllegalStatements(SyntaxTree tree)
+    internal static List<ExpressionStatementSyntax> IllegalStatements(SyntaxTree tree)
         => tree.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>()
             .Where(s => !IsLegalStatementExpression(s.Expression))
             .ToList();
@@ -391,7 +391,7 @@ static class ValidityCheck
         _ => false,
     };
 
-    static bool IsError(Diagnostic diagnostic) => diagnostic.Severity == DiagnosticSeverity.Error;
+    internal static bool IsError(Diagnostic diagnostic) => diagnostic.Severity == DiagnosticSeverity.Error;
 
     /// <summary>
     /// The body is wrapped in an instance method on a synthetic <c>__Shell</c>
@@ -401,9 +401,9 @@ static class ValidityCheck
     /// source compiled, so the declaring-type form is valid), not a defect in the
     /// decompiled output. Filtered like the binding-visibility codes.
     /// </summary>
-    static bool IsShellArtifact(Diagnostic diagnostic) => diagnostic.GetMessage().Contains("__Shell");
+    internal static bool IsShellArtifact(Diagnostic diagnostic) => diagnostic.GetMessage().Contains("__Shell");
 
-    static ImmutableArray<MetadataReference> RuntimeReferences()
+    internal static ImmutableArray<MetadataReference> RuntimeReferences()
     {
         var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Summary
- add `--library-report` to DecompilerHarness for per-assembly unsupported-pattern reporting
- combine IR residual/fidelity buckets with Roslyn parse/bind validity buckets
- include examples per bucket and optional `--json` output
- document the new report mode and usage examples

## Validation
- dotnet build tools/DecompilerHarness -c Release --nologo --verbosity minimal
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --library-report --compile-cap 10000 --max-examples 3
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --library-report --json --compile-cap 10000 --max-examples 1
- npx markdownlint-cli tools/DecompilerHarness/README.md