### PR TITLE
Cast enum switch case labels to fix CS0266 (#1031)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -765,6 +765,22 @@ public class CfgSampleClass
     // argument to the enum: `s.Equals("x", (StringComparison)5)`.
     public static bool CrossAssemblyEnumCallArgument(string s) => s.Equals("x", System.StringComparison.OrdinalIgnoreCase);
 
+    // A `switch` over a cross-assembly enum (DayOfWeek, CoreLib): the IL jump
+    // table switches on the enum's underlying int, so the raised case labels are
+    // bare integers. With the enum shape unknown, `case 1:` is CS0266 — C#
+    // converts int->enum implicitly only for the literal 0 — so the printer must
+    // spell each label as the enum: `case (DayOfWeek)1:`.
+    public static int CrossAssemblyEnumSwitch(System.DayOfWeek day)
+    {
+        switch (day)
+        {
+            case System.DayOfWeek.Sunday: return 10;
+            case System.DayOfWeek.Monday: return 11;
+            case System.DayOfWeek.Tuesday: return 12;
+            default: return -1;
+        }
+    }
+
     // --- Unsigned/unordered comparison fixtures (cgt.un/clt.un/b*.un) ---
 
     public static bool UnsignedBoundsCheck(int index, int[] array) => (uint)index < (uint)array.Length;

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
@@ -51,4 +51,18 @@ public class CrossAssemblyEnumIntegerTests
         // and is then called on an instance — CS0176.
         Assert.DoesNotContain("\"x\", 5)", output);
     }
