### PR TITLE
Report selected package readme in info

### DIFF
--- a/src/DotnetInspector.Core/InfoTracker.cs
+++ b/src/DotnetInspector.Core/InfoTracker.cs
@@ -14,6 +14,8 @@ public static class InfoTracker
     private static int _cacheHits;
     private static int _cacheMisses;
     private static CountingTextWriter? _countingWriter;
+    private static readonly object _detailsLock = new();
+    private static readonly Dictionary<string, string> _details = new(StringComparer.OrdinalIgnoreCase);
 
     public static bool Enabled => _enabled;
 
@@ -23,6 +25,8 @@ public static class InfoTracker
     public static void Start()
     {
         _enabled = true;
+        lock (_detailsLock)
+            _details.Clear();
         _countingWriter = new CountingTextWriter(Console.Out);
         Console.SetOut(_countingWriter);
         _stopwatch.Start();
@@ -31,6 +35,33 @@ public static class InfoTracker
     public static void RecordHttpRequest() => Interlocked.Increment(ref _httpRequests);
     public static void RecordCacheHit() => Interlocked.Increment(ref _cacheHits);
     public static void RecordCacheMiss() => Interlocked.Increment(ref _cacheMisses);
+
+    public static void SetDetail(string key, string value)
+    {
+        if (!_enabled)
+            return;
+
+        lock (_detailsLock)
+            _details[key] = value;
+    }
+
+    public static string? GetDetail(string key)
+    {
+        lock (_detailsLock)
+            return _details.GetValueOrDefault(key);
+    }
+
+    internal static void ResetForTests()
+    {
+        _enabled = false;
+        _stopwatch.Reset();
+        _httpRequests = 0;
+        _cacheHits = 0;
+        _cacheMisses = 0;
+        _countingWriter = null;
+        lock (_detailsLock)
+            _details.Clear();
+    }
 
     public static long CharsWritten => _countingWriter?.CharCount ?? 0;
     public static TimeSpan Elapsed => _stopwatch.Elapsed;

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4679,6 +4679,37 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_ReadmeInfo_RecordsSelectedReadmeProvenance()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Info", "README.md", "readme", "agents");
+        try
+        {
+            InfoTracker.ResetForTests();
+            var (exit, output, error) = await ConsoleCapture.RunAsync(async () =>
+            {
+                InfoTracker.Start();
+                return await PackageCommand.ExecuteAsync(new InspectionOptions
+                {
+                    PackageArgs = [packagePath],
+                    ShowReadme = true,
+                    TipLevel = TipLevel.Quiet
+                });
+            });
+
+            Assert.Equal(0, exit);
+            Assert.Contains("agents", output);
+            Assert.DoesNotContain("readme", output);
+            Assert.Empty(error);
+            Assert.Equal("AGENTS.md (6 B)", InfoTracker.GetDetail("readme"));
+        }
+        finally
+        {
+            InfoTracker.ResetForTests();
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_Signals_ReportsAgentDocumentation()
     {
         var (packagePath, tempDir) = CreateLocalReadmePackage("Test.AgentDocs.Signal", "README.md", "readme", "agents");

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2396,7 +2396,9 @@ public class PackageCommand
             return 1;
         }
 
-        string content = result.Files[0].Content;
+        var file = result.Files[0];
+        InfoTracker.SetDetail("readme", $"{file.Path} ({file.Size.ToString(CultureInfo.InvariantCulture)} B)");
+        string content = file.Content;
         if (!string.IsNullOrEmpty(options.OutputPath))
         {
             File.WriteAllText(options.OutputPath, content);

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -171,7 +171,8 @@ if (showInfo)
             : null,
         Cache = InfoTracker.CacheHits > 0 || InfoTracker.CacheMisses > 0
             ? $"{InfoTracker.CacheHits} {(InfoTracker.CacheHits == 1 ? "hit" : "hits")}, {InfoTracker.CacheMisses} {(InfoTracker.CacheMisses == 1 ? "miss" : "misses")}"
-            : null
+            : null,
+        Readme = InfoTracker.GetDetail("readme")
     };
 
     Console.Error.WriteLine();

--- a/src/dotnet-inspect/Views/InfoView.cs
+++ b/src/dotnet-inspect/Views/InfoView.cs
@@ -16,6 +16,9 @@ public class InfoView
 
     [MarkoutSkipNull]
     public string? Cache { get; set; }
+
+    [MarkoutSkipNull]
+    public string? Readme { get; set; }
 }
 
 [MarkoutContext(typeof(InfoView))]


### PR DESCRIPTION
## Summary

- add readme provenance to `--info` for successful `package --readme` calls
- keep stdout as the raw selected document so existing `--readme | ...` pipelines are unaffected
- report the selected file as `Readme | <path> (<bytes> B)` on stderr alongside Output/Time/Cache

Fixes #962.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `git diff --check`
- `dotnet run --project src/dotnet-inspect -c Release -- package Markout@0.13.6 --readme --info`
