### PR TITLE
Bind a labeled comment-only EH tail to an empty statement

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StrandedLabelRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StrandedLabelRenderingTests.cs
@@ -49,4 +49,45 @@ public class StrandedLabelRenderingTests
         Assert.True(labelIndex + 1 < lines.Count, "label is the last token — it is stranded");
         Assert.Equal(";", lines[labelIndex + 1]);
     }
+
+    static IrFunction BuildWithLabeledEndFinally(int targetOffset)
+    {
+        // Block 0: if (flag) goto IL_<target>; return 1;
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(0, "flag", Boolean), targetOffset));
+        entry.Add(new Return(new Constant(1, Int32)));
+        // The branch target is a block whose only statement is an `endfinally` —
+        // which renders as a bare `// endfinally` comment, not a real statement.
+        // A comment cannot satisfy the label, so without the empty-statement guard
+        // the label sits directly before the closing brace (CS1525).
+        var tail = new Block(targetOffset);
+        tail.Add(new EndFinally());
+
+        var container = new BlockContainer();
+        container.Add(entry);
+        container.Add(tail);
+
+        var signature = new MethodSignature(Int32, [new Parameter("flag", Boolean)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [], container);
+    }
+
+    [Fact]
+    public void LabeledCommentOnlyTail_BindsLabelToEmptyStatement()
+    {
+        var result = CSharpPrinter.Print(BuildWithLabeledEndFinally(0x10));
+
+        var lines = (result.Output ?? "")
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+
+        int labelIndex = lines.IndexOf("IL_0010:");
+        Assert.True(labelIndex >= 0, $"expected a label in:\n{result.Output}");
+        // The label is followed by the `// endfinally` comment and then an empty
+        // statement; a comment is whitespace, so the `;` is what makes the label
+        // legal. The label must not be left as the final token.
+        Assert.Contains(";", lines.Skip(labelIndex + 1));
+        Assert.NotEqual(labelIndex, lines.Count - 1);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -280,7 +280,9 @@ public sealed partial class CSharpPrinter
         // A label binds to the next statement, even one in a following block, so
         // an empty labeled block is fine mid-container. It only strands when the
         // container ends with no statement after the label; track that and emit a
-        // labeled empty statement (';') to keep the C# valid.
+        // labeled empty statement (';') to keep the C# valid. A comment-only
+        // render (an `// endfinally` marker, an unsupported `/* … */` node) is not
+        // a statement, so it does not satisfy a pending label either.
         bool labelPendingStatement = false;
         for (int i = 0; i < blocks.Count; i++)
         {
@@ -304,13 +306,29 @@ public sealed partial class CSharpPrinter
                     break;
                 emit.Add(statement);
             }
-            if (emit.Count > 0)
+            if (emit.Any(n => !RendersAsCommentOnly(n)))
                 labelPendingStatement = false;
             AppendStatements(sb, emit, indent);
         }
         if (labelPendingStatement)
             sb.Append(pad).AppendLine(";");
     }
+
+    /// <summary>
+    /// A statement node that renders only as a comment — an <c>// endfinally</c>/
+    /// <c>// endfilter</c> EH marker or an unsupported <c>/* … */</c> node — so it
+    /// is not a real C# statement. A label sitting before one stays unsatisfied:
+    /// the trailing empty statement (';') must still follow to keep a labeled
+    /// region legal (a label requires a statement; a bare label before a closing
+    /// brace is <c>CS1525</c>).
+    /// </summary>
+    static bool RendersAsCommentOnly(IrNode node) => node switch
+    {
+        EndFinally or EndFilter => true,
+        UnsupportedNode => true,
+        ExpressionStatement { Expression: UnsupportedNode } => true,
+        _ => false,
+    };
 
     static HashSet<int> CollectBranchTargets(IrFunction function)
     {


### PR DESCRIPTION
## Problem

A block whose only statement is an `endfinally`/`endfilter` renders as a bare `// endfinally` comment — not a real C# statement. When such a block carries a branch-target label and ends the container, the label was left sitting directly before the closing brace:

```csharp
IL_0074:
// endfinally
```

That is invalid C# — `CS1525: Invalid expression term '}'` — because a label must be followed by a statement, and a comment is whitespace.

The printer already guards against a *stranded* trailing label by emitting a labeled empty statement (`;`), but the guard cleared its pending flag for **any** emitted node, including comment-only ones. So a labeled block holding only an `endfinally` suppressed the `;` and produced malformed output while still claiming `Full` fidelity.

## Fix

Treat a comment-only render (`endfinally`/`endfilter`, an unsupported `/* … */` node) as **not** satisfying a pending label, so the existing trailing empty-statement path fires:

```csharp
IL_0074:
// endfinally
;
```

## Evidence

Measured via the harness validity sweep over CoreLib (`--validity-check`):

| | Full malformed |
| --- | --- |
| before | **2** (`ConcurrentQueue.EnqueueSlow`, `ConcurrentQueue.TryDequeueSlow`) |
| after | **0** |

This clears the entire "claimed good but won't parse" set.

The change is semantically inert — an empty `;` statement emits no IL, so it cannot alter any opcode stream or fidelity grade. It only appears in the rare flat-EH-dump case where structuring left a labeled `endfinally` at a container tail.

## Tests

- New `StrandedLabelRenderingTests.LabeledCommentOnlyTail_BindsLabelToEmptyStatement` covering a labeled `endfinally` tail.
- Full `ILInspector.Decompiler.Tests` suite: **775 passing** (includes `FidelityGateTests`/`LoweredFidelityGateTests`/validity gates).
- Full `dotnet-inspect.Tests`: **1174 passing**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>