### PR TITLE
Raise classic async state machines

### DIFF
--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -147,6 +147,17 @@ public sealed record DecompilerResult(
     public IReadOnlyList<(string Field, string Value)> FieldInitializers { get; init; } = [];
 
     /// <summary>
+    /// True when the body must be emitted under a C# <c>async</c> method modifier
+    /// to recompile to equivalent IL. Classic async state-machine reconstruction
+    /// sets this; runtime-async helper-call recovery does not, because compiling it
+    /// as C# async would emit a different lowering.
+    /// </summary>
+    public bool RequiresAsyncBodyModifier { get; init; }
+
+    /// <summary>True when the rendered IR contains at least one recovered <c>await</c> expression.</summary>
+    public bool ContainsAwaitExpression { get; init; }
+
+    /// <summary>
     /// A telemetry-free record of what the decompilation observed — its fidelity
     /// outcome, the symbol source it used, and its diagnostics — for a host to
     /// convert into its own diagnostics. Null for projections that do not build

--- a/src/ILInspector.Decompiler/Pipeline/Facts/AwaitRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/AwaitRecoveryFacts.cs
@@ -11,9 +11,11 @@ internal sealed class AwaitRecoveryFacts : ILoweringFactProvider
             typeof(AwaitRecoveryPass),
             [
                 new FactPrimitive("member.corelib-identity:AsyncHelpers.Await", "MemberIdentity.IsAsyncHelpersAwait"),
+                new FactPrimitive("state-machine.classic-async-kickoff", "ClassicAsyncReconstructionPass kickoff/MoveNext correlation"),
+                new FactPrimitive("state-machine.classic-async-await", "ClassicAsyncReconstructionPass awaiter GetAwaiter/GetResult/AwaitUnsafeOnCompleted shape"),
             ],
-            PositiveCoverage: "CfgSampleClass runtime-async await fixtures",
+            PositiveCoverage: "CfgSampleClass runtime-async await fixtures; Fixtures.ClassicAsync overlay single, sequential, branch, loop, ValueTask, and try/finally awaits",
             AdversarialCoverage: "AwaitAdversarialTests namespace/type/assembly/instance lookalikes",
-            MissingDiscriminator: "classic async state-machine awaits require PDB/state-machine facts"),
+            MissingDiscriminator: "classic async reconstruction is fixture-backed; broader user state-machine lookalikes still need adversarial hardening"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -104,6 +104,8 @@ public sealed partial class CSharpPrinter
             {
                 ConstructorChain = printer._constructorChain,
                 FieldInitializers = printer._fieldInitializers,
+                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
+                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             };
         }
         catch (Exception ex)
@@ -169,6 +171,8 @@ public sealed partial class CSharpPrinter
             {
                 ConstructorChain = printer._constructorChain,
                 FieldInitializers = printer._fieldInitializers,
+                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
+                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             };
         }
         catch (Exception ex)
@@ -202,6 +206,8 @@ public sealed partial class CSharpPrinter
             {
                 ConstructorChain = printer._constructorChain,
                 FieldInitializers = printer._fieldInitializers,
+                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
+                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             };
         }
         catch (Exception ex)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -200,6 +200,15 @@ public sealed class IrFunction : IrNode
     public bool SkipLocalsInit { get; set; }
 
     /// <summary>
