### PR TITLE
Pin float relational pattern decline as adversarial negative (#998)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1051,6 +1051,19 @@ public class CfgSampleClass
         public int Y { get; init; }
     }
 
+    public sealed class FloatHolder
+    {
+        public double Magnitude { get; init; }
+    }
+
+    // Negative: a relational sub-pattern on a floating-point property must NOT
+    // fold to `{ Magnitude: > 1.5 }`. A float `>` lowers to an ordered compare
+    // (`cgt`), but the same source relation can also surface as the unordered
+    // (`cgt.un`) form, and the two disagree on NaN; folding either into a
+    // relational pattern would silently fix one NaN answer. The type pattern is
+    // still raised, but the comparison stays an explicit `&&`.
+    public static bool IsPatternFloatPropertyRelational(object o) => o is FloatHolder { Magnitude: > 1.5 };
+
     public static bool IsPatternMultiProperty(object o) => o is PatternPoint { X: 1, Y: 2 };
 
     public static bool IsPatternMultiPropertyMixed(object o) => o is PatternPoint { X: > 0, Y: 2 };

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -89,6 +89,25 @@ public class IsPatternPassTests
     }
 
     [Fact]
+    public void FloatPropertyRelational_IsNotFoldedToRelationalPattern()
+    {
+        // Adversarial near-miss: `o is FloatHolder { Magnitude: > 1.5 }` over a
+        // floating-point property must NOT round-trip into a relational property
+        // sub-pattern. The ordered (`cgt`) and unordered (`cgt.un`) float compares
+        // disagree on NaN, and a relational pattern fixes one answer — so the type
+        // pattern is raised but the comparison stays an explicit `&&`. This pins
+        // the IsFloatComparison discriminator behind TryPropertySubpattern.
+        var function = Raised(nameof(CfgSampleClass.IsPatternFloatPropertyRelational));
+
+        Assert.Single(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("is FloatHolder", output);
+        Assert.Contains("&&", output);
+        Assert.Contains("> 1.5", output);
+        Assert.DoesNotContain("{ Magnitude:", output);
+    }
+
+    [Fact]
     public void PropertyPattern_RendersPropertyPatternClause()
     {
         // `o is string { Length: 5 }` lowers to the same as-store plus

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
@@ -12,7 +12,7 @@ internal sealed class IsPatternRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("property-subpattern-comparison", "CSharpPrinter.TryPropertySubpattern"),
             ],
             PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures",
-            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, and duplicate-property negatives",
-            MissingDiscriminator: "positional/list sub-patterns and non-integral relational sub-patterns remain unraised"),
+            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, duplicate-property, and floating-point relational sub-pattern (NaN-unsafe fold) negatives",
+            MissingDiscriminator: "positional/list sub-patterns remain unraised; float relational sub-patterns are deliberately declined (ordered/unordered compares disagree on NaN) rather than folded"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -82,7 +82,7 @@ internal static class LoweringCoverage
     public static IndexFromEndPass Index => new();
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and property-pattern equality/relational sub-patterns, including same-local multi-property conjunctions (`value is T { P: constant, Q: > constant }`); positional/list sub-patterns and non-integral relational sub-patterns not raised")]
+    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and property-pattern equality/relational sub-patterns, including same-local multi-property conjunctions (`value is T { P: constant, Q: > constant }`); positional/list sub-patterns not raised, and float relational sub-patterns deliberately declined (ordered/unordered compares disagree on NaN)")]
     public static IsPatternPass IsPatternOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LabeledStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal => default!;


### PR DESCRIPTION
Advances the **Pattern frontier** row of #998 (adversarial / honesty slice).

## Claim

`CSharpPrinter.TryPropertySubpattern` folds a pattern local's property comparison into a property sub-pattern (`{ Length: > 5 }`), but **deliberately declines floating-point relational folds**. A source `>` lowers to an ordered `cgt`; the same relation can also surface as the unordered `cgt.un`; the two disagree on NaN. Folding either into a relational pattern would silently fix one NaN answer — so the float relational is left as an explicit `&&`.

That correctness discriminator (`IsFloatComparison` at the `TryPropertySubpattern` gate) had **no test**.

## Changes

- New fixture `IsPatternFloatPropertyRelational` (`o is FloatHolder { Magnitude: > 1.5 }`).
- Near-miss negative `FloatPropertyRelational_IsNotFoldedToRelationalPattern`: asserts the type pattern raises while the comparison stays `o is FloatHolder t && t.Magnitude > 1.5` (recompiles **opcode-exact**, `fidelity: Full`).
- Narrowed the is-pattern ledger note + `LoweringCoverage` Partial note: the float relational decline moves from `MissingDiscriminator` (owed) into `AdversarialCoverage` (proven); positional/list sub-patterns remain the stated frontier.

## Done signal

One ledger note narrows; near-miss negative fixture added; fidelity gate stays green. No product behavior change. Decompiler tests: 853 to 854, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
