### PR TITLE
Add a Declined mechanism marker for no-IL-anchor lowerings (#944)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -47,7 +47,7 @@ Conflicts between class 1 and class 2 are rare by construction — most fixer su
 
 **3. No IL anchor — follow the oracle as a tiebreaker.** Conventions with no IL consequence at all (`var` policy, explicit types on declarations, brace style) follow the runtime `.editorconfig`, purely for corpus coherence.
 
-- LINQ query syntax (`from x in xs select f`) compiles to the *same* `Enumerable.Where/Select/...` calls as the fluent chain — query expressions are translated during binding, before any lowering, so the two forms are IL-identical. With no anchor to choose between them, the oracle decides: the runtime writes fluent method chains, so that is what we render. We do not re-sugar back to `from..select`. (This is why the `Query` row in the lowering ledger is `None`/declined, not owed.)
+- LINQ query syntax (`from x in xs select f`) compiles to the *same* `Enumerable.Where/Select/...` calls as the fluent chain — query expressions are translated during binding, before any lowering, so the two forms are IL-identical. With no anchor to choose between them, the oracle decides: the runtime writes fluent method chains, so that is what we render. We do not re-sugar back to `from..select`. (This is why the `Query` row in the lowering ledger is `Declined` — a no-anchor mechanism distinct from `Unhandled`/owed, not a gap to fill.)
 
 ## Names
 

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -93,7 +93,9 @@ public class LoweringCoverageTests
                 if (p.PropertyType == typeof(ImporterNative))
                     Assert.True(level == CompletenessLevel.Full, $"{name}.{p.Name}: importer-native must be Full.");
                 else if (p.PropertyType == typeof(Unhandled))
-                    Assert.True(level == CompletenessLevel.None, $"{name}.{p.Name}: Unhandled must be None.");
+                    Assert.True(level == CompletenessLevel.None, $"{name}.{p.Name}: Unhandled (owed) must be None.");
+                else if (p.PropertyType == typeof(Declined))
+                    Assert.True(level == CompletenessLevel.None, $"{name}.{p.Name}: Declined (no IL anchor) must be None — none of the idiom comes back.");
                 else if (IsPass(p))
                 {
                     Assert.True(level is CompletenessLevel.Full or CompletenessLevel.Partial,
@@ -102,8 +104,31 @@ public class LoweringCoverageTests
                         $"{name}.{p.Name} -> {p.PropertyType.Name}: pass is not registered in IrPasses.Default.");
                 }
                 else
-                    Assert.Fail($"{name}.{p.Name}: unknown mechanism type {p.PropertyType.Name} (expected a pass, ImporterNative, or Unhandled).");
+                    Assert.Fail($"{name}.{p.Name}: unknown mechanism type {p.PropertyType.Name} (expected a pass, ImporterNative, Unhandled, or Declined).");
             }
+    }
+
+    // The owed roadmap — "what's left to raise?" — is exactly the Unhandled rows.
+    // Declined rows are also (None) but carry NO owed work: they have no IL anchor,
+    // so they must never be counted as owed (the trap that nearly spawned a QueryPass
+    // during the LINQ work). This pins the two markers as disjoint roadmap classes.
+    [Fact]
+    public void DeclinedRows_AreNotOwed_AndAreDistinctFromUnhandled()
+    {
+        var declined = CoverageRegisters
+            .SelectMany(r => Props(r.Type))
+            .Where(p => p.PropertyType == typeof(Declined))
+            .Select(p => p.Name)
+            .ToArray();
+        var owed = CoverageRegisters
+            .SelectMany(r => Props(r.Type))
+            .Where(p => p.PropertyType == typeof(Unhandled))
+            .Select(p => p.Name)
+            .ToHashSet();
+
+        Assert.Contains("Query", declined);
+        foreach (var name in declined)
+            Assert.DoesNotContain(name, owed);
     }
 
     [Fact]
@@ -145,8 +170,9 @@ public class LoweringCoverageTests
     // Where the mechanism axis already tells the full story (a Full importer-native
     // lowering needs no caveat), a note is optional. But anything LESS than Full is a
     // gap, and an undocumented gap is a silent "trust me": a Partial row must say what
