### PR TITLE
Promote generated-field-name folklore into GeneratedCodeIdentity (#998)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedCodeIdentityTests.cs
@@ -112,6 +112,39 @@ public class GeneratedCodeIdentityTests
         Assert.False(GeneratedCodeIdentity.IsLocalFunctionMethod(method with { Name = "Helper" }));
     }
 
+    [Fact]
+    public void GeneratedFieldName_TrueForAnyAngleBracketField()
+    {
+        // The leading '<' is unspeakable in C# source, so it alone marks a
+        // synthesized field — state-machine plumbing or a hoisted local alike.
+        Assert.True(GeneratedCodeIdentity.IsGeneratedFieldName("<>1__state"));
+        Assert.True(GeneratedCodeIdentity.IsGeneratedFieldName("<>2__current"));
+        Assert.True(GeneratedCodeIdentity.IsGeneratedFieldName("<i>5__2"));
+        Assert.True(GeneratedCodeIdentity.IsGeneratedFieldName("<>9__0_0"));
+        // A source-named field is never generated.
+        Assert.False(GeneratedCodeIdentity.IsGeneratedFieldName("count"));
+        Assert.False(GeneratedCodeIdentity.IsGeneratedFieldName(""));
+    }
+
+    [Fact]
+    public void HoistedLocalFieldName_RequiresSingleAnglePrefixAndHoistKind()
+    {
+        // <name>5__N is a lifted source local/parameter — the field a state-machine
+        // reconstruction materializes back into a kickoff local.
+        Assert.True(GeneratedCodeIdentity.IsHoistedLocalFieldName("<i>5__2"));
+        Assert.True(GeneratedCodeIdentity.IsHoistedLocalFieldName("<text>5__1"));
+        // Pure state-machine plumbing wears the '<>' double prefix, not a hoist.
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("<>1__state"));
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("<>2__current"));
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("<>9__0_0"));
+        // A single-angle generated name without the '>5__' hoist kind is not a
+        // hoisted local (e.g. a lambda body or local-function method name shape).
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("<M>b__0_0"));
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("<M>d__0"));
+        // A source-named field is never a hoisted local.
+        Assert.False(GeneratedCodeIdentity.IsHoistedLocalFieldName("count"));
+    }
+
     static MethodRef LambdaMethod(bool declaringTypeIsCompilerGenerated)
         => new(s_closureHolder, "<M>b__0_0", s_int, [s_int], HasThis: true)
         {

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -63,6 +63,32 @@ public static class GeneratedCodeIdentity
         => name.StartsWith("<", StringComparison.Ordinal)
             && name.Contains(">g__", StringComparison.Ordinal);
 
+    /// <summary>
+    /// A compiler-generated field name. The leading <c>&lt;</c> is unspeakable in
+    /// C# source, so the name alone is reliable evidence the field was
+    /// synthesized — whether state-machine plumbing (<c>&lt;&gt;1__state</c>,
+    /// <c>&lt;&gt;2__current</c>) or a hoisted local (<c>&lt;i&gt;5__2</c>). The
+    /// iterator/async reconstructions use this to spot a residual state-machine
+    /// field a rewrite failed to remap.
+    /// </summary>
+    public static bool IsGeneratedFieldName(string name)
+        => name.StartsWith("<", StringComparison.Ordinal);
+
+    /// <summary>
+    /// A hoisted user-local field — <c>&lt;name&gt;5__N</c>, the lifted form of a
+    /// source local or parameter inside a state machine. The single <c>&lt;</c>
+    /// marks it generated; the absent <c>&lt;&gt;</c> double prefix and the
+    /// <c>&gt;5__</c> infix (Roslyn's hoisted-local kind) together distinguish it
+    /// from pure state-machine plumbing (<c>&lt;&gt;1__state</c>,
+    /// <c>&lt;&gt;2__current</c>), which a reconstruction maps to its own
+    /// constructs rather than to a source local. This is exactly the field set
+    /// those passes materialize back into kickoff locals and parameters.
+    /// </summary>
+    public static bool IsHoistedLocalFieldName(string name)
+        => IsGeneratedFieldName(name)
+            && !name.StartsWith("<>", StringComparison.Ordinal)
+            && name.Contains(">5__", StringComparison.Ordinal);
+
     static string LeafTypeName(string name)
     {
         int plus = name.LastIndexOf('+');

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
@@ -57,7 +57,7 @@ internal static class CountingLoopReconstruction
                 StoreField { Field.Name: "<>1__state" },
                 StoreField { Instance: LoadArgument { Index: 0 }, Field: var loopField } initStore,
                 Branch initBranch]
-            || !IsHoistedLocal(loopField.Name))
+            || !GeneratedCodeIdentity.IsHoistedLocalFieldName(loopField.Name))
             return false;
         var initExpr = initStore.Value;
         var condOff = initBranch.TargetOffset;
