### PR TITLE
Curate decompiler roadmap metadata

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1810,7 +1810,7 @@ public class CfgSampleClass
     public static int InterpolationAsArgument(string name, int age)
         => ConsumeInterpolation($"Hello {name}, you are {age}");
 
-    // Format specifier: AppendFormatted<T>(T, string) — owed scorecard climb.
+    // Format specifier: AppendFormatted<T>(T, string).
     public static string InterpolationWithFormat(decimal amount)
         => $"Total: {amount:N2}";
 

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -31,6 +31,8 @@ public class IdiomShapeScorecardTests
         new("StringInterpolationPass", nameof(CfgSampleClass.StringInterpolation), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationToLocal), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
         new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationAsArgument), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.AddExpression]),
+        new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationWithFormat), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.InvocationExpression]),
+        new("StringInterpolationPass", nameof(CfgSampleClass.InterpolationWithAlignmentAndFormat), SyntaxKind.InterpolatedStringExpression, [SyntaxKind.InvocationExpression]),
         new("UsingStatementPass", nameof(CfgSampleClass.NormalUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("UsingStatementPass", nameof(CfgSampleClass.RefStructPatternUsing), SyntaxKind.UsingStatement, [SyntaxKind.TryStatement]),
         new("LockSugarPass", nameof(CfgSampleClass.ClassicLock), SyntaxKind.LockStatement, [SyntaxKind.TryStatement]),

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -14,8 +14,15 @@ public class LoweringFactCatalogTests
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ForEachStatement");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Index");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.IsPatternOperator");
-        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ObjectOrCollectionInitializerExpression");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.PatternSwitchStatement");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.StringInterpolation");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.TupleBinaryOperator");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.TupleCreationExpression");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.UsingStatement");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Yield");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.DeconstructionAssignmentOperator");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.LocalFunction");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.CapturedClosure");


### PR DESCRIPTION
## Summary

- expand the lowering fact catalog smoke test so it names the current fact sidecar providers, including switch, string interpolation, tuple, using, yield, and deconstruction rows
- add recovered formatted string-interpolation fixtures to the idiom scorecard
- remove stale wording that still called the recovered format interpolation case an owed scorecard climb

## Context

This is a small roadmap curation slice for #998. It keeps scorecard and sidecar/test intent metadata current after recent decompiler raises without changing product decompiler behavior.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`