### PR TITLE
Pin pinned and stackalloc stepper audit

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StepperTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StepperTests.cs
@@ -108,6 +108,49 @@ public class StepperTests
         Assert.Contains(descriptions, d => d.Contains("fold dup", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PinnedLocalAudit_RecordsFixedStatementRewrite()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.SumPinnedArray));
+
+        var stepper = IrPasses.RunWithSteps(function);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+
+        Assert.Contains(descriptions, d => d == "raise pinned locals to fixed statements");
+        var fixedStatement = Assert.Single(function.Descendants.OfType<Fixed>());
+        Assert.Equal("int", fixedStatement.ElementType.ToDisplayString());
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store =>
+            store.Type.Kind == TypeRefKind.Pinned);
+    }
+
+    [Fact]
+    public void PinnedArrayAudit_RecordsFixedArrayRewrite()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.FixedWholeArray));
+
+        var stepper = IrPasses.RunWithSteps(function);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+
+        Assert.Contains(descriptions, d => d == "raise pinned array to fixed statement");
+        var fixedStatement = Assert.Single(function.Descendants.OfType<Fixed>());
+        Assert.Equal("byte", fixedStatement.ElementType.ToDisplayString());
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store =>
+            store.Type.Kind == TypeRefKind.Pinned);
+    }
+
+    [Fact]
+    public void RawStackAllocAudit_RecordsNoStackAllocSpanRewrite()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.StackAllocFirst));
+
+        var stepper = IrPasses.RunWithSteps(function);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+
+        Assert.DoesNotContain(descriptions, d => d == "raise Span-over-stackalloc to stackalloc T[n]");
+        Assert.Single(function.Descendants.OfType<StackAllocate>());
+        Assert.DoesNotContain(function.Descendants.OfType<StackAllocArray>(), _ => true);
+    }
+
     static IEnumerable<Step> Flatten(IEnumerable<Step> steps)
     {
         foreach (var step in steps)


### PR DESCRIPTION
Part of #1011.

## Summary
- Took the **Pinned, volatile, and unsafe locals** stepper semantic audit row.
- Added stepper audit coverage proving fixed-statement rewrites record the expected pinned-local and whole-array pin steps.
- Added a raw stackalloc control proving `StackAllocFirst` keeps `StackAllocate` evidence and does not run the Span/ReadOnlySpan stackalloc raise.

## Phase claim
`FixedStatementPass` may remove pinned locals only after it proves the pinned local, derived pointer, and unpin shape belong to one compiler-owned fixed region; `StackAllocSpanPass` may rewrite stackalloc only for the Span/ReadOnlySpan constructor shape, while raw `StackAllocate` evidence must remain visible for unsafe/lifetime rendering.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.StepperTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
