### PR TITLE
Use Markout field ordering for Package Info

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.13.6" />
+    <PackageVersion Include="Markout" Version="0.13.7" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />

--- a/src/dotnet-inspect.Tests/InspectionResultTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionResultTests.cs
@@ -120,6 +120,32 @@ public class InspectionResultTests
     }
 
     [Fact]
+    public void PackageInfo_RendersFieldsAlphabetically()
+    {
+        var result = new InspectionResult
+        {
+            PackageName = "Test",
+            Version = "1.0.0",
+            Authors = "authors",
+            ContentDirectories = ["lib", "analyzers"],
+            License = "MIT",
+            TargetFrameworks = ["net8.0", "net10.0"]
+        };
+
+        var output = MarkoutSerializer.Serialize(new InspectionResultView(result), InspectionContext.Default);
+        var packageInfo = output[
+            output.IndexOf("## Package Info", StringComparison.Ordinal)..
+            output.IndexOf("## Target Frameworks", StringComparison.Ordinal)];
+
+        Assert.True(
+            packageInfo.IndexOf("| Authors |", StringComparison.Ordinal) < packageInfo.IndexOf("| Content |", StringComparison.Ordinal)
+            && packageInfo.IndexOf("| Content |", StringComparison.Ordinal) < packageInfo.IndexOf("| Highest TFM |", StringComparison.Ordinal)
+            && packageInfo.IndexOf("| Highest TFM |", StringComparison.Ordinal) < packageInfo.IndexOf("| License |", StringComparison.Ordinal)
+            && packageInfo.IndexOf("| License |", StringComparison.Ordinal) < packageInfo.IndexOf("| Version |", StringComparison.Ordinal),
+            output);
+    }
+
+    [Fact]
     public void Manifest_RendersManifestVersionWhenPresent()
     {
         var result = new InspectionResult

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -98,7 +98,7 @@ public class InspectionResultView
         || _data.ToolCommands is { Count: > 0 }
         || _data.RuntimeIdentifierPackages is { Count: > 0 };
 
-    [MarkoutSection(Name = PackageSections.PackageInfo)]
+    [MarkoutSection(Name = PackageSections.PackageInfo, FieldOrder = MarkoutFieldOrder.Alphabetical)]
     public List<MarkoutField> Metadata => GetMetadataFields();
 
     [MarkoutSection(Name = PackageSections.RuntimeDependencies)]


### PR DESCRIPTION
## Summary
- bump Markout to `0.13.7`
- opt `Package Info` into `FieldOrder = MarkoutFieldOrder.Alphabetical`
- add a regression test for rendered Package Info field ordering

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- smoke: `dotnet run --project src/dotnet-inspect -c Release -- package System.Text.Json --offline --tips q`