+    /// True when a pass reconstructed a body whose compile-back shell must carry
+    /// the C# <c>async</c> modifier to re-emit equivalent IL. Runtime-async
+    /// <see cref="AwaitExpression"/> bodies deliberately leave this false: compiling
+    /// those as C# async would produce classic state-machine IL, not the original
+    /// runtime-async helper-call form.
+    /// </summary>
+    public bool RequiresAsyncBodyModifier { get; set; }
+
+    /// <summary>
     /// Exception regions over the flat block container, by IL offset. The
     /// importer keeps blocks flat (region boundaries are block leaders);
     /// the EH structuring pass consumes these into <see cref="TryCatch"/>/

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClassicAsyncReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClassicAsyncReconstructionPass.cs
@@ -1,0 +1,828 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Reconstructs classic async state-machine kickoffs (runtime-async=off) back to
+/// async bodies. The source logic lives in <c>&lt;M&gt;d__N.MoveNext</c>; the public
+/// kickoff only initializes the state machine and returns the builder's task.
+/// This pass imports the sibling <c>MoveNext</c>, recovers the fixture-backed
+/// await shapes, and replaces the kickoff body with the source-shaped body.
+/// </summary>
+public sealed class ClassicAsyncReconstructionPass : IIrPass
+{
+    public string Name => "classic-async-reconstruction";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        if (TryAcknowledgeSupportMethod(function, context))
+            return;
+
+        if (context.ImportMethodBody is null)
+            return;
+        if (!TryGetKickoff(function, out var kickoff))
+            return;
+
+        var moveNext = context.ImportMethodBody(new MethodRef(
+            kickoff.StateMachineType,
+            "MoveNext",
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            HasThis: true));
+        if (moveNext is null)
+            return;
+
+        var moveNextPasses = IrPasses.Default
+            .Where(static pass => pass is not ClassicAsyncReconstructionPass)
+            .ToImmutableArray();
+        IrPasses.Run(moveNext, moveNextPasses, context);
+
+        if (!TryReconstruct(moveNext, function, kickoff, out var body, out var locals, out var localNames))
+            return;
+
+        context.Stepper.StepOver($"reconstruct classic async '{function.Name}' from {kickoff.StateMachineType.Name}.MoveNext");
+        function.ResetLocals(locals, localNames);
+        function.RequiresAsyncBodyModifier = true;
+        function.Body.DetachChildren();
+        foreach (var block in body.Blocks.ToList())
+        {
+            block.Detach();
+            function.Body.Add(block);
+        }
+    }
+
+    sealed record Kickoff(TypeRef StateMachineType, int StateMachineLocal, int SourceOffset);
+
+    sealed class LocalBuilder
+    {
+        readonly ImmutableArray<TypeRef>.Builder _locals = ImmutableArray.CreateBuilder<TypeRef>();
+        readonly ImmutableArray<string?>.Builder _names = ImmutableArray.CreateBuilder<string?>();
+
+        public int Add(TypeRef type, string? name)
+        {
+            var index = _locals.Count;
+            _locals.Add(type);
+            _names.Add(name);
+            return index;
+        }
+
+        public ImmutableArray<TypeRef> Locals => _locals.ToImmutable();
+        public ImmutableArray<string?> Names => _names.ToImmutable();
+    }
+
+    static bool TryAcknowledgeSupportMethod(IrFunction function, PassContext context)
+    {
+        if (function.Name is not ("MoveNext" or "SetStateMachine"))
+            return false;
+        if (!LooksLikeClassicAsyncStateMachine(function))
+            return false;
+
+        context.Stepper.StepOver($"acknowledge generated classic async support method '{function.DeclaringType.Name}.{function.Name}'");
+        function.ResetLocals([], []);
+        function.Body.DetachChildren();
+        var block = new Block(0);
+        block.Add(new Return(null));
+        function.Body.Add(block);
+        return true;
+    }
+
+    static bool LooksLikeClassicAsyncStateMachine(IrFunction function)
+        => IsStateMachineType(function.DeclaringType)
+            && function.Descendants.Any(static node => node switch
+            {
+                LoadField { Field.Name: "<>t__builder" } => true,
+                LoadFieldAddress { Field.Name: "<>t__builder" } => true,
+                StoreField { Field.Name: "<>t__builder" } => true,
+                _ => false,
+            });
+
+    static bool TryGetKickoff(IrFunction function, out Kickoff kickoff)
+    {
+        kickoff = null!;
+        if (function.Body.Blocks is not [var block])
+            return false;
+
+        StoreField? builderStore = null;
+        ExpressionStatement? startStatement = null;
+        Return? returnTask = null;
+
+        foreach (var statement in block.Children)
+        {
+            if (statement is StoreField { Field.Name: "<>t__builder", Instance: LoadLocalAddress builderLocal } store
+                && builderStore is null)
+            {
+                builderStore = store;
+                if (builderLocal.Index < 0 || builderLocal.Index >= function.Locals.Length)
+                    return false;
+                continue;
+            }
+
+            if (statement is ExpressionStatement { Expression: Call { Callee.Name: "Start" } } expression)
+                startStatement = expression;
+            else if (statement is Return { Value: LoadProperty { PropertyName: "Task" } } ret)
+                returnTask = ret;
+        }
+
+        if (builderStore?.Instance is not LoadLocalAddress stateMachineAddress
+            || startStatement is null
+            || returnTask is null)
+        {
+            return false;
+        }
+
+        var stateMachineType = function.Locals[stateMachineAddress.Index];
+        if (IsStateMachineType(stateMachineType))
+        {
+            kickoff = new Kickoff(stateMachineType, stateMachineAddress.Index, builderStore.SourceOffset);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsStateMachineType(TypeRef type)
+    {
+        var name = MetadataName(type);
+        return name.StartsWith("<", StringComparison.Ordinal)
+            && name.Contains(">d__", StringComparison.Ordinal);
+    }
+
+    static string MetadataName(TypeRef type)
+    {
+        var name = type.Kind == TypeRefKind.GenericInstance && type.ElementType is { } definition
+            ? definition.Name
+            : type.Name;
+        var nested = name.LastIndexOf('+');
+        return nested >= 0 ? name[(nested + 1)..] : name;
+    }
+
+    static bool TryReconstruct(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Kickoff kickoffShape,
+        out BlockContainer body,
+        out ImmutableArray<TypeRef> locals,
+        out ImmutableArray<string?> localNames)
+    {
+        body = null!;
+        locals = [];
+        localNames = [];
+
+        var localBuilder = new LocalBuilder();
+        if (!TryBuildStatements(moveNext, kickoff, localBuilder, out var statements))
+            return false;
+
+        var block = new Block(0);
+        foreach (var statement in statements)
+        {
+            Reanchor(statement, kickoffShape.SourceOffset);
+            block.Add(statement);
+        }
+
+        body = new BlockContainer();
+        body.Add(block);
+        locals = localBuilder.Locals;
+        localNames = localBuilder.Names;
+        return true;
+    }
+
+    static bool TryBuildStatements(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        LocalBuilder locals,
+        out List<IrNode> statements)
+    {
+        statements = [];
+
+        var setResult = FinalSetResult(moveNext);
+        var getResults = GetResultCalls(moveNext);
+        if (setResult is null)
+            return false;
+
+        if (TryBuildTryFinally(moveNext, kickoff, setResult, getResults, out var tryFinally))
+        {
+            statements.Add(tryFinally);
+            return true;
+        }
+
+        if (TryBuildLoop(moveNext, kickoff, setResult, locals, out var loopStatements))
+        {
+            statements.AddRange(loopStatements);
+            return true;
+        }
+
+        if (TryBuildConditional(moveNext, kickoff, setResult, getResults, out var conditionalReturn))
+        {
+            statements.Add(conditionalReturn);
+            return true;
+        }
+
+        if (TryBuildSequentialVoid(moveNext, kickoff, setResult, getResults, locals, out var sequential))
+        {
+            statements.AddRange(sequential);
+            return true;
+        }
+
+        if (TryBuildSingleAwaitVoid(moveNext, kickoff, setResult, getResults, out var voidStatements))
+        {
+            statements.AddRange(voidStatements);
+            return true;
+        }
+
+        if (TryBuildSingleAwaitReturn(moveNext, kickoff, setResult, getResults, out var ret))
+        {
+            statements.Add(ret);
+            return true;
+        }
+
+        return false;
+    }
+
+    static Call? FinalSetResult(IrFunction moveNext)
+        => moveNext.Descendants.OfType<Call>()
+            .LastOrDefault(static call => call.Callee.Name == "SetResult" && IsAsyncMethodBuilder(call.Callee.DeclaringType));
+
+    static List<Call> GetResultCalls(IrFunction moveNext)
+        => [.. moveNext.Descendants.OfType<Call>().Where(static call => call.Callee.Name == "GetResult")];
+
+    static bool TryBuildSingleAwaitReturn(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        IReadOnlyList<Call> getResults,
+        out Return ret)
+    {
+        ret = null!;
+        if (setResult.Arguments is not [_, LoadLocal result]
+            || getResults.Count != 1)
+        {
+            return false;
+        }
+        if (HasUnexpectedExpressionStatement(moveNext) || HasHoistedUserState(moveNext))
+            return false;
+
+        var store = moveNext.Descendants.OfType<StoreLocal>()
+            .LastOrDefault(s => s.Index == result.Index && ContainsNode(s.Value, getResults[0]));
+        if (store is null)
+            return false;
+        if (HasUnexpectedStore(moveNext, store))
+            return false;
+
+        var value = CloneWithAwaitsAndRemap(store.Value, moveNext, kickoff);
+        if (value is null)
+            return false;
+
+        ret = new Return(value);
+        return true;
+    }
+
+    static bool TryBuildSingleAwaitVoid(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        IReadOnlyList<Call> getResults,
+        out List<IrNode> statements)
+    {
+        statements = [];
+        if (setResult.Arguments.Count != 1 || getResults.Count != 1)
+            return false;
+        if (HasHoistedUserState(moveNext))
+            return false;
+
+        var awaited = AwaitForGetResult(moveNext, kickoff, getResults[0]);
+        if (awaited is null)
+            return false;
+        var getResultStatement = getResults[0].Parent as ExpressionStatement;
+        if (getResultStatement is null || HasUnexpectedExpressionStatement(moveNext, getResultStatement))
+            return false;
+        if (HasUnexpectedStore(moveNext))
+            return false;
+
+        statements.Add(new ExpressionStatement(awaited));
+        statements.Add(new Return(null));
+        return true;
+    }
+
+    static bool TryBuildSequentialVoid(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        IReadOnlyList<Call> getResults,
+        LocalBuilder locals,
+        out List<IrNode> statements)
+    {
+        statements = [];
+        if (setResult.Arguments.Count != 1 || getResults.Count != 2)
+            return false;
+
+        var firstResultStore = moveNext.Descendants.OfType<StoreLocal>()
+            .FirstOrDefault(store => ContainsNode(store.Value, getResults[0]));
+        if (firstResultStore is null)
+            return false;
+
+        var firstStore = moveNext.Descendants.OfType<StoreField>()
+            .FirstOrDefault(store => IsHoistedLocal(store.Field.Name)
+                && store.Value is LoadLocal local
+                && local.Index == firstResultStore.Index);
+        if (firstStore is null || firstStore.Field.Type is not { } firstType)
+            return false;
+
+        var firstName = ExtractSourceName(firstStore.Field.Name);
+        var firstIndex = locals.Add(firstType, firstName);
+        var firstAwait = AwaitForGetResult(moveNext, kickoff, getResults[0]);
+        if (firstAwait is null)
+            return false;
+        statements.Add(new StoreLocal(firstIndex, firstType, firstAwait));
+
+        var secondStore = moveNext.Descendants.OfType<StoreLocal>()
+            .FirstOrDefault(store => ContainsNode(store.Value, getResults[1]));
+        if (secondStore is null)
+            return false;
+        var secondName = "y";
+        var secondIndex = locals.Add(secondStore.Type, secondName);
+        var secondAwait = AwaitForGetResult(moveNext, kickoff, getResults[1]);
+        if (secondAwait is null)
+            return false;
+        statements.Add(new StoreLocal(secondIndex, secondStore.Type, secondAwait));
+
+        var keepAlive = moveNext.Descendants.OfType<ExpressionStatement>()
+            .FirstOrDefault(static statement => statement.Expression is Call { Callee.Name: "KeepAlive" });
+        if (keepAlive is not { Expression: Call call })
+            return false;
+        if (HasUnexpectedExpressionStatement(moveNext, keepAlive))
+            return false;
+
+        var hoisted = new Dictionary<string, (int Index, TypeRef Type)>(StringComparer.Ordinal)
+        {
+            [firstStore.Field.Name] = (firstIndex, firstType),
+        };
+        var replacements = new Dictionary<int, (int Index, TypeRef Type)> { [secondStore.Index] = (secondIndex, secondStore.Type) };
+        var mapped = CloneAndRemap(call, kickoff, hoisted, replacements);
+        if (mapped is null)
+            return false;
+        statements.Add(new ExpressionStatement(mapped));
+        statements.Add(new Return(null));
+        return true;
+    }
+
+    static bool TryBuildConditional(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        IReadOnlyList<Call> getResults,
+        out Return ret)
+    {
+        ret = null!;
+        if (setResult.Arguments is not [_, LoadLocal result] || getResults.Count != 1)
+            return false;
+        if (HasUnexpectedExpressionStatement(moveNext) || HasHoistedUserState(moveNext))
+            return false;
+
+        var flag = moveNext.Descendants.OfType<LoadField>()
+            .FirstOrDefault(static field => field.Field.Type is { Name: "Boolean", Namespace: "System" }
+                && field.Instance is LoadArgument { Index: 0 }
+                && !field.Field.Name.StartsWith("<", StringComparison.Ordinal));
+        if (flag is null)
+            return false;
+        if (!moveNext.Descendants.OfType<ConditionalBranch>().Any(branch => ContainsEquivalentField(branch.Condition, flag.Field.Name)))
+            return false;
+
+        var tempStores = moveNext.Descendants.OfType<StoreLocal>().Where(store => store.Index != result.Index).ToList();
+        var awaitStore = tempStores.SingleOrDefault(store => ContainsNode(store.Value, getResults[0]));
+        if (awaitStore is null)
+            return false;
+        var zeroStore = tempStores.SingleOrDefault(store => store.Index == awaitStore.Index
+            && store.Value is Constant { Value: 0 });
+        if (zeroStore is null)
+            return false;
+        if (zeroStore.Parent is not Block zeroBlock
+            || !moveNext.Descendants.OfType<ConditionalBranch>().Any(branch =>
+                branch.TargetOffset == zeroBlock.StartOffset
+                && branch.Condition is LogicalNot not
+                && ContainsEquivalentField(not.Operand, flag.Field.Name)))
+        {
+            return false;
+        }
+        var finalStore = moveNext.Descendants.OfType<StoreLocal>()
+            .SingleOrDefault(store => store.Index == result.Index
+                && store.Value is LoadLocal load
+                && load.Index == awaitStore.Index);
+        if (finalStore is null)
+            return false;
+        if (HasUnexpectedStore(moveNext, awaitStore, zeroStore, finalStore))
+            return false;
+
+        var condition = CloneAndRemap((IrExpression)flag, kickoff);
+        var awaited = AwaitForGetResult(moveNext, kickoff, getResults[0]);
+        if (condition is null || awaited is null)
+            return false;
+
+        ret = new Return(new Conditional(condition, awaited, new Constant(0, TypeRef.CoreLib("System", "Int32"))));
+        return true;
+    }
+
+    static bool TryBuildLoop(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        LocalBuilder locals,
+        out List<IrNode> statements)
+    {
+        statements = [];
+        if (setResult.Arguments is not [_, LoadLocal])
+            return false;
+        if (HasUnexpectedExpressionStatement(moveNext))
+            return false;
+
+        var tasksField = moveNext.Descendants.OfType<LoadField>()
+            .FirstOrDefault(static field => field.Field.Name == "tasks"
+                && field.Field.Type is { Kind: TypeRefKind.SzArray, ElementType: { } element }
+                && IsTaskLike(element));
+        if (tasksField is null || tasksField.Field.Type.ElementType is not { } taskType)
+            return false;
+
+        var getResult = GetResultCalls(moveNext).SingleOrDefault();
+        if (getResult is null)
+            return false;
+        if (!HasField(moveNext, "<>7__wrap1")
+            || !HasField(moveNext, "<>7__wrap2")
+            || !HasField(moveNext, "<>7__wrap3"))
+        {
+            return false;
+        }
+        if (!moveNext.Descendants.OfType<StoreLocal>().Any(static store => store.Value is Constant { Value: 0 }))
+            return false;
+        var resultStore = moveNext.Descendants.OfType<StoreLocal>()
+            .SingleOrDefault(store => ContainsNode(store.Value, getResult));
+        if (resultStore is null)
+            return false;
+        var accumulatorStore = moveNext.Descendants.OfType<StoreLocal>()
+            .SingleOrDefault(store => store.Value is Binary { Kind: BinaryKind.Add } binary
+                && IsWrap3Load(binary.Left)
+                && binary.Right is LoadLocal load
+                && load.Index == resultStore.Index);
+        if (accumulatorStore is null)
+            return false;
+
+        var sumType = accumulatorStore.Type;
+        var sumIndex = locals.Add(sumType, "sum");
+        var taskIndex = locals.Add(taskType, "task");
+
+        statements.Add(new StoreLocal(sumIndex, sumType, new Constant(0, sumType)));
+        var body = new Block(0);
+        var awaited = new AwaitExpression(new LoadLocal(taskIndex, taskType), getResult.Callee.ReturnType);
+        body.Add(new StoreLocal(
+            sumIndex,
+            sumType,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(sumIndex, sumType), awaited)));
+
+        var collection = CloneAndRemap((IrExpression)tasksField, kickoff);
+        if (collection is null)
+            return false;
+
+        statements.Add(new ForeachStatement(taskIndex, taskType, collection, body));
+        statements.Add(new Return(new LoadLocal(sumIndex, sumType)));
+        return true;
+    }
+
+    static bool TryBuildTryFinally(
+        IrFunction moveNext,
+        IrFunction kickoff,
+        Call setResult,
+        IReadOnlyList<Call> getResults,
+        out TryFinally tryFinally)
+    {
+        tryFinally = null!;
+        if (setResult.Arguments is not [_, LoadLocal result] || getResults.Count != 1)
+            return false;
+
+        var originalTryFinally = moveNext.Descendants.OfType<TryFinally>().FirstOrDefault();
+        if (originalTryFinally is null)
+            return false;
+
+        var resultStore = originalTryFinally.TryBody.Descendants.OfType<StoreLocal>()
+            .LastOrDefault(store => store.Index == result.Index && ContainsNode(store.Value, getResults[0]));
+        if (resultStore is null)
+            return false;
+        var resultValue = CloneWithAwaitsAndRemap(resultStore.Value, moveNext, kickoff);
+        if (resultValue is null)
+            return false;
+
+        var finallyStatements = originalTryFinally.FinallyBody.Blocks
+            .SelectMany(block => block.Children)
+            .OfType<IfStatement>()
+            .SelectMany(ifStatement => ifStatement.Then.Children)
+            .OfType<ExpressionStatement>()
+            .ToList();
+        if (finallyStatements.Count != 1)
+            return false;
+        if (HasUnexpectedExpressionStatement(moveNext, finallyStatements[0]))
+            return false;
+
+        var mappedFinally = CloneAndRemap(finallyStatements[0], kickoff);
+        if (mappedFinally is null)
+            return false;
+
+        tryFinally = new TryFinally(
+            Container(new Return(resultValue)),
+            Container(mappedFinally));
+        return true;
+    }
+
+    static AwaitExpression? AwaitForGetResult(IrFunction moveNext, IrFunction kickoff, Call getResult)
+    {
+        if (getResult.Arguments is not [LoadLocalAddress awaiterAddress])
+            return null;
+
+        var nodes = moveNext.Descendants.ToList();
+        var getResultPosition = nodes.IndexOf(getResult);
+        if (getResultPosition < 0)
+            return null;
+
+        StoreLocal? awaiterStore = null;
+        for (var i = 0; i < getResultPosition; i++)
+        {
+            if (nodes[i] is StoreLocal { Index: var index, Value: Call { Callee.Name: "GetAwaiter" } call } store
+                && index == awaiterAddress.Index
+                && call.Arguments.Count == 1)
+            {
+                if (store.Value is Call { Arguments: [LoadField { Field.Name: var maybeAwaiterField }] }
+                    && maybeAwaiterField.StartsWith("<>u__", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                awaiterStore = store;
+            }
+        }
+
+        if (awaiterStore?.Value is not Call { Arguments: [var awaitedOperand] })
+            return null;
+
+        var operand = CloneAndRemap(awaitedOperand, kickoff);
+        return operand is null ? null : new AwaitExpression(operand, getResult.Callee.ReturnType);
+    }
+
+    static bool HasUnexpectedExpressionStatement(IrFunction moveNext, params ExpressionStatement[] allowed)
+    {
+        var allowedSet = allowed.ToHashSet();
+        foreach (var statement in moveNext.Descendants.OfType<ExpressionStatement>())
+        {
+            if (allowedSet.Contains(statement))
+                continue;
+            if (statement.Expression is Call { Callee.Name: "AwaitUnsafeOnCompleted" or "SetException" or "SetResult" })
+                continue;
+            return true;
+        }
+        return false;
+    }
+
+    static bool HasUnexpectedStore(IrFunction moveNext, params IrNode[] allowed)
+    {
+        var allowedSet = allowed.ToHashSet();
+        var stateLocal = moveNext.Descendants.OfType<StoreLocal>()
+            .FirstOrDefault(static store => store.Value is LoadField { Field.Name: "<>1__state" })
+            ?.Index;
+
+        foreach (var node in moveNext.Descendants)
+        {
+            switch (node)
+            {
+                case StoreField store:
+                    if (allowedSet.Contains(store) || store.Field.Name.StartsWith("<>", StringComparison.Ordinal))
+                        continue;
+                    return true;
+                case StoreProperty or StoreElement or StoreIndirect or StoreArgument:
+                    if (!allowedSet.Contains(node))
+                        return true;
+                    break;
+                case StoreLocal store:
+                    if (allowedSet.Contains(store))
+                        continue;
+                    if (stateLocal is { } state && store.Index == state
+                        && store.Value is Constant or LoadStackSlot or LoadField { Field.Name: "<>1__state" })
+                        continue;
+                    if (store.Value is Call { Callee.Name: "GetAwaiter" }
+                        || store.Value is LoadField { Field.Name: var fieldName } && fieldName.StartsWith("<>u__", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    static bool HasHoistedUserState(IrFunction moveNext)
+        => moveNext.Descendants.OfType<StoreField>().Any(static store =>
+            IsHoistedLocal(store.Field.Name) || store.Field.Name.StartsWith("<>7__wrap", StringComparison.Ordinal));
+
+    static bool HasField(IrFunction moveNext, string name)
+        => moveNext.Descendants.Any(node => node switch
+        {
+            LoadField { Field.Name: var fieldName } => fieldName == name,
+            StoreField { Field.Name: var fieldName } => fieldName == name,
+            LoadFieldAddress { Field.Name: var fieldName } => fieldName == name,
+            _ => false,
+        });
+
+    static bool ContainsEquivalentField(IrNode node, string fieldName)
+        => node.Descendants.Prepend(node).Any(candidate =>
+            candidate is LoadField { Field.Name: var name, Instance: LoadArgument { Index: 0 } } && name == fieldName);
+
+    static bool IsWrap3Load(IrExpression expression)
+        => expression is LoadField { Field.Name: "<>7__wrap3", Instance: LoadArgument { Index: 0 } };
+
+    static IrExpression? CloneWithAwaitsAndRemap(IrExpression expression, IrFunction moveNext, IrFunction kickoff)
+    {
+        var clone = (IrExpression)expression.Clone();
+        var originalGetResults = expression.Descendants.Prepend(expression).OfType<Call>()
+            .Where(static call => call.Callee.Name == "GetResult")
+            .ToList();
+        var clonedGetResults = clone.Descendants.Prepend(clone).OfType<Call>()
+            .Where(static call => call.Callee.Name == "GetResult")
+            .ToList();
+        if (originalGetResults.Count != clonedGetResults.Count)
+            return null;
+
+        IrExpression? rootReplacement = null;
+        for (var i = 0; i < originalGetResults.Count; i++)
+        {
+            var awaited = AwaitForGetResult(moveNext, kickoff, originalGetResults[i]);
+            if (awaited is null)
+                return null;
+            if (ReferenceEquals(clonedGetResults[i], clone))
+                rootReplacement = awaited;
+            else
+                clonedGetResults[i].ReplaceWith(awaited);
+        }
+
+        var result = rootReplacement ?? clone;
+        return RemapInPlace(result, kickoff) ? result : null;
+    }
+
+    static IrExpression? CloneAndRemap(IrExpression expression, IrFunction kickoff)
+    {
+        var clone = (IrExpression)expression.Clone();
+        if (clone is LoadField { Instance: LoadArgument { Index: 0, Name: "this" }, Field: var field }
+            && TryGetParameter(kickoff, field.Name, out var argIndex, out var parameter))
+        {
+            return new LoadArgument(argIndex, parameter.Name, parameter.Type);
+        }
+        if (clone is LoadFieldAddress { Instance: LoadArgument { Index: 0, Name: "this" }, Field: var addressField }
+            && TryGetParameter(kickoff, addressField.Name, out var addressArgIndex, out var addressParameter))
+        {
+            return new LoadArgument(addressArgIndex, addressParameter.Name, addressParameter.Type);
+        }
+
+        return RemapInPlace(clone, kickoff) ? clone : null;
+    }
+
+    static T? CloneAndRemap<T>(T node, IrFunction kickoff) where T : IrNode
+    {
+        var clone = (T)node.Clone();
+        return RemapInPlace(clone, kickoff) ? clone : null;
+    }
+
+    static Call? CloneAndRemap(
+        Call call,
+        IrFunction kickoff,
+        IReadOnlyDictionary<string, (int Index, TypeRef Type)> hoisted,
+        IReadOnlyDictionary<int, (int Index, TypeRef Type)> locals)
+    {
+        var clone = (Call)call.Clone();
+        return RemapInPlace(clone, kickoff, hoisted, locals) ? clone : null;
+    }
+
+    static bool RemapInPlace(
+        IrNode node,
+        IrFunction kickoff,
+        IReadOnlyDictionary<string, (int Index, TypeRef Type)>? hoisted = null,
+        IReadOnlyDictionary<int, (int Index, TypeRef Type)>? localReplacements = null)
+    {
+        var swaps = new List<(IrNode Old, IrNode New)>();
+        var ok = true;
+        Visit(node);
+        if (!ok)
+            return false;
+
+        foreach (var (old, replacement) in swaps)
+        {
+            if (ReferenceEquals(old, node))
+                return false;
+            old.ReplaceWith(replacement);
+        }
+        return true;
+
+        void Visit(IrNode current)
+        {
+            if (!ok)
+                return;
+            switch (current)
+            {
+                case LoadField { Instance: LoadArgument { Index: 0 }, Field: var field }:
+                    if (hoisted is not null && hoisted.TryGetValue(field.Name, out var local))
+                    {
+                        swaps.Add((current, new LoadLocal(local.Index, local.Type)));
+                    }
+                    else if (TryGetParameter(kickoff, field.Name, out var argIndex, out var parameter))
+                    {
+                        swaps.Add((current, new LoadArgument(argIndex, parameter.Name, parameter.Type)));
+                    }
+                    else
+                    {
+                        ok = false;
+                    }
+                    return;
+                case LoadFieldAddress { Instance: LoadArgument { Index: 0 }, Field: var field }:
+                    if (TryGetParameter(kickoff, field.Name, out var addressArgIndex, out var addressParameter))
+                    {
+                        swaps.Add((current, new LoadArgument(addressArgIndex, addressParameter.Name, addressParameter.Type)));
+                    }
+                    else
+                    {
+                        ok = false;
+                    }
+                    return;
+                case LoadLocal load when localReplacements is not null && localReplacements.TryGetValue(load.Index, out var replacement):
+                    swaps.Add((current, new LoadLocal(replacement.Index, replacement.Type)));
+                    return;
+                case LoadArgument { Index: 0, Name: "this" }:
+                    ok = false;
+                    return;
+            }
+
+            foreach (var child in current.Children)
+                Visit(child);
+        }
+    }
+
+    static bool TryGetParameter(IrFunction kickoff, string fieldName, out int index, out Parameter parameter)
+    {
+        var argumentBase = kickoff.Signature.HasThis ? 1 : 0;
+        for (var i = 0; i < kickoff.Signature.Parameters.Length; i++)
+        {
+            var candidate = kickoff.Signature.Parameters[i];
+            if (candidate.Name == fieldName)
+            {
+                index = argumentBase + i;
+                parameter = candidate;
+                return true;
+            }
+        }
+
+        index = -1;
+        parameter = null!;
+        return false;
+    }
+
+    static bool ContainsNode(IrNode root, IrNode target)
+        => ReferenceEquals(root, target) || root.Descendants.Any(descendant => ReferenceEquals(descendant, target));
+
+    static bool IsAsyncMethodBuilder(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is
+        {
+            Namespace: "System.Runtime.CompilerServices",
+            Name: "AsyncTaskMethodBuilder" or "AsyncTaskMethodBuilder`1" or "AsyncValueTaskMethodBuilder`1",
+        };
+    }
+
+    static bool IsTaskLike(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is
+        {
+            Namespace: "System.Threading.Tasks",
+            Name: "Task" or "Task`1" or "ValueTask" or "ValueTask`1",
+        };
+    }
+
+    static bool IsHoistedLocal(string fieldName)
+        => fieldName.StartsWith("<", StringComparison.Ordinal)
+            && !fieldName.StartsWith("<>", StringComparison.Ordinal)
+            && fieldName.Contains(">5__", StringComparison.Ordinal);
+
+    static string ExtractSourceName(string fieldName)
+    {
+        var close = fieldName.IndexOf('>');
+        return close > 1 ? fieldName[1..close] : "value";
+    }
+
+    static BlockContainer Container(params IrNode[] statements)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        container.Add(block);
+        return container;
+    }
+
+    static void Reanchor(IrNode node, int offset)
+    {
+        foreach (var descendant in node.Descendants)
+            descendant.SetSourceOffset(-1);
+        node.SetSourceOffset(offset >= 0 ? offset : -1);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -218,6 +218,11 @@ public static class IrPasses
         // before the acknowledgment pass: reconstruction raises when it can; the
         // acknowledgment is the honest fallback for shapes it declines.
         new IteratorReconstructionPass(),
+        // Reconstruct runtime-async=off classic async kickoffs from their
+        // compiler-generated MoveNext state machines. Runs late with the other
+        // cross-method reconstruction passes so ordinary expression/statement
+        // sugar is already available for the recovered async body.
+        new ClassicAsyncReconstructionPass(),
         // Reconstruction rebuilds the hoisted loop variable's increment through a
         // spill slot (`V = i; i = V + 1;`), the dead-temp post-increment shape the
         // earlier IncrementDecrementPass run (before reconstruction) never saw.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -49,7 +49,7 @@ internal static class LoweringCoverage
     public static AnonymousObjectPass AnonymousObjectCreation => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AssignmentOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) exact corelib AsyncHelpers.Await call sites recovered to `await`, multi-await order preserved; classic state-machine async not raised")]
+    [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) exact corelib AsyncHelpers.Await call sites recovered to `await`, multi-await order preserved; classic state-machine async fixture overlay raised for single, sequential, branch, loop, and try/finally awaits")]
     public static AwaitRecoveryPass Await => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BasePatternSwitchLocalRewriter => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BinaryOperator => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -55,6 +55,8 @@ internal static class NativePasses
     public static LambdaCachePass LambdaCache => new();
     [Native(NativeCategory.EmitArtifact, "the finalizer try/finally + base.Finalize() scaffold emitted for ~T() collapsed back to the destructor body")]
     public static DestructorRecoveryPass DestructorRecovery => new();
+    [Native(NativeCategory.EmitArtifact, "classic async state-machine kickoff/MoveNext scaffolding reconstructed to async/await body")]
+    public static ClassicAsyncReconstructionPass ClassicAsyncReconstruction => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -251,9 +251,10 @@ public static class TypeSourceComposer
                         sb.AppendLine($"    [{attribute}]");
 
                     string? constructorChain = null;
+                    bool requiresAsync = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, type.FullName, member, index, bodyNamespaces, out constructorChain);
+                        : DecompileBody(pipelineSource, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -301,7 +302,10 @@ public static class TypeSourceComposer
                         break;
                     }
 
-                    AppendMember(sb, MethodDeclaration(type, member), body, constructorChain);
+                    var declaration = MethodDeclaration(type, member);
+                    if (body is not null && requiresAsync && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+                        declaration = AddAsyncModifier(declaration);
+                    AppendMember(sb, declaration, body, constructorChain);
                     break;
                 }
 
@@ -403,6 +407,22 @@ public static class TypeSourceComposer
         sb.AppendLine("    {");
         AppendIndented(sb, body, "        ");
         sb.AppendLine("    }");
+    }
+
+    static string AddAsyncModifier(string signature)
+    {
+        var parts = signature.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+        if (parts.Contains("async"))
+            return signature;
+        int insert = 0;
+        while (insert < parts.Count && parts[insert] is
+               "public" or "private" or "protected" or "internal" or "static" or
+               "virtual" or "override" or "sealed" or "abstract" or "new" or "extern" or "unsafe")
+        {
+            insert++;
+        }
+        parts.Insert(insert, "async");
+        return string.Join(" ", parts);
     }
 
     /// <summary>An accessor that just passes through the auto-property backing field — `return this.Name;` or `this.Name = value;`.</summary>
@@ -510,12 +530,12 @@ public static class TypeSourceComposer
 
     static string? DecompileBody(
         Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member, int overloadIndex,
-        SortedSet<string> bodyNamespaces, out string? constructorChain)
+        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync)
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
         // ordering the running index is built from.
         => DecompileMethod(pipelineSource, member.DeclaringType ?? typeFullName, member.Name, overloadIndex,
-            publicOnly: member.Kind != "explicit-interface-implementation", bodyNamespaces, out constructorChain);
+            publicOnly: member.Kind != "explicit-interface-implementation", bodyNamespaces, out constructorChain, out requiresAsync);
 
     static string? DecompileAccessor(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string accessorName,
@@ -523,7 +543,7 @@ public static class TypeSourceComposer
         // Accessors are non-public special-name methods; count across all
         // visibilities (a property has one get_/set_ per name anyway).
         => DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces, out _);
+            publicOnly: false, bodyNamespaces, out _, out _);
 
     /// <summary>
     /// Imports one method to typed IR, runs the raising passes, and prints the
@@ -535,9 +555,10 @@ public static class TypeSourceComposer
     /// </summary>
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
-        bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain)
+        bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync)
     {
         constructorChain = null;
+        requiresAsync = false;
         var function = Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly);
         if (function is null)
             return null;
