### PR TITLE
Structure compound-latch while loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1517,6 +1517,18 @@ public class CfgSampleClass
         return i;
     }
 
+    public static int CompoundLatchLoop(int count)
+    {
+        int i = 0;
+        int result = 0;
+        while (i < count && result == 0)
+        {
+            result = i - 3;
+            i++;
+        }
+        return result;
+    }
+
     public static int DoWhileLoop(int n)
     {
         int i = 0;

--- a/src/ILInspector.Decompiler.Tests/CompoundLatchLoopStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompoundLatchLoopStructuringTests.cs
@@ -1,0 +1,91 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CompoundLatchLoopStructuringTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void CompoundLatchLoop_RaisesToWhileLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.CompoundLatchLoop));
+
+        var loop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.IsType<LogicalBinary>(loop.Condition);
+        Assert.Empty(function.Descendants.OfType<Branch>());
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+    }
+
+    [Fact]
+    public void CompoundLatchLoop_PrintsConditionWithoutGotos()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.CompoundLatchLoop)))
+            .Output!
+            .ReplaceLineEndings("\n");
+
+        Assert.Contains("while (i < count && result == 0)", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void CompoundLatchLoop_DeclinesImpureLatchBlock()
+    {
+        var function = ImpureSecondLatchBlock();
+        var diagnostics = new StructuringDiagnostics();
+
+        IrPasses.Run(function, IrPasses.Default, new PassContext(new Stepper(enabled: false), diagnostics));
+
+        Assert.Equal(0, diagnostics.Structured);
+        Assert.Contains("forward-branch-not-region-exit", diagnostics.Stops);
+    }
+
+    static IrFunction ImpureSecondLatchBlock()
+    {
+        LoadArgument Count() => new(0, "count", Int32);
+        LoadLocal I() => new(0, Int32);
+        LoadLocal Result() => new(1, Int32);
+
+        var container = new BlockContainer();
+        var init = new Block(0);
+        init.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        init.Add(new StoreLocal(1, Int32, new Constant(0, Int32)));
+        init.Add(new Branch(16));
+
+        var body = new Block(4);
+        body.Add(new StoreLocal(1, Int32, new Binary(BinaryKind.Subtract, isChecked: false, isUnsigned: false, I(), new Constant(3, Int32))));
+        body.Add(new StoreLocal(0, Int32, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, I(), new Constant(1, Int32))));
+
+        var firstLatch = new Block(16);
+        firstLatch.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.GreaterThanOrEqual, false, I(), Count()), 32));
+
+        var impureSecondLatch = new Block(24);
+        impureSecondLatch.Add(new StoreLocal(2, Int32, new Constant(1, Int32)));
+        impureSecondLatch.Add(new ConditionalBranch(new LogicalNot(Result()), 4));
+
+        var exit = new Block(32);
+        exit.Add(new Return(Result()));
+
+        foreach (var block in (Block[])[init, body, firstLatch, impureSecondLatch, exit])
+            container.Add(block);
+
+        var signature = new MethodSignature(
+            Int32,
+            [new Parameter("count", Int32)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [Int32, Int32, Int32], container);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -57,6 +57,8 @@ public sealed class StructuringPass : IIrPass
         public void Record(string reason) => Reason ??= reason;
     }
 
+    readonly record struct WhileShape(int ContinueAt, ConditionalBranch BackBranch, ConditionalBranch? ExitBranch);
+
     public void Run(IrFunction function, PassContext context)
     {
         if (!function.Regions.IsEmpty)
@@ -281,7 +283,7 @@ public sealed class StructuringPass : IIrPass
                         break;
                     }
                     // csc's guarded while: br COND; BODY...; COND: brtrue BODY.
