### PR TITLE
Raise OR-chain diamonds: fold shared-true-arm guard runs before structuring (#911)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -789,6 +789,25 @@ public class CfgSampleClass
         return "";
     }
 
+    // An OR-chain DIAMOND: two short-circuit conditions select between a true and
+    // a non-empty false arm. csc lowers this to two conditionals both branching to
+    // the shared true arm, with the false arm jumping past it to the merge — a
+    // forward branch the structuring pass's one-conditional-per-diamond model
+    // cannot name, so the container stays flat (issue #911). OrChainDiamondPass
+    // folds the guards into one `||` conditional, leaving the single-conditional
+    // diamond the structuring pass raises into if/else; recompiling the `a < 0 ||
+    // b < 0` guard restores the same two-branch IL. The else arm is what
+    // distinguishes this from the guard-only OrChainGuardPass shape (IfOr above).
+    public static int OrChainDiamond(int a, int b, int x)
+    {
+        int r;
+        if (a < 0 || b < 0)
+            r = x * 2;
+        else
+            r = x + 7;
+        return r - a;
+    }
+
     public static string UnsignedBoundsBranch(int index, int[] array)
     {
         if ((uint)index >= (uint)array.Length)

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -70,6 +70,10 @@ public class FidelityGateTests
     /// on a sub-int (char/byte/short) binary result stored into a uint slot —
     /// the cast is a same-width reinterpret that emits no conv, so it recompiles
     /// opcode-exact.
+    /// OrChainDiamond must keep folding csc's OR-chain diamond (two conditionals to
+    /// a shared true arm, the else arm jumping past it to the merge) into one `||`
+    /// guard so the structuring pass raises the if/else; the `a < 0 || b < 0` guard
+    /// recompiles to the same two-branch IL.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -124,6 +128,7 @@ public class FidelityGateTests
         "IsNotNullReference",
         "LineSeparatorLiteral",
         "NegativeNativeInt",
+        "OrChainDiamond",
         "OrLongIntoULong",
         "MulLongIntoULong",
         "MulIntIntoUInt",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2529,6 +2529,140 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void OrChainDiamond_FoldsToSingleConditionDiamond()
+    {
+        // The csc OR-chain diamond shape (HashCode.Combine / ValueTuple, the
+        // `(a || b) ? T : F` family): two guards branch to the shared true arm,
+        // an unconditional false arm jumps past it to the merge, then the true
+        // arm. Built directly so the test is independent of csc codegen:
+        //   if (a < 0) goto IL_000C;   // → true arm
+        //   if (b < 0) goto IL_000C;   // → true arm
+        //   IL_0008: V_0 = 99; goto IL_0010;   // false arm, jumps past
+        //   IL_000C: V_0 = 1;                  // true arm
+        //   IL_0010: return V_0;
+        // The fold collapses the two guards into one || conditional, leaving the
+        // single-conditional diamond the structuring pass raises into if/else.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 12));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, B(), new Constant(0, intType)), 12));
+        var falseArm = new Block(8);
+        falseArm.Add(new StoreLocal(0, intType, new Constant(99, intType)));
+        falseArm.Add(new Branch(16));
+        var trueArm = new Block(12);
+        trueArm.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        var join = new Block(16);
+        join.Add(new Return(new LoadLocal(0, intType)));
+        foreach (var block in (Block[])[b0, b1, falseArm, trueArm, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal("""
+            if (!(a < 0 || b < 0))
+            {
+                return 99;
+            }
+            else
+            {
+                return 1;
+            }
+            """.ReplaceLineEndings("\n"), output);
+    }
+
+    [Fact]
+    public void OrChainDiamond_InnerGuardWithPrologue_StaysFlat()
+    {
+        // The adversarial near-miss: the inner guard carries a prologue (V_0 = 5)
+        // ahead of its conditional, so it is NOT a pure single-condition block.
+        // This is the HashCode.Combine `value?.GetHashCode() ?? 0` shape, where
+        // the second null test reloads the struct first. Folding to `a || b` would
+        // hoist that prologue out of short-circuit order (it must run only when
+        // the first guard fell through, and cannot live inside the || expression),
+        // so the pass refuses and the container stays flat. Differs from the
+        // positive fixture by exactly one statement on the inner guard.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 12));
+        var b1 = new Block(4);
+        b1.Add(new StoreLocal(0, intType, new Constant(5, intType)));   // prologue
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, B(), new Constant(0, intType)), 12));
+        var falseArm = new Block(8);
+        falseArm.Add(new StoreLocal(0, intType, new Constant(99, intType)));
+        falseArm.Add(new Branch(16));
+        var trueArm = new Block(12);
+        trueArm.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        var join = new Block(16);
+        join.Add(new Return(new LoadLocal(0, intType)));
+        foreach (var block in (Block[])[b0, b1, falseArm, trueArm, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        // The prologue forbids the fold: no combined || guard, and the always-correct
+        // flat goto form survives.
+        Assert.DoesNotContain("a < 0 || b < 0", output);
+        Assert.Contains("V_0 = 5", output);
+        Assert.Contains("goto", output);
+    }
+
+    [Fact]
+    public void OrChainDiamond_GuardsToDifferentTargets_NotFolded()
+    {
+        // Near-miss: the two guards branch to DIFFERENT targets (an `&&`-mixed
+        // dispatch, not a shared-true-arm OR chain). The run extends only while
+        // the next guard targets the same block, so a single guard is all it sees
+        // — below the two-guard bar — and nothing folds. No `a < 0 || …` guard.
+        //   if (a < 0) goto IL_0008;   // → one place
+        //   if (b < 0) goto IL_000C;   // → a DIFFERENT place
+        //   IL_0008: return 7;
+        //   IL_000C: return 9;
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, A(), new Constant(0, intType)), 8));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, B(), new Constant(0, intType)), 12));
+        var arm1 = new Block(8);
+        arm1.Add(new Return(new Constant(7, intType)));
+        var arm2 = new Block(12);
+        arm2.Add(new Return(new Constant(9, intType)));
+        foreach (var block in (Block[])[b0, b1, arm1, arm2])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("a < 0 || b < 0", output);
+    }
+
+    [Fact]
     public void SharedThrowGuards_InlineAsGuardClauses()
     {
         // Two guards branch to one shared throw block — the shape that breaks

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -99,6 +99,12 @@ public static class IrPasses
         // tree csc emits for a sparse switch (each arm goto-ing one ldloc; ret
         // tail) nests as guard clauses instead of staying flat goto soup.
         new ReturnMergePass(),
+        // Fold a short-circuit OR chain that selects between a diamond's two arms
+        // (two-plus guards sharing one true arm, an else arm jumping past it) into
+        // a single-conditional diamond the structuring pass can name. The sibling
+        // of or-chain-guard for the else-arm case; runs last so it folds the final
+        // normalized shape just before structuring.
+        new OrChainDiamondPass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -43,6 +43,8 @@ internal static class NativePasses
     public static ReturnSinkingPass ReturnSinking => new();
     [Native(NativeCategory.EmitArtifact, "short-circuit OR-guard chains folded so structuring can consume them")]
     public static OrChainGuardPass OrChainGuard => new();
+    [Native(NativeCategory.EmitArtifact, "short-circuit OR chain selecting a diamond's two arms folded so structuring can consume it")]
+    public static OrChainDiamondPass OrChainDiamond => new();
     [Native(NativeCategory.EmitArtifact, "branch-to-adjacent / dead branches removed before structuring")]
     public static RedundantBranchEliminationPass RedundantBranchElimination => new();
     [Native(NativeCategory.EmitArtifact, "identity conversions dropped (ldlen; conv.i4 array-length idiom)")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OrChainDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OrChainDiamondPass.cs
@@ -1,0 +1,254 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a short-circuit OR chain that selects between two arms of a diamond
+/// into one guard, before structuring. csc lowers
+/// <c>x = (a || b) ? TRUE : FALSE;</c> (and the <c>?.</c>/<c>??</c> forms that
+/// expand to it) to a run of single-condition blocks that all branch to the
+/// shared true arm, an unconditional false arm that jumps past it to the merge,
+/// then the true arm:
+/// <code>
+///   if (a) goto T;    // → true arm
+///   if (b) goto T;    // → true arm
+///   FALSE: …; goto M;  // else arm, jumps past the true arm
+///   T: TRUE …          // true arm, falls (or branches) to M
+///   M: REST
+/// </code>
+/// The two conditionals share one target, so the false arm's <c>goto M</c> lands
+/// past the true arm — a forward branch the <see cref="StructuringPass"/> diamond
+/// model (one conditional per diamond) cannot name, and the whole container stays
+/// flat (the <c>forward-branch-not-region-exit</c> stop, issue #911). This pass
+/// rebuilds the run of guards into a single <c>ConditionalBranch</c> whose
+/// condition is <c>a || b</c> to the true arm, collapsing the chain to the
+/// single-conditional diamond the structuring pass already raises (it negates the
+/// condition back to <c>if (a || b) { TRUE } else { FALSE }</c>).
+///
+/// Distinct from <see cref="OrChainGuardPass"/>: there the chain ends in a
+/// conditional <em>skip</em> guard and the consequence falls through to the join
+/// (no else arm); here the block after the chain is an unconditional <em>false
+/// arm</em> that branches past the shared true arm. The two shapes are disjoint
+/// in the block right after the guard run (a conditional vs. a goto-terminated
+/// arm), so they never contend for the same chain.
+///
+/// Conservative and sound: only a run of two or more pure single-condition blocks
+/// folds (a lone conditional is already the diamond the structuring pass raises),
+/// every guard must branch to the same true arm, a non-empty false arm must sit
+/// between the chain and that arm and end by branching strictly past it, and
+/// nothing outside the run may branch into the inner guard blocks the fold drops.
+/// Short-circuit order is preserved exactly: <c>a || b</c> evaluates <c>b</c> only
+/// when <c>a</c> was false, just as the fall-through chain did, and re-lowers to
+/// the same branch sequence (the fidelity invariant <see cref="OrChainGuardPass"/>
+/// also relies on).
+/// </summary>
+public sealed class OrChainDiamondPass : IIrPass
+{
+    public string Name => "or-chain-diamond";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        // A surviving leave may target a block this fold drops (an inner guard) —
+        // including from another container the per-container scan cannot see.
+        // Collect every leave target function-wide and refuse to fold across one.
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            if (TryFold(container, leaveTargets, stepper))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        for (int p = 0; p < blocks.Count; p++)
+        {
+            if (Chain(blocks, offsetToIndex, p) is { } chain
+                && NoExternalEntry(blocks, p, chain.LastGuard, leaveTargets))
+            {
+                Fold(container, p, chain.LastGuard, chain.TrueArmOffset, stepper);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// The OR-chain diamond rooted at <paramref name="p"/>: guards
+    /// [p, LastGuard] are all single-condition blocks (the root may carry leading
+    /// setup) branching to the same true arm; a non-empty false arm sits right
+    /// after the chain and ends by branching strictly past the true arm. Null when
+    /// block p does not start such a chain.
+    /// </summary>
+    static (int LastGuard, int TrueArmOffset)? Chain(
+        IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
+    {
+        if (ConditionTargetAtEnd(blocks[p]) is not { } trueArmOffset
+            || !offsetToIndex.TryGetValue(trueArmOffset, out int trueArm))
+        {
+            return null;
+        }
+
+        // Extend the run while each following block is a pure single-condition
+        // guard branching to the same true arm.
+        int lastGuard = p;
+        while (lastGuard + 1 < blocks.Count
+            && ConditionTarget(blocks[lastGuard + 1]) == trueArmOffset)
+        {
+            lastGuard++;
+        }
+
+        // A real chain needs two or more guards: a lone conditional is already the
+        // single-target diamond the structuring pass raises, so folding it would
+        // be a no-op reshape.
+        if (lastGuard == p)
+            return null;
+
+        // The false arm occupies [lastGuard+1, trueArm): at least one block, and
+        // the block right before the true arm ends with an unconditional branch
+        // strictly past it (the merge). The intervening arm shape is the
+        // structuring pass's to validate.
+        int falseStart = lastGuard + 1;
+        if (falseStart >= trueArm)
+            return null;
+        if (UnconditionalBranchTarget(blocks[trueArm - 1]) is not { } mergeOffset
+            || !offsetToIndex.TryGetValue(mergeOffset, out int mergeIndex)
+            || mergeIndex <= trueArm)
+        {
+            return null;
+        }
+        return (lastGuard, trueArmOffset);
+    }
+
+    /// <summary>The single branch target of a pure one-statement condition block, or null.</summary>
+    static int? ConditionTarget(Block block)
+        => block.Children is [ConditionalBranch conditional] ? conditional.TargetOffset : null;
+
+    /// <summary>
+    /// The branch target of a block whose last statement is a conditional branch
+    /// and whose earlier statements are all straight-line (no control flow), or
+    /// null. Only the chain root may carry such setup — the unconditional prologue
+    /// that computes the first guard's operands; inner guards must be pure, since
+    /// their leading statements would move out of short-circuit order if folded.
+    /// </summary>
+    static int? ConditionTargetAtEnd(Block block)
+    {
+        if (block.Children.Count == 0 || block.Children[^1] is not ConditionalBranch conditional)
+            return null;
+        for (int s = 0; s < block.Children.Count - 1; s++)
+        {
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return null;
+        }
+        return conditional.TargetOffset;
+    }
+
+    /// <summary>
+    /// The target of a block that ends with an unconditional <see cref="Branch"/>
+    /// and is otherwise straight-line (no control flow among its earlier
+    /// statements), or null. The false arm's terminating goto.
+    /// </summary>
+    static int? UnconditionalBranchTarget(Block block)
+    {
+        if (block.Children.Count == 0 || block.Children[^1] is not Branch branch)
+            return null;
+        for (int s = 0; s < block.Children.Count - 1; s++)
+        {
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return null;
+        }
+        return branch.TargetOffset;
+    }
+
+    /// <summary>
+    /// No block outside the chain may branch into the inner guards [p+1, LastGuard]
+    /// the fold drops — those edges would dangle at a vanished offset. The chain
+    /// entry (p) and every block from the false arm onward stay in place, so edges
+    /// to them are fine; a leave into a dropped guard aborts the fold too.
+    /// </summary>
+    static bool NoExternalEntry(
+        IReadOnlyList<Block> blocks, int p, int lastGuard, HashSet<int> leaveTargets)
+    {
+        var forbidden = new HashSet<int>();
+        for (int idx = p + 1; idx <= lastGuard; idx++)
+            forbidden.Add(blocks[idx].StartOffset);
+
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        for (int idx = 0; idx < blocks.Count; idx++)
+        {
+            if (idx > p && idx <= lastGuard)
+                continue;   // inside the dropped run — internal fall-throughs are fine
+            foreach (var node in blocks[idx].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        _ => [],
+    };
+
+    static void Fold(BlockContainer container, int p, int lastGuard, int trueArmOffset, Stepper stepper)
+    {
+        var blocks = container.Blocks.ToList();
+
+        // Build the OR condition in evaluation order: each guard contributes its
+        // own taken-path condition (the test that branches to the true arm). The
+        // guard conditional is always the block's last statement; only the root
+        // may carry leading setup ahead of it.
+        IrExpression? condition = null;
+        for (int j = p; j <= lastGuard; j++)
+        {
+            var conditional = (ConditionalBranch)blocks[j].Children[^1];
+            var guard = (IrExpression)conditional.DetachChildren()[0];
+            condition = condition is null
+                ? guard
+                : new LogicalBinary(LogicalKind.Or, condition, guard);
+        }
+
+        // The folded guard keeps the root block's leading statements (the
+        // unconditional prologue) and branches to the true arm when the OR holds;
+        // the structuring pass negates it back to `if (a || b) { TRUE } else { … }`.
+        var folded = new Block(blocks[p].StartOffset);
+        var rootChildren = blocks[p].DetachChildren();
+        for (int k = 0; k < rootChildren.Count - 1; k++)
+            folded.Add(rootChildren[k]);
+        folded.Add(new ConditionalBranch(condition!, trueArmOffset));
+
+        foreach (var block in blocks)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx < p; idx++)
+            rebuilt.Add(blocks[idx]);
+        rebuilt.Add(folded);
+        for (int idx = lastGuard + 1; idx < blocks.Count; idx++)
+            rebuilt.Add(blocks[idx]);
+        stepper.StepOver("fold short-circuit OR chain diamond", container);
+        container.ReplaceWith(rebuilt);
+    }
+}


### PR DESCRIPTION
## Target

`forward-branch-not-region-exit` — the largest `StructuringPass` fidelity stop (issue #911), 453 of 1015 flat containers on `origin/main`.

## The sub-shape

Sub-classifying the stop reason (non-switch, non-loop, forward-only) isolates the dominant in-scope sub-shape: the short-circuit **OR-chain diamond**. csc lowers `(a || b) ? T : F` (and the `?.`/`??` forms that expand to it — `HashCode.Combine`, `ValueTuple`, `Path.Join…`) to a run of single-condition blocks that **all branch to one shared true arm**, with a non-empty false arm that jumps *past* that arm to the merge:

```
if (a) goto T;    // → true arm
if (b) goto T;    // → true arm
FALSE: …; goto M;  // else arm, jumps past the true arm
T: TRUE …          // true arm
M: REST
```

The two conditionals share a target, so the false arm's `goto M` lands past the true arm — a forward branch `StructuringPass`'s one-conditional-per-diamond model cannot name, so the whole container stays flat.

## The fix

Add `OrChainDiamondPass`, the **else-arm sibling of `OrChainGuardPass`**: it folds a run of two-plus pure single-condition guards that share a true arm into one `ConditionalBranch` with the OR'd condition, collapsing the chain to the single-conditional diamond `StructuringPass` already raises into `if/else`. **`StructuringPass` itself is untouched** (it owns the known merge-conflict hotspot, #754). The fold re-lowers `a || b` to the same branch sequence, so it is fidelity-preserving — the same invariant `OrChainGuardPass` relies on.

### Soundness

Conservative and gated: only a run of **two-plus pure** guards folds (a lone conditional is already the diamond `StructuringPass` raises), every guard must branch to the **same** true arm, a non-empty false arm must sit between the chain and that arm and end by branching strictly past it, and nothing outside the run may branch into the inner guards the fold drops. Short-circuit order is preserved exactly.

The critical adversarial near-miss (pinned negative fixture): an inner guard carrying a **reload prologue** — the `HashCode.Combine` `value?.GetHashCode() ?? 0` shape — must **not** fold, because hoisting the prologue out of short-circuit order would change semantics. The pass refuses it (differs from the positive fixture by exactly one statement on the inner guard).

## Measurement (CoreLib, 41012 methods)

| Metric | before | after |
| --- | --- | --- |
| `forward-branch-not-region-exit` | 453 | **356** |
| containers structured | 10927 | **11021** |
| pass bugs | 0 | 0 |

- **Validity:** `--diff-validity-defects` vs `origin/main` — **0 regressed, 0 improved** (2670 methods compared).
- **Fidelity:** the `OrChainDiamond` fixture recompiles **opcode-exact** (pinned in `FidelityGateTests.PinnedExact`); a scratch round-trip of the raised `if (a || b) { … } else { … }` is 100% exact.
- Full decompiler suite green (823 tests).

## Fixtures

- Positive pass-level test + a pinned `CfgSampleClass.OrChainDiamond` source fixture (fidelity gate).
- Adversarial negatives: inner-guard-with-prologue (must stay flat) and guards-to-different-targets (`&&`-mixed, not a shared-true-arm chain).

Closes #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)