### PR TITLE
Reduce CS0029 decompiler validity defects

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2705,6 +2705,23 @@ public class CfgSampleClass
         return result;
     }
 
+    // A nullable bool test whose lowering reuses one stack slot first as the
+    // nullable receiver string, then as the synthesized bool result. The bool
+    // live range must not declare with the earlier receiver type (CS0029).
+    public static string ReusedSlotNullableBool(JoinBase node)
+        => node?.Label.Contains("x") == true ? "hit" : "miss";
+
+    // The object-initializer-like lowering reuses a stack slot first for the
+    // string Status value, then for the nullable list receiver, then for Count.
+    // Those disjoint live ranges need distinct synthetic carriers.
+    public static SlotReuseSection ReusedSlotStringListCount(System.Collections.Generic.List<string>? missing, bool complete)
+    {
+        var section = new SlotReuseSection();
+        section.Status = complete ? "Complete" : "Partial";
+        section.Missing = missing?.Count ?? 0;
+        return section;
+    }
+
     // Same-assembly callees with explicit ref-kinds, so the importer can recover
     // each parameter's keyword from the MethodDef parameter rows.
     public static void RefHelper(ref int x) => x++;
@@ -3004,6 +3021,12 @@ public sealed class JoinDerived : JoinBase
 public sealed class JoinImpl : IJoinShape
 {
     public string Shape() => "impl";
+}
+
+public sealed class SlotReuseSection
+{
+    public string Status { get; set; } = "";
+    public int Missing { get; set; }
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1559,6 +1559,38 @@ public class RaisingPassTests
         Assert.Contains("S_0 = false;", output);
     }
 
+    [Fact]
+    public void BooleanMaterialization_ReusedReceiverSlot_KeepsBoolLiveRangeDistinct()
+    {
+        // A ?. bool test can reuse the same edge slot first for the string
+        // receiver and then for the bool result. The bool live range must not
+        // inherit the receiver slot's string declaration (CS0029).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReusedSlotNullableBool), source);
+
+        Assert.Contains("node.Label.Contains(\"x\")", output);
+        Assert.Contains("return \"hit\";", output);
+        Assert.Contains("return \"miss\";", output);
+        Assert.DoesNotContain(": 0", output);
+        Assert.DoesNotContain("string S_0 = ", output);
+    }
+
+    [Fact]
+    public void StackSlotLiveRange_ReusedStringListCount_SplitsTypedCarriers()
+    {
+        // One edge slot can carry unrelated straight-line values: a string
+        // property value, then a nullable list receiver, then the int Count. The
+        // final C# needs distinct synthetic carriers rather than assigning the
+        // list/int values through the earlier string slot (CS0029).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReusedSlotStringListCount), source);
+
+        Assert.Contains(".Missing", output);
+        Assert.Contains(".Count", output);
+        Assert.DoesNotContain("string S_0 = missing", output);
+        Assert.DoesNotContain("string S_0 = S_", output);
+    }
+
 
     [Fact]
     public void IncrementDecrement_DupSlotIdiom_FoldsToOperatorAtUseSite()

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -155,17 +155,104 @@ public sealed class BooleanFoldingPass : IIrPass
             return false;
         if (other is Constant || other.ResultType is not { Namespace: "System", Name: "Boolean" })
             return false;
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        StoreStackSlot? slotStore = conditional.Parent as StoreStackSlot;
+        List<LoadStackSlot>? liveLoads = null;
+        int? freshSlot = null;
+        if (slotStore is not null)
+        {
+            liveLoads = LiveLoadsAfterStore(function, slotStore).ToList();
+            if (!liveLoads.All(load => ConsumerAcceptsBool(function, load)))
+                return false;
+            if (SlotHasNonBoolUseOutsideLiveRange(function, slotStore, liveLoads))
+                freshSlot = FreshStackSlot(function);
+        }
         // Only recover the bool spelling when the ternary's result is consumed as
         // a bool; otherwise retyping it (and its merged type) would push a bool
         // into a position a later pass treats as int — no TypedConstantsPass runs
         // after boolean-folding to reconcile it (CS0029/CS0266).
