### PR TITLE
Add checked arithmetic fixture axis

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -587,7 +587,8 @@ that produces the same IL and differs only in mode metadata. It is small by
 construction — only mode-sensitive fixtures get thin per-flag overlay assemblies
 — so the cost is one default plus a few shrinking single-flag overlays, never the
 corpus times N. The active axes are the `runtime-async=off` overlay
-(`Fixtures.ClassicAsync`) and the old/new memory-safety pair
+(`Fixtures.ClassicAsync`), the checked-arithmetic overlay
+(`Fixtures.CheckedArithmetic`), and the old/new memory-safety pair
 (`Fixtures.LegacyUnsafe` / `Fixtures.NewUnsafe`, plus `UnsafeChainA/B/C` for
 cross-assembly `RequiresUnsafeAttribute` resolution). The mechanics, axis
 switches, and recipe for adding an axis live in

--- a/src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/CheckedArithmeticFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/CheckedArithmeticFixtures.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace ILInspector.Decompiler.Fixtures.CheckedArithmetic;
+
+/// <summary>
+/// Representative source compiled with project-wide overflow checking enabled.
+/// Plain arithmetic here lowers to checked IL opcodes, unlike the repo default
+/// unchecked context.
+/// </summary>
+public static class CheckedArithmeticFixtures
+{
+    public static int Add(int left, int right) => left + right;
+
+    public static int Subtract(int left, int right) => left - right;
+
+    public static int Multiply(int left, int right) => left * right;
+
+    public static int Increment(int value)
+    {
+        value++;
+        return value;
+    }
+
+    public static int CompoundAdd(int value, int delta)
+    {
+        value += delta;
+        return value;
+    }
+
+    public static short NarrowToInt16(int value) => (short)value;
+
+    public static byte AddThenNarrowToByte(int left, int right) => (byte)(left + right);
+
+    public static ulong SignedToUInt64(long value) => (ulong)value;
+
+    public static int UncheckedIsland(int left, int right) => unchecked(left + right);
+
+    public static int CatchesOverflow(int left, int right)
+    {
+        try
+        {
+            return left + right;
+        }
+        catch (OverflowException)
+        {
+            return -1;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Checked-arithmetic axis of the multi-mode fixture matrix.
+
+    This assembly flips the project-wide C# overflow-checking mode with
+    CheckForOverflowUnderflow=true. The source intentionally avoids explicit
+    checked(...) syntax for the primary arithmetic methods: the mode switch is
+    what changes plain add/sub/mul/conv IL into *.ovf opcodes.
+
+    On-demand only: deliberately NOT referenced by the test project or any CI gate.
+    Build it, then point the harness at the DLL in library-report mode to measure
+    the checked-context lowering.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -104,6 +104,20 @@ both assemblies are 8/8 full and fully raised, with no unsupported patterns.
 `RequiresUnsafeAttribute` resolution and optimistic `--simulate-new-rules`
 diagnostics.
 
+The checked-arithmetic axis is `src/ILInspector.Decompiler.Fixtures.CheckedArithmetic`:
+
+```bash
+dotnet build src/ILInspector.Decompiler.Fixtures.CheckedArithmetic -c Release
+dotnet run --project tools/DecompilerHarness -c Release -- --library-report \
+  artifacts/bin/ILInspector.Decompiler.Fixtures.CheckedArithmetic/release/ILInspector.Decompiler.Fixtures.CheckedArithmetic.dll
+```
+
+It sets `<CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>` so plain
+arithmetic/conversions lower to `*.ovf` opcodes. Baseline: 10/10 full and fully
+raised, with no unsupported patterns or pass bugs. The axis is still useful as a
+discovery guard: any future checked-context fixture that does not remain full
+should become a focused issue from the report.
+
 **The quality loop it drives — discovery, then bring-down.** This is how the
 matrix feeds the quality program (see
 [docs/decompiler-quality.md](../../docs/decompiler-quality.md), "Multi-mode


### PR DESCRIPTION
## Summary
- add `ILInspector.Decompiler.Fixtures.CheckedArithmetic` as an on-demand multi-mode fixture axis
- compile the overlay with `<CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>` so plain arithmetic lowers to checked `*.ovf` opcodes
- document the axis and its baseline in the harness README and decompiler quality notes

## Validation
- `npx markdownlint-cli tools/DecompilerHarness/README.md docs/decompiler-quality.md`
- `dotnet build src/ILInspector.Decompiler.Fixtures.CheckedArithmetic -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --library-report artifacts/bin/ILInspector.Decompiler.Fixtures.CheckedArithmetic/release/ILInspector.Decompiler.Fixtures.CheckedArithmetic.dll`
- `dotnet build src/dotnet-inspect -c Release`

CheckedArithmetic baseline: 10/10 Full, 10/10 fully raised, 0 Full malformed, 0 bound Full defects, 0 pass bugs, no unsupported patterns.

Part of #998