### PR TITLE
Consume inline-used catch exceptions in StructuringPass (#913)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InlineCatchVariableTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineCatchVariableTests.cs
@@ -1,0 +1,67 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A once-used catch variable is left on the stack by Release codegen, so the
+// caught exception imports as a bare CaughtException in value position with no
+// `E e = …` store to fold. EhStructuringPass would previously leave the whole
+// method flat (unconsumed-regions); it now synthesizes the catch variable back
+// so the try/catch structures and recompiles opcode-exact.
+public class InlineCatchVariableTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void InlineCaughtException_SynthesizesCatchVariableAndStructures()
+    {
+        var function = Raised(nameof(CfgSampleClass.CatchLogs));
+
+        // The region is consumed: a real try/catch, no surviving goto.
+        var tryCatch = Assert.Single(function.Descendants.OfType<TryCatch>());
+        var clause = Assert.Single(tryCatch.Clauses);
+        Assert.NotNull(clause.VariableIndex);                 // a variable was bound
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<Branch>());
+        // No bare CaughtException leaks — every use reads the bound variable.
+        Assert.Empty(clause.Body.Descendants.OfType<CaughtException>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("catch (FormatException", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("__exception", output);
+    }
+
+    [Fact]
+    public void DiscardedCatch_BindsNoVariable()
+    {
+        var function = Raised(nameof(CfgSampleClass.CatchDiscards));
+
+        var tryCatch = Assert.Single(function.Descendants.OfType<TryCatch>());
+        var clause = Assert.Single(tryCatch.Clauses);
+        Assert.Null(clause.VariableIndex);                    // exception discarded — no synthetic var
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("catch (FormatException)", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
+    public void BareRethrow_BindsNoVariable()
+    {
+        var function = Raised(nameof(CfgSampleClass.LogAndRethrow));
+
+        var tryCatch = Assert.Single(function.Descendants.OfType<TryCatch>());
+        var clause = Assert.Single(tryCatch.Clauses);
+        Assert.Null(clause.VariableIndex);                    // a `throw;` rethrow names nothing
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("throw;", output);
+        Assert.DoesNotContain("goto", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2896,21 +2896,17 @@ public class EhStructuringTests
     {
         var (function, output) = RaiseFixture(nameof(CfgSampleClass.CatchLogs));
 
-#if DEBUG
-        // Debug stores the catch variable at handler entry; the store folds
-        // into the clause header.
+        // Debug stores the catch variable at handler entry, folding the store into
+        // the clause header; Release leaves the once-used exception on the stack and
+        // EhStructuring synthesizes the variable back. Either way the region is
+        // consumed and the try/catch binds a variable used by the handler body.
+        Assert.Empty(function.Regions);
         var clause = Assert.Single(function.Descendants.OfType<CatchClause>());
         Assert.NotNull(clause.VariableIndex);
         Assert.Matches(@"catch \(FormatException V_\d+\)", output);
         Assert.DoesNotContain("__exception", output);
         // The clause owns the declaration — nothing declares the local up front.
         Assert.DoesNotMatch(@"FormatException V_\d+;", output);
-#else
-        // Release consumes the exception inline (callvirt get_Message on the
-        // raw stack value, no store) — outside the slice, honestly flat.
-        Assert.NotEmpty(function.Regions);
-        Assert.Empty(function.Descendants.OfType<TryCatch>());
-#endif
         // ldc.i4.m1 must print -1, not the ushort-wrapped 65535.
         Assert.Contains("-1;", output);
         Assert.DoesNotContain("65535", output);

--- a/src/ILInspector.Decompiler.Tests/MultiUseCatchExceptionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiUseCatchExceptionTests.cs
@@ -1,0 +1,72 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// SynthesizeInlineCatchVariables binds a catch variable for a handler that uses the
+// caught exception inline (no entry store), but only when it is used exactly once —
+// the single shape Release's store-elision produces. A handler with two or more
+// inline uses can only come from hand-written or obfuscated IL (a duped exception
+// on the stack); binding a variable there would re-introduce a store the original
+// lacked, so EhStructuring must leave the method unconsumed instead of mis-raising
+// it. The compiler never emits that shape, so it is constructed directly as IR.
+public class MultiUseCatchExceptionTests
+{
+    static readonly TypeRef ExceptionType = TypeRef.CoreLib("System", "Exception");
+    static readonly TypeRef VoidType = TypeRef.CoreLib("System", "Void");
+    static readonly MethodRef Sink = new(TypeRef.CoreLib("System", "Sample"), "Sink", VoidType, [ExceptionType], HasThis: false);
+    static readonly MethodRef Work = new(TypeRef.CoreLib("System", "Sample"), "Work", VoidType, [], HasThis: false);
+
+    // try { Work(); } catch (Exception) { Sink(<caught>); … }  — `inlineUses` copies
+    // of the caught-exception value use, with no entry store.
+    static IrFunction BuildInlineCatch(int inlineUses)
+    {
+        var tryBlock = new Block(0x00);
+        tryBlock.Add(new ExpressionStatement(new Call(Work, isVirtual: false, [])));
+        tryBlock.Add(new Leave(0x20));
+
+        var handlerBlock = new Block(0x10);
+        for (int i = 0; i < inlineUses; i++)
+            handlerBlock.Add(new ExpressionStatement(new Call(Sink, isVirtual: false, [new CaughtException(ExceptionType)])));
+        handlerBlock.Add(new Leave(0x20));
+
+        var exit = new Block(0x20);
+        exit.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(tryBlock);
+        body.Add(handlerBlock);
+        body.Add(exit);
+
+        var signature = new MethodSignature(VoidType, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [], body)
+        {
+            Regions = [new HandlerRegion(HandlerKind.Catch, 0x00, 0x10, 0x10, 0x10, 0, ExceptionType)],
+        };
+    }
+
+    [Fact]
+    public void SingleInlineUse_StructuresWithSynthesizedVariable()
+    {
+        var function = BuildInlineCatch(inlineUses: 1);
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Regions);                                  // region consumed
+        var clause = Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses.Single();
+        Assert.NotNull(clause.VariableIndex);                            // a variable was bound
+        Assert.Empty(function.Descendants.OfType<CaughtException>());    // no bare exception leaks
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void TwoInlineUses_StayFlatRatherThanReintroduceAStore()
+    {
+        var function = BuildInlineCatch(inlineUses: 2);
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.NotEmpty(function.Regions);                              // not consumed
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+        function.CheckInvariant();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -450,7 +450,7 @@ public sealed class CatchClause : IrNode
     public TypeRef ExceptionType { get; }
 
     /// <summary>Local the handler stores the caught exception into; null when the exception is discarded.</summary>
-    public int? VariableIndex { get; init; }
+    public int? VariableIndex { get; set; }
 
     public BlockContainer Body => (BlockContainer)Children[0];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -269,6 +269,11 @@ public sealed class EhStructuringPass : IIrPass
     /// </summary>
     static bool ValidateCaughtExceptions(IReadOnlyList<Block> blocks, List<Construct> all)
     {
+        // Inline (non-entry, non-rethrow) value uses of the caught exception, by
+        // handler. A handler that uses the exception inline must use it exactly once
+        // for SynthesizeInlineCatchVariables to bind a variable opcode-exactly; see
+        // its remarks for why two or more cannot round-trip.
+        var inlineUses = new Dictionary<int, int>();
         foreach (var block in blocks)
         {
             var handler = InnermostCatchHandler(all, block.StartOffset);
@@ -286,18 +291,22 @@ public sealed class EhStructuringPass : IIrPass
                     continue;
                 if (statement is Throw { Value: CaughtException { Type: null } } && handler is not null)
                     continue;  // rethrow
-                // Any other use of the caught exception as a value — a once-used
-                // catch variable Release leaves on the stack rather than storing,
-                // e.g. `catch (E ex) { throw new TIE(ex); }` — must be inside a
-                // catch handler so SynthesizeInlineCatchVariables can bind it; a
-                // CaughtException outside one cannot be spelled.
                 foreach (var node in statement.Descendants.Prepend(statement))
                 {
-                    if (node is CaughtException && handler is null)
+                    if (node is not CaughtException)
+                        continue;
+                    // A CaughtException outside any catch handler cannot be spelled.
+                    if (handler is null)
                         return false;
+                    inlineUses[handler.HandlerOffset] = inlineUses.GetValueOrDefault(handler.HandlerOffset) + 1;
                 }
             }
         }
+        // Two or more inline uses in one handler only come from a duped exception in
+        // hand-written/obfuscated IL; binding a variable would re-introduce a store
+        // the original lacked. Leave such a method flat rather than mis-raise it.
+        if (inlineUses.Values.Any(count => count > 1))
+            return false;
         return true;
     }
 
@@ -519,13 +528,22 @@ public sealed class EhStructuringPass : IIrPass
 
     /// <summary>
     /// Binds a catch variable for a handler that uses the caught exception as a
-    /// value without an entry store. Release leaves a once-used catch variable on
-    /// the stack — <c>catch (E ex) { throw new TIE(ex); }</c> imports as a bare
-    /// <see cref="CaughtException"/> in value position, with no <c>E ex = …</c> to
-    /// fold. C# has no spelling for the stack exception, so synthesize a local,
-    /// make it the clause's variable, and rewrite the value uses to read it.
-    /// Recompiling re-elides the store, so the round trip is opcode-exact. A bare
-    /// rethrow (<c>throw;</c>) names no variable and is left alone.
+    /// value without an entry store. Release leaves a <em>once-used</em> catch
+    /// variable on the stack — <c>catch (E ex) { throw new TIE(ex); }</c> imports as
+    /// a single bare <see cref="CaughtException"/> in value position, with no
+    /// <c>E ex = …</c> to fold. C# has no spelling for the stack exception, so
+    /// synthesize a local, make it the clause's variable, and rewrite that one use
+    /// to read it. Recompiling re-elides the store, so the round trip is
+    /// opcode-exact.
+    ///
+    /// <para>Gated to exactly one value use, which is the only shape this elision
+    /// produces: any C# that reads the exception twice forces the store, taking the
+    /// entry-store fold path instead. A handler with two or more inline
+    /// <see cref="CaughtException"/> values can only come from hand-written or
+    /// obfuscated IL (a duped exception on the stack); binding one variable there
+    /// would re-introduce a store the original lacked — a roundtrip the proof does
+    /// not cover — so it is left unconsumed. A bare rethrow (<c>throw;</c>) names no
+    /// variable and is not a value use.</para>
     /// </summary>
     static void SynthesizeInlineCatchVariables(IrFunction function, BlockContainer root)
     {
@@ -536,13 +554,12 @@ public sealed class EhStructuringPass : IIrPass
             var uses = clause.Body.Descendants.OfType<CaughtException>()
                 .Where(caught => InnermostCatchClause(caught) == clause && !IsBareRethrow(caught))
                 .ToList();
-            if (uses.Count == 0)
+            if (uses.Count != 1)
                 continue;
 
             int slot = function.AddLocal(clause.ExceptionType);
             clause.VariableIndex = slot;
-            foreach (var caught in uses)
-                caught.ReplaceWith(new LoadLocal(slot, clause.ExceptionType));
+            uses[0].ReplaceWith(new LoadLocal(slot, clause.ExceptionType));
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -59,6 +59,7 @@ public sealed class EhStructuringPass : IIrPass
         var rebuilt = BuildContainer(blocks, 0, blocks.Count, forest.Roots, offsetToIndex, continuations);
         TrimTailLeaves(rebuilt, continuations);
         InlineReturnLeaves(rebuilt);
+        SynthesizeInlineCatchVariables(function, rebuilt);
         context.Stepper.StepOver("raise exception regions into try/catch/finally", function.Body);
         function.Body.ReplaceWith(rebuilt);
         function.Regions = [];
@@ -285,9 +286,14 @@ public sealed class EhStructuringPass : IIrPass
                     continue;
                 if (statement is Throw { Value: CaughtException { Type: null } } && handler is not null)
                     continue;  // rethrow
+                // Any other use of the caught exception as a value — a once-used
+                // catch variable Release leaves on the stack rather than storing,
+                // e.g. `catch (E ex) { throw new TIE(ex); }` — must be inside a
+                // catch handler so SynthesizeInlineCatchVariables can bind it; a
+                // CaughtException outside one cannot be spelled.
                 foreach (var node in statement.Descendants.Prepend(statement))
                 {
-                    if (node is CaughtException)
+                    if (node is CaughtException && handler is null)
                         return false;
                 }
             }
@@ -510,6 +516,46 @@ public sealed class EhStructuringPass : IIrPass
         LoadArgument argument => new LoadArgument(argument.Index, argument.Name, argument.Type),
         _ => null,
     };
+
+    /// <summary>
+    /// Binds a catch variable for a handler that uses the caught exception as a
+    /// value without an entry store. Release leaves a once-used catch variable on
+    /// the stack — <c>catch (E ex) { throw new TIE(ex); }</c> imports as a bare
+    /// <see cref="CaughtException"/> in value position, with no <c>E ex = …</c> to
+    /// fold. C# has no spelling for the stack exception, so synthesize a local,
+    /// make it the clause's variable, and rewrite the value uses to read it.
+    /// Recompiling re-elides the store, so the round trip is opcode-exact. A bare
+    /// rethrow (<c>throw;</c>) names no variable and is left alone.
+    /// </summary>
+    static void SynthesizeInlineCatchVariables(IrFunction function, BlockContainer root)
+    {
+        foreach (var clause in root.Descendants.OfType<CatchClause>())
+        {
+            if (clause.VariableIndex is not null)
+                continue;
+            var uses = clause.Body.Descendants.OfType<CaughtException>()
+                .Where(caught => InnermostCatchClause(caught) == clause && !IsBareRethrow(caught))
+                .ToList();
+            if (uses.Count == 0)
+                continue;
+
+            int slot = function.AddLocal(clause.ExceptionType);
+            clause.VariableIndex = slot;
+            foreach (var caught in uses)
+                caught.ReplaceWith(new LoadLocal(slot, clause.ExceptionType));
+        }
+    }
+
+    static bool IsBareRethrow(CaughtException caught)
+        => caught.Type is null && caught.Parent is Throw { } throwNode && ReferenceEquals(throwNode.Value, caught);
+
+    static CatchClause? InnermostCatchClause(IrNode node)
+    {
+        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+            if (parent is CatchClause clause)
+                return clause;
+        return null;
+    }
 
     /// <summary>Folds the handler-entry store into the clause's variable; the discard pop just disappears.</summary>
     static int? FoldEntryConsumption(BlockContainer body)


### PR DESCRIPTION
Addresses #913 (`unconsumed-regions`, the StructuringPass stop reason). Per the issue's suggested approach, this isolates and raises the **dominant single sub-shape** within the bucket.

## The sub-shape

47 of 109 `unconsumed-regions` methods are a typed `catch` that `EhStructuringPass` rejects in `ValidateCaughtExceptions`. The dominant cause: a catch handler that uses the caught exception **as a value with no entry store** —

```csharp
try { … } catch (Exception ex) { throw new TargetInvocationException(ex); }
```

Release leaves a once-used catch variable on the stack instead of storing it, so the exception imports as a bare `CaughtException` in value position. The validator rejected it, the EH region stayed unconsumed, and `StructuringPass` bailed entirely → the whole method rendered as goto soup with an unspellable `__exception`.

## The fix

C# has no spelling for the stack exception, so `SynthesizeInlineCatchVariables` binds a fresh local as the clause's variable and rewrites the value uses to read it. The bare `throw;` rethrow names nothing and is left alone; the existing entry-store and discard paths are untouched.

`RuntimeType::CreateInstanceOfT` before → after:
```diff
- if (V_0.CtorIsPublic) goto IL_0020;
- throw new MissingMethodException(…);
- IL_0020: V_1 = V_0.CreateUninitializedObject(this);
- V_0.CallRefConstructor(V_1);
- goto IL_0037; // leave
- throw new TargetInvocationException(__exception);
- IL_0037: return V_1;
+ if (!V_0.CtorIsPublic) throw new MissingMethodException(…);
+ object V_1 = V_0.CreateUninitializedObject(this);
+ try { V_0.CallRefConstructor(V_1); }
+ catch (Exception V_2) { throw new TargetInvocationException(V_2); }
+ return V_1;
```

## Opcode-exact

Recompiling `catch (E ex) { … ex … }` re-elides the store, so the round trip is faithful. Verified directly: **decompile → recompile (Release) → decompile is byte-identical**.

## Impact (CoreLib)

- `unconsumed-regions`: **109 → 65**; **+68** containers structured; **0 pass bugs**.
- `--diff-validity-defects` vs baseline: **REGRESSED: (none)** — zero validity regressions.

## Fixtures / tests

- Positive: `CatchLogs` (inline use → synthesized variable) — `InlineCatchVariableTests` and the updated `IrImporter` test now assert the structured form in both Debug (entry store) and Release (synthesis).
- Negatives: `CatchDiscards` (no variable bound), `LogAndRethrow` (`throw;`, no variable).
- Out of slice (still flat): `Filter`/`Fault` handlers and untyped `catch` — the next sub-shapes.

**780/780** `ILInspector.Decompiler.Tests` green (`FidelityGateTests`, `LoweredFidelityGateTests`, `CorpusSweepGateTests` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)