### PR TITLE
Clarify member source views

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ dotnet-inspect project ./src/App --agents-index --jsonl
 dotnet-inspect project ./src/App --readme Markout
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Audit` expand to scenario-focused section groups.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Source` and `@Audit` expand to scenario-focused section groups.
 
 ## Common examples
 
@@ -139,7 +139,7 @@ dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize -S "Member Index"
-dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
+dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S @Source
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Callers
 dotnet-inspect member string IndexOf:7 -S Callers --caller-package System.Text.Json@9.0.0 --tfm net9.0

--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -54,9 +54,9 @@ family is registering one classifier; the core does not change.
 
 Three projections share one classification pass:
 
-- **Decompiled Source** — the mixed view: C# primary, hidden-fact comments to the
+- **Annotated Source** — the mixed view: C# primary, hidden-fact comments to the
   right of each statement, and the annotated IL interleaved beneath. The default
-  human view (normal verbosity for a selected overload).
+  human view when exact IL context matters.
 - **Annotated IL** — the IL projection with the same facts attached by offset.
 - **Facts** — the structured table (id, category, detail, conditionality, IL
   offset), the agent-facing dual. `ExplicitOnly`: never auto-renders, requested

--- a/docs/design/info-view.md
+++ b/docs/design/info-view.md
@@ -25,7 +25,7 @@ Sections are stable content units. Presets decide where those sections appear. T
 | --- | --- | --- | --- |
 | `package X` | What is this package, and what does it ship? | `Package Info`, `Library Files` | Identity/metadata plus asset shape answer most package triage questions without a dependency inventory. |
 | `library X` | What is this assembly, and what dense metadata signals are present? | `Library Info` | Library Info includes identity plus counts for large metadata lists, avoiding noisy inventories while signaling what exists. |
-| selected `member Type.Member:N` | What is this overload, and what does it do? | `Signature`, `Decompiled Source` | Contract plus readable implementation usually answers the first implementation question without IL or SourceLink source. |
+| selected `member Type.Member:N` | What is this overload, and what does it do? | `Signature`, `Decompiled Source` | Contract plus readable raised C# usually answers the first implementation question without IL or SourceLink source. |
 | `type Type` or broad `member Type` list view | What API member groups are in this type space? | Member summary sections (`Constructors`, `Properties`, `Method Groups`, etc.) | Compact per-member-kind summaries show return types and overload counts without full signatures. |
 | `member Type -m Name` | Which overloads exist for this logical member? | `Methods` or the matching member-kind section | The query is already narrowed to one member name, so overload rows with signatures are the bounded high-value answer. |
 

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -45,7 +45,7 @@ For package, library, and selected-overload member output, focused selected sect
 
 Bare `-S` is command/context-specific shorthand for `-S @Default`: package uses `Package Info` and `Library Files`; library uses `Library Info`; type and broad member list views use compact member summaries such as `Method Groups`; member-name views use `Methods` overload rows; selected member overloads use `Signature` and `Decompiled Source`. See [Bare `-S` default view](info-view.md) for the bullseye question each preset is meant to answer.
 
