### PR TITLE
Classify DEC0009 by generated source family (--dec0009-shapes, #1031)

### DIFF
--- a/tools/DecompilerHarness/Dec0009Classifier.cs
+++ b/tools/DecompilerHarness/Dec0009Classifier.cs
@@ -1,0 +1,84 @@
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Sub-classifies a <c>DEC0009</c> (<c>UnrepresentableMetadataName</c>) remark by
+/// the compiler-generated source family of the offending name. DEC0009 fires when
+/// a surviving metadata name is not a usable C# identifier
+/// (<c>CSharpSpellability.UnrepresentableMetadataNameReason</c>) — almost always a
+/// Roslyn-synthesized name. The library report counts DEC0009 as one flat bucket
+/// (the largest fidelity residual, ~2.4k product / ~2.9k popular NuGet); this turns
+/// it into a per-family histogram so each family gets a focused decision —
+/// hide/degrade, spell legally, or classify as expected non-user source (#1031).
+///
+/// <para>The reason text is <c>&lt;kind&gt; name 'NAME' has no C# spelling</c>;
+/// the kind word and the quoted NAME are parsed out. Families key on Roslyn's
+/// stable generated-name conventions (<c>docs/compiler/generated-names</c> in
+/// dotnet/roslyn: <c>GeneratedNames.cs</c>).</para>
+/// </summary>
+static class Dec0009Classifier
+{
+    public readonly record struct Classified(string Family, string Kind, string Name);
+
+    public static Classified Classify(string reason)
+    {
+        var (kind, name) = Parse(reason);
+        return new Classified(Family(name), kind, name);
+    }
+
+    /// <summary>The <c>&lt;kind&gt; name 'NAME' …</c> reason split into its kind word and quoted name.</summary>
+    static (string Kind, string Name) Parse(string reason)
+    {
+        int open = reason.IndexOf('\'');
+        int close = reason.LastIndexOf('\'');
+        string name = open >= 0 && close > open ? reason[(open + 1)..close] : reason;
+        // The kind is the text before " name '": "type", "method", "field",
+        // "property", or "generic parameter".
+        int nameWord = reason.IndexOf(" name '", System.StringComparison.Ordinal);
+        string kind = nameWord > 0 ? reason[..nameWord] : "unknown";
+        return (kind, name);
+    }
+
+    /// <summary>The leaf of a nested name (<c>Outer+Inner</c> → <c>Inner</c>); the reason already strips arity.</summary>
+    static string Leaf(string name)
+    {
+        int nested = name.LastIndexOf('+');
+        return nested < 0 ? name : name[(nested + 1)..];
+    }
+
+    static string Family(string rawName)
+    {
+        string name = Leaf(rawName);
+        // Order matters: the more specific <>-prefixed forms before the generic
+        // angle-bracket fallbacks.
+        if (name.StartsWith("<>f__AnonymousType", System.StringComparison.Ordinal)
+            || name.StartsWith("<>f__AnonymousDelegate", System.StringComparison.Ordinal))
+            return "anonymous-type";
+        if (name.StartsWith("<>z__", System.StringComparison.Ordinal))
+            return "collection-expr-synthesized";   // <>z__ReadOnlyArray / ReadOnlySingleElementList
+        if (rawName.Contains("RegexGenerator", System.StringComparison.Ordinal)
+            || name.StartsWith("<RegexGenerator", System.StringComparison.Ordinal))
+            return "regex-source-generator";
+        if (name == "<PrivateImplementationDetails>" || name.StartsWith("<PrivateImplementationDetails>", System.StringComparison.Ordinal))
+            return "private-implementation-details";
+        if (name.StartsWith("<>c__DisplayClass", System.StringComparison.Ordinal))
+            return "display-class";
+        if (name == "<>c")
+            return "lambda-closure-holder";
+        if (name.StartsWith("<>O", System.StringComparison.Ordinal))
+            return "function-pointer-cache";
+        if (name.Contains(">d__", System.StringComparison.Ordinal))
+            return "state-machine";          // async / iterator MoveNext scaffold
+        if (name.Contains(">g__", System.StringComparison.Ordinal))
+            return "local-function";
+        if (name.Contains(">b__", System.StringComparison.Ordinal))
+            return "lambda";
+        if (name.StartsWith("<Main>", System.StringComparison.Ordinal))
+            return "top-level-entrypoint";
+        // Any remaining angle-bracketed name is a generated form not yet split out;
+        // a name with no angle brackets is a genuinely unspellable user/other-language
+        // identifier (the actionable, user-facing tail).
+        if (name.Contains('<') || name.Contains('>'))
+            return "other-generated";
+        return "other-unspellable";
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -51,6 +51,7 @@ static class Program
         bool showDiff = false;
         bool structuringStops = false;
         bool libraryReport = false;
+        bool dec0009Shapes = false;
         bool json = false;
         int topPatterns = 10;
         int? topLibraries = null;
@@ -95,6 +96,7 @@ static class Program
                 case "--show-diff": showDiff = true; break;
                 case "--structuring-stops": structuringStops = true; break;
                 case "--library-report": libraryReport = true; break;
+                case "--dec0009-shapes": dec0009Shapes = true; break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
@@ -122,6 +124,9 @@ static class Program
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
+
+        if (dec0009Shapes)
+            return Dec0009Shapes(assemblies, maxExamples);
 
         // --dump is single-method inspection through the shipped product
         // pipeline (StageDump -> PrintRaised).
@@ -487,6 +492,62 @@ static class Program
         Console.WriteLine();
         foreach (var entry in reasons.OrderByDescending(e => e.Value.Count))
             Console.WriteLine($"  {entry.Value.Count,8}  {entry.Key,-30}  e.g. {entry.Value.Example}");
+        return crashes > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Sub-classifies every <c>DEC0009</c> (unrepresentable metadata name) remark
+    /// across the corpus by compiler-generated source family
+    /// (<see cref="Dec0009Classifier"/>) — the category split #1031 asks for before
+    /// any DEC0009 implementation work. Counts are per remark site (a method may
+    /// carry several); the per-family kind histogram and examples scope each
+    /// family's decision (spell, degrade, or classify as expected non-user source).
+    /// </summary>
+    static int Dec0009Shapes(List<string> assemblies, int maxExamples)
+    {
+        long total = 0, methodsWithDec0009 = 0, sites = 0, crashes = 0;
+        var families = new Dictionary<string, (long Count, Dictionary<string, long> Kinds, List<string> Examples)>();
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                total++;
+                try { IrPasses.Run(function); }
+                catch { crashes++; continue; }
+
+                bool any = false;
+                foreach (var remark in FidelityRemarks.Collect(function))
+                {
+                    if (remark.Code != DiagnosticIds.UnrepresentableMetadataName)
+                        continue;
+                    any = true;
+                    sites++;
+                    var classified = Dec0009Classifier.Classify(remark.Reason);
+                    if (!families.TryGetValue(classified.Family, out var bucket))
+                        bucket = (0, new Dictionary<string, long>(), new List<string>());
+                    bucket.Kinds[classified.Kind] = bucket.Kinds.GetValueOrDefault(classified.Kind) + 1;
+                    if (bucket.Examples.Count < maxExamples)
+                        bucket.Examples.Add($"{typeName}::{methodName} — {classified.Name}");
+                    families[classified.Family] = (bucket.Count + 1, bucket.Kinds, bucket.Examples);
+                }
+                if (any)
+                    methodsWithDec0009++;
+            }
+        }
+
+        Console.WriteLine($"DEC0009 (unrepresentable metadata name) by source family over {total} methods ({crashes} crashes):");
+        Console.WriteLine($"  {sites} remark sites across {methodsWithDec0009} methods");
+        Console.WriteLine();
+        foreach (var (family, bucket) in families.OrderByDescending(f => f.Value.Count))
+        {
+            string kinds = string.Join(", ", bucket.Kinds.OrderByDescending(k => k.Value).Select(k => $"{k.Key} {k.Value}"));
+            Console.WriteLine($"  {bucket.Count,8}  {family,-32}  [{kinds}]");
+            foreach (var example in bucket.Examples.Take(3))
+                Console.WriteLine($"            e.g. {example}");
+        }
         return crashes > 0 ? 1 : 0;
     }
 
@@ -1041,6 +1102,11 @@ static class Program
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by
                                 unsupported-pattern load (default all).
+          --dec0009-shapes      sub-classify every DEC0009 (unrepresentable
+                                metadata name) remark by compiler-generated source
+                                family (display class, lambda, state machine,
+                                anonymous type, regex generator, …) with a per-kind
+                                histogram — the category split behind #1031.
           --pass-impact [pass]  blast-radius sweep — the inverse of --dump --diff.
                                 With no pass: histogram of how many corpus methods
                                 each pass changes. With a pass name (e.g.


### PR DESCRIPTION
Backlog row **"Classify `DEC0009` by source category"** (#1031) — the prerequisite the guardrail requires before any DEC0009 implementation PR.

## What this adds

`Dec0009Classifier` + a `--dec0009-shapes` harness mode that splits every DEC0009 (unrepresentable metadata name) remark by the Roslyn-generated source family of the offending name, with a per-kind (type/method/field/generic-param) histogram and examples. Harness-only diagnostic; no product/pipeline change.

## Counts by family (per remark *site*; the library report counts methods)

| Family | Product (24,074 sites / 2,907 methods) | Popular NuGet (20,494 / 3,122) |
|---|---:|---:|
| display-class (`<>c__DisplayClass`) | 10,784 | 8,787 |
| state-machine (`<M>d__N`) | 3,778 | 6,130 |
| lambda-closure-holder (`<>c`) | 7,115 | 1,170 |
| lambda (`<M>b__`) | 1 | 1,608 |
| local-function (`<M>g__`) | 103 | 1,271 |
| anonymous-type (`<>f__AnonymousType`) | 494 | 436 |
| private-implementation-details | 720 | — |
| function-pointer-cache (`<>O`) | 308 | 154 |
| collection-expr (`<>z__ReadOnlyArray`) | 297 | 87 |
| regex-source-generator | 47 | 265 |
| other-generated | 426 | 586 |
| **other-unspellable (user-facing)** | **0** | **0** |

## Headline finding

**Zero genuinely user-facing unspellable names.** Every DEC0009 is a compiler-generated name, and ~95% are names that leak because their **construct isn't raised yet** — lambdas (`<>c`/`<>c__DisplayClass`/`b__`), local functions (`g__`), and async/iterator state machines (`d__`). DEC0009 is therefore mostly a *symptom of unraised generated code*, not a name-spelling problem: those sites vanish when lambda/closure/local-function and state-machine raising land (large separate efforts; state machines = #948 + iterator reconstruction).

The genuinely name-spelling-actionable tail is small: `private-implementation-details` (#916, already open), `anonymous-type`, `collection-expr`, `function-pointer-cache`, and the `other-generated` bucket (notably ~267 NuGet *types* + ~270 generic params like `<sink>P` — worth one inspection). Per-family decline rationale / focused follow-ups go in the #1031 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)