### PR TITLE
Raise init-only local inline-array span casts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -7,6 +7,7 @@ public class InlineArrayElementRefPassTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Buffer = TypeRef.Definition("UserAssembly", "Samples", "Inline4", ValueTypeHint.ValueType);
+    static readonly TypeRef SpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [Int32]);
 
     [Fact]
     public void FirstElementRef_RaisesToInlineArrayIndexAddress()
@@ -45,6 +46,31 @@ public class InlineArrayElementRefPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void InitOnlyLocalBufferAsSpan_RaisesToCast()
+    {
+        var function = LocalBufferAsSpan(includeElementStore: false);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsSpan");
+        Assert.Contains("(Span<int>)V_0", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void LocalBufferWithElementRefStore_StaysOutOfPlaceConversion()
+    {
+        var function = LocalBufferAsSpan(includeElementStore: true);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsSpan");
+        function.CheckInvariant();
+    }
+
     static IrFunction StoreThroughHelper(MethodRef helper, IReadOnlyList<IrExpression> arguments)
     {
         var block = new Block();
@@ -63,11 +89,37 @@ public class InlineArrayElementRefPassTests
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
     }
 
+    static IrFunction LocalBufferAsSpan(bool includeElementStore)
+    {
+        var block = new Block();
+        block.Add(new InitObject(Buffer, new LoadLocalAddress(0, Buffer)));
+        if (includeElementStore)
+        {
+            block.Add(new StoreIndirect(
+                Int32,
+                new Call(Helper("InlineArrayElementRef", [TypeRef.ByRef(Buffer), Int32]), isVirtual: false,
+                    [new LoadLocalAddress(0, Buffer), new Constant(0, Int32)]),
+                new LoadArgument(0, "value", Int32)));
+        }
+        block.Add(new StoreLocal(1, SpanInt, new Call(
+            Helper("InlineArrayAsSpan", [TypeRef.ByRef(Buffer), Int32], SpanInt),
+            isVirtual: false,
+            [new LoadLocalAddress(0, Buffer), new Constant(4, Int32)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(Void, [new Parameter("value", Int32)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [Buffer, SpanInt], body);
+    }
+
     static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes)
+        => Helper(name, parameterTypes, TypeRef.ByRef(Int32));
+
+    static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes, TypeRef returnType)
         => new(
             TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
             name,
-            TypeRef.ByRef(Int32),
+            returnType,
             [.. parameterTypes],
             HasThis: false)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -87,20 +87,22 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// <summary>
     /// Raises a direct inline-array span conversion — an
     /// <c>InlineArrayAsSpan</c>/<c>InlineArrayAsReadOnlySpan</c> over a
-    /// pre-existing inline-array <em>place</em> (a field, parameter, or array
-    /// element) — to a C# cast <c>(Span&lt;T&gt;)place</c>. This is the
+    /// pre-existing inline-array <em>place</em> (a field, parameter, array
+    /// element, or init-only local buffer) — to a C# cast
+    /// <c>(Span&lt;T&gt;)place</c>. This is the
     /// complement of the collection-expression recovery above: there is no
     /// synthesized buffer to fold, just an <c>[InlineArray(N)]</c> location an
     /// implicit/explicit span conversion was applied to (e.g.
     /// <c>BitVector256.Set</c> viewing its <c>_values</c> field as a
     /// <c>Span&lt;uint&gt;</c>).
     ///
-    /// <para>Scoped to field/parameter/array-element places — a
-    /// <see cref="LoadLocalAddress"/> is never matched, so a synthesized
-    /// collection temporary whose full shape the loop above declined can never
-    /// be mis-raised here. The span the call produced is the cast's target type,
-    /// so replacing the call leaves the surrounding type unchanged and the
-    /// compiler re-lowers the cast to the same AsSpan call.</para>
+    /// <para>Scoped to field/parameter/array-element places, plus locals that are
+    /// only default-initialized and never written through
+    /// <c>InlineArrayElementRef</c>. That keeps synthesized collection-expression
+    /// temporaries disjoint from this direct-conversion path. The span the call
+    /// produced is the cast's target type, so replacing the call leaves the
+    /// surrounding type unchanged and the compiler re-lowers the cast to the same
+    /// AsSpan call.</para>
     /// </summary>
     static void RaisePlaceConversions(IrFunction function, PassContext context)
     {
@@ -110,14 +112,13 @@ public sealed class InlineArrayCollectionPass : IIrPass
                 continue;
             if (!IsPrivateImpl(span.Callee, "InlineArrayAsReadOnlySpan") && !IsPrivateImpl(span.Callee, "InlineArrayAsSpan"))
                 continue;
-            if (span.Callee.TypeArguments is not [_, _])
+            if (span.Callee.TypeArguments is not [var arrayType, _])
                 continue;
             if (span.ResultType is not { } spanType)
                 continue;
-            // A field, parameter, or array element — never a local. The
-            // collection-expression buffer is always a local, so excluding
-            // LoadLocalAddress keeps the two recoveries disjoint.
-            if (span.Arguments is not [LoadFieldAddress or LoadArgumentAddress or LoadElementAddress, Constant { Value: int }])
+            if (span.Arguments is not [var placeCandidate, Constant { Value: int }])
+                continue;
+            if (!CanRaisePlaceConversion(function, placeCandidate, arrayType))
                 continue;
 
             var place = (IrExpression)span.DetachChildren()[0];
@@ -125,6 +126,30 @@ public sealed class InlineArrayCollectionPass : IIrPass
             context.Stepper.StepOver("raise inline-array span conversion to cast", span);
             span.ReplaceWith(conversion);
         }
+    }
+
+    static bool CanRaisePlaceConversion(IrFunction function, IrExpression place, TypeRef arrayType)
+        => place switch
+        {
+            LoadFieldAddress or LoadArgumentAddress or LoadElementAddress => true,
+            LoadLocalAddress local => local.Type.Equals(arrayType) && IsInitOnlyLocalBuffer(function, local.Index),
+            _ => false,
+        };
+
+    static bool IsInitOnlyLocalBuffer(IrFunction function, int local)
+    {
+        if (function.Descendants.OfType<LoadLocal>().Any(load => load.Index == local)
+            || function.Descendants.OfType<StoreLocal>().Any(store => store.Index == local)
+            || function.Descendants.OfType<Call>().Any(call =>
+                IsInlineArrayElementRef(call.Callee, out _, out _)
+                && call.Arguments.FirstOrDefault() is LoadLocalAddress address
+                && address.Index == local))
+        {
+            return false;
+        }
+
+        return function.Descendants.OfType<InitObject>()
+            .Count(init => init.Address is LoadLocalAddress address && address.Index == local) == 1;
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #916.

## Summary
- Allow direct `InlineArrayAsSpan` / `InlineArrayAsReadOnlySpan` conversions over init-only local inline-array buffers.
- Keep locals written through `InlineArrayElementRef*` out of this place-conversion path, so collection-expression temporaries and mixed BigInteger validity-risk bodies stay Partial.
- Add focused positive and negative pass tests.

## Impact
- Current CoreLib `<PrivateImplementationDetails>` gap bucket drops from 9 to 8 by raising `System.Array::FindAll`.
- Full methods increase from 39498 to 39499.
- Pass bugs remain 0.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- CoreLib `--gaps --max-examples 100`
- CoreLib `--validity-check --compile-cap 10000` with current-main defect-map diff: no gained defect codes; Full malformed remains 0.