### PR TITLE
Fix residual switch branch labels

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -5,9 +5,9 @@ namespace ILInspector.Decompiler.Tests;
 
 // An IL `switch` opcode the switch-raising pass could not lift into a structured
 // `switch` stays in the tree as a SwitchBranch jump table. The printer must
-// render it as valid lowered C# — a `switch` block with one terminating case per
-// target — not the placeholder `switch (...) goto [..]` form, which is not legal
-// C# (CS1513/CS1514). Out-of-range values fall through, matching the opcode.
+// render it as valid lowered C# — a single-evaluated temp plus one `if`/`goto`
+// per target — not a C# `switch` whose cases goto labels outside the switch
+// section (CS0159). Out-of-range values fall through, matching the opcode.
 public class SwitchBranchRenderingTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
@@ -40,10 +40,11 @@ public class SwitchBranchRenderingTests
         var output = result.Output ?? "";
 
         Assert.DoesNotContain("goto [", output);
-        Assert.Contains("switch (x)", output);
-        Assert.Contains("case 0:\n        goto IL_0010;\n        break;", output);
-        Assert.Contains("case 1:\n        goto IL_0020;\n        break;", output);
-        Assert.Contains("case 2:\n        goto IL_0030;\n        break;", output);
+        Assert.Contains("int __dotnet_inspect_switch0 = default;", output);
+        Assert.Contains("__dotnet_inspect_switch0 = (int)(x);", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 1) goto IL_0020;", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 2) goto IL_0030;", output);
     }
 
     [Fact]
@@ -54,8 +55,27 @@ public class SwitchBranchRenderingTests
         var result = RenderSwitch(0x10, 0x20, 0x10);
         var output = result.Output ?? "";
 
-        Assert.Contains("case 0:\n        goto IL_0010;\n        break;", output);
-        Assert.Contains("case 1:\n        goto IL_0020;\n        break;", output);
-        Assert.Contains("case 2:\n        goto IL_0010;\n        break;", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 1) goto IL_0020;", output);
+        Assert.Contains("if (__dotnet_inspect_switch0 == 2) goto IL_0010;", output);
+    }
+
+    [Fact]
+    public void Structuring_PreservesFlattenedSwitchTargetLabels()
+    {
+        // OperandLength has residual switch tables whose target blocks are also
+        // comparison-tree return leaves. Structuring must keep those labels
+        // available for the lowered if/goto switch rendering.
+        using var source = MetadataSource.Open(typeof(IlProjection).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(IlProjection).FullName!, "OperandLength");
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        string output = result.Output ?? "";
+
+        Assert.Contains("if (__dotnet_inspect_switch", output);
+        Assert.Contains("goto IL_024F;", output);
+        Assert.Contains("IL_024F:", output);
+        Assert.DoesNotContain("case 0: goto", output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -222,6 +222,10 @@ public sealed partial class CSharpPrinter
     /// <summary>Offsets some surviving goto targets — labels print wherever the block lives, top-level or inside a flat EH body.</summary>
     HashSet<int> _labelTargets = [];
 
+    readonly HashSet<int> _emittedLabels = [];
+
+    readonly Dictionary<SwitchBranch, string> _switchTemps = [];
+
     /// <summary>
     /// True while rendering inside an emitted <c>checked(...)</c> expression. A
     /// checked operation (overflow binary or conversion) nested in this context
@@ -334,7 +338,7 @@ public sealed partial class CSharpPrinter
             var block = blocks[i];
             if (_labelTargets.Contains(block.StartOffset))
             {
-                sb.Append(pad).AppendLine($"IL_{block.StartOffset:X4}:");
+                AppendLabel(sb, pad, block.StartOffset);
                 labelPendingStatement = true;
             }
             // The trailing 'return;' trims, current-style — unless it is a
@@ -351,12 +355,19 @@ public sealed partial class CSharpPrinter
                     break;
                 emit.Add(statement);
             }
+
             if (emit.Any(n => !RendersAsCommentOnly(n)))
                 labelPendingStatement = false;
             AppendStatements(sb, emit, indent);
         }
         if (labelPendingStatement)
             sb.Append(pad).AppendLine(";");
