### PR TITLE
Raise padded byte RVA-spans to array literals (#916)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -43,4 +43,49 @@ public class RvaSpanPassTests
         var signature = new MethodSignature(s_readOnlySpanInt, [], HasThis: false, GenericParameterCount: 0);
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
     }
+
+    static readonly TypeRef s_byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef s_readOnlySpanByte = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_byte]);
+
+    [Fact]
+    public void ReadOnlySpanByte_FromPaddedRvaField_RaisesToExactLengthLiteral()
+    {
+        // csc's 1-byte-element optimization sizes the backing holder struct one
+        // byte past the span's length (a trailing pad), so the captured blob runs
+        // one byte longer than the data the span reads. The raise must honour the
+        // span's own length (3 here), decoding exactly those bytes and ignoring the
+        // pad — not bail because blob length (4) != span length (3).
+        var function = BuildReadOnlySpanByteCtor([10, 20, 30, 0], spanLength: 3);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var literal = Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Equal(s_byte, literal.ElementType);
+        Assert.Equal([10, 20, 30], literal.Elements.Select(e => (byte)((Constant)e).Value!));
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
+    {
+        var ctor = new MethodRef(
+            s_readOnlySpanByte,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.ByRef(s_byte), s_int],
+            HasThis: true);
+        var field = new FieldRef(
+            TypeRef.Definition("CoreLib", "", "<PrivateImplementationDetails>"),
+            "HASH",
+            TypeRef.Definition("CoreLib", "", "__StaticArrayInitTypeSize"));
+        var address = new LoadFieldAddress(field, instance: null) { FieldRvaData = blob };
+        var newObject = new NewObject(ctor, [address, new Constant(spanLength, s_int)]);
+
+        var block = new Block();
+        block.Add(new Return(newObject));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(s_readOnlySpanByte, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -55,16 +55,19 @@ public sealed class RvaSpanPass : IIrPass
             // RVA blob plus its length — rather than through CreateSpan. The field
             // name has angle brackets, so left as-is it never parses; decode the
             // blob and rebuild the `new byte[] { ... }` literal the optimization
-            // came from (csc re-lowers it to the same content-addressed blob, so
-            // the round-trip is opcode-exact).
+            // came from (csc re-lowers it to the same content-addressed blob).
+            // The backing field's holder struct is sized one byte past the span's
+            // length (a trailing pad), so the captured blob runs longer than the
+            // data the span reads — decode exactly `rvaLength` elements from the
+            // start, the span's own authoritative length.
             if (construction.Constructor.DeclaringType is not
                 { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: "ReadOnlySpan`1" }, TypeArguments: [var spanElement] } spanInstance)
                 continue;
             if (construction.Arguments is not [LoadFieldAddress { FieldRvaData: { } rvaData }, Constant { Value: int rvaLength }])
                 continue;
 
-            var spanElements = DecodeElements(spanElement, rvaData);
-            if (spanElements is null || spanElements.Count != rvaLength)
+            var spanElements = DecodeElements(spanElement, rvaData, rvaLength);
+            if (spanElements is null)
                 continue;
 
             var spanLiteral = new SpanLiteral(spanElement, spanInstance, spanElements);
@@ -137,8 +140,14 @@ public sealed class RvaSpanPass : IIrPass
     /// when the element type is not a fixed-size primitive (the bytes carry no
     /// unambiguous reading without resolving an enum's underlying type or a struct's
     /// layout).
+    /// <para>When <paramref name="elementCount"/> is given, decodes exactly that many
+    /// elements from the start of the blob (and requires the blob to hold at least
+    /// that many): the constant-<c>ReadOnlySpan&lt;byte&gt;</c> optimization sizes its
+    /// backing field to the element bytes plus a trailing pad, so the holder struct's
+    /// layout size — the blob length captured at import — runs one byte past the
+    /// span's own length. The span's length is authoritative for what it reads.</para>
     /// </summary>
-    static List<IrExpression>? DecodeElements(TypeRef element, byte[] data)
+    static List<IrExpression>? DecodeElements(TypeRef element, byte[] data, int? elementCount = null)
     {
         if (element.Kind != TypeRefKind.Definition || element.Namespace != "System")
             return null;
@@ -151,12 +160,16 @@ public sealed class RvaSpanPass : IIrPass
             "Int64" or "UInt64" or "Double" => 8,
             _ => 0,
         };
-        if (width == 0 || data.Length % width != 0)
+        if (width == 0)
+            return null;
+
+        int length = elementCount is { } count ? count * width : data.Length;
+        if (length > data.Length || length % width != 0)
             return null;
 
         var span = data.AsSpan();
-        var result = new List<IrExpression>(data.Length / width);
-        for (int offset = 0; offset < data.Length; offset += width)
+        var result = new List<IrExpression>(length / width);
+        for (int offset = 0; offset < length; offset += width)
         {
             var chunk = span.Slice(offset, width);
             object value = element.Name switch


### PR DESCRIPTION
Addresses the byte-span bucket of #916 (residual `<PrivateImplementationDetails>` type-name leaks).

## Root cause

csc's 1-byte-element optimization builds a constant `ReadOnlySpan<byte>` directly as `new ReadOnlySpan<byte>(ref <PrivateImplementationDetails>.HASH, length)` — a ref to the mapped RVA blob plus its length — rather than through `CreateSpan`. #647's raiser (`RvaSpanPass` 2nd loop) required the captured blob length to equal the span length **exactly**. But the backing holder struct (`__StaticArrayInitTypeSize`) is sized one byte past the span — a trailing pad — so the blob runs `length + 1`. Every byte span was therefore rejected and leaked the unspellable `<PrivateImplementationDetails>` field name (never parses).

## Fix

`DecodeElements` gains an optional `elementCount`: when set it decodes exactly that many elements from the blob start — the span's own authoritative length — tolerating the trailing pad. The byte-ctor loop passes the span's `length` instead of requiring an exact blob match.

## Impact

- Raises **18** CoreLib byte-span getters to faithful `new byte[] { ... }`: Base64/Base32 alphabets, culture/region 3-letter codes, `GetTempFileName` template, `Number::get_TwoDigitsBytes`, `UTF7Encoding::MakeTables`, AdvSimd LUTs, etc.
- Inventory **Full +15**; unspellable stop-reason **34 → 19**.
- **Full malformed stays 0**; **0 validity regressions** vs clean main (per-method `--diff-validity-defects`: REGRESSED none, 0 only-baseline); **0 importer bugs**.
- The existing `ConstantByteSpan` fixture (unpadded blob) is unaffected — fix is backward-compatible.

## Tests

New `RvaSpanPassTests.ReadOnlySpanByte_FromPaddedRvaField_RaisesToExactLengthLiteral` pins the padded-blob path (local csc doesn't emit the pad, so a synthetic unit test is the right level). 783 decompiler + 1174 product tests green.

## Out of scope (future #916 PRs)

Enum-element RVA spans (`get_DateParsingStates`), the `<PrivateImplementationDetails>::Inline*` helpers themselves, and methods consuming `InlineArrayAsSpan`/`InlineArrayElementRef`.
