### PR TITLE
Mixed-sign integer arithmetic with rendered-type propagation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -71,6 +71,19 @@ public class CfgSampleClass
     // same `mul` opcode.
     public static ulong MulLongIntoULong(ulong a, long b) => a * (ulong)b;
 
+    // The 32-bit case: `a * (uint)b` over a uint and an int. The `(uint)` is a
+    // same-width no-op, so the importer sees `mul(uint, int)` — which C# widens to
+    // a 64-bit `long` mul (a fidelity break) rather than the original 32-bit one.
+    // The printer reinterprets the signed operand to unsigned (`a * (uint)b`),
+    // keeping the same 32-bit `mul`.
+    public static uint MulIntIntoUInt(uint a, int b) => a * (uint)b;
+
+    // Nested mixed-sign arithmetic: `(a * (uint)b) + count`. The inner mul renders
+    // unsigned, and EffectiveType must report that so the outer add sees a uint
+    // left operand (rather than the ECMA-signed ResultType) and stays unsigned —
+    // the rendered-type propagation. The whole expression is one 32-bit `mul`/`add`.
+    public static uint NestedMixedSignArithmetic(uint a, int b, uint count) => (a * (uint)b) + count;
+
     // A `ldind.i4` through a `ref` enum parameter is typed by the opcode width
     // (int), not the pointee enum, so `styles & 16` reads as `int & int` in the
     // IR. The importer must register the ref/pointer pointee's enum shape (and

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -63,6 +63,14 @@ public class CfgSampleClass
 
     public static ulong OrLongIntoULong(ulong mask, long flag) => mask | (ulong)flag;
 
+    // The arithmetic sibling of OrLongIntoULong: `a * (ulong)b` over a ulong and a
+    // long. The `(ulong)` is a same-width no-op (no conv in IL), so the importer
+    // sees `mul(ulong, long)` — a mixed-sign 64-bit pair with no C# common type
+    // (CS0019). add/sub/mul are sign-neutral at the same width, so the printer
+    // reinterprets the signed operand as unsigned (`a * (ulong)b`), keeping the
+    // same `mul` opcode.
+    public static ulong MulLongIntoULong(ulong a, long b) => a * (ulong)b;
+
     // A `ldind.i4` through a `ref` enum parameter is typed by the opcode width
     // (int), not the pointee enum, so `styles & 16` reads as `int & int` in the
     // IR. The importer must register the ref/pointer pointee's enum shape (and

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -117,6 +117,8 @@ public class FidelityGateTests
         "NegativeNativeInt",
         "OrLongIntoULong",
         "MulLongIntoULong",
+        "MulIntIntoUInt",
+        "NestedMixedSignArithmetic",
         "RefEnumMask",
     };
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -116,6 +116,7 @@ public class FidelityGateTests
         "LineSeparatorLiteral",
         "NegativeNativeInt",
         "OrLongIntoULong",
+        "MulLongIntoULong",
         "RefEnumMask",
     };
 

--- a/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
@@ -26,4 +26,15 @@ public class MixedSignBitwiseTests
 
         Assert.Contains("mask | (ulong)flag", output);
     }
