### PR TITLE
[codex] Fix constructor-call CS0175 decompiler defects

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ConstructorCallDiagnosticsPassTests
+{
+    static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");
+    static readonly TypeRef Base = TypeRef.CoreLib("Synthetic", "Base");
+    static readonly TypeRef StructType = TypeRef.CoreLib("Synthetic", "StructType");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void Run_MarksUnraisedDirectConstructorCallUnsupported()
+    {
+        var ctor = new MethodRef(StructType, ".ctor", Void, [Int32], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadStackSlot(0, StructType), new Constant(5, Int32)]);
+        var function = Function("M", [new ExpressionStatement(call)]);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(Assert.Single(function.Body.Blocks[0].Children));
+        var marker = Assert.IsType<UnsupportedNode>(statement.Expression);
+        Assert.Contains("direct constructor call", marker.Reason);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void Run_LeavesLiftableConstructorChain()
+    {
+        var ctor = new MethodRef(Base, ".ctor", Void, [Int32], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner), new Constant(5, Int32)]);
+        var function = Function(".ctor", [new ExpressionStatement(call)]);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(Assert.Single(function.Body.Blocks[0].Children));
+        Assert.Same(call, statement.Expression);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void Run_MarksConstructorChainWithParameterStoreBeforeCallUnsupported()
+    {
+        var field = new FieldRef(Owner, "_value", Int32);
+        var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
+        var ctor = new MethodRef(Base, ".ctor", Void, [], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner)]);
+        var function = Function(".ctor", [store, new ExpressionStatement(call)]);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(function.Body.Blocks[0].Children[1]);
+        Assert.IsType<UnsupportedNode>(statement.Expression);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    static IrFunction Function(string name, IEnumerable<IrNode> statements)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        foreach (var statement in statements)
+            block.Add(statement);
+        body.Add(block);
+
+        var signature = new MethodSignature(
+            Void,
+            ImmutableArray.Create(new Parameter("value", Int32)),
+            HasThis: true,
+            GenericParameterCount: 0);
+
+        return new IrFunction(name, Owner, signature, [], body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1564,6 +1564,32 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void StructConstructor_ByRefStackSlotReceiver_RaisesToNewObject()
+    {
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var structType = TypeRef.Definition("Synthetic", "Samples", "Carrier", ValueTypeHint.ValueType);
+        var ctor = new MethodRef(structType, ".ctor", voidType, [intType], HasThis: true);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new LoadLocalAddress(0, structType)));
+        block.Add(new ExpressionStatement(new Call(ctor, isVirtual: false, [new LoadStackSlot(0, TypeRef.ByRef(structType)), new Constant(42, intType)])));
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("Synthetic", "Samples", "Owner"), signature, [structType], container);
+
+        new StructConstructorPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreStackSlot>(), s => s.Slot == 0);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), s => s.Slot == 0);
+        var store = Assert.IsType<StoreLocal>(Assert.Single(block.Children));
+        Assert.Equal(0, store.Index);
+        var value = Assert.IsType<NewObject>(store.Value);
+        Assert.Equal(ctor, value.Constructor);
+        Assert.Equal("Carrier V_0 = new Carrier(42);", CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim());
+    }
+
+    [Fact]
     public void CallSite_RefKinds_PrintRefOutAndBareIn()
     {
         // A managed pointer forwarded to a by-ref parameter needs the parameter's

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
@@ -1,0 +1,70 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Marks direct constructor calls that survived all constructor-raising passes as
+/// explicit unsupported residuals. C# can spell only a constructor chain
+/// (<c>: base(...)</c>/<c>: this(...)</c>) or an object creation expression; a
+/// leftover <c>call instance .ctor</c> body statement has no faithful statement
+/// spelling and must not leak as <c>base(...)</c> in arbitrary methods.
+/// </summary>
+public sealed class ConstructorCallDiagnosticsPass : IIrPass
+{
+    public string Name => "constructor-call-diagnostics";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var statement in function.Descendants.OfType<ExpressionStatement>().ToList())
+        {
+            if (statement.Expression is not Call { Callee: { Name: ".ctor", HasThis: true } } call)
+                continue;
+            if (IsLiftableConstructorChain(function, statement, call))
+                continue;
+
+            var marker = new UnsupportedNode(
+                call.SourceOffset >= 0 ? call.SourceOffset : statement.SourceOffset,
+                "call .ctor",
+                $"direct constructor call to {call.Callee.DeclaringType.ToDisplayString()} is not representable as a C# statement");
+            marker.InheritSourceOffset(call);
+            var replacement = new ExpressionStatement(marker);
+            replacement.InheritSourceOffset(statement);
+            context.Stepper.StepOver($"mark unraised {call.Callee.DeclaringType.Name}..ctor call unsupported", statement);
+            statement.ReplaceWith(replacement);
+        }
+    }
+
+    static bool IsLiftableConstructorChain(IrFunction function, ExpressionStatement statement, Call call)
+    {
+        if (function.Name != ".ctor"
+            || call.Arguments is not [LoadArgument { Index: 0 }, ..]
+            || function.Body.Blocks is not [{ } entry, ..])
+        {
+            return false;
+        }
+
+        int chainIndex = ChildIndexOf(entry, statement);
+        return chainIndex >= 0
+            && entry.Children.Take(chainIndex).All(IsFieldInitializerStore);
+    }
+
+    static int ChildIndexOf(Block block, IrNode node)
+    {
+        for (int i = 0; i < block.Children.Count; i++)
+            if (ReferenceEquals(block.Children[i], node))
+                return i;
+        return -1;
+    }
+
+    static bool IsFieldInitializerStore(IrNode node)
+        => node is StoreField { HasInstance: true, Instance: LoadArgument { Index: 0 } } store
+            && !ReferencesPlace(store.Value);
+
+    static bool ReferencesPlace(IrExpression value)
+    {
+        foreach (var node in (IEnumerable<IrNode>)[value, .. value.Descendants])
+        {
+            if (node is LoadArgument or LoadLocal or LoadStackSlot or LoadLocalAddress or LoadArgumentAddress)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -184,6 +184,11 @@ public static class IrPasses
         // printer lifts it to a signature initializer rather than an invalid
         // base(temp); body call (CS0175).
         new ConstructorChainArgumentPass(),
+        // Any direct .ctor call still standing after the constructor-chain and
+        // struct-constructor raises has no faithful C# statement spelling. Mark
+        // it as an explicit residual before the printer can leak invalid
+        // base(...)/this(...) text from a body statement.
+        new ConstructorCallDiagnosticsPass(),
         // Eliminate return-accumulator temporaries the compiler spilled across
         // an EH region or lock (try { V = e; } finally { } return V; back to
         // try { return e; }). Runs after structuring and the second inlining so

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -79,6 +79,8 @@ internal static class NativePasses
     public static FunctionPointerDiagnosticsPass FunctionPointerDiagnostics => new();
     [Native(NativeCategory.Diagnostic, "lost in/out/ref kind at a call site — DEC0007 residual")]
     public static RefKindDiagnosticsPass RefKindDiagnostics => new();
+    [Native(NativeCategory.Diagnostic, "direct .ctor call with no C# statement spelling — DEC0004 residual")]
+    public static ConstructorCallDiagnosticsPass ConstructorCallDiagnostics => new();
     [Native(NativeCategory.Diagnostic, "compiler-generated iterator kickoff acknowledged honestly (Partial) instead of a misleading <X>d__N handoff stub — DEC0004 residual; yield body not yet reconstructed")]
     public static IteratorAcknowledgmentPass IteratorAcknowledgment => new();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
@@ -23,17 +23,21 @@ public sealed class StructConstructorPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        var byRefSlots = ByRefSlotTargets(function);
         foreach (var statement in function.Descendants.OfType<ExpressionStatement>().ToList())
         {
             if (statement.Parent is null)
                 continue;  // detached by an earlier rewrite in this walk
             if (statement.Expression is not Call { Callee: { Name: ".ctor", HasThis: true } } call)
                 continue;
-            if (call.Arguments.Count == 0 || !IsRaisableTarget(call.Arguments[0]))
+            if (call.Arguments.Count == 0)
+                continue;
+
+            var receiver = ResolveTarget(call.Arguments[0], byRefSlots);
+            if (receiver is null)
                 continue;
 
             var children = call.DetachChildren().Cast<IrExpression>().ToList();
-            var receiver = children[0];
             var value = new NewObject(call.Callee, children.Skip(1));
             context.Stepper.StepOver($"raise in-place {call.Callee.DeclaringType.Name}..ctor to assignment", statement);
             statement.ReplaceWith(Assign(receiver, value));
@@ -46,6 +50,24 @@ public sealed class StructConstructorPass : IIrPass
     static bool IsRaisableTarget(IrExpression receiver)
         => receiver is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress;
 
+    static IrExpression? ResolveTarget(IrExpression receiver, Dictionary<int, SlotTarget> byRefSlots)
+    {
+        if (IsRaisableTarget(receiver))
+            return receiver;
+
+        if (receiver is LoadStackSlot slot
+            && byRefSlots.TryGetValue(slot.Slot, out var target)
+            && ReferenceEquals(target.Load, receiver))
+        {
+            var address = target.Address;
+            address.Detach();
+            target.Store.Detach();
+            return address;
+        }
+
+        return null;
+    }
+
     static IrNode Assign(IrExpression receiver, NewObject value) => receiver switch
     {
         LoadLocalAddress local => new StoreLocal(local.Index, local.Type, value),
@@ -53,6 +75,42 @@ public sealed class StructConstructorPass : IIrPass
         LoadFieldAddress field => new StoreField(field.Field, DetachInstance(field), value),
         _ => throw new InvalidOperationException($"Unexpected struct-ctor target {receiver.Describe()}."),
     };
+
+    static Dictionary<int, SlotTarget> ByRefSlotTargets(IrFunction function)
+    {
+        var slots = new Dictionary<int, SlotUsage>();
+
+        SlotUsage Entry(int slot)
+        {
+            if (!slots.TryGetValue(slot, out var entry))
+                slots[slot] = entry = new SlotUsage();
+            return entry;
+        }
+
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case StoreStackSlot store when IsRaisableTarget(store.Value):
+                    Entry(store.Slot).Stores.Add(store);
+                    break;
+                case StoreStackSlot store:
+                    Entry(store.Slot).OtherStores++;
+                    break;
+                case LoadStackSlot load:
+                    Entry(load.Slot).Loads.Add(load);
+                    break;
+            }
+        }
+
+        var result = new Dictionary<int, SlotTarget>();
+        foreach (var (slot, usage) in slots)
+        {
+            if (usage.Stores is [var store] && usage.Loads is [var load] && usage.OtherStores == 0)
+                result[slot] = new SlotTarget(store, load, store.Value);
+        }
+        return result;
+    }
 
     // The field address has already left the call tree; lift its own receiver
     // out so the new StoreField can adopt it without a double parent.
@@ -62,4 +120,13 @@ public sealed class StructConstructorPass : IIrPass
         instance?.Detach();
         return instance;
     }
