### PR TITLE
Preserve copied static lock receivers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3225,6 +3225,21 @@ public class LockSugarTests
         Assert.DoesNotContain("Monitor", output);
     }
 
+    [Fact]
+    public void CoreLibStaticFieldLock_PreservesCopiedReceiverLocal()
+    {
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.AppContext", "GetData");
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+
+        var output = CSharpPrinter.Print(function!).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("lock (V_1)", output);
+        Assert.DoesNotContain("lock (AppContext.s_dataStore)", output);
+    }
+
     static IrFunction IrImportFor(string methodName)
     {
         using var source = MetadataSource.Open(typeof(LockFixtureSamples).Assembly.Location);
@@ -3244,7 +3259,7 @@ public class LockSugarTests
 /// </summary>
 public class LockSugarSoundnessTests
 {
-    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef, bool malformedEnterSignature = false)
+    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef, bool malformedEnterSignature = false, bool staticFieldLockObject = false)
     {
         var voidType = TypeRef.CoreLib("System", "Void");
         var objType = TypeRef.CoreLib("System", "Object");
@@ -3272,7 +3287,10 @@ public class LockSugarSoundnessTests
         finallyBody.Add(finallyBlock);
 
         var entry = new Block(0);
-        entry.Add(new StoreLocal(0, objType, new Constant(null, objType)));
+        IrExpression lockObject = staticFieldLockObject
+            ? new LoadField(new FieldRef(TypeRef.Definition("SyntheticAssembly", "Samples", "Owner"), "Gate", objType), instance: null)
+            : new Constant(null, objType);
+        entry.Add(new StoreLocal(0, objType, lockObject));
         entry.Add(new StoreLocal(1, boolType, new Constant(0, boolType)));
         entry.Add(new TryFinally(tryBody, finallyBody));
         if (strayTakenRef)
@@ -3291,6 +3309,20 @@ public class LockSugarSoundnessTests
         new LockSugarPass().Run(function, PassContext.None);
 
         Assert.Single(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void StaticFieldReceiver_RaisesButKeepsObjectCopy()
+    {
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false, staticFieldLockObject: true);
+        new LockSugarPass().Run(function, PassContext.None);
+
+        var lockNode = Assert.Single(function.Descendants.OfType<Pipeline.Lock>());
+        var lockObject = Assert.IsType<LoadLocal>(lockNode.LockObject);
+        Assert.Equal(0, lockObject.Index);
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
         Assert.Empty(function.Descendants.OfType<TryFinally>());
         function.CheckInvariant();
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -84,6 +84,8 @@ public sealed class ExpressionInliningPass : IIrPass
             }
             if (!IsInside(load, next))
                 continue;
+            if (store is StoreLocal { Value: LoadField { Instance: null } } && IsLockObject(load))
+                continue;  // keep copied static lock receivers; inlining can fail to bind in reconstructed shells
 
             bool pure = IsPure(store is StoreLocal sl ? sl.Value : ((StoreStackSlot)store).Value, locals, argumentAddresses, function);
             if (!IsFirstEvaluatedLeaf(load, next) && !pure)
@@ -101,6 +103,9 @@ public sealed class ExpressionInliningPass : IIrPass
         }
         return false;
     }
+
+    static bool IsLockObject(IrNode node)
+        => node.Parent is Lock lockNode && ReferenceEquals(lockNode.LockObject, node);
 
     // A place the dataflow tracks: a method argument, a local, or a stack slot.
     enum PlaceKind { Argument, Local, Slot }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LockSugarPass.cs
@@ -9,10 +9,14 @@ namespace ILInspector.Decompiler.Pipeline;
 ///   try { Monitor.Enter(V_0, ref V_1); BODY }
 ///   finally { if (V_1) Monitor.Exit(V_0); }
 /// </code>
-/// becomes <c>lock (obj) { BODY }</c>. Runs after structuring so the finally
-/// guard is an <see cref="IfStatement"/>. Transactional: the whole shape,
-/// including that the two synthetic locals appear nowhere in BODY, is proven
-/// before anything is detached — otherwise the construct is left flat.
+/// usually becomes <c>lock (obj) { BODY }</c>. Static-field receivers keep the
+/// copied local (<c>var tmp = T.Field; lock (tmp) { BODY }</c>) because the
+/// reconstructed shell may not bind the private static field expression in the
+/// lock header, while the copied local is always in scope. Runs after
+/// structuring so the finally guard is an <see cref="IfStatement"/>.
+/// Transactional: the whole shape, including that the two synthetic locals
+/// appear nowhere in BODY, is proven before anything is detached — otherwise the
+/// construct is left flat.
 /// </summary>
 public sealed class LockSugarPass : IIrPass
 {
@@ -58,7 +62,10 @@ public sealed class LockSugarPass : IIrPass
                     continue;
                 }
 
-                var lockObject = (IrExpression)match.StoreObject.DetachChildren()[0];
+                bool preserveObjectLocal = ShouldPreserveObjectLocal(match.StoreObject.Value);
+                var lockObject = preserveObjectLocal
+                    ? new LoadLocal(match.StoreObject.Index, match.StoreObject.Type)
+                    : (IrExpression)match.StoreObject.DetachChildren()[0];
                 match.EnterStatement.Detach();
                 var body = match.TryFinally.TryBody;
                 body.Detach();                          // reparent the try body into the lock
@@ -66,12 +73,16 @@ public sealed class LockSugarPass : IIrPass
                 stepper.StepOver("raise Monitor enter/exit to lock", match.TryFinally);
                 match.TryFinally.ReplaceWith(lockNode); // slot i+2 → Lock
                 match.StoreTaken.Detach();              // drop synthetic locals (high index first)
-                match.StoreObject.Detach();
+                if (!preserveObjectLocal)
+                    match.StoreObject.Detach();
                 return true;
             }
         }
         return false;
     }
+
+    static bool ShouldPreserveObjectLocal(IrExpression lockObject)
+        => lockObject is LoadField { Instance: null };
 
     /// <summary>Matches the three-statement lock shape; null when it does not fit.</summary>
     static Match? TryMatch(IrNode first, IrNode second, IrNode third)


### PR DESCRIPTION
## Summary
- keep copied static-field lock receiver locals when raising Monitor lock lowering
- prevent expression inlining from collapsing those copied lock locals back into private static field lock headers
- add synthetic and CoreLib AppContext regression coverage

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 800