### PR TITLE
Pin EhStructuringPass fault/filterless-catch flat-form contract (#1031 EH-entangled audit)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -2,6 +2,14 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+/// <summary>
+/// <see cref="EhStructuringPass"/> is transactional: a function either raises
+/// completely into try/catch/finally or keeps the always-correct flat form with
+/// <see cref="IrFunction.Regions"/> intact. These tests pin the legality-preserving
+/// bails — filter, fault, and filterless (null catch type) handlers stay flat
+/// rather than emit a partial or illegal structuring — which is why those methods
+/// surface as the "eh-entangled" shape instead of a structured (but wrong) shell.
+/// </summary>
 public class EhStructuringPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
@@ -170,6 +178,81 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction FaultRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0030));
+        body.Add(tryBlock);
+
+        var faultBlock = new Block(0x0020);
+        faultBlock.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        faultBlock.Add(new EndFinally());
+        body.Add(faultBlock);
+
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Fault,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction FilterlessCatchRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0030));
+        body.Add(tryBlock);
+
+        var handlerBlock = new Block(0x0020);
+        handlerBlock.Add(new Leave(0x0030));
+        body.Add(handlerBlock);
+
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Catch,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
     [Fact]
     public void LeaveRetryOutsideTry_ConsumesFinallyRegion()
     {
@@ -212,6 +295,29 @@ public class EhStructuringPassTests
     public void FilterRegion_KeepsRegionFlat()
     {
         var function = FilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+    }
+
+    [Fact]
+    public void FaultRegion_KeepsRegionFlat()
+    {
+        var function = FaultRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+    }
+
+    [Fact]
+    public void FilterlessCatchRegion_KeepsRegionFlat()
+    {
+        var function = FilterlessCatchRegion();
 
         new EhStructuringPass().Run(function, PassContext.None);
 


### PR DESCRIPTION
## Audit: conditional-branch `eh-entangled` shape (#1031)

**Row:** Conditional-branch EH-entangled slice (stepper semantic audit).
**Done-signal taken:** phase-contract note (no illegal transform found).

### Audit

The `eh-entangled` shape (`ConditionalBranchShapeClassifier`: a `Leave`/`EndFinally`/`EndFilter` survives) is **not** a defect or an illegal rewrite. It is `EhStructuringPass` keeping the **always-correct flat form** on purpose. The pass is transactional — "a function either raises completely or keeps the always-correct flat form with `IrFunction.Regions` intact" — and bails the whole function when it sees:

- a `Filter` or `Fault` region (`EhStructuringPass.cs:42`), or
- a `Catch` with no catch type (`EhStructuringPass.cs:44`).

Representative CoreLib specimen `System.Enum::TryParseRareTypeByValueOrName` carries a filter (`catch when`), so it hits the filter bail and stays flat. Stepper audit confirmed the pass declines to structure rather than emitting a partial/illegal try/catch — EH legality is preserved. CoreLib has 50 `eh-entangled` methods by shape.

### Change

The **filter** bail was already pinned by `FilterRegion_KeepsRegionFlat`. The sibling **fault** and **filterless-catch** bails on the same legality slice were unguarded. This PR pins them:

- `FaultRegion_KeepsRegionFlat`
- `FilterlessCatchRegion_KeepsRegionFlat`
- class-doc note recording the legality-preserving invariant.

A future change cannot half-raise fault/filterless handlers into a structured-but-wrong shell without a failing test.

Test-only; no product behavior change. Full decompiler suite: **917 passed, 0 failed**.

### Follow-up

Actually raising filter (`catch when`) and fault handlers is left as a future raise target (pivot issue filed), since it requires new structured EH nodes beyond this audit's scope.
