### PR TITLE
Reject AND-ed trailing comparisons in tuple-binary raise

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -213,6 +213,53 @@ public class TupleBinaryOperatorPassTests
     }
 
     [Fact]
+    public void TupleEqualsAndedWithComparison_IsNotCollapsedToHigherArity()
+    {
+        // `(a, b) == (c, d) && e == f` is one arity-2 tuple comparison AND a separate
+        // scalar comparison. The trailing `e == f` is lazy and unbacked by the eager
+        // spill prologue; collapsing it into `(a, b, e) == (c, d, f)` invents a third
+        // element. Only the genuine arity-2 tuple may raise.
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.TupleEqualsAndedWithComparison),
+            typeof(TupleBinaryAdversarialSamples));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("&&", output);
+        Assert.DoesNotContain(", e)", output);
+        foreach (var tupleBinary in function.Descendants.OfType<TupleBinaryExpression>())
+            if (tupleBinary.Left is TupleExpression literal)
+                Assert.Equal(2, literal.Elements.Count);
+    }
+
+    [Fact]
+    public void TupleEqualsAndedWithSideEffectComparison_PreservesShortCircuit()
+    {
+        // The collapse would evaluate SideEffect(e)/SideEffect(f) unconditionally
+        // rather than only when the tuple compares equal. The trailing comparison
+        // must stay behind the `&&`.
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.TupleEqualsAndedWithSideEffectComparison),
+            typeof(TupleBinaryAdversarialSamples));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("&&", output);
+        foreach (var tupleBinary in function.Descendants.OfType<TupleBinaryExpression>())
+            if (tupleBinary.Left is TupleExpression literal)
+                Assert.Equal(2, literal.Elements.Count);
+    }
+
+    [Fact]
+    public void TupleEqualsAndedWithTwoComparisons_IsNotCollapsed()
+    {
+        var function = Raised(nameof(TupleBinaryAdversarialSamples.TupleEqualsAndedWithTwoComparisons),
+            typeof(TupleBinaryAdversarialSamples));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("&&", output);
+        foreach (var tupleBinary in function.Descendants.OfType<TupleBinaryExpression>())
+            if (tupleBinary.Left is TupleExpression literal)
+                Assert.Equal(2, literal.Elements.Count);
+    }
+
+    [Fact]
     public void HandWrittenMixedTupleFieldComparison_IsNotRaised()
     {
         var function = Raised(nameof(TupleBinaryAdversarialSamples.LazyMixedLiteralVariableComparison), typeof(TupleBinaryAdversarialSamples));
@@ -277,4 +324,26 @@ public static class TupleBinaryAdversarialSamples
         var rightCopy = right;
         return leftCopy.Sum == rightCopy.Sum && leftCopy.Product == rightCopy.Product;
     }
+
+    // A genuine arity-2 tuple comparison AND-ed with an unrelated scalar comparison.
+    // csc spills the tuple operands eagerly, then lowers the whole expression to
+    // `a == c && b == d && e == f`. The eager prologue belongs ONLY to the tuple
+    // operands; `e == f` is a separate, lazily evaluated source comparison. The pass
+    // must NOT collapse all three comparisons into `(a, b, e) == (c, d, f)`.
+    public static bool TupleEqualsAndedWithComparison(int a, int b, int c, int d, int e, int f)
+        => (a, b) == (c, d) && e == f;
+
+    // The soundness twin: the trailing comparison has observable side effects. An
+    // arity-3 collapse would call SideEffect(e)/SideEffect(f) unconditionally instead
+    // of only when the tuple compares equal, changing short-circuit behavior.
+    public static bool TupleEqualsAndedWithSideEffectComparison(int a, int b, int c, int d, int e, int f)
+        => (a, b) == (c, d) && SideEffect(e) == SideEffect(f);
+
+    // Two appended comparisons: the flattened chain ends in `g == h`, also unbacked
+    // by the prologue, so `(a, b, e, g) == (c, d, f, h)` must not be raised either.
+    public static bool TupleEqualsAndedWithTwoComparisons(int a, int b, int c, int d, int e, int f, int g, int h)
+        => (a, b) == (c, d) && e == f && g == h;
+
+    static int s_ticks;
+    static int SideEffect(int v) { s_ticks++; return v; }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -33,7 +33,7 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("pdb.hidden-local", "absence of source local names on operand spills"),
             ],
             PositiveCoverage: "TupleBinaryOperatorPassTests whole-tuple equality fixtures including arity 3, arity-2 whole-tuple inequality, tuple-literal equality/inequality (including arity 3), mixed literal-vs-variable, side-effect-order, and const-element fixtures",
-            AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, hand-written mixed tuple-field comparison, direct manual field comparison, and source-named local field comparison",
+            AdversarialCoverage: "TupleBinaryOperatorPassTests lazy short-circuit comparison, hand-written mixed tuple-field comparison, direct manual field comparison, source-named local field comparison, and tuple-equality AND-ed with a trailing unbacked comparison (last-comparison must consume a prologue spill, so `(a,b)==(c,d) && e==f` is not collapsed to arity 3)",
             MissingDiscriminator: "whole-tuple inequality arity 3+ control-flow forms, nested/rest tuples, and no-PDB source-local comparisons still owed"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
