### PR TITLE
Add package README and file content views

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ dotnet-inspect library Microsoft.Extensions.Logging.Abstractions -S Integrations
 dotnet-inspect library Microsoft.Extensions.Logging.Abstractions -S Logging
 dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S Signals
+dotnet-inspect package System.Text.Json --path @readme --content --frontmatter
 ```
 
 For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` expand to scenario-focused section groups.

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -46,20 +46,24 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 | `-v:q` | Title and fields only |
 | `-v:m` | Package Info |
 | `-v:n` | Dependencies, Library Files, Manifest, Package Info, Runtime Dependencies, Signature, Target Frameworks |
-| `-v:d` | Dependencies, Files, Library Files, Manifest, Package Info, Runtime Dependencies, Signature, Statistics, Target Frameworks, Vulnerabilities |
+| `-v:d` | Dependencies, Library Files, Manifest, Package Info, Runtime Dependencies, Signature, Statistics, Target Frameworks, Vulnerabilities |
 
 **Mode-switch flags (lenses):**
 
 | Flag | View | Description |
 | ---- | ---- | ----------- |
 | `--files` | File structure | Tree of DLLs (or all files with `--all`) |
-| `--readme` | README content | Raw readme text from the package |
+| `--path` | File resolution | Table of package-relative file paths and sizes; repeatable with `--match all` or `--match first` |
+| `--content` | File content | Contents for files selected by `--path`, with separator blocks or `--jsonl` rows |
+| `--readme` | README content | Best package README content (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); supports `--frontmatter`/`--body` |
 | `--versions` | Version history | Available versions from nuget.org |
 | `--library` | Library metadata | Delegates to library inspection |
 
 Each lens is self-contained. `--files` shows a file tree and exits. It does not also show metadata or dependencies -- those belong to the identity view.
 
-**Why Files is not in `-v:d`:** Files are structural layout data (what the package contains on disk), not identity metadata (what the package is). Mixing structural content into the identity view conflates two different concerns. The `--files` flag is the correct entry point for structural exploration.
+`Files`, `Package README`, `Library Files`, and `Markdown Files` all use the same row schema: package-relative `Path` and uncompressed byte `Size`. `Files` is explicit-only and renders the full package depth; `Package README` is explicit-only and returns the best README candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` is explicit-only and renders all `.md` files; `Library Files` is the default library asset slice over the same schema.
+
+**Why Files is not in `-v:d`:** Files are structural layout data (what the package contains on disk), not identity metadata (what the package is). Mixing structural content into the identity view conflates two different concerns. The `--path`/`-S Files` file-resolution view is the correct entry point for structural exploration.
 
 ### `api` Command
 

--- a/docs/design/schema-query.md
+++ b/docs/design/schema-query.md
@@ -65,10 +65,12 @@ Two paths:
 ```csharp
 var schema = new DocumentSchema()
     .Add("Package Info", "field", "Version", "Type", "Size", "Highest TFM", "TFM Count", "Built", ...)
+    .Add("Package README", "column", "Path", "Size")
     .Add("Target Frameworks", "column", "TFM")
-    .Add("Library Files", "column", "TFM", "File")
+    .Add("Library Files", "column", "Path", "Size")
+    .Add("Markdown Files", "column", "Path", "Size")
     .Add("Dependencies", "column", "Target Framework", "Id", "Version")
-    .Add("Files", "list", "Path");
+    .Add("Files", "column", "Path", "Size");
 ```
 
 This is `SectionSchemaMap` today, migrated to Markout's `DocumentSchema` type. It works. It drifts.

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -164,16 +164,18 @@ When the user runs `-S "Package Info"`, the pipeline returns `{"Package Info"}` 
 
 ## Package Sections
 
-The package command has 12 registered sections:
+The package command has 14 registered sections:
 
 | Section | MinVerbosity | Scanner Key | Notes |
 | ------- | ------------ | ----------- | ----- |
 | Summary | Quiet | — | Headless; compact inline fields |
 | Dependencies | Normal | — | Only when dependency groups present |
-| Files | Detailed | — | Package file listing |
-| Library Files | Normal | — | Files under lib/ across all target frameworks |
+| Files | Explicit | — | Full-depth package file listing with `Path` and `Size` |
+| Library Files | Normal | — | Files under lib/ across all target frameworks with `Path` and `Size` |
+| Markdown Files | Explicit | — | Full-depth `.md` file listing with `Path` and `Size` |
 | Manifest | Minimal | — | Basic package manifest rows, with extra tool manifest rows when present |
 | Package Info | Minimal | — | Full metadata field table |
+| Package README | Explicit | — | Best README candidate with `Path` and `Size`; at most one row |
 | Runtime Dependencies | Minimal | — | Only when runtime deps present |
 | Signals | Explicit | — | Opt-in package metadata/assets, dependency, provenance, and NuGet registry observations |
 | Signature | Normal | — | Only when signature information is available |

--- a/docs/workflows/core/package-inspection.md
+++ b/docs/workflows/core/package-inspection.md
@@ -200,6 +200,17 @@ dotnet-inspect package System.CommandLine --readme -n 10
 # System.CommandLine
 ```
 
+Use `--path` to resolve package-relative file locations, then add `--content`
+to print selected file bodies. Markdown content can be scoped to the YAML header
+or body:
+
+```bash
+dotnet-inspect package Markout -S "Package README"
+dotnet-inspect package Markout -S "Markdown Files"
+dotnet-inspect package Markout --path @agents --content --frontmatter
+dotnet-inspect package Markout Polly --path @agents --path @readme --match first --content --jsonl
+```
+
 ## 7. Search NuGet for packages
 
 > Goal: Find packages by keyword, with download counts and descriptions.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -157,21 +157,26 @@ Use `package` for NuGet package structure and registry-backed signals. Use `libr
 ```bash
 dnx dotnet-inspect -y -- package System.Text.Json -S Signals
 dnx dotnet-inspect -y -- package System.Text.Json -S "Library Files"
+dnx dotnet-inspect -y -- package System.Text.Json -S "Package README"
+dnx dotnet-inspect -y -- package System.Text.Json -S "Markdown Files"
 dnx dotnet-inspect -y -- package System.Text.Json --path "*.md" --jsonl
