### PR TITLE
Fix CS0029 stack slot reuse validity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
@@ -8,6 +8,7 @@ public class StackSlotReuseRenderingTests
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
 
@@ -58,11 +59,37 @@ public class StackSlotReuseRenderingTests
         var output = CSharpPrinter.Print(function).Output!;
 
         Assert.Contains("object S_0;", output);
-        Assert.Contains("bool S_0_1 = default;", output);
+        Assert.Contains("bool S_0_1;", output);
         Assert.DoesNotContain("int S_0_1", output);
         Assert.Contains("S_0_1 = false;", output);
         Assert.Contains("S_0_1 = flag;", output);
         Assert.Contains("ConsumeBool(S_0_1 | other);", output);
+    }
+
+    [Fact]
+    public void SubtypeStoreSupertypeLoadStaysOneVariable()
+    {
+        var consumeObject = new MethodRef(Holder, "ConsumeObject", Void, [Object], HasThis: false);
+        var block = new Block(0);
+        block.Add(new IfStatement(
+            new LoadArgument(0, "flag", Bool),
+            BlockOf(new StoreStackSlot(0, new LoadArgument(1, "s", String))),
+            BlockOf(new StoreStackSlot(0, new LoadArgument(2, "o", Object)))));
+        block.Add(new IfStatement(
+            new LoadArgument(3, "useException", Bool),
+            BlockOf(new StoreStackSlot(0, new LoadArgument(4, "e", Exception))),
+            null));
+        block.Add(new ExpressionStatement(new Call(consumeObject, isVirtual: false, [new LoadStackSlot(0, Object)])));
+        block.Add(new Return(null));
+
+        var output = CSharpPrinter.Print(Function(Void, block)).Output!;
+
+        Assert.Contains("object S_0;", output);
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.Contains("S_0 = s;", output);
+        Assert.Contains("S_0 = o;", output);
+        Assert.Contains("S_0 = e;", output);
+        Assert.Contains("ConsumeObject(S_0);", output);
     }
 
     static Block BlockOf(IrNode statement)

--- a/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
@@ -1,0 +1,81 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StackSlotReuseRenderingTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void FoldedDiamondUsesPostDiamondStackSlotType()
+    {
+        var contains = new MethodRef(String, "Contains", Bool, [String], HasThis: true);
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(256, new LoadArgument(0, "text", String)));
+        block.Add(new StoreStackSlot(0, new LoadStackSlot(256, String)));
+        block.Add(new IfStatement(
+            new LoadStackSlot(256, String),
+            BlockOf(new StoreStackSlot(0, new Call(
+                contains,
+                isVirtual: false,
+                [new LoadStackSlot(0, String), new Constant("x", String)]))),
+            BlockOf(new StoreStackSlot(0, new Constant(0, Int32)))));
+        block.Add(new Return(new LoadStackSlot(0, Int32)));
+
+        var function = Function(Int32, block);
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("string S_0;", output);
+        Assert.Contains("int S_0_1", output);
+        Assert.Contains("S_0_1 = S_256 is not null ? S_0.Contains(\"x\") ? 1 : 0 : 0;", output);
+        Assert.Contains("return S_0_1;", output);
+    }
+
+    [Fact]
+    public void BooleanSlotMaterializationIgnoresUnrelatedSameNumberLiveRange()
+    {
+        var consumeObject = new MethodRef(Holder, "ConsumeObject", Void, [Object], HasThis: false);
+        var consumeBool = new MethodRef(Holder, "ConsumeBool", Void, [Bool], HasThis: false);
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "value", Object)));
+        block.Add(new ExpressionStatement(new Call(consumeObject, isVirtual: false, [new LoadStackSlot(0, Object)])));
+        block.Add(new StoreStackSlot(0, new Constant(0, Int32)));
+        block.Add(new StoreStackSlot(0, new LoadArgument(1, "flag", Bool)));
+        block.Add(new ExpressionStatement(new Call(
+            consumeBool,
+            isVirtual: false,
+            [new Binary(BinaryKind.Or, isChecked: false, isUnsigned: false, new LoadStackSlot(0, Int32), new LoadArgument(2, "other", Bool))])));
+        block.Add(new Return(null));
+
+        var function = Function(Void, block);
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("object S_0;", output);
+        Assert.Contains("bool S_0_1 = default;", output);
+        Assert.DoesNotContain("int S_0_1", output);
+        Assert.Contains("S_0_1 = false;", output);
+        Assert.Contains("S_0_1 = flag;", output);
+        Assert.Contains("ConsumeBool(S_0_1 | other);", output);
+    }
+
+    static Block BlockOf(IrNode statement)
+    {
+        var block = new Block(0);
+        block.Add(statement);
+        return block;
+    }
+
+    static IrFunction Function(TypeRef returnType, Block block)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction("M", Holder, new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0), [], body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
@@ -34,7 +34,8 @@ public class StackSlotReuseRenderingTests
 
         Assert.Contains("string S_0;", output);
         Assert.Contains("int S_0_1", output);