-For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (a mixed view: lowered C# with hidden-fact comments — allocations, unsafety, lifetime — and the IL interleaved beneath each statement) and `Recovered IL` (raw IL). `Original Source` is SourceLink-backed source text for one method, so it is enabled by detailed verbosity or explicit `-S`. The structured dual of `Decompiled Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
+For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments, and `Original Source` is SourceLink-backed source text for one method; both render via explicit `-S` (or `-S @Source` for source views). The structured dual of `Annotated Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
 
 ## Discovery
 

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -71,8 +71,9 @@ Library signals describe assemblies: SourceLink presence/reachability, PDB/symbo
 ## Fidelity expectations
 
 - `Original Source` is SourceLink-backed original source when available.
-- `Decompiled Source` is lowered C#, a best-effort readable reconstruction from IL; it may use PDB debug names when available.
-- Raw IL and annotated IL are the highest-fidelity views for exact instructions, offsets, branches, tokens, and calls.
+- `Decompiled Source` is raised C#, a best-effort readable reconstruction from IL; it may use PDB debug names when available.
+- `Annotated Source` is raised C# with hidden-fact comments and interleaved IL.
+- `Recovered IL` and `Annotated Source` are the highest-fidelity views for exact instructions, offsets, branches, tokens, and calls.
 
 ## Skill guidance
 

--- a/docs/workflows/core/member-lookup-docs-code.md
+++ b/docs/workflows/core/member-lookup-docs-code.md
@@ -145,7 +145,7 @@ Tips:
 
 ## 3. View member implementation code
 
-> Goal: When selecting a specific member, discover and select implementation sections: lowered C# (`Decompiled Source`), SourceLink-backed source (`Original Source`), and IL.
+> Goal: When selecting a specific member, discover and select implementation sections: raised C# (`Decompiled Source`), mixed C#+IL (`Annotated Source`), SourceLink-backed source (`Original Source`), and IL.
 
 ### 3a. Single member (no overloads)
 
@@ -270,15 +270,15 @@ Tips:
 
 ## 8. View IL disassembly
 
-> Goal: See raw IL with resolved tokens, plus the mixed Decompiled Source view
+> Goal: See raw IL with resolved tokens, plus the mixed Annotated Source view
 > (C# with hidden-fact comments and the IL interleaved beneath each statement).
 
 ```bash
-dotnet-inspect member --package System.CommandLine Command SetAction:2 -v:n -n 80
+dotnet-inspect member --package System.CommandLine Command SetAction:2 -S "Annotated Source,Recovered IL" -n 80
 ```
 
 ```expect
-## Decompiled Source
+## Annotated Source
 // alloc.closure
 // IL_0000: newobj
 ```

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -17,7 +17,7 @@ Verbosity levels:
 | Minimal (default) | (none) | H1, description, metadata field list, one section table | Yes |
 | Detailed | `-v:d` | H1, description, metadata field list, all sections | No |
 
-The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (a mixed view: lowered C# with hidden-fact comments and the IL interleaved beneath each statement) and `Recovered IL` (raw IL). Detailed verbosity adds `Original Source` when SourceLink-backed source is available. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
+The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
 
 Section selection (`-S`, with lowercase `-s` as an alias) lists available sections or filters to specific ones. Tips are suppressed when sections are selected. `--count` with exactly one selected section returns a single integer.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.10.5
+version: 0.12.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/symbol provenance, and version-to-version API changes.
 ---
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,8 +25,8 @@ dnx dotnet-inspect -y -- <command>
 | Inspect a type | `type Type --package Foo` | Add `--all` for non-public, hidden, and extra members. |
 | Inspect members and overloads | `member Type --package Foo -m Name` | Add `-S "Member Index"` or `--show-index` for copyable `Name:N` and digest selectors. |
 | Compare API versions | `diff --package Foo@old..new --breaking` | Use `--additive` for new APIs or `-t Type` to narrow. |
-| Locate source or implementation | `source Type --package Foo` | For a selected overload use `member Type Member:1 -S "Original Source"`, `-S Calls`, `-S Callers`, `-S "Call Graph"`, or `-S "Recovered IL"`. |
-| Audit unsafe calls | `library MyLib.dll -S @Audit` | Drill into a selected member with `member Type Method:N --library MyLib.dll -S @Audit`. |
+| Locate source or implementation | `source Type --package Foo` | For a selected overload use `member Type Member:1 -S @Source`, `-S Calls`, `-S Callers`, `-S "Call Graph"`, or `-S "Recovered IL"`. |
+| Audit unsafe calls | `library MyLib.dll -S @Audit` | Drill into a selected member with `member Type Method:N --library MyLib.dll -S "Unsafe Operations,Recovered IL"`. |
 | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` | Add package, platform, or project scope as needed. |
 
 ## Output modes
@@ -59,7 +59,7 @@ dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --count
 dnx dotnet-inspect -y -- library System.Text.Json -S "Async*" --rows -n 10
 ```
 
-`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Workflow categories such as `@Audit`, plus focused categories such as `@Integrations` and `@Switches`, expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
+`@` represents a category or grouping of sections. Bare `-S` renders `@Default`, a curated high-density view; `-S @All` renders an exhaustive document with all sections. Workflow categories such as `@Source`, plus focused categories such as `@Audit`, `@Integrations`, and `@Switches`, expand to related sections. Sections marked opt-in must be selected explicitly with `-S`. Focused library/member `-S Section` output keeps a compact context row before the selected section.
 
 ## General tips
 
@@ -118,11 +118,11 @@ dnx dotnet-inspect -y -- diff --platform System.Runtime@9.0.0..10.0.0 --additive
 
 ## Source and implementation workflow
 
-Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S "Decompiled Source"` when you need a selected member's reconstructed C# body — idiomatically raised (`for`/`lock`/`++`) and annotated with hidden-fact comments (allocations, unsafety, lifetime) and the IL interleaved beneath each statement — `-S "Lowered Source"` for the de-sugared (SharpLab-style) C# instead, `-S "Original Source"` for SourceLink-backed source text, `-S Calls` for direct call-site evidence, `-S Callers` for the reverse edges (methods that call the selected member; defaults to the member's own assembly, widen with `--bin <dir>` / `--project <proj>` / `--caller-package <pkg>` for cross-assembly callers), `-S "Call Graph"` for the bounded outbound call tree (callees, depth/node-capped, in-assembly), `-S "Unsafe*"` for unsafe API-member and operation evidence, `-S "Recovered IL"` for raw IL, or `-S "Facts"` for the hidden facts as a structured table (`--tsv` for agents).
+Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S @Source` when you want all source views for a selected overload: `Decompiled Source` (best-effort raised C# without IL comments), `Annotated Source` (the same raised C# with hidden-fact comments and IL interleaved beneath each statement), `Lowered Source` (de-sugared SharpLab-style C# without IL comments), and `Original Source` (SourceLink-backed source text when available). Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (defaults to the member's own assembly, widen with `--bin <dir>` / `--project <proj>` / `--caller-package <pkg>`), `-S "Call Graph"` for the bounded outbound call tree, `-S "Unsafe*"` for unsafe API-member and operation evidence, `-S "Recovered IL"` for raw IL, or `-S "Facts"` for hidden facts as a structured table (`--tsv` for agents).
 
 ```bash
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S "Decompiled Source"
+dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S @Source
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
 dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serialize:1 -S Callers
 dnx dotnet-inspect -y -- member string IndexOf:7 -S Callers --caller-package System.Text.Json@9.0.0 --tfm net9.0
@@ -131,7 +131,7 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serial
 dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
 ```
 
-A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `Original Source` or `Recovered IL` when you need specific implementation evidence. The four code views are `Decompiled Source` (annotated, idiomatically-raised C# with interleaved IL), `Lowered Source` (the de-sugared SharpLab-style C# — `for`/`lock`/`++` shown as their underlying `while`, `Monitor.Enter`/`try…finally`, explicit-increment shapes; opt-in via `-S "Lowered Source"` or `-v:d`), `Recovered IL` (raw IL), and `Original Source` (SourceLink-backed original C#).
+A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `@Source`, `Annotated Source`, `Original Source`, or `Recovered IL` when you need specific implementation evidence. The code views are `Decompiled Source` (raised C# without IL comments), `Annotated Source` (raised C# with hidden-fact comments and interleaved IL), `Lowered Source` (de-sugared SharpLab-style C# without IL comments), `Recovered IL` (raw IL), and `Original Source` (SourceLink-backed original C#).
 
 When `Decompiled Source` looks wrong and you need to see *how* the decompiler raised IL to C#, dump the per-pass IR pipeline (JitDump-style) with `--dump-stages` (or `-S "IR (Stages)"`): it prints the typed IR tree after import and after each raising pass, so you can spot which pass introduced a defect. Like the other code sections it needs a selected overload (`Name:N` or `Name~digest` from Member Index), and it is a deep decompiler-debugging view — not a normal lookup path. To learn how to read the dump, see [Reading IR Dumps](https://github.com/richlander/dotnet-inspect/blob/main/docs/decompiler-ir-dumps.md).
 
@@ -145,7 +145,7 @@ To read a whole type instead of one member, use `type Name -S "Decompiled Source
 dnx dotnet-inspect -y -- type Stack --platform System.Collections -S "Decompiled Source" --raw > Stack.cs
 ```
 
-Fidelity expectations: `Original Source` is the SourceLink-backed original source when available. `Decompiled Source` is a best-effort readable C# reconstruction from IL, idiomatically raised, that helps explain intent; it uses PDB debug information such as local names when available, but is not guaranteed to match original syntax or compiler transformations. `Lowered Source` is the same reconstruction with the cosmetic statement-sugar passes declined — the de-sugared (SharpLab-style) shape. `Recovered IL` and the interleaved IL in `Decompiled Source` are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
+Fidelity expectations: `Original Source` is SourceLink-backed original source when available. `Decompiled Source` is a best-effort readable C# reconstruction from IL, idiomatically raised, that helps explain intent; it may use PDB local names but is not guaranteed to match original syntax or compiler transformations. `Lowered Source` is the same reconstruction with cosmetic statement-sugar passes declined. `Annotated Source` and `Recovered IL` are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.
 
@@ -155,11 +155,11 @@ Start with the library/type roll-up, then drill into a selected overload for exa
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
-dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S @Audit
+dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S "Unsafe Operations,Recovered IL"
 dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S "Calls,Recovered IL"
 ```
 
-At library/type scope, `@Audit` surfaces unsafe members, P/Invoke, and switch evidence. On a selected member, `@Audit` expands to signature, direct calls, unsafe operations, and `Recovered IL`; use the IL offsets and metadata tokens to confirm the exact binary evidence.
+At library/type scope, `@Audit` surfaces unsafe members, P/Invoke, and switch evidence. On a selected member, choose exact evidence sections such as `Unsafe Operations`, `Calls`, `Callers`, and `Recovered IL`; use the IL offsets and metadata tokens to confirm the exact binary evidence.
 
 ## Package, library, integrations, and Signals workflow
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1706,6 +1706,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("| Signature | section |", output);
         Assert.Contains("| Decompiled Source | section |", output);
+        Assert.Contains("| Annotated Source | section (opt-in) |", output);
         Assert.Contains("| Original Source | section |", output);
         Assert.Contains("| Recovered IL | section |", output);
         // Call Graph is opt-in, so it is listed with an opt-in annotation and the @All hint appears.
@@ -1738,7 +1739,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_SelectedOverload_SelectDecompiledSource_RendersMixedView()
+    public async Task Member_SelectedOverload_SelectDecompiledSource_RendersPlainCSharp()
     {
         var options = new MemberOptions
         {
@@ -1754,9 +1755,27 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("## Decompiled Source", output);
-        // The Decompiled Source view is C#-primary (a csharp fence) with the
-        // annotated IL interleaved beneath each statement as `// IL_xxxx:`
-        // comment lines.
+        Assert.Contains("```csharp", output);
+        Assert.DoesNotMatch(@"// IL_[0-9A-Fa-f]{4}: ", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_SelectAnnotatedSource_RendersMixedView()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToElement" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Annotated Source" }
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Annotated Source", output);
         Assert.Contains("```csharp", output);
         Assert.Matches(@"// IL_[0-9A-Fa-f]{4}: ", output);
     }
@@ -1825,7 +1844,7 @@ public class CommandExecutionTests
             () => MemberCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        // Facts is opt-in: the inline Decompiled Source view shows the same facts
+        // Facts is opt-in: the inline Annotated Source view shows the same facts
         // for humans, so the structured table never auto-renders, even at -v:d.
         Assert.DoesNotContain("## Facts", output);
     }
@@ -1850,6 +1869,7 @@ public class CommandExecutionTests
         Assert.Contains("## Custom Attributes", output);
         Assert.Contains("## Decompiled Source", output);
         Assert.Contains("## Recovered IL", output);
+        Assert.DoesNotContain("## Annotated Source", output);
         Assert.DoesNotContain("## Original Source", output);
         // WriteNode<TValue>'s first parameter is `in TValue`; the call site
         // passes it without a keyword (an explicit `ref` here is CS1615). The

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1354,18 +1354,18 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void ApiMemberDetailPipeline_AuditCategory_MapsToSelectedMemberEvidenceSections()
+    public void ApiMemberDetailPipeline_SourceCategory_MapsToSourceViews()
     {
         var categories = ApiMemberDetailSectionDescriptors.CreatePipeline().GetCategoryMap();
 
+        Assert.DoesNotContain(SectionCategoryNames.Audit, categories.Keys);
         Assert.Equal(
             [
-                SectionNames.Signature,
-                SectionNames.Calls,
-                SectionNames.Callers,
-                SectionNames.UnsafeOperations,
-                SectionNames.IL
+                SectionNames.DecompiledSource,
+                SectionNames.AnnotatedSource,
+                SectionNames.LoweredSource,
+                SectionNames.OriginalSource
             ],
-            categories[SectionCategoryNames.Audit]);
+            categories[SectionCategoryNames.Source]);
     }
 }

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -48,7 +48,7 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
-    public async Task MemberAuditCategory_RendersSelectedMemberEvidenceSections()
+    public async Task MemberAuditCategory_IsNotAvailableForSelectedMember()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -62,11 +62,8 @@ public class UnsafeMembersSectionTests
             FormatExplicitlySet = true,
         }));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Contains("## Signature", result.Output);
