### PR TITLE
Add classic-async fixture axis for the multi-mode harness (on-demand)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,8 +3,12 @@
   <!-- Runtime async (compiler "async v2") is only valid on net11.0. Enable it there.
        This lives in Directory.Build.targets (not .props) because TargetFramework is
        not yet set when .props files are imported, so a net11.0 condition would never
-       match there. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0'">
+       match there.
+
+       A project can opt out with <RuntimeAsync>off</RuntimeAsync> to compile classic
+       async state machines instead — the async axis of the multi-mode fixture matrix
+       (see tools/DecompilerHarness/README.md). Default (property unset) is on. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0' and '$(RuntimeAsync)' != 'off'">
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
 

--- a/src/ILInspector.Decompiler.Fixtures.ClassicAsync/AsyncFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicAsync/AsyncFixtures.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ILInspector.Decompiler.Fixtures.ClassicAsync;
+
+/// <summary>
+/// Representative async source compiled with <c>runtime-async=off</c>, so each method
+/// lowers to a classic <c>AsyncTaskMethodBuilder</c> state machine (a <c>&lt;M&gt;d__N</c>
+/// struct + <c>MoveNext</c>) rather than the runtime-async <c>AsyncHelpers.Await</c> form
+/// the rest of the repo uses. This is the async axis of the multi-mode fixture matrix:
+/// the same source the runtime-async build covers, recompiled in the other mode so the
+/// decompiler is measured (via <c>--library-report</c>) on the classic lowering too.
+///
+/// On-demand only — not swept by any CI gate. Build it and point the harness at the DLL.
+/// </summary>
+public static class AsyncFixtures
+{
+    public static async Task<int> AwaitValue(Task<int> a, int b) => await a + b;
+
+    public static async Task AwaitVoid(Task a) => await a;
+
+    public static async Task TwoSequentialAwaits(Task<int> a, Task<int> b)
+    {
+        int x = await a;
+        int y = await b;
+        GC.KeepAlive((x, y));
+    }
+
+    public static async ValueTask<int> AwaitValueTask(ValueTask<int> a) => await a;
+
+    public static async Task<int> AwaitInLoop(Task<int>[] tasks)
+    {
+        int sum = 0;
+        foreach (var task in tasks)
+        {
+            sum += await task;
+        }
+        return sum;
+    }
+
+    public static async Task<int> AwaitInTryFinally(Task<int> a)
+    {
+        try
+        {
+            return await a;
+        }
+        finally
+        {
+            GC.KeepAlive(a);
+        }
+    }
+
+    public static async Task<int> AwaitConditional(Task<int> a, bool flag)
+        => flag ? await a : 0;
+}

--- a/src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The async axis of the multi-mode fixture matrix. Opts out of the repo-global
+    runtime-async (Directory.Build.targets) so AsyncFixtures.cs lowers to classic
+    AsyncTaskMethodBuilder state machines — the dominant real-world async form, which
+    the runtime-async CoreLib corpus never exercises.
+
+    On-demand only: deliberately NOT referenced by the test project or any CI gate.
+    Build it, then point the harness at the DLL in library-report mode to measure the
+    classic-async gap (see tools/DecompilerHarness/README.md).
+  -->
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <RuntimeAsync>off</RuntimeAsync>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -16,6 +16,40 @@ library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
 `--top-libraries N` limits the detailed library sections to the noisiest
 libraries, and `--json` emits the same data as structured JSON.
 
