### PR TITLE
Record generic ref-kind import audit invariant

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1738,7 +1738,13 @@ public static class IrImporter
     /// is a same-assembly call on a generic type instance (TypeSpec parent),
     /// where the keyword would otherwise be dropped. Returns empty (the printer
     /// keeps its default spelling) when the declaring type is not a same-assembly
-    /// definition or no signature-matching method is found.
+    /// definition or no signature-matching method is found. Stepper audit
+    /// specimen: <c>CfgSampleClass.GenericRefKindCallSites</c>, where the
+    /// import-time boundary is the whole proof — later passes record no rewrites,
+    /// and the two MemberRef call sites must already carry
+    /// <see cref="ParameterRefKindFacts.Known"/> with <c>out</c>/<c>in</c>
+    /// respectively so <see cref="MethodRef.HasUnverifiableByRefArgument"/> stays
+    /// false.
     /// </summary>
     static ParameterRefKindResult MemberReferenceRefKinds(MetadataReader reader, MemberReference member, string memberName, ImmutableArray<TypeRef> parameterTypes)
     {


### PR DESCRIPTION
## Summary

- Completes the #1011 **Constrained calls and generic/ref-kind calls** stepper audit for `CfgSampleClass::GenericRefKindCallSites`.
- No illegal transform was found; no later pass rewrites the specimen.
- Records the audited import/render invariant near `MemberReferenceRefKinds`: same-assembly generic-instance MemberRef calls recover `out`/`in` from the underlying MethodDef parameter rows and stay verified.

## Stepper packet

Specimen: `CfgSampleClass::GenericRefKindCallSites`, calling `RefKindBox<int>.TryGet(out T)` and `Put(in T)` through a constructed generic instance.

Commands:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::GenericRefKindCallSites" --steps
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::GenericRefKindCallSites" --diff
dotnet run /tmp/refkind-audit.cs
```

Observed import facts:

```text
TryGet: facts=Known; kinds=Out; params=ref int; unverified=False
Put: facts=Known; kinds=In; params=ref int; unverified=False
```

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*CallSite_RefKinds*" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`

Part of #1011.