### PR TITLE
Cast integer operands to cross-assembly enums to fix CS0019

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -737,6 +737,24 @@ public class CfgSampleClass
     // (CfgPriority)value cast — C# converts int->enum implicitly only for 0.
     public static CfgPriority ToPriority(int value) => (CfgPriority)value;
 
+    // --- Cross-assembly enum vs integer (CS0019) ---
+    // System.DayOfWeek / System.AttributeTargets live in CoreLib, not this test
+    // assembly, so on decompile ResolveShape returns Unknown — the enum loses its
+    // shape and a sibling int constant or value never retypes. The printer must
+    // recognize the enum structurally (a named definition with no stack family,
+    // opposite an integer) and cast the integer operand to the enum type, or the
+    // comparison/bitwise op is CS0019 (`enum == int` / `enum & int`).
+
+    // `(int)day` is a no-op on the stack (an enum is already its underlying int),
+    // so the IL is a bare `ceq` of the enum arg against the int arg. Decompiled
+    // cross-assembly that is `day == code` (CS0019); the fix casts: `day == (DayOfWeek)code`.
+    public static bool CrossAssemblyEnumEqualsInt(System.DayOfWeek day, int code) => (int)day == code;
+
+    // `t & AttributeTargets.Class` compiles to `ldarg; ldc.i4.4; and`; the 4 stays
+    // a bare int once the enum shape is unknown, so the mask is `t & 4` (CS0019).
+    // The fix casts the int operand to the enum: `t & (AttributeTargets)4`.
+    public static System.AttributeTargets CrossAssemblyEnumBitwise(System.AttributeTargets t) => t & System.AttributeTargets.Class;
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
@@ -1,0 +1,43 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A cross-assembly enum (System.DayOfWeek, System.AttributeTargets — CoreLib, not
+// this test assembly) resolves to TypeShape.Unknown on decompile: EnsureTypeMaps
+// only walks the target assembly's own type defs, so no referenced enum's shape is
+// registered. A sibling int therefore never retypes, leaving `enum == int` /
+// `enum & int` (CS0019). The printer recognizes the enum structurally and casts the
+// integer operand to the enum type. The same-assembly enums (CfgPriority, CfgStyles)
+// resolve to TypeShape.Enum and are unaffected — covered by RefEnumBitwiseTests.
+public class CrossAssemblyEnumIntegerTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void EnumComparedToInt_CastsIntegerToEnum()
+    {
+        var output = Render(nameof(CfgSampleClass.CrossAssemblyEnumEqualsInt));
+
+        Assert.Contains("(DayOfWeek)", output);
+        // The bare `day == code` (enum == int) would be CS0019.
+        Assert.DoesNotContain("== code", output);
+    }
+
+    [Fact]
+    public void EnumBitwiseWithInt_CastsIntegerToEnum()
+    {
+        var output = Render(nameof(CfgSampleClass.CrossAssemblyEnumBitwise));
+
+        Assert.Contains("(AttributeTargets)", output);
+        // The bare `t & 4` (enum & int) would be CS0019.
+        Assert.DoesNotContain("& 4", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -32,8 +32,49 @@ public sealed partial class CSharpPrinter
         }
     }
 
+    /// <summary>
+    /// True when <paramref name="type"/> can only be an enum where it meets an
+    /// integer operand: a named definition with no primitive stack family that
+    /// the shape map does not class as a reference or (non-enum) struct. A
+    /// cross-assembly enum loads no definition, so it resolves to
+    /// <see cref="TypeShape.Unknown"/> — this structural test, not a shape
+    /// lookup, is what recognizes it. Callers pair it with an integer sibling:
+    /// IL verification admits no other value type as an integer-op operand, so
+    /// the pairing is the proof it is an enum.
+    /// </summary>
+    bool IsEnumLikeInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition }
+            && TypeFamilies.Of(type) is null
+            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.Reference or TypeShape.ValueType);
+
+    /// <summary>
+    /// Casts an integer operand to the enum type it is compared or combined with
+    /// — <c>(MethodAttributes)access</c> — so an enum-vs-integer comparison or
+    /// bitwise op type-checks (CS0019). The cast reinterprets the integer bits
+    /// the IL already carries as the enum, so it is faithful. A negative literal
+    /// is parenthesized (CS0075), mirroring <see cref="CastValue"/>'s enum path.
+    /// </summary>
+    string EnumIntegerCast(IrExpression value, TypeRef enumType)
+    {
+        bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
+            || value is Constant { Value: long lv } && lv < 0;
+        return $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
+    }
+
     string BinaryBody(Binary binary, bool wrap)
     {
+        // A bitwise &/|/^ of an enum and an integer (`method.Attributes & 7`) is
+        // CS0019 though the IL combines the shared underlying integer; cast the
+        // integer operand to the enum type. A cross-assembly enum is unresolved
+        // (TypeShape.Unknown), so this structural test is what catches it. A
+        // bitwise op is never checked, so it never needs the `wrap` form.
+        if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
+        {
+            if (IsEnumLikeInteger(binary.Left.ResultType) && TypeFamilies.IsInteger(binary.Right.ResultType))
+                return $"{Operand(binary.Left)} {BinaryOperator(binary)} {EnumIntegerCast(binary.Right, binary.Left.ResultType!)}";
+            if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
+                return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
+        }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
         // float, where .un means unordered, not unsigned) print plain.
@@ -281,6 +322,15 @@ public sealed partial class CSharpPrinter
                 }
             }
         }
