### PR TITLE
Pin one-sided span range negatives

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -210,6 +210,24 @@ public class RangeFromGetSubArrayPassTests
     }
 
     [Fact]
+    public void OneSidedSpanRange_FromStart_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.SpanRangeFromStart), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Slice(i);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void OneSidedSpanRange_ToEnd_IsNotRaised()
+    {
+        var function = Raised(nameof(RangeAdversarialSamples.SpanRangeToEnd), typeof(RangeAdversarialSamples));
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains("return s.Slice(0, j);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
     public void FromEndOpenStringRange_RaisesToRangeIndexer()
     {
         var function = Raised(nameof(RangeAdversarialSamples.StringRangeFromEnd), typeof(RangeAdversarialSamples));
@@ -361,6 +379,10 @@ public static class RangeAdversarialSamples
     public static string StringRangeFromStart(string s, int i) => s[i..];
 
     public static string StringRangeToEnd(string s, int j) => s[..j];
+
+    public static System.ReadOnlySpan<int> SpanRangeFromStart(System.ReadOnlySpan<int> s, int i) => s[i..];
+
+    public static System.ReadOnlySpan<int> SpanRangeToEnd(System.ReadOnlySpan<int> s, int j) => s[..j];
 
     public static string StringRangeFromEnd(string s, int i) => s[^i..];
 

--- a/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/RangeRecoveryFacts.cs
@@ -13,13 +13,15 @@ internal sealed class RangeRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("member.corelib-identity:Span.Slice", "MemberIdentity.IsSpanSlice"),
                 new FactPrimitive("member.corelib-identity:System.Range", "MemberIdentity.IsCoreLibraryType"),
                 new FactPrimitive("member.corelib-identity:System.Index", "MemberIdentity.IsCoreLibraryType"),
+                new FactPrimitive("pdb.hidden-start-local", "RangeFromGetSubArrayPass HasSourceLocalName guard"),
+                new FactPrimitive("place.stack-slot", "PlaceIdentity.SameStackSlot"),
             ],
             PositiveCoverage: "RangeFromGetSubArrayPassTests array range endpoint matrix plus string/span two-bound and from-end open fixtures",
-            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike, manual/one-sided Substring/Slice negatives, source-named start-temp negative, and mismatched receiver-spill / start-temp negatives. Adversarial review (#959) confirmed the GetSubArray identity and the string/span hidden start-temp + spilled-receiver (PlaceIdentity.SameStackSlot) discriminators reject hand-written reloads, source-named temps, and user-assembly lookalikes",
+            AdversarialCoverage: "RangeFromGetSubArrayPassTests user RuntimeHelpers lookalike, manual two-bound Substring/Slice negatives, one-sided string/span Substring/Slice negatives, source-named start-temp negative, and mismatched receiver-spill / start-temp negatives. Adversarial review (#959) confirmed the GetSubArray identity and the string/span hidden start-temp + spilled-receiver (PlaceIdentity.SameStackSlot) discriminators reject hand-written reloads, source-named temps, and user-assembly lookalikes",
             // from-end-open string/span ranges (s[^n..]) ARE recovered; the still-unraised string/span
             // forms are specifically from-start (s[i..] lowers to the 1-arg Substring(i)) and to-end
             // (s[..j] lowers to Substring(0, j)), whose overloads carry no spill the pass keys on, plus
             // broader manual Substring/Slice calls.
-            MissingDiscriminator: "from-start (s[i..] -> Substring(i)) and to-end (s[..j] -> Substring(0, j)) one-sided string/span forms, plus broader manual Substring/Slice calls, remain unraised"),
+            MissingDiscriminator: "from-start (s[i..] -> Substring/Slice(i)) and to-end (s[..j] -> Substring/Slice(0, j)) one-sided string/span forms, plus broader manual Substring/Slice calls, remain unraised because those overloads carry no hidden start temp or spilled receiver discriminator"),
     ];
 }


### PR DESCRIPTION
## Summary

- add one-sided `ReadOnlySpan<T>` range fixtures that stay lowered to `Slice(i)` / `Slice(0, j)`
- record the range pass discriminators in the sidecar facts: hidden start locals and stack-slot receiver identity
- sharpen the missing discriminator note to explain why one-sided string/span forms remain unraised

## Context

This starts the #998 **Range and slicing frontier** row with a discriminator/coverage slice rather than broadening the matcher. The pass already raises two-bound string/span and from-end-open forms when hidden compiler spills prove the source range, but ordinary one-sided `Substring`/`Slice` overloads lack that proof and must stay lowered.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- post-rebase focused check: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RangeFromGetSubArrayPassTests -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests`