### PR TITLE
Raise enum RVA span literals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -394,6 +394,8 @@ public class CfgSampleClass
 
     public static int ReadOnlySpanLastHandWritten(System.ReadOnlySpan<int> span) => span[span.Length - 1];
 
+    public static int ReadOnlySpanEnumFirst(System.ReadOnlySpan<CfgPriority> span) => (int)span[0];
+
     public static int SpanLastHandWritten(System.Span<int> span) => span[span.Length - 1];
 
     public static void SetFirstElement(int[] a, int v) => a[0] = v;

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3895,6 +3895,21 @@ public class TypeShapeTruthinessTests
 public class EnumConstantTests
 {
     [Fact]
+    public void GenericArgumentEnumShape_RegistersEnumMembers()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(
+            source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReadOnlySpanEnumFirst));
+        Assert.NotNull(function);
+
+        var enumType = function!.Signature.Parameters[0].Type.TypeArguments[0];
+
+        Assert.Equal(TypeShape.Enum, function.TypeShapes.GetValueOrDefault(enumType));
+        Assert.True(function.EnumMembers.TryGetValue(enumType, out var members));
+        Assert.Contains(members!, member => member.Value == nameof(CfgPriority.High));
+    }
+
+    [Fact]
     public void EnumArgument_RendersMemberName()
     {
         // TakesPriority(CfgPriority.High) — the ldc.i4.2 names as High, not 2.

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -90,11 +90,55 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void ReadOnlySpanEnum_FromRvaField_RaisesToEnumLiteral()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "Samples", "State", ValueTypeHint.ValueType);
+        var function = BuildReadOnlySpanEnumCtor(enumType, [0, 2, 3], spanLength: 3);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumMembers = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+        {
+            [enumType] = new Dictionary<long, string> { [0] = "Start", [2] = "Done" },
+        };
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var literal = Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Equal(enumType, literal.ElementType);
+        Assert.Equal([0, 2, 3], literal.Elements.Select(e => (int)((Constant)e).Value!));
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("State.Start", output);
+        Assert.Contains("State.Done", output);
+        Assert.Contains("(State)3", output);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ReadOnlySpanEnum_WithUnknownShape_StaysUnraised()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "Samples", "State", ValueTypeHint.ValueType);
+        var function = BuildReadOnlySpanEnumCtor(enumType, [0, 1, 2], spanLength: 3);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.Name == ".ctor");
+        function.CheckInvariant();
+    }
+
     static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
         => BuildReadOnlySpanCtor(s_byte, s_readOnlySpanByte, blob, spanLength);
 
     static IrFunction BuildReadOnlySpanIntCtor(byte[] blob, int spanLength)
         => BuildReadOnlySpanCtor(s_int, s_readOnlySpanInt, blob, spanLength);
+
+    static IrFunction BuildReadOnlySpanEnumCtor(TypeRef element, byte[] blob, int spanLength)
+        => BuildReadOnlySpanCtor(
+            element,
+            TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [element]),
+            blob,
+            spanLength);
 
     static IrFunction BuildReadOnlySpanCtor(TypeRef element, TypeRef spanType, byte[] blob, int spanLength)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -301,12 +301,21 @@ public static class IrImporter
 
         void Consider(TypeRef? type)
         {
-            // ByRef/pointer carry the real type in their element: a `ref Enum`
-            // parameter or `Enum*` only ever reaches the importer wrapped, so the
-            // pointee enum's shape (and member names) would never be registered —
-            // leaving `*styles & 64` as `int & 64` (CS0019). Unwrap to the pointee.
-            while (type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } element })
-                type = element;
+            switch (type)
+            {
+                case null:
+                    return;
+                case { ElementType: { } element }:
+                    Consider(element);
+                    break;
+            }
+            foreach (var argument in type.TypeArguments)
+                Consider(argument);
+
+            // ByRef/pointer wrappers are handled through ElementType above; only
+            // named definitions carry a shape/member map entry themselves.
+            if (type.Kind == TypeRefKind.GenericInstance)
+                type = type.ElementType;
             if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
                 return;
             var shape = source.ResolveShape(type);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -17,9 +17,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <para>The pass decodes the field's mapped RVA blob (captured on the
 /// <see cref="LoadToken"/> at import) as the call's element type and rebuilds the
 /// element constants. The compiler re-lowers the reconstructed array literal to the
