### PR TITLE
Add unsupported-node harness report

### DIFF
--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -51,6 +51,7 @@ static class Program
         bool showDiff = false;
         bool structuringStops = false;
         bool libraryReport = false;
+        bool unsupportedNodes = false;
         bool json = false;
         int topPatterns = 10;
         int? topLibraries = null;
@@ -95,6 +96,7 @@ static class Program
                 case "--show-diff": showDiff = true; break;
                 case "--structuring-stops": structuringStops = true; break;
                 case "--library-report": libraryReport = true; break;
+                case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
@@ -122,6 +124,9 @@ static class Program
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
+
+        if (unsupportedNodes)
+            return UnsupportedNodeReport.Run(assemblies, maxExamples, json);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -1037,6 +1042,9 @@ static class Program
           --library-report       per-assembly summary: Full %, fully-raised %,
                                 validity defects, residual pattern buckets, and
                                 examples. Use --json for machine-readable output.
+          --unsupported-nodes    report every unsupported IL marker left in the
+                                raised tree, grouped by opcode/reason. Use --json
+                                for machine-readable output.
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -53,7 +53,6 @@ static class Program
         bool libraryReport = false;
         bool unsupportedNodes = false;
         bool classifyDec0009 = false;
-        bool unsupportedNodes = false;
         bool json = false;
         int topPatterns = 10;
         int? topLibraries = null;
@@ -100,7 +99,6 @@ static class Program
                 case "--library-report": libraryReport = true; break;
                 case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
-                case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
@@ -1054,9 +1052,6 @@ static class Program
           --classify-dec0009     classify DEC0009 unrepresentable metadata-name
                                 remarks by generated-name family. Use --json for
                                 machine-readable output.
-          --unsupported-nodes    report every unsupported IL marker left in the
-                                raised tree, grouped by opcode/reason. Use --json
-                                for machine-readable output.
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -52,6 +52,7 @@ static class Program
         bool structuringStops = false;
         bool libraryReport = false;
         bool classifyDec0009 = false;
+        bool unsupportedNodes = false;
         bool json = false;
         int topPatterns = 10;
         int? topLibraries = null;
@@ -97,6 +98,7 @@ static class Program
                 case "--structuring-stops": structuringStops = true; break;
                 case "--library-report": libraryReport = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
+                case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
@@ -127,6 +129,9 @@ static class Program
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
+
+        if (unsupportedNodes)
+            return UnsupportedNodeReport.Run(assemblies, maxExamples, json);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -1045,6 +1050,9 @@ static class Program
           --classify-dec0009     classify DEC0009 unrepresentable metadata-name
                                 remarks by generated-name family. Use --json for
                                 machine-readable output.
+          --unsupported-nodes    report every unsupported IL marker left in the
+                                raised tree, grouped by opcode/reason. Use --json
+                                for machine-readable output.
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -25,6 +25,15 @@ read-only-array helpers. The report prints both every method with a `DEC0009`
 remark and the subset whose primary `--library-report` bucket is
 `fidelity: DEC0009`; `--json` emits the same data for issue triage.
 
+**Unsupported nodes** (`--unsupported-nodes`): a focused view of the
+`fidelity: unsupported-node` bucket. It runs the normal raising pipeline, walks
+the finished tree for every `UnsupportedNode`, and groups sites by opcode and
+normalized reason while keeping concrete method examples. Use it after
+`--gaps`/`--library-report` show a small unsupported-node bucket and you need to
+classify it into intentional unrepresentable IL, a missing printer/importer
+slice, or a larger raise such as iterator reconstruction. `--json` emits the
+same report as structured data.
+
 ### Multi-mode fixture matrix (on-demand)
 
 **Why it exists.** The CoreLib corpus and the CI gates measure **one compiler
@@ -234,6 +243,10 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
 # Self-contained completeness view (the completeness signal)
 dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/System.Private.CoreLib.dll --gaps
+
+# Classify unsupported-node residue by opcode/reason
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --unsupported-nodes --max-examples 30
 
 # Why structuring left containers flat (the why-not companion to --gaps)
 dotnet run --project tools/DecompilerHarness -c Release -- \

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -16,6 +16,15 @@ library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
 `--top-libraries N` limits the detailed library sections to the noisiest
 libraries, and `--json` emits the same data as structured JSON.
 
+**Unsupported nodes** (`--unsupported-nodes`): a focused view of the
+`fidelity: unsupported-node` bucket. It runs the normal raising pipeline, walks
+the finished tree for every `UnsupportedNode`, and groups sites by opcode and
+normalized reason while keeping concrete method examples. Use it after
+`--gaps`/`--library-report` show a small unsupported-node bucket and you need to
+classify it into intentional unrepresentable IL, a missing printer/importer
+slice, or a larger raise such as iterator reconstruction. `--json` emits the
+same report as structured data.
+
 ### Multi-mode fixture matrix (on-demand)
 
 **Why it exists.** The CoreLib corpus and the CI gates measure **one compiler
@@ -221,6 +230,10 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
 # Self-contained completeness view (the completeness signal)
 dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/System.Private.CoreLib.dll --gaps
+
+# Classify unsupported-node residue by opcode/reason
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --unsupported-nodes --max-examples 30
 
 # Why structuring left containers flat (the why-not companion to --gaps)
 dotnet run --project tools/DecompilerHarness -c Release -- \

