### PR TITLE
Subdivide the fidelity (typed) bucket by DEC#### cause (#920)

### DIFF
--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -106,7 +106,7 @@ internal static class LibraryReport
                 }
 
                 string? residual = Completeness.Residual(function)
-                    ?? (!full ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}" : null);
+                    ?? (!full ? $"fidelity: {BucketFor(function, function.Diagnostics.FirstOrDefault())}" : null);
                 if (residual is null)
                 {
                     report.FullyRaisedMethods++;
@@ -193,11 +193,20 @@ internal static class LibraryReport
         return report.ToReport(buckets);
     }
 
-    static string BucketFor(DecompilerDiagnostic diagnostic)
+    static string BucketFor(IrFunction function, DecompilerDiagnostic diagnostic)
     {
         if (diagnostic.Id is null)
         {
-            return "(typed)";
+            // No pass recorded a reason — but fidelity is computed from the final
+            // tree, never asserted by a pass, so the lowering cause still lives in
+            // the tree (an unrepresentable compiler-generated name, an unverified
+            // by-ref argument, a residual function pointer, ...). Recover it with the
+            // same walk the score uses (FidelityRemarks) and bucket by the stable
+            // DEC#### code, so the opaque "(typed)" catch-all becomes the same
+            // per-cause buckets the recorded diagnostics already produce. The walk
+            // always finds at least one site for a non-Full function, so the
+            // "(typed)" fallback is unreachable in practice — kept only for safety.
+            return FidelityRemarks.Collect(function).FirstOrDefault()?.Code ?? "(typed)";
         }
         if (diagnostic.Id == DiagnosticIds.UnsupportedType)
         {


### PR DESCRIPTION
Closes #920.

## Diagnosis

The library report bucketed every non-Full method whose lowering reason was **not** recorded as a `function.Diagnostics` entry under an opaque `fidelity: (typed)` catch-all (2320+ across all 8 product libraries). `IrFunction.Fidelity` is computed from the final tree, never asserted by a pass, so these methods genuinely lowered fidelity but carried no recorded diagnostic — leaving `BucketFor` with a null id and the uninformative `(typed)` label.

## Fix

Recover the real cause with `FidelityRemarks.Collect` — the *same walk* `IrFunction.Fidelity` uses to score, so the bucket can never drift from the score — and bucket by the stable `DEC####` code. The opaque bucket becomes the same per-cause buckets the recorded diagnostics already produce:

| Bucket | What it is |
| --- | --- |
| `fidelity: DEC0009` | unrepresentable compiler-generated names — anonymous types, display classes, async state machines, primary-ctor `<x>P` capture fields, `<>O` delegate caches (the bulk; inherently unspellable) |
| `fidelity: DEC0007` | unverified by-ref argument (out/in vs ref unknown at a MemberReference call site) |
| `fidelity: DEC0006` | residual function-pointer load |
| `fidelity: DEC0011` | residual exception-filter boundary |
| `fidelity: DEC0010` | residual runtime method/field token |

The smaller actionable causes were previously hidden inside `(typed)`; each is now its own triage target, consistent with the per-code bucketing used everywhere else in the report.

## Verification

`--library-report` over all 8 libraries:

- `fidelity: (typed)` → **0 occurrences** (was 2320+), across every library.
- No `(typed)` label remains; the residual is `fidelity: DEC0009` (~2454) plus the pre-existing recorded-diagnostic fidelity buckets.
- **Report-only change** — the validity and pass-bug code paths are untouched, so no new pass bugs and no validity regressions (every per-library Pass-bugs count stays 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)