+
+    [Fact]
+    public void EnumSwitchLabels_CastIntegerToEnum()
+    {
+        var output = Render(nameof(CfgSampleClass.CrossAssemblyEnumSwitch));
+
+        Assert.Contains("switch (day)", output);
+        // The jump-table labels raise as bare ints; `case 1:`/`case 2:` over an
+        // enum governing expression is CS0266 (only the literal 0 converts).
+        Assert.Contains("case (DayOfWeek)1:", output);
+        Assert.Contains("case (DayOfWeek)2:", output);
+        Assert.DoesNotContain("case 1:", output);
+        Assert.DoesNotContain("case 2:", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -86,6 +86,9 @@ public class FidelityGateTests
     /// format clause (the backslash-escaped `h\:mm\:ss` TimeSpan spelling) so the
     /// non-verbatim `$"…"` is valid C# and the format constant recompiles
     /// opcode-exact — a raw `\:` is CS1009.
+    /// CrossAssemblyEnumSwitch must keep casting each `switch` case label to the
+    /// (cross-assembly, Unknown-shape) enum governing type — `case (DayOfWeek)1:`
+    /// — since a bare `case 1:` over an enum is CS0266 (#1031 CS0266 slice).
     /// GenericNullConditionalToString must keep folding csc's generic
     /// null-conditional invocation (the default(T)-box two-stage null test with a
     /// reload) back into `value?.ToString() ?? "none"`, which recompiles to the
@@ -155,6 +158,7 @@ public class FidelityGateTests
         "RefEnumMask",
         "RvaIntArray",
         "BoolBitwiseOrWidened",
+        "CrossAssemblyEnumSwitch",
         "Finalize",
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -978,10 +978,11 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).Append("switch (").Append(Expression(switchNode.Value)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
             string labelPad = pad + "    ";
+            var labelEnum = SwitchLabelEnumType(switchNode.Value);
             foreach (var section in switchNode.Sections)
             {
                 foreach (var label in section.Labels)
-                    sb.Append(labelPad).Append("case ").Append(ConstantText(label)).AppendLine(":");
+                    sb.Append(labelPad).Append("case ").Append(SwitchLabelText(label, labelEnum)).AppendLine(":");
                 if (section.IsDefault)
                     sb.Append(labelPad).AppendLine("default:");
                 AppendContainer(sb, section.Body, indent + 2);
@@ -2070,6 +2071,50 @@ public sealed partial class CSharpPrinter
             && members.TryGetValue(value, out var name)
             ? $"{TypeText(constant.Type)}.{name}"
             : null;
+
+    /// <summary>
+    /// The enum type a <c>switch</c> governing expression carries, or null when it
+    /// is not an enum. Mirrors <see cref="TypedConstantsPass"/>'s operand typing
+    /// (an <c>ldind</c> through a <c>ref EnumType</c> yields a load typed by the
+    /// opcode width, so see through it to the pointee enum) and the cross-assembly
+    /// enum reasoning in the numeric cast path: a framework enum like
+    /// <c>DateTimeKind</c> resolves to <see cref="TypeShape.Unknown"/> rather than
+    /// <see cref="TypeShape.Enum"/> because shape classification only sees the
+    /// inspected assembly's own types. Type-safe IL only switches on an integral,
+    /// char, or enum, so a non-primitive named governing type is an enum.
+    /// </summary>
+    TypeRef? SwitchLabelEnumType(IrExpression value)
+    {
+        var type = value is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } pointee } }
+            ? pointee
+            : value.ResultType;
+        if (type is null)
+            return null;
+        if (_function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum)
+            return type;
+        return type is { Kind: TypeRefKind.Definition, Name: not ("Boolean" or "String") }
+            && _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Unknown
+            && !TypeFamilies.IsNumericPrimitive(type)
+            ? type
+            : null;
+    }
+
+    /// <summary>
+    /// Renders a <c>switch</c> case label. When the governing expression is an
+    /// enum, a bare integer label is CS0266 (only the literal <c>0</c> converts
+    /// implicitly), so the label is spelled by member name when resolved or an
+    /// explicit enum cast otherwise — matching how enum constants render
+    /// elsewhere. A negative value is parenthesized after the cast (CS0075).
+    /// </summary>
+    string SwitchLabelText(Constant label, TypeRef? enumType)
+    {
+        if (enumType is null || label.Value is not int value)
+            return ConstantText(label);
+        var typed = new Constant(value, enumType);
+        if (EnumMemberName(typed) is { } named)
+            return named;
+        return $"({TypeText(enumType)}){(value < 0 ? $"({value.ToString(CultureInfo.InvariantCulture)})" : value.ToString(CultureInfo.InvariantCulture))}";
+    }
 
     static string ConstantText(Constant constant) => constant.Value switch
     {


### PR DESCRIPTION
## #1031 — Product/ecosystem validity: CS0266 conversions

Fixes the dominant CS0266 class in the ecosystem validity buckets: a `switch`
over an **enum** governing expression whose case labels render as bare integers.

### Finding

A jump-table `switch` raises its case labels as `Constant int`. The printer
emitted `case 0:`, `case 1:`, `case 2:` regardless of the governing type. C#
converts an integer to an enum implicitly **only for the literal `0`**, so every
non-zero label over an enum is **CS0266** ("cannot implicitly convert int to
`<Enum>`").

Newtonsoft.Json `DateTimeUtils` (switching over `DateTimeKind`):

```csharp
switch (kind)
{
    case 0: ...
    case 1: ...   // CS0266
    case 2: ...   // CS0266
}
```

### Fix

The printer now spells each label by the governing enum — a **member name**
when the enum's members are resolved, otherwise an explicit **`(Enum)value`
cast** — matching how enum constants already render elsewhere:

```csharp
switch (kind)
{
    case (DateTimeKind)0: ...
    case (DateTimeKind)1: ...
    case (DateTimeKind)2: ...
}
```

The governing enum is detected like the existing numeric cast path: a
same-assembly enum is `TypeShape.Enum`; a cross-assembly framework enum (e.g.
`DateTimeKind`) resolves to `TypeShape.Unknown` because shape classification only
walks the inspected assembly's own types, so a non-primitive named governing type
is recognized structurally as an enum. String/char/bool switches are excluded.

### Verification — defect diffs (`--diff-validity-defects`, 0 regressions)

| Library | CS0266 methods fixed | Regressions |
| --- | --- | --- |
| Newtonsoft.Json | 3 | 0 |
| Dapper | 2 | 0 |
| Humanizer | 0 (no match) | 0 |

- `ILInspector.Decompiler.Tests`: **900 passed, 0 failed.**
- `CrossAssemblyEnumSwitch` fixture added to `CfgSampleClass`, pinned
  **opcode-exact** in `FidelityGateTests.PinnedExact`.
- `EnumSwitchLabels_CastIntegerToEnum` behavioral test in
  `CrossAssemblyEnumIntegerTests`.

### Scope / pivot

The remaining CS0266 instances are a separate `int -> char` class (e.g.
Newtonsoft `WriteDateTimeOffset`: `char[] element = int slot`), which is a
stack-slot/array-element typing issue, not enum-switch labels. Left for a
follow-up per the row's "keep rows narrow" guardrail.

Addresses the **Product/ecosystem validity: CS0266 conversions** row of #1031.
