### PR TITLE
Escape the interpolation format clause so backslash formats round-trip (#959 String interpolation)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1797,6 +1797,14 @@ public class CfgSampleClass
     public static string InterpolationMixedHoles(string name, int score)
         => $"{name} scored {score:D4}!";
 
+    // A backslash-escaped custom format (the common TimeSpan/DateTime spelling):
+    // the IR carries the format as the single-backslash `h\:mm\:ss`, but the hole
+    // sits inside a non-verbatim `$"…"`, so it must render escaped (`h\\:mm\\:ss`)
+    // or the bare `\:` is CS1009. Recompiling the escaped form restores the same
+    // format constant opcode-exact.
+    public static string InterpolationWithBackslashFormat(System.TimeSpan ts)
+        => $@"{ts:h\:mm\:ss}";
+
     static int ConsumeInterpolation(string text) => text.Length;
 
     public static int UsingStatement(string path)

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -74,6 +74,10 @@ public class FidelityGateTests
     /// a shared true arm, the else arm jumping past it to the merge) into one `||`
     /// guard so the structuring pass raises the if/else; the `a < 0 || b < 0` guard
     /// recompiles to the same two-branch IL.
+    /// InterpolationWithBackslashFormat must keep escaping the interpolation
+    /// format clause (the backslash-escaped `h\:mm\:ss` TimeSpan spelling) so the
+    /// non-verbatim `$"…"` is valid C# and the format constant recompiles
+    /// opcode-exact — a raw `\:` is CS1009.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -127,6 +131,7 @@ public class FidelityGateTests
         "KeywordParam",
         "IsNotNullReference",
         "LineSeparatorLiteral",
+        "InterpolationWithBackslashFormat",
         "NegativeNativeInt",
         "OrChainDiamond",
         "OrLongIntoULong",

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -202,6 +202,45 @@ public class StringInterpolationPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void BackslashFormat_RendersEscaped_SoItRoundTrips()
+    {
+        // The common TimeSpan/DateTime custom format `h\:mm\:ss` reaches the IR as
+        // a single backslash, but the hole sits inside a non-verbatim `$"…"`, which
+        // csc escape-processes. The printer must escape it (`h\\:mm\\:ss`) or the
+        // bare `\:` is CS1009 — the #811 format clause rendered the raw string and
+        // produced malformed C# for every backslash-escaped format.
+        var function = BuildAppendFormattedOverload(
+            [s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant(@"h\:mm\:ss", s_string)]);
+
+        new StringInterpolationPass().Run(function, PassContext.None);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains(@"$""{value:h\\:mm\\:ss}""", output);
+        Assert.DoesNotContain("AppendFormatted", output);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void QuoteAndNewlineFormat_RenderEscaped_StayValid()
+    {
+        // A double quote or newline in a format equally cannot appear raw in a
+        // non-verbatim `$"…"` (the quote closes the literal, the newline is
+        // CS1010). The shared string escaping handles both: `\"` and `\n`. These
+        // come from hand-written handlers, but the printer must never emit invalid
+        // C# for a matched shape.
+        var quote = BuildAppendFormattedOverload(
+            [s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant("a\"b", s_string)]);
+        new StringInterpolationPass().Run(quote, PassContext.None);
+        Assert.Contains(@"{value:a\""b}", CSharpPrinter.Print(quote).Output);
+
+        var newline = BuildAppendFormattedOverload(
+            [s_int, s_string], [new LoadArgument(0, "value", s_int), new Constant("a\nb", s_string)]);
+        new StringInterpolationPass().Run(newline, PassContext.None);
+        Assert.Contains(@"{value:a\nb}", CSharpPrinter.Print(newline).Output);
+    }
+
     static string FormatClause(InterpolatedStringExpression node)
     {
         var part = node.Parts.Single(p => !p.IsLiteral);

--- a/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/StringInterpolationFacts.cs
@@ -10,8 +10,8 @@ internal sealed class StringInterpolationFacts : ILoweringFactProvider
             [
                 new FactPrimitive("member.corelib-identity:DefaultInterpolatedStringHandler", "MemberIdentity interpolated-string handler predicates"),
             ],
-            PositiveCoverage: "StringInterpolationPassTests straight-line handler append fixtures, including alignment and format specifiers",
-            AdversarialCoverage: "StringInterpolationPassTests user handler lookalike",
+            PositiveCoverage: "StringInterpolationPassTests straight-line handler append fixtures, including alignment, format specifiers, and backslash-escaped formats that round-trip through the escaped clause (CfgSampleClass.InterpolationWithBackslashFormat)",
+            AdversarialCoverage: "StringInterpolationPassTests user handler lookalike, brace-in-format (stays lowered), and backslash/quote/newline format clauses (escaped, not raw)",
             MissingDiscriminator: "non-straight-line handler flows need dataflow facts"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -168,7 +168,7 @@ public sealed partial class CSharpPrinter
                     if (format.HasAlignment)
                         sb.Append(',').Append(format.Alignment.ToString(System.Globalization.CultureInfo.InvariantCulture));
                     if (format.FormatString is { } formatString)
-                        sb.Append(':').Append(formatString);
+                        sb.Append(':').Append(InterpolatedFormatText(formatString));
                 }
                 sb.Append('}');
             }
@@ -193,6 +193,25 @@ public sealed partial class CSharpPrinter
             else
                 sb.Append(EscapeChar(c, inString: true));
         }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The format clause of an interpolation hole (<c>{value:format}</c>) sits
