### PR TITLE
Harden pattern relational subpattern folding

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -162,6 +162,22 @@ public class IsPatternPassTests
     }
 
     [Fact]
+    public void UnsignedPropertyComparisonLookalike_DoesNotFoldToRelationalPropertyPattern()
+    {
+        // `(uint)p.X > 0u` is an unsigned IL comparison. The C# relational
+        // subpattern `{ X: > 0 }` would use signed `int` semantics and disagree
+        // for negative X values, so the property-pattern printer must keep the
+        // flat conjunction.
+        var function = FunctionWithUnsignedPropertyComparison();
+
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("&&", output);
+        Assert.DoesNotContain("{ X: > 0 }", output);
+    }
+
+    [Fact]
     public void AsLocalReadOnFallThroughPath_StaysFlat()
     {
         // The `as` local is read on both the matched and fall-through paths, so
@@ -228,5 +244,39 @@ public class IsPatternPassTests
             new MethodSignature(intType, [new Parameter("owner", TypeRef.Definition("Synthetic", "Samples", "Owner"))], HasThis: false, GenericParameterCount: 0),
             [stringType],
             body);
+    }
+
+    static IrFunction FunctionWithUnsignedPropertyComparison()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var point = TypeRef.Definition("Synthetic", "Samples", "PatternPoint");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var getX = new MethodRef(point, "get_X", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var block = new Block();
+        block.Add(new Return(new LogicalBinary(
+            LogicalKind.And,
+            new IsPattern(new LoadArgument(0, "o", objectType), point, localIndex: 0),
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadProperty(getX, new LoadLocal(0, point), []),
+                new Constant(0, intType)))));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "UnsignedPropertyComparison",
+            owner,
+            new MethodSignature(boolType, [new Parameter("o", objectType)], HasThis: false, GenericParameterCount: 0),
+            [point],
+            body)
+        {
+            LocalNames = ["p"],
+        };
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
@@ -12,7 +12,7 @@ internal sealed class IsPatternRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("property-subpattern-comparison", "CSharpPrinter.TryPropertySubpattern"),
             ],
             PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures",
-            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, and duplicate-property negatives",
+            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, duplicate-property, and unsigned relational-property negatives",
             MissingDiscriminator: "positional/list sub-patterns and non-integral relational sub-patterns remain unraised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1729,7 +1729,7 @@ public sealed partial class CSharpPrinter
             ComparisonKind.GreaterThanOrEqual => ">=",
             _ => null,
         };
-        if (relationalOperator is null || IsFloatComparison(comparison.Left, comparison.Right))
+        if (relationalOperator is null || comparison.IsUnsigned || IsFloatComparison(comparison.Left, comparison.Right))
             return false;
 
         subpattern = $"{relationalOperator} {ConstantText(constant)}";


### PR DESCRIPTION
## Summary

- Adversarial review claim: property-pattern folding may raise only comparisons whose C# pattern semantics match the original IL comparison.
- Add a near-miss negative for an unsigned property comparison lookalike (`(uint)p.X > 0u`) that previously folded to signed `{ X: > 0 }`.
- Narrow `TryPropertySubpattern` so unsigned relational comparisons remain as a flat conjunction.
- Update IsPattern sidecar adversarial coverage for this reviewed discriminator.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*IsPatternPassTests*" -reporter quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`

Part of #998 Pattern frontier.