-        Assert.Contains("S_0_1 = S_256 is not null ? S_0.Contains(\"x\") ? 1 : 0 : 0;", output);
+        Assert.Contains("S_0_1 = S_256 is not null", output);
+        Assert.Contains("S_0.Contains(\"x\") ? 1 : 0", output);
         Assert.Contains("return S_0_1;", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1322,17 +1322,6 @@ public sealed partial class CSharpPrinter
         _ => $"/* {node.Describe()} */",
     };
 
-    string ConditionalText(Conditional conditional)
-    {
-        string whenTrue = conditional.MergedType is { } target
-            ? CastValue(conditional.WhenTrue, target)
-            : Operand(conditional.WhenTrue);
-        string whenFalse = conditional.MergedType is { } target2
-            ? CastValue(conditional.WhenFalse, target2)
-            : Operand(conditional.WhenFalse);
-        return $"{Condition(conditional.Condition)} ? {whenTrue} : {whenFalse}";
-    }
-
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -265,6 +265,7 @@ public sealed partial class CSharpPrinter
 
     readonly Dictionary<StackSlotRenderKey, string> _stackSlotNames = [];
     readonly Dictionary<StoreStackSlot, TypeRef?> _stackSlotStoreTypes = [];
+    readonly Dictionary<int, TypeRef> _stackSlotUnifiedTypes = [];
     readonly SortedDictionary<(int Slot, int Ordinal), (string Name, TypeRef? Type)> _stackSlotDeclarations = [];
 
     string PrintBody(IrFunction function)
@@ -460,9 +461,7 @@ public sealed partial class CSharpPrinter
             // (CS8174); spell IL's null-reference zero-init as Unsafe.NullRef<T>().
             yield return type is { Kind: TypeRefKind.ByRef }
                 ? $"{TypeText(type)} {name} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
-                : ordinal > 0 && type is not null
-                    ? $"{TypeText(type)} {name} = default;"
-                    : $"{(type is null ? "var" : TypeText(type))} {name};";
+                : $"{(type is null ? "var" : TypeText(type))} {name};";
         }
     }
 
