### PR TITLE
Raise eight-or-more element tuple literals (rest tuples) (#998)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1598,6 +1598,13 @@ public class CfgSampleClass
 
     public static (int Sum, int Product) TuplePair(int a, int b) => (a + b, a * b);
 
+    // An eight-element tuple literal: csc builds it as the nested-TRest form
+    // `new ValueTuple<…T7, ValueTuple<int>>(…, new ValueTuple<int>(h))`, which
+    // TupleCreationPass flattens back to one `(…, h)` literal. Recompiling the
+    // literal rebuilds the same nested construction opcode-exact.
+    public static (int, int, int, int, int, int, int, int) TupleRest(int a)
+        => (a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7);
+
     public static bool TupleValueEquals((int Sum, int Product) left, (int Sum, int Product) right) => left == right;
 
     public static bool TupleValueNotEquals((int Sum, int Product) left, (int Sum, int Product) right) => left != right;

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -75,6 +75,9 @@ public class FidelityGateTests
     /// on a sub-int (char/byte/short) binary result stored into a uint slot —
     /// the cast is a same-width reinterpret that emits no conv, so it recompiles
     /// opcode-exact.
+    /// TupleRest must keep flattening the eight-element nested-TRest construction
+    /// into one `(…)` literal, which recompiles to the same nested ValueTuple
+    /// construction opcode-exact.
     /// OrChainDiamond must keep folding csc's OR-chain diamond (two conditionals to
     /// a shared true arm, the else arm jumping past it to the merge) into one `||`
     /// guard so the structuring pass raises the if/else; the `a < 0 || b < 0` guard
@@ -129,6 +132,7 @@ public class FidelityGateTests
         "AnonSingle",
         "AnonNested",
         "AnonDeepNested",
+        "TupleRest",
         "NthFromEnd",
         "NthFromEndComputed",
         "NthCharFromEnd",

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -23,6 +23,7 @@ public class IdiomShapeScorecardTests
         new("SwitchRaisingPass", nameof(CfgSampleClass.SmallStringSwitch), SyntaxKind.SwitchStatement, [SyntaxKind.GotoStatement]),
         new("SwitchRaisingPass", nameof(CfgSampleClass.ClassifyMode), SyntaxKind.SwitchStatement, [SyntaxKind.IfStatement]),
         new("TupleCreationPass", nameof(CfgSampleClass.TuplePair), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
+        new("TupleCreationPass", nameof(CfgSampleClass.TupleRest), SyntaxKind.TupleExpression, [SyntaxKind.ObjectCreationExpression]),
         new("TupleBinaryOperatorPass", nameof(CfgSampleClass.TupleValueEquals), SyntaxKind.EqualsExpression, [SyntaxKind.ConditionalExpression]),
         new("TupleBinaryOperatorPass", nameof(CfgSampleClass.TupleValueNotEquals), SyntaxKind.NotEqualsExpression, [SyntaxKind.ConditionalExpression]),
         new("AnonymousObjectPass", nameof(CfgSampleClass.AnonShorthand), SyntaxKind.AnonymousObjectCreationExpression, [SyntaxKind.ObjectCreationExpression]),

--- a/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
@@ -37,6 +37,57 @@ public class TupleCreationPassTests
     }
 
     [Fact]
+    public void RestTuple_FlattensNestedConstructionToOneLiteral()
+    {
+        var function = Raised(nameof(CfgSampleClass.TupleRest));
+
+        var tuple = Assert.Single(function.Descendants.OfType<TupleExpression>());
+        Assert.Equal(8, tuple.Elements.Count);
+        // Both the outer ValueTuple`8 and the inner ValueTuple`1 rest are consumed.
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("new ValueTuple", output);
+        Assert.DoesNotContain("ValueTuple<", output);
+    }
+
+    [Fact]
+    public void RestTuple_NonInlineRest_StaysNewObject()
+    {
+        // The eighth argument is a pre-existing ValueTuple value, not an inline
+        // `new ValueTuple<int>(h)` — a hand-written construction, not a literal, so
+        // it must stay a constructor (a literal always builds its rest inline).
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var rest1 = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple`1"), [intType]);
+        var octType = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "ValueTuple`8"),
+            [intType, intType, intType, intType, intType, intType, intType, rest1]);
+        var ctor = new MethodRef(octType, ".ctor", voidType,
+            [intType, intType, intType, intType, intType, intType, intType, rest1], HasThis: false);
+        IrExpression Arg(int i) => new Constant(i, intType);
+        var newObject = new NewObject(ctor,
+            [Arg(1), Arg(2), Arg(3), Arg(4), Arg(5), Arg(6), Arg(7), new LoadArgument(0, "rest", rest1)]);
+        var block = new Block();
+        block.Add(new Return(newObject));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(octType, [new Parameter("rest", rest1)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new TupleCreationPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<TupleExpression>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void ValueTupleConstructor_AsExpressionStatement_StaysNewObject()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -351,11 +351,21 @@ public static class MemberIdentity
         => IsValueTupleType(type, out arity) && arity is >= 2 and <= 7;
 
     public static bool IsValueTupleConstructor(NewObject newObject, out int arity)
+        => IsValueTupleConstructorOfArity(newObject, out arity) && arity is >= 2 and <= 7;
+
+    /// <summary>
+    /// A direct <c>System.ValueTuple&lt;...&gt;</c> constructor of any arity 1-8,
+    /// with the constructor's parameter types matching its type arguments. Arity 8
+    /// is the nested <c>TRest</c> head and arity 1 the innermost rest of an
+    /// eight-or-more-element tuple literal; <see cref="IsValueTupleConstructor"/> is
+    /// the arity 2-7 subset that is itself a complete C# tuple.
+    /// </summary>
+    public static bool IsValueTupleConstructorOfArity(NewObject newObject, out int arity)
     {
         arity = 0;
         var ctor = newObject.Constructor;
         if (ctor.Name != ".ctor"
-            || !IsSupportedValueTupleType(ctor.DeclaringType, out arity)
+            || !IsValueTupleType(ctor.DeclaringType, out arity)
             || ctor.ParameterTypes.Length != arity
             || newObject.Arguments.Count != arity)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -115,7 +115,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static EhStructuringPass TryStatement => new();
     [Completeness(CompletenessLevel.Partial, "tuple-valued `==`/`!=` with hidden ValueTuple operand spills: whole-tuple equality (`left == right`, supported arities 2-7) and arity-2 whole-tuple inequality, the element-literal form (`(a, b) == (c, d)`, any arity, recovered from csc's eager operand spills), and the mixed literal-vs-variable form (`(a, b) == pair`); whole-tuple inequality arity 3+ control-flow forms, nested/rest tuples, and source-named local field comparisons not raised")]
     public static TupleBinaryOperatorPass TupleBinaryOperator => new();
-    [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7; nested TRest/names not recovered")]
+    [Completeness(CompletenessLevel.Partial, "exact BCL ValueTuple constructor arities 2-7, plus the eight-or-more nested-TRest form flattened to one literal; element names not recovered")]
     public static TupleCreationPass TupleCreationExpression => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative UnaryOperator => default!;
     [Completeness(CompletenessLevel.Partial, "reference-type exact BCL IDisposable null-guard, value-type constrained dispose, same-assembly value/ref-struct pattern Dispose(), and runtime-async await using DisposeAsync(); classic async state-machine await using not raised")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleCreationPass.cs
@@ -3,9 +3,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <summary>
 /// Raises direct <c>System.ValueTuple&lt;...&gt;</c> constructor calls into C#
 /// tuple literals. This covers the compiler's ordinary tuple-creation lowering:
-/// <c>(a, b)</c> becomes <c>new ValueTuple&lt;T1, T2&gt;(a, b)</c>. Scoped to
-/// arities 2-7; eight-or-more tuples use the nested <c>TRest</c> representation
-/// and stay as constructors for a later slice.
+/// <c>(a, b)</c> becomes <c>new ValueTuple&lt;T1, T2&gt;(a, b)</c>. Arities 2-7 map
+/// one constructor to one literal; an eight-or-more element tuple uses the nested
+/// <c>TRest</c> representation — <c>(a, …, h)</c> is
+/// <c>new ValueTuple&lt;T1..T7, ValueTuple&lt;T8&gt;&gt;(a, …, g, new ValueTuple&lt;T8&gt;(h))</c>
+/// — which this pass flattens back into one <c>(a, …, h)</c> literal. The rest is
+/// only flattened when it is constructed inline; a non-inline eighth argument (a
+/// pre-existing <c>ValueTuple</c> value) is a hand-written construction, not a
+/// literal, and stays a constructor.
 /// </summary>
 public sealed class TupleCreationPass : IIrPass
 {
@@ -15,16 +20,57 @@ public sealed class TupleCreationPass : IIrPass
     {
         foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
         {
-            if (!MemberIdentity.IsValueTupleConstructor(newObject, out _))
+            // A rest tuple's inner ValueTuple nodes are flattened into their outer
+            // literal, so by the time the snapshot reaches them they are detached.
+            if (newObject.Parent is null || newObject.Parent is ExpressionStatement)
                 continue;
-            if (newObject.Parent is ExpressionStatement)
+            if (TupleLiteralElements(newObject) is not { } elements)
                 continue;
 
-            var elements = newObject.DetachChildren().Cast<IrExpression>().ToList();
+            // Validation is complete and non-mutating; now move the gathered leaf
+            // elements out of their (possibly nested) constructors into the literal.
+            foreach (var element in elements)
+                element.Detach();
             var tuple = new TupleExpression(newObject.Constructor.DeclaringType, elements);
             context.Stepper.StepOver("raise ValueTuple constructor to tuple literal", newObject);
             newObject.ReplaceWith(tuple);
         }
     }
 
+    /// <summary>
+    /// The flattened elements of a tuple-literal construction (arity 2-7, or the
+    /// eight-or-more nested-<c>TRest</c> form), or null when <paramref name="newObject"/>
+    /// is not a complete tuple literal. Pure — gathers element references without
+    /// mutating the tree, so a partial match leaves nothing detached.
+    /// </summary>
+    static List<IrExpression>? TupleLiteralElements(NewObject newObject)
+    {
+        if (!MemberIdentity.IsValueTupleConstructorOfArity(newObject, out int arity) || arity < 2)
+            return null;
+        var elements = new List<IrExpression>();
+        return CollectElements(newObject, arity, elements) ? elements : null;
+    }
+
+    /// <summary>
+    /// Appends one ValueTuple construction's elements in order. Arities 1-7
+    /// contribute their arguments directly; arity 8 contributes its first seven and
+    /// then the nested rest, which must itself be an inline ValueTuple construction
+    /// (csc always builds the rest inline for a literal). False when the rest is not
+    /// inline — a hand-written <c>new ValueTuple&lt;…&gt;(…, restValue)</c>.
+    /// </summary>
+    static bool CollectElements(NewObject newObject, int arity, List<IrExpression> elements)
+    {
+        var arguments = newObject.Arguments;
+        if (arity <= 7)
+        {
+            elements.AddRange(arguments);
+            return true;
+        }
+
+        for (int i = 0; i < 7; i++)
+            elements.Add(arguments[i]);
+        return arguments[7] is NewObject rest
+            && MemberIdentity.IsValueTupleConstructorOfArity(rest, out int restArity)
+            && CollectElements(rest, restArity, elements);
+    }
 }


### PR DESCRIPTION
Part of the **Tuple / deconstruction frontier** row in #998.

## Gap

An 8+-element tuple literal lowers to the nested `TRest` representation — `(a, …, h)` is `new ValueTuple<T1..T7, ValueTuple<T8>>(a, …, g, new ValueTuple<T8>(h))`. `TupleCreationPass` handled arities 2–7 only, leaving these as the raw `new ValueTuple<…, ValueTuple<int>>(…)` constructor (the ledger's "nested TRest not recovered").

## Fix

Flatten the nested-rest construction back into one tuple literal. The recursion handles deeper nesting (15-element = two rest levels). The matcher walks the structure **without mutating**, so a partial match leaves nothing detached.

**Discriminator:** the rest is flattened only when it is built **inline** — csc always constructs a literal's rest inline. A non-inline eighth argument (a pre-existing `ValueTuple` value) is a hand-written `new ValueTuple<…>(…, restValue)`, not a literal, and stays a constructor — the near-miss negative.

`(a, …, h)` re-lowers to the same nested construction, so the round-trip is **opcode-exact**.

## Verification

- Fixtures dumped 8-, 9-, and 15-element tuples → flat `(…)` literals; the non-inline rest stays a constructor.
- Pinned fixture `CfgSampleClass.TupleRest` recompiles **opcode-exact** in the fidelity gate; scorecard positive added (recovers `TupleExpression`, rejects `ObjectCreationExpression`).
- CoreLib validity diff vs `origin/main`: **0 regressed, 0 improved**; **0 fidelity opcode-diffs** on the tuple fixtures.
- Full decompiler suite green (872).

## Changes

- `TupleCreationPass` flattens the nested-`TRest` form (pure validation + extraction).
- New `MemberIdentity.IsValueTupleConstructorOfArity` (arity 1–8 structural validator); `IsValueTupleConstructor` stays the arity 2–7 subset.
- Pinned fixture + scorecard positive + pass-level positive/negative tests; `TupleCreationExpression` ledger note narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)