### PR TITLE
Add library report limits

### DIFF
--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -14,7 +14,7 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 internal static class LibraryReport
 {
-    public static int Run(IReadOnlyList<string> assemblies, int compileCap, int maxExamples, bool json)
+    public static int Run(IReadOnlyList<string> assemblies, int compileCap, int maxExamples, bool json, int topPatterns, int? topLibraries)
     {
         var reports = new List<AssemblyReport>();
         using var metadata = CorpusMetadata.Create(assemblies);
@@ -32,17 +32,36 @@ internal static class LibraryReport
             reports.Add(AnalyzeAssembly(assembly, metadata, references, parseOptions, compileOptions, compileCap, maxExamples));
         }
 
+        int patternLimit = Math.Max(1, topPatterns);
+        var selectedReports = SelectLibraries(reports, topLibraries);
+        var topPatternReports = TopPatterns(selectedReports, patternLimit, maxExamples);
+
         if (json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(reports, new JsonSerializerOptions { WriteIndented = true }));
+            Console.WriteLine(JsonSerializer.Serialize(
+                new LibraryPortfolioReport(topPatternReports, selectedReports),
+                new JsonSerializerOptions { WriteIndented = true }));
         }
         else
         {
-            PrintMarkdown(reports);
+            PrintMarkdown(selectedReports, topPatternReports, patternLimit, topLibraries);
         }
 
         return reports.Any(r => r.PassBugs > 0) ? 1 : 0;
     }
+
+    static IReadOnlyList<AssemblyReport> SelectLibraries(IReadOnlyList<AssemblyReport> reports, int? topLibraries)
+    {
+        if (topLibraries is not { } limit)
+            return reports;
+        return [.. reports
+            .OrderByDescending(UnsupportedLoad)
+            .ThenBy(r => r.Assembly, StringComparer.Ordinal)
+            .Take(Math.Max(1, limit))];
+    }
+
+    static int UnsupportedLoad(AssemblyReport report)
+        => report.Patterns.Sum(p => p.Count);
 
     static AssemblyReport AnalyzeAssembly(
         string path,
@@ -202,15 +221,71 @@ internal static class LibraryReport
         }
     }
 