+    /// inside the enclosing <c>$"…"</c>, so csc escape-processes it exactly like
+    /// literal text: a backslash-escaped custom format such as a TimeSpan
+    /// <c>h\:mm\:ss</c> reaches the IR as a single backslash and must be rendered
+    /// <c>h\\:mm\\:ss</c> or the bare <c>\:</c> is CS1009 "unrecognized escape
+    /// sequence". Braces never appear here — a brace cannot round-trip through a
+    /// format spec, so <see cref="MemberIdentity"/> keeps such handlers lowered —
+    /// so this only needs the string escaping, not the literal text's brace
+    /// doubling.
+    /// </summary>
+    static string InterpolatedFormatText(string format)
+    {
+        var sb = new StringBuilder(format.Length);
+        foreach (char c in format)
+            sb.Append(EscapeChar(c, inString: true));
         return sb.ToString();
     }
 


### PR DESCRIPTION
Adversarial review of the **String interpolation** raise — review-queue row in #959.

## Claim under review

`StringInterpolationPass` raises a `DefaultInterpolatedStringHandler` sequence to `$"…"` only when the handler is a compiler temp consumed in place and each `AppendFormatted` overload's alignment/format is a constant that can round-trip through `{value,align:format}`. The #811 format/alignment work added the format clause but rendered the format string **raw**.

## Falsified

The format spec sits inside the non-verbatim `$"…"`, so csc **escape-processes** it. A backslash-escaped custom format — the common TimeSpan/DateTime spelling `$@"{ts:h\:mm\:ss}"` — reaches the IR as a single backslash and was rendered `$"{ts:h\:mm\:ss}"`, where the bare `\:` is **CS1009 "unrecognized escape sequence"**. Quotes and newlines in a format clause break the literal the same way (CS1010). The identity guard only rejected braces, so every such format produced **Full-malformed C#**.

This is reachable from ordinary source: any `$@"{ts:h\:mm}"` / `$"{ts:h\\:mm}"`.

## Fix — printer, not matcher

Render the format clause through the shared string escaping (`\\`, `\"`, `\n`, …), exactly as interpolated **literal** text is already escaped. This keeps the recovered idiom **and** makes it valid: the escaped form recompiles to the same format constant opcode-exact (`$@"{ts:h\:mm}"` → `$"{ts:h\\:mm}"` → same IL). Braces stay out via the existing identity guard (a brace genuinely cannot round-trip through a format spec).

## Evidence

- `CfgSampleClass.InterpolationWithBackslashFormat` pinned **opcode-exact** in the fidelity gate.
- Pass-level tests for backslash, quote, and newline format clauses (escaped, not raw); the brace-in-format negative still stays lowered.
- Scratch lib with `$@"{ts:h\:mm\:ss}"`: **2 Full-malformed (CS1009) → 0**, fidelity **100% opcode-exact**.
- CoreLib validity diff vs `origin/main`: **0 regressed, 0 improved**.
- Full decompiler suite green (826).
- Sidecar `AdversarialCoverage` updated to record the reviewed edge.

Part of #959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)