-        Assert.Contains("## Unsafe Operations", result.Output);
-        Assert.Contains("## Recovered IL", result.Output);
-        Assert.DoesNotContain("## Decompiled Source", result.Output);
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("@Audit", result.Error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -673,6 +673,8 @@ public class ApiCommand
                 ? included.First() switch
                 {
                     SectionNames.DecompiledSource => view.MemberCode?.DecompiledSourceCode.Content,
+                    SectionNames.AnnotatedSource => view.MemberCode?.AnnotatedSourceCode.Content,
+                    SectionNames.LoweredSource => view.MemberCode?.LoweredSourceCode.Content,
                     SectionNames.OriginalSource => view.MemberCode?.OriginalSourceCode.Content,
                     SectionNames.IL => view.MemberCode?.ILCode.Content,
                     SectionNames.IRStages => view.MemberCode?.IRStages.Content,
@@ -682,7 +684,7 @@ public class ApiCommand
             if (raw is null)
             {
                 Console.Error.WriteLine(
-                    "Error: --raw requires a single -S code section with content (Decompiled Source, Recovered IL, Original Source).");
+                    "Error: --raw requires a single -S code section with content (Decompiled Source, Annotated Source, Lowered Source, Recovered IL, Original Source).");
                 return;
             }
             sink.WriteLine(raw.TrimEnd());

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -416,6 +416,7 @@ public static class MemberCommand
         return sections.Contains(SectionNames.Signature)
                || sections.Contains(SectionNames.CustomAttributes)
                || sections.Contains(SectionNames.DecompiledSource)
+               || sections.Contains(SectionNames.AnnotatedSource)
                || sections.Contains(SectionNames.OriginalSource)
                || sections.Contains(SectionNames.Calls)
                || sections.Contains(SectionNames.Callers)
@@ -460,6 +461,8 @@ public static class MemberCommand
                              || options.Verbosity >= Verbosity.Detailed;
         return pdbAuthorized
                && (sections.Contains(SectionNames.DecompiledSource)
+                   || sections.Contains(SectionNames.AnnotatedSource)
+                   || sections.Contains(SectionNames.LoweredSource)
                    || sections.Contains(SectionNames.Facts));
     }
 }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
