### PR TITLE
Pin lock-sugar extra-finally and exit-mismatch near-misses (#959)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3358,13 +3358,14 @@ public class LockSugarTests
 /// <summary>
 /// Soundness of the lock-sugar match, on shapes the C# compiler never emits
 /// but hand-written or obfuscated IL could: a lockTaken local read after the
-/// try/finally, and a same-named Monitor from a non-BCL assembly. Both must
-/// leave the construct flat. Built directly in the post-structuring shape and
-/// run through LockSugarPass alone.
+/// try/finally, a same-named Monitor from a non-BCL assembly, a wrong Enter
+/// signature, extra trailing work in the finally, and an Exit whose object does
+/// not match the Enter. Each must leave the construct flat. Built directly in the
+/// post-structuring shape and run through LockSugarPass alone.
 /// </summary>
 public class LockSugarSoundnessTests
 {
-    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef, bool malformedEnterSignature = false, bool staticFieldLockObject = false)
+    static IrFunction BuildLock(string monitorAssembly, bool strayTakenRef, bool malformedEnterSignature = false, bool staticFieldLockObject = false, bool extraFinallyWork = false, bool mismatchedExitObject = false)
     {
         var voidType = TypeRef.CoreLib("System", "Void");
         var objType = TypeRef.CoreLib("System", "Object");
@@ -3377,6 +3378,10 @@ public class LockSugarSoundnessTests
         var enterReturn = malformedEnterSignature ? objType : voidType;
         var enterRef = new MethodRef(monitor, "Enter", enterReturn, [objType, TypeRef.ByRef(boolType)], HasThis: false);
         var exitRef = new MethodRef(monitor, "Exit", voidType, [objType], HasThis: false);
+        // A second object local (index 2) so the finally can Exit a DIFFERENT
+        // object than Enter locked — Enter(V_0)/Exit(V_2): not a real lock.
+        System.Collections.Immutable.ImmutableArray<TypeRef> locals = mismatchedExitObject ? [objType, boolType, objType] : [objType, boolType];
+        int exitObjectIndex = mismatchedExitObject ? 2 : 0;
 
         var tryBlock = new Block(0);
         tryBlock.Add(new ExpressionStatement(new Call(enterRef, false,
@@ -3385,9 +3390,11 @@ public class LockSugarSoundnessTests
         tryBody.Add(tryBlock);
 
         var thenBlock = new Block(0);
-        thenBlock.Add(new ExpressionStatement(new Call(exitRef, false, [new LoadLocal(0, objType)])));
+        thenBlock.Add(new ExpressionStatement(new Call(exitRef, false, [new LoadLocal(exitObjectIndex, objType)])));
         var finallyBlock = new Block(0);
         finallyBlock.Add(new IfStatement(new LoadLocal(1, boolType), thenBlock, null));
+        if (extraFinallyWork)
+            finallyBlock.Add(new ExpressionStatement(new LoadLocal(0, objType)));   // finally does more than guarded Exit
         var finallyBody = new BlockContainer();
         finallyBody.Add(finallyBlock);
 
@@ -3404,7 +3411,7 @@ public class LockSugarSoundnessTests
         body.Add(entry);
 
         var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
-        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [objType, boolType], body);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, locals, body);
     }
 
     [Fact]
@@ -3459,6 +3466,32 @@ public class LockSugarSoundnessTests
         // Right name, type, and argument shapes — but Enter returns object,
         // not void. The signature check rejects it.
         var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false, malformedEnterSignature: true);
+        new LockSugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void ExtraFinallyWork_StaysFlat()
+    {
+        // The finally does more than the guarded Monitor.Exit. csc's lock never
+        // emits trailing finally work, so the single-statement finally check
+        // must reject it — raising would drop that extra statement.
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false, extraFinallyWork: true);
+        new LockSugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+    }
+
+    [Fact]
+    public void ExitObjectMismatch_StaysFlat()
+    {
+        // Enter locks V_0 but the finally Exits a different object (V_2). The two
+        // are not a matched lock acquire/release, so the object-identity check
+        // must reject it rather than invent lock (V_0).
+        var function = BuildLock(TypeRef.CoreLibrary, strayTakenRef: false, mismatchedExitObject: true);
         new LockSugarPass().Run(function, PassContext.None);
 
         Assert.Empty(function.Descendants.OfType<Pipeline.Lock>());


### PR DESCRIPTION
## Adversarial review — Using/lock (#959)

PR-intent-informed adversarial review of the `LockSugarPass` raise. Reconstructed claim:

> Raise `lock (obj) { BODY }` **only** when the IL is exactly csc's Monitor lockTaken lowering — `object V_0 = obj; bool V_1 = false; try { Monitor.Enter(V_0, ref V_1); BODY } finally { if (V_1) Monitor.Exit(V_0); }` — with `V_0`/`V_1` referenced only by the consumed nodes.

### Result: no bug found
The matcher is sound across every shape probed (real csc lowerings, decompiled and fidelity-checked): static-field receiver (preserves the copied local, verified **byte-identical** IL on round-trip), instance-field, `lock(this)`, a re-evaluable call receiver `lock(f())`, nested locks, two sequential locks, and `return` inside the body. All hand-written near-misses correctly stay flat: extra finally work, escaping `lockTaken`, and an `Exit` on the wrong object.

Identity is exact: `MemberIdentity.IsMonitorEnter/Exit` enforce arity and `[object, ref bool]`/`[object]` from corelib `Monitor`; the finally must be a single guarded `Monitor.Exit`.

### What this PR adds
Two near-misses the matcher rejects today were **not pinned** by a test, so a future loosening of `TryMatch` could silently over-match. Both extend the existing `BuildLock` synthetic-IR helper in `LockSugarSoundnessTests`:

- **`ExtraFinallyWork_StaysFlat`** — finally does more than the guarded `Monitor.Exit`; exercises the single-statement-finally guard.
- **`ExitObjectMismatch_StaysFlat`** — finally `Exit`s a different object than `Enter` locked; exercises the `exitObject.Index == storeObject.Index` identity check.

Each was confirmed to bail at exactly its intended discriminator.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 820 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)