### PR TITLE
Narrow the CS0305 validity filter to consult the decompiler's type model

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -48,6 +48,8 @@
              Link="VolatileFieldDetector.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\Completeness.cs"
              Link="Completeness.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ShellNoise.cs"
+             Link="ShellNoise.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Decompiler.Tests/ShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShellNoiseTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using Xunit;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The validity check filters a CS0305 ("generic type requires N type arguments")
+/// on a bare identifier ONLY when it is a sibling-free-shell import collision (the
+/// decompiler emitted a non-generic type, or a member receiver, whose simple name
+/// collides with a <c>using</c>-imported generic). A genuinely mis-rendered generic
+/// — a dropped type-argument list — lands on the same bare identifier, so the filter
+/// must NOT suppress it: these tests prove the model-consulting discriminator keeps
+/// that real defect reported.
+/// </summary>
+public class ShellNoiseTests
+{
+    static TypeRef ListOfInt =>
+        TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "List`1"),
+            [TypeRef.CoreLib("System", "Int32")]);
+
+    static TypeRef NonGenericComparison =>
+        TypeRef.Definition("ILInspector.Decompiler", "ILInspector.Decompiler.Pipeline.Ir", "Comparison");
+
+    [Fact]
+    public void GenericInstance_IsRecognizedByItsSimpleName()
+    {
+        // List<int> in the model => a bare `List` render is a dropped-argument
+        // defect, not a collision => NOT filtered (stays reported).
+        Assert.True(ShellNoise.ContainsGenericTypeNamed(ListOfInt, "List"));
+    }
+
+    [Fact]
+    public void BareGenericDefinition_IsRecognized()
+    {
+        // The exact shape a dropped-type-argument bug renders: a generic definition
+        // (arity suffix `1) reached with no type-argument list.
+        var bareGeneric = TypeRef.CoreLib("System.Collections.Generic", "List`1");
+        Assert.True(ShellNoise.ContainsGenericTypeNamed(bareGeneric, "List"));
+    }
+
+    [Fact]
+    public void NestedGeneric_IsRecognizedThroughElementAndArguments()
+    {
+        Assert.True(ShellNoise.ContainsGenericTypeNamed(TypeRef.SzArray(ListOfInt), "List"));
+        var dictionaryOfList = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "Dictionary`2"),
+            [TypeRef.CoreLib("System", "String"), ListOfInt]);
+        Assert.True(ShellNoise.ContainsGenericTypeNamed(dictionaryOfList, "List"));
+    }
+
+    [Fact]
+    public void NonGenericType_IsNotMistakenForAGeneric()
+    {
+        // The collision case: a non-generic type whose bare name happens to match an
+        // imported generic. No generic of that name in the model => filtered as noise.
+        Assert.False(ShellNoise.ContainsGenericTypeNamed(NonGenericComparison, "Comparison"));
+    }
+
+    [Fact]
+    public void DifferentSimpleName_DoesNotMatch()
+    {
+        Assert.False(ShellNoise.ContainsGenericTypeNamed(ListOfInt, "Comparison"));
+    }
+
+    [Fact]
+    public void ReferencesGenericTypeNamed_KeepsADroppedArgumentGenericReported()
+    {
+        // A function whose model references List<int> => a bare `List` CS0305 must
+        // stay reported (the discriminator returns true, so the filter declines).
+        var withGeneric = Function(locals: [ListOfInt]);
+        Assert.True(ShellNoise.ReferencesGenericTypeNamed(withGeneric, "List"));
+    }
+
+    [Fact]
+    public void ReferencesGenericTypeNamed_FiltersTheNonGenericCollision()
+    {
+        // A function whose model holds only a non-generic `Comparison` => its bare
+        // CS0305 is the import collision and is filtered.
+        var withCollision = Function(locals: [NonGenericComparison]);
+        Assert.False(ShellNoise.ReferencesGenericTypeNamed(withCollision, "Comparison"));
+    }
+
+    static IrFunction Function(ImmutableArray<TypeRef> locals) =>
+        new(
+            "M",
+            TypeRef.Definition("asm", "NS", "Host"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            locals,
+            new BlockContainer());
+}

