### PR TITLE
Raise inline-array element ref helpers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -1,0 +1,76 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class InlineArrayElementRefPassTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Buffer = TypeRef.Definition("UserAssembly", "Samples", "Inline4", ValueTypeHint.ValueType);
+
+    [Fact]
+    public void FirstElementRef_RaisesToInlineArrayIndexAddress()
+    {
+        var function = StoreThroughHelper(
+            Helper("InlineArrayFirstElementRef", [TypeRef.ByRef(Buffer)]),
+            [new LoadArgumentAddress(0, "buffer", Buffer)]);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var store = Assert.Single(function.Descendants.OfType<StoreIndirect>());
+        var address = Assert.IsType<LoadElementAddress>(store.Address);
+        Assert.Equal(0, Assert.IsType<Constant>(address.Index).Value);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        Assert.Contains("buffer[0] = value;", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ElementRef_RaisesToInlineArrayIndexAddress()
+    {
+        var function = StoreThroughHelper(
+            Helper("InlineArrayElementRef", [TypeRef.ByRef(Buffer), Int32]),
+            [
+                new LoadArgumentAddress(0, "buffer", Buffer),
+                new LoadArgument(2, "index", Int32),
+            ]);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var store = Assert.Single(function.Descendants.OfType<StoreIndirect>());
+        var address = Assert.IsType<LoadElementAddress>(store.Address);
+        Assert.IsType<LoadArgument>(address.Index);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        Assert.Contains("buffer[index] = value;", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    static IrFunction StoreThroughHelper(MethodRef helper, IReadOnlyList<IrExpression> arguments)
+    {
+        var block = new Block();
+        block.Add(new StoreIndirect(Int32, new Call(helper, isVirtual: false, arguments), new LoadArgument(1, "value", Int32)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            Void,
+            [
+                new Parameter("buffer", Buffer),
+                new Parameter("value", Int32),
+                new Parameter("index", Int32),
+            ],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
+
+    static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes)
+        => new(
+            TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+            name,
+            TypeRef.ByRef(Int32),
+            [.. parameterTypes],
+            HasThis: false)
+        {
+            TypeArguments = [Buffer, Int32],
+        };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -81,6 +81,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         }
 
         RaisePlaceConversions(function, context);
+        RaiseElementRefs(function, context);
     }
 
     /// <summary>
@@ -126,8 +127,93 @@ public sealed class InlineArrayCollectionPass : IIrPass
         }
     }
 
+    /// <summary>
+    /// Raises the compiler's inline-array element-address helpers to ordinary
+    /// inline-array indexer addresses. The helpers are emitted for direct
+    /// reads/writes of a real <c>[InlineArray]</c> buffer, not just collection
+    /// expressions; left flat, the <c>&lt;PrivateImplementationDetails&gt;</c>
+    /// method name caps fidelity and cannot parse as C#.
+    /// </summary>
+    static void RaiseElementRefs(IrFunction function, PassContext context)
+    {
+        // Methods that also view the same inline-array buffers as spans often have
+        // additional validity work (ref locals/unsigned stores). Leave that mixed
+        // shape Partial for a dedicated slice rather than exposing invalid Full C#.
+        if (function.Descendants.OfType<InlineArraySpanConversion>().Any())
+            return;
+
+        foreach (var elementRef in function.Descendants.OfType<Call>().ToList())
+        {
+            if (elementRef.Parent is null)
+                continue;
+            if (!IsInlineArrayElementRef(elementRef.Callee, out bool first, out bool readOnly))
+                continue;
+            if (elementRef.Callee.TypeArguments is not [_, var element])
+                continue;
+
+            if (first)
+            {
+                if (elementRef.Arguments is not [_])
+                    continue;
+            }
+            else
+            {
+                if (elementRef.Arguments is not [_, _])
+                    continue;
+            }
+            if (!CanPlaceFromAddress(elementRef.Arguments[0]))
+                continue;
+
+            var children = elementRef.DetachChildren().Cast<IrExpression>().ToArray();
+            var place = PlaceFromAddress(children[0])!;
+            var index = first ? new Constant(0, TypeRef.CoreLib("System", "Int32")) : children[1];
+            var address = new LoadElementAddress(element, place, index, readOnly);
+            context.Stepper.StepOver("raise inline-array element ref to indexed address", elementRef);
+            elementRef.ReplaceWith(address);
+        }
+    }
+
+    static bool CanPlaceFromAddress(IrExpression address)
+        => address is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress;
+
+    static IrExpression? PlaceFromAddress(IrExpression address) => address switch
+    {
+        LoadLocalAddress local => new LoadLocal(local.Index, local.Type),
+        LoadArgumentAddress argument => new LoadArgument(argument.Index, argument.Name, argument.Type),
+        LoadFieldAddress field => new LoadField(
+            field.Field,
+            field.Instance is null ? null : (IrExpression)field.DetachChildren()[0]),
+        LoadElementAddress element => element,
+        _ => null,
+    };
+
     static bool IsPrivateImpl(MethodRef callee, string name)
         => callee.Name == name && callee.DeclaringType.Name == PrivateImpl;
+
+    static bool IsInlineArrayElementRef(MethodRef callee, out bool first, out bool readOnly)
+    {
+        first = false;
+        readOnly = false;
+        if (callee.DeclaringType.Name != PrivateImpl)
+            return false;
+        switch (callee.Name)
+        {
+            case "InlineArrayElementRef":
+                return true;
+            case "InlineArrayElementRefReadOnly":
+                readOnly = true;
+                return true;
+            case "InlineArrayFirstElementRef":
+                first = true;
+                return true;
+            case "InlineArrayFirstElementRefReadOnly":
+                first = true;
+                readOnly = true;
+                return true;
+            default:
+                return false;
+        }
+    }
 
     /// <summary>
     /// True for a compiler-synthesized inline-array buffer — the span source csc


### PR DESCRIPTION
Part of #916.

## Summary
- Raise simple `<PrivateImplementationDetails>.InlineArrayElementRef*` and `InlineArrayFirstElementRef*` helper calls to indexed inline-array addresses.
- Leave mixed span-conversion bodies Partial for a later validity slice, because exposing those currently surfaces separate validity defects.
- Add focused tests for first-element and indexed helper rewrites.

## Impact
- CoreLib `<PrivateImplementationDetails>` gap bucket drops from 16 to 9.
- Full methods increase from 39478 to 39485.
- Pass bugs remain 0.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- CoreLib `--gaps --max-examples 100`
- CoreLib `--validity-check --compile-cap 10000` with current-main defect-map diff: no gained defect codes; Full malformed remains 0.