### PR TITLE
Redirect .claude/CLAUDE.md to AGENTS.md as the single source of truth

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,61 +1,7 @@
 # Project Instructions
 
-## Testing
+All contributor guidance lives in [AGENTS.md](../AGENTS.md) — it is the single
+source of truth (repository map, building and testing, file-based apps, git and
+branching rules, the output-verbosity contract, and markdown linting).
 
-This project uses **xunit v3** with `OutputType Exe`. Tests MUST be run with `dotnet run`, NOT `dotnet test`:
-
-```bash
-dotnet run --project src/dotnet-inspect.Tests
-dotnet run --project src/ILInspector.Analysis.Tests
-dotnet run --project src/ILInspector.Decompiler.Tests
-dotnet run --project src/DotnetInspector.Services.Tests
-dotnet run --project tests/ILInspector.Metadata.Tests
-dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests
-```
-
-`dotnet test` will silently produce no output and appear to hang.
-
-Some tests require `ilasm`/`ildasm` and will skip if not installed.
-
-`DotnetInspector.ILRoundtrip.Tests` requires the vendored managed ILAssembler
-(orphan branch `vendor/ilassembler`); run `eng/restore-ilassembler.sh` once to
-materialize it at `external/ILAssembler`. Edits under `external/ILAssembler`
-commit directly to the vendor branch — see its README for the fork policy.
-
-## Building
-
-```bash
-dotnet build src/dotnet-inspect -c Release
-```
-
-## File-Based Apps
-
-Do NOT use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files. Use .NET 10 file-based apps instead. Prefer file-based apps over Python unless a specific Python library is needed.
-
-Run with `dotnet run /tmp/check.cs`. Write throwaway scripts to `/tmp/`.
-
-To reference a project:
-
-```csharp
-#:project ../src/MyLib/MyLib.csproj
-
-using MyLib.Domain;
-
-var items = await MyService.LoadAsync();
-Console.WriteLine($"Found {items.Count} items");
-```
-
-## Branching
-
-The `main` branch is protected. Create feature branches like `feature/issue-3-assembly-references` or `fix/null-reference-in-parser`.
-
-## Markdown Linting
-
-All markdown files must pass `markdownlint` before committing. Run the auto-fixer first:
-
-```bash
-npx markdownlint-cli --fix <file>
-npx markdownlint-cli <file>
-```
-
-Run `markdownlint` on all changed markdown files when preparing a PR.
+**Read [AGENTS.md](../AGENTS.md) before doing any work in this repo.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
 
 Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if not installed.
 
+`DotnetInspector.ILRoundtrip.Tests` requires the vendored managed ILAssembler
+(orphan branch `vendor/ilassembler`); run `eng/restore-ilassembler.sh` once to
+materialize it at `external/ILAssembler`. Edits under `external/ILAssembler`
+commit directly to the vendor branch — see its README for the fork policy.
+
 ## Output Verbosity Contract
 
 Commands that render sections should follow this verbosity model:


### PR DESCRIPTION
## Problem

`.claude/CLAUDE.md` (the file Claude Code auto-loads) duplicated parts of `AGENTS.md` and had drifted from it. Its Branching section omitted the **worktree requirement** and the **never-amend** rule that AGENTS.md states — so an agent trusting the auto-loaded CLAUDE.md never saw them. Two sources of truth that diverge is the recurring problem.

## Change

- **`.claude/CLAUDE.md`** → a redirect: AGENTS.md is named as the single source of truth, with an instruction to read it before any work.
- **`AGENTS.md`** → migrated in the one detail that lived *only* in CLAUDE.md: the vendored-ILAssembler restore note (`eng/restore-ilassembler.sh` / `external/ILAssembler` / vendor-branch fork policy) for `DotnetInspector.ILRoundtrip.Tests`, appended to Building and Testing. Everything else in CLAUDE.md was already an AGENTS.md subset, so nothing is lost.

CLAUDE.md is **kept, not deleted**: it is the file Claude Code auto-loads, whereas AGENTS.md is not — so the redirect is the guaranteed breadcrumb that points every session at the real guidance. (If AGENTS.md is later confirmed to auto-load natively, deleting CLAUDE.md becomes safe.)

This is a deliberately minimal "pure redirect" so we can see whether the redirect alone is effective; a short critical-rules callout (worktree + never-amend) can be added later if it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)