### PR TITLE
Fold boolExpr == 0/1(int) to negation for any bool operand (#1031)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3038,6 +3038,33 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void FoldBoolConstantComparison_NonSlotBoolEqualsIntZero_FoldsToNegation()
+    {
+        // The general bool/int-join fix (#1031 follow-through to #1019): csc's
+        // `ceq 0` negation idiom over a non-slot bool — here a comparison result
+        // `(a > b) == 0` — must fold to `!(a > b)`, not leave the CS0019
+        // `bool == int`. FoldBoolConstantComparison now accepts the 0/1 int
+        // spelling, not only a bool constant (the LibrarySections.CanRender defect).
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var block = new Block(0);
+        block.Add(new Return(new Comparison(ComparisonKind.Equal, false,
+            new Comparison(ComparisonKind.GreaterThan, false,
+                new LoadArgument(0, "a", intType), new LoadArgument(1, "b", intType)),
+            new Constant(0, intType))));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType,
+            [new Parameter("a", intType), new Parameter("b", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("== 0", output);   // no `bool == int` (CS0019)
+    }
+
+    [Fact]
     public void SharedThrowGuards_InlineAsGuardClauses()
     {
         // Two guards branch to one shared throw block — the shape that breaks

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -329,7 +329,7 @@ public sealed class BooleanFoldingPass : IIrPass
         if (comparison.Kind is not (ComparisonKind.Equal or ComparisonKind.NotEqual))
             return false;
         if (comparison.Left.ResultType is not { Namespace: "System", Name: "Boolean" }
-            || comparison.Right is not Constant { Value: bool constant })
+            || BoolConstant(comparison.Right) is not { } constant)
         {
             return false;
         }
@@ -340,6 +340,20 @@ public sealed class BooleanFoldingPass : IIrPass
         comparison.ReplaceWith(keepIdentity ? operand : Conditions.Negate(operand));
         return true;
     }
+
+    /// <summary>
+    /// A bool literal, or csc's <c>0</c>/<c>1</c> int spelling of one (a
+    /// <c>ceq</c>/<c>cgt</c> against 0 is the <c>!x</c>/<c>x</c> idiom over a
+    /// bool-typed operand). Returns the bool value, or null when the operand is
+    /// not a bool/0/1 constant. Generalizes the bool-slot retype (#1019) to any
+    /// bool-typed left operand — a ternary, call result, or field, not only a slot.
+    /// </summary>
+    static bool? BoolConstant(IrExpression expression) => expression switch
+    {
+        Constant { Value: bool value } => value,
+        Constant { Value: int value } when value is 0 or 1 => value == 1,
+        _ => null,
+    };
 
     /// <summary>if (a) { if (b) { T } } → if (a &amp;&amp; b) { T }</summary>
     static bool FoldNestedGuard(IfStatement outer, Stepper stepper)


### PR DESCRIPTION
#1031 backlog row **"Join-type / bool-int-type audit follow-through"** — the general fix beyond #1019.

## Follow-through finding

After #1019 (which fixed the `ceq 0` bool-negation idiom for stack **slots**), rebaselining the bool/int validity buckets on the product corpus surfaced the **same idiom over non-slot bool operands** still emitting the CS0019 `bool == int`:

- `LibrarySections.References::CanRender`: `return (V_1 is not null ? (V_1.Count > 0) : false) == 0;`

`FoldBoolConstantComparison` only accepted a **bool** constant on the right; #1019's sibling-retype was slot-specific in `MaterializeBooleanSlots`. So a bool **ternary** (or call result / field) compared `== 0(int)` wasn't folded.

## Fix

Generalize `FoldBoolConstantComparison` to accept the `0`/`1` int spelling (new `BoolConstant` helper) whenever the **left** operand is bool-typed — `bool == int` is only ever csc's `ceq`/`cgt`-against-0 idiom, so the fold to `!x`/`x` is sound. `CanRender` now renders `return !(V_1 is not null ? V_1.Count > 0 : false);`.

## Validation

- Validity defect diff vs parent on the 6 external product libraries (9,343 methods): **0 regressed, 1 improved** (`CanRender`).
- **915 decompiler tests green**, +1 regression test (`FoldBoolConstantComparison_NonSlotBoolEqualsIntZero_FoldsToNegation`).

## Residual family (for #1031)

One more bool/int sub-shape remains, **distinct** from this idiom: a bool comparison result used in **int arithmetic** — `LevenshteinDistance::Compute`: `prev + (source[i] != target[j])` (`int + bool`). That's a bool-as-int coercion in arithmetic, not a `== 0` negation; it needs a separate cast/coercion decision. Recommending a focused follow-up row rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)