### PR TITLE
Structure try bodies around a container-exiting leave (#915)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2903,6 +2903,39 @@ public class CfgSampleClass
             yield return -i;
         }
     }
+
+    // An early `break` out of the INNER foreach over a disposable enumerator:
+    // the inner loop body lives in a try (the enumerator's dispose finally), and
+    // the break lowers to a non-tail `leave` to the continuation after the inner
+    // try/finally — the `if (!matched)` check, NOT a trivial return, so the EH
+    // pass cannot inline it away and the leave survives. This is exactly the
+    // surviving-leave shape of HashSetEqualityComparer::Equals. The structuring
+    // pass treats that container-exiting leave as a clean path terminator (the
+    // printer renders the same `goto IL_xxxx; // leave`), so the inner try body
+    // raises into `while (...) { if (...) { ...; goto ...; } }` instead of
+    // staying flat goto-soup. The post-try continuation block holds the leave's
+    // target label and keeps the outer container flat (leave-target-in-container),
+    // so the goto's label always survives.
+    public static bool AllOuterMatchInner(
+        System.Collections.Generic.IEnumerable<int> outer,
+        System.Collections.Generic.IEnumerable<int> inner)
+    {
+        foreach (int o in outer)
+        {
+            bool matched = false;
+            foreach (int i in inner)
+            {
+                if (i == o)
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched)
+                return false;
+        }
+        return true;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -55,4 +55,42 @@ public class StructuringDiagnosticsTests
 
         Assert.Equal(IrPrinter.Dump(withoutSink), IrPrinter.Dump(withSink));
     }
+
+    [Fact]
+    public void EarlyBreakFromInnerTry_StructuresTryBody_NoTerminatorSurvivorStop()
+    {
+        // A nested foreach whose inner loop early-`break`s lowers to a non-tail
+        // `leave` that exits the inner try (the enumerator-dispose finally) to the
+        // `if (!matched)` continuation — the surviving-leave shape of
+        // HashSetEqualityComparer::Equals. The structuring pass treats a leave
+        // that exits its container as a clean path terminator, so the inner try
+        // body raises into `while (...) { if (...) { ...; goto ...; } }` instead
+        // of bailing flat with `eh-terminator-survivor`. The outer body keeps the
+        // leave's target label, so it stays flat (leave-target-in-container) — the
+        // remaining, deliberately conservative, stop.
+        var diag = RunWithDiagnostics(nameof(CfgSampleClass.AllOuterMatchInner));
+
+        Assert.DoesNotContain("eh-terminator-survivor", diag.Stops);
+        Assert.True(diag.Structured > 0);
+        Assert.Equal("leave-target-in-container", Assert.Single(diag.Stops));
+    }
+
+    [Fact]
+    public void EarlyBreakFromInnerTry_RaisesWhileLoopOverFlatGotoSoup()
+    {
+        // The readability win: the inner try body is a structured `while` whose
+        // early exit is the surviving `goto ...; // leave`, not a flat chain of
+        // gotos. Fidelity stays Full (the leave still renders the same goto).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.AllOuterMatchInner));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+
+        var output = result.Output!.ReplaceLineEndings("\n");
+        Assert.Contains("while (", output);
+        Assert.Contains("// leave", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -226,6 +226,16 @@ public sealed class StructuringPass : IIrPass
                     // the break, so this block ends its region cleanly.
                     i++;
                     break;
+                case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
+                    // A leave that exits this container (its target is an
+                    // enclosing construct's continuation, not a block here) ends
+                    // its path like a return/break: control leaves the region and
+                    // the printer still emits the same `goto IL_xxxx; // leave`.
+                    // The target block lives in an enclosing container, which the
+                    // leave-target-in-container guard (Structure) keeps flat, so
+                    // its label always survives — safe to structure around here.
+                    i++;
+                    break;
                 case Leave or EndFinally or EndFilter:
                     // Survivors of the EH pass (an early exit through outer
                     // constructs) keep their container flat: structure would
@@ -587,6 +597,12 @@ public sealed class StructuringPass : IIrPass
             switch (last)
             {
                 case Return or Throw or Break:
+                    result.Add(last);
+                    i++;
+                    break;
+                case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
+                    // A container-exiting leave (mirrors Validate): emit it as the
+                    // path terminator; the printer renders the `goto IL_xxxx`.
                     result.Add(last);
                     i++;
                     break;


### PR DESCRIPTION
Closes #915.

## What

The `StructuringPass` bailed with `eh-terminator-survivor` whenever a try body held a non-tail `leave` that exits the try to an enclosing construct's continuation — the surviving-leave shape of `HashSetEqualityComparer<T>::Equals`, `SemaphoreSlim::WaitCore`, `EventSource::DebugCheckEvent`, and 11 others. The body stayed flat goto-soup.

This teaches the pass to treat a **container-exiting** `leave` (its target is not a block in the current container) as a clean path terminator — exactly like `return`/`throw`/`break`. The printer still emits the identical `goto IL_xxxx; // leave`, so fidelity is unchanged, but the surrounding guards in the try body now raise into nested `while`/`if`.

### Why it is safe

The leave's target block lives in an *enclosing* container, which the existing `leave-target-in-container` guard keeps flat — so that block's label always survives, and the emitted goto never dangles. The change only fires where the old code already bailed, so the blast radius is exactly the previously-stuck containers.

## Before / after (`HashSetEqualityComparer<T>::Equals`, inner try body)

Before — flat:

```
goto IL_006A;
IL_0052: V_5 = V_4.Current;
if (!V_0.Equals(V_2, V_5)) goto IL_006A;
V_3 = true;
goto IL_0083; // leave
IL_006A: if (V_4.MoveNext()) goto IL_0052;
```

After — structured:

```
while (V_4.MoveNext())
{
    V_5 = V_4.Current;
    if (V_0.Equals(V_2, V_5))
    {
        V_3 = true;
        goto IL_0083; // leave
    }
}
```

## Results

- `eh-terminator-survivor` structuring stops: **15 to 0** across CoreLib (10827 to 10842 containers structured).
- All 14 affected methods stay **Full** fidelity (the lone pre-existing Partial, `TimeZoneInfo::GetSystemTimeZones`, is Partial for an unrelated `<>c` lambda-cache name).
- Validity-defect diff over the full corpus: **0 regressed, 0 introduced**.
- 0 importer/pass bugs.

The companion `leave-target-in-container` stop (the enclosing body container, also 14) is deliberately left conservative — it is what guarantees the goto labels survive.

## Tests

- New positive fixture `CfgSampleClass.AllOuterMatchInner` (nested foreach with an inner early-`break`) reproducing the survivor shape.
- `StructuringDiagnosticsTests` assert (1) the `eh-terminator-survivor` stop is gone and the container structures, and (2) the raised output contains the `while` loop and the surviving `goto ...; // leave`, at Full fidelity.
- Full decompiler suite (incl. corpus sweep gate): 788 passing.