@@ -545,6 +566,7 @@ public static class TypeSourceComposer
         var result = Pipeline.CSharpPrinter.PrintRaised(
             function, importMethodBody: method => Pipeline.IrImporter.Import(pipelineSource, method));
         constructorChain = result.ConstructorChain;
+        requiresAsync = result.ContainsAwaitExpression;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -36,7 +36,9 @@ internal static class MemberCodeProvider
         // The lowered C# view (issue #636) — the de-sugared render. Distinct from
         // LoweredBody above, which is the (misnamed) fully-raised decompiled body.
         string? LoweredSourceBody = null,
-        string? LoweredSourceDiagnostic = null);
+        string? LoweredSourceDiagnostic = null,
+        bool RequiresAsyncDeclaration = false,
+        bool LoweredSourceRequiresAsyncDeclaration = false);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -185,7 +187,9 @@ internal static class MemberCodeProvider
                 facts,
                 decompileTrace,
                 loweredSourceBody,
-                loweredSourceDiagnostic)));
+                loweredSourceDiagnostic,
+                RequiresAsyncDeclaration: ContainsAwaitKeyword(loweredBody),
+                LoweredSourceRequiresAsyncDeclaration: ContainsAwaitKeyword(loweredSourceBody))));
         }
 
         return results;
@@ -194,6 +198,28 @@ internal static class MemberCodeProvider
     /// <summary>Renders a failed result as comment lines so sections degrade honestly instead of disappearing.</summary>
     static string DiagnosticComment(Decompiler.DecompilerResult result)
         => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