-        if (!ConsumerAcceptsBool(function, conditional))
+        else if (!ConsumerAcceptsBool(function, conditional))
+        {
             return false;
-        var boolType = TypeRef.CoreLib("System", "Boolean");
+        }
         stepper.StepOver("materialize bool ternary constant arm", conditional);
         constant.ReplaceWith(new Constant(value == 1, boolType));
         conditional.MergedType = boolType;
+        if (liveLoads is not null)
+        {
+            int slot = freshSlot ?? slotStore!.Slot;
+            foreach (var load in liveLoads)
+                if (!IsBool(load.Type))
+                    load.ReplaceWith(new LoadStackSlot(slot, boolType));
+            if (freshSlot is { } newSlot)
+            {
+                var valueNode = (IrExpression)slotStore!.DetachChildren()[0];
+                var replacement = new StoreStackSlot(newSlot, valueNode);
+                replacement.InheritSourceOffset(slotStore);
+                slotStore.ReplaceWith(replacement);
+            }
+        }
         return true;
+    }
+
+    static IEnumerable<LoadStackSlot> LiveLoadsAfterStore(IrFunction function, StoreStackSlot store)
+    {
+        var nodes = function.Descendants.ToList();
+        int storeIndex = nodes.IndexOf(store);
+        if (storeIndex < 0)
+            yield break;
+        for (int i = storeIndex + 1; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            if (IsDescendantOf(node, store))
+                continue;
+            if (node is StoreStackSlot nextStore && nextStore.Slot == store.Slot)
+                yield break;
+            if (node is LoadStackSlot load && load.Slot == store.Slot)
+                yield return load;
+        }
+    }
+
+    static bool SlotHasNonBoolUseOutsideLiveRange(IrFunction function, StoreStackSlot store, IReadOnlyCollection<LoadStackSlot> liveLoads)
+    {
+        var live = liveLoads.ToHashSet();
+        foreach (var node in function.Descendants)
+        {
+            if (ReferenceEquals(node, store) || IsDescendantOf(node, store))
+                continue;
+            if (node is LoadStackSlot load && load.Slot == store.Slot && !live.Contains(load) && !IsBool(load.Type))
+                return true;
+            if (node is StoreStackSlot otherStore && otherStore.Slot == store.Slot
+                && !IsZeroOne(otherStore.Value) && !IsBool(otherStore.Value.ResultType))
+                return true;
+        }
+        return false;
+    }
+
+    static bool IsDescendantOf(IrNode node, IrNode ancestor)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, ancestor))
+                return true;
+        return false;
+    }
+
+    static int FreshStackSlot(IrFunction function)
+    {
+        int maxSlot = StoreStackSlot.DupSlotBase - 1;
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case StoreStackSlot store:
+                    maxSlot = Math.Max(maxSlot, store.Slot);
+                    break;
+                case LoadStackSlot load:
+                    maxSlot = Math.Max(maxSlot, load.Slot);
+                    break;
+            }
+        }
+        return maxSlot + 1;
     }
 
     /// <summary>X == false → !X (via the type-aware duals), X == true → X, and the != duals — the ceq-with-zero value form of boolean tests.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -91,6 +91,8 @@ public sealed class BooleanFoldingPass : IIrPass
     {
         null => true,
         Return => IsBool(function.Signature.ReturnType),
+        IfStatement statement => ReferenceEquals(statement.Condition, node),
+        ConditionalBranch branch => ReferenceEquals(branch.Condition, node),
         LogicalBinary or LogicalNot or Coalesce => true,
         Conditional conditional => ReferenceEquals(conditional.Condition, node) || IsBool(conditional.ResultType),
         Comparison comparison => comparison.Kind is ComparisonKind.Equal or ComparisonKind.NotEqual,
@@ -158,14 +160,11 @@ public sealed class BooleanFoldingPass : IIrPass
         var boolType = TypeRef.CoreLib("System", "Boolean");
         StoreStackSlot? slotStore = conditional.Parent as StoreStackSlot;
         List<LoadStackSlot>? liveLoads = null;
-        int? freshSlot = null;
         if (slotStore is not null)
         {
             liveLoads = LiveLoadsAfterStore(function, slotStore).ToList();
             if (!liveLoads.All(load => ConsumerAcceptsBool(function, load)))
                 return false;
-            if (SlotHasNonBoolUseOutsideLiveRange(function, slotStore, liveLoads))
-                freshSlot = FreshStackSlot(function);
         }
         // Only recover the bool spelling when the ternary's result is consumed as
         // a bool; otherwise retyping it (and its merged type) would push a bool
@@ -180,17 +179,9 @@ public sealed class BooleanFoldingPass : IIrPass
         conditional.MergedType = boolType;
         if (liveLoads is not null)
         {
-            int slot = freshSlot ?? slotStore!.Slot;
             foreach (var load in liveLoads)
                 if (!IsBool(load.Type))
-                    load.ReplaceWith(new LoadStackSlot(slot, boolType));
-            if (freshSlot is { } newSlot)
-            {
-                var valueNode = (IrExpression)slotStore!.DetachChildren()[0];
-                var replacement = new StoreStackSlot(newSlot, valueNode);
-                replacement.InheritSourceOffset(slotStore);
-                slotStore.ReplaceWith(replacement);
-            }
+                    load.ReplaceWith(new LoadStackSlot(slotStore!.Slot, boolType));
         }
         return true;
     }
