### PR TITLE
Fix CS0266 stack slot validity in decompiler

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -971,6 +971,36 @@ public class JoinTypeConflictTests : IDisposable
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void DisjointStackCarryTargets_DoNotSharePositionSlot()
+    {
+        // Two unrelated forward targets each carry one stack value. They both use
+        // stack position 0, but they are different entry stacks: sharing S_0 would
+        // force the later long store into the earlier int slot (CS0266).
+        var function = BuildSynthetic(
+        [
+            0x17,                         // ldc.i4.1
+            0x2B, 0x00,                   // br.s IL_0003
+            0x26,                         // pop
+            0x21, 0x02, 0, 0, 0, 0, 0, 0, 0, // ldc.i8 2
+            0x2B, 0x00,                   // br.s IL_000F
+            0x26,                         // pop
+            0x2A,                         // ret
+        ]);
+
+        var stores = function.Descendants.OfType<StoreStackSlot>().ToArray();
+
+        Assert.Contains(stores, s => s is { Slot: 0, Value.ResultType.Name: "Int32" });
+        Assert.Contains(stores, s => s is { Slot: 1, Value.ResultType.Name: "Int64" });
+        Assert.DoesNotContain(stores, s => s is { Slot: 0, Value.ResultType.Name: "Int64" });
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+        Assert.Contains("int S_0 = 1;", output);
+        Assert.Contains("long S_1;", output);
+        Assert.DoesNotContain("S_0 = 2L;", output);
+        function.CheckInvariant();
+    }
+
     IrFunction BuildSyntheticWithRegion(byte[] il, HandlerRegion region)
     {
         var source = MetadataSource.Open(typeof(object).Assembly.Location);
@@ -1559,6 +1589,40 @@ public class RaisingPassTests
         Assert.Contains("S_0 = false;", output);
     }
 
+    [Fact]
+    public void BooleanMaterialization_IndirectBoolStore_DeclaresBoolSlot()
+    {
+        // A bool computed into a stack slot and stored through ref bool is still a
+        // bool consumer. Without this, the slot stays int and the ref bool store is
+        // `target = S_0` (CS0029).
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var sbyteType = TypeRef.CoreLib("System", "SByte");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new Constant(0, intType),
+            new LoadArgument(1, "other", boolType))
+        { MergedType = intType }));
+        block.Add(new StoreIndirect(sbyteType,
+            new LoadArgument(2, "target", TypeRef.ByRef(boolType)),
+            new LoadStackSlot(0, intType)));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("flag", boolType), new Parameter("other", boolType), new Parameter("target", TypeRef.ByRef(boolType))],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("bool S_0", output);
+        Assert.Contains("? false :", output);
+        Assert.DoesNotContain("int S_0", output);
+        Assert.Contains("target = S_0;", output);
+    }
 
     [Fact]
     public void IncrementDecrement_DupSlotIdiom_FoldsToOperatorAtUseSite()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -440,6 +440,18 @@ public sealed partial class CSharpPrinter
         return $"({TypeText(target!)}){Operand(value)}";
     }
 
+    string ConditionalText(Conditional conditional)
+    {
+        var target = conditional.MergedType;
+        return $"{Condition(conditional.Condition)} ? {ConditionalArm(conditional.WhenTrue, target)} : {ConditionalArm(conditional.WhenFalse, target)}";
+    }
+
+    string ConditionalArm(IrExpression arm, TypeRef? target)
+        => target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
+            && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
+                ? $"({Condition(arm)} ? 1 : 0)"
+                : Operand(arm);
+
     /// <summary>
     /// An integer constant rendered for a numeric target: bare when in range (C#
     /// converts it implicitly), reinterpreted with an unchecked cast when out of

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1104,7 +1104,7 @@ public sealed partial class CSharpPrinter
         Comparison c => ComparisonText(c),
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
-        Conditional t => $"{Condition(t.Condition)} ? {Operand(t.WhenTrue)} : {Operand(t.WhenFalse)}",
+        Conditional t => ConditionalText(t),
         SwitchExpression se => SwitchExpressionInline(se),
         Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
         NullConditional nc => NullConditionalText(nc),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -399,41 +399,55 @@ public static class IrImporter
         return ilLength;
     }
 
