### PR TITLE
Reject clobbered receiver slot in object-initializer fold (#1011)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -153,6 +153,30 @@ public class ObjectInitializerPassTests
     }
 
     [Fact]
+    public void ReceiverSlotClobberedBeforeEscape_IsNotFolded()
+    {
+        // The threaded receiver slot is re-stored with a *different* object between
+        // the member-store run and its single downstream load:
+        //
+        //   S_3 = new T(); S_3.X = 1; S_3 = new T(); return S_3;
+        //
+        // The escape (`return S_3`) yields the SECOND object, unmutated. Folding the
+        // run into `new T { X = 1 }` at that load would drop the re-store and return
+        // the wrong object. Dup slots are unique per dup so real lowerings never reuse
+        // a receiver slot, but carry slots (and hand-written IL) can — the alias-slot
+        // gate must reject a clobbered slot, mirroring the named-local single-store guard.
+        var function = FunctionWithClobberedReceiverSlot();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        // Both NewObject creations and the member store survive untouched.
+        Assert.Equal(2, function.Descendants.OfType<NewObject>().Count());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void PrintRaised_RendersInitializers()
     {
         Assert.Contains("return new InitTarget { X = a, Y = b };", Print(nameof(CfgSampleClass.MakePoint)));
@@ -316,6 +340,35 @@ public class ObjectInitializerPassTests
         body.Add(block);
         return new IrFunction(
             "DuplicateMember",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction FunctionWithClobberedReceiverSlot()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", TypeRef.CoreLib("System", "Void"), [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        // A reusable carry slot (< DupSlotBase) holds the receiver, gets one member
+        // store, then is re-stored with a second, unrelated object before the escape.
+        const int slot = 3;
+        var block = new Block();
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(slot, type), [], new Constant(1, intType)));
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new Return(new LoadStackSlot(slot, type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "ClobberedReceiver",
             TypeRef.Definition("Synthetic", "Samples", "Owner"),
             new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
             [],

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
@@ -14,7 +14,7 @@ internal sealed class ObjectInitializerFacts : ILoweringFactProvider
                 new FactPrimitive("ir.initializer-entry-shape", "InitializerEntry member/indexer/Add argument model"),
             ],
             PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, dictionary, nested object/collection, nested-reassign (Inner = new U { ... }, folded inner-first), and named-local object/collection fixtures",
-            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; non-IEnumerable Add lookalikes stay lowered; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... })",
+            AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; non-IEnumerable Add lookalikes stay lowered; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... }); a receiver slot re-stored (clobbered) between the run and its escape stays lowered",
             MissingDiscriminator: "named locals with extra outside uses remain lowered"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -189,9 +189,23 @@ public sealed class ObjectInitializerPass : IIrPass
             if (ReferencesAnySlot(leaf, aliasSlots))
                 return null;
 
+        var consumedSet = consumed.ToHashSet();
+
+        // The threaded reference must not be clobbered between the run and its
+        // escape: any store to an alias slot outside the consumed dup chain means
+        // the slot was reused for an unrelated value, so a later load is not this
+        // receiver and folding into it would drop the re-store. Dup slots are
+        // unique per dup, so real dup-chain lowerings never hit this; carry-slot
+        // reuse (and hand-written IL) can. The named-local form has the analogous
+        // single-store guard below.
+        foreach (var store in function.Descendants.OfType<StoreStackSlot>())
+            if (aliasSlots.Contains(store.Slot)
+                && !consumedSet.Contains(store)
+                && !HasAncestorIn(store, consumedSet))
+                return null;
+
         // The threaded reference must escape the run exactly once: that single
         // downstream load is where the initializer expression belongs.
-        var consumedSet = consumed.ToHashSet();
         var outsideUses = function.Descendants.OfType<LoadStackSlot>()
             .Where(load => aliasSlots.Contains(load.Slot) && !HasAncestorIn(load, consumedSet))
             .ToList();


### PR DESCRIPTION
Stepper semantic audit of the **`dup` / spill provenance** row of #1011.

## Finding

`ObjectInitializerPass` folds a run of member stores on a threaded receiver into `new T { ... }` and replaces the *single* outside load of the receiver with that initializer. The stack-slot form proved ownership by counting outside **loads** of the alias slots, but never checked whether an alias slot was **re-stored (clobbered)** between the member-store run and its escape.

- Dup slots (`>= DupSlotBase`, 256) are allocated fresh per `dup`, so real Roslyn dup-chain lowerings never reuse a receiver slot — the product path was never wrong.
- But carry slots (`< 256`) are reused per stack-position+type (this is exactly what `StackSlotLiveRangePass` exists to untangle, and it runs *after* this pass), and the decompiler ingests arbitrary IL.

On the reused-slot shape:

```
S_3 = new T();   // receiver
S_3.X = 1;       // member store on the threaded receiver
S_3 = new T();   // reuse slot 3 with a *different* object
return S_3;      // single outside load -> yields the SECOND object
```

the fold dropped the re-store and emitted `return new T { X = 1 };` — plausible but **wrong** C# that returns the first object instead of the second. That is precisely the "honest degradation" violation AGENTS.md warns against (unsupported IL becoming plausible-wrong C# rather than staying explicit).

## Fix

Add the missing guard to the stack-slot `TryBuild`: bail if any alias slot is stored outside the consumed dup chain. This mirrors the named-local form's existing single-store guard (`ObjectInitializerPass.cs:281`). Real dup-chains have only the seed + dup copies storing alias slots (all consumed), so they still fold unchanged.

## Coverage / validation

- New synthetic-IR adversarial fixture `ReceiverSlotClobberedBeforeEscape_IsNotFolded` pins the decline (mirrors the existing `FunctionWithDuplicateMemberStores` pattern).
- Narrowed the `ObjectInitializerFacts` adversarial-coverage ledger note.
- Decompiler tests: **858/858**, 0 failed.
- CoreLib `--gaps`: **0 pass bugs**; fold counts unchanged (guard only fires on reused alias slots).

## Done signal

Illegal-transform fixture pins the offending pass/step and the pass contract is narrowed — matches the #1011 row's definition of done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)