### PR TITLE
Render isinst-in-condition as `is` for any target (#932)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3749,6 +3749,34 @@ public class EnumConstantTests
         Assert.DoesNotContain("!= 0", output);
     }
 
+    [Fact]
+    public void IsInstanceUnknownShape_AsCondition_RendersIs()
+    {
+        // A cross-assembly value type (e.g. BigInteger, Guid) whose shape the
+        // printer could not resolve is still `obj is T` when tested as a branch
+        // condition — `as` would be CS0077. The bug in issue #932: with no shape
+        // entry the printer fell back to `as`, producing `if (obj as BigInteger)`.
+        var objType = TypeRef.CoreLib("System", "Object");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var bigIntType = TypeRef.Definition("System.Runtime.Numerics", "System.Numerics", "BigInteger");
+        var then = new Block(0);
+        then.Add(new Return(new Constant(1, intType)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(new IsInstance(bigIntType, new LoadArgument(0, "obj", objType)), then, null));
+        entry.Add(new Return(new Constant(0, intType)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var signature = new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0);
+        // No TypeShapes entry for BigInteger: shape is unresolved, as for a real
+        // cross-assembly struct.
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [objType], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("obj is BigInteger", output);
+        Assert.DoesNotContain(" as BigInteger", output);
+    }
+
     static string PrintEnumConstant(int value, TypeRef enumType, IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> members)
     {
         var block = new Block(0);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1192,11 +1192,18 @@ public sealed partial class CSharpPrinter
     /// </summary>
     (string Direct, string Inverted)? Truthiness(IrExpression operand)
     {
-        // A value-type `isinst` already renders as the boolean `obj is T`, so it
-        // is its own truth value — wrapping it in `!= 0` would be `bool != int`
-        // (CS0019). The inverse spells the negated pattern.
-        if (operand is IsInstance ii && IsValueTypeTarget(ii.Type))
-            return ($"{Operand(operand)}", $"!({Operand(operand)})");
+        // An `isinst T` tested as a branch condition is the C# type-test operator
+        // `obj is T` — valid for any target, reference or value. Spelling it with
+        // `as` (the value-context form) is CS0077 on a non-nullable value type
+        // whose shape the printer could not resolve (e.g. a cross-assembly struct
+        // like Guid or BigInteger), and even for a reference type a bare `obj as T`
+        // is not a bool. The pattern is already its own truth value — wrapping it
+        // in `!= 0` would be `bool != int` (CS0019); the inverse negates it.
+        if (operand is IsInstance ii)
+        {
+            string test = $"{Operand(ii.Operand)} is {TypeText(ii.Type)}";
+            return (test, $"!({test})");
+        }
 
         // A `ref bool`/`bool*` deref loads via `ldind.u1`, so its IR ResultType is
         // `byte`, but it renders as the C# bool place (`flag`/`*p`). Spelling it


### PR DESCRIPTION
Closes #932.

## Problem

An `isinst T` opcode tested as a branch condition is the C# type-test operator `obj is T`, which is valid whether `T` is a reference or a value type. The printer's truthiness path only special-cased it as `is` when it could *prove* `T` was a value type (a numeric primitive, `bool`, or a resolved value/enum `TypeShape`). For a cross-assembly value type whose shape did not resolve — e.g. `BigInteger` or `Guid` — it fell through to the value-context spelling `obj as T`, which is **CS0077** on a non-nullable value type (and isn't a `bool` even for a reference type).

```csharp
// before
if (V_1 as BigInteger)            // CS0077
if (!(V_6 as Guid)) goto IL_0109; // CS0077

// after
if (V_1 is BigInteger)
if (!(V_6 is Guid)) goto IL_0109;
```

## Fix

In `CSharpPrinter.Truthiness`, spell any `isinst` branch condition as `obj is T` / `!(obj is T)` regardless of the resolved shape. This is also the more faithful rendering for reference targets, which previously spelled the longer `(obj as T) is not null`.

## Results (popular NuGet sweep)

- `validity: CS0077` bucket: **125 → 0** (was the largest validity bucket; now absent). Newtonsoft.Json 40→0 methods, Serilog 8→0.
- **No new pass bugs** (0 across all six libraries) and **no validity regressions** — `Full%` unchanged per library; bound Full defects dropped (Newtonsoft 150→78, Serilog 22→17).
- Several cascading errors on the same methods also cleared (CS0023, CS0029, CS0413).

## Tests

- All 810 `ILInspector.Decompiler.Tests` pass.
- Added `IsInstanceUnknownShape_AsCondition_RendersIs` covering the exact gap: an `isinst` against a value type with **no** `TypeShape` entry (as a real cross-assembly struct) must render `is`, not `as`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)