### PR TITLE
Support multiple package arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,14 +214,14 @@ jobs:
 
       - name: Smoke test - package quiet
         run: |
-          dotnet-inspect package System.Text.Json 10.0.0 -v:q > smoke-package.md
+          dotnet-inspect package System.Text.Json@10.0.0 -v:q > smoke-package.md
           cat smoke-package.md
           grep -q "System.Text.Json" smoke-package.md
           grep -q "Library" smoke-package.md
 
       - name: Smoke test - package normal
         run: |
-          dotnet-inspect package System.Text.Json 10.0.0 -v:n > smoke-package-normal.md
+          dotnet-inspect package System.Text.Json@10.0.0 -v:n > smoke-package-normal.md
           cat smoke-package-normal.md
           grep -q "## Package Info" smoke-package-normal.md
           grep -q "## Dependencies" smoke-package-normal.md

--- a/prompts/package-vulnerability-check.md
+++ b/prompts/package-vulnerability-check.md
@@ -5,7 +5,7 @@ I'm using System.Text.Json 8.0.0. Is it marked vulnerable?
 ## Optimal Path (Expert, Markdown)
 
 ```bash
-dotnet-inspect package System.Text.Json 8.0.0
+dotnet-inspect package System.Text.Json@8.0.0
 ```
 
 Look for the "Vulnerabilities" section in output.
@@ -13,14 +13,14 @@ Look for the "Vulnerabilities" section in output.
 ## Optimal Path (Expert, JSON)
 
 ```bash
-dotnet-inspect package System.Text.Json 8.0.0 --json | jq '.vulnerabilities'
+dotnet-inspect package System.Text.Json@8.0.0 --json | jq '.vulnerabilities'
 ```
 
 ## Discovery Path (Learning)
 
 ```bash
 # Step 1: Check specific version for vulnerabilities
-dotnet-inspect package System.Text.Json 8.0.0
+dotnet-inspect package System.Text.Json@8.0.0
 
 # Output shows: 2 vulnerabilities listed
 
@@ -30,7 +30,7 @@ dotnet-inspect package System.Text.Json
 # Output shows: 10.0.2 with 0 vulnerabilities
 
 # Step 3: Get details with verbose output
-dotnet-inspect package System.Text.Json 8.0.0 -v:d
+dotnet-inspect package System.Text.Json@8.0.0 -v:d
 
 # Shows full vulnerability table with CVE, severity, and summary
 ```

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -51,8 +51,8 @@ run_test "version flag" $TOOL_NAME --version || FAILED=$((FAILED + 1))
 run_test "help flag" $TOOL_NAME --help || FAILED=$((FAILED + 1))
 
 # Package command
-run_test "package info (quiet)" $TOOL_NAME System.Text.Json 10.0.0 -v:q || FAILED=$((FAILED + 1))
-run_test "package info (normal)" $TOOL_NAME System.Text.Json 10.0.0 || FAILED=$((FAILED + 1))
+run_test "package info (quiet)" $TOOL_NAME System.Text.Json@10.0.0 -v:q || FAILED=$((FAILED + 1))
+run_test "package info (normal)" $TOOL_NAME System.Text.Json@10.0.0 || FAILED=$((FAILED + 1))
 run_test_output "package versions" "10.0" $TOOL_NAME System.Text.Json --versions 5 || FAILED=$((FAILED + 1))
 
 # API command