+
+    static bool ContainsAwaitKeyword(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return false;
+        const string keyword = "await";
+        var span = text.AsSpan();
+        var index = text.IndexOf(keyword, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            var before = index == 0 ? '\0' : span[index - 1];
+            var afterIndex = index + keyword.Length;
+            var after = afterIndex >= span.Length ? '\0' : span[afterIndex];
+            if (!IsIdentifierPart(before) && !IsIdentifierPart(after))
+                return true;
+            index = text.IndexOf(keyword, index + keyword.Length, StringComparison.Ordinal);
+        }
+        return false;
+    }
+
+    static bool IsIdentifierPart(char c)
+        => c == '_' || char.IsLetterOrDigit(c);
 
     /// <summary>
     /// Resolves the selected method overload's generic parameter names directly

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1096,7 +1096,7 @@ public static class ApiOutputFormatter
                 string source;
                 try
                 {
-                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered);
+                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered, code.RequiresAsyncDeclaration);
                 }
                 catch (Exception ex)
                 {
@@ -1118,7 +1118,7 @@ public static class ApiOutputFormatter
                 string source;
                 try
                 {
-                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, loweredSource);
+                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, loweredSource, code.LoweredSourceRequiresAsyncDeclaration);
                 }
                 catch (Exception ex)
                 {
@@ -1309,9 +1309,16 @@ public static class ApiOutputFormatter
         RequestTelemetry.Breadcrumb(stage, detail);
     }
 
