### PR TITLE
Fix lambda raise dropping mutated-capture stores (#959)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -56,6 +56,37 @@ public class LambdaRaisingPassTests
         Assert.Contains("new Func", output);
     }
 
+    // A captured variable mutated after the lambda is created: the display-class
+    // field is stored twice. The environment is shared by reference, so a call
+    // before the second store must see the first value. Eliding both stores and
+    // substituting one value would miscompile (every call reads the last value,
+    // and the mutation itself vanishes), so the environment must stay lowered.
+    // A branch/loop keeps the display class in a local even in Release, so this
+    // reproduces in the shipped compiler mode, not only in Debug.
+    [Fact]
+    public void CaptureMutatedInBranch_StaysLowered()
+    {
+        string output = PrintRaised(
+            nameof(ClosureMutationAdversarialSamples.MutatedCaptureInBranch),
+            typeof(ClosureMutationAdversarialSamples));
+
+        Assert.DoesNotContain("=>", output);   // not raised to a lambda...
+        Assert.Contains("new Func", output);   // ...the delegate creation survives
+        Assert.Contains("= q", output);        // and the mutating store is preserved, not elided
+    }
+
+    [Fact]
+    public void CaptureMutatedInLoop_StaysLowered()
+    {
+        string output = PrintRaised(
+            nameof(ClosureMutationAdversarialSamples.MutatedCaptureInLoop),
+            typeof(ClosureMutationAdversarialSamples));
+
+        Assert.DoesNotContain("=>", output);
+        Assert.Contains("new Func", output);
+        Assert.Contains("= q", output);
+    }
+
     [Fact]
     public void CapturingExpressionBody_SubstitutesCaptureAndRaisesLambda()
         => Assert.Equal("return x => x + n;", PrintRaised(nameof(CfgSampleClass.CapturingLambda)));
@@ -149,5 +180,32 @@ public class LambdaRaisingPassTests
             new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: true, GenericParameterCount: 0),
             [],
             body);
+    }
+}
+
+// Negative fixtures for LambdaRaisingPass: a captured variable mutated after the
+// lambda is created. The display class must stay lowered — substituting one
+// captured value and eliding the stores would lose the closure's by-reference
+// semantics. Kept out of CfgSampleClass because the lowered form renders the
+// raw <>c__DisplayClass names the fidelity gate cannot recompile.
+public static class ClosureMutationAdversarialSamples
+{
+    public static int MutatedCaptureInBranch(int p, int q, bool c)
+    {
+        int x = p;
+        System.Func<int> f = () => x;
+        int a = f();
+        if (c) x = q;
+        int b = f();
+        return a * 100 + b;
+    }
+
+    public static int MutatedCaptureInLoop(int p, int q)
+    {
+        int x = p;
+        System.Func<int> f = () => x;
+        int sum = 0;
+        for (int i = 0; i < 2; i++) { sum += f(); x = q; }
+        return sum;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -137,7 +137,16 @@ public sealed class LambdaRaisingPass : IIrPass
                     && Equals(store.Field.DeclaringType, dcType)
                     && IsCaptureValue(store.Value, function))
                 {
-                    captures[store.Field.Name] = store.Value;
+                    // A field stored more than once is mutated after the capture:
+                    // the environment is shared by reference, so a lambda call
+                    // between the stores must observe the earlier value. Eliding
+                    // the stores and substituting one value would lose that —
+                    // bail and leave the environment lowered.
+                    if (!captures.TryAdd(store.Field.Name, store.Value))
+                    {
+                        elidable = false;
+                        break;
+                    }
                     captureStores.Add(store);
                 }
                 else if (load.Parent is DelegateCreation creation


### PR DESCRIPTION
## Adversarial review — Lambda/local function (#959)

Reviewing `LambdaRaisingPass` against the queue's falsification list (mutation after capture, shared/nested environments) surfaced a **silent miscompile**, reproducible in **Release**.

### The bug
`RaiseLocalDisplayClasses` raises a local `<>c__DisplayClass` environment by substituting each captured `this.field` read with the captured value and eliding the setup stores. But it treated *every* capture-value store to a field as an elidable capture — including a **post-capture mutation** (`x = p; … x = q;`, both load-valued). It took last-write-wins for the substituted value and elided all stores, losing the closure's by-reference semantics.

```csharp
int x = p;
Func<int> f = () => x;
int a = f();        // must see p
if (c) x = q;       // mutation
int b = f();        // must see c ? q : p
return a * 100 + b;
```

decompiled (before this PR) to:

```csharp
Func<int> S_256 = () => q;
int a = S_256.Invoke();   // q
if (c) { }                // the x = q store VANISHED
int b = S_256.Invoke();   // q
return (a * 100) + b;     // q*100 + q, regardless of p and c
```

A branch/loop keeps the display class in a **local** even in Release, so this hits the shipped compiler mode, not just Debug. (Straight-line variants happen to spill the environment to stack slots, outside this `StoreLocal`-based path, which is why it had escaped notice.)

### Fix
A display-class field stored more than once is a post-capture mutation → bail and leave the environment lowered (mirrors the existing single-store guard on the environment local). The lowered form preserves the stores and is faithful; single-capture lambdas still raise. One-line guard:

```csharp
if (!captures.TryAdd(store.Field.Name, store.Value)) { elidable = false; break; }
```

### Tests
Adds branch and loop regression fixtures in a dedicated `ClosureMutationAdversarialSamples` class (kept out of `CfgSampleClass`, whose lowered `<>c__DisplayClass` names the fidelity gate cannot recompile). Both **fail before the fix**, pass after.

## Validation
- Full `ILInspector.Decompiler.Tests` suite: **829 passed**, 0 failed.
- Confirmed the two new tests fail on the pre-fix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)