### PR TITLE
Sub-classify the conditional-branch gap bucket by shape (#921)

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -80,6 +80,15 @@ after every step of this plan.
   are **per container** (a method may bail in more than one container), which is
   why the totals differ from `--gaps`'s per-method residual count. Honors
   `--cap` to bound a partial sweep.
+- **The bucket shape histogram** — `decompiler-harness --gaps --by-shape`
+  sub-classifies the `structuring: conditional-branch` bucket itself
+  (`ConditionalBranchShapeClassifier`) by the shape around each method's first
+  residual guard: `loop-residue` (an unraised back-edge), `eh-entangled` (a
+  surviving EH terminator), `comparison-tree` (a sparse-switch if-tree),
+  `shared-forward-merge` (a join reached by two or more branches), and
+  `nonnested-forward-guards` (interleaved single-predecessor guards — the
+  is-pattern / type-test dispatch). Unlike `--structuring-stops` this counts
+  **per method in the bucket**, so it scopes which slice clears the most methods.
 
 Two shapes that are **already handled** and are out of scope: short-circuit
 `&&`/`||` guard chains (they nest cleanly today — the `TripleAnd`/`IfAnd`/

--- a/tools/DecompilerHarness/ConditionalBranchShapeClassifier.cs
+++ b/tools/DecompilerHarness/ConditionalBranchShapeClassifier.cs
@@ -1,0 +1,131 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Sub-classifies a method in the <c>structuring: conditional-branch</c> bucket by
+/// the structural shape of the residual control flow around its first surviving
+/// <see cref="ConditionalBranch"/>. Backs <c>--gaps --by-shape</c>: turning the
+/// flat bucket count into a shape histogram is what scopes the next
+/// <see cref="StructuringPass"/> slice (issue #921).
+///
+/// <para>Unlike <see cref="SwitchShapeClassifier"/> — which reads the imported
+/// (pre-pass) tree because the passes flatten an unraised switch — a residual
+/// conditional branch survives in the FINISHED tree: when the structuring slice
+/// rejects a container it keeps the always-correct flat block list, so the
+/// surviving <c>if (c) goto</c> is read directly from the post-pass function.</para>
+///
+/// <para>The buckets are checked in priority order, most-blocking first, and each
+/// was verified against a <c>--dump</c> of a representative method. They mirror the
+/// container-level stop reasons of <c>--structuring-stops</c>, attributed here to
+/// the method that lands in the bucket:</para>
+/// <list type="bullet">
+/// <item><c>loop-residue</c> — the container has a backward branch (a do/while,
+///   <c>continue</c>, or iterator state machine the loop passes did not raise,
+///   e.g. TypeSourceComposer::ShortenSegment); out of scope for forward
+///   structuring.</item>
+/// <item><c>eh-entangled</c> — an unstructured EH terminator (<see cref="Leave"/>/
+///   <see cref="EndFinally"/>/<see cref="EndFilter"/>) survives, so the conditional
+///   sits in or beside a try/catch/finally the EH pass left flat (e.g.
+///   TypeSourceComposer::ComposeFields).</item>
+/// <item><c>comparison-tree</c> — four or more constant comparisons on a value (a
+///   csc sparse <c>switch</c> or range cascade lowered to an if-tree, e.g.
+///   HttpClientFactory::IsNonPublic); a dedicated multi-way raise.</item>
+/// <item><c>shared-forward-merge</c> — a forward target reached by two or more
+///   branches: a genuine shared join past a region that strict nesting cannot
+///   name (the <c>cond-target-past-region</c>/<c>forward-branch-not-region-exit</c>
+///   family, e.g. TypeSourceComposer::ComposeMembers).</item>
+/// <item><c>nonnested-forward-guards</c> — only forward branches, each to a
+///   single-predecessor target, whose ranges interleave instead of nesting: the
+///   csc lowering for an <c>is</c>-pattern / type-test dispatch or a short-circuit
+///   guard chain (e.g. CSharpPrinter::IsUnsafeOperation, SamePlace). The
+///   single-predecessor sibling of <c>shared-forward-merge</c> — the index-range
+///   slice rejects the overlap. (Had the forward branches nested cleanly the
+///   method would already be raised, so this is never a trivial single guard.)</item>
+/// </list>
+/// </summary>
+static class ConditionalBranchShapeClassifier
+{
+    /// <summary>Mirrors ComparisonTrees.MinComparisons (internal to the decompiler): the sparse-switch floor.</summary>
+    const int MinComparisons = 4;
+
+    public static string Classify(IrFunction function)
+    {
+        // The container holding the first residual conditional branch. A fully
+        // raised method keeps none; the caller filtered to the bucket that does.
+        BlockContainer? container = null;
+        foreach (var c in function.Descendants.OfType<BlockContainer>())
+        {
+            if (c.Blocks.Any(b => b.Children.Count > 0 && b.Children.Any(n => n is ConditionalBranch)))
+            {
+                container = c;
+                break;
+            }
+        }
+        if (container is null)
+            return "no-residual-conditional";   // defensive: caller filtered to the bucket
+
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        // 1. Loop residue: any branch in the container targets a block at or before
+        // the branching block — a back-edge, the signature of an unraised loop or a
+        // mid-body continue. Forward structuring cannot consume it.
+        for (int i = 0; i < blocks.Count; i++)
+            foreach (int t in BranchTargets(blocks[i]))
+                if (offsetToIndex.TryGetValue(t, out int ti) && ti <= i)
+                    return "loop-residue";
+
+        // 2. EH entanglement: an unstructured EH terminator survives anywhere in the
+        // method, so the EH pass left a try/catch/finally flat and the conditional
+        // cannot structure across its boundary.
+        if (function.Descendants.Any(n => n is Leave or EndFinally or EndFilter))
+            return "eh-entangled";
+
+        // 3. Comparison tree: four or more constant comparisons (csc's sparse switch
+        // or range cascade as an if-tree). Mirrors ComparisonTrees.IsLikely.
+        int constantComparisons = 0;
+        foreach (var block in blocks)
+            if (block.Children.Count > 0
+                && block.Children[^1] is ConditionalBranch { Condition: Comparison comparison }
+                && (comparison.Left is Constant || comparison.Right is Constant))
+                constantComparisons++;
+        if (constantComparisons >= MinComparisons)
+            return "comparison-tree";
+
+        // 4. Shared forward merge: a forward target reached by two or more branches.
+        // A genuine multi-goto join that strict nesting cannot express — the merge
+        // past the region the index-range model could not name.
+        var forwardPredecessors = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            foreach (int t in BranchTargets(blocks[i]))
+                if (offsetToIndex.TryGetValue(t, out int ti) && ti > i)
+                    forwardPredecessors[ti] = forwardPredecessors.GetValueOrDefault(ti) + 1;
+        if (forwardPredecessors.Values.Any(count => count >= 2))
+            return "shared-forward-merge";
+
+        // Only forward branches remain, each to a single-predecessor target: had
+        // they nested cleanly the method would be raised, so their ranges
+        // interleave (the is-pattern/type-test dispatch and short-circuit chains).
+        return "nonnested-forward-guards";
+    }
+
+    static IEnumerable<int> BranchTargets(Block block)
+    {
+        foreach (var node in block.Children)
+        {
+            switch (node)
+            {
+                case Branch b: yield return b.TargetOffset; break;
+                case ConditionalBranch c: yield return c.TargetOffset; break;
+                case SwitchBranch sw:
+                    foreach (int t in sw.TargetOffsets) yield return t;
+                    break;
+                case Leave lv: yield return lv.TargetOffset; break;
+            }
+        }
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -175,8 +175,10 @@ static class Program
         long total = 0, clean = 0, crashes = 0;
         var buckets = new Dictionary<string, (long Count, List<string> Examples)>();
         // When --by-shape is set, sub-classify the switch-branch bucket by the
-        // structural shape of its residual switch (issue #682 item 2).
+        // structural shape of its residual switch (issue #682 item 2) and the
+        // conditional-branch bucket by the shape around its residual guard (#921).
         var switchShapes = new Dictionary<string, (long Count, List<string> Examples)>();
+        var conditionalShapes = new Dictionary<string, (long Count, List<string> Examples)>();
 
         void Record(string bucket, string method)
         {
@@ -187,13 +189,13 @@ static class Program
             buckets[bucket] = (b.Count + 1, b.Examples);
         }
 
-        void RecordShape(string shape, string method)
+        void RecordShape(Dictionary<string, (long Count, List<string> Examples)> shapes, string shape, string method)
         {
-            if (!switchShapes.TryGetValue(shape, out var b))
+            if (!shapes.TryGetValue(shape, out var b))
                 b = (0, new List<string>());
             if (b.Examples.Count < maxExamples)
                 b.Examples.Add(method);
-            switchShapes[shape] = (b.Count + 1, b.Examples);
+            shapes[shape] = (b.Count + 1, b.Examples);
         }
 
         using var metadata = CorpusMetadata.Create(assemblies);
@@ -229,7 +231,11 @@ static class Program
                 {
                     Record(bucket, id);
                     if (byShape && bucket == "structuring: switch-branch")
-                        RecordShape(SwitchShapeClassifier.Classify(prePass!), id);
+                        RecordShape(switchShapes, SwitchShapeClassifier.Classify(prePass!), id);
+                    // The residual conditional survives in the finished tree, so
+                    // classify the post-pass function rather than the pre-pass clone.
+                    if (byShape && bucket == "structuring: conditional-branch")
+                        RecordShape(conditionalShapes, ConditionalBranchShapeClassifier.Classify(function), id);
                 }
             }
         }
@@ -247,6 +253,13 @@ static class Program
             Console.WriteLine();
             Console.WriteLine("switch-branch bucket by structural shape (--by-shape):");
             foreach (var s in switchShapes.OrderByDescending(s => s.Value.Count))
+                Console.WriteLine($"  {s.Value.Count,8}  {s.Key,-38}  e.g. {string.Join(" | ", s.Value.Examples.Take(3))}");
+        }
+        if (byShape && conditionalShapes.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("conditional-branch bucket by structural shape (--by-shape):");
+            foreach (var s in conditionalShapes.OrderByDescending(s => s.Value.Count))
                 Console.WriteLine($"  {s.Value.Count,8}  {s.Key,-38}  e.g. {string.Join(" | ", s.Value.Examples.Take(3))}");
         }
         return crashes > 0 ? 1 : 0;
@@ -1008,9 +1021,10 @@ static class Program
                                 raised tree still holds unstructured control flow
                                 (a surviving goto) or an unsupported node, bucketed
                                 by residual kind. The completeness signal.
-          --by-shape            with --gaps: sub-classify the switch-branch bucket
-                                by the structural shape of its residual switch, so
-                                a bucket count becomes a per-shape slice docket.
+          --by-shape            with --gaps: sub-classify the switch-branch and
+                                conditional-branch buckets by the structural shape
+                                of their residual control flow, so a bucket count
+                                becomes a per-shape slice docket.
           --annotation-check      hidden-fact annotation check — the analyzer analog
                                 of --fidelity-check. Cross-checks each allocation/
                                 unsafety/lifetime annotation against the raw IL


### PR DESCRIPTION
Investigation step for #921.

`structuring: conditional-branch` is the largest structuring gap — **633 methods across the 8 product libraries** — but the flat count gives no signal about which structuring slice would clear the most methods. This adds a shape sub-classifier (mirroring the existing `SwitchShapeClassifier`) and wires it into `--gaps --by-shape`, turning the bucket into a per-shape docket.

## Breakdown (full 8-library corpus)

| Shape | Count | Nature |
|---|---:|---|
| `shared-forward-merge` | 242 | a join reached by 2+ branches (the `cond-target-past-region` family) |
| `loop-residue` | 237 | an unraised back-edge / `continue` — loop-pass work |
| `nonnested-forward-guards` | 76 | interleaved single-predecessor guards (csc `is`-pattern / type-test dispatch) |
| `comparison-tree` | 51 | a sparse-`switch` lowered to an if-tree |
| `eh-entangled` | 25 | a surviving EH terminator blocks structuring |

## How it works

The residual `ConditionalBranch` survives in the **finished** tree (a container the structuring slice rejects keeps its always-correct flat form), so the classifier reads the post-pass function directly — unlike `SwitchShapeClassifier`, which reads the pre-pass clone because the passes flatten an unraised switch.

Categories were verified against `--dump` of representatives (e.g. `SamePlace`/`IsUnsafeOperation` for `nonnested-forward-guards`, `ComposeFields` for `loop-residue`, `IsNonPublic` for `comparison-tree`) and cross-checked against the per-container `--structuring-stops` histogram.

## Scope

Harness-only diagnostic (`tools/DecompilerHarness`) plus a docs paragraph. **No product or pipeline behavior changes** — `--gaps` totals, `--structuring-stops`, and the switch-branch sub-classification are unchanged (`RecordShape` was generalized to take the target dict). The histogram scopes the follow-up slices; the self-contained `comparison-tree` raise is the most tractable next target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)