-    private static string FormatLoweredSourceWithDeclaration(ApiType type, ApiMember member, IReadOnlyList<string>? methodGenericParameters, string lowered)
+    private static string FormatLoweredSourceWithDeclaration(
+        ApiType type,
+        ApiMember member,
+        IReadOnlyList<string>? methodGenericParameters,
+        string lowered,
+        bool requiresAsyncDeclaration = false)
     {
         var declaration = FormatMemberDeclaration(type, member, abbreviate: false, methodGenericParameters);
+        if (requiresAsyncDeclaration && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+            declaration = AddAsyncModifier(declaration);
         var body = lowered.TrimEnd();
 
         // A constructor's base/this initializer is surfaced by the renderer as a
@@ -1335,6 +1342,22 @@ public static class ApiOutputFormatter
             body.ReplaceLineEndings("\n").Split('\n').Select(line => line.Length == 0 ? "" : $"    {line}"));
 
         return $"{declaration}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
+    }
+
+    private static string AddAsyncModifier(string declaration)
+    {
+        var parts = declaration.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+        if (parts.Contains("async"))
+            return declaration;
+        int insert = 0;
+        while (insert < parts.Count && parts[insert] is
+               "public" or "private" or "protected" or "internal" or "static" or
+               "virtual" or "override" or "sealed" or "abstract" or "new" or "extern" or "unsafe")
+        {
+            insert++;
+        }
+        parts.Insert(insert, "async");
+        return string.Join(" ", parts);
     }
 
     private static string FormatMemberDeclaration(

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -206,7 +206,7 @@ static class FidelityCheck
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
-            entries.Add(new Entry(mh, name, overload, new TargetBody(body, chain), fieldInits,
+            entries.Add(new Entry(mh, name, overload, new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
         }
         return (fullType, entries);
@@ -290,7 +290,7 @@ static class FidelityCheck
         CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions, string fullType, Entry e)
     {
         string unit;
-        try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.FieldInits); }
+        try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.FieldInits); }
         catch { return new(fullType, e.Name, e.Overload, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
 
         var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
@@ -401,13 +401,14 @@ static class FidelityCheck
     /// dropped or mis-bound access surfaces as a true opcode diff, not CS0234/CS0122.
     /// </summary>
     /// <summary>The real decompiled body (and optional ctor chain) for one target method.</summary>
-    public readonly record struct TargetBody(string Body, string? Chain);
+    public readonly record struct TargetBody(string Body, string? Chain, bool RequiresAsync);
 
     /// <summary>Single-method unit — the per-method fallback path when a grouped build fails.</summary>
     static string BuildUnit(MetadataReader reader, MethodDefinitionHandle target, string targetBody, string? targetChain,
+        bool targetRequiresAsync,
         IReadOnlyList<(string Field, string Value)> targetFieldInits)
     {
-        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain) };
+        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync) };
         var fieldInitType = reader.GetMethodDefinition(target).GetDeclaringType();
         return BuildUnit(reader, targets, targetFieldInits, fieldInitType);
     }
