### PR TITLE
[codex] Structure region-exit diamonds

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -33,15 +33,12 @@ public class CompletenessTests
     }
 
     [Fact]
-    public void CommonExitGotos_FlaggedAsStructuringGap()
+    public void CommonExitGotos_RecoveredByRegionExitDiamond()
     {
-        // GotoCommonExitGuardedMerge's gotos reach a merge that is not a short
-        // return tail (it ends in a guard), so the return-merge pass leaves it and
-        // the index-range structurer still cannot express the past-region join —
-        // a surviving branch the gap docket records.
-        var residual = Completeness.Residual(Raised(nameof(CfgSampleClass.GotoCommonExitGuardedMerge)));
-        Assert.NotNull(residual);
-        Assert.StartsWith("structuring:", residual);
+        // GotoCommonExitGuardedMerge's inner arms both branch to the enclosing
+        // diamond's tracked join. The region-exit diamond recovery names that as
+        // an if/else local merge without consuming the outer sibling block.
+        Assert.Null(Completeness.Residual(Raised(nameof(CfgSampleClass.GotoCommonExitGuardedMerge))));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -537,16 +537,15 @@ public class IrImporterTests
     [Fact]
     public void DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath()
     {
-        // GotoCommonExitGuardedMerge's gotos to a shared guarded exit are a
-        // forward-common-merge the structuring pass leaves flat (the merge is not
-        // a short return tail, so the return-merge pass leaves it too), so the body
-        // is a goto graph. The old global bail flooded every local to `= default`;
-        // CFG definite-assignment proves `result` assigned on every path first.
+        // GotoCommonExitGuardedMerge assigns result on every path before the
+        // shared guarded exit. The old global bail flooded every local to
+        // `= default`; CFG definite-assignment proves `result` assigned on every
+        // path first, and the region-exit diamond now structures the gotos away.
         var function = ImportFixture(nameof(CfgSampleClass.GotoCommonExitGuardedMerge));
         IrPasses.Run(function);
         var output = CSharpPrinter.PrintRaised(function).Output!;
 
-        Assert.Contains("goto ", output);   // guard: the body really did stay flat
+        Assert.DoesNotContain("goto ", output);
         Assert.DoesNotContain("= default", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -14,14 +14,60 @@ public class StructuringDiagnosticsTests
         return diagnostics;
     }
 
-    [Fact]
-    public void CommonExitMerge_RecordsForwardBranchStop()
+    static StructuringDiagnostics RunWithDiagnostics(IrFunction function)
     {
-        // Two nested guards both `goto done` onto a shared exit past the region
-        // whose merge is not a short return tail (it ends in a guard, so the
-        // return-merge pass leaves it): the index-range model cannot express the
-        // merge, so the container stays flat and the sink records exactly why.
+        var diagnostics = new StructuringDiagnostics();
+        IrPasses.Run(function, IrPasses.Default, new PassContext(new Stepper(enabled: false), diagnostics));
+        return diagnostics;
+    }
+
+    [Fact]
+    public void CommonExitMerge_StructuresRegionExitDiamond()
+    {
+        // The inner if's two arms both branch to the enclosing diamond's tracked
+        // join, which lies past the inner region's lexical stop. The structurer
+        // can now name the local merge without swallowing the outer sibling block.
         var diag = RunWithDiagnostics(nameof(CfgSampleClass.GotoCommonExitGuardedMerge));
+
+        Assert.True(diag.Structured > 0);
+        Assert.Empty(diag.Stops);
+    }
+
+    [Fact]
+    public void RegionExitDiamond_RequiresBothArmsToExitTrackedJoin()
+    {
+        // Near miss for the region-exit diamond: the fallthrough arm exits to the
+        // enclosing join, but the taken arm branches to the local sibling block.
+        // That is not the same structured if/else shape, so the pass keeps the
+        // container flat instead of erasing a still-meaningful goto.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument X() => new(0, "x", intType);
+
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.LessThanOrEqual, false, X(), new Constant(0, intType)), 16));
+        var innerHead = new Block(4);
+        innerHead.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.LessThanOrEqual, false, X(), new Constant(100, intType)), 12));
+        var falseArm = new Block(8);
+        falseArm.Add(new StoreLocal(0, intType, new Constant(2, intType)));
+        falseArm.Add(new Branch(20));
+        var nearMissArm = new Block(12);
+        nearMissArm.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        nearMissArm.Add(new Branch(16));
+        var outerSibling = new Block(16);
+        outerSibling.Add(new StoreLocal(0, intType, new Constant(0, intType)));
+        var join = new Block(20);
+        join.Add(new Return(new LoadLocal(0, intType)));
+        foreach (var block in (Block[])[head, innerHead, falseArm, nearMissArm, outerSibling, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        var diag = RunWithDiagnostics(function);
 
         Assert.Equal(0, diag.Structured);
         Assert.Equal("forward-branch-not-region-exit", Assert.Single(diag.Stops));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -323,6 +323,16 @@ public sealed class StructuringPass : IIrPass
                     // Diamond: the fallthrough arm ends with goto M past the
                     // true arm.
                     int falseStart = i + 1;
+                    if (FindRegionExitDiamond(ctx, falseStart, target, stop, joinIndex) is { } exitDiamond)
+                    {
+                        if (!Validate(ctx, falseStart, target, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget)
+                            || !Validate(ctx, target, exitDiamond.LocalJoin, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget))
+                        {
+                            return false;
+                        }
+                        i = exitDiamond.LocalJoin;
+                        break;
+                    }
                     if (FindDiamondJoin(blocks, offsetToIndex, falseStart, target, stop) is { } join)
                     {
                         // False arm exits by goto join; true arm falls (or
@@ -423,6 +433,52 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>The <c>true</c> condition of a raised <c>while (true)</c> loop.</summary>
     static Constant TrueLiteral() => new(true, TypeRef.CoreLib("System", "Boolean"));
+
+    /// <summary>
+    /// A diamond whose arms both end by branching to the enclosing region's
+    /// tracked join. The local C# merge is this region's lexical stop; the
+    /// branch target is outside that stop, so the ordinary contiguous diamond
+    /// helper must not return it as the local join or it would swallow the next
+    /// sibling block.
+    /// </summary>
+    static (int LocalJoin, int ExitTarget)? FindRegionExitDiamond(Ctx ctx, int falseStart, int trueStart, int stop, int joinIndex)
+    {
+        if (falseStart >= trueStart || trueStart >= stop)
+            return null;
+        if (trueStart != falseStart + 1 || stop != trueStart + 1)
+            return null;
+        if (!EndsWithBranchTo(ctx, trueStart - 1, joinIndex))
+            return null;
+        if (!EndsWithBranchTo(ctx, stop - 1, joinIndex))
+            return null;
+        if (!IsStraightLineUntilFinalBranch(ctx.Blocks[trueStart - 1])
+            || !IsStraightLineUntilFinalBranch(ctx.Blocks[stop - 1]))
+        {
+            return null;
+        }
+        return (stop, joinIndex);
+    }
+
+    static bool IsStraightLineUntilFinalBranch(Block block)
+    {
+        for (int s = 0; s < block.Children.Count - 1; s++)
+        {
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return false;
+        }
+        return true;
+    }
+
+    static bool EndsWithBranchTo(Ctx ctx, int blockIndex, int targetIndex)
+    {
+        if (blockIndex < 0 || blockIndex >= ctx.Blocks.Count)
+            return false;
+        var children = ctx.Blocks[blockIndex].Children;
+        return children.Count > 0
+            && children[^1] is Branch branch
+            && ctx.OffsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget)
+            && branchTarget == targetIndex;
+    }
 
     /// <summary>The diamond join: the false arm's last block ends with a goto past the true arm; null means guard shape.</summary>
     static int? FindDiamondJoin(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int falseStart, int trueStart, int stop)
@@ -655,6 +711,14 @@ public sealed class StructuringPass : IIrPass
                         break;
                     }
                     int falseStart = i + 1;
+                    if (FindRegionExitDiamond(ctx, falseStart, target, stop, joinIndex) is { } exitDiamond)
+                    {
+                        var thenArm = BuildRegion(ctx, falseStart, target, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget);
+                        var elseArm = BuildRegion(ctx, target, exitDiamond.LocalJoin, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget);
+                        result.Add(new IfStatement(Negate(condition), thenArm, elseArm));
+                        i = exitDiamond.LocalJoin;
+                        break;
+                    }
                     if (FindDiamondJoin(blocks, offsetToIndex, falseStart, target, stop) is { } join)
                     {
                         // Fallthrough arm first, current-emitter guard style:


### PR DESCRIPTION
## Summary

Addresses a scoped sub-shape from #911: conditional diamonds whose two single-block arms both branch to the enclosing region's tracked join. The local C# merge is the arm range's lexical stop, while the branch target is outside that stop; the previous contiguous-diamond helper could not name that without swallowing the next sibling block.

This change:

- adds a conservative region-exit diamond recognizer to `StructuringPass`
- requires both arms to be single straight-line blocks ending in the tracked exit branch
- updates the recovered `GotoCommonExitGuardedMerge` fixture expectations
- adds an adversarial near-miss where only one arm exits to the tracked join, which must stay flat

## Measurement

On the final base (`origin/main` at `958b87d6`):

- `forward-branch-not-region-exit`: 530 -> 511
- structured containers: 10890 -> 10907
- flat containers: 1169 -> 1152
- fully raised methods: 39335 -> 39348
- real gaps: 1824 -> 1811
- pass bugs: 0 before and after

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*DeadDefaultInitializer_DroppedAcrossGotoCfgWhenAssignedOnEveryPath*" -method "*StructuringDiagnosticsTests*" -method "*CompletenessTests*" -method "*InfiniteLoopStructuringTests*" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps`
- `dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --diff-validity-defects /tmp/issue911-validity-baseline-958.tsv`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` (787 tests, 0 failures)