### PR TITLE
Record bool join stepper audit invariant

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -179,8 +179,13 @@ public sealed class BooleanFoldingPass : IIrPass
     /// 0/1 beside a genuine bool arm is a boolean expression. Retyping the
     /// constant — and the conditional's merged result — recovers it; the slot
     /// then declares as <c>bool</c>, not <c>int</c> (the source of CS0029 when a
-    /// bool-returning method returns the slot). The non-constant bool arm is the
-    /// proof: a real integer select never pairs with one.
+    /// bool-returning method returns the slot). The non-constant bool arm plus
+    /// the downstream consumer check are the proof: a real integer select never
+    /// pairs with one, and a reused spill slot is not retyped unless every live
+    /// load after the store is consumed as bool. Stepper audit specimen:
+    /// <c>CfgSampleClass.SelectBoolReturn</c>, where step 1 folds the stack-slot
+    /// diamond and step 2 may materialize the <c>0</c> arm only because the slot
+    /// feeds a bool return.
     /// </summary>
     static bool MaterializeBoolConditional(IrFunction function, Conditional conditional, Stepper stepper)
     {


### PR DESCRIPTION
## Summary

- Performs the #1011 **Bool/int/type joins** stepper semantic audit on `CfgSampleClass.SelectBoolReturn`.
- No illegal intermediate rewrite was found. The audited boundary is BooleanFolding step 2: `materialize bool ternary constant arm`.
- Records the pass contract in `BooleanFoldingPass`: a 0/1 arm may be retyped to bool only with a non-constant bool arm plus downstream bool-consumer proof; reused spill slots remain guarded by live-load consumer checks.

## Stepper packet

Claim: at step 2, `BooleanFoldingPass` may rewrite `cond ? boolExpr : 0` to `cond ? boolExpr : false` because prior structuring/slot-diamond folding has produced one `Conditional`, one arm is a genuine non-constant bool expression, and every live load of the stack slot is consumed as bool.

Commands:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::SelectBoolReturn" --steps
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::SelectBoolReturn" --diff
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::SelectBoolReturn" --step-limit 2
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::SelectBoolReturn" --step-limit 3
```

Observed steps:

```text
[0] structure container at IL_0000 (4 blocks) into nested if/diamond regions
[1] fold store diamond into ternary
[2] materialize bool ternary constant arm
```

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*BooleanMaterialization*" -method "*BoolToIntNormalizationPassTests*" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`

Part of #1011.