@@ -431,6 +432,7 @@ static class FidelityCheck
         // (e.g. `Span<int>`), matching the product view's assumed `using System;`;
         // the skeleton imports the same namespace so those names bind.
         sb.AppendLine("using System;");
+        sb.AppendLine("using System.Threading.Tasks;");
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -516,7 +518,8 @@ static class FidelityCheck
         // struct otherwise has no such conversion and the body fails to recompile.
         if (kind == TypeKind.Struct && InlineArrayAttributeText(reader, typeDef) is { } inlineArrayAttr)
             sb.AppendLine($"{pad}{inlineArrayAttr}");
-        sb.AppendLine($"{pad}public unsafe {keyword} {Identifier(name)}{genParams}{baseClause}");
+        string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{baseClause}");
         sb.AppendLine($"{pad}{{");
 
         // Field initializers lifted from a target ctor apply to this type's
@@ -527,15 +530,34 @@ static class FidelityCheck
             EmitField(reader, fh, typeContext, thisFieldInits, sb, pad + "    ");
 
         foreach (var mh in typeDef.GetMethods())
+        {
+            var hasTarget = targets.TryGetValue(mh, out var target);
             EmitMethod(reader, typeHandle, mh,
-                targets.TryGetValue(mh, out var t) ? t.Body : null,
-                targets.TryGetValue(mh, out var t2) ? t2.Chain : null, sb, pad + "    ");
+                hasTarget ? target.Body : null,
+                hasTarget ? target.Chain : null,
+                hasTarget && target.RequiresAsync,
+                sb, pad + "    ");
+        }
 
         foreach (var nested in typeDef.GetNestedTypes())
         {
             if (reader.GetString(reader.GetTypeDefinition(nested).Name).Contains('<'))
                 continue; // compiler-generated (display class, iterator) — not valid C#
             EmitType(reader, nested, targets, fieldInits, fieldInitType, sb, indent + 1);
+        }
+
+        static bool TypeHasAwaitTarget(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets)
+        {
+            foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
+                if (targets.TryGetValue(methodHandle, out var target)
+                    && target.RequiresAsync)
+                {
+                    return true;
+                }
+            return false;
         }
 
         sb.AppendLine($"{pad}}}");