-    /// <summary>Cross-block import state: stack types at block entries, blocks already built, and the dup slot counter.</summary>
+    /// <summary>Cross-block import state: stack types/slots at block entries, blocks already built, and synthetic slot counters.</summary>
     sealed class BuildState
     {
-        public Dictionary<int, List<TypeRef?>> EntryStacks { get; } = [];
+        public Dictionary<int, EntryStack> EntryStacks { get; } = [];
         public HashSet<int> Built { get; } = [];
+        public Dictionary<int, List<CarriedSlot>> CarrySlotsByPosition { get; } = [];
+        public int NextCarrySlot { get; set; }
         public int NextDupSlot { get; set; } = StoreStackSlot.DupSlotBase;
 
         /// <summary>Catch/filter entry offsets and their exception types — the CLR-pushed value, not a slot load.</summary>
         public Dictionary<int, TypeRef?> HandlerEntries { get; } = [];
+
+        public int GetCarrySlot(int position, TypeRef? type)
+        {
+            if (!CarrySlotsByPosition.TryGetValue(position, out var slots))
+                CarrySlotsByPosition[position] = slots = [];
+            foreach (var candidate in slots)
+                if (Equals(candidate.Type, type))
+                    return candidate.Slot;
+            int slot = AllocateCarrySlot();
+            slots.Add(new CarriedSlot(type, slot));
+            return slot;
+        }
+
+        int AllocateCarrySlot()
+            => NextCarrySlot++ < StoreStackSlot.DupSlotBase
+                ? NextCarrySlot - 1
+                : NextDupSlot++;
     }
 
     /// <summary>
