### PR TITLE
Classify rectangular array allocations

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AllocationClassifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationClassifierTests.cs
@@ -51,6 +51,19 @@ public class AllocationClassifierTests
     }
 
     [Fact]
+    public void RectangularArrayNewObject_IsAnArrayAllocation()
+    {
+        // Multidimensional arrays are constructed with a newobj array
+        // constructor, not newarr. They are still array allocations, not generic
+        // object allocations.
+        var annotations = Classify(nameof(AllocSampleClass.MakeRectangularArray));
+
+        var array = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.array");
+        Assert.Equal("int[,]", array.Detail);
+        Assert.DoesNotContain(annotations, a => a.Descriptor.Id == "alloc.new");
+    }
+
+    [Fact]
     public void ValueTypeNewObject_IsNotAnAllocation()
     {
         // new KeyValuePair<int, int>(...) is a struct constructor — it constructs
@@ -150,6 +163,8 @@ public static class AllocSampleClass
     public static object BoxInt(int x) => x;
 
     public static int[] MakeArray(int n) => new int[n];
+
+    public static int[,] MakeRectangularArray(int rows, int columns) => new int[rows, columns];
 
     public static object MakeObject() => new object();
 

--- a/src/ILInspector.Decompiler/Annotations/AllocationClassifier.cs
+++ b/src/ILInspector.Decompiler/Annotations/AllocationClassifier.cs
@@ -78,6 +78,9 @@ public sealed class AllocationClassifier : IHiddenFactClassifier
         if (IsValueType(type, shapes))
             return null;
 
+        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
+            return Make(Array, node, type.ToDisplayString());
+
         string name = MetadataName(type);
 
         // The delegate constructor signature — .ctor(object, native int) — is an

--- a/tools/DecompilerHarness/AnnotationCheck.cs
+++ b/tools/DecompilerHarness/AnnotationCheck.cs
@@ -39,7 +39,7 @@ static class AnnotationCheck
     static readonly Dictionary<string, ILOpCode[]> Witnesses = new()
     {
         ["alloc.box"] = [ILOpCode.Box],
-        ["alloc.array"] = [ILOpCode.Newarr],
+        ["alloc.array"] = [ILOpCode.Newarr, ILOpCode.Newobj],
         ["alloc.new"] = [ILOpCode.Newobj],
         ["alloc.closure"] = [ILOpCode.Newobj],
         ["alloc.statemachine"] = [ILOpCode.Newobj],
@@ -84,7 +84,7 @@ static class AnnotationCheck
     const string NewObjValueWitness = "newobj.value(no-alloc)";
     static readonly HashSet<string> NewObjFamily = new(StringComparer.Ordinal)
     {
-        "alloc.new", "alloc.closure", "alloc.statemachine", "alloc.delegate",
+        "alloc.array", "alloc.new", "alloc.closure", "alloc.statemachine", "alloc.delegate",
     };
 
     enum ConstructedKind { ReferenceType, ValueType, Unresolved }


### PR DESCRIPTION
## Summary

- classify multidimensional array constructor `newobj` instructions as `alloc.array` instead of generic `alloc.new`
- teach the annotation-check oracle that `alloc.array` may sit on either `newarr` or array-constructor `newobj`
- add a focused rectangular-array fixture that asserts the array fact and rejects the object-allocation fact

## Context

This addresses the #998 **Annotation and hidden-fact coverage** row with a small classifier witness edge. The hidden-fact design already describes array allocations as `newarr` or array `newobj`; this makes the classifier and annotation oracle match that contract.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build tools/DecompilerHarness -c Release`