-                    if (FindWhileShape(blocks, offsetToIndex, i, branchTarget, stop) is { } loop)
+                    if (FindWhileShape(ctx, i, branchTarget, stop) is { } loop)
                     {
                         // The body's breaks target the block after the loop.
                         if (!Validate(ctx, i + 1, branchTarget, joinIndex: branchTarget, breakTarget: loop.ContinueAt, continueTarget))
@@ -400,20 +402,68 @@ public sealed class StructuringPass : IIrPass
     /// block and whose breaks target the block after it (ContinueAt).
     /// Multi-statement condition blocks are outside this slice.
     /// </summary>
-    static (int ContinueAt, ConditionalBranch BackBranch)? FindWhileShape(
-        IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int i, int conditionIndex, int stop)
+    static WhileShape? FindWhileShape(Ctx ctx, int i, int conditionIndex, int stop)
     {
+        var blocks = ctx.Blocks;
+        var offsetToIndex = ctx.OffsetToIndex;
         if (conditionIndex <= i + 1 || conditionIndex >= stop)
             return null;
         var conditionBlock = blocks[conditionIndex];
         if (conditionBlock.Children.Count != 1
-            || conditionBlock.Children[0] is not ConditionalBranch backBranch
-            || !offsetToIndex.TryGetValue(backBranch.TargetOffset, out int bodyStart)
+            || conditionBlock.Children[0] is not ConditionalBranch firstBranch)
+        {
+            return null;
+        }
+        if (offsetToIndex.TryGetValue(firstBranch.TargetOffset, out int bodyStart)
+            && bodyStart == i + 1)
+        {
+            return new WhileShape(conditionIndex + 1, firstBranch, ExitBranch: null);
+        }
+
+        // Compound latch: init jumps to the first latch test; that test exits,
+        // and the adjacent second test is the only branch back to the loop body.
+        // This is csc's `while (a && b)` latch shape. Requiring single-statement
+        // latch blocks keeps side effects in their original condition terms and
+        // rejects latch blocks with extra work that cannot be folded into `&&`.
+        int secondConditionIndex = conditionIndex + 1;
+        if (secondConditionIndex >= stop
+            || !offsetToIndex.TryGetValue(firstBranch.TargetOffset, out int exitIndex)
+            || exitIndex != secondConditionIndex + 1)
+        {
+            return null;
+        }
+
+        var secondBlock = blocks[secondConditionIndex];
+        if (secondBlock.Children.Count != 1
+            || secondBlock.Children[0] is not ConditionalBranch backBranch
+            || !offsetToIndex.TryGetValue(backBranch.TargetOffset, out bodyStart)
             || bodyStart != i + 1)
         {
             return null;
         }
-        return (conditionIndex + 1, backBranch);
+
+        return CountBranchTargets(ctx, bodyStart) == 1
+            ? new WhileShape(exitIndex, backBranch, firstBranch)
+            : null;
+    }
+
+    static int CountBranchTargets(Ctx ctx, int targetIndex)
+    {
+        int targetOffset = ctx.Blocks[targetIndex].StartOffset;
+        int count = 0;
+        foreach (var block in ctx.Blocks)
+        {
+            foreach (var child in block.Children)
+            {
+                if (child is Branch branch && branch.TargetOffset == targetOffset)
+                    count++;
+                else if (child is ConditionalBranch conditional && conditional.TargetOffset == targetOffset)
+                    count++;
+                else if (child is SwitchBranch switchBranch)
+                    count += switchBranch.TargetOffsets.Count(offset => offset == targetOffset);
+            }
+        }
+        return count;
     }
 
     /// <summary>
@@ -697,10 +747,10 @@ public sealed class StructuringPass : IIrPass
                         i = stop;
                         break;
                     }
-                    if (FindWhileShape(blocks, offsetToIndex, i, branchTarget, stop) is { } loop)
+                    if (FindWhileShape(ctx, i, branchTarget, stop) is { } loop)
                     {
                         var body = BuildRegion(ctx, i + 1, branchTarget, joinIndex: branchTarget, breakTarget: loop.ContinueAt, continueTarget);
-                        var condition = (IrExpression)loop.BackBranch.DetachChildren()[0];
+                        var condition = BuildWhileCondition(loop);
                         result.Add(new WhileLoop(condition, body));
                         i = loop.ContinueAt;
                         break;
@@ -776,6 +826,16 @@ public sealed class StructuringPass : IIrPass
             }
         }
         return result;
+    }
+
+    static IrExpression BuildWhileCondition(WhileShape loop)
+    {
+        var backCondition = (IrExpression)loop.BackBranch.DetachChildren()[0];
+        if (loop.ExitBranch is null)
+            return backCondition;
+
+        var exitCondition = (IrExpression)loop.ExitBranch.DetachChildren()[0];
+        return new LogicalBinary(LogicalKind.And, Negate(exitCondition), backCondition);
     }
 
     /// <summary>Negation delegates to the shared type-aware duals (see <see cref="Conditions"/>).</summary>


### PR DESCRIPTION
## Summary

- Recognize csc's adjacent two-test loop latch shape as a structured `while (a && b)` condition.
- Keep the matcher narrow: both latch blocks must be single conditional branches, the first exits, the second is the only branch back to the body.
- Add focused positive and near-miss fixtures for compound-latch loop structuring.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --dump 'System.Array::System.Collections.IStructuralComparable.CompareTo'`
- `dotnet run --project tools/DecompilerHarness -c Release -- --dump 'System.Array::System.Collections.IStructuralComparable.CompareTo' --cfg --remarks`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 5`

Base comparison against `origin/main` `1e4fe34`: fully raised improves from 39,427 to 39,471; loop-residue drops from 561 to 516; pass bugs remain 0.

Fixes #1005.