-    /// Spills the leftover evaluation stack into position-indexed slots and
-    /// records the entry stack of every target. Position indexing makes all
-    /// predecessors of a join store to the same slots. Returns false on a
-    /// depth disagreement or a stack-carrying back edge (out of slice).
+    /// Spills the leftover evaluation stack into position/type-indexed slots and
+    /// records the entry stack of every target. All predecessors of the same join
+    /// share that target's slots; unrelated targets reuse the old position slot
+    /// only when the carried type also matches, so incompatible lifetimes do not
+    /// collide. Returns false on a depth disagreement or a stack-carrying back
+    /// edge (out of slice).
     /// </summary>
     static bool PropagateAndSpill(MetadataSource source, IrFunction function, Block body, Stack<IrExpression> stack, BuildState state, int[] targets, int offset)
     {
         var values = stack.Reverse().ToArray();
         stack.Clear();
         var types = values.Select(v => v.ResultType).ToList();
-        for (int i = 0; i < values.Length; i++)
-        {
-            // Re-spilling a slot into itself (S_0 = S_0) happens whenever an
-            // edge re-propagates values it loaded from the same slots.
-            if (values[i] is LoadStackSlot identity && identity.Slot == i)
-                continue;
-            body.Add(new StoreStackSlot(i, values[i]));
-        }
-        foreach (int target in targets)
+        var entries = new List<EntryStack>();
+        foreach (int target in targets.Distinct())
         {
             if (state.EntryStacks.TryGetValue(target, out var existing))
             {
-                if (existing.Count != types.Count)
+                if (existing.Types.Count != types.Count)
                 {
                     Stop(function, body, stack, offset, "(join)",
                         "evaluation-stack depth disagrees between paths into a join, outside the slice");
@@ -441,18 +455,18 @@ public static class IrImporter
                 }
                 for (int i = 0; i < types.Count; i++)
                 {
-                    if (Equals(existing[i], types[i]) || types[i] is null)
+                    if (Equals(existing.Types[i], types[i]) || types[i] is null)
                         continue;
-                    if (existing[i] is null)
+                    if (existing.Types[i] is null)
                     {
                         if (!state.Built.Contains(target))
-                            existing[i] = types[i];
+                            existing.Types[i] = types[i];
                         continue;
                     }
                     // ECMA stack-type model: bool and int are the same I4
                     // stack entry, float and double the same F entry — the
                     // family-canonical type IS the ground truth there.
-                    var merged = MergeSlotTypes(existing[i]!, types[i]!, source);
+                    var merged = MergeSlotTypes(existing.Types[i]!, types[i]!, source);
                     if (state.Built.Contains(target))
                     {
                         if (merged is null)
@@ -469,10 +483,11 @@ public static class IrImporter
                     {
                         function.Diagnostics.Add(new DecompilerDiagnostic(
                             DiagnosticIds.UnsupportedConstruct,
-                            $"IL_{offset:X4} (join-type): slot {i} type unknown — paths carry {existing[i]!.ToDisplayString()} and {types[i]!.ToDisplayString()}"));
+                            $"IL_{offset:X4} (join-type): slot {i} type unknown — paths carry {existing.Types[i]!.ToDisplayString()} and {types[i]!.ToDisplayString()}"));
                     }
-                    existing[i] = merged;  // family-canonical, or null — never a guess
+                    existing.Types[i] = merged;  // family-canonical, or null — never a guess
                 }
+                entries.Add(existing);
             }
             else if (state.Built.Contains(target) && types.Count > 0)
             {
@@ -482,11 +497,55 @@ public static class IrImporter
             }
             else
             {
-                state.EntryStacks[target] = types;
+                existing = new EntryStack([.. types], Enumerable.Repeat(-1, types.Count).ToList());
+                state.EntryStacks[target] = existing;
+                entries.Add(existing);
+            }
+        }
+
+        for (int i = 0; i < types.Count; i++)
+        {
+            int slot = entries.Select(entry => entry.Slots[i]).FirstOrDefault(s => s >= 0, -1);
+            if (slot < 0)
+                slot = state.GetCarrySlot(i, types[i]);
+            foreach (var entry in entries)
+                if (entry.Slots[i] < 0)
+                    entry.Slots[i] = slot;
+        }
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            int? primarySlot = values[i] is LoadStackSlot load
+                && entries.Any(entry => entry.Slots[i] == load.Slot)
+                    ? load.Slot
+                    : null;
+            primarySlot ??= entries.Count > 0 ? entries[0].Slots[i] : null;
+            if (primarySlot is null)
+                continue;
+
+            // Re-spilling a slot into itself (S_N = S_N) happens whenever an
+            // edge re-propagates values it loaded from the same target slot.
+            if (values[i] is not LoadStackSlot identity || identity.Slot != primarySlot.Value)
+                body.Add(new StoreStackSlot(primarySlot.Value, values[i]));
+
+            foreach (var entry in entries)
+            {
+                int slot = entry.Slots[i];
+                if (slot == primarySlot.Value)
+                    continue;
+                body.Add(new StoreStackSlot(slot, new LoadStackSlot(primarySlot.Value, values[i].ResultType)));
             }
         }
         return true;
     }
