### PR TITLE
Consume EH retry leave regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -1,0 +1,121 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class EhStructuringPassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction LeaveRetryOutsideTry()
+    {
+        var body = new BlockContainer();
+
+        var retry = new Block(0x0000);
+        retry.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        body.Add(retry);
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        tryBlock.Add(new Leave(0x0000));
+        body.Add(tryBlock);
+
+        var finallyBlock = new Block(0x0020);
+        finallyBlock.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        finallyBlock.Add(new EndFinally());
+        body.Add(finallyBlock);
+
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Finally,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction LeaveIntoSameTry()
+    {
+        var body = new BlockContainer();
+
+        var tryEntry = new Block(0x0010);
+        tryEntry.Add(new Leave(0x0018));
+        body.Add(tryEntry);
+
+        var tryTarget = new Block(0x0018);
+        tryTarget.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        body.Add(tryTarget);
+
+        var finallyBlock = new Block(0x0030);
+        finallyBlock.Add(new EndFinally());
+        body.Add(finallyBlock);
+
+        var tail = new Block(0x0040);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Finally,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0020,
+                    HandlerOffset: 0x0030,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    [Fact]
+    public void LeaveRetryOutsideTry_ConsumesFinallyRegion()
+    {
+        var function = LeaveRetryOutsideTry();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("try", output);
+        Assert.Contains("finally", output);
+    }
+
+    [Fact]
+    public void LeaveIntoSameTry_KeepsRegionFlat()
+    {
+        var function = LeaveIntoSameTry();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -223,7 +223,9 @@ public sealed class EhStructuringPass : IIrPass
                         // continuation (trimmed or printed as a goto) or a
                         // one-statement return/throw block — the multi-return
                         // idiom the build phase inlines back into the body.
-                        if (!targetsContinuation && !IsInlineableReturn(blocks, offsetToIndex, leave.TargetOffset))
+                        if (!targetsContinuation
+                            && !TargetsOutsideContainingConstructs(all, offset, leave.TargetOffset)
+                            && !IsInlineableReturn(blocks, offsetToIndex, leave.TargetOffset))
                             return false;
                         break;
                     }
@@ -332,6 +334,27 @@ public sealed class EhStructuringPass : IIrPass
             }
         }
         return bestHandler;
+    }
+
+    /// <summary>
+    /// True when a leave exits every EH construct containing <paramref name="offset"/>
+    /// and lands on an ordinary block outside them. C# can spell this as a
+    /// <c>goto</c> out of a <c>try</c>; the runtime still runs the intervening
+    /// finally blocks, preserving the original <c>leave</c> semantics. This is the
+    /// retry-loop shape in helpers such as <c>Interop.Sys.GetCwd</c>.
+    /// </summary>
+    static bool TargetsOutsideContainingConstructs(List<Construct> all, int offset, int targetOffset)
+    {
+        bool enclosed = false;
+        foreach (var construct in all)
+        {
+            if (!construct.Contains(offset))
+                continue;
+            enclosed = true;
+            if (construct.Contains(targetOffset))
+                return false;
+        }
+        return enclosed;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Let `EhStructuringPass` consume finally regions where a `leave` exits every containing EH construct to an outside retry label.
- Preserve finally semantics by leaving the `leave`/goto in the structured try body instead of treating the region as unconsumable.
- Add synthetic positive and negative coverage for leave-out-of-try vs leave-into-same-try shapes.

Partial progress on #913.

## Validation
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops`
- `dotnet run --project tools/DecompilerHarness -c Release --`
- `dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 10000`

Measured on latest `origin/main` (`3eab80b`): `unconsumed-regions` drops from 65 to 32, importer bugs stay 0, and inventory remains `40395/41159 Full (98.14%)`.