-    // it does NOT cover, and an owed (None) row must name the idiom it owes. This keeps
-    // the "finish these" / "start these" roadmap from decaying into bare property names.
+    // it does NOT cover, an owed (None/Unhandled) row must name the idiom it owes, and a
+    // declined (None/Declined) row must state its no-IL-anchor rationale. This keeps the
+    // "finish these" / "start these" roadmap from decaying into bare property names.
     [Fact]
     public void NonFullCoverageEntries_CarryAGapNote()
     {
@@ -159,7 +185,8 @@ public class LoweringCoverageTests
 
                 Assert.False(string.IsNullOrWhiteSpace(attr.Note),
                     $"{name}.{p.Name}: {attr.Level} with no note. A Partial row must state what it does not cover; "
-                        + "an owed (None) row must name the idiom it owes — otherwise the gap is undocumented.");
+                        + "an owed (Unhandled) row must name the idiom it owes; a declined (Declined) row must state "
+                        + "its no-IL-anchor rationale — otherwise the gap is undocumented.");
             }
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -8,9 +8,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <list type="bullet">
 /// <item><b>Mechanism</b> — the property's <em>type</em>: the raising pass that
 /// handles it, <see cref="ImporterNative"/> (the importer builds it directly, no
-/// transform), or <see cref="Unhandled"/> (no mechanism). The dedicated-vs-shared
-/// gradient is derived: a pass type used by one property is dedicated, by several
-/// is a shared/general pass.</item>
+/// transform), <see cref="Unhandled"/> (no mechanism — the owed roadmap), or
+/// <see cref="Declined"/> (no IL anchor, deliberately not owed). The
+/// dedicated-vs-shared gradient is derived: a pass type used by one property is
+/// dedicated, by several is a shared/general pass.</item>
 /// <item><b>Completeness</b> — the <see cref="CompletenessAttribute"/>: how much
 /// of the construct comes back as the idiom (<see cref="CompletenessLevel.Full"/>
 /// / <see cref="CompletenessLevel.Partial"/> / <see cref="CompletenessLevel.None"/>),
@@ -19,7 +20,8 @@ namespace ILInspector.Decompiler.Pipeline;
 ///
 /// <para>These are independent: <c>(Full, ImporterNative)</c> is a mechanical
 /// lowering that needs no pass; <c>(Partial, SwitchRaisingPass)</c> is a dedicated
-/// pass that only covers some shapes; <c>(None, Unhandled)</c> is an owed idiom. A
+/// pass that only covers some shapes; <c>(None, Unhandled)</c> is an owed idiom;
+/// <c>(None, Declined)</c> is a no-anchor construct that will never be raised. A
 /// PR that raises an idiom flips its line — the type to the pass, the completeness
 /// up. The structuring rows (if/while/for/try, …) are <c>Partial</c> as a
 /// pointer, not a measure: their real completeness is the structurer's <c>--gaps</c>
@@ -98,8 +100,8 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PointerElementAccess => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative PreviousSubmissionReference => default!;
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass PropertyAccess => new();
-    [Completeness(CompletenessLevel.None, "declined, not owed: a query expression is translated to Enumerable.Where/Select/SelectMany/... calls during binding, before any lowering, so it leaves no IL anchor distinct from the equivalent fluent chain. It is recovered as that fluent method chain (the runtime-preferred form); re-sugaring to from..select would invent a distinction the IL does not make (taste rule case 3, no IL anchor)")]
-    public static Unhandled Query => default!;
+    [Completeness(CompletenessLevel.None, "no IL anchor: a query expression is translated to Enumerable.Where/Select/SelectMany/... calls during binding, before any lowering, so it leaves no IL distinct from the equivalent fluent chain. It is recovered as that fluent method chain (the runtime-preferred form); re-sugaring to from..select would invent a distinction the IL does not make (taste rule case 3, no IL anchor)")]
+    public static Declined Query => default!;
     [Completeness(CompletenessLevel.Partial, "exact BCL RuntimeHelpers.GetSubArray array range slice, from-start and from-end (^n) endpoints (a[i..j], a[i..^1], a[^3..^1], a[..^1], ...), plus compiler-spilled string/span two-bound Substring/Slice forms (s[i..j]) and from-end open forms (s[^i..]); ordinary one-sided string/span forms plus broader manual Substring/Slice calls not raised")]
     public static RangeFromGetSubArrayPass Range => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative ReturnStatement => default!;