+
+    sealed class EntryStack(List<TypeRef?> types, List<int> slots)
+    {
+        public List<TypeRef?> Types { get; } = types;
+        public List<int> Slots { get; } = slots;
+    }
+
+    readonly record struct CarriedSlot(TypeRef? Type, int Slot);
 
     /// <summary>Builds one block. Returns false when the import stopped honestly inside it.</summary>
     static bool BuildBlock(MetadataSource source, ImportedMethod method, IrFunction function, Block body,
@@ -504,14 +563,14 @@ public static class IrImporter
         if (state.HandlerEntries.TryGetValue(start, out var exceptionType))
         {
             stack.Push(new CaughtException(exceptionType));
-            state.EntryStacks[start] = [];
+            state.EntryStacks[start] = new EntryStack([], []);
         }
         else
         {
-            var entry = state.EntryStacks.TryGetValue(start, out var carried) ? carried : [];
+            var entry = state.EntryStacks.TryGetValue(start, out var carried) ? carried : new EntryStack([], []);
             state.EntryStacks[start] = entry;
-            for (int i = 0; i < entry.Count; i++)
-                stack.Push(new LoadStackSlot(i, entry[i]));
+            for (int i = 0; i < entry.Types.Count; i++)
+                stack.Push(new LoadStackSlot(entry.Slots[i], entry.Types[i]));
         }
 
         // Provenance watermark: statements already in the block (e.g. entry

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1840,8 +1840,9 @@ public sealed class YieldBreak : IrNode
 /// <summary>
 /// A synthetic variable carrying an evaluation-stack value across a block
 /// boundary (ternaries, short-circuit values) or materializing a dup.
-/// Edge slots are position-indexed so every predecessor of a join stores to
-/// the same slot; dup slots allocate from <see cref="DupSlotBase"/> up.
+/// Edge slots are position/type-indexed so every predecessor of a join stores
+/// to the same slot, while unrelated incompatible lifetimes do not collide; dup
+/// slots allocate from <see cref="DupSlotBase"/> up.
 /// </summary>
 public sealed class StoreStackSlot : IrNode
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -78,10 +78,10 @@ public sealed class BooleanFoldingPass : IIrPass
     /// <summary>
     /// Whether the value produced by <paramref name="node"/> is consumed where a
     /// <c>bool</c> is valid. Retyping a value to bool is sound only when it is
-    /// boolean at every USE, not just where it is produced: edge slots are
-    /// position-indexed by stack depth, so one slot number can span disjoint live
-    /// ranges, and a stores-only (or arms-only) check can retype a value that
-    /// another range consumes as an integer — a silent overload miscompile
+    /// boolean at every USE, not just where it is produced: edge slots are keyed
+    /// by stack position and carried type, so one slot number can still span
+    /// disjoint same-typed live ranges, and a stores-only check can retype a
+    /// value that another range consumes as an integer — a silent overload miscompile
     /// (<c>f(1)</c> becomes <c>f(true)</c>) or CS0019/CS0029. Unrecognized
     /// consumers are treated as non-bool (bail), keeping the pass conservative.
     /// </summary>
@@ -99,11 +99,22 @@ public sealed class BooleanFoldingPass : IIrPass
         StoreLocal store => ReferenceEquals(store.Value, node) && IsBool(store.Type),
         StoreArgument store => ReferenceEquals(store.Value, node) && IsBool(store.Type),
         StoreField store => ReferenceEquals(store.Value, node) && IsBool(store.Field.Type),
+        StoreIndirect store => ReferenceEquals(store.Value, node) && IsBool(IndirectStoreType(store)),
         // A value stored into a slot is boolean only if every load of that slot
         // is itself consumed as a bool (the slot carries it onward).
         StoreStackSlot store => SlotLoadsAcceptBool(function, store.Slot, visitedSlots),
         _ => false,
     };
+
+    static TypeRef? IndirectStoreType(StoreIndirect store)
+    {
+        var pointee = store.Address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } element }
+            ? element
+            : null;
+        return pointee is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Boolean" or "Char" }
+            ? pointee
+            : store.Type ?? pointee;
+    }
 
     static bool SlotLoadsAcceptBool(IrFunction function, int slot, HashSet<int> visitedSlots)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
@@ -38,59 +38,121 @@ public sealed class ConstructorChainPass : IIrPass
             var thisArgument = new LoadArgument(0, "this", function.DeclaringType);
             context.Stepper.StepOver($"canonicalize {call.Callee.DeclaringType.Name}..ctor receiver to this", call);
             receiver.ReplaceWith(thisArgument);
-            // The spill's sole load is gone; drop the store so it does not
-            // print as a dead `T S_0 = this;` declaration.
-            spill.Store.Detach();
+            // The spill's sole load is gone; drop the store(s) so they do not
+            // print as dead `T S_0 = this;` declarations.
+            foreach (var store in spill.Stores)
+                store.Detach();
         }
     }
 
     /// <summary>
     /// A receiver that is a slot or local with exactly one load (this call)
