### PR TITLE
Add opt-in readable local names (#998)

### DIFF
--- a/docs/design/readable-local-names.md
+++ b/docs/design/readable-local-names.md
@@ -1,0 +1,78 @@
+# Readable Local Names (opt-in)
+
+Design note for the #998 "Local naming and declaration placement" row. Scope is
+deliberately narrow: an **opt-in** mode that gives synthesized, readable names to
+locals that have no usable PDB source name, while leaving the **default** output
+byte-identical.
+
+## Problem
+
+`CSharpPrinter.LocalName(index)` renders a local as its PDB source name when one
+is present, usable as a C# identifier, and not already taken; otherwise it falls
+back to `V_index`. With no PDB — the common case for shipped/stripped assemblies,
+and the deterministic `--skip-pdb` reading path — every local is `V_0`, `V_1`, …,
+which is the single largest readability gap in otherwise-structured output.
+
+## Constraint: default output is load-bearing
+
+`V_n` is not just cosmetic to leave alone — three things depend on it:
+
+- **Fidelity gate / corpus snapshots** compare rendered text; any default-name
+  change is a churn diff across the whole corpus.
+- **`--skip-pdb`** exists precisely to give a *deterministic, symbol-independent*
+  spelling for diffing; readable names are non-deterministic-looking and would
+  defeat that.
+- **Annotated-IL alignment** (the default member view) pairs source lines with IL
+  offsets; names there should stay IL-aligned, not editorialized.
+
+So readable names must be **opt-in** and must not touch any of those paths.
+
+## Approach
+
+1. A pure **name synthesizer** — `LocalNameSynthesizer` — maps a local's
+   `(TypeRef type, role, ISet<string> taken)` to a readable identifier:
+   - loop-counter `int`/`long` → `i`, `j`, `k`, … (role-driven);
+   - by type: `string` → `text`/`str`, `bool` → `flag`, `T[]` → `items`/`array`,
+     a named type `FooBar` → `fooBar`, etc.;
+   - collision-resolved against `taken` (params, source-named locals, earlier
+     synthesized names) with a numeric suffix.
+   It never invents a name for a local that already has a usable source name.
+2. `LocalName` consults the synthesizer **only when the mode is on and no usable
+   source name exists**; otherwise the existing `V_index` fallback is untouched.
+3. The mode is threaded as an explicit option (see the open fork below), defaulting
+   **off**, so `Print`/`PrintRaised` and every gate keep today's output.
+
+## Role evidence (no guessing)
+
+A readable name is only as honest as the role it rests on. The synthesizer takes
+*evidence already in the IR*, not heuristics over spelling:
+
+- a local that is a `ForLoop`/`ForeachStatement` induction variable → counter name;
+- a local whose only stores are of one concrete type → that type's name;
+- otherwise a neutral type-based name.
+
+When no evidence supports a readable name, it falls back to `V_index` rather than
+fabricating — honest degradation, same as the rest of the pipeline.
+
+## Open fork (needs a decision before wiring)
+
+Where the opt-in lives:
+
+- **A: printer option.** Add a `PrinterOptions` record (first field
+  `ReadableLocalNames`) to `Print`/`PrintRaised`; the CLI maps a
+  `--readable-names` flag to it. Most explicit; touches the printer signature and
+  every caller.
+- **B: IR pre-pass.** A pass populates `IrFunction.LocalNames` with synthesized
+  names when empty, so the printer is unchanged. Cleanest printer, but it mutates
+  the IR the annotation/fidelity views also read — risk of leaking into a
+  non-opt-in path.
+- **C: CLI-only render flag.** Thread a bool through the existing member-code
+  provider to the printer without a formal options record. Smallest diff, least
+  general.
+
+## First contained slice
+
+`LocalNameSynthesizer` as a standalone, fully-tested pure unit (type-based +
+loop-counter roles, collision resolution), plus its single consumer wired through
+whichever surface we pick in the fork. Default output stays byte-identical;
+proven by the unchanged fidelity gate and a `--skip-pdb`-equivalent render test.

--- a/src/ILInspector.Decompiler.Tests/LocalNameSynthesizerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalNameSynthesizerTests.cs
@@ -1,0 +1,69 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LocalNameSynthesizerTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Double = TypeRef.CoreLib("System", "Double");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Builder = TypeRef.Definition("Asm", "System.Text", "StringBuilder");
+
+    static IReadOnlySet<string> Taken(params string[] names) => new HashSet<string>(names);
+
+    [Fact]
+    public void NamesByType()
+    {
+        Assert.Equal("text", LocalNameSynthesizer.Synthesize(String, false, Taken()));
+        Assert.Equal("flag", LocalNameSynthesizer.Synthesize(Boolean, false, Taken()));
+        Assert.Equal("num", LocalNameSynthesizer.Synthesize(Int32, false, Taken()));
+        Assert.Equal("value", LocalNameSynthesizer.Synthesize(Double, false, Taken()));
+        Assert.Equal("items", LocalNameSynthesizer.Synthesize(TypeRef.SzArray(Int32), false, Taken()));
+        // A non-core named type camel-cases its leaf simple name.
+        Assert.Equal("stringBuilder", LocalNameSynthesizer.Synthesize(Builder, false, Taken()));
+    }
+
+    [Fact]
+    public void LoopCounterPrefersIjk()
+    {
+        Assert.Equal("i", LocalNameSynthesizer.Synthesize(Int32, isLoopCounter: true, Taken()));
+        Assert.Equal("j", LocalNameSynthesizer.Synthesize(Int32, isLoopCounter: true, Taken("i")));
+        Assert.Equal("k", LocalNameSynthesizer.Synthesize(Int32, isLoopCounter: true, Taken("i", "j")));
+    }
+
+    [Fact]
+    public void CounterRoleIgnoredForNonIntegerType()
+    {
+        // The counter role only applies to integers; a string "counter" still
+        // names by its type, never i/j/k.
+        Assert.Equal("text", LocalNameSynthesizer.Synthesize(String, isLoopCounter: true, Taken()));
+    }
+
+    [Fact]
+    public void ResolvesCollisionsWithNumericSuffix()
+    {
+        Assert.Equal("text2", LocalNameSynthesizer.Synthesize(String, false, Taken("text")));
+        Assert.Equal("text3", LocalNameSynthesizer.Synthesize(String, false, Taken("text", "text2")));
+        // Counters exhaust i..n, then suffix the primary.
+        Assert.Equal("i2", LocalNameSynthesizer.Synthesize(Int32, isLoopCounter: true, Taken("i", "j", "k", "l", "m", "n")));
+    }
+
+    [Fact]
+    public void NoEvidenceFallsBackToNull()
+    {
+        // Unknown type -> the caller keeps V_index rather than fabricating a name.
+        Assert.Null(LocalNameSynthesizer.Synthesize(null, false, Taken()));
+        // System.Object camel-cases to the keyword `object`, which is unusable, so
+        // it also falls back rather than emitting an escaped or wrong name.
+        Assert.Null(LocalNameSynthesizer.Synthesize(Object, false, Taken()));
+    }
+
+    [Fact]
+    public void NamesThroughRefAndPointerWrappers()
+    {
+        Assert.Equal("text", LocalNameSynthesizer.Synthesize(TypeRef.ByRef(String), false, Taken()));
+        Assert.Equal("num", LocalNameSynthesizer.Synthesize(TypeRef.Pointer(Int32), false, Taken()));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ReadableLocalNamesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReadableLocalNamesTests.cs
@@ -1,0 +1,97 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// The opt-in readable-names mode (PrinterOptions.ReadableLocalNames). The default
+// must stay byte-identical V_index output; the mode synthesizes readable names
+// only for locals with no usable source name, and still falls back to V_index
+// when no IR evidence supports a name.
+public class ReadableLocalNamesTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void DefaultMode_RendersVIndex()
+    {
+        var output = Print(StringLocalFunction(), options: null);
+        Assert.Contains("string V_0 = \"hi\";", output);
+        Assert.Contains("return V_0;", output);
+        Assert.DoesNotContain("text", output);
+    }
+
+    [Fact]
+    public void ReadableMode_NamesLocalByType()
+    {
+        var output = Print(StringLocalFunction(), new PrinterOptions { ReadableLocalNames = true });
+        Assert.Contains("string text = \"hi\";", output);
+        Assert.Contains("return text;", output);
+        Assert.DoesNotContain("V_0", output);
+    }
+
+    [Fact]
+    public void ReadableMode_FallsBackToVIndexWithoutEvidence()
+    {
+        // An object local camel-cases to the keyword `object` (unusable), so even
+        // with the mode on it must keep V_index — honest degradation, not a guess.
+        var output = Print(ObjectLocalFunction(), new PrinterOptions { ReadableLocalNames = true });
+        Assert.Contains("V_0", output);
+        Assert.DoesNotContain("object obj", output);
+    }
+
+    [Fact]
+    public void ReadableMode_NamesForLoopCounterIjk()
+    {
+        // A local written by a for-loop increment is the induction variable, so
+        // the readable mode spells it i (LoopCounterLocals -> isLoopCounter).
+        var output = Print(CounterFunction(), new PrinterOptions { ReadableLocalNames = true });
+        Assert.Contains("int i = 0;", output);
+        Assert.DoesNotContain("V_0", output);
+    }
+
+    // for (int V_0 = 0; true; V_0 = V_0 + 1) { }
+    static IrFunction CounterFunction()
+    {
+        var loop = new ForLoop(
+            new StoreLocal(0, Int32, new Constant(0, Int32)),
+            new Constant(true, Boolean),
+            new StoreLocal(0, Int32, new Constant(1, Int32)),
+            new Block(0));
+        var block = new Block(0);
+        block.Add(loop);
+        block.Add(new Return(null));
+        return Function(Void, [Int32], block);
+    }
+
+    // string V_0 = "hi"; return V_0;
+    static IrFunction StringLocalFunction()
+    {
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, String, new Constant("hi", String)));
+        block.Add(new Return(new LoadLocal(0, String)));
+        return Function(String, [String], block);
+    }
+
+    // object V_0 = null; return V_0;
+    static IrFunction ObjectLocalFunction()
+    {
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Object, new Constant(null, Object)));
+        block.Add(new Return(new LoadLocal(0, Object)));
+        return Function(Object, [Object], block);
+    }
+
+    static string Print(IrFunction function, PrinterOptions? options)
+        => CSharpPrinter.Print(function, options).Output!;
+
+    static IrFunction Function(TypeRef returnType, TypeRef[] locals, Block block)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction("M", Holder, new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0), [.. locals], body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -38,9 +38,12 @@ public sealed partial class CSharpPrinter
     /// </summary>
     int _unsafeDepth;
 