@@ -470,11 +469,38 @@ public sealed partial class CSharpPrinter
     {
         _stackSlotNames.Clear();
         _stackSlotStoreTypes.Clear();
+        _stackSlotUnifiedTypes.Clear();
         _stackSlotDeclarations.Clear();
 
         var nodes = DescendantsOutsideNestedFunctions(function).ToList();
+        var storesBySlot = new Dictionary<int, List<IrExpression>>();
+        var loadsBySlot = new Dictionary<int, List<TypeRef?>>();
+        foreach (var node in nodes)
+        {
+            switch (node)
+            {
+                case StoreStackSlot store:
+                    (storesBySlot.TryGetValue(store.Slot, out var stores) ? stores : storesBySlot[store.Slot] = []).Add(store.Value);
+                    break;
+                case LoadStackSlot load:
+                    (loadsBySlot.TryGetValue(load.Slot, out var loads) ? loads : loadsBySlot[load.Slot] = []).Add(load.Type);
+                    break;
+            }
+        }
+
+        foreach (int slot in storesBySlot.Keys.Concat(loadsBySlot.Keys).Distinct())
+        {
+            if (TryChooseUnifiedStackSlotType(
+                storesBySlot.GetValueOrDefault(slot) ?? [],
+                loadsBySlot.GetValueOrDefault(slot) ?? [],
+                out var unifiedType))
+            {
+                _stackSlotUnifiedTypes[slot] = unifiedType;
+            }
+        }
+
         foreach (var store in nodes.OfType<StoreStackSlot>())
-            _stackSlotStoreTypes[store] = store.Value.ResultType;
+            _stackSlotStoreTypes[store] = StackSlotRenderType(store.Slot, store.Value.ResultType);
 
         var ordinals = new Dictionary<int, int>();
 
@@ -497,7 +523,7 @@ public sealed partial class CSharpPrinter
             switch (node)
             {
                 case LoadStackSlot load:
-                    NameFor(load.Slot, load.Type);
+                    NameFor(load.Slot, StackSlotRenderType(load.Slot, load.Type));
                     break;
                 case StoreStackSlot store:
                     NameFor(store.Slot, StackSlotTargetType(store));
@@ -506,13 +532,90 @@ public sealed partial class CSharpPrinter
         }
     }
 