-    static void PrintMarkdown(IReadOnlyList<AssemblyReport> reports)
+    static IReadOnlyList<PatternSummary> TopPatterns(IReadOnlyList<AssemblyReport> reports, int topPatterns, int maxExamples)
+    {
+        return [.. reports
+            .SelectMany(report => report.Patterns.Select(pattern => (report, pattern)))
+            .GroupBy(entry => entry.pattern.Name, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var affected = group
+                    .GroupBy(entry => entry.report.Assembly, StringComparer.Ordinal)
+                    .Select(library => new PatternLibrarySummary(
+                        library.Key,
+                        library.Sum(entry => entry.pattern.Count),
+                        [.. library.SelectMany(entry => entry.pattern.Examples).Distinct(StringComparer.Ordinal).Take(maxExamples)]))
+                    .OrderByDescending(library => library.Count)
+                    .ThenBy(library => library.Assembly, StringComparer.Ordinal)
+                    .ToArray();
+                return new PatternSummary(
+                    group.Key,
+                    group.Sum(entry => entry.pattern.Count),
+                    affected.Length,
+                    affected,
+                    [.. group.SelectMany(entry => entry.pattern.Examples).Distinct(StringComparer.Ordinal).Take(maxExamples)]);
+            })
+            .OrderByDescending(pattern => pattern.Count)
+            .ThenBy(pattern => pattern.Name, StringComparer.Ordinal)
+            .Take(topPatterns)];
+    }
+
+    static void PrintMarkdown(
+        IReadOnlyList<AssemblyReport> reports,
+        IReadOnlyList<PatternSummary> topPatterns,
+        int patternLimit,
+        int? topLibraries)
     {
         Console.WriteLine("# Decompiler library report");
+        Console.WriteLine();
+        if (topLibraries is { } limit)
+            Console.WriteLine($"Showing top {Math.Max(1, limit)} libraries by unsupported-pattern load.");
+        else
+            Console.WriteLine($"Showing all {reports.Count} libraries.");
+        Console.WriteLine();
+
+        Console.WriteLine($"## Top {patternLimit} unsupported patterns");
+        Console.WriteLine();
+        if (topPatterns.Count == 0)
+        {
+            Console.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var pattern in topPatterns)
+            {
+                Console.WriteLine($"- **{pattern.Name}**: {pattern.Count} across {pattern.LibraryCount} librar{(pattern.LibraryCount == 1 ? "y" : "ies")}");
+                foreach (var library in pattern.AffectedLibraries.Take(5))
+                    Console.WriteLine($"  - {library.Assembly}: {library.Count} — {string.Join("; ", library.Examples.Take(2).Select(e => $"`{e}`"))}");
+            }
+        }
+        Console.WriteLine();
+        Console.WriteLine("## Libraries");
         Console.WriteLine();
         Console.WriteLine("| Assembly | Methods | Full | Fully raised | Full malformed | Bound Full defects | Pass bugs | Top patterns |");
         Console.WriteLine("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
         foreach (var report in reports)
         {
-            var top = report.Patterns.Take(3)
+            var top = report.Patterns.Take(Math.Min(3, patternLimit))
                 .Select(p => $"{p.Count} {Escape(p.Name)}");
             Console.WriteLine($"| {Escape(report.Assembly)} | {report.TotalMethods} | {CountPercent(report.FullMethods, report.TotalMethods)} | {CountPercent(report.FullyRaisedMethods, report.TotalMethods)} | {report.FullMalformed} | {report.SemanticDefectMethods}/{report.SemanticChecked} | {report.PassBugs} | {string.Join("<br>", top)} |");
         }
@@ -222,14 +297,14 @@ internal static class LibraryReport
             Console.WriteLine();
             Console.WriteLine($"Path: `{report.Path}`");
             Console.WriteLine();
-            Console.WriteLine("Top unsupported patterns:");
+            Console.WriteLine($"Top {patternLimit} unsupported patterns:");
             if (report.Patterns.Count == 0)
             {
                 Console.WriteLine("- (none)");
                 continue;
             }
 
-            foreach (var pattern in report.Patterns.Take(10))
+            foreach (var pattern in report.Patterns.Take(patternLimit))
             {
                 Console.WriteLine($"- **{pattern.Name}**: {pattern.Count}");
                 foreach (var example in pattern.Examples.Take(3))
@@ -305,3 +380,16 @@ internal sealed record AssemblyReport(
     IReadOnlyList<PatternReport> Patterns);
 
 internal sealed record PatternReport(string Name, int Count, IReadOnlyList<string> Examples);
+
+internal sealed record LibraryPortfolioReport(
+    IReadOnlyList<PatternSummary> TopPatterns,
+    IReadOnlyList<AssemblyReport> Libraries);
+
+internal sealed record PatternSummary(
+    string Name,
+    int Count,
+    int LibraryCount,
+    IReadOnlyList<PatternLibrarySummary> AffectedLibraries,
+    IReadOnlyList<string> Examples);
+
+internal sealed record PatternLibrarySummary(string Assembly, int Count, IReadOnlyList<string> Examples);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -52,6 +52,8 @@ static class Program
         bool structuringStops = false;
         bool libraryReport = false;
         bool json = false;
+        int topPatterns = 10;
+        int? topLibraries = null;
         int cap = int.MaxValue;
 
         for (int i = 0; i < args.Length; i++)
@@ -94,6 +96,8 @@ static class Program
                 case "--structuring-stops": structuringStops = true; break;
                 case "--library-report": libraryReport = true; break;
                 case "--json": json = true; break;
+                case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
+                case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
                 case "--cap": cap = int.Parse(args[++i]); break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
@@ -117,7 +121,7 @@ static class Program
             return AnnotationCheck.Run(assemblies, maxExamples);
 
         if (libraryReport)
-            return LibraryReport.Run(assemblies, compileCap, maxExamples, json);
+            return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -1006,6 +1010,10 @@ static class Program
           --library-report       per-assembly summary: Full %, fully-raised %,
                                 validity defects, residual pattern buckets, and
                                 examples. Use --json for machine-readable output.
+          --top-patterns <n>     with --library-report: show top n patterns
+                                overall and per library (default 10).
+          --top-libraries <n>    with --library-report: show top n libraries by
+                                unsupported-pattern load (default all).
           --pass-impact [pass]  blast-radius sweep — the inverse of --dump --diff.
                                 With no pass: histogram of how many corpus methods
                                 each pass changes. With a pass name (e.g.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,12 +8,13 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Gaps** (`--gaps`): the completeness view — see below.
 
-**Library report** (`--library-report`): a portfolio view, one row per assembly.
-It combines the IR residual buckets from `--gaps` with the Roslyn-backed validity
-oracle from `--validity-check`, then prints the top unsupported patterns and
-example methods for each library. Use this for the direct
-"which patterns are unsupported in which library?" loop. `--json` emits the same
-data as structured JSON.
+**Library report** (`--library-report`): a portfolio view. It combines the IR
+residual buckets from `--gaps` with the Roslyn-backed validity oracle from
+`--validity-check`, then prints a global top-pattern section and one section per
+library. Use this for the direct "which patterns are unsupported in which
+library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
+`--top-libraries N` limits the detailed library sections to the noisiest
+libraries, and `--json` emits the same data as structured JSON.
 
 **Validity check** (`--validity-check`): the *validity* check — `--gaps` is *completeness*, `--fidelity-check` is *fidelity*, this is *does it even compile*. The pipeline guarantees by construction only that it never crashes and never silently fabricates (unrepresentable IL becomes a visible `/* … */` comment and drops fidelity to `Partial`) — **not** that the rendered text is valid C#. This mode measures the gap: each body is wrapped in a method shell carrying its real signature (return type, generic parameters with their `where` constraints reconstructed from metadata, parameters, so locals/params/type-params and `this` all bind — without the constraints a constrained generic-math call like `byte.TryConvertFromTruncating<TOther>` spuriously fails CS0314), then (1) parsed — a parse error is unambiguously a decompiler defect; (2) checked for statement legality (the CS0201 rule — a bare cast/expression statement parses but isn't valid); (3) bound against the runtime references. Diagnostics are bucketed by code with the member/type-**visibility** codes (the shell can't see the real declaring type's fields/methods) filtered as noise, so genuine defects stand out — `CS0193` (`*`-deref of a managed ref), `CS0175` (`base(...)` rendered as a statement), `CS1620` (an `out` argument not marked `out`), `CS0165` (a local used before the decompiler assigned it). Reported split by fidelity: a `Partial` method is *expected* to carry invalid fragments; a **`Full` method that fails to compile is the real "claimed good but isn't" signal** and the prioritized fix docket. Compiler-generated members are excluded (their metadata names aren't valid identifiers). `--compile-cap N` bounds the (slow) semantic-binding pass.
 
@@ -53,9 +54,11 @@ dotnet run --project tools/DecompilerHarness -c Release
 
 # Per-assembly unsupported-pattern report for a product or shared framework folder
 dotnet run --project tools/DecompilerHarness -c Release -- \
-  artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --library-report
+  artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --library-report \
+  --top-patterns 5
 dotnet run --project tools/DecompilerHarness -c Release -- \
-  /path/to/shared/Microsoft.NETCore.App/11.0.0 --library-report --json
+  /path/to/shared/Microsoft.NETCore.App/11.0.0 --library-report \
+  --top-patterns 10 --top-libraries 12 --json
 
 # Whole shared framework: fidelity histogram + stop-reason roadmap
 dotnet run --project tools/DecompilerHarness -c Release -- \


### PR DESCRIPTION
## Summary
- add `--top-patterns` and `--top-libraries` for `DecompilerHarness --library-report`
- add a global top unsupported-pattern section before per-library details
- limit detailed library sections to the noisiest libraries when requested
- document the new options and examples

## Validation
- dotnet build tools/DecompilerHarness -c Release --nologo --verbosity minimal
- dotnet run --project tools/DecompilerHarness -c Release -- <product assemblies> --library-report --compile-cap 1000 --max-examples 2 --top-patterns 5 --top-libraries 3
- dotnet run --project tools/DecompilerHarness -c Release -- <product assemblies> --library-report --json --compile-cap 1000 --max-examples 1 --top-patterns 2 --top-libraries 2
- npx markdownlint-cli tools/DecompilerHarness/README.md