-    /// and a single store of <c>this</c>; null when it is anything else.
+    /// and store(s) that all carry <c>this</c>; null when it is anything else.
+    /// Branch-shaped constructor arguments can copy an earlier <c>this</c> spill
+    /// into the chain receiver slot on each arm, so one level of copy is accepted
+    /// when every source load is inside a receiver store that will be removed.
     /// </summary>
-    static (IrNode Store, IrExpression Load)? ResolveThisSpill(IrFunction function, IrExpression receiver)
+    static (IReadOnlyList<IrNode> Stores, IrExpression Load)? ResolveThisSpill(IrFunction function, IrExpression receiver)
     {
-        (bool IsSlot, int Index)? key = receiver switch
-        {
-            LoadStackSlot slot => (true, slot.Slot),
-            LoadLocal local => (false, local.Index),
-            _ => null,
-        };
+        var key = PlaceKey(receiver);
         if (key is not { } place)
             return null;
 
-        IrNode? store = null;
-        int loads = 0;
-        bool storeIsThis = false;
+        var usage = CountUsage(function, place);
+        if (usage.AddressTaken || usage.Loads.Count != 1 || !ReferenceEquals(usage.Loads[0], receiver)
+            || usage.Stores.Count == 0)
+            return null;
+
+        if (usage.Stores.All(StoreIsThis))
+            return (usage.Stores, receiver);
+
+        if (TryResolveCopiedThis(function, usage.Stores, out var sourceStore))
+            return (usage.Stores.Append(sourceStore).Distinct().ToList(), receiver);
+
+        return null;
+    }
+
+    static bool TryResolveCopiedThis(IrFunction function, IReadOnlyList<IrNode> receiverStores, out IrNode sourceStore)
+    {
+        sourceStore = null!;
+        (bool IsSlot, int Index)? sourceKey = null;
+        foreach (var store in receiverStores)
+        {
+            var valueKey = PlaceKey(StoreValue(store));
+            if (valueKey is null || sourceKey is { } existing && existing != valueKey)
+                return false;
+            sourceKey = valueKey;
+        }
+        if (sourceKey is not { } place)
+            return false;
+
+        var source = CountUsage(function, place);
+        if (source.AddressTaken || source.Stores.Count != 1 || !StoreIsThis(source.Stores[0]))
+            return false;
+
+        foreach (var load in source.Loads)
+            if (!receiverStores.Any(store => IsInside(load, store)))
+                return false;
+
+        sourceStore = source.Stores[0];
+        return true;
+    }
+
+    static (bool IsSlot, int Index)? PlaceKey(IrExpression expression) => expression switch
+    {
+        LoadStackSlot slot => (true, slot.Slot),
+        LoadLocal local => (false, local.Index),
+        _ => null,
+    };
+
+    static IrExpression StoreValue(IrNode store) => store switch
+    {
+        StoreStackSlot slot => slot.Value,
+        StoreLocal local => local.Value,
+        _ => throw new InvalidOperationException("Expected a stack slot or local store."),
+    };
+
+    static bool StoreIsThis(IrNode store) => StoreValue(store) is LoadArgument { Index: 0 };
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+
+    static Place CountUsage(IrFunction function, (bool IsSlot, int Index) place)
+    {
+        var result = new Place();
         foreach (var node in function.Descendants)
         {
             if (place.IsSlot)
             {
                 if (node is LoadStackSlot l && l.Slot == place.Index)
-                    loads++;
+                    result.Loads.Add(l);
                 else if (node is StoreStackSlot s && s.Slot == place.Index)
-                {
-                    if (store is not null)
-                        return null;  // multiple stores
-                    store = s;
-                    storeIsThis = s.Value is LoadArgument { Index: 0 };
-                }
+                    result.Stores.Add(s);
             }
             else
             {
                 if (node is LoadLocal l && l.Index == place.Index)
-                    loads++;
+                    result.Loads.Add(l);
                 else if (node is LoadLocalAddress a && a.Index == place.Index)
-                    return null;  // an escaped address makes the rename unsound
+                    result.AddressTaken = true;
                 else if (node is StoreLocal s && s.Index == place.Index)
-                {
-                    if (store is not null)
-                        return null;
-                    store = s;
-                    storeIsThis = s.Value is LoadArgument { Index: 0 };
-                }
+                    result.Stores.Add(s);
             }
         }
-        return store is not null && storeIsThis && loads == 1 ? (store, receiver) : null;
+        return result;
+    }
+
+    sealed class Place
+    {
+        public List<IrExpression> Loads { get; } = [];
+        public List<IrNode> Stores { get; } = [];
+        public bool AddressTaken { get; set; }
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -11,13 +11,13 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <item>
 /// <b>Spilled receiver</b> (a field load, an <c>as</c> result — anything the
 /// compiler will not re-evaluate). The receiver is spilled into a stack slot
-/// and reloaded for the access, reusing ONE slot index for both the receiver (a
-/// reference type) and the member result (often an unrelated type) — an unsound
-/// <c>Full</c> render. The shape is two adjacent stores to the same slot j:
+/// and reloaded for the access. Older imports can reuse one slot for both the
+/// receiver and result; newer position/type slots can keep them split. The shape
+/// is two adjacent stores:
 /// <code>
-///   StoreStackSlot(j, LoadStackSlot(s))                      // spill the receiver
+///   StoreStackSlot(r, LoadStackSlot(s))                      // spill the receiver
 ///   StoreStackSlot(j, Conditional(LoadStackSlot(s),          // s is not null ?
-///                                 member(receiver: LoadStackSlot(j)),  //   recv.Member :
+///                                 member(receiver: LoadStackSlot(r)),  //   recv.Member :
 ///                                 Constant null))                       //   null
 /// </code>
 /// Raising drops the spill, moves the real receiver into the access, and leaves
@@ -49,7 +49,7 @@ public sealed class NullConditionalPass : IIrPass
         }
     }
 