@@ -213,46 +204,12 @@ public sealed class BooleanFoldingPass : IIrPass
         }
     }
 
-    static bool SlotHasNonBoolUseOutsideLiveRange(IrFunction function, StoreStackSlot store, IReadOnlyCollection<LoadStackSlot> liveLoads)
-    {
-        var live = liveLoads.ToHashSet();
-        foreach (var node in function.Descendants)
-        {
-            if (ReferenceEquals(node, store) || IsDescendantOf(node, store))
-                continue;
-            if (node is LoadStackSlot load && load.Slot == store.Slot && !live.Contains(load) && !IsBool(load.Type))
-                return true;
-            if (node is StoreStackSlot otherStore && otherStore.Slot == store.Slot
-                && !IsZeroOne(otherStore.Value) && !IsBool(otherStore.Value.ResultType))
-                return true;
-        }
-        return false;
-    }
-
     static bool IsDescendantOf(IrNode node, IrNode ancestor)
     {
         for (var current = node.Parent; current is not null; current = current.Parent)
             if (ReferenceEquals(current, ancestor))
                 return true;
         return false;
-    }
-
-    static int FreshStackSlot(IrFunction function)
-    {
-        int maxSlot = StoreStackSlot.DupSlotBase - 1;
-        foreach (var node in function.Descendants)
-        {
-            switch (node)
-            {
-                case StoreStackSlot store:
-                    maxSlot = Math.Max(maxSlot, store.Slot);
-                    break;
-                case LoadStackSlot load:
-                    maxSlot = Math.Max(maxSlot, load.Slot);
-                    break;
-            }
-        }
-        return maxSlot + 1;
     }
 
     /// <summary>X == false → !X (via the type-aware duals), X == true → X, and the != duals — the ceq-with-zero value form of boolean tests.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -128,6 +128,9 @@ public static class IrPasses
         // Folding merges slot diamonds into single stores; a second inlining
         // run collapses those slots into their uses (ternaries inline).
         new ExpressionInliningPass(),
+        // When a reused edge slot still carries disjoint typed live ranges after
+        // inlining, split the synthetic carrier so declarations stay valid.
+        new StackSlotLiveRangePass(),
         // Raise the bare delegate creation left by the cache collapse into the
         // lambda itself — imports the synthesized method's body and re-presents
         // it as `(params) => body`. Needs the cross-method import seam on the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -29,6 +29,8 @@ internal static class NativePasses
     // ───────── EmitArtifact — inverse of codegen/spilling, not a LocalRewriter ─────────
     [Native(NativeCategory.EmitArtifact, "inverse of expression spilling — fold single-use temps back into their use")]
     public static ExpressionInliningPass ExpressionInlining => new();
