### PR TITLE
Add project grounding index command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ dnx dotnet-inspect -y -- <command>
 | Source | Examples | Notes |
 | ------ | -------- | ----- |
 | NuGet packages | `package System.Text.Json`, `type --package Markout` | Supports versions, custom sources, `nuget.config`, TFMs, package layout, dependencies, and vulnerabilities. |
+| Restored projects | `project ./src/App --agents-index`, `project ./src/App --readme Markout` | Resolves direct package references from `project.assets.json` for compact package grounding manifests and version-pinned docs. |
 | Platform libraries | `library System.Private.CoreLib`, `library System.Text.Json --version 10.0.0`, `diff --platform System.Runtime@9.0.0..10.0.0` | Resolves installed SDK/runtime assemblies, including runtime-only implementation assemblies with no NuGet package. |
 | Local assets | `library ./bin/MyLib.dll`, `package ./pkg/MyLib.nupkg` | Useful for auditing builds before publishing. |
 
@@ -30,6 +31,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | Capability | Commands | Highlights |
 | ---------- | -------- | ---------- |
 | Package inventory | `package` | Metadata, versions, TFMs, file layout, dependency tree, metadata audit, vulnerability data, custom feeds, NuGet config support. |
+| Project grounding | `project` | Direct dependency `AGENTS.md` frontmatter indexes and version-resolved package docs from restored projects. |
 | Library audit | `library` | Assembly identity, public key token, trim/AOT metadata, unsafe/interoperability signals, OpenTelemetry support, symbols/PDBs, SourceLink and determinism audit, references, resources, async method classification. |
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type filters. |
@@ -42,6 +44,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | Command | Purpose |
 | ------- | ------- |
 | `package X` | Inspect NuGet metadata, versions, dependencies, TFMs, layout, and vulnerabilities. |
+| `project [path]` | Inspect restored direct package references for grounding indexes and package docs. |
 | `library X` | Inspect assembly metadata, symbols, SourceLink, references, resources, and async methods. |
 | `type X` | Discover types or render a single type shape. |
 | `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
@@ -113,6 +116,8 @@ dotnet-inspect library Microsoft.Extensions.Logging.Abstractions -S Logging
 dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S Signals
 dotnet-inspect package System.Text.Json --path @readme --content --frontmatter
+dotnet-inspect project ./src/App --agents-index --jsonl
+dotnet-inspect project ./src/App --readme Markout
 ```
 
 For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` expand to scenario-focused section groups.
@@ -128,6 +133,8 @@ dotnet-inspect library System.Text.Json -S "Signals,SourceLink Availability,Sour
 dotnet-inspect library System.Text.Json -S "SourceLink Integrity"
 dotnet-inspect package System.Text.Json -S Signals
 dotnet-inspect package System.Text.Json --versions
+dotnet-inspect project ./src/App --agents-index
+dotnet-inspect project ./src/App --readme Markout
 dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,9 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 │                        package                               │
 │  NuGet package metadata, dependencies, file structure        │
 ├─────────────────────────────────────────────────────────────┤
+│                        project                               │
+│  Restored direct dependency docs and grounding index         │
+├─────────────────────────────────────────────────────────────┤
 │                        library                              │
 │  PE headers, SourceLink, determinism audit                   │
 ├─────────────────────────────────────────────────────────────┤
@@ -54,6 +57,14 @@ Inspects NuGet package metadata without extracting libraries:
 - Target frameworks and dependencies per TFM
 - File listing (DLLs or all files with `--all`)
 - Version history from nuget.org
+
+### project
+
+Inspects a restored project through `project.assets.json`:
+
+- Direct package references with resolved versions per selected TFM
+- Compact `AGENTS.md` frontmatter index for package grounding
+- Version-resolved best package docs for one direct dependency
 
 ### library
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -20,6 +20,7 @@ dnx dotnet-inspect -y -- <command>
 | ---- | ---------- | -------- |
 | Find the right API | `find Pattern` | `type Type --package Foo`, then `member Type --package Foo`. |
 | Inspect a package | `package Foo` | Add `-S Signals`, `-S Manifest`, `-S "Library Files"`, or `--library` to inspect the package DLL. |
+| Load project package grounding | `project ./App --agents-index` | Use `--readme PackageId` only after the index identifies a dependency whose full docs matter. |
 | Inspect a library or assembly | `library Foo` or `library path/to.dll` | Add `--platform`, `--package`, `-S Signals` when source matters, or `-S Integrations` when ecosystem support matters. |
 | Inspect a type | `type Type --package Foo` | Add `--all` for non-public, hidden, and extra members. |
 | Inspect members and overloads | `member Type --package Foo -m Name --show-index` | Use `Name:N` selectors for a specific overload. |
@@ -162,6 +163,8 @@ dnx dotnet-inspect -y -- package System.Text.Json -S "Markdown Files"
 dnx dotnet-inspect -y -- package System.Text.Json --path "*.md" --jsonl
 dnx dotnet-inspect -y -- package System.Text.Json --path @readme --content --frontmatter
 dnx dotnet-inspect -y -- package Markout Polly --path @agents --path @readme --match first --content --jsonl
+dnx dotnet-inspect -y -- project ./App --agents-index --jsonl
+dnx dotnet-inspect -y -- project ./App --readme Markout
 dnx dotnet-inspect -y -- package Aspire.Azure.AI.OpenAI --library -S @Integrations
 dnx dotnet-inspect -y -- library System.Text.Json -S Signals
 dnx dotnet-inspect -y -- library System.Text.Json -S Switches
@@ -177,6 +180,8 @@ Use `-S Switches` when runtime feature switches or compatibility switches may af
 Package file sections share one sparse-free schema: `Path` and uncompressed byte `Size`. `Library Files` shows files under `lib/`; `Package README` returns the best README candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` shows all `.md` files at full package depth; explicit `Files` shows all package files at full depth. `--path` scopes the same file-resolution primitive: `/` lists root files only, `"lib/net8.0/"` a directory's immediate children, `"*.md"` globs across the package, `README.md` a single file, `@readme` the best README candidate, and `@agents` a root `AGENTS.md`. Repeat `--path` or separate selectors with commas/semicolons; `--match all` returns every hit and `--match first` uses selectors as an ordered fallback. Multi-package file rows add `package` and `version`; JSON/JSONL keep `size` numeric; empty rows are preserved unless `--skip-empty`.
 
 Add `--content` to print selected file bodies instead of path rows. Default content output uses machine-splittable separator blocks; `--jsonl` emits one row per file with `package`, `version`, `path`, `found`, and `content`. Use `--frontmatter`/`--yaml-header` or `--body` with `--content` or `--readme` to scope markdown output.