--- a/tools/DecompilerHarness/UnsupportedNodeReport.cs
+++ b/tools/DecompilerHarness/UnsupportedNodeReport.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Focused inventory for the <see cref="UnsupportedNode"/> completeness bucket.
+/// The general gaps/library views intentionally show only a few examples per
+/// bucket; this view keeps every marker visible so small buckets can be
+/// classified into intentional unrepresentable IL versus missing coverage.
+/// </summary>
+internal static class UnsupportedNodeReport
+{
+    public static int Run(IReadOnlyList<string> assemblies, int maxExamples, bool json)
+    {
+        List<UnsupportedNodeSite> sites = [];
+        int totalMethods = 0;
+        int passBugs = 0;
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assembly in assemblies)
+        {
+            using var source = MetadataSource.Open(assembly, context: metadata);
+            string assemblyName = source.AssemblyName;
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                totalMethods++;
+                try
+                {
+                    var context = new PassContext(
+                        new Stepper(enabled: false),
+                        importMethodBody: method => IrImporter.Import(source, method));
+                    IrPasses.Run(function, IrPasses.Default, context);
+                }
+                catch
+                {
+                    passBugs++;
+                    continue;
+                }
+
+                foreach (var unsupported in function.Descendants.OfType<UnsupportedNode>())
+                {
+                    sites.Add(new UnsupportedNodeSite(
+                        assemblyName,
+                        typeName,
+                        methodName,
+                        unsupported.ILOffset,
+                        unsupported.Opcode,
+                        unsupported.Reason));
+                }
+            }
+        }
+
+        var groups = sites
+            .GroupBy(site => new { site.Opcode, Reason = CategoryReason(site) })
+            .Select(group => new UnsupportedNodeGroup(
+                group.Key.Opcode,
+                group.Key.Reason,
+                group.Count(),
+                [.. group
+                    .OrderBy(site => site.Assembly, StringComparer.Ordinal)
+                    .ThenBy(site => site.Type, StringComparer.Ordinal)
+                    .ThenBy(site => site.Method, StringComparer.Ordinal)
+                    .Take(maxExamples)]))
+            .OrderByDescending(group => group.Count)
+            .ThenBy(group => group.Opcode, StringComparer.Ordinal)
+            .ThenBy(group => group.Reason, StringComparer.Ordinal)
+            .ToArray();
+
+        var report = new UnsupportedNodePortfolioReport(totalMethods, passBugs, sites.Count, groups);
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        else
+        {
+            PrintMarkdown(report);
+        }
+
+        return passBugs > 0 ? 1 : 0;
+    }
+
+    static void PrintMarkdown(UnsupportedNodePortfolioReport report)
+    {
+        Console.WriteLine("# Unsupported-node report");
+        Console.WriteLine();
+        Console.WriteLine($"Methods scanned: {report.TotalMethods}");
+        Console.WriteLine($"Pass bugs: {report.PassBugs}");
+        Console.WriteLine($"Unsupported node sites: {report.SiteCount}");
+        Console.WriteLine();
+
+        if (report.Groups.Count == 0)
+        {
+            Console.WriteLine("- (none)");
+            return;
+        }
+
+        foreach (var group in report.Groups)
+        {
+            Console.WriteLine($"- **{Escape(group.Opcode)}**: {group.Count} — {Escape(group.Reason)}");
+            foreach (var site in group.Examples)
+            {
+                Console.WriteLine($"  - `{Escape(site.Assembly)}::{Escape(site.Type)}::{Escape(site.Method)} @ IL_{site.ILOffset:X4}`");
+            }
+        }
+    }
+
+    static string Escape(string value)
+        => value.Replace("|", "\\|").Replace("\n", " ");
+
+    static string CategoryReason(UnsupportedNodeSite site)
+        => site.Opcode == "iterator" && site.Reason.Contains("yield body (MoveNext) not reconstructed", StringComparison.Ordinal)
+            ? "compiler-generated iterator state machine; yield body (MoveNext) not reconstructed"
+            : site.Reason;
+}
+
+internal sealed record UnsupportedNodePortfolioReport(
+    int TotalMethods,
+    int PassBugs,
+    int SiteCount,
+    IReadOnlyList<UnsupportedNodeGroup> Groups);
+
+internal sealed record UnsupportedNodeGroup(
+    string Opcode,
+    string Reason,
+    int Count,
+    IReadOnlyList<UnsupportedNodeSite> Examples);
+
+internal sealed record UnsupportedNodeSite(
+    string Assembly,
+    string Type,
+    string Method,
+    int ILOffset,
+    string Opcode,
+    string Reason);


### PR DESCRIPTION
## Summary

Adds a focused `--unsupported-nodes` mode to `tools/DecompilerHarness` for the #1031 unsupported-node backlog row.

The mode runs the normal decompiler raising pipeline, walks the finished tree for `UnsupportedNode` instances, and groups sites by opcode plus normalized reason. It supports Markdown output and `--json`, and keeps concrete method examples so small buckets can be classified without scraping `--gaps` or `--library-report` output.

The README now documents the mode and includes a CoreLib classification command.

## Initial classification

Using the new report on .NET 11 preview 5 CoreLib:

- `iterator`: 10 sites, compiler-generated iterator kickoff markers whose `MoveNext` bodies are not reconstructed.
- `refanytype`: 3 sites, all in `System.TypedReference` methods.

Local product/harness inspection showed the unsupported-node methods in the measured product bucket are iterator kickoff markers; the two `dotnet-inspect` examples were also confirmed by direct `--remarks` dumps.

## Validation

- `dotnet build tools/DecompilerHarness -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` => 899 passed
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- `dotnet run --no-build --project tools/DecompilerHarness -c Release -- /usr/local/share/dotnet/shared/Microsoft.NETCore.App/11.0.0-preview.5.26302.115/System.Private.CoreLib.dll --unsupported-nodes --json --max-examples 1`

One parallel post-rebase smoke command hit a transient MSBuild file-lock race while a build was running; the same smoke command passed serially with `--no-build`.