-dnx dotnet-inspect -y -- package System.Text.Json --path @readme --json
+dnx dotnet-inspect -y -- package System.Text.Json --path @readme --content --frontmatter
+dnx dotnet-inspect -y -- package Markout Polly --path @agents --path @readme --match first --content --jsonl
 dnx dotnet-inspect -y -- package Aspire.Azure.AI.OpenAI --library -S @Integrations
 dnx dotnet-inspect -y -- library System.Text.Json -S Signals
 dnx dotnet-inspect -y -- library System.Text.Json -S Switches
 dnx dotnet-inspect -y -- library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 ```
 
-`Signals` reports observations, not a safety or trust verdict. Library Signals include SourceLink presence, SourceLink availability, determinism, trim/AOT markers, async kind (`Runtime`, `State machine`, `Mixed`, or `None`), memory-safety metadata, unsafe/PInvoke observations, and direct references. Package Signals include TFMs, manifest, readme/license, dependencies, package signature, local provenance, vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age.
+`Signals` reports observations, not a safety or trust verdict. Library Signals include SourceLink presence, SourceLink availability, determinism, trim/AOT markers, async kind (`Runtime`, `State machine`, `Mixed`, or `None`), memory-safety metadata, unsafe/PInvoke observations, and direct references. Package Signals include TFMs, manifest, README and agent documentation, license, dependencies, package signature, local provenance, vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age.
 
 Use `package Foo --library` to inspect the package's primary DLL when it is unambiguous; add a DLL name when a package contains multiple libraries. Use `package Foo --all-libraries` when a package contains multiple relevant DLLs or a tool package carries libraries under `tools/`; aggregate Markdown sections such as `@Integrations` include library provenance when needed. For row modes such as `--tsv`/`--jsonl`, select one concrete section such as `Integrations` or `OpenTelemetry`, not a category like `@Integrations`. Use `-S Integrations` for the ecosystem roll-up, `-S @Integrations` for roll-up plus focused sections, or a focused section such as `OpenTelemetry`. Integration sections cover AI, ASP.NET Core, Aspire resources, Authentication, Configuration, Dependency Injection, Logging, Options, Hosting, Health Checks, HTTP Client, OpenAPI, and OpenTelemetry. Focused sections list package-owned starter APIs, support types, and telemetry controls, not raw assembly references.
 
 Use `-S Switches` when runtime feature switches or compatibility switches may affect behavior.
 
-List package contents with the opt-in `Files` section: `-S Files` for the whole package with uncompressed sizes, or `--path` to scope it. `--path /` lists root files only, `--path "lib/net8.0/"` a directory's immediate children, `--path "*.md"` globs across the package (handy for spotting oversized README/docs), `--path README.md` a single file, and `--path @readme` the package's declared readme whatever its filename (e.g. `PACKAGE.md`, `package-readme.md`). Sizes are read from the package layout — no file contents are fetched. Use `--json` for a lossless row (numeric `size`, boolean `is_readme`); `--jsonl`/`--tsv` stringify those fields.
+Package file sections share one sparse-free schema: `Path` and uncompressed byte `Size`. `Library Files` shows files under `lib/`; `Package README` returns the best README candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` shows all `.md` files at full package depth; explicit `Files` shows all package files at full depth. `--path` scopes the same file-resolution primitive: `/` lists root files only, `"lib/net8.0/"` a directory's immediate children, `"*.md"` globs across the package, `README.md` a single file, `@readme` the best README candidate, and `@agents` a root `AGENTS.md`. Repeat `--path` or separate selectors with commas/semicolons; `--match all` returns every hit and `--match first` uses selectors as an ordered fallback. Multi-package file rows add `package` and `version`; JSON/JSONL keep `size` numeric; empty rows are preserved unless `--skip-empty`.
+
+Add `--content` to print selected file bodies instead of path rows. Default content output uses machine-splittable separator blocks; `--jsonl` emits one row per file with `package`, `version`, `path`, `found`, and `content`. Use `--frontmatter`/`--yaml-header` or `--body` with `--content` or `--readme` to scope markdown output.
 
 `library X -S Signals` resolves SourceLink by acquiring a missing PDB. Per-source-file reachability is opt-in: add `-S "SourceLink Availability"` and `-S "SourceLink Missing Files"` for HTTP HEAD checks, or `-S "SourceLink Integrity"` to download source files and compare checksums. For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -58,14 +58,14 @@ public class CacheCommandTests : IDisposable
     [Fact]
     public void CacheMiss_CleansObsoleteVersionedCategories()
     {
-        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v7");
-        var currentDir = Path.Combine(_cacheBasePath, "pkg-index-v8");
+        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v8");
+        var currentDir = Path.Combine(_cacheBasePath, "pkg-index-v9");
         Directory.CreateDirectory(oldDir);
         Directory.CreateDirectory(currentDir);
         File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
         File.WriteAllText(Path.Combine(currentDir, "current.txt"), "keep");
 
-        CoreCache.RegisterVersionedCategory("pkg-index-v", "pkg-index-v8");
+        CoreCache.RegisterVersionedCategory("pkg-index-v", "pkg-index-v9");
 
         Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
         var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(5));

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4585,11 +4585,109 @@ public class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Contains("## Library Files", output);
-            Assert.Contains("| TFM | File |", output);
-            Assert.Contains("| net10.0 | lib/net10.0/Latest.One.dll |", output);
-            Assert.Contains("| net10.0 | lib/net10.0/Latest.One.xml |", output);
-            Assert.Contains("| net10.0 | lib/net10.0/Latest.Two.dll |", output);
-            Assert.Contains("| net8.0 | lib/net8.0/Older.dll |", output);
+            Assert.Contains("| Path | Size |", output);
+            Assert.Contains("| lib/net10.0/Latest.One.dll |", output);
+            Assert.Contains("| lib/net10.0/Latest.One.xml | 7 |", output);
+            Assert.Contains("| lib/net10.0/Latest.Two.dll |", output);
+            Assert.Contains("| lib/net8.0/Older.dll |", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MarkdownFiles_RendersAllMarkdownFilesWithFileSchema()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.MarkdownFiles", "PACKAGE.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Markdown Files");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("## Markdown Files", output);
+            Assert.Contains("| Path | Size |", output);
+            Assert.Contains("| AGENTS.md | 6 |", output);
+            Assert.Contains("| PACKAGE.md | 6 |", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PackageInfoReadme_UsesBestReadme()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Info", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Package Info");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("| Readme | AGENTS.md |", output);
+            Assert.DoesNotContain("| Readme | README.md |", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PackageReadme_RendersSingleBestReadmeFile()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Section", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Package README");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("## Package README", output);
+            Assert.Contains("| Path | Size |", output);
+            Assert.Contains("| AGENTS.md | 6 |", output);
+            Assert.DoesNotContain("| README.md | 6 |", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_Readme_PrintsBestReadmeContent()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Content", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "--readme");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("agents", output);
+            Assert.DoesNotContain("readme", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_Signals_ReportsAgentDocumentation()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.AgentDocs.Signal", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Signals");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("| Documentation | Agent documentation | Yes | AGENTS.md |", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally
@@ -4609,9 +4707,9 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "@readme", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
-            Assert.Contains("Test.First\t1.0.0\tPACKAGE.md\t12\ttrue\tfalse", output);
-            Assert.Contains("Test.Second\t1.0.0\tdocs-readme.md\t13\ttrue\tfalse", output);
+            Assert.Contains("package\tversion\tpath\tsize", output);
+            Assert.Contains("Test.First\t1.0.0\tPACKAGE.md\t12", output);
+            Assert.Contains("Test.Second\t1.0.0\tdocs-readme.md\t13", output);
             Assert.DoesNotContain("not a valid package version", error);
             Assert.DoesNotContain("Tip:", error);
         }
@@ -4633,9 +4731,9 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "MISSING.md", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
-            Assert.Contains("Test.HasReadme\t1.0.0\t\t\t\t", output);
-            Assert.Contains("Test.NoMatch\t1.0.0\t\t\t\t", output);
+            Assert.Contains("package\tversion\tpath\tsize", output);
+            Assert.Contains("Test.HasReadme\t1.0.0\t\t", output);
+            Assert.Contains("Test.NoMatch\t1.0.0\t\t", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally
@@ -4674,7 +4772,92 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Package_MultiplePackages_PathAgents_TsvMarksAgentsRows()
+    public async Task Package_PathReadme_JsonEmitsNumericSizeForDeclaredReadme()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Json.Readme", "PACKAGE.md", "declared readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--path", "@readme", "--json");
+
+            Assert.Equal(0, exit);
+            using var document = JsonDocument.Parse(output);
+            var file = Assert.Single(document.RootElement.GetProperty("files").EnumerateArray());
+            Assert.Equal("PACKAGE.md", file.GetProperty("path").GetString());
+            Assert.Equal(JsonValueKind.Number, file.GetProperty("size").ValueKind);
+            Assert.Equal(15, file.GetProperty("size").GetInt64());
+            Assert.False(file.TryGetProperty("is_readme", out _));
+            Assert.False(file.TryGetProperty("is_agents", out _));
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PathReadme_JsonlEmitsNumericSizeForDeclaredReadme()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Jsonl.Readme", "PACKAGE.md", "declared readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--path", "@readme", "--jsonl");
+
+            Assert.Equal(0, exit);
+            var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            using var document = JsonDocument.Parse(line);
+            Assert.Equal("PACKAGE.md", document.RootElement.GetProperty("path").GetString());
+            Assert.Equal(JsonValueKind.Number, document.RootElement.GetProperty("size").ValueKind);
+            Assert.Equal(15, document.RootElement.GetProperty("size").GetInt64());
+            Assert.False(document.RootElement.TryGetProperty("is_readme", out _));
+            Assert.False(document.RootElement.TryGetProperty("is_agents", out _));
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathReadme_JsonlEmitsNumericSizeForDeclaredReadme()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Multi.Jsonl.Readme", "PACKAGE.md", "declared readme");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Multi.Jsonl.Empty", "README.md", "readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "PACKAGE.md", "--jsonl");
+
+            Assert.Equal(0, exit);
+            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, lines.Length);
+
+            using var hit = JsonDocument.Parse(lines[0]);
+            Assert.Equal("Test.Multi.Jsonl.Readme", hit.RootElement.GetProperty("package").GetString());
+            Assert.Equal("1.0.0", hit.RootElement.GetProperty("version").GetString());
+            Assert.Equal("PACKAGE.md", hit.RootElement.GetProperty("path").GetString());
+            Assert.Equal(JsonValueKind.Number, hit.RootElement.GetProperty("size").ValueKind);
+            Assert.Equal(15, hit.RootElement.GetProperty("size").GetInt64());
+            Assert.False(hit.RootElement.TryGetProperty("is_readme", out _));
+
+            using var empty = JsonDocument.Parse(lines[1]);
+            Assert.Equal("Test.Multi.Jsonl.Empty", empty.RootElement.GetProperty("package").GetString());
+            Assert.Equal("", empty.RootElement.GetProperty("path").GetString());
+            Assert.Equal(JsonValueKind.Null, empty.RootElement.GetProperty("size").ValueKind);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathAgents_TsvResolvesAgentsRows()
     {
         var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Agents.One", "README.md", "readme", "agents one");
         var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Agents.Two", "README.md", "readme");
@@ -4684,9 +4867,9 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "@agents", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("package\tversion\tpath\tsize\tis_readme\tis_agents", output);
-            Assert.Contains("Test.Agents.One\t1.0.0\tAGENTS.md\t10\tfalse\ttrue", output);
-            Assert.Contains("Test.Agents.Two\t1.0.0\t\t\t\t", output);
+            Assert.Contains("package\tversion\tpath\tsize", output);
+            Assert.Contains("Test.Agents.One\t1.0.0\tAGENTS.md\t10", output);
+            Assert.Contains("Test.Agents.Two\t1.0.0\t\t", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally
@@ -4707,8 +4890,8 @@ public class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "@agents", "--path", "@readme", "--match", "first", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("Test.Match.First\t1.0.0\tAGENTS.md\t6\tfalse\ttrue", output);
-            Assert.Contains("Test.Match.Second\t1.0.0\tREADME.md\t6\ttrue\tfalse", output);
+            Assert.Contains("Test.Match.First\t1.0.0\tAGENTS.md\t6", output);
+            Assert.Contains("Test.Match.Second\t1.0.0\tREADME.md\t6", output);
         }
         finally
         {
@@ -4724,11 +4907,11 @@ public class CommandExecutionTests
         try
         {
             var (exit, output, _) = await RunAppAsync(
-                "package", packagePath, packagePath, "--path", "@agents", "--path", "@readme", "--tsv");
+                "package", packagePath, packagePath, "--path", "@agents", "--path", "README.md", "--tsv");
 
             Assert.Equal(0, exit);
-            Assert.Contains("Test.Match.All\t1.0.0\tAGENTS.md\t6\tfalse\ttrue", output);
-            Assert.Contains("Test.Match.All\t1.0.0\tREADME.md\t6\ttrue\tfalse", output);
+            Assert.Contains("Test.Match.All\t1.0.0\tAGENTS.md\t6", output);
+            Assert.Contains("Test.Match.All\t1.0.0\tREADME.md\t6", output);
         }
         finally
         {
@@ -4774,6 +4957,173 @@ public class CommandExecutionTests
         {
             Directory.Delete(firstDir, recursive: true);
             Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PathContent_PrintsSelectedFileWithSeparator()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Content.Agents", "README.md", "readme", "agents body");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--path", "@agents", "--content");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("------------ Test.Content.Agents :: AGENTS.md ------------", output);
+            Assert.Contains("agents body", output);
+            Assert.DoesNotContain("readme", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathContent_PreservesEmptyPackageBlock()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Content.HasAgents", "README.md", "readme", "agents");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Content.NoAgents", "README.md", "readme");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@agents", "--content");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("------------ Test.Content.HasAgents :: AGENTS.md ------------", output);
+            Assert.Contains("agents", output);
+            Assert.Contains("------------ Test.Content.NoAgents :: <absent> ------------", output);
+            Assert.Contains("(absent)", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_PathContentSkipEmpty_OmitsAbsentBlock()
+    {
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.Content.SkipHasAgents", "README.md", "readme", "agents");
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.Content.SkipNoAgents", "README.md", "readme");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--path", "@agents", "--content", "--skip-empty");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Test.Content.SkipHasAgents :: AGENTS.md", output);
+            Assert.DoesNotContain("Test.Content.SkipNoAgents", output);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PathContent_JsonlIncludesContentField()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Content.Jsonl", "README.md", "readme", "line one\nline two");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, "--path", "@agents", "--content", "--jsonl");
+
+            Assert.Equal(0, exit);
+            var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            using var document = JsonDocument.Parse(line);
+            Assert.Equal("Test.Content.Jsonl", document.RootElement.GetProperty("package").GetString());
+            Assert.Equal("1.0.0", document.RootElement.GetProperty("version").GetString());
+            Assert.Equal("AGENTS.md", document.RootElement.GetProperty("path").GetString());
+            Assert.True(document.RootElement.GetProperty("found").GetBoolean());
+            Assert.Equal("line one\nline two", document.RootElement.GetProperty("content").GetString());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_ReadmeFrontmatter_PrintsOnlyYamlHeader()
+    {
+        var readme = """
+            ---
+            name: test
+            description: resident
+            ---
+            # Body
+            """;
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Readme.Frontmatter", "README.md", readme);
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, "--readme", "--frontmatter");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("name: test", output);
+            Assert.Contains("description: resident", output);
+            Assert.DoesNotContain("# Body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_ReadmeBody_PrintsContentAfterYamlHeader()
+    {
+        var readme = """
+            ---
+            name: test
+            ---
+            # Body
+            """;
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Readme.Body", "README.md", readme);
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, "--readme", "--body");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("# Body", output);
+            Assert.DoesNotContain("name: test", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_PathContentFrontmatter_PrintsOnlyYamlHeader()
+    {
+        var agents = """
+            ---
+            name: agents
+            ---
+            # Agent body
+            """;
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Content.Frontmatter", "README.md", "readme", agents);
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, "--path", "@agents", "--content", "--frontmatter");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("name: agents", output);
+            Assert.DoesNotContain("# Agent body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
         }
     }
 

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -464,6 +464,18 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void PackageCommand_WithMultipleAtPathSelectorsInOneTokenGroup_ParsesCorrectly()
+    {
+        var args = CommandLineBuilder.PreprocessArgs(["package", "Foo", "--path", "@agents", "@readme", "--match", "first"]);
+
+        Assert.Equal(
+            ["package", "Foo", "--path", "__dotnet_inspect_at__agents", "__dotnet_inspect_at__readme", "--match", "first"],
+            args);
+        var result = CommandLineBuilder.CreateRootCommand().Parse(args);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void PreprocessArgs_DoesNotEscapeNonAtPathValue()
     {
         var args = new[] { "package", "Foo", "--path", "lib/" };

--- a/src/dotnet-inspect.Tests/PackageFileListerTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFileListerTests.cs
@@ -226,4 +226,36 @@ public class PackageFileListerTests
         Assert.Equal("AGENTS.md", result[0].Path);
         Assert.True(result[0].IsAgents);
     }
+
+    [Fact]
+    public void ResolvePackageReadme_PrefersAgentsThenReadmeThenPackage()
+    {
+        var root = CreateExtractDir("PACKAGE.md", "README.md", "AGENTS.md");
+        try
+        {
+            Assert.Equal("AGENTS.md", PackageFileLister.ResolvePackageReadme(root, "PACKAGE.md"));
+            File.Delete(Path.Combine(root, "AGENTS.md"));
+            Assert.Equal("README.md", PackageFileLister.ResolvePackageReadme(root, "PACKAGE.md"));
+            File.Delete(Path.Combine(root, "README.md"));
+            Assert.Equal("PACKAGE.md", PackageFileLister.ResolvePackageReadme(root, "PACKAGE.md"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolvePackageReadme_FallsBackToDeclaredReadme()
+    {
+        var root = CreateExtractDir("package-readme.md");
+        try
+        {
+            Assert.Equal("package-readme.md", PackageFileLister.ResolvePackageReadme(root, "package-readme.md"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -794,7 +794,7 @@ public class SectionPipelineTests
     public void PackagePipeline_HasExpectedSectionCount()
     {
         var pipeline = PackageSectionDescriptors.CreatePipeline();
-        Assert.Equal(12, pipeline.AllSectionNames.Length);
+        Assert.Equal(14, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -805,9 +805,11 @@ public class SectionPipelineTests
 
         Assert.Contains("Summary", names);
         Assert.Contains("Package Info", names);
+        Assert.Contains("Package README", names);
         Assert.Contains("Signals", names);
         Assert.Contains("Target Frameworks", names);
         Assert.Contains("Library Files", names);
+        Assert.Contains("Markdown Files", names);
         Assert.Contains("Statistics", names);
         Assert.Contains("Dependencies", names);
         Assert.Contains("Files", names);

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -28,7 +28,7 @@ public static class PackageCommandDefinitions
         layoutOption.Aliases.Add("--tree");
         var pathOption = new Option<string[]>("--path")
         {
-            Description = "List package files with sizes (the Files section), scoped to a file, directory, glob, @readme, or @agents. Can repeat. Pass --path with no value for the whole package.",
+            Description = "List package files with sizes (the Files section), scoped to a file, directory, glob, @readme (AGENTS.md > README.md > PACKAGE.md), or @agents. Can repeat. Pass --path with no value for the whole package.",
             Arity = ArgumentArity.ZeroOrMore,
             AllowMultipleArgumentsPerToken = true
         };
@@ -50,7 +50,11 @@ public static class PackageCommandDefinitions
         versionsOption.DefaultValueFactory = _ => null;
         var prereleaseOption = new Option<bool>("--preview") { Description = "Include prerelease versions for --versions and latest resolution" };
         prereleaseOption.Aliases.Add("--prerelease");
-        var readmeOption = new Option<bool>("--readme") { Description = "Show the README.md content from the package" };
+        var readmeOption = new Option<bool>("--readme") { Description = "Show the best package README content (AGENTS.md, README.md, PACKAGE.md, then declared readme)" };
+        var contentOption = new Option<bool>("--content") { Description = "Print contents of files selected by --path; use --jsonl for structured rows" };
+        var frontmatterOption = new Option<bool>("--frontmatter") { Description = "When printing markdown content, output only the leading YAML frontmatter block" };
+        frontmatterOption.Aliases.Add("--yaml-header");
+        var bodyOption = new Option<bool>("--body") { Description = "When printing markdown content, output only content after YAML frontmatter" };
         var outOption = new Option<string?>("--out") { Description = "Write output to file instead of stdout" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
         var versionOption = new Option<string?>("--version") { Description = "Package version (or use alone to show resolved version)", Arity = ArgumentArity.ZeroOrOne };
@@ -69,6 +73,9 @@ public static class PackageCommandDefinitions
         packageCommand.Options.Add(versionsOption);
         packageCommand.Options.Add(prereleaseOption);
         packageCommand.Options.Add(readmeOption);
+        packageCommand.Options.Add(contentOption);
+        packageCommand.Options.Add(frontmatterOption);
+        packageCommand.Options.Add(bodyOption);
         packageCommand.Options.Add(tfmOption);
         packageCommand.Options.Add(versionOption);
         packageCommand.Options.Add(latestVersionOption);
@@ -89,6 +96,7 @@ public static class PackageCommandDefinitions
         var commandArgs = new PackageOptionsParser.PackageCommandArgs(
             packageNameArg, dependenciesOption, layoutOption, pathOption, tfmsOption,
             libOption, toolsOption, libraryOption, allLibrariesOption, versionsOption, prereleaseOption, readmeOption,
+            contentOption, frontmatterOption, bodyOption,
             tfmOption, versionOption, latestVersionOption, outOption, pathMatchOption, skipEmptyOption, opts.OneLine, opts.NoHeaders);
 
         packageCommand.SetAction(async (parseResult, ct) =>

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -52,7 +52,8 @@ public static class ArgumentPreprocessor
         args = MergeRepeatedListOption(args, SelectAliases, "-S");
         args = MergeRepeatedListOption(args, ["--columns"], "--columns");
         args = MergeRepeatedListOption(args, ["--fields"], "--fields");
-        args = EscapeAtCategoryOptionValues(args, [.. SelectAliases, "-D", "--discover", "--path"]);
+        args = EscapeAtCategoryOptionValues(args, [.. SelectAliases, "-D", "--discover"]);
+        args = EscapeAtCategoryPathValues(args);
 
         // Expand -NN shorthand (e.g., -30) into -n 30, like head -30
         for (int i = 0; i < args.Length; i++)
@@ -144,6 +145,27 @@ public static class ArgumentPreprocessor
                     result[i + 1] = EscapeAtCategoryValue(result[i + 1]);
                 }
             }
+        }
+
+        return result;
+    }
+
+    private static string[] EscapeAtCategoryPathValues(string[] args)
+    {
+        var result = args.ToArray();
+        for (var i = 0; i < result.Length; i++)
+        {
+            if (!IsListOptionAlias(result[i], ["--path"], out var inlineValue))
+                continue;
+
+            if (inlineValue != null)
+            {
+                result[i] = result[i][..result[i].IndexOf('=')] + "=" + EscapeAtCategoryValue(inlineValue);
+                continue;
+            }
+
+            for (var j = i + 1; j < result.Length && !result[j].StartsWith('-'); j++)
+                result[j] = EscapeAtCategoryValue(result[j]);
         }
 
         return result;

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -28,6 +28,9 @@ public static class PackageOptionsParser
         Option<int?> VersionsOption,
         Option<bool> PrereleaseOption,
         Option<bool> ReadmeOption,
+        Option<bool> ContentOption,
+        Option<bool> FrontmatterOption,
+        Option<bool> BodyOption,
         Option<string?> TfmOption,
         Option<string?> VersionOption,
         Option<bool> LatestVersionOption,
@@ -81,6 +84,13 @@ public static class PackageOptionsParser
         bool showVersions = bareVersion || showLatestVersion || parseResult.GetResult(args.VersionsOption) is { Implicit: false };
 
         var verbosity = opts.ParseVerbosity(parseResult);
+        bool frontmatterRequested = parseResult.GetValue(args.FrontmatterOption);
+        bool bodyRequested = parseResult.GetValue(args.BodyOption);
+        var contentScope = frontmatterRequested
+            ? PackageFileContentScope.Frontmatter
+            : bodyRequested
+                ? PackageFileContentScope.Body
+                : PackageFileContentScope.Full;
 
         // --path scopes the file listing and selects the Files section. A bare
         // --path (present without a value) means the whole package (root and below);
@@ -120,6 +130,10 @@ public static class PackageOptionsParser
             ListVersions = showVersions,
             IncludePrerelease = parseResult.GetValue(args.PrereleaseOption),
             ShowReadme = parseResult.GetValue(args.ReadmeOption),
+            ShowContent = parseResult.GetValue(args.ContentOption),
+            ContentScope = contentScope,
+            FrontmatterRequested = frontmatterRequested,
+            BodyRequested = bodyRequested,
             OutputPath = parseResult.GetValue(args.OutOption),
             Limit = (bareVersion || showLatestVersion) ? 1 : versionsValue,
             ForceLatest = showLatestVersion,

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -91,6 +91,8 @@ public class PackageCommand
 
         if (!ValidatePathMatchMode(options))
             return 1;
+        if (!ValidatePackageContentMode(options))
+            return 1;
 
         if (options.AllLibraries && !ValidatePackageAllLibrariesMode(options))
             return 1;
@@ -303,10 +305,24 @@ public class PackageCommand
             if (nuspecFiles.Length > 0)
                 nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
 
+            // Handle file content modes and exit early.
+            if (options.ShowContent)
+            {
+                var packageId = nuspec?.PackageName ?? packageName;
+                var packageVersion = nuspec?.Version ?? version;
+                var packageReadme = PackageFileLister.ResolvePackageReadme(extractPath, nuspec?.ReadmeFile);
+                return PrintPackageFileContents(
+                    [ReadPackageFileContents(extractPath, packageId, packageVersion, packageReadme, options)],
+                    options);
+            }
+
             // Handle --readme mode: print README and exit early
             if (options.ShowReadme)
             {
-                return PrintReadme(extractPath, nuspec?.ReadmeFile, options);
+                var packageId = nuspec?.PackageName ?? packageName;
+                var packageVersion = nuspec?.Version ?? version;
+                var packageReadme = PackageFileLister.ResolvePackageReadme(extractPath, nuspec?.ReadmeFile);
+                return PrintReadme(extractPath, packageId, packageVersion, packageReadme, options);
             }
 
             // Handle --dependencies mode: resolve transitive deps and show tree
@@ -373,18 +389,7 @@ public class PackageCommand
 
             result.Source = isLocalFile ? SourceKind.File : SourceKind.NuGet;
 
-            // Populate the Files section from the already-extracted package (sizes
-            // come from FileInfo, so no extra download). Scoped by --path when given.
-            // The section is opt-in (-S Files / --path), so this stays cheap.
-            bool wantsFilesSection = HasPathFilter(options)
-                || options.IncludeSections?.Contains(PackageSections.Files) == true
-                || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
-            if (wantsFilesSection)
-            {
-                string declaredReadme = result.ReadmeFile ?? "README.md";
-                var files = PackageFileLister.ListAll(extractPath, declaredReadme);
-                result.Files = FilterPackageFiles(files, options);
-            }
+            PopulatePackageFileSections(result, extractPath, options);
 
             // Filter output based on options
             FilterResultForOutput(result, options);
@@ -439,6 +444,12 @@ public class PackageCommand
             }
             else if (options.OneLine)
             {
+                if (options.Jsonl && TryGetSingleFileSection(options, out var fileSection) && !hasProjection)
+                {
+                    WritePackageFilesJsonl(result, fileSection);
+                    return 0;
+                }
+
                 // Multi-section check: narrow to main section or error if user explicitly selected multiple sections
                 var diagnostic = OutputFormatter.CheckMultiSection(result, options, pipeline);
                 if (diagnostic != null)
@@ -527,11 +538,14 @@ public class PackageCommand
         if (!ValidateMultiPackageMode(options))
             return 1;
 
+        if (options.ShowContent)
+            return await ExecuteMultiPackageContentAsync(packageArgs, options, context);
+
         if (!TryResolveMultiPackageRowSection(options, out var rowSection))
             return 1;
         bool wantsFilesSection = HasPathFilter(options)
-            || string.Equals(rowSection, PackageSections.Files, StringComparison.OrdinalIgnoreCase)
-            || options.IncludeSections?.Contains(PackageSections.Files) == true
+            || IsPackageFileSection(rowSection)
+            || options.IncludeSections?.Any(IsPackageFileSection) == true
             || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
         if (!options.JsonOutput && rowSection == null)
         {
@@ -603,13 +617,13 @@ public class PackageCommand
 
         section = options.IncludeSections.Single();
         if (section.Equals(PackageSections.PackageInfo, StringComparison.OrdinalIgnoreCase)
-            || section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase))
+            || IsPackageFileSection(section))
         {
             return true;
         }
 
         Console.Error.WriteLine($"Error: Multiple package row output does not support section: {section}.");
-        Console.Error.WriteLine("Use --json, or select Package Info or Files.");
+        Console.Error.WriteLine("Use --json, or select Package Info, Files, Library Files, or Markdown Files.");
         return false;
     }
 
@@ -632,6 +646,73 @@ public class PackageCommand
         Console.Error.WriteLine($"Error: Multiple package inspection cannot be combined with {string.Join(", ", conflicts)}.");
         Console.Error.WriteLine("Use id@version for per-package version pins.");
         return false;
+    }
+
+    private static bool ValidatePackageContentMode(InspectionOptions options)
+    {
+        bool scopedContent = options.ContentScope != PackageFileContentScope.Full;
+        if (options.FrontmatterRequested && options.BodyRequested)
+        {
+            Console.Error.WriteLine("Error: --frontmatter/--yaml-header cannot be combined with --body.");
+            return false;
+        }
+
+        if (options.ShowReadme && options.ShowContent)
+        {
+            Console.Error.WriteLine("Error: --readme cannot be combined with --content. Use --content --path @readme for separator or JSONL output.");
+            return false;
+        }
+
+        if (options.ShowContent && !HasPathFilter(options))
+        {
+            Console.Error.WriteLine("Error: --content requires at least one --path selector.");
+            return false;
+        }
+
+        if (scopedContent && !options.ShowReadme && !options.ShowContent)
+        {
+            Console.Error.WriteLine("Error: --frontmatter/--yaml-header and --body require --readme or --content.");
+            return false;
+        }
+
+        if (options.ShowContent && options.JsonOutput)
+        {
+            Console.Error.WriteLine("Error: --content supports --jsonl for structured output, not --json.");
+            return false;
+        }
+
+        if (options.ShowContent && options.OneLine && !options.Jsonl)
+        {
+            Console.Error.WriteLine("Error: --content supports separator output or --jsonl; it cannot be combined with --table or --tsv.");
+            return false;
+        }
+
+        if (options.ShowContent && options.Count)
+        {
+            Console.Error.WriteLine("Error: --content cannot be combined with --count.");
+            return false;
+        }
+
+        if (options.ShowContent)
+        {
+            List<string> conflicts = [];
+            if (options.ListLayout) conflicts.Add("--layout");
+            if (options.ListTfms) conflicts.Add("--tfms");
+            if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
+            if (options.ShowDependencies) conflicts.Add("--dependencies");
+            if (options.PackageLibrary != null) conflicts.Add("--library");
+            if (options.AllLibraries) conflicts.Add("--all-libraries");
+            if (options.Discover != null) conflicts.Add("-D/--discover");
+            if (options.Columns != null) conflicts.Add("--columns");
+            if (options.Fields != null) conflicts.Add("--fields");
+            if (conflicts.Count > 0)
+            {
+                Console.Error.WriteLine($"Error: --content cannot be combined with {string.Join(", ", conflicts)}.");
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool ValidatePathMatchMode(InspectionOptions options)
@@ -687,6 +768,90 @@ public class PackageCommand
 
         target = new PackageTarget(packageArg, IsLocalFile: false, packageName, version);
         return true;
+    }
+
+    private sealed record PackageFileContentSet(string PackageName, string Version, List<PackageFileContent> Files);
+
+    private static async Task<int> ExecuteMultiPackageContentAsync(
+        string[] packageArgs,
+        InspectionOptions options,
+        CommandContext context)
+    {
+        var targets = new List<PackageTarget>();
+        foreach (var packageArg in packageArgs)
+        {
+            if (!TryCreatePackageTarget(packageArg, out var target))
+                return 1;
+            targets.Add(target);
+        }
+
+        var results = new List<PackageFileContentSet>();
+        foreach (var target in targets)
+        {
+            var result = await ReadPackageFileContentsAsync(target, options, context);
+            if (result == null)
+                return 1;
+            results.Add(result);
+        }
+
+        return PrintPackageFileContents(results, options);
+    }
+
+    private static async Task<PackageFileContentSet?> ReadPackageFileContentsAsync(
+        PackageTarget target,
+        InspectionOptions options,
+        CommandContext context)
+    {
+        var logger = context.Logger;
+        string? extractPath = null;
+        PackageExtractionResult? resolution = null;
+        string version = target.Version;
+
+        try
+        {
+            var outcome = await PackageExtractor.ExtractPackageAsync(
+                context.HttpClient,
+                target.IsLocalFile ? target.OriginalArgument : target.PackageName,
+                logger.Log,
+                sourceOptions: options.SourceOptions,
+                version: target.IsLocalFile ? null : (version.Length > 0 ? version : null),
+                forceLatest: options.ForceLatest,
+                includePrerelease: options.IncludePrerelease);
+
+            if (!outcome.IsSuccess)
+            {
+                Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");
+                return null;
+            }
+
+            resolution = outcome.Result!;
+            extractPath = resolution.ExtractPath;
+            version = resolution.Version ?? version;
+
+            NuspecData? nuspec = null;
+            string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
+            if (nuspecFiles.Length > 0)
+                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
+
+            var packageId = nuspec?.PackageName ?? target.PackageName;
+            var packageVersion = nuspec?.Version ?? version;
+            var packageReadme = PackageFileLister.ResolvePackageReadme(extractPath, nuspec?.ReadmeFile);
+            return ReadPackageFileContents(extractPath, packageId, packageVersion, packageReadme, options);
+        }
+        finally
+        {
+            if (resolution is { FromCache: false, TempDir: not null } && Directory.Exists(resolution.TempDir))
+            {
+                try
+                {
+                    Directory.Delete(resolution.TempDir, recursive: true);
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
     }
 
     private static async Task<InspectionResult?> InspectPackageAsync(
@@ -751,11 +916,7 @@ public class PackageCommand
             result.Source = target.IsLocalFile ? SourceKind.File : SourceKind.NuGet;
 
             if (wantsFilesSection)
-            {
-                string declaredReadme = result.ReadmeFile ?? "README.md";
-                var files = PackageFileLister.ListAll(extractPath, declaredReadme);
-                result.Files = FilterPackageFiles(files, options);
-            }
+                PopulatePackageFileSections(result, extractPath, options);
 
             if (wantsSignals)
             {
@@ -819,39 +980,245 @@ public class PackageCommand
 
     private static bool HasPathFilter(InspectionOptions options) => PathSelectors(options).Length > 0;
 
+    private static bool TryGetSingleFileSection(InspectionOptions options, out string section)
+    {
+        section = "";
+        if (options.IncludeSections is not { Count: 1 })
+            return false;
+
+        section = options.IncludeSections.Single();
+        return IsPackageFileSection(section);
+    }
+
+    private static bool IsPackageFileSection(string? section)
+        => section != null
+           && (section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase)
+               || section.Equals(PackageSections.PackageReadme, StringComparison.OrdinalIgnoreCase)
+               || section.Equals(PackageSections.LibraryFiles, StringComparison.OrdinalIgnoreCase)
+               || section.Equals(PackageSections.MarkdownFiles, StringComparison.OrdinalIgnoreCase));
+
+    private static void PopulatePackageFileSections(InspectionResult result, string extractPath, InspectionOptions options)
+    {
+        bool wantsPackageFileRows = HasPathFilter(options)
+            || options.IncludeSections?.Any(IsPackageFileSection) == true
+            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
+        if (!wantsPackageFileRows)
+            return;
+
+        var packageReadme = result.PackageReadmeFile
+            ?? PackageFileLister.ResolvePackageReadme(extractPath, result.ReadmeFile);
+        result.PackageReadmeFile = packageReadme;
+        result.HasReadme = packageReadme != null;
+        result.HasAgentDocumentation = File.Exists(Path.Combine(extractPath, "AGENTS.md"));
+        var files = PackageFileLister.ListAll(extractPath, packageReadme);
+        result.PackageFiles = files;
+        if (HasPathFilter(options)
+            || options.IncludeSections?.Contains(PackageSections.Files) == true
+            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+        {
+            result.Files = HasPathFilter(options)
+                ? FilterPackageFiles(files, options)
+                : files;
+        }
+    }
+
+    private static PackageFileContentSet ReadPackageFileContents(
+        string extractPath,
+        string packageName,
+        string version,
+        string? readmeFile,
+        InspectionOptions options)
+    {
+        var files = PackageFileLister.ListAll(extractPath, readmeFile);
+        var selectedFiles = options.ShowReadme
+            ? PackageFileLister.Filter(files, "@readme")
+            : FilterPackageFiles(files, options);
+        var contents = selectedFiles
+            .Select(file => ReadPackageFileContent(extractPath, packageName, version, file, options.ContentScope))
+            .ToList();
+        return new PackageFileContentSet(packageName, version, contents);
+    }
+
+    private static PackageFileContent ReadPackageFileContent(
+        string extractPath,
+        string packageName,
+        string version,
+        PackageFile file,
+        PackageFileContentScope scope)
+    {
+        var fullPath = Path.Combine(extractPath, file.Path.Replace('/', Path.DirectorySeparatorChar));
+        var content = ApplyMarkdownContentScope(File.ReadAllText(fullPath), scope);
+        return new PackageFileContent(packageName, version, file.Path, file.Size, Found: true, content);
+    }
+
+    private static string ApplyMarkdownContentScope(string content, PackageFileContentScope scope)
+    {
+        if (scope == PackageFileContentScope.Full)
+            return content;
+
+        if (!TryFindYamlFrontmatter(content, out var frontmatterEnd, out var bodyStart))
+            return scope == PackageFileContentScope.Frontmatter ? "" : content;
+
+        return scope == PackageFileContentScope.Frontmatter
+            ? content[..frontmatterEnd]
+            : content[bodyStart..];
+    }
+
+    private static bool TryFindYamlFrontmatter(string content, out int frontmatterEnd, out int bodyStart)
+    {
+        frontmatterEnd = 0;
+        bodyStart = 0;
+        if (content.Length == 0)
+            return false;
+
+        var firstLineStart = content[0] == '\uFEFF' ? 1 : 0;
+        var firstLineEnd = FindLineEnd(content, firstLineStart);
+        if (!LineEquals(content, firstLineStart, firstLineEnd, "---"))
+            return false;
+
+        var lineStart = NextLineStart(content, firstLineEnd);
+        while (lineStart < content.Length)
+        {
+            var lineEnd = FindLineEnd(content, lineStart);
+            if (LineEquals(content, lineStart, lineEnd, "---"))
+            {
+                frontmatterEnd = lineEnd;
+                bodyStart = NextLineStart(content, lineEnd);
+                return true;
+            }
+
+            lineStart = NextLineStart(content, lineEnd);
+        }
+
+        return false;
+    }
+
+    private static int FindLineEnd(string content, int start)
+    {
+        var newline = content.IndexOf('\n', start);
+        return newline >= 0 ? newline : content.Length;
+    }
+
+    private static int NextLineStart(string content, int lineEnd)
+        => lineEnd < content.Length ? lineEnd + 1 : lineEnd;
+
+    private static bool LineEquals(string content, int lineStart, int lineEnd, string value)
+    {
+        if (lineEnd > lineStart && content[lineEnd - 1] == '\r')
+            lineEnd--;
+        return content.AsSpan(lineStart, lineEnd - lineStart).SequenceEqual(value);
+    }
+
+    private static int PrintPackageFileContents(IReadOnlyList<PackageFileContentSet> results, InspectionOptions options)
+    {
+        var rows = FlattenPackageFileContentRows(results, options).ToList();
+        var output = options.Jsonl
+            ? RenderPackageFileContentJsonl(rows)
+            : RenderPackageFileContentBlocks(rows);
+
+        if (!string.IsNullOrEmpty(options.OutputPath))
+            File.WriteAllText(options.OutputPath, output);
+        else
+            Console.Write(output);
+
+        return 0;
+    }
+
+    private static IEnumerable<PackageFileContent> FlattenPackageFileContentRows(
+        IReadOnlyList<PackageFileContentSet> results,
+        InspectionOptions options)
+    {
+        foreach (var result in results)
+        {
+            if (result.Files.Count > 0)
+            {
+                foreach (var file in result.Files)
+                    yield return file;
+            }
+            else if (!options.SkipEmpty)
+            {
+                yield return new PackageFileContent(
+                    result.PackageName,
+                    result.Version,
+                    Path: "",
+                    Size: 0,
+                    Found: false,
+                    Content: "");
+            }
+        }
+    }
+
+    private static string RenderPackageFileContentJsonl(IReadOnlyList<PackageFileContent> rows)
+    {
+        var builder = new StringBuilder();
+        foreach (var row in rows)
+            builder.AppendLine(JsonSerializer.Serialize(row, PackageFileContentJsonContext.Default.PackageFileContent));
+        return builder.ToString();
+    }
+
+    private static string RenderPackageFileContentBlocks(IReadOnlyList<PackageFileContent> rows)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (i > 0)
+                builder.AppendLine();
+
+            var row = rows[i];
+            var path = row.Found ? row.Path : "<absent>";
+            builder.AppendLine($"------------ {row.Package} :: {path} ------------");
+            if (!row.Found)
+            {
+                builder.AppendLine("(absent)");
+                continue;
+            }
+
+            builder.Append(row.Content);
+            if (row.Content.Length == 0 || row.Content[^1] != '\n')
+                builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
     private static int CountMultiPackageRows(IReadOnlyList<InspectionResult> results, string? section, InspectionOptions options)
-        => section != null && section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase)
-            ? results.Sum(result => options.SkipEmpty ? result.Files?.Count ?? 0 : Math.Max(1, result.Files?.Count ?? 0))
+        => IsPackageFileSection(section)
+            ? results.Sum(result => options.SkipEmpty ? GetPackageFileRows(result, section!).Count : Math.Max(1, GetPackageFileRows(result, section!).Count))
             : results.Sum(result => new InspectionResultView(result).Metadata.Count);
 
     private static void WriteMultiPackageTable(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
     {
-        if (section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase))
+        if (IsPackageFileSection(section))
         {
-            WriteMultiPackageFilesTable(results, options);
+            WriteMultiPackageFilesTable(results, section, options);
             return;
         }
 
         WriteMultiPackagePackageInfoTable(results, options);
     }
 
-    private static void WriteMultiPackageFilesTable(IReadOnlyList<InspectionResult> results, InspectionOptions options)
+    private static void WriteMultiPackageFilesTable(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
     {
+        if (options.Jsonl)
+        {
+            WriteMultiPackageFilesJsonl(results, section, options);
+            return;
+        }
+
         var rows = results
             .SelectMany(result =>
             {
-                if (result.Files is not { Count: > 0 })
-                    return options.SkipEmpty ? [] : [[result.PackageName, result.Version, "", "", "", ""]];
+                var files = GetPackageFileRows(result, section);
+                if (files.Count == 0)
+                    return options.SkipEmpty ? [] : [[result.PackageName, result.Version, "", ""]];
 
-                return result.Files
+                return files
                     .Select(file => new[]
                     {
                         result.PackageName,
                         result.Version,
                         file.Path,
                         file.Size.ToString(CultureInfo.InvariantCulture),
-                        file.IsReadme ? "true" : "false",
-                        file.IsAgents ? "true" : "false",
                     });
             })
             .ToArray();
@@ -861,11 +1228,75 @@ public class PackageCommand
             var writerOptions = OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl);
             var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
             markoutWriter.WriteTable(
-                ["Package", "Version", "Path", "Size", "Readme", "Agents"],
-                ["package", "version", "path", "size", "is_readme", "is_agents"],
+                ["Package", "Version", "Path", "Size"],
+                ["package", "version", "path", "size"],
                 rows);
             markoutWriter.Flush();
         });
+    }
+
+    private static void WritePackageFilesJsonl(InspectionResult result, string section)
+    {
+        var files = GetPackageFileRows(result, section);
+        if (files.Count == 0)
+            return;
+
+        foreach (var file in files)
+        {
+            var row = new PackageFileJsonRow(file.Path, file.Size);
+            Console.WriteLine(JsonSerializer.Serialize(row, PackageFileJsonRowContext.Default.PackageFileJsonRow));
+        }
+    }
+
+    private static void WriteMultiPackageFilesJsonl(IReadOnlyList<InspectionResult> results, string section, InspectionOptions options)
+    {
+        foreach (var result in results)
+        {
+            var files = GetPackageFileRows(result, section);
+            if (files.Count == 0)
+            {
+                if (!options.SkipEmpty)
+                {
+                    var empty = new PackageFileMultiJsonRow(result.PackageName, result.Version, "", null);
+                    Console.WriteLine(JsonSerializer.Serialize(empty, PackageFileMultiJsonRowContext.Default.PackageFileMultiJsonRow));
+                }
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                var row = new PackageFileMultiJsonRow(result.PackageName, result.Version, file.Path, file.Size);
+                Console.WriteLine(JsonSerializer.Serialize(row, PackageFileMultiJsonRowContext.Default.PackageFileMultiJsonRow));
+            }
+        }
+    }
+
+    private static List<PackageFile> GetPackageFileRows(InspectionResult result, string section)
+    {
+        if (section.Equals(PackageSections.Files, StringComparison.OrdinalIgnoreCase))
+            return result.Files ?? [];
+
+        if (section.Equals(PackageSections.PackageReadme, StringComparison.OrdinalIgnoreCase))
+        {
+            if (result.PackageFiles is not { Count: > 0 } readmeFiles || string.IsNullOrWhiteSpace(result.PackageReadmeFile))
+                return [];
+
+            return readmeFiles
+                .Where(file => string.Equals(file.Path, result.PackageReadmeFile, StringComparison.OrdinalIgnoreCase))
+                .Take(1)
+                .ToList();
+        }
+
+        if (result.PackageFiles is not { Count: > 0 } files)
+            return [];
+
+        if (section.Equals(PackageSections.LibraryFiles, StringComparison.OrdinalIgnoreCase))
+            return files.Where(file => file.Path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (section.Equals(PackageSections.MarkdownFiles, StringComparison.OrdinalIgnoreCase))
+            return files.Where(file => file.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        return [];
     }
 
     private static void WriteMultiPackagePackageInfoTable(IReadOnlyList<InspectionResult> results, InspectionOptions options)
@@ -1951,20 +2382,21 @@ public class PackageCommand
         }).ToList();
     }
 
-    private static int PrintReadme(string extractPath, string? readmeFile, InspectionOptions options)
+    private static int PrintReadme(
+        string extractPath,
+        string packageName,
+        string version,
+        string? readmeFile,
+        InspectionOptions options)
     {
-        // Use nuspec-specified readme file or fall back to README.md
-        string readmeFileName = readmeFile ?? "README.md";
-        string readmePath = Path.Combine(extractPath, readmeFileName);
-        
-        if (!File.Exists(readmePath))
+        var result = ReadPackageFileContents(extractPath, packageName, version, readmeFile, options);
+        if (result.Files is not { Count: > 0 })
         {
             Console.Error.WriteLine("Error: This package does not contain a readme file.");
             return 1;
         }
 
-        string content = File.ReadAllText(readmePath);
-        
+        string content = result.Files[0].Content;
         if (!string.IsNullOrEmpty(options.OutputPath))
         {
             File.WriteAllText(options.OutputPath, content);

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -165,6 +165,7 @@ internal static class AuditSignalBuilder
             PackageSignalRows.CompatibilitySupportedTfm,
             PackageSignalRows.CompatibilityPortable,
             PackageSignalRows.DocumentationReadme,
+            PackageSignalRows.DocumentationAgentDocumentation,
             PackageSignalRows.LegalLicense,
             PackageSignalRows.ProvenanceSymbols,
             PackageSignalRows.ProvenanceSourceLink,
@@ -340,6 +341,9 @@ internal static class AuditSignalBuilder
         public static SignalRow<PackageSignalContext> DocumentationReadme =>
             new("Documentation", "README", ResolveDocumentationReadme);
 
+        public static SignalRow<PackageSignalContext> DocumentationAgentDocumentation =>
+            new("Documentation", "Agent documentation", ResolveDocumentationAgentDocumentation);
+
         public static SignalRow<PackageSignalContext> LegalLicense =>
             new("Legal", "License", ResolveLegalLicense);
 
@@ -374,7 +378,10 @@ internal static class AuditSignalBuilder
             FormatPortability(context.Result).ToSignalValue();
 
         private static SignalValue? ResolveDocumentationReadme(in PackageSignalContext context) =>
-            new(FormatBool(context.Result.HasReadme), "nuspec/package files");
+            new(FormatBool(context.Result.HasReadme), context.Result.PackageReadmeFile ?? "package files");
+
+        private static SignalValue? ResolveDocumentationAgentDocumentation(in PackageSignalContext context) =>
+            new(FormatBool(context.Result.HasAgentDocumentation), "AGENTS.md");
 
         private static SignalValue? ResolveLegalLicense(in PackageSignalContext context) =>
             new(string.IsNullOrWhiteSpace(context.Result.License) ? "Not declared" : context.Result.License, "nuspec metadata");

--- a/src/dotnet-inspect/Inspectors/PackageFileLister.cs
+++ b/src/dotnet-inspect/Inspectors/PackageFileLister.cs
@@ -11,11 +11,30 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 public static class PackageFileLister
 {
+    private static readonly string[] PackageReadmeCandidates = ["AGENTS.md", "README.md", "PACKAGE.md"];
+
+    public static string? ResolvePackageReadme(string extractPath, string? declaredReadme = null)
+    {
+        foreach (var candidate in PackageReadmeCandidates)
+        {
+            if (TryFindPackageRelativeFile(extractPath, candidate, out var match))
+                return match;
+        }
+
+        if (!string.IsNullOrWhiteSpace(declaredReadme)
+            && TryFindPackageRelativeFile(extractPath, declaredReadme, out var declaredMatch))
+        {
+            return declaredMatch;
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Enumerates every package file (excluding zip plumbing) with its size,
     /// ordered by path. Paths are package-relative with forward slashes.
-    /// <paramref name="declaredReadme"/> is the package-relative path the
-    /// <c>.nuspec</c> declares as its readme (e.g. <c>PACKAGE.md</c>); the
+    /// <paramref name="declaredReadme"/> is the package-relative path selected
+    /// as the package readme (e.g. <c>AGENTS.md</c> or <c>PACKAGE.md</c>); the
     /// matching row is flagged <see cref="PackageFile.IsReadme"/>.
     /// </summary>
     public static List<PackageFile> ListAll(string extractPath, string? declaredReadme = null)
@@ -39,7 +58,7 @@ public static class PackageFileLister
     /// <summary>
     /// Restricts a listing to the <c>--path</c> pattern. Semantics:
     /// <list type="bullet">
-    /// <item><c>@readme</c>: the file the package declares as its readme,
+    /// <item><c>@readme</c>: the best package readme
     /// regardless of filename (resolved via <see cref="PackageFile.IsReadme"/>).</item>
     /// <item>Root (<c>/</c>, <c>.</c>, or empty): files directly at the package root.</item>
     /// <item>Directory (trailing <c>/</c>, e.g. <c>lib/</c>): files directly in that directory.</item>
@@ -113,4 +132,21 @@ public static class PackageFileLister
             || rel.Equals(".nupkg.metadata", StringComparison.OrdinalIgnoreCase)
             || rel.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
             || rel.EndsWith(".nupkg.sha512", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryFindPackageRelativeFile(string extractPath, string packageRelativePath, out string match)
+    {
+        var normalized = packageRelativePath.Replace('\\', '/').Trim().TrimStart('/');
+        foreach (var fullPath in Directory.EnumerateFiles(extractPath, "*", SearchOption.AllDirectories))
+        {
+            var rel = System.IO.Path.GetRelativePath(extractPath, fullPath).Replace('\\', '/');
+            if (string.Equals(rel, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                match = rel;
+                return true;
+            }
+        }
+
+        match = "";
+        return false;
+    }
 }

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -15,7 +15,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class PackageIndexCache
 {
-    internal const string Category = "pkg-index-v8";
+    internal const string Category = "pkg-index-v9";
 
     static PackageIndexCache()
     {
@@ -48,7 +48,9 @@ internal static class PackageIndexCache
                 RepositoryType = doc.GetString("repositoryType"),
                 RepositoryCommit = doc.GetString("repositoryCommit"),
                 ReadmeFile = doc.GetString("readmeFile"),
+                PackageReadmeFile = doc.GetString("packageReadmeFile"),
                 HasReadme = doc.GetBool("hasReadme"),
+                HasAgentDocumentation = doc.GetBool("hasAgentDocumentation"),
                 IsToolPackage = doc.GetBool("isToolPackage"),
                 AssemblyCount = doc.GetInt32("assemblyCount"),
                 IsFrameworkDependent = doc.GetBool("isFrameworkDependent"),
@@ -137,6 +139,7 @@ internal static class PackageIndexCache
         WriteField(buf, "repositoryCommit"u8, result.RepositoryCommit);
         WriteField(buf, "assemblyCount"u8, result.AssemblyCount);
         WriteField(buf, "hasReadme"u8, result.HasReadme);
+        WriteField(buf, "hasAgentDocumentation"u8, result.HasAgentDocumentation);
         WriteField(buf, "isToolPackage"u8, result.IsToolPackage);
         WriteField(buf, "isFrameworkDependent"u8, result.IsFrameworkDependent);
         WriteField(buf, "hasRidSpecificAssets"u8, result.HasRidSpecificAssets);
@@ -159,6 +162,7 @@ internal static class PackageIndexCache
             WriteField(buf, "otherSourceLinkPdbs"u8, binarySignals.OtherSourceLinkPdbs);
         }
         WriteField(buf, "readmeFile"u8, result.ReadmeFile);
+        WriteField(buf, "packageReadmeFile"u8, result.PackageReadmeFile);
         WriteField(buf, "toolFormat"u8, result.ToolFormat);
         WriteField(buf, "runtimeTargetRid"u8, result.RuntimeTargetRid);
         if (result.BuiltDate.HasValue)

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -74,9 +74,9 @@ internal static class PackageInspector
             result.DependencyGroups = nuspec.DependencyGroups;
         }
 
-        // Check for README (use nuspec-specified file or fall back to README.md)
-        string readmeFileName = result.ReadmeFile ?? "README.md";
-        result.HasReadme = File.Exists(Path.Combine(extractPath, readmeFileName));
+        result.PackageReadmeFile = PackageFileLister.ResolvePackageReadme(extractPath, result.ReadmeFile);
+        result.HasReadme = result.PackageReadmeFile != null;
+        result.HasAgentDocumentation = File.Exists(Path.Combine(extractPath, "AGENTS.md"));
 
         // Analyze directory structure
         string toolsDir = Path.Combine(extractPath, "tools");

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -34,6 +34,26 @@ public partial class JsonContext : JsonSerializerContext
 {
 }
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(PackageFileJsonRow))]
+internal partial class PackageFileJsonRowContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(PackageFileMultiJsonRow))]
+internal partial class PackageFileMultiJsonRowContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PackageFileContent))]
+internal partial class PackageFileContentJsonContext : JsonSerializerContext
+{
+}
+
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -80,7 +80,7 @@ public class InspectionResult
     public List<PackageVulnerability>? Vulnerabilities { get; set; }
 
     /// <summary>
-    /// Indicates whether the package contains a README.md file.
+    /// Indicates whether the package contains a best package README candidate.
     /// </summary>
     public bool HasReadme { get; set; }
 
@@ -89,6 +89,14 @@ public class InspectionResult
     /// </summary>
     [JsonIgnore]
     public string? ReadmeFile { get; set; }
+
+    /// <summary>
+    /// Best package README path: AGENTS.md, README.md, PACKAGE.md, then the declared readme fallback.
+    /// </summary>
+    [JsonIgnore]
+    public string? PackageReadmeFile { get; set; }
+
+    public bool HasAgentDocumentation { get; set; }
 
     public bool IsToolPackage { get; set; }
 
@@ -164,6 +172,12 @@ public class InspectionResult
     public List<PackageFile>? Files { get; set; }
 
     /// <summary>
+    /// Complete package file listing used to derive focused file sections.
+    /// </summary>
+    [JsonIgnore]
+    public List<PackageFile>? PackageFiles { get; set; }
+
+    /// <summary>
     /// Result of NuGet package signature verification.
     /// </summary>
     public SignatureVerificationResult? SignatureResult { get; set; }
@@ -210,4 +224,30 @@ public record class PackageBinarySignals
 /// package's <c>.nuspec</c> declares as its readme (not always <c>README.md</c>);
 /// <paramref name="IsAgents"/> marks a root <c>AGENTS.md</c> file.
 /// </summary>
-public sealed record PackageFile(string Path, long Size, bool IsReadme = false, bool IsAgents = false);
+public sealed record PackageFile(
+    string Path,
+    long Size,
+    [property: JsonIgnore] bool IsReadme = false,
+    [property: JsonIgnore] bool IsAgents = false);
+
+public sealed record PackageFileJsonRow(
+    string Path,
+    long Size);
+
+public sealed record PackageFileMultiJsonRow(
+    string Package,
+    string Version,
+    string Path,
+    long? Size);
+
+/// <summary>
+/// Content for one selected package file. Empty rows preserve package input
+/// cardinality for surveys when a selector has no match.
+/// </summary>
+public sealed record PackageFileContent(
+    string Package,
+    string Version,
+    string Path,
+    long Size,
+    bool Found,
+    string Content);

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -94,6 +94,20 @@ public record InspectionOptions
     public bool ShowReadme { get; init; }
 
     /// <summary>
+    /// Print the contents of files selected by <see cref="PathFilters"/>.
+    /// </summary>
+    public bool ShowContent { get; init; }
+
+    /// <summary>
+    /// Scope markdown content output to the full file, YAML frontmatter, or body.
+    /// </summary>
+    public PackageFileContentScope ContentScope { get; init; } = PackageFileContentScope.Full;
+
+    public bool FrontmatterRequested { get; init; }
+
+    public bool BodyRequested { get; init; }
+
+    /// <summary>
     /// Path to write output to instead of stdout.
     /// </summary>
     public string? OutputPath { get; init; }
@@ -215,10 +229,17 @@ public record InspectionOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
+    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || ShowContent || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
 
     /// <summary>
     /// All inspection features enabled.
     /// </summary>
     public static InspectionOptions All => new();
+}
+
+public enum PackageFileContentScope
+{
+    Full,
+    Frontmatter,
+    Body
 }

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -16,10 +16,12 @@ public static class PackageSectionDescriptors
         return new SectionPipeline<InspectionResult>()
             .Add<Summary>()
             .Add<PackageInfo>()
+            .Add<PackageReadme>()
             .Add<Signals>()
             .Add<Statistics>()
             .Add<TargetFrameworks>()
             .Add<LibraryFiles>()
+            .Add<MarkdownFiles>()
             .Add<Signature>()
             .Add<Dependencies>()
             .Add<Vulnerabilities>()
@@ -45,6 +47,17 @@ public static class PackageSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model) => true;
+    }
+
+    public sealed class PackageReadme : ISectionDescriptor<InspectionResult>
+    {
+        public static string Name => PackageSections.PackageReadme;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(InspectionResult model)
+            => model.PackageReadmeFile != null
+               || model.PackageFiles?.Any(file => file.IsReadme) == true;
     }
 
     public sealed class Signals : ISectionDescriptor<InspectionResult>
@@ -83,7 +96,18 @@ public static class PackageSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model)
-            => model.LibraryFiles is { Count: > 0 };
+            => model.PackageFiles?.Any(IsLibraryFile) == true
+               || model.LibraryFiles is { Count: > 0 };
+    }
+
+    public sealed class MarkdownFiles : ISectionDescriptor<InspectionResult>
+    {
+        public static string Name => PackageSections.MarkdownFiles;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(InspectionResult model)
+            => model.PackageFiles?.Any(IsMarkdownFile) == true;
     }
 
     public sealed class Signature : ISectionDescriptor<InspectionResult>
@@ -146,4 +170,10 @@ public static class PackageSectionDescriptors
         public static bool CanRender(InspectionResult model)
             => model.Files is { Count: > 0 };
     }
+
+    private static bool IsLibraryFile(PackageFile file)
+        => file.Path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMarkdownFile(PackageFile file)
+        => file.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -69,14 +69,23 @@ public class InspectionResultView
 
     [MarkoutSection(Name = PackageSections.Files)]
     public List<PackageFileRow>? Files => _data.Files?
-        .Select(f => new PackageFileRow(f.Path, f.Size, f.IsReadme, f.IsAgents))
+        .Select(ToFileRow)
+        .ToList();
+
+    [MarkoutSection(Name = PackageSections.PackageReadme)]
+    public List<PackageFileRow>? PackageReadme => PackageReadmeFiles()
+        ?.Select(ToFileRow)
         .ToList();
 
     [MarkoutSection(Name = PackageSections.LibraryFiles)]
-    public List<LibraryFileRow>? LibraryFiles => _data.LibraryFiles?
-        .Select(f => new LibraryFileRow(TfmResolver.ExtractTfmFromPath(f) ?? "", f))
-        .OrderByDescending(f => TfmResolver.GetTfmPriority(f.Tfm))
-        .ThenBy(f => f.File, StringComparer.OrdinalIgnoreCase)
+    public List<PackageFileRow>? LibraryFiles => LibraryPackageFiles()
+        ?.Select(ToFileRow)
+        .ToList();
+
+    [MarkoutSection(Name = PackageSections.MarkdownFiles)]
+    public List<PackageFileRow>? MarkdownFiles => _data.PackageFiles?
+        .Where(IsMarkdownFile)
+        .Select(ToFileRow)
         .ToList();
 
     [MarkoutSection(Name = PackageSections.Manifest)]
@@ -179,7 +188,7 @@ public class InspectionResultView
 
     [MarkoutPropertyName("Readme")]
     public string? ReadmeFile => _data.HasReadme
-        ? _data.ReadmeFile ?? "README.md"
+        ? _data.PackageReadmeFile ?? _data.ReadmeFile ?? "README.md"
         : _data.ReadmeFile;
 
     [MarkoutSkipDefault]
@@ -249,6 +258,42 @@ public class InspectionResultView
     [MarkoutJoin(", ")]
     [MarkoutPropertyName("Native Files")]
     public List<string>? NativeFiles => _data.NativeFiles;
+
+    private List<PackageFile>? LibraryPackageFiles()
+    {
+        if (_data.PackageFiles is { Count: > 0 } files)
+        {
+            var rows = files
+                .Where(IsLibraryFile)
+                .ToList();
+            return rows.Count > 0 ? rows : null;
+        }
+
+        return _data.LibraryFiles?
+            .Select(path => new PackageFile(path, 0))
+            .ToList();
+    }
+
+    private List<PackageFile>? PackageReadmeFiles()
+    {
+        if (_data.PackageFiles is not { Count: > 0 } files || string.IsNullOrWhiteSpace(_data.PackageReadmeFile))
+            return null;
+
+        var readme = files
+            .Where(file => string.Equals(file.Path, _data.PackageReadmeFile, StringComparison.OrdinalIgnoreCase))
+            .Take(1)
+            .ToList();
+        return readme.Count > 0 ? readme : null;
+    }
+
+    private static PackageFileRow ToFileRow(PackageFile file)
+        => new(file.Path, file.Size);
+
+    private static bool IsLibraryFile(PackageFile file)
+        => file.Path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMarkdownFile(PackageFile file)
+        => file.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
 
     private List<MarkoutField> GetCompactFields()
     {
@@ -325,7 +370,7 @@ public class InspectionResultView
         if (_data.AssemblyCount > 1)
             fields.Add(new("Libraries", _data.AssemblyCount.ToString()));
         if (_data.HasReadme)
-            fields.Add(new("Readme", _data.ReadmeFile ?? "README.md"));
+            fields.Add(new("Readme", _data.PackageReadmeFile ?? _data.ReadmeFile ?? "README.md"));
         if (_data.Vulnerabilities is { Count: > 0 })
             fields.Add(new("Vulnerabilities", _data.Vulnerabilities.Count.ToString()));
 
@@ -390,18 +435,9 @@ public record TargetFrameworkRow(
     [property: MarkoutPropertyName("TFM")] string Tfm);
 
 [MarkoutSerializable]
-public record LibraryFileRow(
-    [property: MarkoutPropertyName("TFM")] string Tfm,
-    [property: MarkoutPropertyName("File")] string File);
-
-[MarkoutSerializable]
 public record PackageFileRow(
     [property: MarkoutPropertyName("Path")] string Path,
-    [property: MarkoutPropertyName("Size")] long Size,
-    [property: MarkoutPropertyName("Readme")]
-    [property: MarkoutBoolFormat("readme", "")] bool IsReadme,
-    [property: MarkoutPropertyName("Agents")]
-    [property: MarkoutBoolFormat("agents", "")] bool IsAgents);
+    [property: MarkoutPropertyName("Size")] long Size);
 
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(InspectionResultView))]
@@ -424,7 +460,6 @@ public record PackageFileRow(
 [MarkoutContext(typeof(PackageDependency))]
 [MarkoutContext(typeof(FlatDependency))]
 [MarkoutContext(typeof(TargetFrameworkRow))]
-[MarkoutContext(typeof(LibraryFileRow))]
 [MarkoutContext(typeof(PackageFileRow))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -131,10 +131,10 @@ public class LibraryInspectionView
         CustomAttributes = CountOrZero(_data.CustomAttributes),
         Deterministic = _data.IsDeterministic,
         ExtensionMethods = CountExtensionMethods(_data.ExtensionMethods),
+        Facade = _data.IsFacadeAssembly,
         FileSize = _data.FileSize > 0 ? ByteSizeFormatter.FormatBytes(_data.FileSize) : null,
         InformationalVersion = info.InformationalVersion,
         Integrations = CountIntegrations(_data),
-        Facade = _data.IsFacadeAssembly,
         Methods = info.MethodDefinitionCount > 0 ? info.MethodDefinitionCount.ToString("N0") : null,
         Modified = _data.LastModified?.ToString("yyyy-MM-dd"),
         Name = info.AssemblyName,
@@ -748,11 +748,11 @@ public class LibraryInfoSection
     [MarkoutBoolFormat("Yes", "No")]
     public bool Deterministic { get; init; }
     public int ExtensionMethods { get; init; }
+    [MarkoutBoolFormat("Yes", "No")]
+    public bool? Facade { get; init; }
     public string? FileSize { get; init; }
     public string? InformationalVersion { get; init; }
     public int Integrations { get; init; }
-    [MarkoutBoolFormat("Yes", "No")]
-    public bool? Facade { get; init; }
     public string? Methods { get; init; }
     public string? Modified { get; init; }
     public string? Name { get; init; }

--- a/src/dotnet-inspect/Views/PackageSections.cs
+++ b/src/dotnet-inspect/Views/PackageSections.cs
@@ -8,10 +8,12 @@ public static class PackageSections
 {
     public const string Summary = "Summary";
     public const string PackageInfo = "Package Info";
+    public const string PackageReadme = "Package README";
     public const string Signals = "Signals";
     public const string Statistics = "Statistics";
     public const string TargetFrameworks = "Target Frameworks";
     public const string LibraryFiles = "Library Files";
+    public const string MarkdownFiles = "Markdown Files";
     public const string Dependencies = "Dependencies";
     public const string Files = "Files";
     public const string Vulnerabilities = "Vulnerabilities";


### PR DESCRIPTION
## Summary

- add package file content printing with separator blocks and JSONL rows
- add frontmatter/body scoping for `--content` and `--readme`
- unify package file sections around a sparse-free `Path`/`Size` schema, with `Files`, `Library Files`, `Markdown Files`, and `Package README`
- add best package README selection: `AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme fallback
- add package Signals coverage for agent documentation and make `Library Info` fields alphabetical

Fixes #889.
Fixes #952.
Fixes #953.
Fixes #954.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `npx markdownlint-cli README.md docs/design/rendering-model.md docs/design/schema-query.md docs/design/section-pipeline.md docs/workflows/core/package-inspection.md skills/dotnet-inspect/SKILL.md`
- `git diff --check`