+using ILInspector.Decompiler.Pipeline;
 
 using Decompiler = ILInspector.Decompiler;
 
@@ -15,7 +16,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Stages = false, bool Facts = false, bool LoweredSource = false);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Stages = false, bool Facts = false, bool LoweredSource = false);
 
     /// <summary>
     /// Code content for one member. Body and diagnostic are mutually
@@ -26,6 +27,8 @@ internal static class MemberCodeProvider
         string? LoweredBody,
         string? LoweredDiagnostic,
         IReadOnlyList<string>? MethodGenericParameters,
+        string? AnnotatedBody,
+        string? AnnotatedDiagnostic,
         string? ILText,
         string? ILDiagnostic,
         IReadOnlyList<(string Name, string? Value)>? Attributes,
@@ -98,35 +101,41 @@ internal static class MemberCodeProvider
             var methodGenericParameters = MethodGenericParameterNames(
                 reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
 
-            // Decompiled source: the annotated C# view — the method raised to C#
-            // with hidden-fact comments and the recovered IL interleaved beneath
-            // each statement. A null/empty render means no body (abstract/extern)
-            // or an import failure, which surfaces as a diagnostic. Render never
-            // throws.
+            // Decompiled source: raised C# only, without annotations or interleaved IL.
             string? loweredBody = null, loweredDiagnostic = null;
             Decompiler.DecompilerTrace? decompileTrace = null;
             if (request.DecompiledSource && pipelineSource is not null)
+            {
+                var result = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Raised, lookupOverloadIndex, publicOnly);
+                decompileTrace = new Decompiler.DecompilerTrace(result.Fidelity, pipelineSource.Symbols, result.Diagnostics);
+                if (result.Output is { } plain)
+                    loweredBody = plain.TrimEnd();
+                else
+                    loweredDiagnostic = DiagnosticComment(result);
+            }
+
+            // Annotated source: raised C# with hidden-fact comments and the
+            // recovered IL interleaved beneath each statement.
+            string? annotatedBody = null, annotatedDiagnostic = null;
+            if (request.AnnotatedSource && pipelineSource is not null)
             {
                 var result = Decompiler.Annotations.MixedSourceRenderer.Render(
                     pipelineSource, lookupType, method.Name, lookupOverloadIndex, publicOnly);
                 decompileTrace = result.Trace;
                 if (result.Output is { } annotated)
-                    loweredBody = annotated.TrimEnd();
+                    annotatedBody = annotated.TrimEnd();
                 else
-                    loweredDiagnostic = DiagnosticComment(result);
+                    annotatedDiagnostic = DiagnosticComment(result);
             }
 
