### PR TITLE
Cover manual awaited DisposeAsync finally

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2994,6 +2994,19 @@ public class CfgSampleClass
         return resource.Value;
     }
 
+    public static async System.Threading.Tasks.Task<int> ManualAwaitDisposeAsyncInFinally(int value)
+    {
+        var resource = new AsyncDisposableResource(value);
+        try
+        {
+            return resource.Value;
+        }
+        finally
+        {
+            await resource.DisposeAsync();
+        }
+    }
+
     // ---- iterator fixtures: kickoff hands off to a <Method>d__N state machine ----
     // The simplest linear case: two constant yields, no params or captures.
     public static System.Collections.Generic.IEnumerable<int> YieldTwo()

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -150,6 +150,15 @@ public class UsingStatementPassTests
     }
 
     [Fact]
+    public void ManualAwaitDisposeAsyncInFinally_IsNotRaisedToAwaitUsing()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualAwaitDisposeAsyncInFinally));
+
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.NotEmpty(function.Descendants.OfType<TryCatch>());
+    }
+
+    [Fact]
     public void ValueTypeDisposeLookalike_IsLeftAsTryFinally()
     {
         var function = BuildValueTypeUsingLookalike(
@@ -230,7 +239,7 @@ public class UsingStatementPassTests
     public void RealDisposeAsyncInFinally_IsNotRaisedToUsing()
     {
         // A real compiled finally that calls DisposeAsync() on a reference-type
-        // resource (the manual await-using lookalike) must never collapse into a
+        // resource (the manual async-dispose lookalike) must never collapse into a
         // synchronous `using`: DisposeAsync is not IDisposable.Dispose.
         var function = Raised(nameof(CfgSampleClass.ManualDisposeAsyncInFinally));
 

--- a/src/ILInspector.Decompiler/Pipeline/Facts/UsingRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/UsingRecoveryFacts.cs
@@ -14,7 +14,7 @@ internal sealed class UsingRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("dataflow.local-write-region", "UsingStatementPass local reference/write checks"),
             ],
             PositiveCoverage: "UsingStatementPassTests reference, value-type constrained, ref-struct pattern dispose, and runtime-async await using DisposeAsync shapes",
-            AdversarialCoverage: "UsingStatementPassTests resource reassignment lookalike, wrong-signature pattern Dispose negatives, await-using DisposeAsync/ValueTask-returning negatives, and manual DisposeAsync-in-finally negative",
+            AdversarialCoverage: "UsingStatementPassTests resource reassignment lookalike, wrong-signature pattern Dispose negatives, await-using DisposeAsync/ValueTask-returning negatives, and sync/awaited manual DisposeAsync-in-finally negatives",
             MissingDiscriminator: "classic async state-machine await using and broader DisposeAsync pattern/provider shapes are not raised"),
     ];
 }


### PR DESCRIPTION
## Summary

- add a minimized manual `try/finally` fixture that awaits `DisposeAsync` without using source `await using`
- add an adversarial using-statement test proving this near-miss does not raise to `await using`
- update using recovery facts to call out both sync and awaited manual `DisposeAsync` finally negatives

Resolves the manual async-dispose finally row in #1045.

## Verification

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.UsingStatementPassTests`
- `dotnet build src/dotnet-inspect -c Release`