### PR TITLE
Add foreach copied-current adversarial pin

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -351,6 +351,57 @@ public class ForeachStatementPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void EnumeratorUsingLoop_WithCopiedCurrentReceiver_StaysUsingWhile()
+    {
+        var function = BuildEnumeratorUsingWhileWithCopiedCurrentReceiver();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildEnumeratorUsingWhileWithCopiedCurrentReceiver()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var enumerableType = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [intType]);
+        var enumeratorType = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerator`1"),
+            [intType]);
+        var getEnumerator = new MethodRef(enumerableType, "GetEnumerator", enumeratorType, [], HasThis: true);
+        var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var loopBody = new Block();
+        loopBody.Add(new StoreLocal(2, enumeratorType, new LoadLocal(0, enumeratorType)));
+        loopBody.Add(new StoreLocal(1, intType, new LoadProperty(current, new LoadLocal(2, enumeratorType), [])));
+
+        var usingBody = new BlockContainer();
+        var usingBlock = new Block();
+        usingBlock.Add(new WhileLoop(new Call(moveNext, isVirtual: true, [new LoadLocal(0, enumeratorType)]), loopBody));
+        usingBody.Add(usingBlock);
+
+        var entry = new Block();
+        entry.Add(new UsingStatement(0, enumeratorType, new Call(getEnumerator, isVirtual: true, [new LoadArgument(0, "items", enumerableType)]), usingBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("items", enumerableType)], HasThis: false, GenericParameterCount: 0),
+            [enumeratorType, intType, enumeratorType],
+            body);
+    }
+
     static IrFunction BuildCustomPatternEnumeratorUsingWhile()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
@@ -16,7 +16,7 @@ internal sealed class ForeachRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("pdb.hidden-pattern-enumerator-local", "ForeachStatementPass HasLocalNameSlot + HasSourceLocalName guard"),
             ],
             PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, strings, rank-2 rectangular arrays, and PDB-discriminated custom pattern enumerators",
-            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop, hand-written indexed array/string/rectangular-array loops, and no-symbols/manual pattern enumerator loops",
+            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop, copied Current receiver, hand-written indexed array/string/rectangular-array loops, and no-symbols/manual pattern enumerator loops",
             MissingDiscriminator: "higher-rank arrays, no-symbol custom pattern enumerators, and broader collection/extension GetEnumerator shapes not raised"),
     ];
 }


### PR DESCRIPTION
Part of #959.

## Summary
- Took the Foreach adversarial review row.
- Added a copied-`Current` receiver near-miss: an enumerator using/while shape where `MoveNext` uses the enumerator local but `Current` is read from a copied receiver must stay lowered.
- Updated `ForeachRecoveryFacts` adversarial coverage to record the reviewed copied receiver edge.

## Review claim
ForeachStatementPass may raise an enumerator using/while only when the hidden enumerator local itself proves the source `foreach` shape: `GetEnumerator`, `MoveNext`, and `Current` must all use that enumerator carrier with no residual uses.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ForeachStatementPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
