### PR TITLE
Harden object initializer Add receiver matching

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1656,6 +1656,13 @@ public class CfgSampleClass
         public System.Collections.Generic.List<int> Items { get; } = new();
     }
 
+    public sealed class NonEnumerableAddTarget
+    {
+        public int Total { get; private set; }
+
+        public void Add(int value) => Total += value;
+    }
+
     public static InitContainer MakeNestedObject(int a, int b)
         => new InitContainer { Inner = { X = a, Y = b } };
 
@@ -1700,6 +1707,13 @@ public class CfgSampleClass
 
     public static System.Collections.Generic.Dictionary<string, int> MakeDictionaryByAdd(int a, int b)
         => new System.Collections.Generic.Dictionary<string, int> { { "x", a }, { "y", b } };
+
+    public static NonEnumerableAddTarget MakeNonEnumerableAddLookalike(int a)
+    {
+        var target = new NonEnumerableAddTarget();
+        target.Add(a);
+        return target;
+    }
 
     public static InitTarget MakeEmpty() => new InitTarget();
 

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -6,7 +7,7 @@ public class ObjectInitializerPassTests
 {
     static IrFunction Raised(string methodName)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, locator: RuntimeLocator);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
@@ -15,6 +16,18 @@ public class ObjectInitializerPassTests
     }
 
     static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
+        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
+
+    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
+        trust == AssemblyTrust.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
+            ? path
+            : null;
 
     [Fact]
     public void ObjectInitializer_RaisesPropertyMembers()
@@ -172,6 +185,18 @@ public class ObjectInitializerPassTests
         // Each dictionary Add element keeps both arguments (key, value).
         Assert.All(initializer.Entries, entry => Assert.Equal(2, entry.Arguments.Count));
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
+    }
+
+    [Fact]
+    public void CollectionInitializerRequiresEnumerableReceiver()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeNonEnumerableAddLookalike));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".Add(a);", output);
+        Assert.DoesNotContain("new NonEnumerableAddTarget {", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -9,9 +9,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// assembly's metadata cannot state on its own. A bare type token (a
 /// <c>newobj</c> target, a <c>box</c>/<c>sizeof</c> operand) carries no
 /// <c>VALUETYPE</c>/<c>CLASS</c> byte, so <see cref="TypeRef.ValueTypeHint"/> is
-/// <see cref="ValueTypeHint.Unknown"/> for cross-assembly references; this
-/// resolver locates the defining assembly and reads the answer from its
-/// metadata.
+/// <see cref="ValueTypeHint.Unknown"/> for cross-assembly references; collection
+/// initializer raising also needs interface evidence from the defining assembly.
+/// This resolver locates that assembly and reads the answer from its metadata.
 /// </summary>
 /// <remarks>
 /// Precision-preserving: a fact is returned only when the defining assembly is
@@ -36,6 +36,7 @@ internal sealed class CrossAssemblyTypeResolver
     readonly MetadataContext _context;
     readonly Dictionary<TypeRef, ValueTypeHint> _valueTypeCache = [];
     readonly Dictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = [];
+    readonly Dictionary<(TypeRef Type, TypeRef Interface), MetadataFactState> _interfaceCache = [];
 
     public CrossAssemblyTypeResolver(string selfSimpleName, MetadataReader selfReader, MetadataContext context)
     {
@@ -110,6 +111,109 @@ internal sealed class CrossAssemblyTypeResolver
             IsExtension = needsExtension ? resolved.IsExtension : callee.IsExtension,
         };
     }