@@ -676,11 +698,13 @@ static class FidelityCheck
         bool isVolatile = false;
         try { isVolatile = field.DecodeSignature(VolatileFieldDetector.Instance, null); }
         catch { /* signature already decoded above; treat as non-volatile */ }
-        sb.AppendLine($"{pad}public {(isStatic ? "static " : "")}{(isVolatile ? "volatile " : "")}{Clean(type)} {Identifier(name)}{suffix};");
+        string fieldType = Clean(type);
+        string unsafeModifier = RequiresUnsafeSignature(fieldType) ? "unsafe " : "";
+        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{(isVolatile ? "volatile " : "")}{fieldType} {Identifier(name)}{suffix};");
     }
 
     static void EmitMethod(MetadataReader reader, TypeDefinitionHandle typeHandle,
-        MethodDefinitionHandle mh, string? realBody, string? realChain, StringBuilder sb, string pad)
+        MethodDefinitionHandle mh, string? realBody, string? realChain, bool realRequiresAsync, StringBuilder sb, string pad)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var method = reader.GetMethodDefinition(mh);
@@ -705,7 +729,8 @@ static class FidelityCheck
             // (field inits, base call) matches; strip the IL name. A lifted
             // base(...)/this(...) chain prints as the signature initializer it is.
             string initializer = realChain is { Length: > 0 } ? $" : {realChain}" : "";