+
+    sealed class SlotUsage
+    {
+        public List<StoreStackSlot> Stores { get; } = [];
+        public List<LoadStackSlot> Loads { get; } = [];
+        public int OtherStores { get; set; }
+    }
+
+    sealed record SlotTarget(StoreStackSlot Store, LoadStackSlot Load, IrExpression Address);
 }


### PR DESCRIPTION
## Summary

Addresses the CS0175 constructor/base-call row from #1031.

- Raises struct constructor calls whose receiver is carried through a single-use byref stack slot back to `local = new S(...)`.
- Adds a constructor-call diagnostic pass so remaining direct `.ctor` calls that cannot be represented as C# statements degrade explicitly instead of leaking invalid `base(...)` / `this(...)` body text.
- Adds focused tests for the byref stack-slot struct-constructor case and the direct-constructor diagnostic cases.

## Root Cause

`StructConstructorPass` only recognized direct address receivers such as `LoadLocalAddress`. Dapper-style IL can spill that byref address through a stack slot before the `.ctor` call, so the pass missed it and the printer later treated the surviving `.ctor` call as a constructor-chain call, rendering invalid body `base(...)` text.

A second residual family is true unrepresentable direct constructor calls. Those should be explicit unsupported residuals, not invalid C#.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method 'ILInspector.Decompiler.Tests.ConstructorCallDiagnosticsPassTests.*' -method 'ILInspector.Decompiler.Tests.RaisingPassTests.StructConstructor_ByRefStackSlotReceiver_RaisesToNewObject'`
- `dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --diff-validity-defects /tmp/cs0175-baseline.txt /Users/rich/Library/Caches/dotnet-inspect/packages/dapper/2.1.79/lib/net10.0/Dapper.dll /Users/rich/Library/Caches/dotnet-inspect/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll /Users/rich/Library/Caches/dotnet-inspect/packages/automapper/16.1.1/lib/net10.0/AutoMapper.dll`

Defect diff result: `REGRESSED: (none)`, `IMPROVED: CS0175: 5`; the rebased baseline also showed `CS0305: 3` and `CS0149: 1` improvements.
