### PR TITLE
Reduce cond-target-past-region structuring stops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -73,6 +73,80 @@ public class StructuringDiagnosticsTests
         Assert.Equal("forward-branch-not-region-exit", Assert.Single(diag.Stops));
     }
 
+    [Fact]
+    public void ComparisonTree_PastRegionTerminatingCaseBody_StructuresCleanly()
+    {
+        var function = BuildPastRegionCaseBody(longCaseBody: false);
+
+        var diag = RunWithDiagnostics(function);
+        IrPasses.Run(function);
+
+        Assert.True(diag.Structured > 0);
+        Assert.Empty(diag.Stops);
+        Assert.DoesNotContain(function.Descendants, node => node is Branch or ConditionalBranch);
+    }
+
+    [Fact]
+    public void ComparisonTree_PastRegionCaseBody_TooLarge_StaysFlat()
+    {
+        var function = BuildPastRegionCaseBody(longCaseBody: true);
+
+        var diag = RunWithDiagnostics(function);
+
+        Assert.Equal(0, diag.Structured);
+        Assert.Equal("cond-target-past-region", Assert.Single(diag.Stops));
+    }
+
+    static IrFunction BuildPastRegionCaseBody(bool longCaseBody)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument X() => new(0, "x", intType);
+        Constant C(int value) => new(value, intType);
+
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, X(), C(100)), 20));
+        var falseGuard1 = new Block(4);
+        falseGuard1.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(1)), 32));
+        var falseGuard2 = new Block(8);
+        falseGuard2.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(2)), 32));
+        var falseDefault = new Block(12);
+        falseDefault.Add(new Return(C(10)));
+        var trueArm = new Block(20);
+        trueArm.Add(new Return(C(20)));
+
+        var caseHead = new Block(32);
+        caseHead.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(3)), longCaseBody ? 48 : 40));
+        var caseFalse = new Block(36);
+        caseFalse.Add(new Return(C(31)));
+
+        var blocks = new List<Block> { head, falseGuard1, falseGuard2, falseDefault, trueArm, caseHead, caseFalse };
+        if (longCaseBody)
+        {
+            var p1 = new Block(40);
+            p1.Add(new StoreLocal(0, intType, C(40)));
+            var p2 = new Block(44);
+            p2.Add(new StoreLocal(0, intType, C(44)));
+            var p3 = new Block(48);
+            p3.Add(new StoreLocal(0, intType, C(48)));
+            var p4 = new Block(52);
+            p4.Add(new Return(C(32)));
+            blocks.AddRange([p1, p2, p3, p4]);
+        }
+        else
+        {
+            var caseTrue = new Block(40);
+            caseTrue.Add(new Return(C(32)));
+            blocks.Add(caseTrue);
+        }
+
+        foreach (var block in blocks)
+            container.Add(block);
+
+        var signature = new MethodSignature(intType, [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+    }
+
     [Theory]
     [InlineData(nameof(CfgSampleClass.TripleAnd))]
     [InlineData(nameof(CfgSampleClass.IfAnd))]

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -76,7 +76,7 @@ public class StructuringDiagnosticsTests
     [Fact]
     public void ComparisonTree_PastRegionTerminatingCaseBody_StructuresCleanly()
     {
-        var function = BuildPastRegionCaseBody(longCaseBody: false);
+        var function = BuildPastRegionCaseBody(comparisonTree: true);
 
         var diag = RunWithDiagnostics(function);
         IrPasses.Run(function);
@@ -87,17 +87,17 @@ public class StructuringDiagnosticsTests
     }
 
     [Fact]
-    public void ComparisonTree_PastRegionCaseBody_TooLarge_StaysFlat()
+    public void PastRegionCaseBody_WithoutComparisonTree_StaysFlat()
     {
-        var function = BuildPastRegionCaseBody(longCaseBody: true);
+        var function = BuildPastRegionCaseBody(comparisonTree: false);
 
         var diag = RunWithDiagnostics(function);
 
-        Assert.Equal(0, diag.Structured);
-        Assert.Equal("cond-target-past-region", Assert.Single(diag.Stops));
+        Assert.Contains("cond-target-past-region", diag.Stops);
+        Assert.Contains(function.Descendants, node => node is Branch or ConditionalBranch);
     }
 
-    static IrFunction BuildPastRegionCaseBody(bool longCaseBody)
+    static IrFunction BuildPastRegionCaseBody(bool comparisonTree)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         LoadArgument X() => new(0, "x", intType);
@@ -116,29 +116,15 @@ public class StructuringDiagnosticsTests
         trueArm.Add(new Return(C(20)));
 
         var caseHead = new Block(32);
-        caseHead.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(3)), longCaseBody ? 48 : 40));
+        var caseCondition = new Comparison(ComparisonKind.Equal, false, X(), C(3));
+        caseHead.Add(new ConditionalBranch(comparisonTree ? caseCondition : new LogicalNot(caseCondition), 40));
         var caseFalse = new Block(36);
         caseFalse.Add(new Return(C(31)));
 
         var blocks = new List<Block> { head, falseGuard1, falseGuard2, falseDefault, trueArm, caseHead, caseFalse };
-        if (longCaseBody)
-        {
-            var p1 = new Block(40);
-            p1.Add(new StoreLocal(0, intType, C(40)));
-            var p2 = new Block(44);
-            p2.Add(new StoreLocal(0, intType, C(44)));
-            var p3 = new Block(48);
-            p3.Add(new StoreLocal(0, intType, C(48)));
-            var p4 = new Block(52);
-            p4.Add(new Return(C(32)));
-            blocks.AddRange([p1, p2, p3, p4]);
-        }
-        else
-        {
-            var caseTrue = new Block(40);
-            caseTrue.Add(new Return(C(32)));
-            blocks.Add(caseTrue);
-        }
+        var caseTrue = new Block(40);
+        caseTrue.Add(new Return(C(32)));
+        blocks.Add(caseTrue);
 
         foreach (var block in blocks)
             container.Add(block);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -19,6 +19,7 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>A terminator block longer than this is not inlined as a guard (keeps duplication small).</summary>
     const int MaxTerminatorChildren = 3;