-            sb.AppendLine($"{pad}public {Identifier(StripArity(reader.GetString(typeDef.Name)))}({parameters}){initializer} {{{body}}}");
+            string ctorUnsafeModifier = RequiresUnsafeSignature(parameters) ? "unsafe " : "";
+            sb.AppendLine($"{pad}public {ctorUnsafeModifier}{Identifier(StripArity(reader.GetString(typeDef.Name)))}({parameters}){initializer} {{{body}}}");
             return;
         }
         // A finalizer (void Finalize() override) recovered as a destructor: emit
@@ -723,8 +748,26 @@ static class FidelityCheck
         }
 
         string genParams = GenericParamList(reader, method.GetGenericParameters());
-        sb.AppendLine($"{pad}public {(isStatic ? "static " : "")}{Clean(sig.ReturnType)} {Identifier(name)}{genParams}({parameters}) {{{body}}}");
+        string returnType = Clean(sig.ReturnType);
+        string asyncModifier = realBody is not null && realRequiresAsync && CanBeAsync(returnType)
+            ? "async "
+            : "";
+        string unsafeModifier = asyncModifier.Length == 0 ? "unsafe " : "";
+        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}) {{{body}}}");
     }
+
+    static bool CanBeAsync(string returnType)
+        => returnType is "void" or "Task"
+            || returnType.StartsWith("Task<", StringComparison.Ordinal)
+            || returnType.EndsWith(".Task", StringComparison.Ordinal)
+            || returnType.Contains(".Task<", StringComparison.Ordinal)
+            || returnType is "ValueTask"
+            || returnType.StartsWith("ValueTask<", StringComparison.Ordinal)
+            || returnType.EndsWith(".ValueTask", StringComparison.Ordinal)
+            || returnType.Contains(".ValueTask<", StringComparison.Ordinal);
+
+    static bool RequiresUnsafeSignature(string typeText)
+        => typeText.Contains('*', StringComparison.Ordinal);
 
     static string Parameters(MetadataReader reader, MethodDefinition method, MethodSignature<string> sig)
     {


### PR DESCRIPTION
## Summary

- Implements `ClassicAsyncReconstructionPass` for runtime-async=off state-machine kickoffs, reconstructing the ClassicAsync overlay bodies back to `async`/`await`.
- Acknowledges generated `MoveNext`/`SetStateMachine` support methods after the kickoff owns the source logic, removing the generated-type residuals from the overlay.
- Threads async-body metadata into decompiled source declarations so product output emits `async` signatures for await bodies.
- Updates await coverage/facts and the fidelity compile-back scaffold so reconstructed classic async bodies round-trip under an async method context without changing runtime-async fidelity behavior.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- --library-report artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicAsync/release/ILInspector.Decompiler.Fixtures.ClassicAsync.dll` → 21/21 Full, 21/21 fully raised
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicAsync/release/ILInspector.Decompiler.Fixtures.ClassicAsync.dll --fidelity-check --compile-cap 100` → 7/7 exact
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`
- CLI spot check: `member AsyncFixtures --library ... -m AwaitValue -S "Decompiled Source"` emits an `async` signature

Fixes #948.