--- a/scripts/stress-test.sh
+++ b/scripts/stress-test.sh
@@ -29,16 +29,16 @@ TOOL_NAME="${3:-dotnet-inspect}"
 # Organized by download surface exercised.
 COMMANDS=(
     # Package download — basic
-    "pkg-quiet|$TOOL_NAME package System.Text.Json 10.0.0 -v:q"
-    "pkg-normal|$TOOL_NAME package System.Text.Json 10.0.0"
-    "pkg-detailed|$TOOL_NAME package System.Text.Json 10.0.0 -v:d"
-    "pkg-vuln|$TOOL_NAME package System.Text.Json 8.0.0 -s Vuln*"
+    "pkg-quiet|$TOOL_NAME package System.Text.Json@10.0.0 -v:q"
+    "pkg-normal|$TOOL_NAME package System.Text.Json@10.0.0"
+    "pkg-detailed|$TOOL_NAME package System.Text.Json@10.0.0 -v:d"
+    "pkg-vuln|$TOOL_NAME package System.Text.Json@8.0.0 -s Vuln*"
 
     # Package metadata variants
-    "pkg-files|$TOOL_NAME package System.Text.Json 10.0.0 --files"
-    "pkg-tfms|$TOOL_NAME package System.Text.Json 10.0.0 --tfms"
-    "pkg-layout-lib|$TOOL_NAME package System.Text.Json 10.0.0 --layout --lib"
-    "pkg-deps|$TOOL_NAME package System.Text.Json 10.0.0 --tfm net9.0 --dependencies"
+    "pkg-files|$TOOL_NAME package System.Text.Json@10.0.0 --files"
+    "pkg-tfms|$TOOL_NAME package System.Text.Json@10.0.0 --tfms"
+    "pkg-layout-lib|$TOOL_NAME package System.Text.Json@10.0.0 --layout --lib"
+    "pkg-deps|$TOOL_NAME package System.Text.Json@10.0.0 --tfm net9.0 --dependencies"
 
     # Version index download
     "versions|$TOOL_NAME package System.Text.Json --versions -n 5"

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -59,6 +59,30 @@ public class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
+    private static (string PackagePath, string TempDir) CreateLocalReadmePackage(string id, string readmeFile, string readmeText)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
+        var packageRoot = Path.Combine(tempDir, "content");
+        Directory.CreateDirectory(packageRoot);
+        File.WriteAllText(Path.Combine(packageRoot, readmeFile), readmeText);
+        File.WriteAllText(Path.Combine(packageRoot, $"{id}.nuspec"), $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>{{id}}</id>
+                <version>1.0.0</version>
+                <authors>tests</authors>
+                <description>test package</description>
+                <readme>{{readmeFile}}</readme>
+              </metadata>
+            </package>
+            """);
+
+        var packagePath = Path.Combine(tempDir, $"{id}.1.0.0.nupkg");
+        ZipFile.CreateFromDirectory(packageRoot, packagePath);
+        return (packagePath, tempDir);
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalPrimaryLibPackage()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -4511,6 +4535,79 @@ public class CommandExecutionTests
         finally
         {
             Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathReadme_TsvCombinesRowsWithPackageColumn()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.First", "PACKAGE.md", "first readme");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Second", "docs-readme.md", "second readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@readme", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("package\tpath\tsize\tis_readme", output);
+            Assert.Contains("Test.First\tPACKAGE.md\t12\ttrue", output);
+            Assert.Contains("Test.Second\tdocs-readme.md\t13\ttrue", output);
+            Assert.DoesNotContain("not a valid package version", error);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_JsonEmitsArray()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Json.One", "README.md", "one");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Json.Two", "README.md", "two");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", firstPackage, secondPackage, "--json");
+
+            Assert.Equal(0, exit);
+            using var doc = JsonDocument.Parse(output);
+            Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+            Assert.Equal(2, doc.RootElement.GetArrayLength());
+            Assert.Equal("Test.Json.One", doc.RootElement[0].GetProperty("package_name").GetString());
+            Assert.Equal("Test.Json.Two", doc.RootElement[1].GetProperty("package_name").GetString());
+            Assert.DoesNotContain("not a valid package version", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_TableCombinesPackageInfoRows()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Info.One", "README.md", "one");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Info.Two", "README.md", "two");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", firstPackage, secondPackage, "--table");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Package", output);
+            Assert.Contains("Field", output);
+            Assert.Contains("Value", output);
+            Assert.Contains("Test.Info.One", output);
+            Assert.Contains("Test.Info.Two", output);
+            Assert.Contains("Version", output);
+            Assert.DoesNotContain("not a valid package version", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
         }
     }
 

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -73,6 +73,15 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PackageCommand_WithMultiplePackageNames_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["package", "System.Text.Json", "Polly"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("package", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
     public void PackageCommand_WithVersionsFlag_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["package", "System.Text.Json", "--versions"]);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -13,6 +13,7 @@ using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
+using System.Globalization;
 using System.Text;
 
 namespace DotnetInspector.Commands;
@@ -95,6 +96,9 @@ public class PackageCommand
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
+
+        if (packageArgs.Length > 1)
+            return await ExecuteMultiPackageAsync(packageArgs, options, context, pipeline);
 
         // Handle --versions mode: list versions and exit early
         if (options.ListVersions)
@@ -225,11 +229,6 @@ public class PackageCommand
                 packageName = packageArg[..atIndex].ToLowerInvariant();
                 version = packageArg[(atIndex + 1)..].ToLowerInvariant();
                 logger.Log($"Using specified version: {version}");
-            }
-            else if (packageArgs.Length >= 2)
-            {
-                packageName = packageArg.ToLowerInvariant();
-                version = packageArgs[1].ToLowerInvariant();
             }
             else
             {
@@ -507,6 +506,328 @@ public class PackageCommand
                 }
             }
         }
+    }
+
+    private sealed record PackageTarget(
+        string OriginalArgument,
+        bool IsLocalFile,
+        string PackageName,
+        string Version);
+
+    private static async Task<int> ExecuteMultiPackageAsync(
+        string[] packageArgs,
+        InspectionOptions options,
+        CommandContext context,
+        SectionPipeline<InspectionResult> pipeline)
+    {
+        if (!ValidateMultiPackageMode(options))
+            return 1;
+
+        if (!TryResolveMultiPackageRowSection(options, out var rowSection))
+            return 1;
+        bool wantsFilesSection = string.Equals(rowSection, PackageSections.Files, StringComparison.OrdinalIgnoreCase)
+            || options.IncludeSections?.Contains(PackageSections.Files) == true
+            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
+        if (!options.JsonOutput && rowSection == null)
+        {
+            Console.Error.WriteLine("Error: Multiple package output requires --json or a row format such as --table, --tsv, or --jsonl.");
+            Console.Error.WriteLine("For package surveys, try: dotnet-inspect package <pkg>... --path @readme --tsv");
+            return 1;
+        }
+
+        var targets = new List<PackageTarget>();
+        foreach (var packageArg in packageArgs)
+        {
+            if (!TryCreatePackageTarget(packageArg, out var target))
+                return 1;
+            targets.Add(target);
+        }
+
+        var results = new List<InspectionResult>();
+        foreach (var target in targets)
+        {
+            using var packageRequestScope = RequestTelemetry.Scope(
+                target.Version.Length > 0 ? $"package {target.PackageName}@{target.Version}" : $"package {target.PackageName}",
+                "package inspect");
+            var result = await InspectPackageAsync(target, options, context, wantsFilesSection);
+            if (result == null)
+                return 1;
+            FilterResultForOutput(result, options);
+            results.Add(result);
+        }
+
+        if (options.Count)
+        {
+            Console.WriteLine(CountMultiPackageRows(results, rowSection).ToString(CultureInfo.InvariantCulture));
+            return 0;
+        }
+
+        if (options.JsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(results.ToArray(), JsonContext.Default.InspectionResultArray));
+            return 0;
+        }
+
+        WriteMultiPackageTable(results, rowSection!, options);
+        return 0;
+    }
+
+    private static bool TryResolveMultiPackageRowSection(InspectionOptions options, out string? section)
+    {
+        section = null;
+        if (!options.OneLine)
+            return true;
+
+        if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+        {
+            Console.Error.WriteLine("Error: Multiple package row output requires one concrete section; @All produces a multi-section document.");
+            return false;
+        }
+
+        if (options.IncludeSections is not { Count: > 0 })
+        {
+            section = PackageSections.PackageInfo;
+            return true;
+        }
+
+        if (options.IncludeSections.Count != 1)
+        {
+            Console.Error.WriteLine($"Error: Multiple package row output requires exactly one section; matched {options.IncludeSections.Count}: {string.Join(", ", options.IncludeSections)}.");
+            return false;
+        }
+
+        section = options.IncludeSections.Single();
+        if (section.Equals(PackageSections.PackageInfo, StringComparison.OrdinalIgnoreCase)
+            || section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        Console.Error.WriteLine($"Error: Multiple package row output does not support section: {section}.");
+        Console.Error.WriteLine("Use --json, or select Package Info or Files.");
+        return false;
+    }
+
+    private static bool ValidateMultiPackageMode(InspectionOptions options)
+    {
+        List<string> conflicts = [];
+        if (options.ExplicitVersion != null) conflicts.Add("--version");
+        if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
+        if (options.ListLayout) conflicts.Add("--layout");
+        if (options.ListTfms) conflicts.Add("--tfms");
+        if (options.ShowReadme) conflicts.Add("--readme");
+        if (options.ShowDependencies) conflicts.Add("--dependencies");
+        if (options.PackageLibrary != null) conflicts.Add("--library");
+        if (options.AllLibraries) conflicts.Add("--all-libraries");
+        if (options.Discover != null) conflicts.Add("-D/--discover");
+
+        if (conflicts.Count == 0)
+            return true;
+
+        Console.Error.WriteLine($"Error: Multiple package inspection cannot be combined with {string.Join(", ", conflicts)}.");
+        Console.Error.WriteLine("Use id@version for per-package version pins.");
+        return false;
+    }
+
+    private static bool TryCreatePackageTarget(string packageArg, out PackageTarget target)
+    {
+        target = null!;
+        bool isLocalFile = packageArg.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+        if (isLocalFile)
+        {
+            if (!File.Exists(packageArg))
+            {
+                Console.Error.WriteLine($"Error: File not found: {packageArg}");
+                return false;
+            }
+
+            target = new PackageTarget(
+                packageArg,
+                IsLocalFile: true,
+                Path.GetFileNameWithoutExtension(packageArg),
+                Version: "local");
+            return true;
+        }
+
+        int atIndex = packageArg.IndexOf('@');
+        string packageName = atIndex > 0
+            ? packageArg[..atIndex].ToLowerInvariant()
+            : packageArg.ToLowerInvariant();
+        string version = atIndex > 0
+            ? packageArg[(atIndex + 1)..].ToLowerInvariant()
+            : "";
+
+        if (version.Length > 0
+            && !string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase)
+            && !version.Contains('*')
+            && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+        {
+            Console.Error.WriteLine($"Error: '{version}' is not a valid package version.");
+            Console.Error.WriteLine("Versions look like: 1.0.0, 8.0.5, 13.0.3-beta1, 11.0.0-preview*");
+            Console.Error.WriteLine("Use id@version for per-package version pins.");
+            return false;
+        }
+
+        target = new PackageTarget(packageArg, IsLocalFile: false, packageName, version);
+        return true;
+    }
+
+    private static async Task<InspectionResult?> InspectPackageAsync(
+        PackageTarget target,
+        InspectionOptions options,
+        CommandContext context,
+        bool wantsFilesSection)
+    {
+        var logger = context.Logger;
+        string? extractPath = null;
+        PackageExtractionResult? resolution = null;
+        string version = target.Version;
+
+        try
+        {
+            var outcome = await PackageExtractor.ExtractPackageAsync(
+                context.HttpClient,
+                target.IsLocalFile ? target.OriginalArgument : target.PackageName,
+                logger.Log,
+                sourceOptions: options.SourceOptions,
+                version: target.IsLocalFile ? null : (version.Length > 0 ? version : null),
+                forceLatest: options.ForceLatest,
+                includePrerelease: options.IncludePrerelease);
+
+            if (!outcome.IsSuccess)
+            {
+                Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");
+                return null;
+            }
+
+            resolution = outcome.Result!;
+            extractPath = resolution.ExtractPath;
+            version = resolution.Version ?? version;
+
+            NuspecData? nuspec = null;
+            string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
+            if (nuspecFiles.Length > 0)
+                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
+
+            long? packageSize = null;
+            if (resolution.NupkgPath != null && File.Exists(resolution.NupkgPath))
+                packageSize = new FileInfo(resolution.NupkgPath).Length;
+
+            bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true;
+            var result = await PackageInspector.InspectAsync(
+                extractPath,
+                target.PackageName,
+                version,
+                target.IsLocalFile,
+                target.IsLocalFile ? target.OriginalArgument : null,
+                nuspec,
+                context.HttpClient,
+                logger,
+                options.ForceLatest,
+                options.Verbosity,
+                resolution.NupkgPath,
+                fetchMetadata: wantsSignals);
+
+            if (packageSize.HasValue)
+                result.PackageSize = packageSize;
+
+            result.Source = target.IsLocalFile ? SourceKind.File : SourceKind.NuGet;
+
+            if (wantsFilesSection)
+            {
+                string declaredReadme = result.ReadmeFile ?? "README.md";
+                var files = PackageFileLister.ListAll(extractPath, declaredReadme);
+                result.Files = PackageFileLister.Filter(files, options.PathFilter);
+            }
+
+            if (wantsSignals)
+            {
+                result.BinarySignals = await PackageInspector.ScanBinarySignalsAsync(
+                    extractPath, target.PackageName, version, context.HttpClient, logger, acquirePdb: true);
+                await AuditSignalBuilder.PopulatePackageAuditAsync(result, context.HttpClient, logger);
+            }
+
+            return result;
+        }
+        finally
+        {
+            if (resolution is { FromCache: false, TempDir: not null } && Directory.Exists(resolution.TempDir))
+            {
+                try
+                {
+                    Directory.Delete(resolution.TempDir, recursive: true);
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+    }
+
+    private static int CountMultiPackageRows(IReadOnlyList<InspectionResult> results, string? section)
+        => section != null && section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase)
+            ? results.Sum(result => result.Files?.Count ?? 0)
+            : results.Sum(result => new InspectionResultView(result).Metadata.Count);
+
+    private static void WriteMultiPackageTable(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
+    {
+        if (section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase))
+        {
+            WriteMultiPackageFilesTable(results, options);
+            return;
+        }
+
+        WriteMultiPackagePackageInfoTable(results, options);
+    }
+
+    private static void WriteMultiPackageFilesTable(IReadOnlyList<InspectionResult> results, InspectionOptions options)
+    {
+        var rows = results
+            .SelectMany(result => (result.Files ?? [])
+                .Select(file => new[]
+                {
+                    result.PackageName,
+                    file.Path,
+                    file.Size.ToString(CultureInfo.InvariantCulture),
+                    file.IsReadme ? "true" : "false",
+                }))
+            .ToArray();
+
+        OutputFormatter.WriteTable(Console.Out, !options.NoHeader, (writer, formatter) =>
+        {
+            var writerOptions = OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl);
+            var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
+            markoutWriter.WriteTable(
+                ["Package", "Path", "Size", "Readme"],
+                ["package", "path", "size", "is_readme"],
+                rows);
+            markoutWriter.Flush();
+        });
+    }
+
+    private static void WriteMultiPackagePackageInfoTable(IReadOnlyList<InspectionResult> results, InspectionOptions options)
+    {
+        var rows = results
+            .SelectMany(result => new InspectionResultView(result).Metadata
+                .Select(field => new[]
+                {
+                    result.PackageName,
+                    field.Key,
+                    field.Value?.ToString() ?? "",
+                }))
+            .ToArray();
+
+        OutputFormatter.WriteTable(Console.Out, !options.NoHeader, (writer, formatter) =>
+        {
+            var writerOptions = OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl);
+            var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
+            markoutWriter.WriteTable(
+                ["Package", "Field", "Value"],
+                ["package", "field", "value"],
+                rows);
+            markoutWriter.Flush();
+        });
     }
 
     private static void ApplyNuspec(NuspecData nuspec, InspectionResult result)

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -14,6 +14,7 @@ namespace DotnetInspector;
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(InspectionResult))]
+[JsonSerializable(typeof(InspectionResult[]))]
 [JsonSerializable(typeof(LibraryInspection))]
 [JsonSerializable(typeof(LibraryInspection[]))]
 [JsonSerializable(typeof(AuditSignal))]


### PR DESCRIPTION
## Summary
- honor the package command variadic package argument instead of treating a second package as a version
- support multi-package JSON array output
- combine Package Info and Files row output across packages with package provenance columns
- keep per-package version pins on id@version syntax

Fixes #898

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandLineTests
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore
- dotnet build src/dotnet-inspect -c Release --no-restore --nologo