+    bool TryChooseUnifiedStackSlotType(IReadOnlyList<IrExpression> stores, IReadOnlyList<TypeRef?> loads, out TypeRef unifiedType)
+    {
+        var candidates = loads.Concat(stores.Select(store => store.ResultType))
+            .Where(type => type is not null)
+            .Cast<TypeRef>()
+            .Distinct()
+            .ToList();
+        foreach (var candidate in candidates)
+        {
+            if (stores.All(store => CanAssignTo(store, candidate))
+                && loads.All(load => load is null || CanAssignType(candidate, load)))
+            {
+                unifiedType = candidate;
+                return true;
+            }
+        }
+
+        unifiedType = TypeRef.CoreLib("System", "Object");
+        return false;
+    }
+
+    bool CanAssignTo(IrExpression value, TypeRef target)
+        => value is Constant { Value: null }
+            ? IsReferenceLike(target)
+            : value.ResultType is { } source && CanAssignType(source, target);
+
+    bool CanAssignType(TypeRef source, TypeRef target)
+    {
+        if (source.Equals(target))
+            return true;
+        if (IsImplicitNumericAssignment(source, target))
+            return true;
+        if (IsCoreObject(target) && IsReferenceLike(source))
+            return true;
+        return false;
+    }
+
+    bool IsReferenceLike(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
+            return false;
+        if (TypeFamilies.Of(type) == StackFamily.O)
+            return true;
+        if (type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType)
+            return true;
+        if (_function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference)
+            return true;
+        return type.Kind is TypeRefKind.Definition or TypeRefKind.GenericInstance
+            && type.DeclaredValueTypeHint != ValueTypeHint.ValueType
+            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.ValueType or TypeShape.Enum)
+            && !TypeFamilies.IsNumericPrimitive(type);
+    }
+
+    static bool IsCoreObject(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
+
+    static bool IsImplicitNumericAssignment(TypeRef source, TypeRef target)
+    {
+        if (!TypeFamilies.IsNumericPrimitive(source) || !TypeFamilies.IsNumericPrimitive(target))
+            return false;
+        return (source.Name, target.Name) switch
+        {
+            ("SByte", "Int16" or "Int32" or "Int64" or "Single" or "Double") => true,
+            ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int16", "Int32" or "Int64" or "Single" or "Double") => true,
+            ("UInt16", "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Char", "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int32", "Int64" or "Single" or "Double") => true,
+            ("UInt32", "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int64" or "UInt64" or "Single", "Double") => true,
+            _ => false,
+        };
+    }
+
+    TypeRef? StackSlotRenderType(int slot, TypeRef? type)
+        => _stackSlotUnifiedTypes.TryGetValue(slot, out var unifiedType) ? unifiedType : type;
+
     static string StackSlotTypeKey(TypeRef? type) => type?.ToDisplayString() ?? "<unknown>";
 
     TypeRef? StackSlotTargetType(StoreStackSlot store)
         => _stackSlotStoreTypes.TryGetValue(store, out var type) ? type : store.Value.ResultType;
 
     string StackSlotName(LoadStackSlot load)
-        => _stackSlotNames.TryGetValue(new StackSlotRenderKey(load.Slot, StackSlotTypeKey(load.Type)), out var name)
+        => _stackSlotNames.TryGetValue(new StackSlotRenderKey(load.Slot, StackSlotTypeKey(StackSlotRenderType(load.Slot, load.Type))), out var name)
             ? name
             : $"S_{load.Slot}";
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -261,6 +261,12 @@ public sealed partial class CSharpPrinter
     /// <summary>Optional sink mapping each printed top-level statement node to its 0-based start line in the output; null on the shipped print path. Drives line-anchored overlays (annotated views) without the printer knowing what they are.</summary>
     Dictionary<IrNode, int>? _statementLines;
 
+    readonly record struct StackSlotRenderKey(int Slot, string TypeKey);
+
+    readonly Dictionary<StackSlotRenderKey, string> _stackSlotNames = [];
+    readonly Dictionary<StoreStackSlot, TypeRef?> _stackSlotStoreTypes = [];
+    readonly SortedDictionary<(int Slot, int Ordinal), (string Name, TypeRef? Type)> _stackSlotDeclarations = [];
+
     string PrintBody(IrFunction function)
     {
         var sb = new StringBuilder();
@@ -278,6 +284,7 @@ public sealed partial class CSharpPrinter
                 if (deconstruction.IsDeclared[i])
                     _deconstructionLocals.Add(deconstruction.LocalIndices[i]);
         CollectDeclaringStores(function);
+        CollectStackSlotNames(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
             _facts.LocalNames = [.. Enumerable.Range(0, function.Locals.Length).Select(LocalName)];
@@ -394,9 +401,6 @@ public sealed partial class CSharpPrinter
     IEnumerable<string> CollectDeclarations(IrFunction function)
     {
         var locals = new SortedSet<int>();
-        var slots = new SortedDictionary<int, TypeRef?>();
-        var slotLoadTypes = new Dictionary<int, TypeRef?>();
-        var slotStoreTypes = new Dictionary<int, TypeRef?>();
         // Catch variables declare in their clause header, not up front.
         var clauseDeclared = function.Descendants.OfType<CatchClause>()
             .Where(clause => clause.VariableIndex is not null)
@@ -412,20 +416,7 @@ public sealed partial class CSharpPrinter
                 case NullCoalescingAssignment n: locals.Add(n.LocalIndex); break;
                 case ForeachStatement f: locals.Add(f.LocalIndex); break;
                 case DeconstructionAssignment d: foreach (int index in d.LocalIndices) locals.Add(index); break;
-                // A slot's declared type is the type it is loaded AS — the merged
-                // join type every predecessor's store is assignable to. A store
-                // value can be a subtype at a join (object slot fed a string),
-                // so store types are only a fallback when the slot is never
-                // loaded with a known type.
-                case LoadStackSlot ls: slotLoadTypes.TryAdd(ls.Slot, ls.Type); break;
-                case StoreStackSlot ss: slotStoreTypes.TryAdd(ss.Slot, ss.Value.ResultType); break;
             }
-        }
-        foreach (int slot in slotLoadTypes.Keys.Concat(slotStoreTypes.Keys).Distinct())
-        {
-            slots[slot] = slotLoadTypes.TryGetValue(slot, out var loaded) && loaded is not null
-                ? loaded
-                : slotStoreTypes.TryGetValue(slot, out var stored) ? stored : null;
         }
         foreach (int index in locals)
         {
@@ -461,16 +452,76 @@ public sealed partial class CSharpPrinter
                         : $"{scoped}{TypeText(type)} {LocalName(index)};";
             }
         }
-        foreach (var (slot, type) in slots)
+        foreach (var ((_, ordinal), (name, type)) in _stackSlotDeclarations)
         {
-            if (_declaringStores.OfType<StoreStackSlot>().Any(s => s.Slot == slot))
+            if (_declaringStores.OfType<StoreStackSlot>().Any(s => StackSlotName(s) == name))
                 continue;
             // A ref-typed slot, like a ref-typed local, can't be declared bare
             // (CS8174); spell IL's null-reference zero-init as Unsafe.NullRef<T>().
             yield return type is { Kind: TypeRefKind.ByRef }
-                ? $"{TypeText(type)} S_{slot} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
-                : $"{(type is null ? "var" : TypeText(type))} S_{slot};";
+                ? $"{TypeText(type)} {name} = ref System.Runtime.CompilerServices.Unsafe.NullRef<{TypeText(type.ElementType!)}>();"
+                : ordinal > 0 && type is not null
+                    ? $"{TypeText(type)} {name} = default;"
+                    : $"{(type is null ? "var" : TypeText(type))} {name};";
         }
+    }
+
+    void CollectStackSlotNames(IrFunction function)
+    {
+        _stackSlotNames.Clear();
+        _stackSlotStoreTypes.Clear();
+        _stackSlotDeclarations.Clear();
+
+        var nodes = DescendantsOutsideNestedFunctions(function).ToList();
+        foreach (var store in nodes.OfType<StoreStackSlot>())
+            _stackSlotStoreTypes[store] = store.Value.ResultType;
+
+        var ordinals = new Dictionary<int, int>();
+
+        string NameFor(int slot, TypeRef? type)
+        {
+            var key = new StackSlotRenderKey(slot, StackSlotTypeKey(type));
+            if (_stackSlotNames.TryGetValue(key, out var existing))
+                return existing;
+
+            int ordinal = ordinals.GetValueOrDefault(slot);
+            ordinals[slot] = ordinal + 1;
+            string name = ordinal == 0 ? $"S_{slot}" : $"S_{slot}_{ordinal}";
+            _stackSlotNames[key] = name;
+            _stackSlotDeclarations[(slot, ordinal)] = (name, type);
+            return name;
+        }
+
+        foreach (var node in nodes)
+        {
+            switch (node)
+            {
+                case LoadStackSlot load:
+                    NameFor(load.Slot, load.Type);
+                    break;
+                case StoreStackSlot store:
+                    NameFor(store.Slot, StackSlotTargetType(store));
+                    break;
+            }
+        }
+    }
+
+    static string StackSlotTypeKey(TypeRef? type) => type?.ToDisplayString() ?? "<unknown>";
+
+    TypeRef? StackSlotTargetType(StoreStackSlot store)
+        => _stackSlotStoreTypes.TryGetValue(store, out var type) ? type : store.Value.ResultType;
+
+    string StackSlotName(LoadStackSlot load)
+        => _stackSlotNames.TryGetValue(new StackSlotRenderKey(load.Slot, StackSlotTypeKey(load.Type)), out var name)
+            ? name
+            : $"S_{load.Slot}";
+
+    string StackSlotName(StoreStackSlot store)
+    {
+        var type = StackSlotTargetType(store);
+        return _stackSlotNames.TryGetValue(new StackSlotRenderKey(store.Slot, StackSlotTypeKey(type)), out var name)
+            ? name
+            : $"S_{store.Slot}";
     }
 
     /// <summary>