+        // An enum compared to an integer (`access == bestAccess`,
+        // `methodAccess == 6`) is CS0019 though the IL compares their shared
+        // underlying integer; cast the integer operand to the enum type. A
+        // cross-assembly enum is unresolved (TypeShape.Unknown), so this is the
+        // path that fixes it.
+        if (IsEnumLikeInteger(left.ResultType) && TypeFamilies.IsInteger(right.ResultType))
+            return $"{Operand(left)} {ComparisonOperator(kind)} {EnumIntegerCast(right, left.ResultType!)}";
+        if (IsEnumLikeInteger(right.ResultType) && TypeFamilies.IsInteger(left.ResultType))
+            return $"{EnumIntegerCast(left, right.ResultType!)} {ComparisonOperator(kind)} {Operand(right)}";
         return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1168,6 +1168,15 @@ public sealed partial class CSharpPrinter
         (string, string) reference = ($"{text} is not null", $"{text} is null");
         (string, string) integer = ($"{text} != 0", $"{text} == 0");
 
+        // A bitwise/shift Binary is provably integral — these IL ops only operate
+        // on integer or enum operands — even when its nominal result type is a
+        // cross-assembly enum (e.g. TypeAttributes) the printer cannot resolve to
+        // a stack family or a TypeShape. Spell the branch test `(expr) != 0`
+        // rather than leaving a non-bool bitwise expression bare (CS0019). A
+        // genuine bool `&`/`|` was filtered by the Boolean guard above.
+        if (operand is Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor or BinaryKind.ShiftLeft or BinaryKind.ShiftRight })
+            return integer;
+
         switch (TypeFamilies.Of(type))
         {
             // Boolean was filtered above, so an I4 family here is a real integer (or char).


### PR DESCRIPTION
## Summary

Dogfooding the decompiler against its own product libraries (issue #929) surfaced a **CS0019** bucket — 59 occurrences absent from the CoreLib corpus — in comparisons and bitwise ops that mix an enum operand with an integer operand:

- `access == bestAccess` (`MethodAttributes == int`)
- `methodAccess == 6` (`MethodAttributes == int` literal)
- `method.Attributes & 7` (`MethodAttributes & int`)
- `if (attrs & 1)` (non-bool bitwise result used bare as a branch condition)

## Root cause

`MetadataSource.EnsureTypeMaps` only walks the **target assembly's own** type definitions, so an enum from a *referenced* assembly (e.g. `TypeAttributes`/`MethodAttributes` from System.Reflection.Metadata) resolves to `TypeShape.Unknown`. Every enum-aware printer path (constant retyping, `CastValue`) gates on `TypeShape.Enum`, so a cross-assembly enum loses its shape and a sibling integer never retypes — leaving `enum == int` / `enum & int`, which is CS0019 in C# even though the IL compares/combines the shared underlying integer. This is invisible in the CoreLib corpus because there those enums are same-assembly.

## Fix

Recognize the enum **structurally** instead of by shape lookup: a named definition with no primitive stack family, sitting opposite a known integer, can only be an enum (IL verification admits no other value type as an integer-op operand). Cast the integer operand to the enum type — `access == (MethodAttributes)bestAccess`, `method.Attributes & (MethodAttributes)7` — a faithful reinterpret of the bits the stack already carries. Applied in `ComparisonText` and the bitwise `BinaryBody`; the bare branch-condition case also now spells `!= 0`.

## Validation

- **Product libraries**: CS0019 bucket drops **59 → 5** (the remainder are unrelated shapes, e.g. an exception-filter `||`).
- **CoreLib corpus**: fidelity unchanged at **40233/41012 Full**, **0 importer bugs**, and a **zero-line defect diff** — same-assembly enums (`TypeShape.Enum`) are unaffected.
- **Tests**: full `ILInspector.Decompiler.Tests` suite green (786). Added `CrossAssemblyEnumIntegerTests` with two fixtures using CoreLib enums (`System.DayOfWeek`, `System.AttributeTargets`) — cross-assembly relative to the test DLL — covering the comparison and bitwise paths; both round-trip opcode-exact (fidelity gates pass).

Fixes #929