+### Multi-mode fixture matrix (on-demand)
+
+The CoreLib corpus and the CI gates measure **one compiler mode** — whatever the
+framework shipped (today: `runtime-async=on`, updated memory-safety rules,
+Release). But the decompiler must handle every assembly anyone feeds it, across
+many lowering modes. A construct that lowers differently under a compiler flag —
+**async** is the biggest: `runtime-async=on` emits `AsyncHelpers.Await`, `off`
+emits a classic `AsyncTaskMethodBuilder` state machine, two unrelated lowerings —
+is invisible to a single-mode sweep.
+
+The fix is a small **mode matrix** of fixture assemblies: the *same* source
+recompiled with one flag flipped. Most fixtures are mode-agnostic (same IL either
+way) and stay in the default assembly; only the mode-*sensitive* ones get a thin
+overlay project that flips one flag. So the cost is one big default assembly plus
+a few shrinking single-flag overlays — never the corpus times N. The axis switch
+lives in `Directory.Build.targets` (e.g. `<RuntimeAsync>off</RuntimeAsync>`).
+
+These overlays are **on-demand, not wired into CI** — build one and point
+`--library-report` at it to measure that mode's gap. The first axis is
+`src/ILInspector.Decompiler.Fixtures.ClassicAsync` (the async fixtures at
+`runtime-async=off`):
+
+```bash
+dotnet build src/ILInspector.Decompiler.Fixtures.ClassicAsync -c Release
+dotnet run --project tools/DecompilerHarness -c Release -- --library-report \
+  artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicAsync/release/ILInspector.Decompiler.Fixtures.ClassicAsync.dll
+```
+
+Baseline (classic async unraised): 21 methods, 0 raised — the state-machine
+`MoveNext`s bucket as `structuring: conditional-branch` (the goto state dispatch
+the structurer can't raise), and the kickoffs plus `SetStateMachine` as
+`fidelity: (typed)`. Raising classic async state machines back to `async`/`await`
+shrinks those buckets; this report is the tracked signal for that work.
+
 **Validity check** (`--validity-check`): the *validity* check — `--gaps` is *completeness*, `--fidelity-check` is *fidelity*, this is *does it even compile*. The pipeline guarantees by construction only that it never crashes and never silently fabricates (unrepresentable IL becomes a visible `/* … */` comment and drops fidelity to `Partial`) — **not** that the rendered text is valid C#. This mode measures the gap: each body is wrapped in a method shell carrying its real signature (return type, generic parameters with their `where` constraints reconstructed from metadata, parameters, so locals/params/type-params and `this` all bind — without the constraints a constrained generic-math call like `byte.TryConvertFromTruncating<TOther>` spuriously fails CS0314), then (1) parsed — a parse error is unambiguously a decompiler defect; (2) checked for statement legality (the CS0201 rule — a bare cast/expression statement parses but isn't valid); (3) bound against the runtime references. Diagnostics are bucketed by code with the member/type-**visibility** codes (the shell can't see the real declaring type's fields/methods) filtered as noise, so genuine defects stand out — `CS0193` (`*`-deref of a managed ref), `CS0175` (`base(...)` rendered as a statement), `CS1620` (an `out` argument not marked `out`), `CS0165` (a local used before the decompiler assigned it). Reported split by fidelity: a `Partial` method is *expected* to carry invalid fragments; a **`Full` method that fails to compile is the real "claimed good but isn't" signal** and the prioritized fix docket. Compiler-generated members are excluded (their metadata names aren't valid identifiers). `--compile-cap N` bounds the (slow) semantic-binding pass.
 
 *Defect tracking — prove a fix regressed nothing.* A raw count (e.g. "CS0266: 263") tells you a bucket shrank but not *which* methods changed, so it cannot distinguish a real fix from a fix that also broke something else. `--emit-validity-defects <file>` writes the per-method defect map (one `Type::Method<TAB>CODE,CODE` row per method) before your change; after the change, `--diff-validity-defects <file>` re-runs the check and prints the differential against that baseline — **REGRESSED** (methods that gained a code) and **IMPROVED** (methods that lost one), per code. A clean fix shows entries only under IMPROVED with an empty REGRESSED; any REGRESSED row is a method your change broke. Only methods checked in *both* runs are compared (cap-boundary methods are excluded), so keep `--compile-cap` identical across the baseline and diff runs. This is the regression-proof loop behind a "N→M occurrences, 0 regressions" claim.


### PR DESCRIPTION
## Why

The CoreLib corpus and CI gates measure **one compiler mode** — whatever the framework shipped (today `runtime-async=on`). But the decompiler must handle every assembly it's given, and **async lowers two completely different ways**:

- `runtime-async=on` → `AsyncHelpers.Await` (raised by `AwaitRecoveryPass`)
- `runtime-async=off` → a classic `AsyncTaskMethodBuilder` state machine (`<M>d__N` struct + `MoveNext`) — **not raised**, and the dominant real-world form, yet invisible to the single-mode corpus.

This stands up the **async axis of a multi-mode fixture matrix** so the classic lowering becomes a measured signal — using the new `--library-report` (#904) as the per-assembly measurement.

## What

- **`Directory.Build.targets`**: the global `runtime-async=on` becomes opt-out-able via `<RuntimeAsync>off</RuntimeAsync>`. Default behavior unchanged (verified: the test assembly still renders `(await a) + b`).
- **`Fixtures.ClassicAsync`**: a representative async source set (single/multi-await, ValueTask, await-in-loop, try/finally, conditional) compiled `runtime-async=off`, so each method lowers to a classic state machine (confirmed: `AsyncTaskMethodBuilder<int>.Create()`).
- **README**: documents the matrix model (same source, one flipped flag; mode-agnostic fixtures stay in the default assembly, only sensitive ones get a thin overlay — cost is "1 big default + shrinking single-flag overlays," never corpus×N) and the on-demand workflow.

**On-demand only — not referenced by the test project or any CI gate.** Build the overlay and point `--library-report` at the DLL.

## Baseline (the tracked signal)

```
ILInspector.Decompiler.Fixtures.ClassicAsync | 21 methods | 0/21 raised
  structuring: conditional-branch : 7   (the MoveNext state machines)
  fidelity: (typed)               : 14  (kickoffs + SetStateMachine)
```

Raising classic async state machines back to `async`/`await` shrinks these buckets. The reconstruction (kickoff recognition is spiked locally) is the follow-up; this PR makes its target measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)