### PR TITLE
Raise the generic null-conditional invocation `recv?.M() ?? x` (#911)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -972,6 +972,15 @@ public class CfgSampleClass
 
     public static T GetAt<T>(T[] array, int index) => array[index];
 
+    // A null-conditional invocation over an unconstrained generic receiver:
+    // `value?.ToString() ?? "none"`. csc cannot know whether T is a reference or
+    // value type, so it emits a default(T)-box two-stage null test with a reload
+    // between, both arms sharing the one ToString() call — a diamond the
+    // structuring pass cannot nest (issue #911). NullConditionalCoalescePass folds
+    // it back to the source idiom, which recompiles to the same two-stage test.
+    public static string GenericNullConditionalToString<T>(T value)
+        => value?.ToString() ?? "none";
+
     public static bool IsValueTypeOf<T>() => typeof(T).IsValueType;
 
     // The generic-math `(U)(object)x` idiom: a type parameter cast to a concrete

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -83,6 +83,10 @@ public class FidelityGateTests
     /// format clause (the backslash-escaped `h\:mm\:ss` TimeSpan spelling) so the
     /// non-verbatim `$"…"` is valid C# and the format constant recompiles
     /// opcode-exact — a raw `\:` is CS1009.
+    /// GenericNullConditionalToString must keep folding csc's generic
+    /// null-conditional invocation (the default(T)-box two-stage null test with a
+    /// reload) back into `value?.ToString() ?? "none"`, which recompiles to the
+    /// same two-stage test opcode-exact.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -137,6 +141,7 @@ public class FidelityGateTests
         "IsNotNullReference",
         "LineSeparatorLiteral",
         "InterpolationWithBackslashFormat",
+        "GenericNullConditionalToString",
         "NegativeNativeInt",
         "OrChainDiamond",
         "OrLongIntoULong",

--- a/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
@@ -1,0 +1,167 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class NullConditionalCoalescePassTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    // A stand-in for the unconstrained generic receiver type; the pass matches the
+    // structural shape, not the type's genericity.
+    static readonly TypeRef s_tk = TypeRef.Definition("Synthetic", "", "T");
+
+    /// <summary>
+    /// Builds csc's generic null-conditional invocation lowering with the given
+    /// fallback as the false arm:
+    ///   A: Vk = default(T); Sj = &amp;value; if ((object)Vk != null) goto TRUE
+    ///   B: Vk = *Sj; Sj = &amp;Vk;          if ((object)Vk != null) goto TRUE
+    ///   FALSE: Sr = fallback; goto MERGE
+    ///   TRUE:  Sr = Sj->GetHashCode()
+    ///   MERGE: return Sr
+    /// Knobs let each adversarial test toggle exactly one discriminator.
+    /// </summary>
+    static IrFunction Build(
+        IrExpression fallback,
+        TypeRef resultType,
+        IrExpression? receiver = null,
+        int guardBTarget = 30,
+        bool entryIntoGuardB = false,
+        bool tempUsedAfterMerge = false)
+    {
+        const int vk = 0, sj = 1, sr = 2;
+        receiver ??= new LoadArgumentAddress(0, "value", s_tk);
+        var ghc = new MethodRef(s_object, "GetHashCode", resultType, [], HasThis: true);
+
+        var a = new Block(0);
+        a.Add(new InitObject(s_tk, new LoadLocalAddress(vk, s_tk)));
+        a.Add(new StoreStackSlot(sj, receiver));
+        a.Add(new ConditionalBranch(new Box(s_tk, new LoadLocal(vk, s_tk)), 30));
+
+        var b = new Block(10);
+        b.Add(new StoreLocal(vk, s_tk, new LoadIndirect(s_tk, new LoadStackSlot(sj, TypeRef.ByRef(s_tk)))));
+        b.Add(new StoreStackSlot(sj, new LoadLocalAddress(vk, s_tk)));
+        b.Add(new ConditionalBranch(new Box(s_tk, new LoadLocal(vk, s_tk)), guardBTarget));
+
+        var falseArm = new Block(20);
+        falseArm.Add(new StoreStackSlot(sr, fallback));
+        falseArm.Add(new Branch(40));
+
+        var trueArm = new Block(30);
+        trueArm.Add(new StoreStackSlot(sr, new Call(ghc, isVirtual: true, [new LoadStackSlot(sj, TypeRef.ByRef(s_tk))]) { ConstrainedTo = s_tk }));
+
+        var merge = new Block(40);
+        // tempUsedAfterMerge references the generic-default temp Vk after the merge,
+        // so it is not dead outside the matched blocks and the fold must refuse.
+        merge.Add(new Return(tempUsedAfterMerge
+            ? new LoadLocal(vk, resultType)
+            : new LoadStackSlot(sr, resultType)));
+
+        var blocks = new List<Block> { a, b, falseArm, trueArm, merge };
+
+        if (entryIntoGuardB)
+        {
+            // A block before the diamond that conditionally jumps INTO the reload
+            // guard (block B at offset 10) — an external entry the fold must refuse.
+            var entry = new Block(-10);
+            entry.Add(new ConditionalBranch(new Constant(true, TypeRef.CoreLib("System", "Boolean")), 10));
+            blocks.Insert(0, entry);
+        }
+
+        var container = new BlockContainer();
+        foreach (var block in blocks)
+            container.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "Host"),
+            new MethodSignature(resultType, [new Parameter("value", s_tk)], HasThis: false, GenericParameterCount: 1),
+            [s_tk],
+            container);
+    }
+
+    [Fact]
+    public void GenericNullConditional_WithIntFallback_RaisesCoalesce()
+    {
+        var function = Build(new Constant(0, s_int), s_int);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+        IrPasses.Run(function);
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("value?.GetHashCode() ?? 0", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.Empty(function.Descendants.OfType<Box>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void GenericNullConditional_LiteralNullFallback_RaisesBareNullConditional()
+    {
+        // A reference-typed member result has a literal-null false arm, so the shape
+        // is the bare recv?.M() with no coalesce.
+        var function = Build(new Constant(null, s_string), s_string);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+        var nc = Assert.Single(function.Descendants.OfType<NullConditional>());
+        Assert.Empty(function.Descendants.OfType<Coalesce>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ImpureReceiver_StaysFlat()
+    {
+        // The receiver is a call result, not a re-evaluable address: evaluating it
+        // once in recv?.M() would change how many times the side effect runs, so the
+        // fold must refuse.
+        var sideEffect = new Call(
+            new MethodRef(s_object, "GetThing", TypeRef.ByRef(s_tk), [], HasThis: false),
+            isVirtual: false, []);
+        var function = Build(new Constant(0, s_int), s_int, receiver: sideEffect);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        Assert.NotEmpty(function.Descendants.OfType<Box>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void GuardsToDifferentArms_StaysFlat()
+    {
+        // The two null tests branch to different targets — not the shared single
+        // call arm of a null-conditional, so the fold must refuse.
+        var function = Build(new Constant(0, s_int), s_int, guardBTarget: 40);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ExternalEntryIntoReloadGuard_StaysFlat()
+    {
+        // A branch from outside lands in the reload guard the fold would drop, so
+        // collapsing the blocks would orphan that edge — the fold must refuse.
+        var function = Build(new Constant(0, s_int), s_int, entryIntoGuardB: true);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void TempLiveAfterMerge_StaysFlat()
+    {
+        // The generic-default temp is read after the merge, so it is not dead
+        // outside the matched blocks; folding them away would lose that definition.
+        var function = Build(new Constant(0, s_int), s_int, tempUsedAfterMerge: true);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        function.CheckInvariant();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -115,6 +115,12 @@ public static class IrPasses
         // Fold whole-method type-test / guard return dispatches once inner
         // return diamonds and isolated return tails are normalized.
         new ReturnDispatchPass(),
+        // Fold the generic null-conditional invocation lowering (`recv?.M() ?? x`
+        // over an unconstrained-generic receiver — csc's default(T)-box two-stage
+        // null test with a reload, both guards sharing one call arm) into a single
+        // `recv?.M() ?? x` store the structuring pass can consume. The sibling of
+        // the or-chain folds for the shared-true-arm-with-prologue case.
+        new NullConditionalCoalescePass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -49,6 +49,8 @@ internal static class NativePasses
     public static OrChainDiamondPass OrChainDiamond => new();
     [Native(NativeCategory.EmitArtifact, "a spilled-to-slot conditional result (flat slot diamond returning one slot) folded to a conditional return so structuring can consume the surrounding dispatch")]
     public static SlotDiamondPass SlotDiamond => new();
+    [Native(NativeCategory.EmitArtifact, "generic null-conditional invocation (recv?.M() ?? x — the default(T)-box two-stage null test) folded so structuring can consume it")]
+    public static NullConditionalCoalescePass NullConditionalCoalesce => new();
     [Native(NativeCategory.EmitArtifact, "branch-to-adjacent / dead branches removed before structuring")]
     public static RedundantBranchEliminationPass RedundantBranchElimination => new();
     [Native(NativeCategory.EmitArtifact, "identity conversions dropped (ldlen; conv.i4 array-length idiom)")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
@@ -1,0 +1,282 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the generic null-conditional invocation <c>recv?.M() ?? fallback</c>
+/// (and the bare <c>recv?.M()</c> when the fallback is literal null), before
+/// structuring. When the receiver is of an unconstrained generic type, csc cannot
+/// know at compile time whether it is a reference or value type, so it emits a
+/// two-stage null test with a reload between, all targeting one shared
+/// member-access arm — a diamond the <see cref="StructuringPass"/> cannot nest
+/// (the <c>forward-branch-not-region-exit</c> stop, issue #911; the shape
+/// <see cref="OrChainDiamondPass"/> deliberately left flat because the inner guard
+/// carries a reload prologue). The lowering of <c>field?.GetHashCode() ?? 0</c>
+/// over a generic field is:
+/// <code>
+///   A: Vk = default(Tk);  Sj = &amp;recv;   if ((object)Vk != null) goto TRUE
+///   B: Vk = *Sj;          Sj = &amp;Vk;     if ((object)Vk != null) goto TRUE
+///   FALSE: Sr = fallback;  goto MERGE
+///   TRUE:  Sr = Sj->M()
+///   MERGE: … uses Sr …
+/// </code>
+/// The first test boxes <c>default(Tk)</c> (non-null exactly when <c>Tk</c> is a
+/// value type, so value types skip straight to the call); the second reloads the
+/// real value and tests it (the reference-type path). Both paths call <c>M</c> on
+/// the receiver, and the false arm supplies the <c>?? fallback</c>. This pass
+/// collapses the four blocks into a single <c>Sr = recv?.M() ?? fallback</c> store
+/// — a straight line the structuring pass then consumes — which re-lowers to the
+/// same two-stage test (the round-trip invariant verified against
+/// <c>ValueTuple&lt;…&gt;</c> / <c>HashCode.Combine</c>).
+///
+/// Conservative and sound: the two guards must share one true arm and one
+/// generic-default temp, the receiver address must be side-effect free (so
+/// evaluating it once in <c>recv?.M()</c> matches the lowering's single spill),
+/// the temp and receiver slot must be dead outside the matched blocks, and nothing
+/// outside may branch into the three blocks the fold drops.
+/// </summary>
+public sealed class NullConditionalCoalescePass : IIrPass
+{
+    public string Name => "null-conditional-coalesce";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    sealed record Shape(
+        int FirstGuard,
+        int TrueArm,
+        int MergeIndex,
+        int ResultSlot,
+        IrExpression Receiver,
+        Call Call,
+        IrExpression Fallback,
+        int TempLocal,
+        int ReceiverSlot);
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            var blocks = container.Blocks;
+            var offsetToIndex = new Dictionary<int, int>();
+            for (int i = 0; i < blocks.Count; i++)
+                offsetToIndex[blocks[i].StartOffset] = i;
+
+            for (int a = 0; a + 4 < blocks.Count + 1 && a + 3 < blocks.Count; a++)
+            {
+                if (Match(blocks, offsetToIndex, a) is { } shape
+                    && DeadOutside(function, shape, blocks, a)
+                    && NoExternalEntry(blocks, a, shape.TrueArm, offsetToIndex, leaveTargets))
+                {
+                    Fold(container, blocks, a, shape, stepper);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Matches the four-block generic null-conditional diamond rooted at block
+    /// <paramref name="a"/> (default-box guard, reload guard, false arm, call arm),
+    /// or null. The true arm is the block right after the false arm and the merge
+    /// is the block right after the true arm.
+    /// </summary>
+    static Shape? Match(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int a)
+    {
+        var blockA = blocks[a];
+        var blockB = blocks[a + 1];
+        var falseArm = blocks[a + 2];
+        // A: initobj Tk(&Vk); Sj = &recv; if ((object)Vk != null) goto TRUE
+        if (blockA.Children is not
+            [
+                InitObject { Type: var tkInit, Address: LoadLocalAddress { Index: var vkInit } },
+                StoreStackSlot { Slot: var sjA, Value: var receiver },
+                ConditionalBranch { TargetOffset: var trueOffA } condA,
+            ]
+            || !IsDefaultBoxTest(condA, vkInit, tkInit)
+            || !IsPureAddress(receiver))
+        {
+            return null;
+        }
+        // B: Vk = *Sj; Sj = &Vk; if ((object)Vk != null) goto TRUE
+        if (blockB.Children is not
+            [
+                StoreLocal { Index: var vkB, Value: LoadIndirect { Address: LoadStackSlot { Slot: var sjReadB } } },
+                StoreStackSlot { Slot: var sjB, Value: LoadLocalAddress { Index: var vkAddrB } },
+                ConditionalBranch { TargetOffset: var trueOffB } condB,
+            ]
+            || vkB != vkInit || vkAddrB != vkInit || sjReadB != sjA || sjB != sjA
+            || trueOffB != trueOffA
+            || !IsDefaultBoxTest(condB, vkInit, tkInit))
+        {
+            return null;
+        }
+        // FALSE: Sr = fallback; goto MERGE
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var srFalse, Value: var fallback },
+                Branch { TargetOffset: var mergeOff },
+            ])
+        {
+            return null;
+        }
+        // TRUE sits right after the false arm and is the shared guard target.
+        int trueArm = a + 3;
+        if (blocks[trueArm].StartOffset != trueOffA)
+            return null;
+        // MERGE sits right after the true arm (the true arm falls through).
+        if (!offsetToIndex.TryGetValue(mergeOff, out int mergeIndex) || mergeIndex != trueArm + 1)
+            return null;
+        // TRUE: Sr = Sj->M()  (one virtual call whose only argument is the slot).
+        if (blocks[trueArm].Children is not
+            [
+                StoreStackSlot { Slot: var srTrue, Value: Call { IsVirtual: true, Arguments: [LoadStackSlot { Slot: var sjCall }] } call },
+            ]
+            || srTrue != srFalse || sjCall != sjA)
+        {
+            return null;
+        }
+
+        return new Shape(a, trueArm, mergeIndex, srTrue, receiver, call, fallback, vkInit, sjA);
+    }
+
+    /// <summary>A <c>brtrue</c> on <c>(object)Vk</c> — the boxed null test the lowering emits for both guards.</summary>
+    static bool IsDefaultBoxTest(ConditionalBranch branch, int tempLocal, TypeRef tempType)
+        => branch.Condition is Box { Type: var boxType, Operand: LoadLocal { Index: var index } }
+            && index == tempLocal
+            && boxType.Equals(tempType);
+
+    /// <summary>
+    /// The receiver address is evaluated once in <c>recv?.M()</c>, so it must
+    /// re-evaluate without side effects: a chain of field/local/argument loads and
+    /// address-of, never a call or other observable expression.
+    /// </summary>
+    static bool IsPureAddress(IrExpression expression) => expression switch
+    {
+        LoadArgument or LoadLocal or LoadArgumentAddress or LoadLocalAddress => true,
+        LoadField field => field.Instance is null || IsPureAddress(field.Instance),
+        LoadFieldAddress field => field.Instance is null || IsPureAddress(field.Instance),
+        _ => false,
+    };
+
+    /// <summary>
+    /// The generic-default temp and the receiver slot are folded away, so they
+    /// must not be read or written anywhere outside the four matched blocks
+    /// [a, a+3]. The result slot survives (it carries the value into the merge).
+    /// </summary>
+    static bool DeadOutside(IrFunction function, Shape shape, IReadOnlyList<Block> blocks, int a)
+    {
+        var matched = new HashSet<Block>(blocks.Skip(a).Take(4));
+        foreach (var node in function.Descendants)
+        {
+            bool touchesTemp = node switch
+            {
+                LoadLocal load => load.Index == shape.TempLocal,
+                StoreLocal store => store.Index == shape.TempLocal,
+                LoadLocalAddress address => address.Index == shape.TempLocal,
+                _ => false,
+            };
+            bool touchesSlot = node switch
+            {
+                LoadStackSlot load => load.Slot == shape.ReceiverSlot,
+                StoreStackSlot store => store.Slot == shape.ReceiverSlot,
+                _ => false,
+            };
+            if ((touchesTemp || touchesSlot) && !InMatchedBlock(node, matched))
+                return false;
+        }
+        return true;
+    }
+
+    static bool InMatchedBlock(IrNode node, HashSet<Block> matched)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (current is Block block && matched.Contains(block))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// No block outside the four matched ones may branch into the reload guard,
+    /// false arm, or true arm [a+1, a+3] — those vanish into the folded store. The
+    /// entry (a) and the merge stay in place, so edges to them are fine; a leave
+    /// into the span aborts the fold too.
+    /// </summary>
+    static bool NoExternalEntry(
+        IReadOnlyList<Block> blocks, int a, int trueArm, Dictionary<int, int> offsetToIndex, HashSet<int> leaveTargets)
+    {
+        var forbidden = new HashSet<int>();
+        for (int idx = a + 1; idx <= trueArm; idx++)
+            forbidden.Add(blocks[idx].StartOffset);
+
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        for (int idx = 0; idx < blocks.Count; idx++)
+        {
+            if (idx >= a && idx <= trueArm)
+                continue;   // inside the matched span — internal edges are fine
+            foreach (var node in blocks[idx].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        _ => [],
+    };
+
+    static void Fold(BlockContainer container, IReadOnlyList<Block> blocks, int a, Shape shape, Stepper stepper)
+    {
+        var ordered = container.Blocks.ToList();
+
+        // Rebuild the call with the receiver as its own receiver: recv?.M(). The
+        // constrained-virtual prefix the generic receiver carries must survive, or
+        // the call re-lowers to a different opcode. The receiver and fallback are
+        // detached from their original blocks before those blocks drop.
+        var receiver = shape.Receiver;
+        receiver.Detach();
+        var call = new Call(shape.Call.Callee, shape.Call.IsVirtual, [receiver])
+        {
+            ConstrainedTo = shape.Call.ConstrainedTo,
+        };
+        var fallback = shape.Fallback;
+        fallback.Detach();
+
+        // A literal-null fallback is just recv?.M() (the member result is a
+        // reference type); any other fallback is the `?? fallback` coalesce.
+        IrExpression value = fallback is Constant { Value: null }
+            ? new NullConditional(call)
+            : new Coalesce(new NullConditional(call), fallback);
+
+        var folded = new Block(ordered[a].StartOffset);
+        folded.Add(new StoreStackSlot(shape.ResultSlot, value));
+
+        foreach (var block in ordered)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx < a; idx++)
+            rebuilt.Add(ordered[idx]);
+        rebuilt.Add(folded);
+        for (int idx = shape.TrueArm + 1; idx < ordered.Count; idx++)
+            rebuilt.Add(ordered[idx]);
+        stepper.StepOver("fold generic null-conditional invocation", container);
+        container.ReplaceWith(rebuilt);
+    }
+}


### PR DESCRIPTION
## Target

Continues the `forward-branch-not-region-exit` climb (#911). After the OR-chain folds (#984), sub-classifying the bucket shows the dominant *coherent, in-scope* remaining sub-shape is the **generic null-conditional invocation** — `field?.GetHashCode() ?? 0` over an unconstrained generic receiver. It accounts for the `ValueTuple<…>::GetHashCode`/`ToString` and `HashCode.Combine` cluster.

## The shape

When the receiver is an unconstrained generic `T`, csc can't know at compile time whether it's a reference or value type, so it emits a `default(T)`-box **two-stage null test with a reload**, both guards sharing one member-access arm:

```
A: Vk = default(T);  Sj = &recv;   if ((object)Vk != null) goto TRUE
B: Vk = *Sj;         Sj = &Vk;     if ((object)Vk != null) goto TRUE
FALSE: Sr = fallback;  goto MERGE
TRUE:  Sr = Sj->M()
MERGE: … uses Sr …
```

The two conditionals share one true arm, so `StructuringPass` can't nest it — and it's exactly the inner-guard-with-reload-prologue case `OrChainDiamondPass` (#984) deliberately left flat. It can't be folded to `||` (the reload prologue can't move into a short-circuit), so it needs the actual `?.`/`??` recovery.

## The fix

Add `NullConditionalCoalescePass` (pre-structuring, the sibling of the OR-chain folds): match the four-block shape and fold it to a single `Sr = recv?.M() ?? fallback` store — a straight line `StructuringPass` then consumes. A literal-null fallback yields the bare `recv?.M()`. The fold reconstructs the receiver from the spilled address and **preserves the constrained-virtual prefix**, so it re-lowers to the same two-stage test.

### Soundness

The two guards must share one true arm and one generic-default temp; the receiver address must be side-effect free (so evaluating it once in `recv?.M()` matches the lowering's single spill); the temp and receiver slot must be dead outside the matched blocks; and nothing outside may branch into the three blocks the fold drops.

## Measurement (CoreLib, 41012 methods)

- `forward-branch-not-region-exit` **356 → 343** (isolated against the same base), recovering `value?.GetHashCode() ?? 0` on `HashCode.Combine` and `ValueTuple<…>::GetHashCode`.
- **Validity diff vs `origin/main`: 0 regressed, 0 improved.**
- **No fidelity regression** — verified against a generic scratch lib: methods that diff after the raise (e.g. two `?.GetHashCode()` results passed directly to `HashCode.Combine`, which the inliner can't reorder into one call) **already diffed flat on main**; one case (`?.ToString() ?? x`) *improved* to opcode-exact.
- Pinned fixture `CfgSampleClass.GenericNullConditionalToString<T>` recompiles **opcode-exact** in the fidelity gate.
- Full decompiler suite green (859); 0 pass bugs.

## Fixtures

- Pinned opcode-exact source fixture + 6 pass-level tests: positive (int `?? 0` coalesce; literal-null → bare `?.`) and adversarial negatives (impure receiver, guards to different arms, external entry into the reload guard, temp live after the merge).

Part of #911 (the `x?.M() ?? fallback` slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)