@@ -1032,12 +1083,12 @@ public sealed partial class CSharpPrinter
         StoreArgument s => AssignmentText(CSharpNaming.EscapeIdentifier(s.Name), s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
-        StoreStackSlot { Value.ResultType.Kind: TypeRefKind.ByRef } s => _declaringStores.Contains(s)
-            ? $"{TypeText(s.Value.ResultType!)} S_{s.Slot} = ref {Deref(s.Value)};"
-            : $"S_{s.Slot} = ref {Deref(s.Value)};",
+        StoreStackSlot s when StackSlotTargetType(s) is { Kind: TypeRefKind.ByRef } refType => _declaringStores.Contains(s)
+            ? $"{TypeText(refType)} {StackSlotName(s)} = ref {Deref(s.Value)};"
+            : $"{StackSlotName(s)} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
-            ? $"{TypeText(s.Value.ResultType!)} S_{s.Slot} = {Expression(s.Value)};"
-            : AssignmentText($"S_{s.Slot}", s.Value, left => left is LoadStackSlot load && load.Slot == s.Slot),
+            ? $"{TypeText(StackSlotTargetType(s)!)} {StackSlotName(s)} = {CastValue(s.Value, StackSlotTargetType(s))};"
+            : AssignmentText(StackSlotName(s), s.Value, left => left is LoadStackSlot load && StackSlotName(load) == StackSlotName(s), StackSlotTargetType(s)),
         StoreField s => AssignmentText(
             FieldTarget(s.Field, s.Instance), s.Value,
             left => left is LoadField load
@@ -1090,7 +1141,7 @@ public sealed partial class CSharpPrinter
         LoadArgument { Index: 0, Name: "this" } => "this",
         LoadArgument a => CSharpNaming.EscapeIdentifier(a.Name),
         LoadLocal l => $"{LocalName(l.Index)}",
-        LoadStackSlot s => $"S_{s.Slot}",
+        LoadStackSlot s => StackSlotName(s),
         Constant { Value: int } c when EnumMemberName(c) is { } named => named,
         // A retyped enum constant with no single named member (a composite flag
         // value, or one outside the resolved member map) is still that enum — a
@@ -1104,7 +1155,7 @@ public sealed partial class CSharpPrinter
         Comparison c => ComparisonText(c),
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
-        Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
+        Conditional t => ConditionalText(t),
         SwitchExpression se => SwitchExpressionInline(se),
         Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
         NullConditional nc => NullConditionalText(nc),
@@ -1162,6 +1213,17 @@ public sealed partial class CSharpPrinter
         UnsupportedNode u => $"/* {u.Describe()} */",
         _ => $"/* {node.Describe()} */",
     };
+
+    string ConditionalText(Conditional conditional)
+    {
+        string whenTrue = conditional.MergedType is { } target
+            ? CastValue(conditional.WhenTrue, target)
+            : Operand(conditional.WhenTrue);
+        string whenFalse = conditional.MergedType is { } target2
+            ? CastValue(conditional.WhenFalse, target2)
+            : Operand(conditional.WhenFalse);
+        return $"{Condition(conditional.Condition)} ? {whenTrue} : {whenFalse}";
+    }
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -48,22 +48,27 @@ public sealed class BooleanFoldingPass : IIrPass
         bool changed = false;
         foreach (var (slot, stores) in storesBySlot)
         {
-            bool evidence = stores.Any(s => s.Value is not Constant && IsBool(s.Value.ResultType));
-            bool consistent = stores.All(s => IsZeroOne(s.Value) || IsBool(s.Value.ResultType));
-            if (!evidence || !consistent)
+            var candidateStores = stores
+                .Where(s => IsZeroOne(s.Value) || IsBool(s.Value.ResultType))
+                .ToList();
+            bool evidence = candidateStores.Any(s => s.Value is not Constant && IsBool(s.Value.ResultType));
+            if (!evidence)
                 continue;
             var loads = loadsBySlot.GetValueOrDefault(slot) ?? [];
-            if (!stores.Any(s => IsZeroOne(s.Value)) && !loads.Any(l => !IsBool(l.Type)))
+            var candidateLoads = loads
+                .Where(load => IsBool(load.Type) || load.Type is { } type && TypeFamilies.IsIntegerLike(type))
+                .ToList();
+            if (!candidateStores.Any(s => IsZeroOne(s.Value)) && !candidateLoads.Any(l => !IsBool(l.Type)))
                 continue;  // nothing left to retype
-            if (!loads.All(load => ConsumerAcceptsBool(function, load)))
+            if (!candidateLoads.All(load => ConsumerAcceptsBool(function, load)))
                 continue;  // a load is consumed as a non-bool; the slot is reused, not purely boolean
 
             var boolType = TypeRef.CoreLib("System", "Boolean");
             stepper.StepOver($"retype stack slot {slot} to bool", stores[0]);
-            foreach (var store in stores)
+            foreach (var store in candidateStores)
                 if (store.Value is Constant { Value: int value })
                     store.Value.ReplaceWith(new Constant(value == 1, boolType));
-            foreach (var load in loads)
+            foreach (var load in candidateLoads)
                 if (!IsBool(load.Type))
                     load.ReplaceWith(new LoadStackSlot(slot, boolType));
             changed = true;
@@ -92,6 +97,13 @@ public sealed class BooleanFoldingPass : IIrPass
         null => true,
         Return => IsBool(function.Signature.ReturnType),
         LogicalBinary or LogicalNot or Coalesce => true,
+        ConditionalBranch branch => ReferenceEquals(branch.Condition, node),
+        IfStatement statement => ReferenceEquals(statement.Condition, node),
+        WhileLoop loop => ReferenceEquals(loop.Condition, node),
+        DoWhileLoop loop => ReferenceEquals(loop.Condition, node),
+        ForLoop loop => ReferenceEquals(loop.Condition, node),
+        Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary
+            when BoolBinaryAcceptsBoolOperand(binary, node) => ConsumerAcceptsBool(function, binary, visitedSlots),
         Conditional conditional => ReferenceEquals(conditional.Condition, node) || IsBool(conditional.ResultType),
         Comparison comparison => comparison.Kind is ComparisonKind.Equal or ComparisonKind.NotEqual,
         Call call => ParameterAcceptsBool(call.Callee.ParameterTypes, call.Callee.HasThis ? node.ChildIndex - 1 : node.ChildIndex),
@@ -116,6 +128,18 @@ public sealed class BooleanFoldingPass : IIrPass
 
     static bool ParameterAcceptsBool(IReadOnlyList<TypeRef> parameterTypes, int index)
         => index >= 0 && index < parameterTypes.Count && IsBool(parameterTypes[index]);
+
+    static bool BoolBinaryAcceptsBoolOperand(Binary binary, IrExpression operand)
+    {
+        if (ReferenceEquals(binary.Left, operand))
+            return IsBoolLike(binary.Right);
+        return ReferenceEquals(binary.Right, operand) && IsBoolLike(binary.Left);
+    }
+
+    static bool IsBoolLike(IrExpression expression)
+        => IsBool(expression.ResultType)
+            || expression is Constant { Value: bool }
+            || IsZeroOne(expression);
 
     static bool FoldOnce(IrFunction function, Stepper stepper)
     {
@@ -416,14 +440,44 @@ public sealed class BooleanFoldingPass : IIrPass
             condition = (IrExpression)doubleNegative.DetachChildren()[0];
             (whenTrue, whenFalse) = (whenFalse, whenTrue);
         }
-        // The importer merged this slot to the genuine common supertype of the
-        // arms; carry it so the ternary types honestly when the arms differ
-        // (the bare WhenTrue fallback would otherwise narrow the result).
-        var mergedType = function.Descendants
-            .OfType<LoadStackSlot>()
-            .FirstOrDefault(load => load.Slot == thenStore.Slot && load.Type is not null)?.Type;
+        // The importer merged this slot to the genuine common supertype at the
+        // join this diamond feeds. Slot numbers are stack-depth positions and can
+        // be reused by earlier live ranges, so look after the whole diamond, not
+        // at the first same-number load in the method.
+        var mergedType = FirstLoadAfter(function, diamond, thenStore.Slot)?.Type
+            ?? EqualArmType(whenTrue, whenFalse);
         stepper.StepOver("fold store diamond into ternary", diamond);
         diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
         return true;
     }
+
+    static LoadStackSlot? FirstLoadAfter(IrFunction function, IrNode node, int slot)
+    {
+        bool after = false;
+        foreach (var candidate in function.Descendants)
+        {
+            if (!after)
+            {
+                if (ReferenceEquals(candidate, node))
+                    after = true;
+                continue;
+            }
+            if (IsDescendantOf(candidate, node))
+                continue;
+            if (candidate is LoadStackSlot load && load.Slot == slot && load.Type is not null)
+                return load;
+        }
+        return null;
+    }
+
+    static bool IsDescendantOf(IrNode node, IrNode ancestor)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, ancestor))
+                return true;
+        return false;
+    }
+
+    static TypeRef? EqualArmType(IrExpression whenTrue, IrExpression whenFalse)
+        => whenTrue.ResultType is { } trueType && trueType.Equals(whenFalse.ResultType) ? trueType : null;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -99,8 +99,6 @@ public sealed class BooleanFoldingPass : IIrPass
         IfStatement statement => ReferenceEquals(statement.Condition, node),
         ConditionalBranch branch => ReferenceEquals(branch.Condition, node),
         LogicalBinary or LogicalNot or Coalesce => true,