--- a/tools/DecompilerHarness/ShellNoise.cs
+++ b/tools/DecompilerHarness/ShellNoise.cs
@@ -1,0 +1,83 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Pure (Roslyn-free) helpers that decide whether a validity-shell diagnostic is
+/// a sibling-free-shell artifact rather than a decompiler defect. Kept separate
+/// from <see cref="ValidityCheck"/> so the discriminator can be linked into the
+/// test project and unit-tested WITHOUT dragging in the shell/Roslyn machinery
+/// (which is also why a stray fidelity-gate regression earlier — the gate
+/// reconstructs every type in the test assembly into a skeleton, so only a
+/// trivially-reconstructable static class may be linked).
+/// </summary>
+internal static class ShellNoise
+{
+    /// <summary>
+    /// Does the decompiler's own model for <paramref name="function"/> reference a
+    /// generic type whose simple name is <paramref name="simpleName"/>? Used to tell
+    /// a bare-name import collision (the model holds a NON-generic type, or no type
+    /// at all, of that name — sibling-free-shell noise) apart from a genuine
+    /// dropped-type-argument render (the model holds a generic of that name, which a
+    /// correct printer would have spelled with its arguments — a real defect that
+    /// must stay reported).
+    /// </summary>
+    internal static bool ReferencesGenericTypeNamed(IrFunction function, string simpleName)
+    {
+        foreach (var node in function.Descendants.Prepend(function))
+            foreach (var type in node.DirectTypes)
+                if (ContainsGenericTypeNamed(type, simpleName))
+                    return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="type"/> — or any type nested inside it (array element,
+    /// by-ref/pointer pointee, or a type argument) — is a generic type whose simple
+    /// name is <paramref name="simpleName"/>. Both a generic instantiation
+    /// (<c>List&lt;int&gt;</c>) and a bare generic definition reference
+    /// (<c>List`1</c> with no arguments — the shape a dropped-argument bug would
+    /// render) count.
+    /// </summary>
+    internal static bool ContainsGenericTypeNamed(TypeRef type, string simpleName)
+    {
+        if (IsGenericNamed(type, simpleName))
+            return true;
+        if (type.ElementType is { } element && ContainsGenericTypeNamed(element, simpleName))
+            return true;
+        foreach (var argument in type.TypeArguments)
+            if (ContainsGenericTypeNamed(argument, simpleName))
+                return true;
+        return false;
+    }
+
+    static bool IsGenericNamed(TypeRef type, string simpleName) => type.Kind switch
+    {
+        // A generic instantiation: the simple name lives on the open definition.
+        TypeRefKind.GenericInstance =>
+            type.ElementType is { } definition && SimpleName(definition.Name) == simpleName,
+        // A bare definition is generic only when its metadata name carries an
+        // arity suffix (`N); a plain non-generic type (the collision case) is not.
+        TypeRefKind.Definition =>
+            HasArity(type.Name) && SimpleName(type.Name) == simpleName,
+        _ => false,
+    };
+
+    /// <summary>The C# simple name of a metadata type name: innermost nested
+    /// segment, with the generic-arity suffix stripped (<c>Outer+List`1</c> → <c>List</c>).</summary>
+    static string SimpleName(string metadataName)
+    {
+        int nested = metadataName.LastIndexOf('+');
+        string innermost = nested < 0 ? metadataName : metadataName[(nested + 1)..];
+        int tick = innermost.IndexOf('`');
+        return tick < 0 ? innermost : innermost[..tick];
+    }
+
+    static bool HasArity(string metadataName)
+    {
+        int nested = metadataName.LastIndexOf('+');
+        string innermost = nested < 0 ? metadataName : metadataName[(nested + 1)..];
+        int tick = innermost.IndexOf('`');
+        return tick >= 0 && int.TryParse(innermost[(tick + 1)..], out int arity) && arity > 0;
+    }
+}

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -152,7 +152,7 @@ static class ValidityCheck
                         .Where(IsError)
                         .Where(d => !BindingNoise.Contains(d.Id))
                         .Where(d => !IsShellArtifact(d))
-                        .Where(d => !IsGenericArityCollisionNoise(d, tree))
+                        .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
                         .ToList();
                     // Record EVERY bound method (clean ones with no codes), so the
                     // diff can restrict to methods checked in BOTH runs — a method
@@ -406,25 +406,39 @@ static class ValidityCheck
 
     /// <summary>
     /// CS0305 ("the generic type 'X&lt;T&gt;' requires N type arguments") on a
-    /// <em>simple</em> identifier the decompiler wrote with no type-argument list.
-    /// The printer always spells a generic type WITH its arguments (it holds the
-    /// full <see cref="TypeRef"/>), so a bare identifier is never an intended
-    /// generic — it is a non-generic local/sibling type, or a member-access
-    /// receiver, whose simple name happens to collide with a <c>using</c>-imported
-    /// generic of the same name (e.g. the decompiler's own <c>Comparison</c> IR
-    /// node vs <c>System.Comparison&lt;T&gt;</c>, or a <c>Lookup</c> property
-    /// receiver vs <c>System.Linq.Lookup&lt;TKey, TElement&gt;</c>). In the real
-    /// namespace the local symbol binds and shadows the import; only the sibling-
-    /// free shell mis-resolves the bare name to the generic. Filtered like the
-    /// other binding noise. A genuine wrong-arity bug spells the arguments (a
-    /// <see cref="GenericNameSyntax"/>) and is kept.
+    /// <em>simple</em> identifier the decompiler wrote with no type-argument list,
+    /// where the decompiler's own model holds <em>no</em> generic type of that
+    /// simple name. That is the sibling-free-shell collision: a non-generic
+    /// local/sibling type, or a member-access receiver, whose bare name happens to
+    /// collide with a <c>using</c>-imported generic of the same name (e.g. the
+    /// decompiler's own non-generic <c>Comparison</c> IR node vs
+    /// <c>System.Comparison&lt;T&gt;</c>, or a <c>Lookup</c> property receiver vs
+    /// <c>System.Linq.Lookup&lt;TKey, TElement&gt;</c>). In the real namespace the
+    /// local symbol binds and shadows the import; only the sibling-free shell
+    /// mis-resolves the bare name to the generic. Filtered like the other binding
+    /// noise.
+    /// <para>
+    /// It is <em>not</em> filtered — so a real defect stays reported — when the model
+    /// DOES reference a generic of that simple name. A genuinely mis-rendered generic
+    /// can land on an <see cref="IdentifierNameSyntax"/> too (a dropped type-argument
+    /// list, e.g. <c>List</c> where <c>List&lt;int&gt;</c> was meant): syntax kind
+    /// alone cannot tell that apart from a collision, so the decompiler's type model
+    /// is consulted (<see cref="ShellNoise.ReferencesGenericTypeNamed"/>). An explicit
+    /// wrong-arity render is a <see cref="GenericNameSyntax"/> and is never matched here.
+    /// </para>
     /// </summary>
-    internal static bool IsGenericArityCollisionNoise(Diagnostic diagnostic, SyntaxTree tree)
+    internal static bool IsGenericArityCollisionNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function)
     {
         if (diagnostic.Id != "CS0305")
             return false;
-        var node = tree.GetRoot().FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
-        return node is IdentifierNameSyntax;
+        if (tree.GetRoot().FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+            is not IdentifierNameSyntax name)
+            return false;
+        // A bare identifier with a same-named generic in the model could be a real
+        // dropped-type-argument render — keep it. Only filter when the model has no
+        // generic of that name, i.e. the bare name is genuinely a non-generic type
+        // (or non-type) that merely collides with an imported generic.
+        return !ShellNoise.ReferencesGenericTypeNamed(function, name.Identifier.ValueText);
     }
 
     internal static ImmutableArray<MetadataReference> RuntimeReferences()


### PR DESCRIPTION
Follow-up to #938 addressing review feedback: the CS0305 validity-shell filter was too broad.

## Problem

`ValidityCheck.IsGenericArityCollisionNoise` (from #938) filtered **every** CS0305 whose diagnostic location is an `IdentifierNameSyntax`. That is broader than the documented import-collision case. A genuine decompiler defect — a dropped type-argument list, e.g. rendering `List` where `List<int>` was meant — also lands on a bare `IdentifierNameSyntax`, so the validity gate would stop reporting that real compile failure.

## Fix

Consult the decompiler's own type model. A bare-identifier CS0305 is filtered as collision noise **only when the model references no generic type of that simple name** (the genuine collision: a non-generic local/sibling type, or a member-access receiver, whose bare name collides with a `using`-imported generic). When the model *does* hold a generic of that name, the bare render is a real dropped-argument defect and stays reported.

The discriminator (`ShellNoise.ReferencesGenericTypeNamed`) is pure (Roslyn-free) and lives in its own file. This matters: the fidelity gate reconstructs **every type in the test assembly** into a whole-module skeleton, so linking the shell/Roslyn machinery there breaks the skeleton (the cause of #938's first CI failure). A trivially-reconstructable static class links safely.

## Validation

- CS0305 still drops to **0** across the 8 product libraries (all 64 were genuine collisions); Full-malformed stays **0**.
- New `ShellNoiseTests` (7) prove a same-named generic — including a bare generic definition and nested generics — stays reported, while the non-generic collision is filtered.
- Full decompiler suite green (793), incl. both fidelity gates (whole-module skeleton reconstructs cleanly).

Because this touches `src/`, CI runs the test/pack jobs (unlike the tools/-only #938).