@@ -204,11 +204,6 @@ internal static class CountingLoopReconstruction
 
     static bool IsReturnFalse(Block block)
         => block.Children is [Return { Value: Constant { Value: false } }];
-
-    static bool IsHoistedLocal(string fieldName)
-        => fieldName.StartsWith("<", System.StringComparison.Ordinal)
-            && !fieldName.StartsWith("<>", System.StringComparison.Ordinal)
-            && fieldName.Contains(">5__", System.StringComparison.Ordinal);
 
     static string ExtractSourceName(string fieldName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -87,7 +87,7 @@ internal static class ForeachIteratorReconstruction
                 LoadField { Instance: LoadArgument { Index: 0 }, Field: var f } => f,
                 _ => null,
             };
-            if (field is null || !IsHoistedLocal(field.Name) || locals.ContainsKey(field.Name))
+            if (field is null || !GeneratedCodeIdentity.IsHoistedLocalFieldName(field.Name) || locals.ContainsKey(field.Name))
                 continue;
             locals[field.Name] = (work.AddLocal(field.Type, ExtractSourceName(field.Name)), field.Type);
         }
@@ -269,8 +269,8 @@ internal static class ForeachIteratorReconstruction
         => node is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter or UnsupportedNode;
 
     static bool IsStateMachineField(IrNode node)
-        => (node is LoadField { Field.Name: var loaded } && loaded.StartsWith("<", StringComparison.Ordinal))
-            || (node is StoreField { Field.Name: var stored } && stored.StartsWith("<", StringComparison.Ordinal));
+        => (node is LoadField { Field.Name: var loaded } && GeneratedCodeIdentity.IsGeneratedFieldName(loaded))
+            || (node is StoreField { Field.Name: var stored } && GeneratedCodeIdentity.IsGeneratedFieldName(stored));
 
     static void Reanchor(IrNode node, int offset)
     {
@@ -329,7 +329,7 @@ internal static class ForeachIteratorReconstruction
                     else
                         ok = false;
                     return;  // never descend into a swapped field's `this` receiver
-                case LoadField { Field.Name: var name } when name.StartsWith("<", StringComparison.Ordinal):
+                case LoadField { Field.Name: var name } when GeneratedCodeIdentity.IsGeneratedFieldName(name):
                     ok = false;  // a state-machine field reached through some other path
                     return;
                 default:
@@ -356,11 +356,6 @@ internal static class ForeachIteratorReconstruction
         parameter = null!;
         return false;
     }
-
-    static bool IsHoistedLocal(string fieldName)
-        => fieldName.StartsWith("<", StringComparison.Ordinal)
-            && !fieldName.StartsWith("<>", StringComparison.Ordinal)
-            && fieldName.Contains(">5__", StringComparison.Ordinal);
 
     static string ExtractSourceName(string fieldName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MultiYieldReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MultiYieldReconstruction.cs
@@ -51,7 +51,7 @@ internal static class MultiYieldReconstruction
                 LoadField { Instance: LoadArgument { Index: 0 }, Field: var f } => f,
                 _ => null,
             };
-            if (field is null || !IsHoistedLocal(field.Name) || hoisted.ContainsKey(field.Name))
+            if (field is null || !GeneratedCodeIdentity.IsHoistedLocalFieldName(field.Name) || hoisted.ContainsKey(field.Name))
                 continue;
             hoisted[field.Name] = (hoistedBase + hoisted.Count, field.Type);
         }
@@ -239,11 +239,6 @@ internal static class MultiYieldReconstruction
         parameter = null!;
         return false;
     }
-
-    static bool IsHoistedLocal(string fieldName)
-        => fieldName.StartsWith("<", StringComparison.Ordinal)
-            && !fieldName.StartsWith("<>", StringComparison.Ordinal)
-            && fieldName.Contains(">5__", StringComparison.Ordinal);
 
     static string ExtractSourceName(string fieldName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReducibleIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReducibleIteratorReconstruction.cs
@@ -82,7 +82,7 @@ internal static class ReducibleIteratorReconstruction
                 LoadField { Instance: LoadArgument { Index: 0 }, Field: var f } => f,
                 _ => null,
             };
