### PR TITLE
Preserve empty multi-package file rows

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4617,6 +4617,75 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_MultiplePackages_PathReadme_TsvIncludesEmptyPackageRow()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.HasReadme", "README.md", "readme");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.NoMatch", "README.md", "readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "MISSING.md", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("package\tpath\tsize\tis_readme", output);
+            Assert.Contains("Test.HasReadme\t\t\t", output);
+            Assert.Contains("Test.NoMatch\t\t\t", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathReadme_JsonlIncludesEmptyPackageObject()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Jsonl.HasReadme", "README.md", "readme");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Jsonl.NoMatch", "README.md", "readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "MISSING.md", "--jsonl");
+
+            Assert.Equal(0, exit);
+            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, lines.Length);
+            Assert.Contains("\"package\":\"Test.Jsonl.HasReadme\"", lines[0]);
+            Assert.Contains("\"path\":\"\"", lines[0]);
+            Assert.Contains("\"package\":\"Test.Jsonl.NoMatch\"", lines[1]);
+            Assert.Contains("\"path\":\"\"", lines[1]);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathReadme_CountIncludesEmptyPackageRows()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Count.HasReadme", "README.md", "readme");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Count.NoMatch", "README.md", "readme");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "MISSING.md", "--tsv", "--count");
+
+            Assert.Equal(0, exit);
+            Assert.Equal("2", output.Trim());
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_MultiplePackages_JsonEmitsArray()
     {
         var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Json.One", "README.md", "one");

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -767,7 +767,7 @@ public class PackageCommand
 
     private static int CountMultiPackageRows(IReadOnlyList<InspectionResult> results, string? section)
         => section != null && section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase)
-            ? results.Sum(result => result.Files?.Count ?? 0)
+            ? results.Sum(result => Math.Max(1, result.Files?.Count ?? 0))
             : results.Sum(result => new InspectionResultView(result).Metadata.Count);
 
     private static void WriteMultiPackageTable(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
@@ -784,14 +784,20 @@ public class PackageCommand
     private static void WriteMultiPackageFilesTable(IReadOnlyList<InspectionResult> results, InspectionOptions options)
     {
         var rows = results
-            .SelectMany(result => (result.Files ?? [])
-                .Select(file => new[]
-                {
-                    result.PackageName,
-                    file.Path,
-                    file.Size.ToString(CultureInfo.InvariantCulture),
-                    file.IsReadme ? "true" : "false",
-                }))
+            .SelectMany(result =>
+            {
+                if (result.Files is not { Count: > 0 })
+                    return [[result.PackageName, "", "", ""]];
+
+                return result.Files
+                    .Select(file => new[]
+                    {
+                        result.PackageName,
+                        file.Path,
+                        file.Size.ToString(CultureInfo.InvariantCulture),
+                        file.IsReadme ? "true" : "false",
+                    });
+            })
             .ToArray();
 
         OutputFormatter.WriteTable(Console.Out, !options.NoHeader, (writer, formatter) =>


### PR DESCRIPTION
## Summary
- preserve package provenance in multi-package Files row output when a package has no matching files
- emit blank path/size/is_readme cells for empty matches in table, TSV, and JSONL row modes
- count empty package rows so row count remains aligned with package count

Fixes #946

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore
- dotnet build src/dotnet-inspect -c Release --no-restore --nologo