+
+For project-scoped grounding, run `project ./App --agents-index` after restore. It resolves direct package versions from `project.assets.json` and emits one compact row per direct dependency; `name` and `description` are populated from root `AGENTS.md` frontmatter when present. Fetch the full best package doc only when needed with `project ./App --readme PackageId`; the package version comes from the project.
 
 `library X -S Signals` resolves SourceLink by acquiring a missing PDB. Per-source-file reachability is opt-in: add `-S "SourceLink Availability"` and `-S "SourceLink Missing Files"` for HTTP HEAD checks, or `-S "SourceLink Integrity"` to download source files and compare checksums. For .NET tool packages, inspect the tool DLL through the package context, for example `library dotnet-inspect.dll --package dotnet-inspect@<version> -S "SourceLink Integrity"`. Tool v2 pointer/RID packages resolve to their inspectable framework-dependent payload.
 

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -166,6 +166,67 @@ public class ProjectAssetsParserTests
     }
 
     [Fact]
+    public void ParsePackageReferences_ReturnsOnlyDirectPackagesWithResolvedVersions()
+    {
+        var json = """
+        {
+            "targets": {
+                "net9.0": {
+                    "Direct.Package/2.1.0": {},
+                    "Transitive.Package/1.0.0": {},
+                    "ProjectRef/1.0.0": {}
+                }
+            },
+            "libraries": {
+                "Direct.Package/2.1.0": {
+                    "type": "package",
+                    "path": "direct.package/2.1.0"
+                },
+                "Transitive.Package/1.0.0": {
+                    "type": "package",
+                    "path": "transitive.package/1.0.0"
+                },
+                "ProjectRef/1.0.0": {
+                    "type": "project",
+                    "path": "../ProjectRef/ProjectRef.csproj"
+                }
+            },
+            "project": {
+                "frameworks": {
+                    "net9.0": {
+                        "dependencies": {
+                            "Direct.Package": {
+                                "target": "Package",
+                                "version": "[2.0.0, )"
+                            },
+                            "ProjectRef": {
+                                "target": "Project"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var result = ProjectAssetsParser.ParsePackageReferences(assetsPath, null, null);
+
+            var dependency = Assert.Single(result);
+            Assert.Equal("Direct.Package", dependency.PackageName);
+            Assert.Equal("2.1.0", dependency.Version);
+            Assert.Equal("net9.0", dependency.TargetFramework);
+            Assert.EndsWith(Path.Combine("direct.package", "2.1.0"), dependency.PackagePath);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
     public void Parse_WithoutTfmFilter_SelectsHighestPriorityTfm()
     {
         var json = """

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -4,11 +4,63 @@ using NuGetFetch;
 
 namespace DotnetInspector.Services;
 
+public sealed record ProjectPackageReference(
+    string PackageName,
+    string Version,
+    string? PackagePath,
+    string TargetFramework);
+
 /// <summary>
 /// Parses project.assets.json to discover NuGet package assemblies in a project.
 /// </summary>
 public static class ProjectAssetsParser
 {
+    public static string? FindAssets(string projectPath)
+    {
+        var fullPath = Path.GetFullPath(string.IsNullOrWhiteSpace(projectPath) ? "." : projectPath);
+        if (File.Exists(fullPath)
+            && Path.GetFileName(fullPath).Equals("project.assets.json", StringComparison.OrdinalIgnoreCase))
+        {
+            return fullPath;
+        }
+
+        string projectDir;
+        string projectName;
+        if (Directory.Exists(fullPath))
+        {
+            projectDir = fullPath;
+            var projectFiles = Directory.GetFiles(projectDir, "*.csproj", SearchOption.TopDirectoryOnly);
+            projectName = projectFiles.Length == 1
+                ? Path.GetFileNameWithoutExtension(projectFiles[0])
+                : new DirectoryInfo(projectDir).Name;
+        }
+        else if (File.Exists(fullPath))
+        {
+            projectDir = Path.GetDirectoryName(fullPath) ?? "";
+            projectName = Path.GetFileNameWithoutExtension(fullPath);
+        }
+        else
+        {
+            return null;
+        }
+
+        var candidatePaths = new[]
+        {
+            Path.Combine(projectDir, "obj", "project.assets.json"),
+            Path.Combine(projectDir, "..", "..", "artifacts", "obj", projectName, "project.assets.json"),
+            Path.Combine(projectDir, "artifacts", "obj", projectName, "project.assets.json")
+        };
+
+        foreach (var candidate in candidatePaths)
+        {
+            var normalized = Path.GetFullPath(candidate);
+            if (File.Exists(normalized))
+                return normalized;
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Parses a project.assets.json file and returns the assembly paths with package metadata.
     /// </summary>
@@ -25,29 +77,7 @@ public static class ProjectAssetsParser
             if (!doc.RootElement.TryGetProperty("targets", out var targets))
                 return results;
 
-            // Find the target TFM
-            string? selectedTfm = null;
-            foreach (var target in targets.EnumerateObject())
-            {
-                var tfmName = target.Name;
-                var baseTfm = tfmName.Contains('/') ? tfmName[..tfmName.IndexOf('/')] : tfmName;
-
-                if (!string.IsNullOrEmpty(tfmFilter))
-                {
-                    if (baseTfm.Equals(tfmFilter, StringComparison.OrdinalIgnoreCase))
-                    {
-                        selectedTfm = tfmName;
-                        break;
-                    }
-                }
-                else
-                {
-                    if (selectedTfm == null || TfmResolver.GetTfmPriority(baseTfm) > TfmResolver.GetTfmPriority(selectedTfm.Contains('/') ? selectedTfm[..selectedTfm.IndexOf('/')] : selectedTfm))
-                    {
-                        selectedTfm = tfmName;
-                    }
-                }
-            }
+            var selectedTfm = SelectTargetFramework(targets, tfmFilter);
 
             if (selectedTfm == null)
                 return results;
@@ -105,5 +135,216 @@ public static class ProjectAssetsParser
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Parses a project.assets.json file and returns direct package references with resolved versions.
+    /// </summary>
+    public static List<ProjectPackageReference> ParsePackageReferences(string assetsPath, string? tfmFilter, Action<string>? log)
+    {
+        List<ProjectPackageReference> results = [];
+
+        try
+        {
+            var json = File.ReadAllText(assetsPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("targets", out var targets))
+                return results;
+            if (!doc.RootElement.TryGetProperty("libraries", out var libraries))
+                return results;
+
+            var selectedTfm = SelectTargetFramework(targets, tfmFilter);
+            if (selectedTfm == null)
+                return results;
+
+            log?.Invoke($"Using target framework: {selectedTfm}");
+            var baseTfm = GetBaseTfm(selectedTfm);
+            if (!TryGetFrameworkDependencies(doc.RootElement, baseTfm, out var frameworkDependencies))
+                return results;
+
+            var targetDependencies = targets.GetProperty(selectedTfm);
+            var directPackages = new List<string>();
+            foreach (var dependency in frameworkDependencies.EnumerateObject())
+            {
+                if (IsProjectDependency(dependency.Value))
+                    continue;
+
+                directPackages.Add(dependency.Name);
+            }
+
+            foreach (var packageName in directPackages)
+            {
+                if (TryResolvePackage(packageName, targetDependencies, libraries, selectedTfm, out var packageReference))
+                    results.Add(packageReference);
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Warning: Failed to parse project.assets.json: {ex.Message}");
+        }
+
+        return results
+            .OrderBy(result => result.PackageName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? SelectTargetFramework(JsonElement targets, string? tfmFilter)
+    {
+        string? selectedTfm = null;
+        foreach (var target in targets.EnumerateObject())
+        {
+            var tfmName = target.Name;
+            var baseTfm = GetBaseTfm(tfmName);
+
+            if (!string.IsNullOrEmpty(tfmFilter))
+            {
+                if (baseTfm.Equals(tfmFilter, StringComparison.OrdinalIgnoreCase))
+                {
+                    selectedTfm = tfmName;
+                    break;
+                }
+            }
+            else if (selectedTfm == null
+                || TfmResolver.GetTfmPriority(baseTfm) > TfmResolver.GetTfmPriority(GetBaseTfm(selectedTfm)))
+            {
+                selectedTfm = tfmName;
+            }
+        }
+
+        return selectedTfm;
+    }
+
+    private static string GetBaseTfm(string tfmName)
+        => tfmName.Contains('/') ? tfmName[..tfmName.IndexOf('/')] : tfmName;
+
+    private static bool TryGetFrameworkDependencies(JsonElement root, string baseTfm, out JsonElement dependencies)
+    {
+        dependencies = default;
+        if (!root.TryGetProperty("project", out var project)
+            || !project.TryGetProperty("frameworks", out var frameworks)
+            || !TryGetPropertyCaseInsensitive(frameworks, baseTfm, out var framework)
+            || !framework.TryGetProperty("dependencies", out dependencies))
+        {
+            return false;
+        }
+
+        return dependencies.ValueKind == JsonValueKind.Object;
+    }
+
+    private static bool TryResolvePackage(
+        string packageName,
+        JsonElement targetDependencies,
+        JsonElement libraries,
+        string targetFramework,
+        out ProjectPackageReference packageReference)
+    {
+        packageReference = null!;
+
+        foreach (var targetDependency in targetDependencies.EnumerateObject())
+        {
+            if (!TrySplitPackageKey(targetDependency.Name, out var resolvedName, out var version)
+                || !resolvedName.Equals(packageName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!TryGetPropertyCaseInsensitive(libraries, targetDependency.Name, out var library)
+                || IsProjectLibrary(library))
+            {
+                return false;
+            }
+
+            packageReference = new ProjectPackageReference(
+                resolvedName,
+                version,
+                ResolvePackagePath(library),
+                targetFramework);
+            return true;
+        }
+
+        foreach (var libraryEntry in libraries.EnumerateObject())
+        {
+            if (!TrySplitPackageKey(libraryEntry.Name, out var resolvedName, out var version)
+                || !resolvedName.Equals(packageName, StringComparison.OrdinalIgnoreCase)
+                || IsProjectLibrary(libraryEntry.Value))
+            {
+                continue;
+            }
+
+            packageReference = new ProjectPackageReference(
+                resolvedName,
+                version,
+                ResolvePackagePath(libraryEntry.Value),
+                targetFramework);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectDependency(JsonElement dependency)
+    {
+        if (dependency.ValueKind != JsonValueKind.Object)
+            return false;
+
+        return dependency.TryGetProperty("target", out var target)
+            && target.GetString()?.Equals("Project", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static bool IsProjectLibrary(JsonElement library)
+        => library.ValueKind == JsonValueKind.Object
+           && library.TryGetProperty("type", out var type)
+           && type.GetString()?.Equals("project", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static string? ResolvePackagePath(JsonElement library)
+    {
+        if (library.ValueKind != JsonValueKind.Object
+            || !library.TryGetProperty("path", out var pathElement))
+        {
+            return null;
+        }
+
+        var packagePath = pathElement.GetString();
+        if (string.IsNullOrWhiteSpace(packagePath))
+            return null;
+
+        var normalized = packagePath.Replace('/', Path.DirectorySeparatorChar);
+        return Path.IsPathRooted(normalized)
+            ? Path.GetFullPath(normalized)
+            : Path.GetFullPath(Path.Combine(NuGetCache.GetNuGetCachePath(), normalized));
+    }
+
+    private static bool TryGetPropertyCaseInsensitive(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.TryGetProperty(propertyName, out value))
+            return true;
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TrySplitPackageKey(string key, out string packageName, out string version)
+    {
+        var separator = key.LastIndexOf('/');
+        if (separator <= 0 || separator == key.Length - 1)
+        {
+            packageName = "";
+            version = "";
+            return false;
+        }
+
+        packageName = key[..separator];
+        version = key[(separator + 1)..];
+        return true;
     }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -89,6 +89,90 @@ public class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
+    private sealed record ProjectDocPackage(
+        string Id,
+        string Version,
+        string ReadmeFile,
+        string ReadmeText,
+        string? AgentsText = null);
+
+    private static (string ProjectPath, string TempDir) CreateProjectWithPackageDocs(params ProjectDocPackage[] packages)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"project-doc-test-{Guid.NewGuid():N}");
+        var projectDir = Path.Combine(tempDir, "App");
+        var objDir = Path.Combine(projectDir, "obj");
+        Directory.CreateDirectory(objDir);
+
+        var projectPath = Path.Combine(projectDir, "App.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        foreach (var package in packages)
+        {
+            var packageRoot = Path.Combine(tempDir, "packages", package.Id.ToLowerInvariant(), package.Version.ToLowerInvariant());
+            Directory.CreateDirectory(packageRoot);
+
+            var readmePath = Path.Combine(packageRoot, package.ReadmeFile.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(readmePath)!);
+            File.WriteAllText(readmePath, package.ReadmeText);
+            if (package.AgentsText != null)
+                File.WriteAllText(Path.Combine(packageRoot, "AGENTS.md"), package.AgentsText);
+
+            File.WriteAllText(Path.Combine(packageRoot, $"{package.Id.ToLowerInvariant()}.nuspec"), $$"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <id>{{package.Id}}</id>
+                    <version>{{package.Version}}</version>
+                    <authors>tests</authors>
+                    <description>test package</description>
+                    <readme>{{package.ReadmeFile}}</readme>
+                  </metadata>
+                </package>
+                """);
+        }
+
+        var targetEntries = string.Join(",\n", packages.Select(package =>
+            $"{JsonString($"{package.Id}/{package.Version}")}: {{}}"));
+        var libraryEntries = string.Join(",\n", packages.Select(package =>
+        {
+            var packageRoot = Path.Combine(tempDir, "packages", package.Id.ToLowerInvariant(), package.Version.ToLowerInvariant());
+            return $"{JsonString($"{package.Id}/{package.Version}")}: {{ \"type\": \"package\", \"path\": {JsonString(packageRoot.Replace('\\', '/'))} }}";
+        }));
+        var dependencyEntries = string.Join(",\n", packages.Select(package =>
+            $"{JsonString(package.Id)}: {{ \"target\": \"Package\", \"version\": {JsonString($"[{package.Version}, )")} }}"));
+        File.WriteAllText(Path.Combine(objDir, "project.assets.json"), $$"""
+            {
+              "targets": {
+                "net10.0": {
+                  {{targetEntries}}
+                }
+              },
+              "libraries": {
+                {{libraryEntries}}
+              },
+              "project": {
+                "frameworks": {
+                  "net10.0": {
+                    "dependencies": {
+                      {{dependencyEntries}}
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        return (projectPath, tempDir);
+    }
+
+    private static string JsonString(string value) => JsonSerializer.Serialize(value);
+
     private static (string PackagePath, string TempDir) CreateLocalPrimaryLibPackage()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -5134,6 +5218,66 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_ReadmeJsonl_IncludesPathSizeAndContent()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Readme.Jsonl", "PACKAGE.md", "package docs");
+        try
+        {
+            var (exit, output, _) = await RunAppAsync(
+                "package", packagePath, "--readme", "--jsonl");
+
+            Assert.Equal(0, exit);
+            var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            using var document = JsonDocument.Parse(line);
+            Assert.Equal("Test.Readme.Jsonl", document.RootElement.GetProperty("package").GetString());
+            Assert.Equal("1.0.0", document.RootElement.GetProperty("version").GetString());
+            Assert.Equal("PACKAGE.md", document.RootElement.GetProperty("path").GetString());
+            Assert.True(document.RootElement.GetProperty("size").GetInt64() > 0);
+            Assert.Equal("package docs", document.RootElement.GetProperty("content").GetString());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_ReadmeFrontmatter_AllowsMultiplePackages()
+    {
+        var firstReadme = """
+            ---
+            name: first
+            ---
+            # First Body
+            """;
+        var secondReadme = """
+            ---
+            name: second
+            ---
+            # Second Body
+            """;
+        var (firstPackage, firstDir) = CreateLocalReadmePackage("Test.MultiReadme.First", "README.md", firstReadme);
+        var (secondPackage, secondDir) = CreateLocalReadmePackage("Test.MultiReadme.Second", "README.md", secondReadme);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", firstPackage, secondPackage, "--readme", "--frontmatter");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("name: first", output);
+            Assert.Contains("name: second", output);
+            Assert.DoesNotContain("# First Body", output);
+            Assert.DoesNotContain("# Second Body", output);
+            Assert.DoesNotContain("Multiple package inspection cannot be combined with --readme", error);
+        }
+        finally
+        {
+            Directory.Delete(firstDir, recursive: true);
+            Directory.Delete(secondDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_PathContentFrontmatter_PrintsOnlyYamlHeader()
     {
         var agents = """
@@ -5151,6 +5295,74 @@ public class CommandExecutionTests
             Assert.Equal(0, exit);
             Assert.Contains("name: agents", output);
             Assert.DoesNotContain("# Agent body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Project_AgentsIndex_EmitsDirectDependencyAgentsFrontmatter()
+    {
+        var agents = """
+            ---
+            name: Markout guidance
+            description: Prefer Markout tables for structured markdown.
+            ---
+            # Body
+            """;
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.Agents", "1.2.3", "README.md", "readme", agents),
+            new ProjectDocPackage("Test.Project.NoAgents", "4.5.6", "README.md", "readme"));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--agents-index", "--jsonl");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, lines.Length);
+            using var agentsDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.Agents")));
+            Assert.Equal("Test.Project.Agents", agentsDocument.RootElement.GetProperty("package").GetString());
+            Assert.Equal("1.2.3", agentsDocument.RootElement.GetProperty("version").GetString());
+            Assert.Equal("Markout guidance", agentsDocument.RootElement.GetProperty("name").GetString());
+            Assert.Equal("Prefer Markout tables for structured markdown.", agentsDocument.RootElement.GetProperty("description").GetString());
+            Assert.Equal("AGENTS.md", agentsDocument.RootElement.GetProperty("path").GetString());
+
+            using var emptyDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.NoAgents")));
+            Assert.Equal("", emptyDocument.RootElement.GetProperty("name").GetString());
+            Assert.Equal("", emptyDocument.RootElement.GetProperty("description").GetString());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Project_Readme_UsesProjectResolvedDependencyVersion()
+    {
+        var agents = """
+            ---
+            name: selected
+            ---
+            # Agent guidance
+            """;
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.Readme", "2.0.0", "README.md", "# README body", agents));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--readme", "Test.Project.Readme");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.Contains("# Agent guidance", output);
+            Assert.DoesNotContain("# README body", output);
         }
         finally
         {

--- a/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
@@ -1,0 +1,91 @@
+using System.CommandLine;
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.CommandLine;
+
+public static class ProjectCommandDefinitions
+{
+    public static Command CreateProjectCommand(SharedOptions opts)
+    {
+        var projectCommand = new Command(ProjectCommand.Name, "Inspect restored project package references");
+
+        var pathArg = new Argument<string?>("path")
+        {
+            Description = "Project file, project directory, or project.assets.json path (defaults to current directory)",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        var agentsIndexOption = new Option<bool>("--agents-index")
+        {
+            Description = "Emit a compact AGENTS.md frontmatter manifest for direct package dependencies"
+        };
+        var readmeOption = new Option<string?>("--readme")
+        {
+            Description = "Print the best package doc for one direct dependency, resolving its version from the project"
+        };
+        var tfmOption = new Option<string?>("--tfm")
+        {
+            Description = "Select target framework from project.assets.json (e.g., net10.0)"
+        };
+        var frontmatterOption = new Option<bool>("--frontmatter")
+        {
+            Description = "With --readme, print only the leading YAML frontmatter block"
+        };
+        frontmatterOption.Aliases.Add("--yaml-header");
+        var bodyOption = new Option<bool>("--body")
+        {
+            Description = "With --readme, print only content after YAML frontmatter"
+        };
+        var outOption = new Option<string?>("--out")
+        {
+            Description = "Write output to file instead of stdout"
+        };
+
+        projectCommand.Arguments.Add(pathArg);
+        projectCommand.Options.Add(agentsIndexOption);
+        projectCommand.Options.Add(readmeOption);
+        projectCommand.Options.Add(tfmOption);
+        projectCommand.Options.Add(frontmatterOption);
+        projectCommand.Options.Add(bodyOption);
+        projectCommand.Options.Add(outOption);
+        projectCommand.Options.Add(opts.Json);
+        opts.AddTableOptionsTo(projectCommand);
+        opts.AddOutputOptionsTo(projectCommand);
+        opts.AddNuGetOptionsTo(projectCommand);
+
+        projectCommand.SetAction(async (parseResult, ct) =>
+        {
+            var frontmatterRequested = parseResult.GetValue(frontmatterOption);
+            var bodyRequested = parseResult.GetValue(bodyOption);
+            var contentScope = frontmatterRequested
+                ? PackageFileContentScope.Frontmatter
+                : bodyRequested
+                    ? PackageFileContentScope.Body
+                    : PackageFileContentScope.Full;
+
+            var options = new ProjectOptions
+            {
+                ProjectPath = parseResult.GetValue(pathArg) ?? ".",
+                AgentsIndex = parseResult.GetValue(agentsIndexOption),
+                ReadmePackageId = parseResult.GetValue(readmeOption),
+                Tfm = parseResult.GetValue(tfmOption),
+                ContentScope = contentScope,
+                FrontmatterRequested = frontmatterRequested,
+                BodyRequested = bodyRequested,
+                OutputPath = parseResult.GetValue(outOption),
+                JsonOutput = parseResult.GetValue(opts.Json),
+                OneLine = opts.ResolveOneLine(parseResult),
+                Tsv = opts.ResolveTsv(parseResult),
+                Jsonl = opts.ResolveJsonl(parseResult),
+                NoHeader = parseResult.GetValue(opts.NoHeaders),
+                Verbose = parseResult.GetValue(opts.Verbose),
+                SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
+            };
+
+            return await ProjectCommand.ExecuteAsync(options);
+        });
+
+        return projectCommand;
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -25,7 +25,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "library", "api", "type", "member", "diff", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "completion", "perf", "perf-test", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "diff", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "completion", "perf", "perf-test", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -99,6 +99,9 @@ public static class CommandLineBuilder
         // Package command
         rootCommand.Subcommands.Add(PackageCommandDefinitions.CreatePackageCommand(opts));
 
+        // Project command
+        rootCommand.Subcommands.Add(ProjectCommandDefinitions.CreateProjectCommand(opts));
+
         // Router command (hidden, implicit default for bare names)
         rootCommand.Subcommands.Add(RouterCommandDefinition.Create(rootCommand));
 
@@ -142,6 +145,7 @@ public static class CommandLineBuilder
                 new Tip(TypeCommand.Name, "--package <package>", "discover types in package"),
                 new Tip(MemberCommand.Name, "JsonSerializer --package System.Text.Json", "inspect type members"),
                 new Tip(FindCommand.Name, "<pattern> --package <package>", "search package types"),
+                new Tip(ProjectCommand.Name, "--agents-index", "index package grounding for a project"),
                 new Tip(FindCommand.Name, "<pattern> --platform", "search platform libraries"));
             return 0;
         });

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -538,7 +538,7 @@ public class PackageCommand
         if (!ValidateMultiPackageMode(options))
             return 1;
 
-        if (options.ShowContent)
+        if (options.ShowContent || (options.ShowReadme && options.ContentScope == PackageFileContentScope.Frontmatter))
             return await ExecuteMultiPackageContentAsync(packageArgs, options, context);
 
         if (!TryResolveMultiPackageRowSection(options, out var rowSection))
@@ -634,7 +634,9 @@ public class PackageCommand
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ListLayout) conflicts.Add("--layout");
         if (options.ListTfms) conflicts.Add("--tfms");
-        if (options.ShowReadme) conflicts.Add("--readme");
+        var multiReadmeFrontmatter = options.ShowReadme && options.ContentScope == PackageFileContentScope.Frontmatter;
+        if (options.ShowReadme && !multiReadmeFrontmatter) conflicts.Add("--readme");
+        if (multiReadmeFrontmatter && options.JsonOutput) conflicts.Add("--json");
         if (options.ShowDependencies) conflicts.Add("--dependencies");
         if (options.PackageLibrary != null) conflicts.Add("--library");
         if (options.AllLibraries) conflicts.Add("--all-libraries");
@@ -1047,66 +1049,8 @@ public class PackageCommand
         PackageFileContentScope scope)
     {
         var fullPath = Path.Combine(extractPath, file.Path.Replace('/', Path.DirectorySeparatorChar));
-        var content = ApplyMarkdownContentScope(File.ReadAllText(fullPath), scope);
+        var content = MarkdownContent.ApplyScope(File.ReadAllText(fullPath), scope);
         return new PackageFileContent(packageName, version, file.Path, file.Size, Found: true, content);
-    }
-
-    private static string ApplyMarkdownContentScope(string content, PackageFileContentScope scope)
-    {
-        if (scope == PackageFileContentScope.Full)
-            return content;
-
-        if (!TryFindYamlFrontmatter(content, out var frontmatterEnd, out var bodyStart))
-            return scope == PackageFileContentScope.Frontmatter ? "" : content;
-
-        return scope == PackageFileContentScope.Frontmatter
-            ? content[..frontmatterEnd]
-            : content[bodyStart..];
-    }
-
-    private static bool TryFindYamlFrontmatter(string content, out int frontmatterEnd, out int bodyStart)
-    {
-        frontmatterEnd = 0;
-        bodyStart = 0;
-        if (content.Length == 0)
-            return false;
-
-        var firstLineStart = content[0] == '\uFEFF' ? 1 : 0;
-        var firstLineEnd = FindLineEnd(content, firstLineStart);
-        if (!LineEquals(content, firstLineStart, firstLineEnd, "---"))
-            return false;
-
-        var lineStart = NextLineStart(content, firstLineEnd);
-        while (lineStart < content.Length)
-        {
-            var lineEnd = FindLineEnd(content, lineStart);
-            if (LineEquals(content, lineStart, lineEnd, "---"))
-            {
-                frontmatterEnd = lineEnd;
-                bodyStart = NextLineStart(content, lineEnd);
-                return true;
-            }
-
-            lineStart = NextLineStart(content, lineEnd);
-        }
-
-        return false;
-    }
-
-    private static int FindLineEnd(string content, int start)
-    {
-        var newline = content.IndexOf('\n', start);
-        return newline >= 0 ? newline : content.Length;
-    }
-
-    private static int NextLineStart(string content, int lineEnd)
-        => lineEnd < content.Length ? lineEnd + 1 : lineEnd;
-
-    private static bool LineEquals(string content, int lineStart, int lineEnd, string value)
-    {
-        if (lineEnd > lineStart && content[lineEnd - 1] == '\r')
-            lineEnd--;
-        return content.AsSpan(lineStart, lineEnd - lineStart).SequenceEqual(value);
     }
 
     private static int PrintPackageFileContents(IReadOnlyList<PackageFileContentSet> results, InspectionOptions options)
@@ -2398,6 +2342,16 @@ public class PackageCommand
 
         var file = result.Files[0];
         InfoTracker.SetDetail("readme", $"{file.Path} ({file.Size.ToString(CultureInfo.InvariantCulture)} B)");
+        if (options.JsonOutput || options.Jsonl)
+        {
+            var json = JsonSerializer.Serialize(file, PackageFileContentJsonContext.Default.PackageFileContent);
+            if (!string.IsNullOrEmpty(options.OutputPath))
+                File.WriteAllText(options.OutputPath, options.Jsonl ? json + Environment.NewLine : json);
+            else
+                Console.WriteLine(json);
+            return 0;
+        }
+
         string content = file.Content;
         if (!string.IsNullOrEmpty(options.OutputPath))
         {

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -1,0 +1,329 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using Markout;
+
+namespace DotnetInspector.Commands;
+
+public class ProjectCommand
+{
+    public const string Name = "project";
+
+    public static async Task<int> ExecuteAsync(ProjectOptions options)
+    {
+        if (!ValidateOptions(options))
+            return 1;
+
+        var context = new CommandContext(options.Verbose);
+        var logger = context.Logger;
+        var assetsPath = ProjectAssetsParser.FindAssets(options.ProjectPath);
+        if (assetsPath == null)
+        {
+            Console.Error.WriteLine($"Error: project.assets.json not found for '{options.ProjectPath}'. Run 'dotnet restore'.");
+            return 1;
+        }
+
+        logger.Log($"Using assets: {assetsPath}");
+        var dependencies = ProjectAssetsParser.ParsePackageReferences(assetsPath, options.Tfm, logger.Log);
+        if (dependencies.Count == 0)
+        {
+            Console.Error.WriteLine($"Error: No direct package references found in '{assetsPath}'.");
+            return 1;
+        }
+
+        if (options.AgentsIndex)
+            return WriteAgentsIndex(dependencies, options);
+
+        return await WriteReadmeAsync(dependencies, options, context);
+    }
+
+    private static bool ValidateOptions(ProjectOptions options)
+    {
+        if (options.FrontmatterRequested && options.BodyRequested)
+        {
+            Console.Error.WriteLine("Error: --frontmatter/--yaml-header cannot be combined with --body.");
+            return false;
+        }
+
+        var modeCount = (options.AgentsIndex ? 1 : 0) + (options.ReadmePackageId != null ? 1 : 0);
+        if (modeCount != 1)
+        {
+            Console.Error.WriteLine("Error: Specify exactly one project mode: --agents-index or --readme <package-id>.");
+            return false;
+        }
+
+        if (options.AgentsIndex && options.BodyRequested)
+        {
+            Console.Error.WriteLine("Error: --body cannot be combined with --agents-index.");
+            return false;
+        }
+
+        if (options.ReadmePackageId != null && options.OneLine && !options.Jsonl)
+        {
+            Console.Error.WriteLine("Error: project --readme supports raw text, --json, or --jsonl; it cannot be combined with --table or --tsv.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int WriteAgentsIndex(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)
+    {
+        var rows = dependencies
+            .Select(CreateAgentsIndexRow)
+            .ToList();
+
+        var output = options.JsonOutput
+            ? JsonSerializer.Serialize(rows.ToArray(), ProjectCommandJsonContext.Default.ProjectAgentsIndexRowArray)
+            : options.Jsonl
+                ? RenderAgentsIndexJsonl(rows)
+                : options.OneLine
+                    ? RenderAgentsIndexTable(rows, options)
+                    : RenderAgentsIndexMarkdown(rows);
+
+        WriteOutput(output, options.OutputPath);
+        return 0;
+    }
+
+    private static ProjectAgentsIndexRow CreateAgentsIndexRow(ProjectPackageReference dependency)
+    {
+        if (string.IsNullOrWhiteSpace(dependency.PackagePath) || !Directory.Exists(dependency.PackagePath))
+            return EmptyAgentsIndexRow(dependency);
+
+        var agentsPath = Path.Combine(dependency.PackagePath, "AGENTS.md");
+        if (!File.Exists(agentsPath))
+            return EmptyAgentsIndexRow(dependency);
+
+        var content = File.ReadAllText(agentsPath);
+        var frontmatter = MarkdownContent.ParseYamlFrontmatter(content);
+        frontmatter.TryGetValue("name", out var name);
+        frontmatter.TryGetValue("description", out var description);
+
+        return new ProjectAgentsIndexRow(
+            dependency.PackageName,
+            dependency.Version,
+            name ?? "",
+            description ?? "",
+            "AGENTS.md");
+    }
+
+    private static ProjectAgentsIndexRow EmptyAgentsIndexRow(ProjectPackageReference dependency)
+        => new(
+            dependency.PackageName,
+            dependency.Version,
+            Name: "",
+            Description: "",
+            Path: "");
+
+    private static string RenderAgentsIndexJsonl(IEnumerable<ProjectAgentsIndexRow> rows)
+    {
+        var builder = new StringBuilder();
+        foreach (var row in rows)
+            builder.AppendLine(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectAgentsIndexRow));
+        return builder.ToString();
+    }
+
+    private static string RenderAgentsIndexTable(IReadOnlyList<ProjectAgentsIndexRow> rows, ProjectOptions options)
+        => OutputFormatter.RenderTable(!options.NoHeader, (writer, formatter) =>
+        {
+            var markoutWriter = new MarkoutWriter(writer, formatter, OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl));
+            markoutWriter.WriteTable(
+                ["Package", "Version", "Name", "Description"],
+                ["package", "version", "name", "description"],
+                rows.Select(row => new[] { row.Package, row.Version, row.Name, row.Description }).ToArray());
+            markoutWriter.Flush();
+        });
+
+    private static string RenderAgentsIndexMarkdown(IReadOnlyList<ProjectAgentsIndexRow> rows)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Project AGENTS.md Index");
+        builder.AppendLine();
+        builder.AppendLine("| Package | Version | Name | Description |");
+        builder.AppendLine("| ------- | ------- | ---- | ----------- |");
+        foreach (var row in rows)
+        {
+            builder.Append("| ");
+            builder.Append(EscapeMarkdownTableCell(row.Package));
+            builder.Append(" | ");
+            builder.Append(EscapeMarkdownTableCell(row.Version));
+            builder.Append(" | ");
+            builder.Append(EscapeMarkdownTableCell(row.Name));
+            builder.Append(" | ");
+            builder.Append(EscapeMarkdownTableCell(row.Description));
+            builder.AppendLine(" |");
+        }
+
+        return builder.ToString();
+    }
+
+    private static async Task<int> WriteReadmeAsync(
+        IReadOnlyList<ProjectPackageReference> dependencies,
+        ProjectOptions options,
+        CommandContext context)
+    {
+        var dependency = dependencies.FirstOrDefault(dep =>
+            dep.PackageName.Equals(options.ReadmePackageId, StringComparison.OrdinalIgnoreCase));
+        if (dependency == null)
+        {
+            Console.Error.WriteLine($"Error: Package '{options.ReadmePackageId}' is not a direct dependency of '{options.ProjectPath}'.");
+            return 1;
+        }
+
+        var document = await ReadBestPackageDocumentAsync(dependency, options, context);
+        if (document == null)
+        {
+            Console.Error.WriteLine($"Error: Package '{dependency.PackageName}' does not contain a readme file.");
+            return 1;
+        }
+
+        InfoTracker.SetDetail("readme", $"{document.Path} ({document.Size.ToString(CultureInfo.InvariantCulture)} B)");
+        var output = options.JsonOutput
+            ? JsonSerializer.Serialize(document, ProjectCommandJsonContext.Default.ProjectPackageDocument)
+            : options.Jsonl
+                ? JsonSerializer.Serialize(document, ProjectCommandCompactJsonContext.Default.ProjectPackageDocument) + Environment.NewLine
+                : document.Content;
+
+        WriteOutput(output, options.OutputPath);
+        return 0;
+    }
+
+    private static async Task<ProjectPackageDocument?> ReadBestPackageDocumentAsync(
+        ProjectPackageReference dependency,
+        ProjectOptions options,
+        CommandContext context)
+    {
+        var fromProjectAssets = ReadBestPackageDocumentFromDirectory(dependency, options.ContentScope);
+        if (fromProjectAssets != null)
+            return fromProjectAssets;
+
+        PackageExtractionResult? resolution = null;
+        try
+        {
+            var outcome = await PackageExtractor.ExtractPackageAsync(
+                context.HttpClient,
+                dependency.PackageName,
+                context.Logger.Log,
+                sourceOptions: options.SourceOptions,
+                version: dependency.Version);
+
+            if (!outcome.IsSuccess)
+            {
+                Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");
+                return null;
+            }
+
+            resolution = outcome.Result!;
+            return ReadBestPackageDocumentFromDirectory(
+                dependency with
+                {
+                    Version = resolution.Version ?? dependency.Version,
+                    PackagePath = resolution.ExtractPath
+                },
+                options.ContentScope);
+        }
+        finally
+        {
+            if (resolution is { FromCache: false, TempDir: not null } && Directory.Exists(resolution.TempDir))
+            {
+                try
+                {
+                    Directory.Delete(resolution.TempDir, recursive: true);
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+    }
+
+    private static ProjectPackageDocument? ReadBestPackageDocumentFromDirectory(
+        ProjectPackageReference dependency,
+        PackageFileContentScope scope)
+    {
+        if (string.IsNullOrWhiteSpace(dependency.PackagePath) || !Directory.Exists(dependency.PackagePath))
+            return null;
+
+        var declaredReadme = ReadDeclaredReadme(dependency.PackagePath);
+        var readme = PackageFileLister.ResolvePackageReadme(dependency.PackagePath, declaredReadme);
+        if (readme == null)
+            return null;
+
+        var fullPath = Path.Combine(dependency.PackagePath, readme.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(fullPath))
+            return null;
+
+        var content = MarkdownContent.ApplyScope(File.ReadAllText(fullPath), scope);
+        return new ProjectPackageDocument(
+            dependency.PackageName,
+            dependency.Version,
+            readme,
+            new FileInfo(fullPath).Length,
+            content);
+    }
+
+    private static string? ReadDeclaredReadme(string packagePath)
+    {
+        var nuspecFiles = Directory.GetFiles(packagePath, "*.nuspec", SearchOption.TopDirectoryOnly);
+        return nuspecFiles.Length == 0
+            ? null
+            : NuspecParser.Parse(nuspecFiles[0]).ReadmeFile;
+    }
+
+    private static void WriteOutput(string output, string? outputPath)
+    {
+        if (!string.IsNullOrWhiteSpace(outputPath))
+            File.WriteAllText(outputPath, output);
+        else
+            Console.Write(output);
+    }
+
+    private static string EscapeMarkdownTableCell(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("|", "\\|", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal);
+}
+
+internal sealed record ProjectAgentsIndexRow(
+    string Package,
+    string Version,
+    string Name,
+    string Description,
+    string Path);
+
+internal sealed record ProjectPackageDocument(
+    string Package,
+    string Version,
+    string Path,
+    long Size,
+    string Content);
+
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ProjectAgentsIndexRow))]
+[JsonSerializable(typeof(ProjectAgentsIndexRow[]))]
+[JsonSerializable(typeof(ProjectPackageDocument))]
+internal partial class ProjectCommandJsonContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ProjectAgentsIndexRow))]
+[JsonSerializable(typeof(ProjectPackageDocument))]
+internal partial class ProjectCommandCompactJsonContext : JsonSerializerContext
+{
+}

--- a/src/dotnet-inspect/Options/ProjectOptions.cs
+++ b/src/dotnet-inspect/Options/ProjectOptions.cs
@@ -1,0 +1,36 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Options;
+
+public record ProjectOptions
+{
+    public string ProjectPath { get; init; } = ".";
+
+    public bool AgentsIndex { get; init; }
+
+    public string? ReadmePackageId { get; init; }
+
+    public string? Tfm { get; init; }
+
+    public PackageFileContentScope ContentScope { get; init; } = PackageFileContentScope.Full;
+
+    public bool FrontmatterRequested { get; init; }
+
+    public bool BodyRequested { get; init; }
+
+    public string? OutputPath { get; init; }
+
+    public bool JsonOutput { get; init; }
+
+    public bool OneLine { get; init; }
+
+    public bool Tsv { get; init; }
+
+    public bool Jsonl { get; init; }
+
+    public bool NoHeader { get; init; }
+
+    public bool Verbose { get; init; }
+
+    public NuGetSourceOptions? SourceOptions { get; init; }
+}

--- a/src/dotnet-inspect/Services/MarkdownContent.cs
+++ b/src/dotnet-inspect/Services/MarkdownContent.cs
@@ -1,0 +1,110 @@
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Services;
+
+public static class MarkdownContent
+{
+    public static string ApplyScope(string content, PackageFileContentScope scope)
+    {
+        if (scope == PackageFileContentScope.Full)
+            return content;
+
+        if (!TryFindYamlFrontmatter(content, out var frontmatterEnd, out var bodyStart))
+            return scope == PackageFileContentScope.Frontmatter ? "" : content;
+
+        return scope == PackageFileContentScope.Frontmatter
+            ? content[..frontmatterEnd]
+            : content[bodyStart..];
+    }
+
+    public static IReadOnlyDictionary<string, string> ParseYamlFrontmatter(string content)
+    {
+        if (!TryFindYamlFrontmatter(content, out var frontmatterEnd, out _))
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var firstLineStart = content.Length > 0 && content[0] == '\uFEFF' ? 1 : 0;
+        var firstLineEnd = FindLineEnd(content, firstLineStart);
+        var lineStart = NextLineStart(content, firstLineEnd);
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        while (lineStart < frontmatterEnd)
+        {
+            var lineEnd = FindLineEnd(content, lineStart);
+            var line = content[lineStart..lineEnd].Trim();
+            if (line.Length > 0 && !line.StartsWith('#'))
+            {
+                var colon = line.IndexOf(':');
+                if (colon > 0)
+                {
+                    var key = line[..colon].Trim();
+                    var value = TrimYamlScalar(line[(colon + 1)..].Trim());
+                    if (key.Length > 0)
+                        values[key] = value;
+                }
+            }
+
+            lineStart = NextLineStart(content, lineEnd);
+        }
+
+        return values;
+    }
+
+    private static string TrimYamlScalar(string value)
+    {
+        if (value.Length >= 2)
+        {
+            if ((value[0] == '"' && value[^1] == '"')
+                || (value[0] == '\'' && value[^1] == '\''))
+            {
+                return value[1..^1];
+            }
+        }
+
+        return value;
+    }
+
+    private static bool TryFindYamlFrontmatter(string content, out int frontmatterEnd, out int bodyStart)
+    {
+        frontmatterEnd = 0;
+        bodyStart = 0;
+        if (content.Length == 0)
+            return false;
+
+        var firstLineStart = content[0] == '\uFEFF' ? 1 : 0;
+        var firstLineEnd = FindLineEnd(content, firstLineStart);
+        if (!LineEquals(content, firstLineStart, firstLineEnd, "---"))
+            return false;
+
+        var lineStart = NextLineStart(content, firstLineEnd);
+        while (lineStart < content.Length)
+        {
+            var lineEnd = FindLineEnd(content, lineStart);
+            if (LineEquals(content, lineStart, lineEnd, "---"))
+            {
+                frontmatterEnd = lineEnd;
+                bodyStart = NextLineStart(content, lineEnd);
+                return true;
+            }
+
+            lineStart = NextLineStart(content, lineEnd);
+        }
+
+        return false;
+    }
+
+    private static int FindLineEnd(string content, int start)
+    {
+        var newline = content.IndexOf('\n', start);
+        return newline >= 0 ? newline : content.Length;
+    }
+
+    private static int NextLineStart(string content, int lineEnd)
+        => lineEnd < content.Length ? lineEnd + 1 : lineEnd;
+
+    private static bool LineEquals(string content, int lineStart, int lineEnd, string value)
+    {
+        if (lineEnd > lineStart && content[lineEnd - 1] == '\r')
+            lineEnd--;
+        return content.AsSpan(lineStart, lineEnd - lineStart).SequenceEqual(value);
+    }
+}


### PR DESCRIPTION
## Summary
- add `project [path] --agents-index` for direct dependency grounding manifests from restored `project.assets.json`
- add `project [path] --readme <package-id>` for version-resolved dependency docs
- add package `--readme --json/--jsonl` output and allow multi-package `--readme --frontmatter`

Closes #973.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `npx markdownlint-cli README.md docs/architecture.md skills/dotnet-inspect/SKILL.md`