### PR TITLE
Type a bool/int bitwise OR as the integer, not bool (CS0029)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BoolBitwiseOrTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolBitwiseOrTests.cs
@@ -1,0 +1,34 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A bitwise OR that mixes a bool flag (a branchless `cgt.un`) with an integer is
+// an integer result, not a bool. Typing the `or` by its left operand read it as
+// bool, so a wider-integer return wrapped it in the spurious `(...) ? 1 : 0`
+// (CS0029). The bitwise result must take the integer operand's type.
+public class BoolBitwiseOrTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void BoolBitwiseOr_IsIntegerResult_NotBool()
+    {
+        var output = Render(nameof(CfgSampleClass.BoolBitwiseOrWidened));
+
+        // The bitwise OR is an integer, so it must flow straight into the uint
+        // return. The bug typed it as bool and wrapped the whole OR in a
+        // `(<or>) ? 1 : 0` materialization (CS0029) — uniquely marked by a
+        // closing paren before `? 1 : 0` (the legitimate `a ? 1 : 0` operand is
+        // preceded by `(a `, never `) `).
+        Assert.Contains("| c", output);
+        Assert.DoesNotContain(") ? 1 : 0", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -85,6 +85,14 @@ public class CfgSampleClass
     // renders as a comment, leaving `InitializeArray(arr, )` — CS1525.
     public static int[] RvaIntArray() => new int[] { 11, 22, 33, 44, 55, 66, 77, 88 };
 
+    // A bitwise OR that mixes a bool flag with an integer, widened to a larger
+    // integer return. csc lowers `cond ? 1 : 0` to a branchless `cgt.un` (a bool
+    // stack value) and `or`s it with the uint argument. The importer types the
+    // `or` by its left operand, so a bool-vs-int OR read as bool — and at the
+    // `uint` return the printer wrapped it in the spurious `(...) ? 1 : 0`
+    // (CS0029). The bitwise result must take the integer operand's type.
+    public static uint BoolBitwiseOrWidened(bool a, uint c) => (a ? 1u : 0u) | c;
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -119,6 +119,7 @@ public class FidelityGateTests
         "MulLongIntoULong",
         "RefEnumMask",
         "RvaIntArray",
+        "BoolBitwiseOrWidened",
     };
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateFixtures()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -52,7 +52,19 @@ public static class TypeFamilies
     {
         var leftFamily = Of(left);
         var rightFamily = Of(right);
-        if (leftFamily is not { } lf || rightFamily is not { } rf || lf == rf)
+        if (leftFamily is not { } lf || rightFamily is not { } rf)
+            return left;
+        // A bitwise And/Or/Xor that mixes a bool comparison with an integer
+        // (e.g. `(a > 0) | (b ? 2 : 0)`) is an integer result, not bool: the
+        // bool operand materializes to 0/1. Prefer the non-bool operand's type
+        // so the expression doesn't read as bool and force a `? 1 : 0` (CS0029)
+        // at a numeric sink. A bool/bool pair (genuine logical `&`/`|`) is
+        // untouched — it falls through to the same-family branch below.
+        var leftBool = IsBoolean(left!);
+        var rightBool = IsBoolean(right!);
+        if (leftBool ^ rightBool)
+            return leftBool ? right : left;
+        if (lf == rf)
             return left;
         return Wider(lf, rf) == rf ? right : left;
     }


### PR DESCRIPTION
## Summary

Types a bitwise `And`/`Or`/`Xor` that mixes a bool comparison with an integer
as the **integer**, not bool.

`(AllowUnassigned ? 1 : 0) | (UseStd3 ? 2 : 0)` is an integer result — the bool
operand materializes to `0`/`1`. But `TypeFamilies.BinaryResult` typed the op by
its left operand (both `bool` and `int` are the same I4 stack family), so a
bool-vs-int OR read as `bool`. At a wider-integer sink (e.g. a `uint` return) the
printer then wrapped the whole expression in a spurious `(<or>) ? 1 : 0`, whose
condition is an `int` — CS0029.

### Before / after — `IdnMapping::get_IcuFlags`

```diff
 int S_0 = AllowUnassigned ? 1 : 0;
 int S_1 = UseStd3AsciiRules ? 2 : 0;
-return S_0 | S_1 ? 1 : 0;     // CS0029: cannot convert int to bool
+return (uint)(S_0 | S_1);
```

The fix prefers the non-bool operand's type when exactly one side is bool. A
bool/bool pair (genuine logical `&`/`|`) is untouched.

### Numbers

- `--validity-check` CS0029: **−2** (`IdnMapping::get_IcuFlags`,
  `EH::AppendExceptionStackFrameViaClasslib`), **0 regressions**.
- Recompile inventory flat **40227/41012 Full**.

### Tests

- New `BoolBitwiseOrWidened` fixture + `BoolBitwiseOrTests` render test.
- Fixture pinned opcode-exact in the fidelity gate.
- 775 decompiler + 1174 product tests green.