-/// same content-addressed blob, so the round-trip is opcode-exact. Scoped to the
-/// primitive element types whose bytes decode unambiguously; any other element type
-/// (an enum, a struct) is left untouched.</para>
+/// same content-addressed blob, so the round-trip is opcode-exact. Scoped to
+/// primitive element types whose bytes decode unambiguously, plus same-assembly
+/// enums when an explicit span length lets the underlying width be inferred.
+/// Other element types (struct layouts) are left untouched.</para>
 /// </summary>
 public sealed class RvaSpanPass : IIrPass
 {
@@ -38,7 +39,7 @@ public sealed class RvaSpanPass : IIrPass
             if (call.ResultType is not { } spanType)
                 continue;
 
-            var elements = DecodeElements(element, data);
+            var elements = DecodeElements(function, element, data);
             if (elements is null)
                 continue;
 
@@ -66,7 +67,7 @@ public sealed class RvaSpanPass : IIrPass
             if (construction.Arguments is not [LoadFieldAddress { FieldRvaData: { } rvaData }, Constant { Value: int rvaLength }])
                 continue;
 
-            var spanElements = DecodeElements(spanElement, rvaData, rvaLength);
+            var spanElements = DecodeElements(function, spanElement, rvaData, rvaLength);
             if (spanElements is null)
                 continue;
 
@@ -92,7 +93,7 @@ public sealed class RvaSpanPass : IIrPass
             if (ResolveArrayCreation(arrayArg, function) is not { } creation)
                 continue;
 
-            var arrayElements = DecodeElements(creation.ElementType, data);
+            var arrayElements = DecodeElements(function, creation.ElementType, data);
             if (arrayElements is null)
                 continue;
             // The blob length is the array's byte size; honour an explicit element
@@ -147,22 +148,38 @@ public sealed class RvaSpanPass : IIrPass
     /// layout size — the blob length captured at import — runs one byte past the
     /// span's own length. The span's length is authoritative for what it reads.</para>
     /// </summary>
-    static List<IrExpression>? DecodeElements(TypeRef element, byte[] data, int? elementCount = null)
+    static List<IrExpression>? DecodeElements(IrFunction function, TypeRef element, byte[] data, int? elementCount = null)
     {
-        if (element.Kind != TypeRefKind.Definition || element.Namespace != "System")
+        if (element.Kind != TypeRefKind.Definition)
             return null;
 
-        int width = element.Name switch
+        if (PrimitiveElementWidth(element) is { } primitiveWidth)
+            return DecodePrimitiveElements(element, data, primitiveWidth, elementCount);
+
+        if (function.TypeShapes.GetValueOrDefault(element) != TypeShape.Enum || elementCount is not { } count)
+            return null;
+        var enumWidth = InferredEnumWidth(data.Length, count);
+        if (enumWidth is null or > 4)
+            return null;
+        return DecodeEnumElements(element, data, enumWidth.Value, count, function.EnumMembers.GetValueOrDefault(element));
+    }
+
+    static int? PrimitiveElementWidth(TypeRef element)
+    {
+        if (element.Namespace != "System")
+            return null;
+        return element.Name switch
         {
             "Boolean" or "SByte" or "Byte" => 1,
             "Int16" or "UInt16" or "Char" => 2,
             "Int32" or "UInt32" or "Single" => 4,
             "Int64" or "UInt64" or "Double" => 8,
-            _ => 0,
+            _ => null,
         };
-        if (width == 0)
-            return null;
+    }
 
+    static List<IrExpression>? DecodePrimitiveElements(TypeRef element, byte[] data, int width, int? elementCount)
+    {
         int length;
         if (elementCount is { } count)
         {
@@ -201,5 +218,47 @@ public sealed class RvaSpanPass : IIrPass
             result.Add(new Constant(value, element));
         }
         return result;
+    }
+
+    static int? InferredEnumWidth(int byteLength, int count)
+    {
+        if (count <= 0 || byteLength % count != 0)
+            return null;
+        int width = byteLength / count;
+        return width is 1 or 2 or 4 or 8 ? width : null;
+    }
+
+    static List<IrExpression>? DecodeEnumElements(
+        TypeRef enumType,
+        byte[] data,
+        int width,
+        int count,
+        IReadOnlyDictionary<long, string>? members)
+    {
+        if (count < 0 || data.Length < count * width)
+            return null;
+
+        var span = data.AsSpan();
+        var result = new List<IrExpression>(count);
+        for (int i = 0; i < count; i++)
+        {
+            var chunk = span.Slice(i * width, width);
+            int value = width switch
+            {
+                1 => EnumValue(chunk[0], unchecked((sbyte)chunk[0]), members),
+                2 => EnumValue(BitConverter.ToUInt16(chunk), BitConverter.ToInt16(chunk), members),
+                4 => BitConverter.ToInt32(chunk),
+                _ => 0,
+            };
+            result.Add(new Constant(value, enumType));
+        }
+        return result;
+    }
+
+    static int EnumValue(long unsignedValue, long signedValue, IReadOnlyDictionary<long, string>? members)
+    {
+        if (members is not null && members.ContainsKey(signedValue))
+            return checked((int)signedValue);
+        return checked((int)unsignedValue);
     }
 }


### PR DESCRIPTION
Part of #916.

## Summary
- Register same-assembly enum shapes nested inside generic type arguments such as `ReadOnlySpan<T>`.
- Extend `RvaSpanPass` to decode same-assembly enum RVA spans when the explicit span length infers element width.
- Raise `System.DateTimeParse::get_DateParsingStates` from an unspellable `<PrivateImplementationDetails>` RVA field constructor to a representable enum span literal.
- Add focused tests for generic-argument enum shape registration and enum RVA span decoding.

## Impact
- Current CoreLib `<PrivateImplementationDetails>` gap bucket drops from 9 to 8.
- Full methods increase from 39498 to 39499.
- Pass bugs remain 0.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- CoreLib `--gaps --max-examples 100`
- CoreLib `--validity-check --compile-cap 10000` with current-main defect-map diff: no gained defect codes; Full malformed remains 0.