### PR TITLE
Classify and fix CS0305 generic type defects

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeOfRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeOfRenderingTests.cs
@@ -1,0 +1,38 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TypeOfRenderingTests
+{
+    [Fact]
+    public void TypeOf_OpenGenericDefinition_RendersUnboundGenericType()
+    {
+        var output = CSharpPrinter.Print(Returning(new TypeOf(TypeRef.CoreLib("System.Collections.Generic", "List`1")))).Output;
+
+        Assert.Contains("return typeof(List<>);", output);
+        Assert.DoesNotContain("typeof(List)", output);
+    }
+
+    [Fact]
+    public void TypeOf_OpenGenericDefinitionArityTwo_RendersAllCommas()
+    {
+        var output = CSharpPrinter.Print(Returning(new TypeOf(TypeRef.CoreLib("System.Collections.Generic", "Dictionary`2")))).Output;
+
+        Assert.Contains("return typeof(Dictionary<,>);", output);
+        Assert.DoesNotContain("typeof(Dictionary)", output);
+    }
+
+    static IrFunction Returning(IrExpression expression)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new Return(expression));
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Tests", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Type"), [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1362,9 +1362,9 @@ public sealed partial class CSharpPrinter
         LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
         LoadIndirect l => DerefLoad(l),
         SizeOf s => $"sizeof({TypeText(s.Type)})",
-        TypeOf t => $"typeof({TypeText(t.Type)})",
+        TypeOf t => $"typeof({TypeOfTypeText(t.Type)})",
         LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
-            ? $"typeof({TypeText(t.Type)})"
+            ? $"typeof({TypeOfTypeText(t.Type)})"
             : $"/* {t.Describe()} */",
         CaughtException => "__exception",
         UnsupportedNode u => $"/* {u.Describe()} */",
@@ -2129,5 +2129,23 @@ public sealed partial class CSharpPrinter
         string text = type.ToDisplayString();
         int tick = text.IndexOf('`');
         return tick < 0 ? text : text[..tick];
+    }
+
+    static string TypeOfTypeText(TypeRef type)
+        => type.Kind == TypeRefKind.Definition && OpenGenericArity(type) is { } arity
+            ? $"{TypeText(type)}<{new string(',', arity - 1)}>"
+            : TypeText(type);
+
+    static int? OpenGenericArity(TypeRef type)
+    {
+        var name = type.Name;
+        var nested = name.LastIndexOf('+');
+        var innermost = nested < 0 ? name : name[(nested + 1)..];
+        var tick = innermost.IndexOf('`');
+        if (tick < 0)
+            return null;
+        return int.TryParse(innermost[(tick + 1)..], out var arity) && arity > 0
+            ? arity
+            : null;
     }
 }

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -174,6 +174,7 @@ internal static class LibraryReport
                     .Where(ValidityCheck.IsError)
                     .Where(d => !ValidityCheck.BindingNoise.Contains(d.Id))
                     .Where(d => !ValidityCheck.IsShellArtifact(d))
+                    .Where(d => !ValidityCheck.IsGenericArityCollisionNoise(d, tree, function))
                     .ToList();
                 if (defects.Count == 0)
                 {


### PR DESCRIPTION
## Summary

- Classifies the #1031 CS0305 backlog row against current product/popular corpus measurements.
- Applies the existing `ValidityCheck.IsGenericArityCollisionNoise` filter to `LibraryReport`, aligning portfolio reports with direct validity-check shell-noise filtering.
- Fixes the real remaining CS0305 family by rendering open generic definitions in `typeof` / type-token expressions as `typeof(List<>)`, `typeof(Dictionary<,>)`, etc.
- Adds focused `TypeOfRenderingTests` for arity 1 and 2 open generic definitions.

## Classification results

Current product 8-library report before this change: `validity: CS0305` = **75**. Direct `--validity-check --emit-validity-defects` already reported **0** CS0305, proving those 75 were library-report shell-filter parity artifacts. After this change, product `--library-report` also reports **0** CS0305.

Popular NuGet 6-library report after applying shell filtering still had real CS0305 defects: **27 report hits / 11 methods**, all caused by open generic type definitions rendered as `typeof(List)`, `typeof(Dictionary)`, `typeof(ICollection)`, etc. After the `typeof(T<...>)` fix, popular `--library-report` drops to **1** CS0305: `Dapper.SqlMapper.DeserializerState::.ctor`, a separate constructor/type-shell case to split into follow-up if desired.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*TypeOfRenderingTests*" -method "*ShellNoiseTests*" -reporter quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo -v:minimal`
- `git diff --check`
- Product 8-library `--library-report --compile-cap 10000`: CS0305 **75 → 0**
- Popular NuGet 6-library `--library-report --compile-cap 10000`: CS0305 **30 baseline / 27 after shell filtering → 1**

Part of #1031.