+
+    /// <summary>
+    /// Returns whether a cross-assembly type implements an interface, resolving
+    /// base classes and base interfaces through the shared metadata context.
+    /// Unreachable metadata returns <see cref="MetadataFactState.Unknown"/>;
+    /// absence is reported as <see cref="MetadataFactState.No"/> only after the
+    /// reachable hierarchy has been walked.
+    /// </summary>
+    public MetadataFactState Implements(TypeRef type, TypeRef iface)
+    {
+        var key = (type, iface);
+        if (_interfaceCache.TryGetValue(key, out var cached))
+            return cached;
+
+        var result = MetadataFactState.Unknown;
+        try
+        {
+            if (NamedDefinition(type) is { } definition
+                && !string.IsNullOrEmpty(definition.Assembly)
+                && definition.Assembly != TypeRefDecoder.Canonical(_selfSimpleName)
+                && TryImplements(type, iface, out var implements))
+            {
+                result = implements ? MetadataFactState.Yes : MetadataFactState.No;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            result = MetadataFactState.Unknown;
+        }
+
+        _interfaceCache[key] = result;
+        return result;
+    }
+
+    bool TryImplements(TypeRef type, TypeRef iface, out bool implements)
+    {
+        implements = false;
+        bool unresolved = false;
+        var seen = new HashSet<TypeRef>();
+        var pending = new Stack<TypeRef>();
+        pending.Push(type);
+
+        while (pending.Count > 0 && seen.Count < 256)
+        {
+            var current = pending.Pop();
+            if (!seen.Add(current))
+                continue;
+
+            if (NamedDefinition(current) is not { } definition)
+                continue;
+            if (Locate(definition) is not { } location
+                || _context.Open(location.AssemblyPath) is not { } assembly
+                || !assembly.TryGetType(location.FullTypeName, out var handle))
+            {
+                unresolved = true;
+                continue;
+            }
+
+            var reader = assembly.Reader;
+            var typeDef = reader.GetTypeDefinition(handle);
+            var typeArguments = current.Kind == TypeRefKind.GenericInstance ? current.TypeArguments : [];
+            foreach (var implemented in DecodeInterfaces(reader, typeDef, typeArguments))
+            {
+                if (implemented.Equals(iface))
+                {
+                    implements = true;
+                    return true;
+                }
+                pending.Push(implemented);
+            }
+
+            if (DecodeBaseType(reader, typeDef, typeArguments) is { } baseType)
+                pending.Push(baseType);
+        }
+
+        return !unresolved;
+    }
+
+    static IEnumerable<TypeRef> DecodeInterfaces(MetadataReader reader, TypeDefinition typeDef, ImmutableArray<TypeRef> typeArguments)
+    {
+        var scope = new GenericScope(MethodDefinitionFacts.GenericParameterNames(reader, typeDef.GetGenericParameters()), []);
+        foreach (var implHandle in typeDef.GetInterfaceImplementations())
+        {
+            var iface = reader.GetInterfaceImplementation(implHandle).Interface;
+            if (DecodeType(reader, iface, scope) is { } decoded)
+                yield return decoded.Instantiate(typeArguments, []);
+        }
+    }
+
+    static TypeRef? DecodeBaseType(MetadataReader reader, TypeDefinition typeDef, ImmutableArray<TypeRef> typeArguments)
+    {
+        var scope = new GenericScope(MethodDefinitionFacts.GenericParameterNames(reader, typeDef.GetGenericParameters()), []);
+        return DecodeType(reader, typeDef.BaseType, scope)?.Instantiate(typeArguments, []);
+    }
+
+    static TypeRef? DecodeType(MetadataReader reader, EntityHandle handle, GenericScope scope)
+        => handle.Kind switch
+        {
+            HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
+            HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)handle, 0),
+            HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, scope, (TypeSpecificationHandle)handle, 0),
+            _ => null,
+        };
 
     ResolvedMethodFacts? ResolveMethodFacts(MethodRef callee, TypeRef type)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
@@ -10,10 +10,11 @@ internal sealed class ObjectInitializerFacts : ILoweringFactProvider
             [
                 new FactPrimitive("dataflow.stack-slot-dup-chain", "ObjectInitializerPass alias-slot tracking"),
                 new FactPrimitive("dataflow.single-use-local", "ObjectInitializerPass named-local tracking"),
+                new FactPrimitive("metadata.collection-initializer-receiver", "IEnumerable receiver proof for Add-based collection entries"),
                 new FactPrimitive("ir.initializer-entry-shape", "InitializerEntry member/indexer/Add argument model"),
             ],
             PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, dictionary, nested object/collection, nested-reassign (Inner = new U { ... }, folded inner-first), and named-local object/collection fixtures",
-            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... })",
+            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; non-IEnumerable Add lookalikes stay lowered; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... })",
             MissingDiscriminator: "named locals with extra outside uses remain lowered"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -297,6 +297,7 @@ public static class IrImporter
     {
         var shapes = new Dictionary<TypeRef, TypeShape>();
         Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? enums = null;
+        var collectionInitializerTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
 
         void Consider(TypeRef? type)
         {
@@ -317,12 +318,24 @@ public static class IrImporter
             }
         }
 
+        void ConsiderCollectionInitializer(TypeRef? type)
+        {
+            while (type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } element })
+                type = element;
+            if (type is not { Kind: TypeRefKind.Definition or TypeRefKind.GenericInstance })
+                return;
+            if (source.SupportsCollectionInitializer(type) == MetadataFactState.Yes)
+                collectionInitializerTypes.Add(type);
+        }
+
         foreach (var node in function.Descendants)
         {
             foreach (var type in node.DirectTypes)
                 Consider(type);
             if (node is IrExpression expression)
                 Consider(expression.ResultType);
+            if (node is Call { Callee.HasThis: true, Callee.Name: "Add", Arguments.Count: >= 2 } call)
+                ConsiderCollectionInitializer(call.Arguments[0].ResultType ?? call.Callee.DeclaringType);
         }
 
         // The signature's own types are not reached by any node's result type —