+    [Native(NativeCategory.EmitArtifact, "reused evaluation-stack slot live ranges split into distinct typed synthetic carriers")]
+    public static StackSlotLiveRangePass StackSlotLiveRange => new();
     [Native(NativeCategory.EmitArtifact, "in-place struct .ctor (ldloca; call S::.ctor) back to s = new S(...)")]
     public static StructConstructorPass StructConstructor => new();
     [Native(NativeCategory.EmitArtifact, "spilled-this base()/this() call back to a chain initializer")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
@@ -1,0 +1,110 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Splits block-local synthetic stack-slot live ranges when the compiler reused
+/// the same evaluation-stack position for unrelated values with different C#
+/// types. The rewrite only renumbers the synthetic carrier and the loads reached
+/// before the next write to that slot; it does not move evaluation.
+/// </summary>
+public sealed class StackSlotLiveRangePass : IIrPass
+{
+    public string Name => "stack-slot-live-range";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (SplitOnce(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool SplitOnce(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>())
+        {
+            for (int i = 0; i < block.Children.Count; i++)
+            {
+                if (block.Children[i] is not StoreStackSlot store || store.Value.ResultType is not { } valueType)
+                    continue;
+
+                var previousType = PreviousSlotType(block, i, store.Slot);
+                if (previousType is null || previousType.Equals(valueType))
+                    continue;
+
+                var liveLoads = LiveLoads(block, i, store.Slot).ToList();
+                if (liveLoads.Count == 0)
+                    continue;
+
+                int newSlot = FreshStackSlot(function);
+                stepper.StepOver($"split stack slot {store.Slot} live range to S_{newSlot}", store);
+                foreach (var load in liveLoads)
+                    load.ReplaceWith(new LoadStackSlot(newSlot, load.Type ?? valueType));
+
+                var value = (IrExpression)store.DetachChildren()[0];
+                var replacement = new StoreStackSlot(newSlot, value);
+                replacement.InheritSourceOffset(store);
+                store.ReplaceWith(replacement);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static TypeRef? PreviousSlotType(Block block, int beforeChild, int slot)
+    {
+        TypeRef? previous = null;
+        for (int i = 0; i < beforeChild; i++)
+        {
+            foreach (var node in block.Children[i].Descendants.Prepend(block.Children[i]))
+            {
+                previous = node switch
+                {
+                    StoreStackSlot store when store.Slot == slot => store.Value.ResultType ?? previous,
+                    LoadStackSlot load when load.Slot == slot => load.Type ?? previous,
+                    _ => previous,
+                };
+            }
+        }
+        return previous;
+    }
+
+    static IEnumerable<LoadStackSlot> LiveLoads(Block block, int storeChild, int slot)
+    {
+        var store = block.Children[storeChild];
+        for (int i = storeChild + 1; i < block.Children.Count; i++)
+        {
+            var statement = block.Children[i];
+            if (statement.Descendants.Prepend(statement).OfType<StoreStackSlot>().Any(s => s.Slot == slot))
+                yield break;
+
+            foreach (var load in statement.Descendants.Prepend(statement).OfType<LoadStackSlot>())
+                if (load.Slot == slot && !IsDescendantOf(load, store))
+                    yield return load;
+        }
+    }
+
+    static bool IsDescendantOf(IrNode node, IrNode ancestor)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, ancestor))
+                return true;
+        return false;
+    }
+
+    static int FreshStackSlot(IrFunction function)
+    {
+        int maxSlot = StoreStackSlot.DupSlotBase - 1;
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case StoreStackSlot store:
+                    maxSlot = Math.Max(maxSlot, store.Slot);
+                    break;
+                case LoadStackSlot load:
+                    maxSlot = Math.Max(maxSlot, load.Slot);
+                    break;
+            }
+        }
+        return maxSlot + 1;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
@@ -12,6 +12,9 @@ public sealed class StackSlotLiveRangePass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        if (function.Descendants.Any(node => node is TryCatch or TryFinally or CatchClause))
+            return;
+
         while (SplitOnce(function, context.Stepper))
         {
         }


### PR DESCRIPTION
## Summary
- materialize bool select constants when stack-slot loads are consumed directly by `if` conditions
- split straight-line reused synthetic stack-slot live ranges into distinct typed carriers
- add regression fixtures for reused nullable-bool and string/list/count stack-slot shapes

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- latest-main product library report: `validity: CS0029` 137 -> 118, pass bugs 0
- latest-main `--diff-validity-defects`: empty REGRESSED; IMPROVED has CS0029 x7 and CS0019 x1

Fixes #924