### PR TITLE
Mark async shell methods async in validity check (#927)

### DIFF
--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -302,6 +302,18 @@ static class ValidityCheck
             : "";
         string returnType = TypeText(function.Signature.ReturnType);
         string parameters = string.Join(", ", function.Signature.Parameters.Select(ParameterText));
+        // A decompiled async method renders its `await` expressions faithfully, but
+        // the original `async` modifier lives in metadata (the state machine), not in
+        // the body. The shell must restore it or every awaiting body trips CS4032
+        // ("'await' can only be used within an async method") — a shell artifact, not
+        // a decompiler defect. The signature return type is already the awaitable
+        // (Task/Task<T>/ValueTask, or void for async void), so `async` binds cleanly.
+        // `unsafe` and `async` are mutually exclusive here: the blanket `unsafe`
+        // modifier puts the whole body in an unsafe context, where `await` is illegal
+        // (CS4004) — so an awaiting body takes `async` INSTEAD of `unsafe`. Async
+        // method bodies do not carry pointer operations across awaits, so dropping the
+        // unsafe context costs nothing.
+        string modifier = function.Descendants.OfType<AwaitExpression>().Any() ? "async" : "unsafe";
         return $$"""
             #pragma warning disable
             using System;
@@ -320,7 +332,7 @@ static class ValidityCheck
             using System.Threading.Tasks;
             class __Shell
             {
-                unsafe {{returnType}} __M{{genericList}}({{parameters}}){{whereClauses}}
+                {{modifier}} {{returnType}} __M{{genericList}}({{parameters}}){{whereClauses}}
                 {
             {{body}}
                 }


### PR DESCRIPTION
Closes #927.

## Diagnosis

`validity: CS4032` is *"the 'await' operator can only be used within an async method."* Every method in this bucket is a faithfully-decompiled `async` method (`ResolveAsync`, `ExecuteWithRetryAsync`, …). The decompiler renders the `await` expressions correctly, but the original `async` modifier lives in metadata (the state machine), not in the body — and the validity harness wrapped each body in a shell method `__M` that was never marked `async`. So every awaiting body tripped CS4032. This is a **validity-shell artifact, not a decompiler defect**.

## Fix

Mark the shell method `async` when the body contains an `AwaitExpression`. `async` and the blanket `unsafe` modifier are mutually exclusive (await in an unsafe context is CS4004), so an awaiting body takes `async` **instead of** `unsafe`; async bodies carry no pointer operations across awaits, so dropping the unsafe context costs nothing. The signature return type is already the awaitable (`Task`/`Task<T>`/`ValueTask`, or `void` for async void), so `async` binds cleanly.

## Verification

Before/after `--emit-validity-defects` diff across all 8 product libraries:

| Code | Before | After |
| --- | ---: | ---: |
| CS4032 | 35 methods | **0** |
| CS4004 | 35 methods | **0** |
| CS0029 | — | **−10** (await methods where `return value` now binds against `Task<T>`) |

- `validity: CS4032` bucket → **0 across all 4 affected libraries**.
- **No previously-passing method regressed.** One method (`HttpRetryHelper::GetBytesWithRetryAsync`) re-buckets CS8135→CS8374 — it was already invalid (a separate, pre-existing `ref DefaultInterpolatedStringHandler` ref-local escape defect, unrelated to async); dropping the unsafe context only changes which code Roslyn reports. Net, the change clears 80 defect-codes while one re-buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)