-    CSharpPrinter(IrFunction function)
+    readonly PrinterOptions _options;
+
+    CSharpPrinter(IrFunction function, PrinterOptions? options = null)
     {
         _function = function;
+        _options = options ?? PrinterOptions.Default;
         _newMemorySafetyRules = function.UsesUpdatedMemorySafetyRules;
         _skipLocalsInit = function.SkipLocalsInit;
     }
@@ -56,8 +59,8 @@ public sealed partial class CSharpPrinter
     public static DecompilerResult PrintRaised(IrFunction function)
         => PrintRaised(function, importMethodBody: null);
 
-    /// <summary>As <see cref="PrintRaised(IrFunction)"/>, with <paramref name="importMethodBody"/> wiring the cross-method import seam (e.g. for lambda raising); null leaves cross-method passes as no-ops.</summary>
-    public static DecompilerResult PrintRaised(IrFunction function, Func<MethodRef, IrFunction?>? importMethodBody)
+    /// <summary>As <see cref="PrintRaised(IrFunction)"/>, with <paramref name="importMethodBody"/> wiring the cross-method import seam (e.g. for lambda raising); null leaves cross-method passes as no-ops. <paramref name="options"/> defaults to the shipped output.</summary>
+    public static DecompilerResult PrintRaised(IrFunction function, Func<MethodRef, IrFunction?>? importMethodBody, PrinterOptions? options = null)
     {
         try
         {
@@ -67,7 +70,7 @@ public sealed partial class CSharpPrinter
         {
             return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
-        return Print(function);
+        return Print(function, options);
     }
 
     /// <summary>
@@ -192,11 +195,11 @@ public sealed partial class CSharpPrinter
         return facts;
     }
 
-    public static DecompilerResult Print(IrFunction function)
+    public static DecompilerResult Print(IrFunction function, PrinterOptions? options = null)
     {
         try
         {
-            var printer = new CSharpPrinter(function);
+            var printer = new CSharpPrinter(function, options);
             string output = printer.PrintBody(function);
             return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics])
             {
@@ -1902,24 +1905,69 @@ public sealed partial class CSharpPrinter
         {
             int count = _function.Locals.Length;
             var display = new string[count];
+            var sourceNamed = new bool[count];
             for (int i = 0; i < count; i++)
                 display[i] = $"V_{i}";
+
+            var taken = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var parameter in _function.Signature.Parameters)
+                taken.Add(parameter.Name);
 
             var names = _function.LocalNames;
             if (!names.IsDefaultOrEmpty)
             {
-                var taken = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var parameter in _function.Signature.Parameters)
-                    taken.Add(parameter.Name);
                 for (int i = 0; i < count && i < names.Length; i++)
                 {
                     if (names[i] is { } name && CSharpNaming.IsUsableIdentifier(name) && taken.Add(name))
+                    {
                         display[i] = name;
+                        sourceNamed[i] = true;
+                    }
+                }
+            }
+
+            // Opt-in readable names: a local with no usable source name gets a
+            // synthesized name from IR evidence (its type, loop-counter role),
+            // collision-resolved against names already taken. Off by default, so
+            // the shipped V_index output is untouched.
+            if (_options.ReadableLocalNames)
+            {
+                var counters = LoopCounterLocals();
+                for (int i = 0; i < count; i++)
+                {
+                    if (sourceNamed[i])
+                        continue;
+                    var type = i < _function.Locals.Length ? _function.Locals[i] : null;
+                    if (LocalNameSynthesizer.Synthesize(type, counters.Contains(i), taken) is { } synthesized)
+                    {
+                        display[i] = synthesized;
+                        taken.Add(synthesized);
+                    }
                 }
             }
             _localDisplayNames = display;
         }
         return index >= 0 && index < _localDisplayNames.Length ? _localDisplayNames[index] : $"V_{index}";
