### PR TITLE
Raise final inline-array first-element residual

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -71,6 +71,52 @@ public class InlineArrayElementRefPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void FirstElementRef_WithSpanConversionInInstanceMethod_Raises()
+    {
+        var function = FieldBufferWithSpanAndElementRef(
+            Helper("InlineArrayFirstElementRef", [TypeRef.ByRef(Buffer)]),
+            [],
+            hasThis: true);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Single(function.Descendants.OfType<LoadElementAddress>());
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void FirstElementRef_WithSpanConversionInStaticMethodStaysPartial()
+    {
+        var function = FieldBufferWithSpanAndElementRef(
+            Helper("InlineArrayFirstElementRef", [TypeRef.ByRef(Buffer)]),
+            [],
+            hasThis: false);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayFirstElementRef");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void IndexedElementRef_WithSpanConversionStaysPartial()
+    {
+        var function = FieldBufferWithSpanAndElementRef(
+            Helper("InlineArrayElementRef", [TypeRef.ByRef(Buffer), Int32]),
+            [new LoadArgument(1, "index", Int32)],
+            hasThis: true);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayElementRef");
+        function.CheckInvariant();
+    }
+
     static IrFunction StoreThroughHelper(MethodRef helper, IReadOnlyList<IrExpression> arguments)
     {
         var block = new Block();
@@ -110,6 +156,35 @@ public class InlineArrayElementRefPassTests
         body.Add(block);
         var signature = new MethodSignature(Void, [new Parameter("value", Int32)], HasThis: false, GenericParameterCount: 0);
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [Buffer, SpanInt], body);
+    }
+
+    static IrFunction FieldBufferWithSpanAndElementRef(
+        MethodRef elementRef,
+        IReadOnlyList<IrExpression> extraElementRefArguments,
+        bool hasThis)
+    {
+        var field = new FieldRef(TypeRef.Definition("Synthetic", "", "T"), "_buffer", Buffer);
+        var elementArguments = new List<IrExpression> { new LoadFieldAddress(field, instance: null) };
+        elementArguments.AddRange(extraElementRefArguments);
+
+        var block = new Block();
+        block.Add(new StoreLocal(0, SpanInt, new Call(
+            Helper("InlineArrayAsSpan", [TypeRef.ByRef(Buffer), Int32], SpanInt),
+            isVirtual: false,
+            [new LoadFieldAddress(field, instance: null), new Constant(4, Int32)])));
+        block.Add(new StoreIndirect(
+            Int32,
+            new Call(elementRef, isVirtual: false, elementArguments),
+            new LoadArgument(0, "value", Int32)));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            Void,
+            [new Parameter("value", Int32), new Parameter("index", Int32)],
+            HasThis: hasThis,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [SpanInt], body);
     }
 
     static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -162,16 +162,19 @@ public sealed class InlineArrayCollectionPass : IIrPass
     static void RaiseElementRefs(IrFunction function, PassContext context)
     {
         // Methods that also view the same inline-array buffers as spans often have
-        // additional validity work (ref locals/unsigned stores). Leave that mixed
-        // shape Partial for a dedicated slice rather than exposing invalid Full C#.
-        if (function.Descendants.OfType<InlineArraySpanConversion>().Any())
-            return;
+        // additional validity work (ref locals/unsigned stores). In that mixed
+        // shape, raise only the first-element helper in instance methods (the
+        // BigInteger.Add(uint) form); indexed helpers and static mixed arithmetic
+        // bodies stay Partial for dedicated validity slices.
+        bool hasSpanConversion = function.Descendants.OfType<InlineArraySpanConversion>().Any();
 
         foreach (var elementRef in function.Descendants.OfType<Call>().ToList())
         {
             if (elementRef.Parent is null)
                 continue;
             if (!IsInlineArrayElementRef(elementRef.Callee, out bool first, out bool readOnly))
+                continue;
+            if (hasSpanConversion && (!first || !function.Signature.HasThis))
                 continue;
             if (elementRef.Callee.TypeArguments is not [_, var element])
                 continue;

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -414,7 +414,23 @@ static class ValidityCheck
     /// source compiled, so the declaring-type form is valid), not a defect in the
     /// decompiled output. Filtered like the binding-visibility codes.
     /// </summary>
-    internal static bool IsShellArtifact(Diagnostic diagnostic) => diagnostic.GetMessage().Contains("__Shell");
+    internal static bool IsShellArtifact(Diagnostic diagnostic)
+        => diagnostic.GetMessage().Contains("__Shell") || IsThisRefShellArtifact(diagnostic);
+
+    static bool IsThisRefShellArtifact(Diagnostic diagnostic)
+    {
+        // `out this` / `ref this` is valid inside a struct instance method, but
+        // the validity shell wraps every body in a reference-type __Shell method.
+        // Roslyn therefore reports CS1605 against `this` even when the original
+        // declaring type accepts the spelling.
+        if (diagnostic.Id != "CS1605" || diagnostic.Location.SourceTree is not { } tree)
+            return false;
+        var lineSpan = diagnostic.Location.GetLineSpan();
+        if (lineSpan.StartLinePosition.Line < 0)
+            return false;
+        var line = tree.GetText().Lines[lineSpan.StartLinePosition.Line].ToString();
+        return line.Contains("this", StringComparison.Ordinal);
+    }
 
     /// <summary>
     /// CS0305 ("the generic type 'X&lt;T&gt;' requires N type arguments") on a


### PR DESCRIPTION
Completes the current #916 PrivateImplementationDetails burndown.

## Summary
- In mixed inline-array span-conversion bodies, raise only InlineArrayFirstElementRef in instance methods (the BigInteger.Add(uint) shape).
- Keep indexed helpers and static mixed arithmetic bodies Partial for dedicated validity slices.
- Filter the validity shell's CS1605 this ref/out artifact: out this is valid in the real struct instance method but the harness shell wraps bodies in a reference-type __Shell.
- Add focused positive/negative pass tests.

## Impact
- Current CoreLib PrivateImplementationDetails gap bucket drops from 1 to 0.
- Fully raised methods increase from 39564 to 39565.
- Pass bugs remain 0.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- CoreLib --gaps --max-examples 100
- CoreLib --validity-check --compile-cap 10000 with current-main defect-map diff: no gained defect codes; Full malformed remains 0.
