### PR TITLE
Add package AGENTS file resolution

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -59,12 +59,18 @@ public class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
-    private static (string PackagePath, string TempDir) CreateLocalReadmePackage(string id, string readmeFile, string readmeText)
+    private static (string PackagePath, string TempDir) CreateLocalReadmePackage(
+        string id,
+        string readmeFile,
+        string readmeText,
+        string? agentsText = null)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
         var packageRoot = Path.Combine(tempDir, "content");
         Directory.CreateDirectory(packageRoot);
         File.WriteAllText(Path.Combine(packageRoot, readmeFile), readmeText);
+        if (agentsText != null)
+            File.WriteAllText(Path.Combine(packageRoot, "AGENTS.md"), agentsText);
         File.WriteAllText(Path.Combine(packageRoot, $"{id}.nuspec"), $$"""
             <?xml version="1.0" encoding="utf-8"?>
             <package>
@@ -4603,9 +4609,9 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "@readme", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("package\tpath\tsize\tis_readme", output);
-            Assert.Contains("Test.First\tPACKAGE.md\t12\ttrue", output);
-            Assert.Contains("Test.Second\tdocs-readme.md\t13\ttrue", output);
+            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
+            Assert.Contains("Test.First\t1.0.0\tPACKAGE.md\t12\ttrue\tfalse", output);
+            Assert.Contains("Test.Second\t1.0.0\tdocs-readme.md\t13\ttrue\tfalse", output);
             Assert.DoesNotContain("not a valid package version", error);
             Assert.DoesNotContain("Tip:", error);
         }
@@ -4627,9 +4633,9 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "MISSING.md", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("package\tpath\tsize\tis_readme", output);
-            Assert.Contains("Test.HasReadme\t\t\t", output);
-            Assert.Contains("Test.NoMatch\t\t\t", output);
+            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
+            Assert.Contains("Test.HasReadme\t1.0.0\t\t\t\t", output);
+            Assert.Contains("Test.NoMatch\t1.0.0\t\t\t\t", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally
@@ -4653,10 +4659,96 @@ public class CommandExecutionTests
             var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(2, lines.Length);
             Assert.Contains("\"package\":\"Test.Jsonl.HasReadme\"", lines[0]);
+            Assert.Contains("\"version\":\"1.0.0\"", lines[0]);
             Assert.Contains("\"path\":\"\"", lines[0]);
             Assert.Contains("\"package\":\"Test.Jsonl.NoMatch\"", lines[1]);
+            Assert.Contains("\"version\":\"1.0.0\"", lines[1]);
             Assert.Contains("\"path\":\"\"", lines[1]);
             Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathAgents_TsvMarksAgentsRows()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Agents.One", "README.md", "readme", "agents one");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Agents.Two", "README.md", "readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@agents", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
+            Assert.Contains("Test.Agents.One\t1.0.0\tAGENTS.md\t10\tfalse\ttrue", output);
+            Assert.Contains("Test.Agents.Two\t1.0.0\t\t\t\t", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathFirst_UsesFirstMatchingSelector()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Match.First", "README.md", "readme", "agents");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Match.Second", "README.md", "readme");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@agents", "--path", "@readme", "--match", "first", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Test.Match.First\t1.0.0\tAGENTS.md\t6\tfalse\ttrue", output);
+            Assert.Contains("Test.Match.Second\t1.0.0\tREADME.md\t6\ttrue\tfalse", output);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathAll_ReturnsAllMatchingSelectors()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Match.All", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, packagePath, "--path", "@agents", "--path", "@readme", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Test.Match.All\t1.0.0\tAGENTS.md\t6\tfalse\ttrue", output);
+            Assert.Contains("Test.Match.All\t1.0.0\tREADME.md\t6\ttrue\tfalse", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathSkipEmpty_OmitsEmptyPackages()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Skip.HasAgents", "README.md", "readme", "agents");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Skip.NoAgents", "README.md", "readme");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@agents", "--skip-empty", "--tsv");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Test.Skip.HasAgents", output);
+            Assert.DoesNotContain("Test.Skip.NoAgents", output);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -454,6 +454,16 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PackageCommand_WithRepeatedPathSelectors_ParsesCorrectly()
+    {
+        var args = CommandLineBuilder.PreprocessArgs(["package", "Foo", "--path", "@agents", "--path", "@readme", "--match", "first", "--skip-empty"]);
+
+        var result = CommandLineBuilder.CreateRootCommand().Parse(args);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void PreprocessArgs_DoesNotEscapeNonAtPathValue()
     {
         var args = new[] { "package", "Foo", "--path", "lib/" };

--- a/src/dotnet-inspect.Tests/PackageFileListerTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFileListerTests.cs
@@ -141,6 +141,23 @@ public class PackageFileListerTests
     }
 
     [Fact]
+    public void ListAll_MarksRootAgentsCaseInsensitively()
+    {
+        var root = CreateExtractDir("agents.md", "docs/AGENTS.md", "README.md");
+        try
+        {
+            var files = PackageFileLister.ListAll(root);
+            var agents = files.Where(f => f.IsAgents).Select(f => f.Path).ToList();
+
+            Assert.Equal(["agents.md"], agents);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ListAll_MarksDeclaredReadme_InSubdirectory()
     {
         var root = CreateExtractDir("docs/package-readme.md", "README.md");
@@ -191,5 +208,22 @@ public class PackageFileListerTests
     {
         List<PackageFile> files = [new("PACKAGE.md", 20, IsReadme: true)];
         Assert.Single(PackageFileLister.Filter(files, "@README"));
+    }
+
+    [Fact]
+    public void Filter_AtAgents_ReturnsRootAgentsOnly()
+    {
+        List<PackageFile> files =
+        [
+            new("AGENTS.md", 10, IsAgents: true),
+            new("docs/AGENTS.md", 20),
+            new("README.md", 30),
+        ];
+
+        var result = PackageFileLister.Filter(files, "@agents");
+
+        Assert.Single(result);
+        Assert.Equal("AGENTS.md", result[0].Path);
+        Assert.True(result[0].IsAgents);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -26,11 +26,14 @@ public static class PackageCommandDefinitions
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree (tip: use 'depends --package' instead)" };
         var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
         layoutOption.Aliases.Add("--tree");
-        var pathOption = new Option<string?>("--path")
+        var pathOption = new Option<string[]>("--path")
         {
-            Description = "List package files with sizes (the Files section), scoped to a file, a directory (e.g. lib/), the root (/), a glob (e.g. *.md), or @readme for the declared readme. Pass --path with no value for the whole package.",
-            Arity = ArgumentArity.ZeroOrOne
+            Description = "List package files with sizes (the Files section), scoped to a file, directory, glob, @readme, or @agents. Can repeat. Pass --path with no value for the whole package.",
+            Arity = ArgumentArity.ZeroOrMore,
+            AllowMultipleArgumentsPerToken = true
         };
+        var pathMatchOption = new Option<string?>("--match") { Description = "For repeated --path: all (default) or first matching selector per package" };
+        var skipEmptyOption = new Option<bool>("--skip-empty") { Description = "With multi-package Files rows, omit packages with no matching files" };
         var tfmsOption = new Option<bool>("--tfms") { Description = "List target frameworks in the package" };
         var libOption = new Option<bool>("--lib") { Description = "Scope to lib/ folder (use with --layout)" };
         var toolsOption = new Option<bool>("--tools") { Description = "Scope to tools/ folder (use with --layout)" };
@@ -56,6 +59,8 @@ public static class PackageCommandDefinitions
         packageCommand.Options.Add(dependenciesOption);
         packageCommand.Options.Add(layoutOption);
         packageCommand.Options.Add(pathOption);
+        packageCommand.Options.Add(pathMatchOption);
+        packageCommand.Options.Add(skipEmptyOption);
         packageCommand.Options.Add(tfmsOption);
         packageCommand.Options.Add(libOption);
         packageCommand.Options.Add(toolsOption);
@@ -84,7 +89,7 @@ public static class PackageCommandDefinitions
         var commandArgs = new PackageOptionsParser.PackageCommandArgs(
             packageNameArg, dependenciesOption, layoutOption, pathOption, tfmsOption,
             libOption, toolsOption, libraryOption, allLibrariesOption, versionsOption, prereleaseOption, readmeOption,
-            tfmOption, versionOption, latestVersionOption, outOption, opts.OneLine, opts.NoHeaders);
+            tfmOption, versionOption, latestVersionOption, outOption, pathMatchOption, skipEmptyOption, opts.OneLine, opts.NoHeaders);
 
         packageCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -19,7 +19,7 @@ public static class PackageOptionsParser
         Argument<string[]> PackageNameArg,
         Option<bool> DependenciesOption,
         Option<bool> LayoutOption,
-        Option<string?> PathOption,
+        Option<string[]> PathOption,
         Option<bool> TfmsOption,
         Option<bool> LibOption,
         Option<bool> ToolsOption,
@@ -32,6 +32,8 @@ public static class PackageOptionsParser
         Option<string?> VersionOption,
         Option<bool> LatestVersionOption,
         Option<string?> OutOption,
+        Option<string?> PathMatchOption,
+        Option<bool> SkipEmptyOption,
         Option<bool> OneLineOption,
         Option<bool> NoHeaderOption);
 
@@ -84,12 +86,19 @@ public static class PackageOptionsParser
         // --path (present without a value) means the whole package (root and below);
         // an explicit /, directory, file, or glob narrows it.
         string? pathFilter = null;
+        string[]? pathFilters = null;
         if (parseResult.GetResult(args.PathOption) is { Implicit: false })
         {
-            var value = parseResult.GetValue(args.PathOption);
-            pathFilter = string.IsNullOrEmpty(value)
-                ? "**"
-                : ArgumentPreprocessor.UnescapeAtCategoryValue(value);
+            var values = parseResult.GetValue(args.PathOption) ?? [];
+            pathFilters = values.Length == 0
+                ? ["**"]
+                : [.. values
+                    .SelectMany(SplitPathSelectors)
+                    .Select(ArgumentPreprocessor.UnescapeAtCategoryValue)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))];
+            if (pathFilters.Length == 0)
+                pathFilters = ["**"];
+            pathFilter = pathFilters.Length == 1 ? pathFilters[0] : null;
         }
 
         var options = new InspectionOptions
@@ -102,6 +111,9 @@ public static class PackageOptionsParser
             AllLibraries = parseResult.GetValue(args.AllLibrariesOption),
             ListLayout = parseResult.GetValue(args.LayoutOption),
             PathFilter = pathFilter,
+            PathFilters = pathFilters,
+            PathMatchMode = parseResult.GetValue(args.PathMatchOption) ?? "all",
+            SkipEmpty = parseResult.GetValue(args.SkipEmptyOption),
             ListTfms = parseResult.GetValue(args.TfmsOption),
             ScopeLib = parseResult.GetValue(args.LibOption),
             ScopeTools = parseResult.GetValue(args.ToolsOption),
@@ -134,6 +146,8 @@ public static class PackageOptionsParser
         // --path is sugar for selecting the Files section (which carries path + size).
         if (pathFilter != null)
             options = options with { Select = [.. options.Select ?? [], Views.PackageSections.Files] };
+        else if (pathFilters != null)
+            options = options with { Select = [.. options.Select ?? [], Views.PackageSections.Files] };
 
         var tipLevel = options.FormatExplicitlySet || options.IsRawOutput || verbosity != Verbosity.Minimal || options.Select != null || options.Discover != null || ArgumentPreprocessor.HeadLines != null || ArgumentPreprocessor.TailLines != null || options.Limit != null
             ? TipLevel.Quiet : opts.ParseTipLevel(parseResult);
@@ -141,4 +155,7 @@ public static class PackageOptionsParser
 
         return new Success(options, verbosity);
     }
+
+    private static IEnumerable<string> SplitPathSelectors(string value)
+        => value.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -89,6 +89,9 @@ public class PackageCommand
             return 1;
         }
 
+        if (!ValidatePathMatchMode(options))
+            return 1;
+
         if (options.AllLibraries && !ValidatePackageAllLibrariesMode(options))
             return 1;
         if (options.PackageLibrary != null && !ValidatePackageLibraryMode(options))
@@ -373,13 +376,14 @@ public class PackageCommand
             // Populate the Files section from the already-extracted package (sizes
             // come from FileInfo, so no extra download). Scoped by --path when given.
             // The section is opt-in (-S Files / --path), so this stays cheap.
-            bool wantsFilesSection = options.IncludeSections?.Contains(PackageSections.Files) == true
+            bool wantsFilesSection = HasPathFilter(options)
+                || options.IncludeSections?.Contains(PackageSections.Files) == true
                 || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
             if (wantsFilesSection)
             {
                 string declaredReadme = result.ReadmeFile ?? "README.md";
                 var files = PackageFileLister.ListAll(extractPath, declaredReadme);
-                result.Files = PackageFileLister.Filter(files, options.PathFilter);
+                result.Files = FilterPackageFiles(files, options);
             }
 
             // Filter output based on options
@@ -525,7 +529,8 @@ public class PackageCommand
 
         if (!TryResolveMultiPackageRowSection(options, out var rowSection))
             return 1;
-        bool wantsFilesSection = string.Equals(rowSection, PackageSections.Files, StringComparison.OrdinalIgnoreCase)
+        bool wantsFilesSection = HasPathFilter(options)
+            || string.Equals(rowSection, PackageSections.Files, StringComparison.OrdinalIgnoreCase)
             || options.IncludeSections?.Contains(PackageSections.Files) == true
             || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
         if (!options.JsonOutput && rowSection == null)
@@ -558,7 +563,7 @@ public class PackageCommand
 
         if (options.Count)
         {
-            Console.WriteLine(CountMultiPackageRows(results, rowSection).ToString(CultureInfo.InvariantCulture));
+            Console.WriteLine(CountMultiPackageRows(results, rowSection, options).ToString(CultureInfo.InvariantCulture));
             return 0;
         }
 
@@ -626,6 +631,18 @@ public class PackageCommand
 
         Console.Error.WriteLine($"Error: Multiple package inspection cannot be combined with {string.Join(", ", conflicts)}.");
         Console.Error.WriteLine("Use id@version for per-package version pins.");
+        return false;
+    }
+
+    private static bool ValidatePathMatchMode(InspectionOptions options)
+    {
+        if (options.PathMatchMode.Equals("all", StringComparison.OrdinalIgnoreCase)
+            || options.PathMatchMode.Equals("first", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        Console.Error.WriteLine($"Error: --match must be 'all' or 'first', not '{options.PathMatchMode}'.");
         return false;
     }
 
@@ -737,7 +754,7 @@ public class PackageCommand
             {
                 string declaredReadme = result.ReadmeFile ?? "README.md";
                 var files = PackageFileLister.ListAll(extractPath, declaredReadme);
-                result.Files = PackageFileLister.Filter(files, options.PathFilter);
+                result.Files = FilterPackageFiles(files, options);
             }
 
             if (wantsSignals)
@@ -765,9 +782,46 @@ public class PackageCommand
         }
     }
 
-    private static int CountMultiPackageRows(IReadOnlyList<InspectionResult> results, string? section)
+    private static List<PackageFile> FilterPackageFiles(List<PackageFile> files, InspectionOptions options)
+    {
+        var selectors = PathSelectors(options);
+        if (selectors.Length == 0)
+            return files;
+
+        if (options.PathMatchMode.Equals("first", StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (var selector in selectors)
+            {
+                var matches = PackageFileLister.Filter(files, selector);
+                if (matches.Count > 0)
+                    return [matches[0]];
+            }
+            return [];
+        }
+
+        var selected = new List<PackageFile>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var selector in selectors)
+        {
+            foreach (var match in PackageFileLister.Filter(files, selector))
+            {
+                if (seen.Add(match.Path))
+                    selected.Add(match);
+            }
+        }
+        return selected;
+    }
+
+    private static string[] PathSelectors(InspectionOptions options)
+        => options.PathFilters is { Length: > 0 } filters ? filters
+            : options.PathFilter is { Length: > 0 } filter ? [filter]
+            : [];
+
+    private static bool HasPathFilter(InspectionOptions options) => PathSelectors(options).Length > 0;
+
+    private static int CountMultiPackageRows(IReadOnlyList<InspectionResult> results, string? section, InspectionOptions options)
         => section != null && section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase)
-            ? results.Sum(result => Math.Max(1, result.Files?.Count ?? 0))
+            ? results.Sum(result => options.SkipEmpty ? result.Files?.Count ?? 0 : Math.Max(1, result.Files?.Count ?? 0))
             : results.Sum(result => new InspectionResultView(result).Metadata.Count);
 
     private static void WriteMultiPackageTable(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
@@ -787,15 +841,17 @@ public class PackageCommand
             .SelectMany(result =>
             {
                 if (result.Files is not { Count: > 0 })
-                    return [[result.PackageName, "", "", ""]];
+                    return options.SkipEmpty ? [] : [[result.PackageName, result.Version, "", "", "", ""]];
 
                 return result.Files
                     .Select(file => new[]
                     {
                         result.PackageName,
+                        result.Version,
                         file.Path,
                         file.Size.ToString(CultureInfo.InvariantCulture),
                         file.IsReadme ? "true" : "false",
+                        file.IsAgents ? "true" : "false",
                     });
             })
             .ToArray();
@@ -805,8 +861,8 @@ public class PackageCommand
             var writerOptions = OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl);
             var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
             markoutWriter.WriteTable(
-                ["Package", "Path", "Size", "Readme"],
-                ["package", "path", "size", "is_readme"],
+                ["Package", "Version", "Path", "Size", "Readme", "Agents"],
+                ["package", "version", "path", "size", "is_readme", "is_agents"],
                 rows);
             markoutWriter.Flush();
         });
@@ -864,7 +920,7 @@ public class PackageCommand
         List<string> conflicts = [];
         if (options.AllLibraries) conflicts.Add("--all-libraries");
         if (options.ListLayout) conflicts.Add("--layout");
-        if (options.PathFilter != null) conflicts.Add("--path");
+        if (HasPathFilter(options)) conflicts.Add("--path");
         if (options.ListTfms) conflicts.Add("--tfms");
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");
@@ -883,7 +939,7 @@ public class PackageCommand
         List<string> conflicts = [];
         if (options.PackageLibrary != null) conflicts.Add("--library");
         if (options.ListLayout) conflicts.Add("--layout");
-        if (options.PathFilter != null) conflicts.Add("--path");
+        if (HasPathFilter(options)) conflicts.Add("--path");
         if (options.ListTfms) conflicts.Add("--tfms");
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");

--- a/src/dotnet-inspect/Inspectors/PackageFileLister.cs
+++ b/src/dotnet-inspect/Inspectors/PackageFileLister.cs
@@ -28,7 +28,8 @@ public static class PackageFileLister
             if (IsPlumbing(rel))
                 continue;
             bool isReadme = readme is not null && string.Equals(rel, readme, StringComparison.OrdinalIgnoreCase);
-            files.Add(new PackageFile(rel, new FileInfo(full).Length, isReadme));
+            bool isAgents = string.Equals(rel, "AGENTS.md", StringComparison.OrdinalIgnoreCase);
+            files.Add(new PackageFile(rel, new FileInfo(full).Length, isReadme, isAgents));
         }
 
         files.Sort(static (a, b) => string.CompareOrdinal(a.Path, b.Path));
@@ -59,6 +60,9 @@ public static class PackageFileLister
         // Declared-readme selector: the nuspec-declared readme, whatever its name.
         if (p.Equals("@readme", StringComparison.OrdinalIgnoreCase))
             return files.Where(f => f.IsReadme).ToList();
+
+        if (p.Equals("@agents", StringComparison.OrdinalIgnoreCase))
+            return files.Where(f => f.IsAgents).ToList();
 
         // Root selector: top-level files only.
         if (p is "/" or "." or "./")

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -207,6 +207,7 @@ public record class PackageBinarySignals
 /// A single file in a NuGet package: its package-relative path (forward slashes)
 /// and uncompressed size in bytes (read from the already-extracted package, so
 /// no extra download is required). <paramref name="IsReadme"/> marks the file the
-/// package's <c>.nuspec</c> declares as its readme (not always <c>README.md</c>).
+/// package's <c>.nuspec</c> declares as its readme (not always <c>README.md</c>);
+/// <paramref name="IsAgents"/> marks a root <c>AGENTS.md</c> file.
 /// </summary>
-public sealed record PackageFile(string Path, long Size, bool IsReadme = false);
+public sealed record PackageFile(string Path, long Size, bool IsReadme = false, bool IsAgents = false);

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -44,10 +44,24 @@ public record InspectionOptions
     public bool ListLayout { get; init; }
 
     /// <summary>
-    /// Scope the file listing to a path: a file, a directory (trailing slash), the
-    /// package root (<c>/</c>), or a glob (<c>*.md</c>). Selects the Files section.
+    /// Scope the file listing to one or more selectors: a file, a directory
+    /// (trailing slash), the package root (<c>/</c>), a glob (<c>*.md</c>), or a
+    /// token such as <c>@readme</c>/<c>@agents</c>. Selects the Files section.
     /// </summary>
     public string? PathFilter { get; init; }
+
+    public string[]? PathFilters { get; init; }
+
+    /// <summary>
+    /// How repeated path selectors are resolved: <c>all</c> returns every match;
+    /// <c>first</c> returns the first matching selector's first result per package.
+    /// </summary>
+    public string PathMatchMode { get; init; } = "all";
+
+    /// <summary>
+    /// In multi-package row output, omit packages whose selected Files section is empty.
+    /// </summary>
+    public bool SkipEmpty { get; init; }
 
     /// <summary>
     /// Scope to lib/ folder (use with --layout).

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -69,7 +69,7 @@ public class InspectionResultView
 
     [MarkoutSection(Name = PackageSections.Files)]
     public List<PackageFileRow>? Files => _data.Files?
-        .Select(f => new PackageFileRow(f.Path, f.Size, f.IsReadme))
+        .Select(f => new PackageFileRow(f.Path, f.Size, f.IsReadme, f.IsAgents))
         .ToList();
 
     [MarkoutSection(Name = PackageSections.LibraryFiles)]
@@ -399,7 +399,9 @@ public record PackageFileRow(
     [property: MarkoutPropertyName("Path")] string Path,
     [property: MarkoutPropertyName("Size")] long Size,
     [property: MarkoutPropertyName("Readme")]
-    [property: MarkoutBoolFormat("readme", "")] bool IsReadme);
+    [property: MarkoutBoolFormat("readme", "")] bool IsReadme,
+    [property: MarkoutPropertyName("Agents")]
+    [property: MarkoutBoolFormat("agents", "")] bool IsAgents);
 
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(InspectionResultView))]


### PR DESCRIPTION
## Summary
- add @agents file selector and is_agents marker for package Files output
- add version and is_agents columns to multi-package Files row output
- support repeated/comma-separated --path selectors with --match all|first
- add --skip-empty for multi-package Files row surveys

Fixes #951
Part of #954

## Validation
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandExecutionTests
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandLineTests
- dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.PackageFileListerTests
- dotnet build src/dotnet-inspect -c Release --no-restore --nologo