-        ConditionalBranch branch => ReferenceEquals(branch.Condition, node),
-        IfStatement statement => ReferenceEquals(statement.Condition, node),
         WhileLoop loop => ReferenceEquals(loop.Condition, node),
         DoWhileLoop loop => ReferenceEquals(loop.Condition, node),
         ForLoop loop => ReferenceEquals(loop.Condition, node),
@@ -523,14 +521,6 @@ public sealed class BooleanFoldingPass : IIrPass
                 return load;
         }
         return null;
-    }
-
-    static bool IsDescendantOf(IrNode node, IrNode ancestor)
-    {
-        for (var current = node.Parent; current is not null; current = current.Parent)
-            if (ReferenceEquals(current, ancestor))
-                return true;
-        return false;
     }
 
     static TypeRef? EqualArmType(IrExpression whenTrue, IrExpression whenFalse)


### PR DESCRIPTION
## Summary
- Split reused synthetic stack-slot names by rendered type so unrelated eval-stack live ranges do not share one C# local declaration.
- Retype bool/int stack-slot diamonds only for candidate bool-like live ranges and preserve bool bitwise consumers.
- Add regression tests for reused stack slots and bool materialization with unrelated same-number live ranges.

Closes #924

## Validation
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll artifacts/bin/ILInspector.Analysis/release/ILInspector.Analysis.dll artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll artifacts/bin/ILInspector.Metadata/release/ILInspector.Metadata.dll artifacts/bin/ILInspector.MetadataPrimitives/release/ILInspector.MetadataPrimitives.dll artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll --library-report --json --compile-cap 10000 --max-examples 5 --top-patterns 10 --top-libraries 8`

Merged with latest `origin/main` (`a17fc582`). Final product-library report shows `validity: CS0029` at 34 across 6 libraries.