+    }
+
+    void AppendLabel(StringBuilder sb, string pad, int offset)
+    {
+        if (_emittedLabels.Add(offset))
+            sb.Append(pad).AppendLine($"IL_{offset:X4}:");
     }
 
     /// <summary>
@@ -426,6 +437,13 @@ public sealed partial class CSharpPrinter
             slots[slot] = slotLoadTypes.TryGetValue(slot, out var loaded) && loaded is not null
                 ? loaded
                 : slotStoreTypes.TryGetValue(slot, out var stored) ? stored : null;
+        }
+        int switchIndex = 0;
+        foreach (var switchBranch in DescendantsOutsideNestedFunctions(function).OfType<SwitchBranch>())
+        {
+            string name = $"__dotnet_inspect_switch{switchIndex++}";
+            _switchTemps.TryAdd(switchBranch, name);
+            yield return $"int {name} = default;";
         }
         foreach (int index in locals)
         {
@@ -795,21 +813,16 @@ public sealed partial class CSharpPrinter
         {
             // The IL switch opcode is a jump table: it branches to
             // targets[value] when 0 <= value < targets.Length and falls through
-            // otherwise. Render it as a valid lowered switch rather than the
-            // placeholder `switch (...) goto [..]` form, which is not legal C#.
-            // The unreachable break after each goto keeps the case section
-            // terminating even when a later pass/report shell cannot bind the
-            // target label; no default preserves the opcode's out-of-range fall-through.
-            sb.Append(pad).Append("switch (").Append(Expression(switchBranch.Value)).AppendLine(")");
-            sb.Append(pad).AppendLine("{");
-            string casePad = pad + "    ";
+            // otherwise. A C# switch section cannot goto a label outside the
+            // switch, so render an if-chain over a single-evaluated temp instead
+            // of `case i: goto IL_xxxx;`. Fall-through preserves out-of-range
+            // behavior.
+            string temp = _switchTemps.TryGetValue(switchBranch, out var name) ? name : "__dotnet_inspect_switch";
+            sb.Append(pad).Append(temp).Append(" = ")
+                .Append("(int)(").Append(Expression(switchBranch.Value)).AppendLine(");");
             for (int t = 0; t < switchBranch.TargetOffsets.Length; t++)
-            {
-                sb.Append(casePad).AppendLine($"case {t}:");
-                sb.Append(casePad).AppendLine($"    goto IL_{switchBranch.TargetOffsets[t]:X4};");
-                sb.Append(casePad).AppendLine("    break;");
-            }
-            sb.Append(pad).AppendLine("}");
+                sb.Append(pad).Append("if (").Append(temp).Append(" == ").Append(t)
+                    .AppendLine($") goto IL_{switchBranch.TargetOffsets[t]:X4};");
             return;
         }
         if (Statement(node) is { } line)
@@ -842,17 +855,27 @@ public sealed partial class CSharpPrinter
                 sb.Append(pad).AppendLine("{");
                 _unsafeDepth++;
                 for (int k = i; k < j; k++)
+                {
+                    AppendStatementLabel(sb, statements[k], indent + 1);
                     AppendStatement(sb, statements[k], indent + 1);
+                }
                 _unsafeDepth--;
                 sb.Append(pad).AppendLine("}");
                 i = j;
             }
             else
             {
+                AppendStatementLabel(sb, statements[i], indent);
                 AppendStatement(sb, statements[i], indent);
                 i++;
             }
         }
