### PR TITLE
[codex] Structure past-region terminating branch targets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2651,6 +2651,112 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void PastRegionTerminatorTarget_InlinesAsGuardExit()
+    {
+        // A #1031 shared-forward-merge slice from Array.CopyImpl: an outer guard
+        // skips to the fast path, while the inner region can jump past that fast
+        // path to a later terminating slow path. Cloning that terminating target
+        // into the inner guard lets the remaining control flow nest.
+        //   if (a > 0) goto IL_0010;   // fast path
+        //   V_0 = b - 1;
+        //   V_1 = V_0;                    // value used by the slow path
+        //   if (V_0 != 0) goto IL_0018;   // slow path past region
+        //   IL_0010: return a + 1;
+        //   IL_0018: if (b >= 0) goto IL_0020;
+        //   IL_001C: throw null;
+        //   IL_0020: return b;
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+        LoadLocal V0() => new(0, intType);
+        LoadLocal V1() => new(1, intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, A(), new Constant(0, intType)), 16));
+        var b1 = new Block(4);
+        b1.Add(new StoreLocal(0, intType, new Binary(BinaryKind.Subtract, isChecked: false, isUnsigned: false, B(), new Constant(1, intType))));
+        b1.Add(new StoreLocal(1, intType, V0()));
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.NotEqual, false, V0(), new Constant(0, intType)), 24));
+        var fast = new Block(16);
+        fast.Add(new Return(new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, A(), new Constant(1, intType))));
+        var slowGuard = new Block(24);
+        slowGuard.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThanOrEqual, false, B(), new Constant(0, intType)), 32));
+        var slowThrow = new Block(28);
+        slowThrow.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        var slowReturn = new Block(32);
+        slowReturn.Add(new Return(new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, V1(), B())));
+        foreach (var block in (Block[])[b0, b1, fast, slowGuard, slowThrow, slowReturn])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType, intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal("""
+            int V_0;
+
+            if (a <= 0)
+            {
+                V_0 = b - 1;
+                if (V_0 != 0)
+                {
+                    if (b < 0)
+                    {
+                        throw null;
+                    }
+                    return V_0 + b;
+                }
+            }
+            return a + 1;
+            """.ReplaceLineEndings("\n"), output);
+    }
+
+    [Fact]
+    public void PastRegionTerminatorTarget_UnconditionalTargetKeepsLabel()
+    {
+        // Near-miss: the past-region target is also reached by an unconditional
+        // branch. Inlining would erase a label that a real goto still needs, so
+        // the container must stay flat.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+        LoadLocal V0() => new(0, intType);
+        LoadLocal V1() => new(1, intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, A(), new Constant(0, intType)), 16));
+        var b1 = new Block(4);
+        b1.Add(new StoreLocal(0, intType, new Binary(BinaryKind.Subtract, isChecked: false, isUnsigned: false, B(), new Constant(1, intType))));
+        b1.Add(new StoreLocal(1, intType, V0()));
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.NotEqual, false, V0(), new Constant(0, intType)), 24));
+        var fast = new Block(16);
+        fast.Add(new Branch(24)); // external unconditional edge into the slow target
+        var slowGuard = new Block(24);
+        slowGuard.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThanOrEqual, false, B(), new Constant(0, intType)), 32));
+        var slowThrow = new Block(28);
+        slowThrow.Add(new Throw(new Constant(null, TypeRef.CoreLib("System", "Object"))));
+        var slowReturn = new Block(32);
+        slowReturn.Add(new Return(new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, V1(), B())));
+        foreach (var block in (Block[])[b0, b1, fast, slowGuard, slowThrow, slowReturn])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType, intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("goto", output);
+        Assert.Contains("IL_0018", output);
+    }
+
+    [Fact]
     public void OrChainDiamond_FoldsToSingleConditionDiamond()
     {
         // The csc OR-chain diamond shape (HashCode.Combine / ValueTuple, the

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -87,14 +87,16 @@ public class StructuringDiagnosticsTests
     }
 
     [Fact]
