### PR TITLE
Honor type hints in condition truthiness

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3737,13 +3737,16 @@ public class LockSugarSoundnessTests
 /// </summary>
 public class TypeShapeTruthinessTests
 {
-    static string PrintConditionOn(TypeRef conditionType, TypeShape shape)
+    static string PrintConditionOn(TypeRef conditionType, TypeShape shape, bool negated = false)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         var then = new Block(0);
         then.Add(new Return(new Constant(1, intType)));
+        IrExpression condition = new LoadLocal(0, conditionType);
+        if (negated)
+            condition = new LogicalNot(condition);
         var entry = new Block(0);
-        entry.Add(new IfStatement(new LoadLocal(0, conditionType), then, null));
+        entry.Add(new IfStatement(condition, then, null));
         entry.Add(new Return(new Constant(0, intType)));
         var container = new BlockContainer();
         container.Add(entry);
@@ -3770,9 +3773,26 @@ public class TypeShapeTruthinessTests
     }
 
     [Fact]
-    public void UnknownShape_StaysRaw()
+    public void ReferenceHint_NullTests()
     {
-        // A cross-assembly definition resolves to Unknown — print raw, no guess.
+        var classType = TypeRef.Definition("other-asm", "NS", "MyClass", ValueTypeHint.ReferenceType);
+
+        Assert.Contains("if (V_0 is not null)", PrintConditionOn(classType, TypeShape.Unknown));
+        Assert.Contains("if (V_0 is null)", PrintConditionOn(classType, TypeShape.Unknown, negated: true));
+    }
+
+    [Fact]
+    public void ValueTypeHint_ZeroTests()
+    {
+        var enumType = TypeRef.Definition("other-asm", "NS", "MyEnum", ValueTypeHint.ValueType);
+        Assert.Contains("if (V_0 != 0)", PrintConditionOn(enumType, TypeShape.Unknown));
+    }
+
+    [Fact]
+    public void UnknownShapeWithoutHint_StaysRaw()
+    {
+        // A cross-assembly definition with no CLASS/VALUETYPE hint resolves to
+        // Unknown — print raw, no guess.
         var classType = TypeRef.Definition("other-asm", "NS", "Mystery");
         string output = PrintConditionOn(classType, TypeShape.Unknown);
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1191,9 +1191,9 @@ public sealed partial class CSharpPrinter
     /// struct value. A generic instance is therefore always a reference type
     /// (generic value types cannot be branch operands, and enums are never
     /// generic), so it null-tests with no resolution. A bare definition is
-    /// reference-or-enum; the importer's same-assembly shape resolution tells
-    /// them apart where it can, and an unresolved (cross-assembly) definition
-    /// still prints raw rather than guess.
+    /// reference-or-enum; signature CLASS/VALUETYPE hints and the importer's
+    /// same-assembly shape resolution tell them apart where they can, and an
+    /// unresolved definition with neither hint still prints raw rather than guess.
     /// </summary>
     (string Direct, string Inverted)? Truthiness(IrExpression operand)
     {
@@ -1249,6 +1249,14 @@ public sealed partial class CSharpPrinter
         // bare definition resolves by its same-assembly shape.
         if (type.Kind == TypeRefKind.GenericInstance)
             return reference;
+
+        switch (type.DeclaredValueTypeHint)
+        {
+            case ValueTypeHint.ReferenceType:
+                return reference;
+            case ValueTypeHint.ValueType:
+                return integer;
+        }
 
         return _function.TypeShapes.GetValueOrDefault(type) switch
         {


### PR DESCRIPTION
Fixes #934.

## Summary
- Use `TypeRef.DeclaredValueTypeHint` when rendering non-bool condition truthiness.
- Render reference-hinted cross-assembly branch operands as `is null` / `is not null` instead of invalid raw values or `!value`.
- Keep value-type hints as zero tests and unknown definitions raw.
- Add focused `TypeShapeTruthinessTests` coverage for reference hints, value-type hints, inverted null tests, and unknown-without-hint fallback.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- Popular NuGet `--library-report --compile-cap 10000 --top-libraries 6`: `validity: CS0023` drops from 116 to 10; pass bugs remain 0.