### PR TITLE
Pin declaration placement stepper contract

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StepperTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StepperTests.cs
@@ -151,6 +151,27 @@ public class StepperTests
         Assert.DoesNotContain(function.Descendants.OfType<StackAllocArray>(), _ => true);
     }
 
+    [Fact]
+    public void DeclarationPlacementAudit_ReturnAccumulatorIsSunkAfterStructuring()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.GotoCommonExit));
+
+        var stepper = IrPasses.RunWithSteps(function);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+
+        Assert.Contains(descriptions, d => d.StartsWith("inline return-merge", StringComparison.Ordinal));
+        Assert.Contains(descriptions, d => d == "sink return-accumulator store into return");
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.DoesNotContain("V_0", output);
+        Assert.DoesNotContain("= default", output);
+        Assert.Contains("return 2;", output);
+        Assert.Contains("return 1;", output);
+        Assert.Contains("return 0;", output);
+    }
+
     static IEnumerable<Step> Flatten(IEnumerable<Step> steps)
     {
         foreach (var step in steps)


### PR DESCRIPTION
## Summary
- Add a stepper semantic audit test for `CfgSampleClass.GotoCommonExit`.
- Pin the phase contract that `ReturnMergePass` duplicates the shared return tail before `StructuringPass`, and `ReturnSinkingPass` later consumes the accumulator stores/loads.
- Assert the final raised body has direct returns and no `V_0`/`= default` declaration artifact.

Part of #1011.

## Validation
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`

Stepper/facts packet used:
```bash
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::GotoCommonExit" --steps --step-limit 160 --diff
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump "ILInspector.Decompiler.Tests.CfgSampleClass::GotoCommonExit" --facts
```