@@ -255,6 +255,23 @@ public sealed class TupleBinaryOperatorPass : IIrPass
         if (spills.Count == 0)
             return false;
 
+        // csc evaluates every tuple operand eagerly into the spill prologue before
+        // the first element comparison, so the LAST element's operands are spilled
+        // even though they are compared last. A hand-written `&& x == y` appended to
+        // a tuple comparison (`(a, b) == (c, d) && e == f`) is evaluated lazily
+        // after the tuple's short-circuit branch, so both its operands are fresh
+        // inline loads, never prologue spills. The flattened chain therefore ends in
+        // a comparison with no spill backing. Require the last comparison to read at
+        // least one operand from the prologue; otherwise the chain ends in an
+        // appended comparison, and collapsing it would invent an extra tuple element
+        // and drop the `&&`'s short-circuit (evaluating e/f — including their side
+        // effects — unconditionally). A genuine inline element (a const or the single
+        // first-evaluated operand) only ever sits opposite a spilled operand, so this
+        // never rejects a real tuple literal.
+        var lastComparison = comparisons[^1];
+        if (!ConsumesSpill(lastComparison.Left, spills) && !ConsumesSpill(lastComparison.Right, spills))
+            return false;
+
         if (!TryClassifySide(comparisons, comparison => comparison.Left, spills, out var leftPlan)
             || !TryClassifySide(comparisons, comparison => comparison.Right, spills, out var rightPlan))
         {
@@ -293,6 +310,17 @@ public sealed class TupleBinaryOperatorPass : IIrPass
             spill.Detach();
         return true;
     }
+
+    // An operand is backed by the eager spill prologue when it is an element spill
+    // load (a literal element) or an Item load on a spilled tuple variable. A fresh
+    // inline load (parameter, field, call) is not — it marks lazily evaluated code.
+    static bool ConsumesSpill(IrExpression operand, Dictionary<int, StoreLocal> spills)
+        => operand switch
+        {
+            LoadLocal load => spills.ContainsKey(load.Index),
+            LoadField { Instance: LoadLocal receiver } => spills.ContainsKey(receiver.Index),
+            _ => false,
+        };
 
     /// <summary>A recovered tuple operand: a literal (rebuild the elements) or a variable (the stored tuple).</summary>
     sealed class SidePlan


### PR DESCRIPTION
Adversarial review of the **Tuple binary** row in the #959 review queue (operand-comparison form of `TupleBinaryOperatorPass`).

## Claim under test

> This pass may raise a `&&`/`||` comparison chain to a tuple `==`/`!=` only when the eager hidden-ValueTuple spill prologue proves the *whole* chain came from a tuple operator, not hand-written short-circuit code.

## Falsification

`TryRaiseOperandComparisonAt` greedily flattens the entire `&&` chain and only required that *some* spill exists and all spills are consumed — it never checked that **every** comparison is backed by the eager prologue. So a genuine tuple compare AND-ed with an independent comparison over-raises (reproduced in Release IL):

| Source | Decompiled (before) | |
| --- | --- | --- |
| `(a, b) == (c, d)` | `(a, b) == (c, d)` | ✓ control |
| `(a, b) == (c, d) && e == f` | `(a, b, e) == (c, d, f)` | wrong idiom — invents a third element |
| `(a, b) == (c, d) && Tick(e) == Tick(f)` | `(a, b, Tick(e)) == (c, d, Tick(f))` | **soundness bug** — `Tick(e)`/`Tick(f)` now run unconditionally instead of only when the tuple is equal; the IL round-trip oracle independently rejects it |

## Discriminator added

csc evaluates every tuple operand eagerly into the spill prologue *before* the first element comparison, so the **last** element's operands are always spilled; an appended lazy `&& x == y` is evaluated after the short-circuit branch and is never in the prologue. The fix requires the **last flattened comparison to read ≥1 operand from the spill prologue**.

This is exact: every currently-raising shape (`(a, 5) == (c, d)`, `(1, x) == (2, y)`, mixed literal-vs-variable, arity-3) keeps a spill-backed last comparison, while both bug shapes are rejected. A genuine inline element (a const or the single first-evaluated operand) only ever sits opposite a spilled operand.

## Tests

- Three failing-first negatives added to `TupleBinaryAdversarialSamples`: the AND-ed comparison, the side-effecting short-circuit twin, and a two-trailing-comparison case.
- `TupleRecoveryFacts` `AdversarialCoverage` sharpened to record the reviewed edge.
- Full decompiler suite in Release (CI config): **814 tests, 0 failures**. The two side-effecting fixtures round-trip cleanly through the fidelity gate.

Tracking: #959 (Tuple binary row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)