### PR TITLE
Raise an inline-array span conversion to a cast `(Span<T>)place`

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2517,6 +2517,34 @@ public class CfgSampleClass
     // it back to `[a, b]`, which csc re-lowers to the same buffer — opcode-exact.
     public static int InlineArraySpan(int a, int b) => SumSpan([a, b]);
 
+    [System.Runtime.CompilerServices.InlineArray(4)]
+    public struct Inline4 { private int _element0; }
+
+    Inline4 _inlineField;
+
+    // A real [InlineArray(4)] FIELD viewed as a Span<int> and indexed. Unlike the
+    // collection-expression case above (a synthesized buffer built from element
+    // stores), this is a direct span conversion of a pre-existing inline-array
+    // place: csc lowers `Span<int> s = _inlineField` to
+    // <PrivateImplementationDetails>.InlineArrayAsSpan<Inline4, int>(ref
+    // _inlineField, 4). The angle-bracketed method name never parses, so the bare
+    // call is malformed C#; InlineArrayCollectionPass raises it to the cast
+    // `(Span<int>)_inlineField`, which csc re-lowers to the same AsSpan call.
+    public int InlineArrayFieldAsSpan(int i)
+    {
+        System.Span<int> s = _inlineField;
+        return s[i];
+    }
+
+    // The ReadOnlySpan dual: a span conversion of the same field through the
+    // read-only path, lowered to InlineArrayAsReadOnlySpan and raised to
+    // `(ReadOnlySpan<int>)_inlineField`.
+    public int InlineArrayFieldAsReadOnlySpan(int i)
+    {
+        System.ReadOnlySpan<int> s = _inlineField;
+        return s[i];
+    }
+
     static void Tick() { }
     void Instance() { }
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -24,12 +24,19 @@ public class FidelityGateTests
     /// GotoCommonExit is the step-2 common-exit fold: the decompiler inlines the
     /// shared return tail into each arm, recompiling to cleaner direct-return IL
     /// than the original goto-and-merge shape — a benign equivalent restructuring.
+    /// SelectBoolReturn is a benign branch-polarity inversion in a bool-select
+    /// ternary (orig <c>bgt</c> vs recmp <c>ble</c>), the same class as
+    /// BothPositive/NeitherOr; it was previously hidden in the recompile-fail
+    /// bucket because its <c>System.GC.KeepAlive</c> call recompiled the short
+    /// <c>GC</c> name with no <c>using System;</c> in the skeleton, and the
+    /// harness now emits that using.
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
         "GotoCommonExit",
         "NeitherOr",
+        "SelectBoolReturn",
     };
 
     /// <summary>
@@ -86,6 +93,8 @@ public class FidelityGateTests
         "ConstantUIntSpan",
         "ConstantByteSpan",
         "InlineArraySpan",