@@ -337,6 +350,8 @@ public static class IrImporter
             function.TypeShapes = shapes;
         if (enums is not null)
             function.EnumMembers = enums;
+        if (collectionInitializerTypes.Count > 0)
+            function.CollectionInitializerTypes = collectionInitializerTypes.ToImmutable();
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -227,6 +227,14 @@ public sealed class IrFunction : IrNode
     public IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> EnumMembers { get; set; }
         = ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty;
 
+    /// <summary>
+    /// Types proven, while metadata was live, to satisfy C# collection-initializer
+    /// receiver rules. `ObjectInitializerPass` consumes this so an arbitrary
+    /// method named `Add` is not enough to raise `new C { ... }`.
+    /// </summary>
+    public IReadOnlySet<TypeRef> CollectionInitializerTypes { get; set; }
+        = ImmutableHashSet<TypeRef>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -9,8 +9,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// an <see cref="AssemblyLocator"/> plus a pool of assemblies opened on demand.
 /// Where <see cref="MetadataSource"/> owns the readers for the ONE assembly being
 /// decompiled, this owns the readers for every OTHER assembly consulted while
-/// recovering cross-assembly facts (the value-type-ness of a bare token today;
-/// type identity and unsafe-callee bodies on the roadmap).
+/// recovering cross-assembly facts (value-type-ness of a bare token, interface
+/// membership for exact raise gates, and method facts such as by-ref call-site
+/// spelling).
 /// </summary>
 /// <remarks>
 /// Each defining assembly is opened at most once: <see cref="Open"/> caches the

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -15,6 +15,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public sealed class MetadataSource : IDisposable
 {
+    static readonly TypeRef s_enumerable = TypeRef.CoreLib("System.Collections", "IEnumerable");
+
     readonly FileStream _stream;
     MetadataReaderProvider? _pdbProvider;
     MetadataReader? _pdbReader;
@@ -309,6 +311,9 @@ public sealed class MetadataSource : IDisposable
     static bool IsObject(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
 
+    static TypeRef? NamedDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+
     /// <summary>True when <paramref name="type"/> (or the definition it instantiates) is an interface.</summary>
     internal bool IsInterface(TypeRef type)
     {
@@ -326,6 +331,26 @@ public sealed class MetadataSource : IDisposable
                 return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="type"/> can legally be the receiver of C#
+    /// collection-initializer `Add` entries. Exact evidence is the non-generic
+    /// <c>System.Collections.IEnumerable</c> interface, resolved same-assembly or
+    /// through the cross-assembly metadata context.
+    /// </summary>
+    internal MetadataFactState SupportsCollectionInitializer(TypeRef type)
+    {
+        if (NamedDefinition(type) is not { } definition || string.IsNullOrEmpty(definition.Assembly))
+            return MetadataFactState.No;
+
+        if (type.Equals(s_enumerable) || definition.Equals(s_enumerable))
+            return MetadataFactState.Yes;
+
+        if (definition.Assembly == TypeRefDecoder.Canonical(AssemblyName))
+            return Implements(type, s_enumerable) ? MetadataFactState.Yes : MetadataFactState.No;
+
+        return CrossAssembly.Implements(type, s_enumerable);
     }
 
     /// <summary>Every interface <paramref name="type"/> implements — its own, its base classes', and those interfaces' bases — fully instantiated.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -128,7 +128,7 @@ public sealed class ObjectInitializerPass : IIrPass
             // A nested initializer op: a store/Add rooted at a member read off the
             // threaded reference (Inner = { ... } / Items = { ... }). Top level is
             // object form (the member is assigned via `=`), never collection.
-            if (TryNestedOp(statement, aliasSlots) is { } nested)
+            if (TryNestedOp(function, statement, aliasSlots) is { } nested)
             {
                 if (isCollection == true)
                     break;
@@ -163,7 +163,7 @@ public sealed class ObjectInitializerPass : IIrPass
             }
 
             // A collection-initializer element: receiver.Add(value, ...) on the reference.
-            if (TryCollectionAdd(statement, aliasSlots) is { } element)
+            if (TryCollectionAdd(function, statement, aliasSlots) is { } element)
             {
                 if (isCollection == false)
                     break;
@@ -226,7 +226,7 @@ public sealed class ObjectInitializerPass : IIrPass
         {
             var statement = statements[i];
 
-            if (TryNestedOp(statement, index) is { } nested)
+            if (TryNestedOp(function, statement, index) is { } nested)
             {
                 if (isCollection == true)
                     break;
@@ -258,7 +258,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
-            if (TryCollectionAdd(statement, index) is { } element)
+            if (TryCollectionAdd(function, statement, index) is { } element)
             {
                 if (isCollection == false)
                     break;
@@ -303,7 +303,7 @@ public sealed class ObjectInitializerPass : IIrPass
     /// inner entry to accumulate. A plain property/field read distinguishes a
     /// nested op from a flat one (which targets the reference directly).
     /// </summary>
-    static NestedOp? TryNestedOp(IrNode statement, HashSet<int> aliasSlots)
+    static NestedOp? TryNestedOp(IrFunction function, IrNode statement, HashSet<int> aliasSlots)
     {
         switch (statement)
         {
@@ -321,7 +321,7 @@ public sealed class ObjectInitializerPass : IIrPass
 
             // Nested collection element: outer.Member.Add(v, ...).
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
-                when call.Callee.Name == "Add" && call.Arguments.Count >= 2
+                when IsCollectionAdd(function, call)
                     && OuterMemberOffSlot(call.Arguments[0], aliasSlots) is { } outer:
                 return new NestedOp(outer, IsCollection: true, new EntryPlan(null, [.. call.Arguments.Skip(1)], null));
 
@@ -330,7 +330,7 @@ public sealed class ObjectInitializerPass : IIrPass
         }
     }
 
-    static NestedOp? TryNestedOp(IrNode statement, int localIndex)
+    static NestedOp? TryNestedOp(IrFunction function, IrNode statement, int localIndex)
     {
         switch (statement)
         {
@@ -346,7 +346,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
 
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
-                when call.Callee.Name == "Add" && call.Arguments.Count >= 2
+                when IsCollectionAdd(function, call)
                     && OuterMemberOffLocal(call.Arguments[0], localIndex) is { } outer:
                 return new NestedOp(outer, IsCollection: true, new EntryPlan(null, [.. call.Arguments.Skip(1)], null));
 
@@ -407,27 +407,39 @@ public sealed class ObjectInitializerPass : IIrPass
         _ => null,
     };
 
-    static EntryPlan? TryCollectionAdd(IrNode statement, HashSet<int> aliasSlots)
+    static EntryPlan? TryCollectionAdd(IrFunction function, IrNode statement, HashSet<int> aliasSlots)
     {
         if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
             return null;
-        if (call.Callee.Name != "Add" || call.Arguments.Count < 2)
-            return null;  // receiver + at least one value; multi-value Add is the dictionary form
+        if (!IsCollectionAdd(function, call))
+            return null;
         if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
             return null;
         return new EntryPlan(null, [.. call.Arguments.Skip(1)], null);
     }
 
-    static EntryPlan? TryCollectionAdd(IrNode statement, int localIndex)
+    static EntryPlan? TryCollectionAdd(IrFunction function, IrNode statement, int localIndex)
     {
         if (statement is not ExpressionStatement { Expression: Call { Callee.HasThis: true } call })
             return null;
-        if (call.Callee.Name != "Add" || call.Arguments.Count < 2)
+        if (!IsCollectionAdd(function, call))
             return null;
         if (call.Arguments[0] is not LoadLocal receiver || receiver.Index != localIndex)
             return null;
         return new EntryPlan(null, [.. call.Arguments.Skip(1)], null);
     }
+
+    static bool IsCollectionAdd(IrFunction function, Call call)
+        => call.Callee.Name == "Add"
+            && call.Arguments.Count >= 2
+            && IsCollectionInitializerType(function, call.Arguments[0].ResultType ?? call.Callee.DeclaringType);
+
+    static bool IsCollectionInitializerType(IrFunction function, TypeRef? type)
+        => type is not null
+            && (function.CollectionInitializerTypes.Contains(type)
+                || (type.Kind == TypeRefKind.GenericInstance
+                    && type.ElementType is { } definition
+                    && function.CollectionInitializerTypes.Contains(definition)));
 
     static bool HasDuplicateNamedMembers(bool isCollection, IEnumerable<EntryPlan> entries)
     {


### PR DESCRIPTION
## Summary

- Review claim: `ObjectInitializerPass` may raise Add-based collection initializer entries only when the receiver is proven collection-initializer-compatible (`System.Collections.IEnumerable`), not merely because the method is named `Add`.
- Add a non-`IEnumerable` same-assembly `Add` lookalike fixture that previously over-raised to invalid collection-initializer C#.
- Thread import-time collection receiver evidence into `IrFunction` and gate top-level/nested Add folds on that evidence, including same-assembly and cross-assembly interface resolution.
- Update object-initializer sidecar adversarial coverage for the reviewed edge.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`

Fixes the Object initializer adversarial review row from #959.