### PR TITLE
Fix by-ref fidelity report resolution

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +19,21 @@ public class CrossAssemblyMethodFactsTests
         AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseOut), "WriteOut", ArgumentRefKind.Out);
         AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseRef), "Mutate", ArgumentRefKind.Ref);
         AssertCallRefKind(source, nameof(CrossAssemblyFixtureMethods.UseIn), "Read", ArgumentRefKind.In);
+    }
+
+    [Fact]
+    public void PlatformForwardedByRefMemberRef_RecoversParameterRefKinds()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: TrustedPlatformLocator());
+
+        var call = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseUri), "TryCreate");
+        Assert.Equal(ParameterRefKindFacts.Known, call.Callee.ParameterRefKindsFacts);
+        Assert.Collection(
+            call.Callee.ParameterRefKinds,
+            kind => Assert.Equal(ArgumentRefKind.Value, kind),
+            kind => Assert.Equal(ArgumentRefKind.Value, kind),
+            kind => Assert.Equal(ArgumentRefKind.Out, kind));
     }
 
     [Fact]
@@ -129,6 +145,9 @@ public class CrossAssemblyMethodFactsTests
 
                         public static int UseGenerated(int value)
                             => Generated__DisplayClass0_0.Run(value);
+
+                        public static bool UseUri(string value)
+                            => System.Uri.TryCreate(value, System.UriKind.Absolute, out var uri) && uri is not null;
                     }
                     """,
                     [MetadataReference.CreateFromFile(libraryPath)]);
@@ -182,11 +201,26 @@ public class CrossAssemblyMethodFactsTests
         public void Dispose() => Directory.Delete(_directory, recursive: true);
     }
 
+    static AssemblyLocator TrustedPlatformLocator()
+    {
+        var assemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        return (name, trust) =>
+            trust == AssemblyTrust.Platform && assemblies.TryGetValue(name, out var path)
+                ? path
+                : null;
+    }
+
     static class CrossAssemblyFixtureMethods
     {
         public const string UseOut = nameof(UseOut);
         public const string UseRef = nameof(UseRef);
         public const string UseIn = nameof(UseIn);
         public const string UseGenerated = nameof(UseGenerated);
+        public const string UseUri = nameof(UseUri);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -132,7 +132,9 @@ internal sealed class CrossAssemblyTypeResolver
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (!string.Equals(reader.GetString(method.Name), callee.Name, StringComparison.Ordinal))
                     continue;
-                if (!TryMatchMethod(reader, typeDef, method, callee, out var parameterRefKinds))
+                bool allowCoreLibraryAliases = type.Assembly == TypeRef.CoreLibrary
+                    || TrustFor(type.Assembly) == AssemblyTrust.Platform;
+                if (!TryMatchMethod(reader, typeDef, method, callee, allowCoreLibraryAliases, out var parameterRefKinds))
                     continue;
 
                 bool methodCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes());
@@ -157,6 +159,7 @@ internal sealed class CrossAssemblyTypeResolver
         TypeDefinition declaringType,
         MethodDefinition method,
         MethodRef callee,
+        bool allowCoreLibraryAliases,
         out ParameterRefKindResult parameterRefKinds)
     {
         parameterRefKinds = default;
@@ -174,7 +177,7 @@ internal sealed class CrossAssemblyTypeResolver
             : [];
         var methodArguments = callee.TypeArguments;
         var returnType = signature.ReturnType.Instantiate(typeArguments, methodArguments);
-        if (!returnType.Equals(callee.ReturnType))
+        if (!SameSignatureType(returnType, callee.ReturnType, allowCoreLibraryAliases))
             return false;
 
         if (signature.ParameterTypes.Length != callee.ParameterTypes.Length)
@@ -183,13 +186,56 @@ internal sealed class CrossAssemblyTypeResolver
         for (int i = 0; i < signature.ParameterTypes.Length; i++)
         {
             var parameter = signature.ParameterTypes[i].Instantiate(typeArguments, methodArguments);
-            if (!parameter.Equals(callee.ParameterTypes[i]))
+            if (!SameSignatureType(parameter, callee.ParameterTypes[i], allowCoreLibraryAliases))
                 return false;
             parameters.Add(parameter);
         }
 
         parameterRefKinds = MethodDefinitionFacts.ReadParameterRefKinds(reader, method, parameters.MoveToImmutable());
         return true;
+    }
+
+    static bool SameSignatureType(TypeRef resolved, TypeRef expected, bool allowCoreLibraryAliases)
+    {
+        if (resolved.Equals(expected))
+            return true;
+        if (resolved.Kind != expected.Kind)
+            return false;
+
+        switch (resolved.Kind)
+        {
+            case TypeRefKind.Definition:
+                return resolved.Namespace == expected.Namespace
+                    && resolved.Name == expected.Name
+                    && (resolved.Assembly == expected.Assembly
+                        || (allowCoreLibraryAliases
+                            && (resolved.Assembly == TypeRef.CoreLibrary
+                                || expected.Assembly == TypeRef.CoreLibrary)));
+            case TypeRefKind.GenericInstance:
+                if (!SameSignatureType(resolved.ElementType!, expected.ElementType!, allowCoreLibraryAliases)
+                    || resolved.TypeArguments.Length != expected.TypeArguments.Length)
+                    return false;
+                for (int i = 0; i < resolved.TypeArguments.Length; i++)
+                    if (!SameSignatureType(resolved.TypeArguments[i], expected.TypeArguments[i], allowCoreLibraryAliases))
+                        return false;
+                return true;
+            case TypeRefKind.SzArray or TypeRefKind.Pointer or TypeRefKind.Pinned or TypeRefKind.ByRef:
+                return SameSignatureType(resolved.ElementType!, expected.ElementType!, allowCoreLibraryAliases);
+            case TypeRefKind.Array:
+                return resolved.Rank == expected.Rank
+                    && SameSignatureType(resolved.ElementType!, expected.ElementType!, allowCoreLibraryAliases);
+            case TypeRefKind.FunctionPointer:
+                if (resolved.CallingConvention != expected.CallingConvention
+                    || !SameSignatureType(resolved.ElementType!, expected.ElementType!, allowCoreLibraryAliases)
+                    || resolved.TypeArguments.Length != expected.TypeArguments.Length)
+                    return false;
+                for (int i = 0; i < resolved.TypeArguments.Length; i++)
+                    if (!SameSignatureType(resolved.TypeArguments[i], expected.TypeArguments[i], allowCoreLibraryAliases))
+                        return false;
+                return true;
+            default:
+                return false;
+        }
     }
 
     ValueTypeHint ResolveValueTypeHint(TypeRef type)

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -1,5 +1,6 @@
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
+using System.Reflection;
 
 namespace ILInspector.DecompilerHarness;
 
@@ -7,9 +8,10 @@ namespace ILInspector.DecompilerHarness;
 /// Builds one <see cref="MetadataContext"/> shared across a whole corpus sweep so
 /// a dependency such as CoreLib is opened and indexed once for the entire run
 /// rather than once per assembly. The locator searches every directory the
-/// corpus assemblies live in — a superset of the per-assembly sibling policy, so
-/// resolution is at least as complete and identical for the common single
-/// -directory corpus.
+/// corpus assemblies live in, plus the running trusted platform assembly set for
+/// platform-trusted references. That keeps same-directory framework sweeps
+/// version-local while letting product artifact directories resolve framework
+/// dependencies that are not copied beside the product DLLs.
 /// </summary>
 static class CorpusMetadata
 {
@@ -20,9 +22,22 @@ static class CorpusMetadata
             .Where(d => !string.IsNullOrEmpty(d))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var platformAssemblies = TrustedPlatformAssemblies();
 
         AssemblyLocator locator = (name, trust) =>
         {
+            if (trust == AssemblyTrust.Platform)
+            {
+                foreach (var directory in directories)
+                {
+                    string candidate = Path.Combine(directory!, name + ".dll");
+                    if (File.Exists(candidate) && IsTrustedPlatformAssembly(candidate))
+                        return candidate;
+                }
+
+                return platformAssemblies.GetValueOrDefault(name);
+            }
+
             foreach (var directory in directories)
             {
                 string candidate = Path.Combine(directory!, name + ".dll");
@@ -33,5 +48,44 @@ static class CorpusMetadata
         };
 
         return new MetadataContext(locator);
+    }
+
+    static IReadOnlyDictionary<string, string> TrustedPlatformAssemblies()
+    {
+        var paths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        var assemblies = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in paths)
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || !File.Exists(path))
+                continue;
+            assemblies.TryAdd(Path.GetFileNameWithoutExtension(path), path);
+        }
+        return assemblies;
+    }
+
+    static bool IsTrustedPlatformAssembly(string path)
+    {
+        try
+        {
+            return PlatformKeys.IsPlatform(ToHex(AssemblyName.GetAssemblyName(path).GetPublicKeyToken()));
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    static string? ToHex(byte[]? bytes)
+    {
+        if (bytes is null || bytes.Length == 0)
+            return null;
+        var chars = new char[bytes.Length * 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            chars[i * 2] = "0123456789abcdef"[bytes[i] >> 4];
+            chars[i * 2 + 1] = "0123456789abcdef"[bytes[i] & 0xF];
+        }
+        return new string(chars);
     }
 }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -493,9 +493,10 @@ static class Program
         string methodName = dumpMethod[(separator + 2)..];
 
         IReadOnlyList<OverloadInfo> overloads = [];
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             overloads = IrImporter.Overloads(source, typeName, methodName);
             if (overloads.Count > 0)
                 break;
@@ -551,9 +552,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             source.SimulateNewRules = simulate;
             // Probe this assembly first so a method in a later one is still found.
             if (IrImporter.Import(source, typeName, methodName, overloadIndex) is null)
@@ -581,9 +583,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
                 continue;
@@ -605,9 +608,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
                 continue;
@@ -655,9 +659,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
                 continue;
@@ -716,9 +721,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
                 continue;
@@ -769,9 +775,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             source.SimulateNewRules = simulate;
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
@@ -812,9 +819,10 @@ static class Program
         string typeName = dumpMethod[..separator];
         string methodName = dumpMethod[(separator + 2)..];
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
-            using var source = skipPdb ? MetadataSource.OpenWithoutSymbols(assemblyPath) : MetadataSource.Open(assemblyPath);
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
             var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
             if (function is null)
                 continue;
@@ -863,6 +871,11 @@ static class Program
         }
         return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
     }
+
+    static MetadataSource OpenSource(string assemblyPath, bool skipPdb, MetadataContext metadata)
+        => skipPdb
+            ? MetadataSource.OpenWithoutSymbols(assemblyPath, context: metadata)
+            : MetadataSource.Open(assemblyPath, context: metadata);
 
     static string Succs(IReadOnlyList<Block> blocks, Cfg.BlockEdges edges)
     {


### PR DESCRIPTION
Fixes #925.

## Summary
- resolve platform-trusted references from the running TPA set in decompiler harness corpus metadata
- use the shared corpus metadata context for all `--dump` submodes
- match platform-forwarded implementation signatures against canonical corelib aliases when recovering by-ref parameter facts
- add a regression test for `Uri.TryCreate(..., out Uri)` ref-kind recovery

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- issue library report: no `fidelity: by-ref` matches, 0 pass bugs, 0 Full malformed