@@ -136,9 +138,17 @@ internal sealed class CompletenessAttribute(CompletenessLevel level, string? not
 /// <summary>Mechanism marker: the importer builds this construct directly out of the stack simulation — no raising pass, no idiom to recover.</summary>
 internal sealed class ImporterNative;
 
-/// <summary>Mechanism marker: no raising pass. Usually the owed roadmap — the
-/// lowered form is emitted as-is until a pass recovers the idiom. The exception
-/// is a construct with no IL anchor (e.g. a query expression, translated to
-/// method calls during binding): it is rendered faithfully as its lower-sugar
-/// equivalent and is deliberately declined, not owed — the note says which.</summary>
+/// <summary>Mechanism marker: no raising pass — the owed roadmap. The lowered
+/// form is emitted as-is until a pass recovers the idiom. Always paired with
+/// <see cref="CompletenessLevel.None"/>; the note names the idiom it owes.</summary>
 internal sealed class Unhandled;
+
+/// <summary>Mechanism marker: deliberately declined, not owed — the construct has
+/// no IL anchor. It is translated away before any lowering (e.g. a query
+/// expression becomes <c>Enumerable</c> calls during binding), so its faithful
+/// rendering is the lower-sugar equivalent the IL is identical to; re-sugaring
+/// would invent a distinction the IL does not make (taste rule case 3). Always
+/// paired with <see cref="CompletenessLevel.None"/> — none of the idiom comes
+/// back, by design — but distinct from <see cref="Unhandled"/>: it carries no
+/// owed work. The note states the no-anchor rationale.</summary>
+internal sealed class Declined;


### PR DESCRIPTION
Fixes #944.

## Problem

`LoweringCoverage`'s mechanism axis had only `ImporterNative` / a pass / `Unhandled`, and the cross-axis invariants made `None ⟺ Unhandled` — so `None` structurally reads as **owed work**. But `Query` is deliberately **declined**, not owed: a query expression is translated to `Enumerable.Where/Select/...` calls during binding, *before any lowering*, so it has no IL anchor distinct from the fluent chain (taste doc, three-class rule, case 3). #815 had to shoehorn it into `(None, Unhandled)` and widen the `Unhandled` doc to mean *either* "owed roadmap" *or* "declined no-anchor" — an overloaded, self-contradictory marker that gives a false positive to any "what's left to raise?" reader.

## Fix (Option 1 from the issue)

- Add a **`Declined`** mechanism marker (sibling to `ImporterNative`/`Unhandled`) for no-anchor constructs — paired with `None`, but carrying no owed work; its note states the no-anchor rationale.
- Move the `Query` row from `Unhandled` to `Declined`.
- Revert the `Unhandled` doc to its single clear meaning: the owed roadmap.
- Update the ledger class doc and the `(None, Declined)` row example.

## Tests

- `CoverageRegisters_CrossAxisInvariants_Hold` gains a `Declined ⇒ None` branch.
- `NonFullCoverageEntries_CarryAGapNote` distinguishes the owed (`Unhandled`) vs declined (`Declined`) rationale.
- New `DeclinedRows_AreNotOwed_AndAreDistinctFromUnhandled` pins the two markers as disjoint roadmap classes — the negative proof that a declined row is never counted as owed (the trap that nearly spawned a `QueryPass`).

`docs/decompiler-taste.md` re-points the `Query` note at the new marker. 810 decompiler tests green (incl. the fidelity-gate reconstruction of the test assembly — `Declined` is read only inside method bodies).
