### PR TITLE
Raise single-block conditional self loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -230,6 +230,36 @@ public class CfgSampleClass
         return s;
     }
 
+    public static int PartitionStyleNestedSelfLoops(int[] values, int pivot, int lo, int hi)
+    {
+        int i = lo;
+        int j = hi - 1;
+        do
+        {
+            do
+            {
+                i++;
+            }
+            while (values[i] < pivot);
+
+            do
+            {
+                j--;
+            }
+            while (pivot < values[j]);
+
+            if (i >= j)
+                break;
+
+            int temp = values[i];
+            values[i] = values[j];
+            values[j] = temp;
+        }
+        while (i < j);
+
+        return i;
+    }
+
     // An infinite (while (true)) loop exited only by early returns: csc lowers
     // the back edge to an unconditional goto to the loop head. StructuringPass
     // raises the head-latch pair into while (true) with the returns as guards.

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -44,6 +44,7 @@ public class IdiomShapeScorecardTests
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternPropertyGreater), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternMultiProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
+        new("DoWhileLoopPass", nameof(CfgSampleClass.PartitionStyleNestedSelfLoops), SyntaxKind.DoStatement, [SyntaxKind.GotoStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachLoop), SyntaxKind.ForEachStatement, [SyntaxKind.UsingStatement, SyntaxKind.WhileStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachArray), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),

--- a/src/ILInspector.Decompiler.Tests/InfiniteLoopStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InfiniteLoopStructuringTests.cs
@@ -107,13 +107,13 @@ public class InfiniteLoopStructuringTests
     public void InfiniteLoopWithMidBodyContinue_DeclinesAndStaysFlat()
     {
         // A mid-body `continue` is a second back-edge to the loop head. The
-        // infinite-loop shape requires a single latch, so the structurer declines
-        // it rather than mis-claiming a while (true); the body keeps its
-        // unstructured back-edges. This pins the single-back-edge discriminator.
+        // infinite-loop shape used to decline it; cond-backward self-loop
+        // recovery now lets the method fully structure without stray gotos.
         var function = Raised(nameof(CfgSampleClass.InfiniteLoopWithContinue));
 
-        Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), IsWhileTrue);
-        Assert.NotEmpty(function.Descendants.OfType<Branch>());
-        Assert.Contains("goto", CSharpPrinter.Print(function).Output);
+        var loop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.True(IsWhileTrue(loop));
+        Assert.Empty(function.Descendants.OfType<Branch>());
+        Assert.DoesNotContain("goto", CSharpPrinter.Print(function).Output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2230,6 +2230,61 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void NestedSelfLoopsWithExternalHeaderEntry_Raise()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(
+            typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.PartitionStyleNestedSelfLoops), source);
+
+        Assert.Contains("do", output);
+        Assert.Contains("break;", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void ExternalEntryIntoMultiBlockDoWhile_StaysFlat()
+    {
+        var function = ExternalEntryIntoMultiBlockLoop();
+
+        new DoWhileLoopPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DoWhileLoop>());
+        Assert.NotEmpty(function.Descendants.OfType<Branch>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction ExternalEntryIntoMultiBlockLoop()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var body = new BlockContainer();
+
+        var entry = new Block(0);
+        entry.Add(new Branch(20));
+        body.Add(entry);
+
+        var head = new Block(10);
+        head.Add(new StoreLocal(0, intType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(0, intType), new Constant(1, intType))));
+        body.Add(head);
+
+        var middle = new Block(20);
+        middle.Add(new StoreLocal(0, intType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(0, intType), new Constant(2, intType))));
+        middle.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, isUnsigned: false, new LoadLocal(0, intType), new Constant(10, intType)), 10));
+        body.Add(middle);
+
+        var exit = new Block(30);
+        exit.Add(new Return(new LoadLocal(0, intType)));
+        body.Add(exit);
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Loops"),
+            new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0),
+            [intType],
+            body);
+    }
+
+    [Fact]
     public void UpFrontLocal_InitializesToDefault()
     {
         // A local referenced with no defining store relies on IL's zero-init;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DoWhileLoopPass.cs
@@ -63,10 +63,13 @@ public sealed class DoWhileLoopPass : IIrPass
     }
 
     /// <summary>
-    /// Pure shape check: the region [header, bottom] is a reducible single-entry
-    /// loop whose only back edge is <paramref name="backEdge"/> and whose only
-    /// exits are breaks to the single canonical exit block (the block right
-    /// after the loop, where the back edge's false path also lands).
+    /// Pure shape check: the region [header, bottom] is a reducible loop whose
+    /// only back edge is <paramref name="backEdge"/> and whose only exits are
+    /// breaks to the single canonical exit block (the block right after the
+    /// loop, where the back edge's false path also lands). The ordinary shape is
+    /// single-entry; a single-block self-loop also permits external branches to
+    /// its header, because that is the loop's only entry and appears in csc's
+    /// partition-style nested scan loops.
     /// </summary>
     static bool Validate(
         IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex,
@@ -99,7 +102,11 @@ public sealed class DoWhileLoopPass : IIrPass
                         continue;           // a break to the loop's single exit
                     }
                     if (!sourceInside && targetInside)
+                    {
+                        if (header == bottom && target == header)
+                            continue;   // external branch to a single-block loop header
                         return false;   // an external jump into the loop body
+                    }
                     if (sourceInside && !ReferenceEquals(node, backEdge) && target <= source)
                         return false;   // a second back edge — nested or irreducible
                 }


### PR DESCRIPTION
## Summary
- relax DoWhileLoopPass for single-block conditional self-loops entered through their header
- add a partition-style nested self-loop fixture and a multi-block external-entry negative
- reduce capped cond-backward-branch structuring stops from 11 to 8

Fixes #914

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops --cap 5000