### PR TITLE
Recover a C# destructor from the finalizer scaffold

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5,6 +5,17 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class CfgSampleClass
 {
+    internal static bool s_finalized;
+
+    // A C# destructor lowers to a Finalize override whose body is
+    // try { s_finalized = true; } finally { base.Finalize(); }. DestructorRecoveryPass
+    // strips the scaffold back to the body and marks the function a destructor; the
+    // fidelity gate proves recompiling ~CfgSampleClass() restores the original IL.
+    ~CfgSampleClass()
+    {
+        s_finalized = true;
+    }
+
     // A non-public overload declared BEFORE the public one of the same name.
     // With publicOnly resolution, the visibility filter must skip this so the
     // overload index lands on the public overload below — masking the access

--- a/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
@@ -1,0 +1,38 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A C# destructor lowers to a Finalize override whose body is
+// try { BODY } finally { base.Finalize(); }. DestructorRecoveryPass strips that
+// scaffold back to BODY and marks the function a destructor.
+public class DestructorRecoveryPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void FinalizeOverride_RecoversAsDestructorBody()
+    {
+        var function = Raised("Finalize");
+
+        Assert.True(function.IsDestructor);
+        // The try/finally scaffold and the base.Finalize() call are gone — the body
+        // is the destructor's own statements.
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            call => call.Callee.Name == "Finalize");
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("s_finalized = true;", output);
+        Assert.DoesNotContain("base.Finalize", output);
+        Assert.DoesNotContain("finally", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -131,6 +131,7 @@ public class FidelityGateTests
         "RefEnumMask",
         "RvaIntArray",
         "BoolBitwiseOrWidened",
+        "Finalize",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -170,6 +170,15 @@ public sealed class IrFunction : IrNode
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 
     /// <summary>
+    /// True when this method is a finalizer (<c>Finalize</c> override) recovered as
+    /// a C# destructor by <see cref="ILInspector.Decompiler.Pipeline.DestructorRecoveryPass"/>:
+    /// the <c>try { … } finally { base.Finalize(); }</c> scaffold the compiler emits
+    /// for <c>~T() { … }</c> has been stripped to its body. Consumers render the
+    /// header as <c>~TypeName()</c>, where the base-finalizer call is implicit.
+    /// </summary>
+    public bool IsDestructor { get; set; }
+
+    /// <summary>
     /// True when the defining module opts into the updated C# memory-safety
     /// rules — it carries a module-level
     /// <c>System.Runtime.CompilerServices.MemorySafetyRulesAttribute</c>. Under

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
@@ -1,0 +1,66 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Recovers a C# destructor (<c>~T() { … }</c>) from the finalizer the compiler
+/// emits for it. A destructor lowers to a <c>Finalize</c> override whose body is
+/// <code>
+/// try { BODY } finally { base.Finalize(); }
+/// </code>
+/// — the <c>base.Finalize()</c> call is implicit in source but mandatory in IL,
+/// and C# forbids writing it (CS0250), so the literal rendering never compiles.
+/// This pass strips the scaffold to <c>BODY</c> and marks the function a
+/// destructor (<see cref="IrFunction.IsDestructor"/>); consumers render the header
+/// as <c>~TypeName()</c>, where the base-finalizer call and the protecting
+/// try/finally are re-emitted by the compiler. Recompiling the destructor restores
+/// the original IL, so the recovery is opcode-exact.
+///
+/// <para>Runs after structuring so the EH region is a <see cref="TryFinally"/>.
+/// Conservative: the method must be a parameterless instance <c>void Finalize</c>
+/// whose body is exactly that try/finally with a finally of nothing but the base
+/// call; anything else (a prologue before the try, extra finally work) keeps the
+/// literal form.</para>
+/// </summary>
+public sealed class DestructorRecoveryPass : IIrPass
+{
+    public string Name => "destructor";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (function.Name != "Finalize"
+            || !function.Signature.HasThis
+            || function.Signature.Parameters.Length != 0
+            || !IsVoid(function.Signature.ReturnType))
+        {
+            return;
+        }
+
+        // The body is a single block whose first statement is the try/finally;
+        // anything after it (the implicit void return) is trailing.
+        if (function.Body.Blocks is not [{ Children: [TryFinally tryFinally, ..] } block])
+            return;
+        if (!IsBaseFinalizeOnly(tryFinally.FinallyBody))
+            return;
+
+        var tryBody = tryFinally.TryBody;
+        var trailing = block.Children.Skip(tryFinally.ChildIndex + 1).ToList();
+
+        tryBody.Detach();
+        var lastBlock = (Block)tryBody.Children[^1];
+        foreach (var statement in trailing)
+        {
+            statement.Detach();
+            lastBlock.Add(statement);
+        }
+
+        context.Stepper.StepOver("recover finalizer try/finally as a destructor body", tryFinally);
+        function.SetChild(0, tryBody);
+        function.IsDestructor = true;
+    }
+
+    static bool IsVoid(TypeRef type) => type is { Namespace: "System", Name: "Void" };
+
+    /// <summary>The finally body is nothing but the implicit <c>base.Finalize()</c> call.</summary>
+    static bool IsBaseFinalizeOnly(BlockContainer finallyBody)
+        => finallyBody.Blocks is [{ Children: [ExpressionStatement { Expression: Call call }] }]
+            && call is { IsVirtual: false, Callee.Name: "Finalize", Callee.HasThis: true, Arguments: [LoadArgument { Index: 0 }] };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -100,6 +100,9 @@ public static class IrPasses
         // tail) nests as guard clauses instead of staying flat goto soup.
         new ReturnMergePass(),
         new StructuringPass(),
+        // Recover a destructor: a Finalize override's try/finally + base.Finalize()
+        // scaffold, structured just above, collapses to the ~T() body.
+        new DestructorRecoveryPass(),
         // After structuring the finally guard is an IfStatement, so the
         // Monitor lock lowering is matchable as lock (obj) { ... }.
         new LockSugarPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -49,6 +49,8 @@ internal static class NativePasses
     public static RvaSpanPass RvaSpan => new();
     [Native(NativeCategory.EmitArtifact, "the lazy <>9__ delegate cache (non-capturing lambda / static method group) collapsed to a bare delegate creation")]
     public static LambdaCachePass LambdaCache => new();
+    [Native(NativeCategory.EmitArtifact, "the finalizer try/finally + base.Finalize() scaffold emitted for ~T() collapsed back to the destructor body")]
+    public static DestructorRecoveryPass DestructorRecovery => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -708,6 +708,14 @@ static class FidelityCheck
             sb.AppendLine($"{pad}public {Identifier(StripArity(reader.GetString(typeDef.Name)))}({parameters}){initializer} {{{body}}}");
             return;
         }
+        // A finalizer (void Finalize() override) recovered as a destructor: emit
+        // ~T() so the recompiled IL re-emits the try/finally + base.Finalize()
+        // scaffold the decompiler stripped, making the round trip opcode-exact.
+        if (name is "Finalize" && !isStatic && sig.ParameterTypes.Length == 0 && Clean(sig.ReturnType) == "void")
+        {
+            sb.AppendLine($"{pad}~{Identifier(StripArity(reader.GetString(typeDef.Name)))}() {{{body}}}");
+            return;
+        }
         if (name is ".cctor")
         {
             sb.AppendLine($"{pad}static {Identifier(StripArity(reader.GetString(typeDef.Name)))}() {{{body}}}");


### PR DESCRIPTION
## Target

A **deliberately-scoped climb** (chosen via the #886 transition guidance), grounded in a CoreLib validity sweep: structured finalizers (`ComAwareWeakReference::Finalize`, `ComInfo::Finalize`) decompiled to invalid C# (CS0250 — you may not write `base.Finalize()`).

A C# destructor `~T() { BODY }` lowers to a `Finalize` override:
```
try { BODY } finally { base.Finalize(); }
```
The `base.Finalize()` call is implicit in source but mandatory in IL, so the literal rendering never compiles.

## Change

`DestructorRecoveryPass` detects that exact scaffold on a parameterless instance `void Finalize` and strips it to `BODY`, marking the function a destructor (`IrFunction.IsDestructor`). Because the base call and protecting try/finally are re-emitted by the compiler for `~T()`, **recompiling the recovered destructor restores the original IL** — the recovery is opcode-exact.

```diff
- try { Marshal.Release(_pComWeakRef); _pComWeakRef = (nint)0; }
- finally { base.Finalize(); }              // CS0250
+ Marshal.Release(_pComWeakRef);
+ _pComWeakRef = (nint)0;                    // ~ComInfo() body
```

- New pass after `StructuringPass` (needs the EH region as a `TryFinally`), classified `EmitArtifact` in `NativePasses` (inverts compiler codegen, not a `LocalRewriter`).
- The fidelity harness emits an `IsDestructor`-shaped `Finalize` as `~T()`, so the `~CfgSampleClass()` fixture **recompiles opcode-exact** (pinned in `PinnedExact`).
- `DestructorRecoveryPassTests` pins the body recovery (scaffold + base call gone).

## Scope / follow-up

This is the decompiler + fidelity-harness slice — complete and self-proving. The product `member`/`type` signature rendering (`~T()` in `ApiOutputFormatter`, parallel to its `op_*` handling) is a clean, separable follow-up; until it lands, the recovered body shows under the metadata `Finalize` signature. The body recovery and its opcode-exact proof stand on their own.

## Verification

- **775/775** `ILInspector.Decompiler.Tests` — `FidelityGateTests` (Finalize pinned opcode-exact), `LoweringCoverageTests` (pass classified), and the new pass test.
- Confirmed on `ComAwareWeakReference::Finalize` / `ComInfo::Finalize` over CoreLib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)