### PR TITLE
Fix nested bool select stack-slot materialization

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1662,6 +1662,55 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void BooleanMaterialization_NestedZeroOneSelect_DeclaresBoolSlot()
+    {
+        // A nested 0/1 select tree can still be a boolean when every live load is
+        // consumed as bool. Without recursively materializing the arms, the store
+        // declares as int while the load declares as bool (S_0_1), causing CS0165.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new Conditional(
+            new LoadArgument(0, "explicitInclude", boolType),
+            new Constant(1, intType),
+            new Conditional(
+                new LoadArgument(1, "wantsFetch", boolType),
+                new Constant(0, intType),
+                new Conditional(
+                    new Comparison(ComparisonKind.GreaterThanOrEqual, isUnsigned: false, new LoadArgument(2, "verbosity", intType), new Constant(3, intType)),
+                    new Constant(1, intType),
+                    new Constant(0, intType))
+                { MergedType = intType })
+            { MergedType = intType })
+        { MergedType = intType }));
+        var then = new Block(4);
+        then.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        block.Add(new IfStatement(new LoadStackSlot(0, intType), then, null));
+        var secondThen = new Block(8);
+        secondThen.Add(new StoreLocal(0, intType, new Constant(2, intType)));
+        block.Add(new IfStatement(new LoadStackSlot(0, intType), secondThen, null));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(voidType,
+            [new Parameter("explicitInclude", boolType), new Parameter("wantsFetch", boolType), new Parameter("verbosity", intType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("bool S_0", output);
+        Assert.Contains("if (S_0)", output);
+        Assert.DoesNotContain("int S_0", output);
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.DoesNotContain(": 0", output);
+        Assert.DoesNotContain(": 1", output);
+    }
+
+    [Fact]
     public void BooleanMaterialization_ReusedReceiverSlot_KeepsBoolLiveRangeDistinct()
     {
         // A ?. bool test can reuse the same edge slot first for the string

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -203,28 +203,30 @@ public sealed class BooleanFoldingPass : IIrPass
     }
 
     /// <summary>
-    /// <c>cond ? 0 : boolExpr</c> → <c>cond ? false : boolExpr</c>. IL has no
-    /// bool constant (ldc.i4 serves bools too), so a select that sets a literal
-    /// 0/1 beside a genuine bool arm is a boolean expression. Retyping the
-    /// constant — and the conditional's merged result — recovers it; the slot
-    /// then declares as <c>bool</c>, not <c>int</c> (the source of CS0029 when a
-    /// bool-returning method returns the slot). The non-constant bool arm plus
-    /// the downstream consumer check are the proof: a real integer select never
-    /// pairs with one, and a reused spill slot is not retyped unless every live
-    /// load after the store is consumed as bool. Stepper audit specimen:
+    /// <c>cond ? 0 : boolExpr</c> (and nested 0/1/bool conditionals) →
+    /// <c>cond ? false : boolExpr</c>. IL has no bool constant (ldc.i4 serves
+    /// bools too), so a select tree that sets literal 0/1 arms beside a genuine
+    /// bool arm is a boolean expression. Retyping the constants — and each
+    /// conditional's merged result — recovers it; the slot then declares as
+    /// <c>bool</c>, not <c>int</c> (the source of CS0029/CS0165 when a bool load
+    /// later gets a split stack-slot name). The non-constant bool arm plus the
+    /// downstream consumer check are the proof: a real integer select never pairs
+    /// with one, and a reused spill slot is not retyped unless every live load
+    /// after the store is consumed as bool. Stepper audit specimen:
     /// <c>CfgSampleClass.SelectBoolReturn</c>, where step 1 folds the stack-slot
     /// diamond and step 2 may materialize the <c>0</c> arm only because the slot
     /// feeds a bool return.
     /// </summary>
     static bool MaterializeBoolConditional(IrFunction function, Conditional conditional, Stepper stepper)
     {
-        var constant = (conditional.WhenTrue as Constant) ?? (conditional.WhenFalse as Constant);
-        var other = conditional.WhenTrue is Constant ? conditional.WhenFalse : conditional.WhenTrue;
-        if (constant is not { Value: int value } || value is not (0 or 1))
-            return false;
-        if (other is Constant || other.ResultType is not { Namespace: "System", Name: "Boolean" })
-            return false;
         var boolType = TypeRef.CoreLib("System", "Boolean");
+        if (!CanMaterializeBoolExpression(conditional, out bool hasBoolEvidence, out bool needsRewrite)
+            || !hasBoolEvidence
+            || !needsRewrite)
+        {
+            return false;
+        }
+
         StoreStackSlot? slotStore = conditional.Parent as StoreStackSlot;
         List<LoadStackSlot>? liveLoads = null;
         if (slotStore is not null)
@@ -242,8 +244,7 @@ public sealed class BooleanFoldingPass : IIrPass
             return false;
         }
         stepper.StepOver("materialize bool ternary constant arm", conditional);
-        constant.ReplaceWith(new Constant(value == 1, boolType));
-        conditional.MergedType = boolType;
+        MaterializeBoolExpression(conditional, boolType);
         if (liveLoads is not null)
         {
             foreach (var load in liveLoads)
@@ -251,6 +252,49 @@ public sealed class BooleanFoldingPass : IIrPass
                     load.ReplaceWith(new LoadStackSlot(slotStore!.Slot, boolType));
         }
         return true;
+    }
+
+    static bool CanMaterializeBoolExpression(IrExpression expression, out bool hasBoolEvidence, out bool needsRewrite)
+    {
+        hasBoolEvidence = false;
+        needsRewrite = false;
+        switch (expression)
+        {
+            case Constant { Value: int value } when value is 0 or 1:
+                needsRewrite = true;
+                return true;
+            case { ResultType: { Namespace: "System", Name: "Boolean" } }:
+                hasBoolEvidence = expression is not Constant;
+                return true;
+            case Conditional conditional:
+            {
+                if (!CanMaterializeBoolExpression(conditional.WhenTrue, out bool trueEvidence, out bool trueRewrite)
+                    || !CanMaterializeBoolExpression(conditional.WhenFalse, out bool falseEvidence, out bool falseRewrite))
+                {
+                    return false;
+                }
+                hasBoolEvidence = trueEvidence || falseEvidence || IsBool(conditional.Condition.ResultType);
+                needsRewrite = trueRewrite || falseRewrite || !IsBool(conditional.MergedType);
+                return true;
+            }
+            default:
+                return false;
+        }
+    }
+
+    static void MaterializeBoolExpression(IrExpression expression, TypeRef boolType)
+    {
+        switch (expression)
+        {
+            case Constant { Value: int value } constant when value is 0 or 1:
+                constant.ReplaceWith(new Constant(value == 1, boolType));
+                break;
+            case Conditional conditional:
+                MaterializeBoolExpression(conditional.WhenTrue, boolType);
+                MaterializeBoolExpression(conditional.WhenFalse, boolType);
+                conditional.MergedType = boolType;
+                break;
+        }
     }
 
     static IEnumerable<LoadStackSlot> LiveLoadsAfterStore(IrFunction function, StoreStackSlot store)


### PR DESCRIPTION
Part of #1031.

## Summary
- Recursively materialize nested `0`/`1` conditional trees as `bool` when the downstream consumer proves the stack-slot value is boolean.
- Prevents split stack-slot names like `S_256` / `S_256_1` where the bool load name is never assigned, causing CS0165.
- Adds a synthetic regression for the nested select tree that caused `SectionPipeline<TModel>::GetAuthorizedSections` to branch on an unassigned bool slot.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RaisingPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- Product defect diff: CS0165 improved for `DotnetInspector.Sections.SectionPipeline`1::GetAuthorizedSections`, 0 regressions.
- Popular defect diff: CS0165 improved for `Newtonsoft.Json.Serialization.JsonArrayContract::.ctor` and `Newtonsoft.Json.Serialization.JsonSerializerInternalWriter::WriteStartArray`, 0 regressions.
