### PR TITLE
[codex] Fix lowered source context and RVA span guards

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -83,6 +83,23 @@ public class MixedSourceRendererTests
     }
 
     [Fact]
+    public void Render_LoweredStage_UsesCrossMethodImportForLambda()
+    {
+        // Lowered Source declines only cosmetic sugar. It still needs the raised
+        // path's cross-method import seam for load-bearing passes that import
+        // compiler-generated companion bodies, such as LambdaRaisingPass.
+        var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+
+        var lowered = MixedSourceRenderer.Render(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.NonCapturingLambda),
+            AnnotationStage.Lowered);
+
+        Assert.NotNull(lowered.Output);
+        Assert.Contains("=>", lowered.Output!);
+        Assert.DoesNotContain("return new Func", lowered.Output!);
+    }
+
+    [Fact]
     public void Render_AttachesTrace_MirroringResultOutcome()
     {
         // The decompiler returns a telemetry-free trace shape a host can convert

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -66,13 +66,43 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void ReadOnlySpanByte_FromNegativeLength_StaysUnraised()
+    {
+        var function = BuildReadOnlySpanByteCtor([10, 20, 30, 0], spanLength: -1);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.Name == ".ctor");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ReadOnlySpanInt_FromOverflowingLength_StaysUnraised()
+    {
+        var function = BuildReadOnlySpanIntCtor([1, 0, 0, 0], spanLength: int.MaxValue);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.Name == ".ctor");
+        function.CheckInvariant();
+    }
+
     static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
+        => BuildReadOnlySpanCtor(s_byte, s_readOnlySpanByte, blob, spanLength);
+
+    static IrFunction BuildReadOnlySpanIntCtor(byte[] blob, int spanLength)
+        => BuildReadOnlySpanCtor(s_int, s_readOnlySpanInt, blob, spanLength);
+
+    static IrFunction BuildReadOnlySpanCtor(TypeRef element, TypeRef spanType, byte[] blob, int spanLength)
     {
         var ctor = new MethodRef(
-            s_readOnlySpanByte,
+            spanType,
             ".ctor",
             TypeRef.CoreLib("System", "Void"),
-            [TypeRef.ByRef(s_byte), s_int],
+            [TypeRef.ByRef(element), s_int],
             HasThis: true);
         var field = new FieldRef(
             TypeRef.Definition("CoreLib", "", "<PrivateImplementationDetails>"),

--- a/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
+++ b/src/ILInspector.Decompiler/Annotations/MixedSourceRenderer.cs
@@ -62,7 +62,8 @@ public static class MixedSourceRenderer
         // classification applies to either altitude.
         var annotations = AnnotationEngine.Default.ClassifyImported(imported);
         var csResult = stage == AnnotationStage.Lowered
-            ? CSharpPrinter.PrintLowered(imported, out var statementLines)
+            ? CSharpPrinter.PrintLowered(imported, out var statementLines,
+                importMethodBody: ImportMethodBody)
             : CSharpPrinter.PrintRaised(imported, out statementLines,
                 importMethodBody: ImportMethodBody);
         if (csResult.Output is not { } csText)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -120,10 +120,14 @@ public sealed partial class CSharpPrinter
     /// altitude than the shipped output.
     /// </summary>
     public static DecompilerResult PrintLowered(IrFunction function)
+        => PrintLowered(function, importMethodBody: null);
+
+    /// <summary>As <see cref="PrintLowered(IrFunction)"/>, with <paramref name="importMethodBody"/> wiring the cross-method import seam for non-cosmetic lowered passes such as lambda, local-function, and iterator reconstruction.</summary>
+    public static DecompilerResult PrintLowered(IrFunction function, Func<MethodRef, IrFunction?>? importMethodBody)
     {
         try
         {
-            IrPasses.Run(function, IrPasses.Lowered);
+            IrPasses.Run(function, IrPasses.Lowered, RaiseContext(importMethodBody));
         }
         catch (Exception ex)
         {
@@ -139,11 +143,16 @@ public sealed partial class CSharpPrinter
     /// <see cref="PrintRaised(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>).
     /// </summary>
     public static DecompilerResult PrintLowered(IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines)
+        => PrintLowered(function, out statementLines, importMethodBody: null);
+
+    /// <inheritdoc cref="PrintLowered(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    public static DecompilerResult PrintLowered(
+        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody)
     {
         statementLines = new Dictionary<IrNode, int>();
         try
         {
-            IrPasses.Run(function, IrPasses.Lowered);
+            IrPasses.Run(function, IrPasses.Lowered, RaiseContext(importMethodBody));
         }
         catch (Exception ex)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -163,7 +163,17 @@ public sealed class RvaSpanPass : IIrPass
         if (width == 0)
             return null;
 
-        int length = elementCount is { } count ? count * width : data.Length;
+        int length;
+        if (elementCount is { } count)
+        {
+            if (count < 0 || count > data.Length / width)
+                return null;
+            length = count * width;
+        }
+        else
+        {
+            length = data.Length;
+        }
         if (length > data.Length || length % width != 0)
             return null;
 


### PR DESCRIPTION
## Summary

- Thread the cross-method import context through the lowered C# product path so load-bearing lowered passes such as lambda, local-function, and iterator reconstruction can import companion bodies.
- Wire the Lowered Source mixed renderer to pass that context, matching the raised view's behavior while still declining cosmetic sugar passes.
- Guard RVA span decoding against negative or overflowing element counts before multiplying by element width.

## Catch-up links

- Follows up on #756, which added Lowered Source for #636.
- Follows up on #936, which raised padded byte RVA spans for #916.

## Root cause

The merged Lowered Source path reused the lowered pass set but ran it with `PassContext.None`, so passes that still need synthesized companion method imports could not recover those shapes. Separately, `RvaSpanPass.DecodeElements` multiplied an IL-provided element count by primitive width without first proving the count was non-negative and within the captured RVA blob.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`