-            // Lowered C# view (issue #636): the same mixed-source renderer at the
-            // lowered altitude — the cosmetic statement-sugar passes are declined,
-            // surfacing the de-sugared shape. Reuses the fact-comment and
-            // interleaved-IL infra of the decompiled-source view.
+            // Lowered C# view (issue #636): plain C# at the lowered altitude —
+            // the cosmetic statement-sugar passes are declined, surfacing the
+            // de-sugared shape without annotation or IL comments.
             string? loweredSourceBody = null, loweredSourceDiagnostic = null;
             if (request.LoweredSource && pipelineSource is not null)
             {
-                var result = Decompiler.Annotations.MixedSourceRenderer.Render(
-                    pipelineSource, lookupType, method.Name,
-                    Decompiler.Annotations.AnnotationStage.Lowered, lookupOverloadIndex, publicOnly);
-                decompileTrace ??= result.Trace;
+                var result = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Lowered, lookupOverloadIndex, publicOnly);
+                decompileTrace ??= new Decompiler.DecompilerTrace(result.Fidelity, pipelineSource.Symbols, result.Diagnostics);
                 if (result.Output is { } loweredText)
                     loweredSourceBody = loweredText.TrimEnd();
                 else
@@ -179,6 +188,8 @@ internal static class MemberCodeProvider
                 loweredBody,
                 loweredDiagnostic,
                 methodGenericParameters,