+        "InlineArrayFieldAsSpan",
+        "InlineArrayFieldAsReadOnlySpan",
         "IsPatternGuard",
         "IsPatternConjunction",
         "IsPatternConjunctionVariableBound",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -52,6 +52,7 @@ public class IdiomShapeScorecardTests
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachPatternEnumerable), SyntaxKind.ForEachStatement, [SyntaxKind.WhileStatement]),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
         new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArraySpan), SyntaxKind.CollectionExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("InlineArrayCollectionPass", nameof(CfgSampleClass.InlineArrayFieldAsSpan), SyntaxKind.CastExpression, [SyntaxKind.InvocationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.ArrayRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.StringRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),
         new("RangeFromGetSubArrayPass", nameof(CfgSampleClass.SpanRangeBoth), SyntaxKind.RangeExpression, [SyntaxKind.InvocationExpression]),

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -397,6 +397,42 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void InlineArrayFieldAsSpan_RaisesToCast()
+    {
+        // A real [InlineArray(4)] field viewed as a Span<int>: csc lowers the
+        // span conversion to <PrivateImplementationDetails>.InlineArrayAsSpan(ref
+        // _inlineField, 4). Left flat the angle-bracketed method name never parses.
+        // InlineArrayCollectionPass raises the bare conversion to `(Span<int>)
+        // _inlineField`, which csc re-lowers to the same AsSpan call.
+        var function = ImportFixture(nameof(CfgSampleClass.InlineArrayFieldAsSpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains("(Span<int>)_inlineField", output);
+        Assert.DoesNotContain("InlineArray", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+    [Fact]
+    public void InlineArrayFieldAsReadOnlySpan_RaisesToCast()
+    {
+        // The ReadOnlySpan dual of InlineArrayFieldAsSpan: the read-only span
+        // conversion lowers to InlineArrayAsReadOnlySpan and raises to the cast
+        // `(ReadOnlySpan<int>)_inlineField`.
+        var function = ImportFixture(nameof(CfgSampleClass.InlineArrayFieldAsReadOnlySpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains("(ReadOnlySpan<int>)_inlineField", output);
+        Assert.DoesNotContain("InlineArray", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+    [Fact]
     public void CheckedCompound_RendersCheckedBlockWithCompoundSugar()
     {
         // `checked(x += v)` lowers to add.ovf; `checked(x += v);` is not a legal

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -20,7 +20,7 @@ public class LoweredFidelityGateTests
     /// Methods whose lowered C# still recompiles to a different opcode stream — the open
     /// lowered docket. The gate tolerates these but fails if a NEW method joins the set.
     /// Beyond the shared sugared docket (BothPositive, GotoCommonExit,
-    /// NeitherOr), the lowered view adds ReverseCopy:
+    /// NeitherOr, SelectBoolReturn), the lowered view adds ReverseCopy:
     /// lowering deliberately skips
     /// IncrementDecrementPass, so the dup-based ++/-- idiom round-trips as an explicit temp
     /// rather than the folded operator — a benign by-design divergence for this view.
@@ -31,6 +31,7 @@ public class LoweredFidelityGateTests
         "GotoCommonExit",
         "NeitherOr",
         "ReverseCopy",
+        "SelectBoolReturn",
     };
 
     /// <summary>
@@ -60,6 +61,8 @@ public class LoweredFidelityGateTests
         "SumTwoPinned",
         "ConstantUIntSpan",
         "InlineArraySpan",
+        "InlineArrayFieldAsSpan",
+        "InlineArrayFieldAsReadOnlySpan",
         "IsPatternGuard",
         "IsPatternConjunction",
         "IsPatternConjunctionVariableBound",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1076,6 +1076,7 @@ public sealed partial class CSharpPrinter
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
         ArrayLiteral a => $"new {TypeText(a.ElementType)}[] {{ {string.Join(", ", a.Elements.Select(Expression))} }}",
         CollectionExpression c => $"[{string.Join(", ", c.Elements.Select(Expression))}]",
+        InlineArraySpanConversion c => $"({TypeText(c.SpanType)}){Deref(c.Place)}",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2179,6 +2179,39 @@ public sealed class ArrayLiteral : IrExpression
     public override string Describe() => $"ArrayLiteral {ElementType.ToDisplayString()}[{Children.Count}]";
 }
 
+/// <summary>
+/// A C# 12 inline-array span conversion — <c>(System.Span&lt;T&gt;)place</c> or
+/// <c>(System.ReadOnlySpan&lt;T&gt;)place</c> — raised from the compiler's
+/// <c>&lt;PrivateImplementationDetails&gt;.InlineArrayAsSpan&lt;TBuffer, T&gt;(ref place, N)</c>
+/// (and the <c>AsReadOnlySpan</c> dual) lowering of the implicit/explicit
+/// conversion an <c>[InlineArray(N)]</c> buffer has to a span. Unlike
+/// <see cref="CollectionExpression"/> (which recovers a synthesized
+/// <c>&lt;&gt;y__InlineArrayN</c> temporary built from element stores), this is a
+/// direct conversion of a pre-existing inline-array <em>place</em> — a field,
+/// parameter, or array element — to a span, e.g. <c>(Span&lt;uint&gt;)_values</c>.
+/// The <see cref="Place"/> is the address node naming the buffer; the printer
+/// dereferences it to the lvalue spelling. Its result type is the span the
+/// call produced, so replacing the call leaves the surrounding expression's type
+/// unchanged and the compiler re-lowers the cast to the same AsSpan call. The
+/// angle-bracketed <c>&lt;PrivateImplementationDetails&gt;</c> method name never
+/// parses, so leaving the call flat is malformed C#.
+/// </summary>
+public sealed class InlineArraySpanConversion : IrExpression
+{
+    public InlineArraySpanConversion(TypeRef spanType, IrExpression place)
+    {
+        SpanType = spanType;
+        AddChild(place);
+    }
+
+    public TypeRef SpanType { get; }
+    public IrExpression Place => (IrExpression)Children[0];
+    public override TypeRef? ResultType => SpanType;
+    public override IEnumerable<TypeRef> DirectTypes => [SpanType];
+
+    public override string Describe() => $"InlineArraySpanConversion {SpanType.ToDisplayString()}";
+}
+
 /// <summary>ldtoken: a runtime handle for a type, method, or field (the typeof/ldtoken patterns raise from this).</summary>
 public sealed class LoadToken : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -5,7 +5,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <summary>
 /// Raises the csc inline-array lowering of a span collection expression back into
 /// a C# 12 collection expression — <c>[e0, e1, ...]</c> in a
-/// <see cref="System.ReadOnlySpan{T}"/> context. A collection expression with
+/// <see cref="System.ReadOnlySpan{T}"/> context — and, as its complement, a
+/// direct inline-array span conversion back into a cast
+/// (<c>(System.Span{T})place</c>). A collection expression with
 /// non-constant elements targeting a span, e.g.
 /// <c>GetFlattenedIndex([index1, index2])</c>, is lowered to a
 /// compiler-synthesized <c>&lt;&gt;y__InlineArrayN&lt;T&gt;</c> temporary that is
@@ -76,6 +78,51 @@ public sealed class InlineArrayCollectionPass : IIrPass
             init.Detach();
             foreach (var store in stores)
                 store.Detach();
+        }
+
+        RaisePlaceConversions(function, context);
+    }
+
+    /// <summary>
+    /// Raises a direct inline-array span conversion — an
+    /// <c>InlineArrayAsSpan</c>/<c>InlineArrayAsReadOnlySpan</c> over a
+    /// pre-existing inline-array <em>place</em> (a field, parameter, or array
+    /// element) — to a C# cast <c>(Span&lt;T&gt;)place</c>. This is the
+    /// complement of the collection-expression recovery above: there is no
+    /// synthesized buffer to fold, just an <c>[InlineArray(N)]</c> location an
+    /// implicit/explicit span conversion was applied to (e.g.
+    /// <c>BitVector256.Set</c> viewing its <c>_values</c> field as a
+    /// <c>Span&lt;uint&gt;</c>).
+    ///
+    /// <para>Scoped to field/parameter/array-element places — a
+    /// <see cref="LoadLocalAddress"/> is never matched, so a synthesized
+    /// collection temporary whose full shape the loop above declined can never
+    /// be mis-raised here. The span the call produced is the cast's target type,
+    /// so replacing the call leaves the surrounding type unchanged and the
+    /// compiler re-lowers the cast to the same AsSpan call.</para>
+    /// </summary>
+    static void RaisePlaceConversions(IrFunction function, PassContext context)
+    {
+        foreach (var span in function.Descendants.OfType<Call>().ToList())
+        {
+            if (span.Parent is null)
+                continue;
+            if (!IsPrivateImpl(span.Callee, "InlineArrayAsReadOnlySpan") && !IsPrivateImpl(span.Callee, "InlineArrayAsSpan"))
+                continue;
+            if (span.Callee.TypeArguments is not [_, _])
+                continue;
+            if (span.ResultType is not { } spanType)
+                continue;
+            // A field, parameter, or array element — never a local. The
+            // collection-expression buffer is always a local, so excluding
+            // LoadLocalAddress keeps the two recoveries disjoint.
+            if (span.Arguments is not [LoadFieldAddress or LoadArgumentAddress or LoadElementAddress, Constant { Value: int }])
+                continue;
+
+            var place = (IrExpression)span.DetachChildren()[0];
+            var conversion = new InlineArraySpanConversion(spanType, place);
+            context.Stepper.StepOver("raise inline-array span conversion to cast", span);
+            span.ReplaceWith(conversion);
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -54,7 +54,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Block => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass BreakStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call => default!;
-    [Completeness(CompletenessLevel.Full)] public static InlineArrayCollectionPass CollectionExpression => new();
+    [Completeness(CompletenessLevel.Full, "collection expressions in a span context; also raises a direct inline-array span conversion (`InlineArrayAsSpan`/`AsReadOnlySpan` over a field/parameter/array-element place) to the cast `(Span<T>)place`")] public static InlineArrayCollectionPass CollectionExpression => new();
     [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, indexer, and ref targets raised, including the checked-context form (`checked(x += v)` recovered as a `checked { x += v; }` block); nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static NullConditionalPass ConditionalAccess => new();

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -427,6 +427,10 @@ static class FidelityCheck
     {
         var sb = new StringBuilder();
         sb.AppendLine("#pragma warning disable");
+        // The decompiled bodies spell common framework types by their short name
+        // (e.g. `Span<int>`), matching the product view's assumed `using System;`;
+        // the skeleton imports the same namespace so those names bind.
+        sb.AppendLine("using System;");
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -507,6 +511,11 @@ static class FidelityCheck
 
         string keyword = kind == TypeKind.Struct ? "struct" : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
+        // An [InlineArray(N)] struct must carry the attribute for its span
+        // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
+        // struct otherwise has no such conversion and the body fails to recompile.
+        if (kind == TypeKind.Struct && InlineArrayAttributeText(reader, typeDef) is { } inlineArrayAttr)
+            sb.AppendLine($"{pad}{inlineArrayAttr}");
         sb.AppendLine($"{pad}public unsafe {keyword} {Identifier(name)}{genParams}{baseClause}");
         sb.AppendLine($"{pad}{{");
 
@@ -780,6 +789,49 @@ static class FidelityCheck
     static string Identifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
         || SyntaxFacts.GetContextualKeywordKind(name) != SyntaxKind.None
         ? "@" + name : name;
+
+    /// <summary>
+    /// The <c>[InlineArray(N)]</c> attribute text for an inline-array struct, or
+    /// null when the type does not carry it. The attribute has a single int32
+    /// constructor argument (the buffer length); the blob is a positional-only
+    /// custom attribute (prolog <c>0x0001</c>, the int32, no named arguments),
+    /// read directly so the harness needs no attribute type provider.
+    /// </summary>
+    static string? InlineArrayAttributeText(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var ah in typeDef.GetCustomAttributes())
+        {
+            var attribute = reader.GetCustomAttribute(ah);
+            if (AttributeTypeName(reader, attribute) != "InlineArrayAttribute")
+                continue;
+            var blob = reader.GetBlobReader(attribute.Value);
+            if (blob.Length < 6 || blob.ReadUInt16() != 1)
+                return null; // not the expected positional-int prolog
+            return $"[System.Runtime.CompilerServices.InlineArray({blob.ReadInt32()})]";
+        }
+        return null;
+    }
+
+    /// <summary>The unqualified name of a custom attribute's type (its constructor's declaring type).</summary>
+    static string AttributeTypeName(MetadataReader reader, CustomAttribute attribute)
+    {
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                var member = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                return member.Parent.Kind switch
+                {
+                    HandleKind.TypeReference => reader.GetString(reader.GetTypeReference((TypeReferenceHandle)member.Parent).Name),
+                    HandleKind.TypeDefinition => reader.GetString(reader.GetTypeDefinition((TypeDefinitionHandle)member.Parent).Name),
+                    _ => "",
+                };
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                return reader.GetString(reader.GetTypeDefinition(method.GetDeclaringType()).Name);
+            default:
+                return "";
+        }
+    }
 
     /// <summary>Drops the metadata generic-arity suffix (<c>Foo`1</c> → <c>Foo</c>).</summary>
     static string StripArity(string name)


### PR DESCRIPTION
## What

Recover the C# 12 inline-array → span conversion. An `[InlineArray(N)]` buffer's implicit/explicit conversion to `Span<T>`/`ReadOnlySpan<T>` lowers to `<PrivateImplementationDetails>.InlineArrayAsSpan<TBuffer, T>(ref place, N)` (and the `AsReadOnlySpan` dual). Since #896 made the angle-bracketed `<PrivateImplementationDetails>` type unrepresentable, every such call site capped its method below Full fidelity, and the bare call never parses.

This raises the conversion back to a cast `(Span<T>)place`, which csc re-lowers to the same AsSpan call — the **compile-back gate confirms opcode-exact** — eliminating the `<PrivateImplementationDetails>` TypeRef so the method grades **Full** again. Real-world win: `System.Buffers.BitVector256.Set` now decompiles to `Span<uint> V_2 = (Span<uint>)_values;` at Full fidelity (was Partial).

## How

- New `InlineArraySpanConversion` IR node — result type is the span (no `<PrivateImplementationDetails>` in `DirectTypes`); the printer renders `(Span<T>)Deref(place)`.
- Extend `InlineArrayCollectionPass` with a `RaisePlaceConversions` loop. It matches `InlineArrayAsSpan`/`AsReadOnlySpan` over a **field/parameter/array-element** place (never a `LoadLocalAddress`), keeping it disjoint from the collection-expression buffer recovery (whose synthesized temp is always a local).
- Fidelity / lowered-fidelity gates, idiom scorecard, and lowering ledger note updated.

## Harness improvements (reusable)

`FidelityCheck` skeleton now emits `[InlineArray(N)]` on inline-array structs (so the conversion binds when recompiling) and `using System;` (so decompiled bodies that spell framework types short — e.g. `Span<int>` — recompile). The `using System;` change surfaces one previously-hidden **benign** diff: `SelectBoolReturn` (calls `System.GC.KeepAlive`) was bucketed RecompileFail on the short `GC` name; it now compiles and shows a benign branch-polarity inversion (`bgt`↔`ble`), added to both dockets.

## Out of scope

Local inline-array conversions (`LoadLocalAddress` place) are left flat to stay disjoint from the collection pass — a possible follow-up.

## Validation

- Decompiler suite **778 green** (incl. compile-back, annotate-check, corpus-sweep gates).
- Product suite **1174 green** (9 skip).
- Spot-checked `BitVector256.Set` on .NET 11 preview CoreLib → Full, `(Span<uint>)_values`.
