### PR TITLE
Cast cross-assembly enum call arguments to fix CS0176 validity defects (#998)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -755,6 +755,14 @@ public class CfgSampleClass
     // The fix casts the int operand to the enum: `t & (AttributeTargets)4`.
     public static System.AttributeTargets CrossAssemblyEnumBitwise(System.AttributeTargets t) => t & System.AttributeTargets.Class;
 
+    // A cross-assembly enum (StringComparison, CoreLib) passed as a CALL ARGUMENT
+    // lowers to `ldc.i4.5` for OrdinalIgnoreCase. With the enum shape unknown, the
+    // bare `5` makes overload resolution miss the instance string.Equals(string,
+    // StringComparison) and fall back to the static object.Equals(object, object),
+    // which then can't be called on an instance (CS0176). The fix casts the
+    // argument to the enum: `s.Equals("x", (StringComparison)5)`.
+    public static bool CrossAssemblyEnumCallArgument(string s) => s.Equals("x", System.StringComparison.OrdinalIgnoreCase);
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
@@ -40,4 +40,15 @@ public class CrossAssemblyEnumIntegerTests
         // The bare `t & 4` (enum & int) would be CS0019.
         Assert.DoesNotContain("& 4", output);
     }
+
+    [Fact]
+    public void EnumCallArgument_CastsIntegerToEnum()
+    {
+        var output = Render(nameof(CfgSampleClass.CrossAssemblyEnumCallArgument));
+
+        Assert.Contains("(StringComparison)", output);
+        // The bare `Equals("x", 5)` picks the static object.Equals(object, object)
+        // and is then called on an instance — CS0176.
+        Assert.DoesNotContain("\"x\", 5)", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -402,6 +402,29 @@ public sealed partial class CSharpPrinter
                 || value is Constant { Value: long lv } && lv < 0;
             return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
         }
+        // The same cast, for a cross-assembly enum. ClassifyShape only sees types
+        // defined in the inspected assembly, so a framework enum like
+        // StringComparison resolves to Unknown rather than Enum and the branch
+        // above does not fire. But type-safe IL only puts a bare integer constant
+        // in a non-primitive named-type position when that type is an enum (a
+        // reference target carries a box, a struct a construction), so the
+        // (Enum)value cast is faithful — it recompiles to the same ldc.i4 — and is
+        // needed: the bare literal makes overload resolution pick a wrong overload
+        // (e.g. string.Equals(string, StringComparison) falls back to the static
+        // object.Equals(object, object), CS0176). The member name is unavailable
+        // without loading the defining assembly, so the cast is the best honest
+        // spelling. Constants only: a non-constant integer into such a position is
+        // rarer and not needed for the validity defects this targets.
+        if (value is Constant { Value: int or long }
+            && target is { Kind: TypeRefKind.Definition, Name: not "Boolean" } unknownEnum
+            && _function.TypeShapes.GetValueOrDefault(unknownEnum) == TypeShape.Unknown
+            && !TypeFamilies.IsNumericPrimitive(unknownEnum)
+            && EffectiveType(value) is { } unknownEnumSource && TypeFamilies.IsIntegerLike(unknownEnumSource))
+        {
+            bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
+                || value is Constant { Value: long lv } && lv < 0;
+            return $"({TypeText(unknownEnum)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
+        }
         // A bool-valued expression flowing into an integer target is IL's
         // comparison/test result consumed as a number — `cgt.un; ret` from an int
         // method (e.g. byte.Sign, Convert.ToInt32(bool)). C# has no implicit


### PR DESCRIPTION
## Validity/fidelity defect bring-down (#998)

Claimed the **Validity/fidelity defect bring-down** roadmap row and fixed one measured bucket end-to-end.

### Defect baseline
`--validity-check` over the 8 product libraries (3,803 methods) found 43 defect methods. Largest single root cause: **CS0176 × 12** — all the same shape, e.g.:

```csharp
if (!category.Equals("symbol-misses", 5))   // CS0176
```

### Root cause
`ClassifyShape` only classifies types **defined in the inspected assembly**, so a framework enum like `StringComparison` resolves to `TypeShape.Unknown`. Neither `TypedConstantsPass` nor the `CastValue` enum branch (both gated on `TypeShape.Enum`) acts on it, so the `StringComparison` argument renders as a bare `5`. That int misses the instance `string.Equals(string, StringComparison)` overload and binds the **static** `object.Equals(object, object)` — which can't be called on an instance → CS0176.

### Fix
A bare integer constant in a non-primitive named-type parameter position is unambiguously an **enum constant** in type-safe IL (a reference target carries a `Box`, a struct a construction). Add a tightly-guarded `CastValue` fallback that emits `(StringComparison)5` for the cross-assembly (`Unknown`-shape) case. The cast is faithful — recompiles to the same `ldc.i4.5` — and binds the intended overload. This mirrors what the comparison/bitwise contexts already do for cross-assembly enums (`CrossAssemblyEnumIntegerTests`); it extends the same treatment to call arguments.

Guards: constants only; `Kind: Definition`; `Unknown` shape; not a numeric primitive; not `Boolean`; value integer-like. (Bool/char are pre-retyped by `TypedConstantsPass`; reference/struct targets never receive a bare int constant in valid IL.)

### Result
- **Defect diff over the product libraries: `CS0176` 12 → 0, 0 regressions.**
- Fidelity gate + lowered fidelity gate green — the cast round-trips exactly.
- Full `ILInspector.Decompiler.Tests`: **843 passed**.

### Fixture
`CfgSampleClass.CrossAssemblyEnumCallArgument` (`s.Equals("x", StringComparison.OrdinalIgnoreCase)`) + a `CrossAssemblyEnumIntegerTests.EnumCallArgument_CastsIntegerToEnum` assertion; the fidelity gate proves round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)