+
+    [Fact]
+    public void ULongMulLong_ReinterpretsSignedOperandAsUnsigned()
+    {
+        // The arithmetic sibling: an unchecked `*` over a ulong/long pair has no
+        // C# common type either, and `mul` is sign-neutral at this width, so the
+        // signed operand reinterprets the same way — `a * (ulong)b`, same opcode.
+        var output = Render(nameof(CfgSampleClass.MulLongIntoULong));
+
+        Assert.Contains("a * (ulong)b", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
@@ -37,4 +37,24 @@ public class MixedSignBitwiseTests
 
         Assert.Contains("a * (ulong)b", output);
     }
+
+    [Fact]
+    public void UIntMulInt_ReinterpretsSignedOperandAsUnsigned()
+    {
+        // The 32-bit case: `uint * int` widens to a 64-bit `long` mul in C# unless
+        // the signed operand is reinterpreted; `a * (uint)b` keeps the 32-bit mul.
+        var output = Render(nameof(CfgSampleClass.MulIntIntoUInt));
+
+        Assert.Contains("a * (uint)b", output);
+    }
+
+    [Fact]
+    public void NestedMixedSignArithmetic_PropagatesUnsignedRenderedType()
+    {
+        // The inner `a * (uint)b` renders unsigned; EffectiveType must report that
+        // so the outer `+ count` (uint) stays unsigned without a spurious cast.
+        var output = Render(nameof(CfgSampleClass.NestedMixedSignArithmetic));
+
+        Assert.Contains("(a * (uint)b) + count", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -71,30 +71,57 @@ public sealed partial class CSharpPrinter
     /// signed/unsigned integer pairs — bool/char are excluded by
     /// <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
     /// </summary>
-    bool MixedSignBitwise(Binary binary)
+    static bool MixedSignBitwise(Binary binary)
         => binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
             && MixedSignSameWidthIntegers(binary);
 
     /// <summary>
     /// True when an <em>unchecked</em> <c>+</c>/<c>-</c>/<c>*</c> has one signed
-    /// and one unsigned <em>64-bit or native</em> integer operand (e.g.
-    /// <c>nuint * nint</c>, <c>ulong - long</c>). Same reinterpret rationale as
-    /// <see cref="MixedSignBitwise"/>: <c>add</c>/<c>sub</c>/<c>mul</c> are
-    /// bit-identical for two's-complement signed and unsigned operands, so casting
-    /// the signed side to unsigned reuses the same opcode — and at this width the
-    /// pair has <em>no</em> C# common type (CS0034/CS0019), so the fix is
-    /// self-contained: the result is unsigned and stays unsigned to its parent.
-    /// <para><c>int</c>/<c>uint</c> (32-bit) is deliberately excluded: there the
-    /// bare form binds to <c>long</c>, so the operand cast must also propagate the
-    /// rendered type to nested parents (<c>1 + (uint)…</c>) — a separate concern
-    /// from this same-width reinterpret. Checked operations are excluded too:
-    /// <c>add.ovf</c> vs <c>add.ovf.un</c> differ by signedness.</para>
+    /// and one unsigned integer operand of the same stack width (e.g.
+    /// <c>int * uint</c>, <c>nuint * nint</c>, <c>ulong - long</c>). Same
+    /// reinterpret rationale as <see cref="MixedSignBitwise"/>: <c>add</c>/
+    /// <c>sub</c>/<c>mul</c> are bit-identical for two's-complement signed and
+    /// unsigned operands, so casting the signed side to unsigned reuses the same
+    /// opcode at the same stack width — whereas the bare C# form binds to the wider
+    /// common type (<c>int * uint</c> ⇒ <c>long</c>, a 64-bit <c>mul</c>) or has
+    /// none at all (<c>ulong * long</c> ⇒ CS0019). <see cref="EffectiveType"/>
+    /// reports this unsigned result so a nested parent (<c>1 + (int * uint)</c>)
+    /// sees the unsigned operand and reconciles in turn. Checked operations are
+    /// excluded: <c>add.ovf</c> vs <c>add.ovf.un</c> differ by signedness.
     /// </summary>
-    bool MixedSignArithmetic(Binary binary)
+    static bool MixedSignArithmetic(Binary binary)
         => !binary.IsChecked
             && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
-            && MixedSignSameWidthIntegers(binary)
-            && TypeFamilies.Of(EffectiveType(binary.Left)) is StackFamily.I8 or StackFamily.I;
+            && MixedSignSameWidthIntegers(binary);
+
+    /// <summary>
+    /// True when an integer arithmetic (unchecked <c>+</c>/<c>-</c>/<c>*</c>) or
+    /// bitwise (<c>&amp;</c>/<c>|</c>/<c>^</c>) binary <em>renders</em> unsigned:
+    /// both operands are the same-width <em>wide</em> integer (int/uint, long/ulong,
+    /// nint/nuint — sub-int byte/short/char excluded, since they promote to int)
+    /// and at least one is unsigned. The printer leaves a both-unsigned pair bare
+    /// and reconciles a mixed-sign pair to unsigned, so either way the rendered
+    /// result is unsigned. Drives <see cref="EffectiveType"/> only; deliberately
+    /// conservative, so a case it misses stays at its ECMA <c>ResultType</c> rather
+    /// than over-claiming an unsigned rendering.
+    /// </summary>
+    static bool RendersUnsigned(Binary binary)
+    {
+        bool arith = !binary.IsChecked && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply;
+        bool bitwise = binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor;
+        if (!arith && !bitwise)
+            return false;
+        var left = EffectiveType(binary.Left);
+        var right = EffectiveType(binary.Right);
+        return IsWideInteger(left) && IsWideInteger(right)
+            && TypeFamilies.Of(left) == TypeFamilies.Of(right)
+            && (TypeFamilies.IsUnsignedIntegerPrimitive(left) || TypeFamilies.IsUnsignedIntegerPrimitive(right));
+    }
+
+    /// <summary>The 4-byte, 8-byte, and native integer primitives — the widths C# does not promote to a wider type (unlike sub-int byte/short/char, which promote to int).</summary>
+    static bool IsWideInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && type.Name is "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr";
 
     /// <summary>
     /// The operand-type test shared by <see cref="MixedSignBitwise"/> and
@@ -103,12 +130,15 @@ public sealed partial class CSharpPrinter
     /// the pair C# rejects (or silently widens) but a sign-neutral IL op permits.
     /// bool/char are excluded by <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
     /// </summary>
-    bool MixedSignSameWidthIntegers(Binary binary)
+    static bool MixedSignSameWidthIntegers(Binary binary)
     {
         var left = EffectiveType(binary.Left);
         var right = EffectiveType(binary.Right);
-        var family = TypeFamilies.Of(left);
-        if (family is not (StackFamily.I4 or StackFamily.I8 or StackFamily.I) || family != TypeFamilies.Of(right))
+        // Both operands must be WIDE integers: a sub-int (byte/short/ushort/char)
+        // promotes to int in C#, so `ushort - int` is already `int - int` and
+        // needs no reconciliation — treating the sub-int as the unsigned partner
+        // would wrongly cast the int operand to uint (`S_0 - (uint)S_1`, CS0266).
+        if (!IsWideInteger(left) || !IsWideInteger(right) || TypeFamilies.Of(left) != TypeFamilies.Of(right))
             return false;
         bool leftSigned = TypeFamilies.UnsignedCastKeyword(left) is not null;
         bool rightSigned = TypeFamilies.UnsignedCastKeyword(right) is not null;
@@ -399,6 +429,19 @@ public sealed partial class CSharpPrinter
             if (binary is { IsUnsigned: true, Kind: BinaryKind.Divide or BinaryKind.Remainder or BinaryKind.ShiftRight }
                 && TypeFamilies.UnsignedCounterpart(binary.ResultType) is { } unsigned)
                 return unsigned;
+            // An integer arithmetic/bitwise binary renders unsigned whenever an
+            // operand renders unsigned at the same width: the printer either leaves
+            // a both-unsigned pair bare (`uint + uint`) or reconciles a mixed-sign
+            // pair by reinterpreting the signed side (`(uint)x + count`). Either
+            // way the rendered result is unsigned even though the ECMA ResultType
+            // keeps a signed operand type. Report it, so a parent (a nested
+            // `1 + (int * uint)`, or a CastValue boundary into a signed target)
+            // sees the unsigned type and reconciles or casts in turn — the
+            // propagation that resolves the `int op uint` family up the whole tree.
+            if (RendersUnsigned(binary))
+                return TypeFamilies.IsUnsignedIntegerPrimitive(binary.ResultType)
+                    ? binary.ResultType
+                    : TypeFamilies.UnsignedCounterpart(binary.ResultType);
         }
         return value.ResultType;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -39,18 +39,19 @@ public sealed partial class CSharpPrinter
         // float, where .un means unordered, not unsigned) print plain.
         bool castBoth = binary.IsUnsigned && binary.Kind is BinaryKind.Divide or BinaryKind.Remainder;
         bool castLeft = castBoth || (binary.IsUnsigned && binary.Kind is BinaryKind.ShiftRight);
-        // A bitwise &/|/^ between a signed and an unsigned integer of the same
-        // stack width is CS0019 (no implicit signed<->unsigned conversion), but
-        // the bit result is identical under either interpretation. Reinterpret
-        // the signed operand as unsigned — `S_0 | (ulong)S_1` — which is a no-op
-        // (same-width) reinterpret, so the `or`/`and`/`xor` opcode is unchanged.
-        bool mixedSignBitwise = MixedSignBitwise(binary);
-        string left = mixedSignBitwise ? BitwiseUnsignedOperand(binary.Left)
+        // A bitwise &/|/^ — or an unchecked +/-/* at 64-bit/native width — between
+        // a signed and an unsigned integer of the same stack width has no C#
+        // common type (CS0019/CS0034), even though the IL op is sign-neutral at
+        // that width. Reinterpret the signed operand as unsigned — `S_0 | (ulong)S_1`,
+        // `count * (nuint)stride` — a no-op same-width cast, so the opcode and its
+        // stack width are unchanged.
+        bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary);
+        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left)
             : castLeft ? UnsignedOperand(binary.Left)
             : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
-            : mixedSignBitwise ? BitwiseUnsignedOperand(binary.Right)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Right)
             : castBoth ? UnsignedOperand(binary.Right)
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
@@ -71,9 +72,39 @@ public sealed partial class CSharpPrinter
     /// <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
     /// </summary>
     bool MixedSignBitwise(Binary binary)