+    }
+
+    void AppendStatementLabel(StringBuilder sb, IrNode statement, int indent)
+    {
+        if (statement.SourceOffset >= 0 && _labelTargets.Contains(statement.SourceOffset))
+            AppendLabel(sb, new string(' ', indent * 4), statement.SourceOffset);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
@@ -36,6 +36,9 @@ public sealed class ReturnSinkingPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        if (function.Descendants.OfType<SwitchBranch>().Any())
+            return;
+
         while (SinkOnce(function, context.Stepper))
         {
         }
@@ -47,6 +50,7 @@ public sealed class ReturnSinkingPass : IIrPass
         var returnLoads = new Dictionary<int, List<Return>>();
         var addressTaken = new HashSet<int>();
         var escapingLoad = new HashSet<int>();
+        var branchTargets = BranchTargets(function);
 
         foreach (var node in function.Descendants)
         {
@@ -78,11 +82,38 @@ public sealed class ReturnSinkingPass : IIrPass
                 continue;
             if (TryPlan(index, indexStores, returns) is { } plan)
             {
+                if (plan.Folds.Any(f => f.Store.Parent is Block block && branchTargets.Contains(block.StartOffset)))
+                    continue;
                 Apply(plan, stepper);
                 return true;
             }
         }
         return false;
+    }
+
+    static HashSet<int> BranchTargets(IrFunction function)
+    {
+        var targets = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case Branch branch:
+                    targets.Add(branch.TargetOffset);
+                    break;
+                case ConditionalBranch branch:
+                    targets.Add(branch.TargetOffset);
+                    break;
+                case SwitchBranch branch:
+                    foreach (int target in branch.TargetOffsets)
+                        targets.Add(target);
+                    break;
+                case Leave leave:
+                    targets.Add(leave.TargetOffset);
+                    break;
+            }
+        }
+        return targets;
     }
 
     sealed record Plan(List<(StoreLocal Store, Break? Break)> Folds, List<Return> Returns);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -35,6 +35,7 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, int> OffsetToIndex { get; init; }
         public required HashSet<int> UnconditionalTargets { get; init; }
         public required Dictionary<int, int> ConditionalTargetCounts { get; init; }
+        public required HashSet<int> BranchTargets { get; init; }
         public required HashSet<int> DroppableTerminators { get; init; }
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
@@ -100,15 +101,30 @@ public sealed class StructuringPass : IIrPass
         // the standard forms already raise cleanly stays untouched.
         var unconditionalTargets = new HashSet<int>();
         var conditionalTargetCounts = new Dictionary<int, int>();
+        var branchTargets = new HashSet<int>();
         foreach (var block in blocks)
         {
             foreach (var child in block.Children)
             {
                 if (child is Branch branch)
+                {
                     unconditionalTargets.Add(branch.TargetOffset);
+                    branchTargets.Add(branch.TargetOffset);
+                }
                 else if (child is ConditionalBranch conditional)
+                {
                     conditionalTargetCounts[conditional.TargetOffset] =
                         conditionalTargetCounts.GetValueOrDefault(conditional.TargetOffset) + 1;
+                    branchTargets.Add(conditional.TargetOffset);
+                }
+                else if (child is SwitchBranch switchBranch)
+                {
+                    foreach (int target in switchBranch.TargetOffsets)
+                    {
+                        unconditionalTargets.Add(target);
+                        branchTargets.Add(target);
+                    }
+                }
             }
         }
 
@@ -145,6 +161,7 @@ public sealed class StructuringPass : IIrPass
             OffsetToIndex = offsetToIndex,
             UnconditionalTargets = unconditionalTargets,
             ConditionalTargetCounts = conditionalTargetCounts,
+            BranchTargets = branchTargets,
             DroppableTerminators = droppable,
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
@@ -647,6 +664,8 @@ public sealed class StructuringPass : IIrPass
                 continue;
             }
             var statements = block.DetachChildren();
+            if (ctx.BranchTargets.Contains(block.StartOffset) && statements.Count > 0)
+                statements[0].SetSourceOffset(block.StartOffset);
             var last = statements[^1];
             for (int s = 0; s < statements.Count - 1; s++)
                 result.Add(statements[s]);


### PR DESCRIPTION
Fixes #922.

## Summary
- Render residual `SwitchBranch` nodes as single-evaluated temp-backed `if`/`goto` chains instead of switch cases whose labels can fall outside the switch section.
- Preserve residual switch branch target labels through structuring.
- Avoid return-sinking when a method still has surviving switch branches.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- Product-library `--library-report --compile-cap 10000 --top-libraries 8`: no `validity: CS0159` rows; pass bugs remain 0.
- Popular NuGet sweep: Newtonsoft.Json `validity: CS0159` drops from 43 to 22; pass bugs remain 0.