### PR TITLE
Curate classic-async overlay baseline after adversarial review (#959)

### DIFF
--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -56,10 +56,15 @@ dotnet run --project tools/DecompilerHarness -c Release -- --library-report \
   artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicAsync/release/ILInspector.Decompiler.Fixtures.ClassicAsync.dll
 ```
 
-Baseline (classic async unraised): 21 methods, 0 raised — the state-machine
-`MoveNext`s bucket as `structuring: conditional-branch` (the goto state dispatch
-the structurer can't raise), and the kickoffs plus `SetStateMachine` as
-`fidelity: (typed)`.
+Baseline (classic async unraised): 21 methods, 0 raised, with 0 pass bugs and 0
+`Full`-malformed — the state machines degrade honestly, never mis-raise. The
+7 `MoveNext`s bucket as `structuring: conditional-branch` (the goto state
+dispatch the structurer can't raise); the 14 kickoffs and state-machine helpers
+bucket as `fidelity: DEC0009` (`UnrepresentableMetadataName` — their residual
+`<>`-prefixed members, `<…>d__N`/`<>t__builder`/`<>1__state`, have no legal C#
+spelling until the shape is raised). A future raise's proof obligations are the
+queue's falsification list: kickoff/`MoveNext` correlation, state dispatch,
+builder identity, await ordering, and exception/finally paths.
 
 The second axis is the old/new memory-safety pair:
 


### PR DESCRIPTION
## Adversarial review — Classic async (#959)

The Classic async row is **not a raise yet**, so there is no discriminator to falsify. The review target was instead the **honest-degradation invariant**: do classic `AsyncTaskMethodBuilder` state machines stay lowered, with no silent partial mis-raise, no crash, and no valid-but-wrong output?

### Result: invariant holds, no bug
`--library-report` over `Fixtures.ClassicAsync`: **21 methods, 0 raised, 0 pass bugs, 0 `Full`-malformed.**
- 7 `MoveNext`s → `structuring: conditional-branch` (the goto state dispatch the structurer can't raise).
- 14 kickoffs/helpers → `fidelity: DEC0009` (`UnrepresentableMetadataName`). The kickoff renders the raw state-machine setup (`<…>d__N`, `<>t__builder`, `<>1__state`) honestly and is classified below `Full` — it never pretends to be raised C#.

### Change (curation only)
The harness README baseline text had **drifted**: it described the kickoffs as `fidelity: (typed)`, but that bucket was subdivided by `DEC####` cause in #920, so they now bucket as `fidelity: DEC0009`. This updates the baseline to the measured numbers, records the no-mis-raise invariant (0 pass bugs / 0 malformed), and notes the proof obligations a future raise must satisfy (kickoff/`MoveNext` correlation, state dispatch, builder identity, await ordering, exception/finally paths).

The overlay stays an **on-demand instrument, not a CI gate** — no new test gate is added, consistent with the documented design.

## Validation
- `--library-report` over `Fixtures.ClassicAsync` (numbers above).
- `markdownlint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)