### PR TITLE
Fix unsafe-chain validity rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -808,6 +808,26 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void NativeIntAddressSlot_DerefsAsItsOwnPointerType_NotNativeInt()
+    {
+        // Release can materialize a pointer through a native-int stack slot before
+        // an indirect read/write. Deref-ing the slot itself (`*S_257`) is CS0193;
+        // the access must cast the native int back to the opcode's pointer type.
+        using var source = MetadataSource.Open(typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).FullName!,
+            nameof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA.M1));
+        Assert.NotNull(function);
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("*(int*)S_", output);
+        Assert.DoesNotContain("*S_", output);
+    }
+
+    [Fact]
     public void ElementAccess_ImportsTypedLoadAndStore()
     {
         var load = ImportFixture(nameof(CfgSampleClass.FirstElement));
@@ -1862,6 +1882,27 @@ public class RaisingPassTests
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StackAllocFirst), source);
         Assert.Contains("stackalloc byte[", output);
+    }
+
+    [Fact]
+    public void StackAlloc_ReturningPointer_PrintsPointerLocal()
+    {
+        // A stackalloc expression cannot be returned directly as a pointer, nor
+        // explicitly cast in expression position (CS8346). Route it through a
+        // pointer local and cast that local to the signature's pointer type.
+        using var source = MetadataSource.Open(typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).FullName!,
+            nameof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA.EscapingStackPointer));
+        Assert.NotNull(function);
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("byte* __stackalloc = stackalloc byte[40];", output);
+        Assert.Contains("return (int*)__stackalloc;", output);
+        Assert.DoesNotContain("return stackalloc", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -661,6 +661,23 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("};");
             return;
         }
+        if (node is Return { Value: StackAllocate stackAllocate }
+            && _function.Signature.ReturnType is { Kind: TypeRefKind.Pointer } returnPointer)
+        {
+            string localName = FreshSyntheticLocalName("__stackalloc");
+            sb.Append(pad)
+                .Append(TypeText(stackAllocate.ResultType!))
+                .Append(' ')
+                .Append(localName)
+                .Append(" = ")
+                .Append(Expression(stackAllocate))
+                .AppendLine(";");
+            string value = returnPointer.Equals(stackAllocate.ResultType)
+                ? localName
+                : $"({TypeText(returnPointer)}){localName}";
+            sb.Append(pad).Append("return ").Append(value).AppendLine(";");
+            return;
+        }
         if (node is ForLoop forLoop)
         {
             string initializer = Statement(forLoop.Initializer)?.TrimEnd(';') ?? "";
@@ -1061,7 +1078,7 @@ public sealed partial class CSharpPrinter
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
-            Deref(s.Address),
+            IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
             left => left is LoadIndirect load && SameLValue(load.Address, s.Address),
             IndirectStoreType(s.Address, s.Type)),
@@ -1352,8 +1369,37 @@ public sealed partial class CSharpPrinter
                 : Operand(conv.Operand);
             return $"*({TypeText(element)}*){addr}";
         }
+        if (load.Type is { } nativeElement && IsNativeInteger(load.Address.ResultType))
+            return NativeIntPointerDeref(load.Address, nativeElement);
         return Deref(load.Address);
     }
+
+    string IndirectTarget(IrExpression address, TypeRef? elementType)
+        => elementType is not null && IsNativeInteger(address.ResultType)
+            ? NativeIntPointerDeref(address, elementType)
+            : Deref(address);
+
+    string NativeIntPointerDeref(IrExpression address, TypeRef elementType)
+        => $"*({TypeText(TypeRef.Pointer(elementType))}){Operand(address)}";
+
+    string FreshSyntheticLocalName(string baseName)
+    {
+        var used = new HashSet<string>(
+            _function.Signature.Parameters.Select(p => p.Name)
+                .Concat(_function.LocalNames.Where(name => !string.IsNullOrWhiteSpace(name)).Select(name => name!)),
+            StringComparer.Ordinal);
+        if (!used.Contains(baseName))
+            return baseName;
+        for (int i = 0; ; i++)
+        {
+            string candidate = $"{baseName}{i}";
+            if (!used.Contains(candidate))
+                return candidate;
+        }
+    }
+
+    static bool IsNativeInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" or "UIntPtr" };
 
     /// <summary>
     /// The C# type a store-indirect writes through. A primitive <c>stind</c>


### PR DESCRIPTION
Fixes #978.

## Summary
- Cast native-int carrier slots back to the indirect access pointer type for `ldind`/`stind` rendering, avoiding invalid `*S_257` native-int dereferences.
- Render pointer-returning raw `stackalloc byte[n]` through a pointer local before casting to the method return pointer type, avoiding CS8346 from direct stackalloc returns.
- Add regression coverage using `UnsafeChainA.LibraryA.M1` and `EscapingStackPointer`.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IrImporterTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- Unsafe-chain `--library-report`: no unsupported patterns; UnsafeChainA/B/C all 0 bound Full defects.