+    }
+
+    /// <summary>
+    /// Locals written by a <see cref="ForLoop"/>'s increment — the induction
+    /// variables that earn the conventional <c>i</c>/<c>j</c>/<c>k</c> name in the
+    /// opt-in readable-names mode. Evidence from the structured tree, not a guess.
+    /// </summary>
+    HashSet<int> LoopCounterLocals()
+    {
+        var counters = new HashSet<int>();
+        foreach (var loop in DescendantsOutsideNestedFunctions(_function).OfType<ForLoop>())
+        {
+            var increment = loop.Increment;
+            if (increment is StoreLocal direct)
+                counters.Add(direct.Index);
+            foreach (var node in increment.Descendants)
+                if (node is StoreLocal store)
+                    counters.Add(store.Index);
+        }
+        return counters;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/LocalNameSynthesizer.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/LocalNameSynthesizer.cs
@@ -1,0 +1,100 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Synthesizes a readable identifier for a local that has no usable PDB source
+/// name, used only by the opt-in readable-names mode (see
+/// <c>docs/design/readable-local-names.md</c>). It names from evidence the IR
+/// already carries — the local's type and whether it is a loop counter — and
+/// resolves collisions against the names already taken (parameters, source-named
+/// locals, and earlier synthesized names).
+///
+/// It never invents a name with no evidence: when the type carries no readable
+/// name it returns <c>null</c> and the caller keeps the <c>V_index</c> fallback,
+/// preserving the pipeline's honest-degradation contract. The mode is opt-in and
+/// off by default, so this never changes shipped output.
+/// </summary>
+static class LocalNameSynthesizer
+{
+    /// <summary>
+    /// A readable name for a local of <paramref name="type"/>, or <c>null</c>
+    /// when no honest readable name applies (the caller then keeps <c>V_index</c>).
+    /// <paramref name="isLoopCounter"/> marks an integer loop-induction local, the
+    /// one role worth the conventional <c>i</c>/<c>j</c>/<c>k</c>. The result is
+    /// guaranteed absent from <paramref name="taken"/>; the caller reserves it.
+    /// </summary>
+    public static string? Synthesize(TypeRef? type, bool isLoopCounter, IReadOnlySet<string> taken)
+    {
+        var bases = BaseNames(type, isLoopCounter);
+        if (bases.Count == 0)
+            return null;
+        foreach (var name in bases)
+            if (!taken.Contains(name))
+                return name;
+        // Every preferred base is taken; suffix the primary until one is free.
+        string primary = bases[0];
+        for (int n = 2; ; n++)
+        {
+            string candidate = primary + n;
+            if (!taken.Contains(candidate))
+                return candidate;
+        }
+    }
+
+    static IReadOnlyList<string> BaseNames(TypeRef? type, bool isLoopCounter)
+    {
+        if (type is null)
+            return [];
+        var core = Unwrap(type);
+        if (isLoopCounter && IsIntegerLike(core))
+            return ["i", "j", "k", "l", "m", "n"];
+        return TypeBaseName(core) is { } name ? [name] : [];
+    }
+
+    // Name from the underlying value type, not its ref/pin/pointer wrapper.
+    static TypeRef Unwrap(TypeRef type)
+        => type.Kind is TypeRefKind.ByRef or TypeRefKind.Pinned or TypeRefKind.Pointer && type.ElementType is { } inner
+            ? Unwrap(inner)
+            : type;
+
+    static string? TypeBaseName(TypeRef type)
+    {
+        if (IsCore(type, "String")) return "text";
+        if (IsCore(type, "Boolean")) return "flag";
+        if (IsCore(type, "Char")) return "ch";
+        if (IsIntegerLike(type)) return "num";
+        if (IsCore(type, "Single") || IsCore(type, "Double") || IsCore(type, "Decimal")) return "value";
+        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array) return "items";
+        if (type.Kind is TypeRefKind.Definition or TypeRefKind.GenericInstance)
+            return CamelCase(SimpleName(type));
+        return null;
+    }
+
+    static bool IsCore(TypeRef type, string name) => MemberIdentity.IsCoreLibraryType(type, "System", name);
+
+    static bool IsIntegerLike(TypeRef type)
+        => IsCore(type, "Int32") || IsCore(type, "Int64") || IsCore(type, "Int16") || IsCore(type, "SByte")
+            || IsCore(type, "Byte") || IsCore(type, "UInt16") || IsCore(type, "UInt32") || IsCore(type, "UInt64")
+            || IsCore(type, "IntPtr") || IsCore(type, "UIntPtr");
+
+    // The leaf simple name, stripped of generic arity backtick and nested-type
+    // '+' segments, so List`1 / Outer+Inner name as `list` / `inner`.
+    static string SimpleName(TypeRef type)
+    {
+        string name = type.Kind == TypeRefKind.GenericInstance && type.ElementType is { } element ? element.Name : type.Name;
+        int tick = name.IndexOf('`');
+        if (tick >= 0) name = name[..tick];
+        int plus = name.LastIndexOf('+');
+        if (plus >= 0) name = name[(plus + 1)..];
+        return name;
+    }
+
+    static string? CamelCase(string name)
+    {
+        if (name.Length == 0 || !char.IsLetter(name[0]))
+            return null;
+        string camel = char.ToLowerInvariant(name[0]) + name[1..];
+        // A name that collides with a keyword (`object`, `string`) or is otherwise
+        // unusable is dropped rather than escaped — V_index is the honest fallback.
+        return CSharpNaming.IsUsableIdentifier(camel) ? camel : null;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -1,0 +1,24 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Opt-in render knobs for <see cref="CSharpPrinter"/>. Every field defaults to
+/// the shipped behavior, so <see cref="Default"/> reproduces today's output
+/// byte-for-byte — the fidelity gate, <c>--skip-pdb</c> deterministic reading,
+/// and annotated-IL alignment all depend on that. This is the single home for
+/// render-quality options (readable names today; declaration placement and other
+/// knobs as the #998 row grows), keeping them off the printer's positional
+/// signature.
+/// </summary>
+public sealed record PrinterOptions
+{
+    /// <summary>
+    /// When set, a local with no usable PDB source name renders a synthesized
+    /// readable name (see <see cref="LocalNameSynthesizer"/>) instead of
+    /// <c>V_index</c>. Off by default; the synthesizer falls back to
+    /// <c>V_index</c> for any local it cannot name from IR evidence.
+    /// </summary>
+    public bool ReadableLocalNames { get; init; }
+
+    /// <summary>The shipped defaults — every knob off.</summary>
+    public static PrinterOptions Default { get; } = new();
+}


### PR DESCRIPTION
## Summary
First slice of the **Local naming and declaration placement** row of #998: an **opt-in** mode that gives synthesized, readable names to locals with no usable PDB source name, while leaving **default output byte-identical**. Design recorded in `docs/design/readable-local-names.md`; surface is **option A** (a `PrinterOptions` record), chosen because it's type-safe-off, leaves the shared IR untouched, and gives the declaration-placement half of this row a home.

## What's here
- **`PrinterOptions`** — the printer's opt-in render-knob home. `Default` reproduces today's output byte-for-byte (the fidelity gate, `--skip-pdb` deterministic reading, and annotated-IL alignment all depend on that). First knob: `ReadableLocalNames`.
- **`LocalNameSynthesizer`** — a pure unit that names a local from *evidence already in the IR*:
  - by type: `string`→`text`, `bool`→`flag`, `int`→`num`, `double`→`value`, `T[]`→`items`, a named type `FooBar`→`fooBar`;
  - by role: a for-loop induction variable → `i`/`j`/`k`;
  - collision-resolved against names already taken (params, source-named locals, earlier synthesized names).
  It returns `null` when no evidence supports a readable name, so the caller keeps `V_index` — honest degradation, not a guess (a keyword-named type like `object` also falls back).
- **`CSharpPrinter.LocalName`** consults the synthesizer only when the mode is on and a local has no usable source name; `LoopCounterLocals` supplies the induction-variable role from the structured tree. `Print`/`PrintRaised` gain an optional `PrinterOptions` param, default off.

## Default output is unchanged
The full decompiler suite — **862 tests**, including the fidelity / lowered-fidelity gates and the existing local-naming tests — passes with the mode **off**, proving byte-identical default output. New tests cover the synthesizer (type names, counter `i/j/k`, collision suffixes, ref/pointer unwrap, null/keyword fallback), the opt-in rendering, the `V_index` fallback, and the for-loop counter end to end.

## Scope / follow-ups
- **CLI exposure** (a `--readable-names` flag wired through `MemberCodeProvider` → `TypeSourceComposer`) is a deliberate next slice; this PR lands the synthesizer + the printer surface it plugs into.
- The **declaration-placement** half of the row gets a natural home on `PrinterOptions` later.

Relation to #1017 (type-name collisions): adjacent — different identifier class (locals vs type names) and opposite posture (opt-in readability vs default correctness fix); no code overlap, though `PrinterOptions` could host a future type-qualification toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)