+    const int MaxInlineRegionBlocks = 4;
 
     /// <summary>
     /// Per-container facts precomputed before any mutation: the block list and
@@ -343,6 +344,11 @@ public sealed class StructuringPass : IIrPass
                     }
                     if (target > stop)
                     {
+                        if (CanInlinePastRegionTarget(ctx, target))
+                        {
+                            i++;
+                            break;
+                        }
                         ctx.Recorder?.Record("cond-target-past-region");
                         return false;  // past region = out of slice (the common-exit merge)
                     }
@@ -493,7 +499,102 @@ public sealed class StructuringPass : IIrPass
             if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
                 return false;
         }
+
         return true;
+    }
+
+    static bool CanInlinePastRegionTarget(Ctx ctx, int target)
+        => ctx.IsComparisonTree
+            && !ctx.UnconditionalTargets.Contains(ctx.Blocks[target].StartOffset)
+            && TryBuildPastRegionTarget(ctx, target, out _);
+
+    static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body)
+    {
+        body = null!;
+        int maxStop = Math.Min(ctx.Blocks.Count, target + MaxInlineRegionBlocks);
+        for (int stop = target + 1; stop <= maxStop; stop++)
+        {
+            if (!EndsWithTerminator(ctx.Blocks[stop - 1]))
+                continue;
+
+            var clonedBlocks = new List<Block>(stop - target);
+            for (int i = target; i < stop; i++)
+                clonedBlocks.Add(CloneBlock(ctx.Blocks[i]));
+
+            var inlineCtx = CreateInlineCtx(clonedBlocks);
+            if (!Validate(inlineCtx, 0, clonedBlocks.Count, joinIndex: clonedBlocks.Count, breakTarget: null, continueTarget: null))
+                continue;
+
+            body = BuildRegion(inlineCtx, 0, clonedBlocks.Count, joinIndex: clonedBlocks.Count, breakTarget: null, continueTarget: null);
+            return true;
+        }
+        return false;
+    }
+
+    static bool EndsWithTerminator(Block block)
+        => block.Children.Count > 0 && block.Children[^1] is Return or Throw;
+
+    static Block CloneBlock(Block source)
+    {
+        var clone = new Block(source.StartOffset);
+        foreach (var statement in source.Children)
+            clone.Add(statement.Clone());
+        return clone;
+    }
+
+    static Ctx CreateInlineCtx(IReadOnlyList<Block> blocks)
+    {
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        var unconditionalTargets = new HashSet<int>();
+        var conditionalTargetCounts = new Dictionary<int, int>();
+        var branchTargets = new HashSet<int>();
+        foreach (var block in blocks)
+        {
+            foreach (var child in block.Children)
+            {
+                if (child is Branch branch)
+                {
+                    unconditionalTargets.Add(branch.TargetOffset);
+                    branchTargets.Add(branch.TargetOffset);
+                }
+                else if (child is ConditionalBranch conditional)
+                {
+                    conditionalTargetCounts[conditional.TargetOffset] =
+                        conditionalTargetCounts.GetValueOrDefault(conditional.TargetOffset) + 1;
+                    branchTargets.Add(conditional.TargetOffset);
+                }
+                else if (child is SwitchBranch switchBranch)
+                {
+                    foreach (int target in switchBranch.TargetOffsets)
+                    {
+                        unconditionalTargets.Add(target);
+                        branchTargets.Add(target);
+                    }
+                }
+            }
+        }
+
+        var fallenInto = new HashSet<int>();
+        for (int i = 1; i < blocks.Count; i++)
+            if (FallsThrough(blocks[i - 1]))
+                fallenInto.Add(blocks[i].StartOffset);
+
+        return new Ctx
+        {
+            Blocks = blocks,
+            OffsetToIndex = offsetToIndex,
+            UnconditionalTargets = unconditionalTargets,
+            ConditionalTargetCounts = conditionalTargetCounts,
+            BranchTargets = branchTargets,
+            DroppableTerminators = [],
+            TerminatorSnapshots = new Dictionary<int, IReadOnlyList<IrNode>>(),
+            FallenInto = fallenInto,
+            IsComparisonTree = false,
+            Recorder = null,
+        };
     }
 
     static bool EndsWithBranchTo(Ctx ctx, int blockIndex, int targetIndex)
@@ -743,6 +844,12 @@ public sealed class StructuringPass : IIrPass
                         var exitArm = BuildRegion(ctx, i + 1, stop, joinIndex, breakTarget, continueTarget);
                         result.Add(new IfStatement(Negate(condition), exitArm, null));
                         i = stop;
+                        break;
+                    }
+                    if (target > stop && TryBuildPastRegionTarget(ctx, target, out var pastRegionArm))
+                    {
+                        result.Add(new IfStatement(condition, pastRegionArm, null));
+                        i++;
                         break;
                     }
                     int falseStart = i + 1;


### PR DESCRIPTION
## Summary
- inline small terminating case-body regions reached by comparison-tree conditionals past the current lexical region
- keep the recovery gated to likely comparison trees and non-unconditional merge targets
- add positive and near-miss diagnostics fixtures for the recovered/declined shapes

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops`: `cond-target-past-region` is 420 with 0 pass bugs (down from latest measured 440 before the branch); structured containers 11118

Fixes #912