### PR TITLE
Sharpen range-recovery sidecar after adversarial review (#959)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
@@ -15,7 +15,11 @@ internal sealed class RangeRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:System.Index", "MemberIdentity.IsCoreLibraryType"),
             ],
             PositiveCoverage: "RangeFromGetSubArrayPassTests array range endpoint matrix plus string/span two-bound and from-end open fixtures",
-            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike, manual/one-sided Substring/Slice negatives, and mismatched receiver-spill negative",
-            MissingDiscriminator: "ordinary one-sided string/span forms plus broader manual Substring/Slice calls remain unraised"),
+            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike, manual/one-sided Substring/Slice negatives, source-named start-temp negative, and mismatched receiver-spill / start-temp negatives. Adversarial review (#959) confirmed the GetSubArray identity and the string/span hidden start-temp + spilled-receiver (PlaceIdentity.SameStackSlot) discriminators reject hand-written reloads, source-named temps, and user-assembly lookalikes",
+            // from-end-open string/span ranges (s[^n..]) ARE recovered; the still-unraised string/span
+            // forms are specifically from-start (s[i..] lowers to the 1-arg Substring(i)) and to-end
+            // (s[..j] lowers to Substring(0, j)), whose overloads carry no spill the pass keys on, plus
+            // broader manual Substring/Slice calls.
+            MissingDiscriminator: "from-start (s[i..] -> Substring(i)) and to-end (s[..j] -> Substring(0, j)) one-sided string/span forms, plus broader manual Substring/Slice calls, remain unraised"),
     ];
 }


### PR DESCRIPTION
## Adversarial review — Range/index (#959)

PR-intent-informed adversarial review of `IndexFromEndPass` (`a[^n]`) and `RangeFromGetSubArrayPass` (`a[range]`).

Reconstructed claim: raise `^n` / `a[range]` **only** when the IL is csc's lowering — proven by exact BCL identity (`GetSubArray`, string/`Span` `Slice`/`Substring`, `Range`/`Index` construction) **plus** the receiver/start spill discriminators (`PlaceIdentity.SameStackSlot`, synthetic non-source-named start temp), so hand-written `a[a.Length - n]` / `s.Substring(start, len)` stay as-is.

### Result: no soundness bug
Pressure-tested with a decompile + `--fidelity-check` matrix over array/string/span positives and hand-written near-misses:

- **Near-misses all reject:** `a[a.Length-1]` on param/local, `a[a.Length-n]`, `s[s.Length-1]`, span reload, source-named-temp `Substring`, and a user `Chars`+`Length` lookalike all stay unraised — the spill discriminator and identity gates hold. (These are already pinned in `IndexFromEndPassTests` / `RangeFromGetSubArrayPassTests`, covering the queue's entire falsification list.)
- **Positives are faithful:** index-from-end and two-bound / from-end-open ranges raise to byte-round-tripping C# for array, string, and span.
- **The one apparent diff is a harness artifact:** `s[^n..]` shows a `--fidelity-check` opcode diff, but the rendered source is the *exact* original and recompiles **byte-identically** under a standalone optimized build (the gate's recompile context just doesn't fire the from-end-open `Substring(Length-n)` peephole). Not a product fidelity defect.

### Change
Coverage is already comprehensive, so rather than add redundant fixtures this records the reviewed edges in `RangeRecoveryFacts` and **corrects an imprecise `MissingDiscriminator`**: from-end-open `s[^n..]` is in fact *recovered* (the old text implied otherwise, which could send a future agent chasing an already-done target). The genuinely unraised one-sided forms are from-start (`s[i..]` → 1-arg `Substring(i)`) and to-end (`s[..j]` → `Substring(0, j)`).

## Validation
- `LoweringFactCatalogTests`, `RangeFromGetSubArrayPassTests`, `IndexFromEndPassTests` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)