### PR TITLE
Retype the sibling 0/1 constant when materializing a bool slot (#1011)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2811,6 +2811,35 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void MaterializeBooleanSlots_NegatedBoolSlot_RetypesSiblingConstant()
+    {
+        // A stack slot holds a bool (a > b), then is negated via csc's `ceq 0`
+        // idiom (S = S == 0) and returned. MaterializeBooleanSlots retypes the slot
+        // to bool; a load-only retype would leave the sibling `0` an int — the
+        // CS0019 `bool == int` (the StackAllocSpanPass::Run defect found via the
+        // #1011 stepper audit). The fix flips the 0 to false alongside the load, so
+        // FoldBoolConstantComparison reduces `S == false` to the negation.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Comparison(ComparisonKind.GreaterThan, false,
+            new LoadArgument(0, "a", intType), new LoadArgument(1, "b", intType))));
+        block.Add(new StoreStackSlot(0, new Comparison(ComparisonKind.Equal, false,
+            new LoadStackSlot(0, intType), new Constant(0, intType))));
+        block.Add(new Return(new LoadStackSlot(0, intType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("== 0", output);   // no `bool == int` (CS0019)
+    }
+
+    [Fact]
     public void SharedThrowGuards_InlineAsGuardClauses()
     {
         // Two guards branch to one shared throw block — the shape that breaks

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -69,8 +69,22 @@ public sealed class BooleanFoldingPass : IIrPass
                 if (store.Value is Constant { Value: int value })
                     store.Value.ReplaceWith(new Constant(value == 1, boolType));
             foreach (var load in candidateLoads)
-                if (!IsBool(load.Type))
-                    load.ReplaceWith(new LoadStackSlot(slot, boolType));
+            {
+                if (IsBool(load.Type))
+                    continue;
+                // A 0/1 literal sibling in a `== `/`!=` with this load is the bool
+                // identity/negation idiom (csc's `ceq`/`cgt` against 0). Retype it
+                // alongside the load so the comparison stays bool == bool, not the
+                // CS0019 `bool == int` a load-only retype would leave;
+                // FoldBoolConstantComparison then reduces it to `x`/`!x`.
+                if (load.Parent is Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison)
+                {
+                    var sibling = ReferenceEquals(comparison.Left, load) ? comparison.Right : comparison.Left;
+                    if (sibling is Constant { Value: int siblingValue } && siblingValue is 0 or 1)
+                        sibling.ReplaceWith(new Constant(siblingValue == 1, boolType));
+                }
+                load.ReplaceWith(new LoadStackSlot(slot, boolType));
+            }
             changed = true;
         }
         return changed;
@@ -105,7 +119,8 @@ public sealed class BooleanFoldingPass : IIrPass
         Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary
             when BoolBinaryAcceptsBoolOperand(binary, node) => ConsumerAcceptsBool(function, binary, visitedSlots),
         Conditional conditional => ReferenceEquals(conditional.Condition, node) || IsBool(conditional.ResultType),
-        Comparison comparison => comparison.Kind is ComparisonKind.Equal or ComparisonKind.NotEqual,
+        Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison
+            => ComparisonSiblingAcceptsBool(comparison, node),
         Call call => ParameterAcceptsBool(call.Callee.ParameterTypes, call.Callee.HasThis ? node.ChildIndex - 1 : node.ChildIndex),
         NewObject newObject => ParameterAcceptsBool(newObject.Constructor.ParameterTypes, node.ChildIndex),
         StoreLocal store => ReferenceEquals(store.Value, node) && IsBool(store.Type),
@@ -117,6 +132,20 @@ public sealed class BooleanFoldingPass : IIrPass
         StoreStackSlot store => SlotLoadsAcceptBool(function, store.Slot, visitedSlots),
         _ => false,
     };
+
+    /// <summary>
+    /// Whether an <c>==</c>/<c>!=</c> comparison stays well-typed after its
+    /// <paramref name="operand"/> retypes to <c>bool</c>: the sibling must already
+    /// be a <c>bool</c>, or a <c>0</c>/<c>1</c> int literal the retype flips to
+    /// <c>false</c>/<c>true</c> alongside it. A non-bool, non-0/1 sibling would
+    /// leave <c>bool == int</c> (CS0019) — the slot is not purely boolean there, so
+    /// the retype must bail.
+    /// </summary>
+    static bool ComparisonSiblingAcceptsBool(Comparison comparison, IrExpression operand)
+    {
+        var sibling = ReferenceEquals(comparison.Left, operand) ? comparison.Right : comparison.Left;
+        return IsBool(sibling.ResultType) || (sibling is Constant { Value: int value } && value is 0 or 1);
+    }
 
     static TypeRef? IndirectStoreType(StoreIndirect store)
     {


### PR DESCRIPTION
A Stepper Semantic Audit finding (#1011), "bool/int joins" / "stack-slot reuse" rows.

## The illegal rewrite

`StackAllocSpanPass::Run` decompiled to invalid C#:

```csharp
S_0 = definition is not null ? (definition.Namespace == "System") : false;  // S_0 is bool
S_0 = S_0 == 0;                                                             // bool == int → CS0019
```

`S_0 == 0` is csc's bool-negation idiom (`ceq` against 0 = `!S_0`). Stepping through the pipeline, the first illegal rewrite is **`BooleanFoldingPass.MaterializeBooleanSlots`** retyping the `S_0` load to `bool` (the bool ternary store is the evidence) — while `ConsumerAcceptsBool`'s `==`/`!=` case approved that consumer **unconditionally**, and the sibling `0` literal stayed `int`. `FoldBoolConstantComparison` only folds `== false(bool)`, so the `bool == int(0)` survived to compile-back as CS0019.

## The contract narrowing

- `ConsumerAcceptsBool` now approves an `==`/`!=` consumer only when the sibling is already `bool` or a `0`/`1` int literal — a non-0/1, non-bool sibling would leave `bool == int`, so the slot is not purely boolean there and the retype bails (conservative).
- The retype loop flips a `0`/`1` sibling literal to `false`/`true` alongside the load, so the comparison stays `bool == bool` and `FoldBoolConstantComparison` reduces `S_0 == false` → `!S_0`.

## Validation

- `StackAllocSpanPass::Run` now renders `S_0 = !S_0;` — valid.
- Validity defect diff vs the parent commit across the 6 product libraries (9,327 methods): **0 regressed, 0 new invalid, 0 malformed**.
- **854 decompiler tests green**, including all fidelity gates; +1 regression test (`MaterializeBooleanSlots_NegatedBoolSlot_RetypesSiblingConstant`) pinning the retype (fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)