### PR TITLE
Fix CS0163 library report switch fallout

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -5,10 +5,9 @@ namespace ILInspector.Decompiler.Tests;
 
 // An IL `switch` opcode the switch-raising pass could not lift into a structured
 // `switch` stays in the tree as a SwitchBranch jump table. The printer must
-// render it as valid lowered C# — a `switch` block with one `case i: goto
-// IL_xxxx;` per target — not the placeholder `switch (...) goto [..]` form, which
-// is not legal C# (CS1513/CS1514). Out-of-range values fall through, matching the
-// opcode.
+// render it as valid lowered C# — a `switch` block with one terminating case per
+// target — not the placeholder `switch (...) goto [..]` form, which is not legal
+// C# (CS1513/CS1514). Out-of-range values fall through, matching the opcode.
 public class SwitchBranchRenderingTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
@@ -42,9 +41,9 @@ public class SwitchBranchRenderingTests
 
         Assert.DoesNotContain("goto [", output);
         Assert.Contains("switch (x)", output);
-        Assert.Contains("case 0: goto IL_0010;", output);
-        Assert.Contains("case 1: goto IL_0020;", output);
-        Assert.Contains("case 2: goto IL_0030;", output);
+        Assert.Contains("case 0:\n        goto IL_0010;\n        break;", output);
+        Assert.Contains("case 1:\n        goto IL_0020;\n        break;", output);
+        Assert.Contains("case 2:\n        goto IL_0030;\n        break;", output);
     }
 
     [Fact]
@@ -55,8 +54,8 @@ public class SwitchBranchRenderingTests
         var result = RenderSwitch(0x10, 0x20, 0x10);
         var output = result.Output ?? "";
 
-        Assert.Contains("case 0: goto IL_0010;", output);
-        Assert.Contains("case 1: goto IL_0020;", output);
-        Assert.Contains("case 2: goto IL_0010;", output);
+        Assert.Contains("case 0:\n        goto IL_0010;\n        break;", output);
+        Assert.Contains("case 1:\n        goto IL_0020;\n        break;", output);
+        Assert.Contains("case 2:\n        goto IL_0010;\n        break;", output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -795,15 +795,20 @@ public sealed partial class CSharpPrinter
         {
             // The IL switch opcode is a jump table: it branches to
             // targets[value] when 0 <= value < targets.Length and falls through
-            // otherwise. Render it as a valid lowered switch — one
-            // `case i: goto IL_xxxx;` per target — rather than the placeholder
-            // `switch (...) goto [..]` form, which is not legal C#. Fall-through
-            // (no default) preserves the opcode's out-of-range behavior.
+            // otherwise. Render it as a valid lowered switch rather than the
+            // placeholder `switch (...) goto [..]` form, which is not legal C#.
+            // The unreachable break after each goto keeps the case section
+            // terminating even when a later pass/report shell cannot bind the
+            // target label; no default preserves the opcode's out-of-range fall-through.
             sb.Append(pad).Append("switch (").Append(Expression(switchBranch.Value)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
             string casePad = pad + "    ";
             for (int t = 0; t < switchBranch.TargetOffsets.Length; t++)
-                sb.Append(casePad).AppendLine($"case {t}: goto IL_{switchBranch.TargetOffsets[t]:X4};");
+            {
+                sb.Append(casePad).AppendLine($"case {t}:");
+                sb.Append(casePad).AppendLine($"    goto IL_{switchBranch.TargetOffsets[t]:X4};");
+                sb.Append(casePad).AppendLine("    break;");
+            }
             sb.Append(pad).AppendLine("}");
             return;
         }

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -86,7 +86,10 @@ internal static class LibraryReport
                 var id = $"{typeName}::{methodName}";
                 try
                 {
-                    IrPasses.Run(function);
+                    var context = new PassContext(
+                        new Stepper(enabled: false),
+                        importMethodBody: method => IrImporter.Import(source, method));
+                    IrPasses.Run(function, IrPasses.Default, context);
                 }
                 catch (Exception ex)
                 {
@@ -124,7 +127,7 @@ internal static class LibraryReport
                 string? rendered;
                 try
                 {
-                    rendered = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method)).Output;
+                    rendered = CSharpPrinter.Print(function).Output;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes #923.

## Summary
- Run the library-report raise pipeline once with the cross-method import context, then print the already-raised tree instead of rerunning `PrintRaised`.
- Make lowered `SwitchBranch` case sections explicitly terminating after label gotos so validity shells do not report switch fallthrough diagnostics.
- Update focused `SwitchBranchRenderingTests` coverage for the valid lowered shape.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- Product-library `--library-report --compile-cap 10000 --top-libraries 8`: no `validity: CS0163` rows; pass bugs remain 0.