### PR TITLE
[codex] Degrade residual exception filters honestly

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
@@ -1,0 +1,31 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// A raw <c>endfilter</c> has no standalone C# spelling. Until a filter is
+/// raised to <c>catch (...) when (...)</c>, the flat residue must degrade
+/// honestly instead of claiming Full.
+/// </summary>
+public class ExceptionFilterFidelityTests
+{
+    [Fact]
+    public void ResidualEndFilter_DegradesToPartialAndReportsRemark()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var block = new Block(0x20);
+        container.Add(block);
+        block.Add(new EndFilter(new Constant(1, i32)));
+
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var remark = Assert.Single(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnsupportedExceptionFilter);
+        Assert.Equal(0x20, remark.Offset);
+        Assert.Contains("endfilter", remark.Reason);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -835,7 +835,9 @@ public class IrImporterTests
     {
         var function = ImportFixture(nameof(CfgSampleClass.FilteredLength));
 
-        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        Assert.Contains(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnsupportedExceptionFilter);
         Assert.Equal(HandlerKind.Filter, Assert.Single(function.Regions).Kind);
         Assert.Single(function.Descendants.OfType<EndFilter>());
         Assert.NotEmpty(function.Descendants.OfType<CaughtException>());

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -105,6 +105,14 @@ public static class DiagnosticIds
     /// and therefore cap fidelity until a pass consumes them.
     /// </summary>
     public const string UnsupportedRuntimeToken = "DEC0010";
+
+    /// <summary>
+    /// Exception filter machinery survived raising. C# has filter syntax
+    /// (<c>catch (...) when (...)</c>) but no standalone expression or statement
+    /// spelling for the raw <c>endfilter</c> IL boundary; left flat it renders as
+    /// comments/gotos and must not claim Full fidelity.
+    /// </summary>
+    public const string UnsupportedExceptionFilter = "DEC0011";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -43,6 +43,10 @@ public static class FidelityRemarks
                     Add(remarks, DiagnosticIds.UnsupportedRuntimeToken, OffsetOf(node), node,
                         "runtime method/field token load (ldtoken) with no C# expression spelling");
                     break;
+                case EndFilter:
+                    Add(remarks, DiagnosticIds.UnsupportedExceptionFilter, OffsetOf(node), node,
+                        "residual exception filter boundary (endfilter) with no standalone C# spelling");
+                    break;
             }
 
             var unsupportedType = node.DirectTypes.FirstOrDefault(t => t.ContainsUnsupported)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -229,9 +229,10 @@ public sealed class IrFunction : IrNode
     /// Computed from the tree, never asserted: any unsupported node, any
     /// unsupported type referenced anywhere, any metadata name the printer would
     /// have to emit with no C# spelling, any residual runtime token with no C#
-    /// expression spelling, any expression whose result type the pipeline does
-    /// not know (null — e.g. a join slot merged from conflicting types), or an
-    /// un-raised <c>pinned T&amp;</c> local (no faithful C# spelling) ⇒ at most
+    /// expression spelling, any residual exception-filter boundary, any
+    /// expression whose result type the pipeline does not know (null — e.g. a
+    /// join slot merged from conflicting types), or an un-raised <c>pinned
+    /// T&amp;</c> local (no faithful C# spelling) ⇒ at most
     /// <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
@@ -241,6 +242,7 @@ public sealed class IrFunction : IrNode
             || n is Call { HasUnverifiedByRefArgument: true }
             || n is NewObject { HasUnverifiedByRefArgument: true }
             || n is LoadToken { Kind: not RuntimeTokenKind.Type }
+            || n is EndFilter
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || CSharpSpellability.HasUnrepresentableMetadataName(n)
             || n is IrExpression { ResultType: null }


### PR DESCRIPTION
## Summary

Residual exception-filter machinery can survive raising as a raw `EndFilter`. That boundary has no standalone C# expression or statement spelling, so the decompiler should not report `Full` fidelity while rendering flat filter residue.

This change:

- caps fidelity at `Partial` when an `EndFilter` remains in the IR
- adds `DEC0011` fidelity remarks for residual exception-filter boundaries
- updates the importer expectation for filter fixtures and adds focused coverage for the new remark

## Measurement

Before the fix, `CfgSampleClass::FilterCatch` and `CfgSampleClass::FilteredLength` reported `Full` with no remarks while rendering invalid/unfaithful flat filter machinery. After the fix they report `Partial` with `DEC0011`.

Fixture validity improved the `Full` binding-error surface from 45 methods to 43 methods; `CS0029` dropped from 10 to 4, with no defect regressions reported by the validity diff.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*ExceptionFilter_ImportsWithEndFilter*" -method "*ExceptionFilterFidelityTests*" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check --diff-validity-defects /tmp/target-hunt-third-defects.tsv`
