### PR TITLE
Do not cap method bodies on hidden declaring types

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UnspellableTypeFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspellableTypeFidelityTests.cs
@@ -6,6 +6,27 @@ namespace ILInspector.Decompiler.Tests;
 public class UnspellableTypeFidelityTests
 {
     [Fact]
+    public void PrivateImplementationDetailsDeclaringTypeAlone_DoesNotDegradeMethodBody()
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var hiddenType = TypeRef.Definition("System.Private.CoreLib", "", "<PrivateImplementationDetails>");
+
+        var block = new Block();
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "Helper",
+            hiddenType,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+    }
+
+    [Fact]
     public void PrivateImplementationDetailsType_DegradesToPartial()
     {
         var voidType = TypeRef.CoreLib("System", "Void");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -247,7 +247,6 @@ public sealed class IrFunction : IrNode
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)
-            .Append(DeclaringType)
             .Concat(Locals)
             .Concat(Regions.Where(r => r.CatchType is not null).Select(r => r.CatchType!));
 


### PR DESCRIPTION
Part of #916.

## Summary
- Stop treating an unspellable declaring type as a method-body fidelity cap.
- Keep Partial fidelity for actual hidden-type references in signatures, locals, member references, and body operands.
- Add coverage showing a `<PrivateImplementationDetails>` helper body can be Full when its body/signature are spellable, while calls to hidden helpers still degrade.

## Impact
- Current CoreLib `<PrivateImplementationDetails>` gap bucket drops from 7 to 1.
- Fully raised methods increase from 39558 to 39564.
- Pass bugs remain 0.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- CoreLib `--gaps --max-examples 100`
- CoreLib `--validity-check --compile-cap 10000` with current-main defect-map diff: no gained defect codes; Full malformed remains 0.