+                annotatedBody,
+                annotatedDiagnostic,
                 ilText,
                 ilDiagnostic,
                 attributes,
@@ -263,7 +274,7 @@ internal static class MemberCodeProvider
     /// </summary>
     static Decompiler.Pipeline.MetadataSource? OpenPipelineSource(Request request, string dllPath, string? pdbPath)
     {
-        if (!request.DecompiledSource && !request.LoweredSource && !request.Stages && !request.Facts)
+        if (!request.DecompiledSource && !request.AnnotatedSource && !request.LoweredSource && !request.Stages && !request.Facts)
             return null;
         try
         {
@@ -272,6 +283,30 @@ internal static class MemberCodeProvider
         catch
         {
             return null;
+        }
+    }
+
+    static Decompiler.DecompilerResult RenderPlainSource(Decompiler.Pipeline.MetadataSource source, string type, string method, Decompiler.Annotations.AnnotationStage stage, int overloadIndex, bool publicOnly)
+    {
+        try
+        {
+            var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
+                ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
+            var result = stage == Decompiler.Annotations.AnnotationStage.Lowered
+                ? Decompiler.Pipeline.CSharpPrinter.PrintLowered(imported, target => IrImporter.Import(source, target))
+                : Decompiler.Pipeline.CSharpPrinter.PrintRaised(imported, target => IrImporter.Import(source, target));
+            if (result.Output is not { } output)
+                return result;
+            var body = result.ConstructorChain is { } chain
+                ? output.Length == 0 ? $": {chain}" : $": {chain}{Environment.NewLine}{output}"
+                : output;
+            return string.IsNullOrWhiteSpace(body)
+                ? Decompiler.DecompilerResult.Failure(Decompiler.DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
+                : result with { Output = body };
+        }
+        catch (Exception ex)
+        {
+            return Decompiler.DecompilerResult.Failure(Decompiler.DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
     }
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -967,6 +967,7 @@ public static class ApiOutputFormatter
     {
         var request = new MemberCodeProvider.Request(
             DecompiledSource: requestedSections.Contains(SectionNames.DecompiledSource),
+            AnnotatedSource: requestedSections.Contains(SectionNames.AnnotatedSource),
             IL: requestedSections.Contains(SectionNames.IL),
             Attributes: requestedSections.Contains(SectionNames.CustomAttributes),
             Calls: requestedSections.Contains(SectionNames.Calls),
@@ -1141,7 +1142,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.DecompiledSource || request.LoweredSource || request.IL || request.Attributes || request.Stages || request.Facts)
+        if (request.DecompiledSource || request.AnnotatedSource || request.LoweredSource || request.IL || request.Attributes || request.Stages || request.Facts)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
         foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath))
@@ -1172,6 +1173,28 @@ public static class ApiOutputFormatter
             {
                 EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
                 memberCode.DecompiledSourceCode = new CodeSection("csharp", loweredDiagnostic);
+                hasCode = true;
+            }
+
+            if (code.AnnotatedBody is { } annotated)
+            {
+                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
+                string source;
+                try
+                {
+                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, annotated);
+                }
+                catch (Exception ex)
+                {
+                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
+                }
+                memberCode.AnnotatedSourceCode = new CodeSection("csharp", source);
+                hasCode = true;
+            }
+            else if (code.AnnotatedDiagnostic is { } annotatedDiagnostic)
+            {
+                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
+                memberCode.AnnotatedSourceCode = new CodeSection("csharp", annotatedDiagnostic);
                 hasCode = true;
             }
 

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -405,6 +405,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<Signature>()
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
+            .Add<AnnotatedSource>()
             .Add<LoweredSource>()
             .Add<OriginalSource>()
             .Add<Calls>()
@@ -414,12 +415,11 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<Facts>()
             .Add<ILBody>()
             .Add<Stages>()
-            .AddCategory(SectionCategoryNames.Audit,
-                SectionNames.Signature,
-                SectionNames.Calls,
-                SectionNames.Callers,
-                SectionNames.UnsafeOperations,
-                SectionNames.IL);
+            .AddCategory(SectionCategoryNames.Source,
+                SectionNames.DecompiledSource,
+                SectionNames.AnnotatedSource,
+                SectionNames.LoweredSource,
+                SectionNames.OriginalSource);
     }
 
     public sealed class Summary : ISectionDescriptor<ApiType>
@@ -455,6 +455,17 @@ public static class ApiMemberDetailSectionDescriptors
         public static string Name => SectionNames.DecompiledSource;
         public static bool IsExpensive => false;
         public static bool Info => true;
+        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class AnnotatedSource : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.AnnotatedSource;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -6,4 +6,5 @@ namespace DotnetInspector.Sections;
 public static class SectionCategoryNames
 {
     public const string Audit = "@Audit";
+    public const string Source = "@Source";
 }

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -78,9 +78,11 @@ public static class SectionNames
     /// <summary>Section for custom attributes on methods.</summary>
     public const string CustomAttributes = "Custom Attributes";
 
-    /// <summary>Section for the decompiled C# method body, annotated inline with
-    /// hidden-fact comments and the recovered IL interleaved beneath each statement.</summary>
+    /// <summary>Section for the decompiled C# method body.</summary>
     public const string DecompiledSource = "Decompiled Source";
+
+    /// <summary>Section for the decompiled C# method body with hidden-fact annotations and interleaved IL.</summary>
+    public const string AnnotatedSource = "Annotated Source";
 
     /// <summary>
     /// Section for the lowered C# view (issue #636): the method de-sugared — the

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -544,7 +544,7 @@ public record ApiOneLineRow(string Kind, string Name,
 public record ApiSurfaceOneLineRow(string Kind, string Type, string Members, string? Description);
 
 /// <summary>
-/// Code sections for member command output (Decompiled Source, Original Source, IL, Annotated IL).
+/// Code sections for member command output (Decompiled Source, Annotated Source, Original Source, IL).
 /// Serialized separately after the main TypeView.
 /// </summary>
 [MarkoutSerializable(AutoFields = false)]
@@ -552,6 +552,9 @@ public class MemberCodeView
 {
     [MarkoutSection(Name = "Decompiled Source")]
     public CodeSection DecompiledSourceCode { get; set; }
+
+    [MarkoutSection(Name = "Annotated Source")]
+    public CodeSection AnnotatedSourceCode { get; set; }
 
     [MarkoutSection(Name = "Lowered Source")]
     public CodeSection LoweredSourceCode { get; set; }

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v0.12.0
+
+### Member source views
+
+- Replaces selected-member `@Audit` with `@Source` for coherent source-view discovery.
+- Splits `Decompiled Source` into plain raised C# and `Annotated Source` into the mixed C#+IL view.
+- Documents the source-view model in repo docs and the embedded skill guidance.
+
 ## v0.10.5
 
 ### Library workflows


### PR DESCRIPTION
## Summary
- Replace the selected-member @Audit category with @Source.
- Split source views so Decompiled Source is plain raised C# and Annotated Source is the mixed C#+IL view.
- Wire Annotated Source through discovery, raw output, docs, SKILL.md, and tests.
- Bump the dotnet-inspect package and embedded skill metadata to 0.12.0.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- dotnet run --project src/dotnet-inspect -c Release -- --version
- dotnet pack src/dotnet-inspect -c Release --no-build -o /tmp/dotnet-inspect-pack-check
- npx markdownlint-cli on changed markdown files