+        => binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
+            && MixedSignSameWidthIntegers(binary);
+
+    /// <summary>
+    /// True when an <em>unchecked</em> <c>+</c>/<c>-</c>/<c>*</c> has one signed
+    /// and one unsigned <em>64-bit or native</em> integer operand (e.g.
+    /// <c>nuint * nint</c>, <c>ulong - long</c>). Same reinterpret rationale as
+    /// <see cref="MixedSignBitwise"/>: <c>add</c>/<c>sub</c>/<c>mul</c> are
+    /// bit-identical for two's-complement signed and unsigned operands, so casting
+    /// the signed side to unsigned reuses the same opcode — and at this width the
+    /// pair has <em>no</em> C# common type (CS0034/CS0019), so the fix is
+    /// self-contained: the result is unsigned and stays unsigned to its parent.
+    /// <para><c>int</c>/<c>uint</c> (32-bit) is deliberately excluded: there the
+    /// bare form binds to <c>long</c>, so the operand cast must also propagate the
+    /// rendered type to nested parents (<c>1 + (uint)…</c>) — a separate concern
+    /// from this same-width reinterpret. Checked operations are excluded too:
+    /// <c>add.ovf</c> vs <c>add.ovf.un</c> differ by signedness.</para>
+    /// </summary>
+    bool MixedSignArithmetic(Binary binary)
+        => !binary.IsChecked
+            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+            && MixedSignSameWidthIntegers(binary)
+            && TypeFamilies.Of(EffectiveType(binary.Left)) is StackFamily.I8 or StackFamily.I;
+
+    /// <summary>
+    /// The operand-type test shared by <see cref="MixedSignBitwise"/> and
+    /// <see cref="MixedSignArithmetic"/>: one signed and one unsigned integer of
+    /// the same stack width (e.g. <c>ulong</c>/<c>long</c>, <c>uint</c>/<c>int</c>),
+    /// the pair C# rejects (or silently widens) but a sign-neutral IL op permits.
+    /// bool/char are excluded by <see cref="TypeFamilies.IsUnsignedIntegerPrimitive"/>.
+    /// </summary>
+    bool MixedSignSameWidthIntegers(Binary binary)
     {
-        if (binary.Kind is not (BinaryKind.And or BinaryKind.Or or BinaryKind.Xor))
-            return false;
         var left = EffectiveType(binary.Left);
         var right = EffectiveType(binary.Right);
         var family = TypeFamilies.Of(left);


### PR DESCRIPTION
## What this is

The rendered-type-propagation work that completes the mixed-sign signedness story and unblocks the 32-bit `int`/`uint` CS0266 family. This branch contains two commits:

1. **Reconcile signedness in a mixed signed/unsigned arithmetic operator** (the 64-bit/native subset — was #903, folded in here).
2. **Propagate the unsigned rendered type** (this — the propagation that reaches 32-bit).

> Supersedes #903, which scoped to the self-contained 64-bit/native subset precisely because the 32-bit case needs this propagation.

## The problem propagation solves

`#888` (bitwise) and the first commit here reconcile a mixed-sign binary by reinterpreting the signed operand as unsigned — `(uint)100 * count`. The result *renders* unsigned, but the IR `ResultType` keeps a signed operand type. So a parent that consulted `ResultType` didn't see the unsigned operand and left the next level bare:

```csharp
return 1 + ((uint)100 * V_0 + …);   // 1 (int) + uint ⇒ long ⇒ CS0266, just relocated
```

That is why the 64-bit/native subset was self-contained (no common type → result stays unsigned) but the 32-bit case (which widens to `long`) was not.

## Fix

Teach `EffectiveType` — the printer's "rendered type" oracle — the rendered type of a mixed-sign binary: an integer arithmetic/bitwise binary renders unsigned whenever an operand renders unsigned at the same **wide** width (`RendersUnsigned`). The unsigned type then flows up the tree:

```csharp
return (int)((uint)1 + (((uint)100 * V_0) + ((V_1 | (uint)3) / (uint)1461)));
```

Each level sees the unsigned operand and reconciles in turn; the top-level boundary casts once. With propagation in place, `MixedSignArithmetic` drops its 64-bit/native restriction and covers `int`/`uint`.

## Soundness

- **Faithful.** `add`/`sub`/`mul`/`and`/`or`/`xor` are sign-neutral at a fixed width; the reinterpret casts are same-width no-ops, and the final boundary `(int)` is a no-op `i4→i4`. The whole-CoreLib fidelity sweep shows **0 Full opcode diffs**, and `MulIntIntoUInt` + `NestedMixedSignArithmetic` are pinned **opcode-exact** in the fidelity gate.
- **Conservative `EffectiveType`.** `RendersUnsigned` is restricted to wide integers (int/uint, long/ulong, nint/nuint); a case it misses keeps its ECMA `ResultType`, so it never *over*-claims an unsigned rendering (which would mis-cast).
- **Sub-int hardening.** `MixedSignSameWidthIntegers` now requires wide integers on both sides: a sub-int (byte/short/ushort/char) promotes to int, so `ushort - int` is `int - int` and must not be reconciled — doing so produced `S_0 - (uint)S_1` (CS0266). This also hardens the #888 bitwise path.

## Validation

- Same-base validity defect diff: **4 methods lose CS0266** (`DateTime.GetYear`/`GetDate`, `Guid.TryParseHex`, `Math.Sign`), **zero regressions** (the two i4 cases that regressed before the sub-int fix — `get_Month`, `Decimal.Round` — are clean).
- Whole-CoreLib `--fidelity-check`: 0 Full opcode diffs.
- Decompiler suite green (**770**), including `FidelityGateTests`, `LoweredFidelityGateTests`, and `CorpusSweepGateTests`.

## Tests

`MulIntIntoUInt` (`a * (uint)b`, the i4 reinterpret) and `NestedMixedSignArithmetic` (`(a * (uint)b) + count`, exercising the propagation through a parent) — both pinned opcode-exact; `MixedSignBitwiseTests` asserts the rendered shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)