-            if (field is null || !IsHoistedLocal(field.Name) || hoisted.ContainsKey(field.Name))
+            if (field is null || !GeneratedCodeIdentity.IsHoistedLocalFieldName(field.Name) || hoisted.ContainsKey(field.Name))
                 continue;
             hoisted[field.Name] = (work.AddLocal(field.Type, ExtractSourceName(field.Name)), field.Type);
         }
@@ -157,8 +157,8 @@ internal static class ReducibleIteratorReconstruction
         => node is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter or UnsupportedNode;
 
     static bool IsStateMachineField(IrNode node)
-        => (node is LoadField { Field.Name: var loaded } && loaded.StartsWith("<", StringComparison.Ordinal))
-            || (node is StoreField { Field.Name: var stored } && stored.StartsWith("<", StringComparison.Ordinal));
+        => (node is LoadField { Field.Name: var loaded } && GeneratedCodeIdentity.IsGeneratedFieldName(loaded))
+            || (node is StoreField { Field.Name: var stored } && GeneratedCodeIdentity.IsGeneratedFieldName(stored));
 
     static void Reanchor(IrNode node, int offset)
     {
@@ -220,7 +220,7 @@ internal static class ReducibleIteratorReconstruction
                     else
                         ok = false;
                     return;  // never descend into a swapped field's `this` receiver
-                case LoadField { Field.Name: var name } when name.StartsWith("<", StringComparison.Ordinal):
+                case LoadField { Field.Name: var name } when GeneratedCodeIdentity.IsGeneratedFieldName(name):
                     ok = false;  // a state-machine field reached through some other path
                     return;
                 default:
@@ -247,11 +247,6 @@ internal static class ReducibleIteratorReconstruction
         parameter = null!;
         return false;
     }
-
-    static bool IsHoistedLocal(string fieldName)
-        => fieldName.StartsWith("<", StringComparison.Ordinal)
-            && !fieldName.StartsWith("<>", StringComparison.Ordinal)
-            && fieldName.Contains(">5__", StringComparison.Ordinal);
 
     static string ExtractSourceName(string fieldName)
     {


### PR DESCRIPTION
## Summary
Claims the **Substrate / identity predicates** row of #998. The iterator/async reconstruction passes each duplicated the same compiler-generated **field-name** string checks; this promotes them into shared `GeneratedCodeIdentity` atoms.

### The drift
- `IsHoistedLocal(name)` = `StartsWith("<") && !StartsWith("<>") && Contains(">5__")` was copy-pasted **verbatim in four passes** (`CountingLoopReconstruction`, `MultiYieldReconstruction`, `ForeachIteratorReconstruction`, `ReducibleIteratorReconstruction`).
- The `StartsWith("<")` "is this a synthesized field" test was duplicated in the two `IsStateMachineField` residual checks plus a couple of inline switch guards.

Four identical copies of a name-folklore gate is exactly the drift the identity-predicate substrate exists to prevent.

### The promotion
Two atoms added to `GeneratedCodeIdentity`, consistent with its existing pure-name predicates (the leading `<` is unspeakable in C# source, so the name is reliable evidence):
- `IsGeneratedFieldName(name)` — any `<`-prefixed synthesized field.
- `IsHoistedLocalFieldName(name)` — a lifted source local `<name>5__N`, distinguished from `<>`-prefixed state-machine plumbing by the absent double prefix and the `>5__` hoist kind.

The six call sites route through the atoms. The node-shaped `IsStateMachineField` helper stays local (its `LoadField`/`StoreField` shape is the caller's concern, per *preserve caller-specific admissibility*); only its name test moves.

## Soundness
Pure consolidation — the promoted `IsHoistedLocalFieldName` keeps **all three** conditions of the original `IsHoistedLocal` (I caught that the helper was not just `StartsWith("<") && !StartsWith("<>")` — it also requires `Contains(">5__")`), so behavior is unchanged.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — **844/844 pass** (842 baseline + 2 new), including the fidelity / lowered-fidelity gates and the iterator-reconstruction pass tests.
- Added lookalike-covering substrate tests for both atoms (`<>1__state`/`<>2__current` plumbing, `<i>5__2` hoist, `<M>b__0_0`/`<M>d__0` non-hoist, source-named fields).

## Done signal (per #998)
Substrate tests cover lookalikes; consuming pass fixtures (the full reconstruction suite) prove unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)