-    public void PastRegionCaseBody_WithoutComparisonTree_StaysFlat()
+    public void PastRegionCaseBody_WithoutComparisonTree_StructuresCleanly()
     {
         var function = BuildPastRegionCaseBody(comparisonTree: false);
 
         var diag = RunWithDiagnostics(function);
+        IrPasses.Run(function);
 
-        Assert.Contains("cond-target-past-region", diag.Stops);
-        Assert.Contains(function.Descendants, node => node is Branch or ConditionalBranch);
+        Assert.True(diag.Structured > 0);
+        Assert.Empty(diag.Stops);
+        Assert.DoesNotContain(function.Descendants, node => node is Branch or ConditionalBranch);
     }
 
     static IrFunction BuildPastRegionCaseBody(bool comparisonTree)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -25,10 +25,10 @@ public sealed class StructuringPass : IIrPass
     /// Per-container facts precomputed before any mutation: the block list and
     /// offset map, the offsets reached by an unconditional <c>goto</c> (so an
     /// inlined terminator never erases a label some goto still needs), the
-    /// terminator blocks whose only predecessors are inlined guards (dropped
-    /// from the linear walk), and a snapshot of each inlinable terminator's
-    /// statements (taken before <see cref="BuildRegion"/> detaches anything,
-    /// so the clone source survives mutation order).
+    /// blocks dropped from the linear walk after being cloned or inlined
+    /// into a guard, and a snapshot of each inlinable terminator's statements
+    /// (taken before <see cref="BuildRegion"/> detaches anything, so the
+    /// clone source survives mutation order).
     /// </summary>
     sealed class Ctx
     {
@@ -37,7 +37,7 @@ public sealed class StructuringPass : IIrPass
         public required HashSet<int> UnconditionalTargets { get; init; }
         public required Dictionary<int, int> ConditionalTargetCounts { get; init; }
         public required HashSet<int> BranchTargets { get; init; }
-        public required HashSet<int> DroppableTerminators { get; init; }
+        public required HashSet<int> DroppableBlocks { get; init; }
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
         public required bool IsComparisonTree { get; init; }
@@ -133,7 +133,9 @@ public sealed class StructuringPass : IIrPass
 
         // A terminator whose only predecessors are inlined guards (no goto
         // targets it and the preceding block does not fall into it) becomes
-        // dead once its guards inline — drop it from the walk. Snapshot every
+        // dead once its guards inline — drop it from the walk. Later, past-region
+        // terminating targets cloned into a guard are added to the same drop set.
+        // Snapshot every
         // inlinable terminator's statements now, before BuildRegion mutates.
         // Blocks the preceding block falls through into — control reaches them
         // in program order, so they are not isolated guard leaves.
@@ -165,7 +167,7 @@ public sealed class StructuringPass : IIrPass
             UnconditionalTargets = unconditionalTargets,
             ConditionalTargetCounts = conditionalTargetCounts,
             BranchTargets = branchTargets,
-            DroppableTerminators = droppable,
+            DroppableBlocks = droppable,
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
             IsComparisonTree = isComparisonTree,
@@ -206,8 +208,8 @@ public sealed class StructuringPass : IIrPass
         int i = start;
         while (i < stop)
         {
-            // A terminator left dead by inlining its guards prints nothing.
-            if (ctx.DroppableTerminators.Contains(i))
+            // A block left dead by inlining/cloning into an earlier guard prints nothing.
+            if (ctx.DroppableBlocks.Contains(i))
             {
                 i++;
                 continue;
@@ -554,17 +556,20 @@ public sealed class StructuringPass : IIrPass
     }
 
     static bool CanInlinePastRegionTarget(Ctx ctx, int target)
-        => ctx.IsComparisonTree
-            && !ctx.UnconditionalTargets.Contains(ctx.Blocks[target].StartOffset)
-            && TryBuildPastRegionTarget(ctx, target, out _);
+        => !ctx.UnconditionalTargets.Contains(ctx.Blocks[target].StartOffset)
+            && !ctx.FallenInto.Contains(ctx.Blocks[target].StartOffset)
+            && TryBuildPastRegionTarget(ctx, target, out _, out _);
 
-    static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body)
+    static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body, out int inlinedStop)
     {
         body = null!;
+        inlinedStop = -1;
         int maxStop = Math.Min(ctx.Blocks.Count, target + MaxInlineRegionBlocks);
         for (int stop = target + 1; stop <= maxStop; stop++)
         {
             if (!EndsWithTerminator(ctx.Blocks[stop - 1]))
+                continue;
+            if (Enumerable.Range(target, stop - target).Any(i => ContainsConstructorChainCall(ctx.Blocks[i])))
                 continue;
 
             var clonedBlocks = new List<Block>(stop - target);
@@ -576,6 +581,7 @@ public sealed class StructuringPass : IIrPass
                 continue;
 
             body = BuildRegion(inlineCtx, 0, clonedBlocks.Count, joinIndex: clonedBlocks.Count, breakTarget: null, continueTarget: null);
+            inlinedStop = stop;
             return true;
         }
         return false;
@@ -639,7 +645,7 @@ public sealed class StructuringPass : IIrPass
             UnconditionalTargets = unconditionalTargets,
             ConditionalTargetCounts = conditionalTargetCounts,
             BranchTargets = branchTargets,
-            DroppableTerminators = [],
+            DroppableBlocks = [],
             TerminatorSnapshots = new Dictionary<int, IReadOnlyList<IrNode>>(),
             FallenInto = fallenInto,
             IsComparisonTree = false,
@@ -793,7 +799,8 @@ public sealed class StructuringPass : IIrPass
         int i = start;
         while (i < stop)
         {
-            if (ctx.DroppableTerminators.Contains(i))
+            // Mirrors Validate: dropped blocks were already cloned/inlined.
+            if (ctx.DroppableBlocks.Contains(i))
             {
                 i++;
                 continue;
@@ -896,9 +903,11 @@ public sealed class StructuringPass : IIrPass
                         i = stop;
                         break;
                     }
-                    if (target > stop && TryBuildPastRegionTarget(ctx, target, out var pastRegionArm))
+                    if (target > stop && TryBuildPastRegionTarget(ctx, target, out var pastRegionArm, out int inlinedStop))
                     {
                         result.Add(new IfStatement(condition, pastRegionArm, null));
+                        for (int drop = target; drop < inlinedStop; drop++)
+                            ctx.DroppableBlocks.Add(drop);
                         i++;
                         break;
                     }


### PR DESCRIPTION
## Summary

- Generalize `StructuringPass` past-region target inlining beyond comparison trees when the target is a short terminating region with no unconditional or fallthrough entry.
- Drop the original cloned target blocks from the linear walk so the slow/exit arm is not emitted twice.
- Add a #1031 shared-forward-merge fixture modeled on `System.Array::CopyImpl`, plus an unconditional-target near-miss that must keep the label/goto.

## Why

The `shared-forward-merge` bucket still had shapes where an inner region branches past its local fast path to a later terminating slow/exit arm. `System.Array::CopyImpl` was the concrete representative: the type-compatible slow path was outside the nested region, so the whole method stayed flat despite all branches being structurally representable.

The safe discriminator here is narrow: clone only a terminating target region, reject unconditional and fallthrough entries so labels are not erased, and reject constructor-chain blocks so constructor initializer legality is preserved.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 906 tests, 0 failed
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 12`
  - fully raised: 39,566 / 41,012 (96.47%)
  - `structuring: conditional-branch`: 751
  - `shared-forward-merge`: 118
  - pass bugs: 0
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops --max-examples 10`
  - 11,183 containers structured; 770 left flat across 755 methods
  - `cond-target-past-region`: 315
  - pass bugs: 0
- Product 8-library `--library-report --compile-cap 10000`
  - `structuring: conditional-branch`: 458 across 7 libraries
  - pass bugs: 0
  - Full malformed: 0

Fixes part of #1031. Tracks #921.