-    /// <summary>Arm 1: the spilled-receiver shape (two adjacent stores to slot j).</summary>
+    /// <summary>Arm 1: the spilled-receiver shape (adjacent receiver/result stores).</summary>
     static bool RaiseSpilled(IrFunction function, Stepper stepper)
     {
         foreach (var block in function.Descendants.OfType<Block>())
@@ -59,15 +59,13 @@ public sealed class NullConditionalPass : IIrPass
             {
                 if (children[i] is not StoreStackSlot spill || children[i + 1] is not StoreStackSlot result)
                     continue;
-                if (spill.Slot != result.Slot)
-                    continue;
                 // The spill holds the receiver, loaded from slot s.
                 if (spill.Value is not LoadStackSlot receiverLoad)
                     continue;
                 if (result.Value is not Conditional conditional || !IsNullConditionalShape(conditional, out var member))
                     continue;
                 // The null test reads the SAME source slot s, and the member's
-                // receiver is the spill slot j — the two stores tie them together.
+                // receiver is the spill slot r — the two stores tie them together.
                 if (conditional.Condition is not LoadStackSlot conditionLoad || conditionLoad.Slot != receiverLoad.Slot)
                     continue;
                 if (MemberReceiver(member) is not LoadStackSlot memberReceiver || memberReceiver.Slot != spill.Slot)


### PR DESCRIPTION
Fixes #933.

## Summary
- Split carried evaluation-stack slots by stack position and carried type so unrelated edge lifetimes no longer force incompatible values into one synthetic slot.
- Integrated with the new `StackSlotLiveRangePass` from `main` and preserved null-literal join tracking.
- Updated dependent raises for split null-conditional receiver/result slots, constructor-chain receiver copies, and bool values stored through `ref bool`.
- Added regression coverage for disjoint stack-carry targets and bool materialization through indirect bool stores.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- Popular NuGet `--library-report --compile-cap 10000`: `validity: CS0266` is now 52, down from 120 in the issue report.
