### PR TITLE
Track recursive property pattern frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1094,6 +1094,11 @@ public class CfgSampleClass
         public int Y { get; init; }
     }
 
+    public sealed class RecursivePatternSource
+    {
+        public object? PublicProperty { get; init; }
+    }
+
     public sealed class FloatHolder
     {
         public double Magnitude { get; init; }
@@ -1110,6 +1115,17 @@ public class CfgSampleClass
     public static bool IsPatternMultiProperty(object o) => o is PatternPoint { X: 1, Y: 2 };
 
     public static bool IsPatternMultiPropertyMixed(object o) => o is PatternPoint { X: > 0, Y: 2 };
+
+    // Runtime-mined frontier shape: a recursive property pattern with a
+    // declaration subpattern whose variable is used in the body. The decompiler
+    // currently raises the outer type test only; `{ PublicProperty: string str }`
+    // is a later pattern-frontier slice.
+    public static int RecursivePropertyPatternBinding(RecursivePatternSource value)
+    {
+        if (value is { PublicProperty: string str })
+            return str.Length;
+        return 0;
+    }
 
     public static int IsPatternManualAsAndPropertiesWithUse(object o)
     {

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -147,6 +147,20 @@ public class IsPatternPassTests
     }
 
     [Fact]
+    public void RecursivePropertyDeclarationPattern_IsPatternFrontier()
+    {
+        var function = Raised(nameof(CfgSampleClass.RecursivePropertyPatternBinding));
+
+        Assert.Empty(function.Descendants.OfType<IsPattern>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("if (value is not null)", output);
+        Assert.Contains("str = value.PublicProperty as string;", output);
+        Assert.Contains("if (str is not null)", output);
+        Assert.DoesNotContain("{ PublicProperty: string str }", output);
+    }
+
+    [Fact]
     public void ManualAsAndPropertyChecks_WithLocalUse_StaysFlatChain()
     {
         var function = Raised(nameof(CfgSampleClass.IsPatternManualAsAndPropertiesWithUse));

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
@@ -13,6 +13,6 @@ internal sealed class IsPatternRecoveryFacts : ILoweringFactProvider
             ],
             PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures",
             AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, duplicate-property, unsigned relational-property, and floating-point relational sub-pattern (NaN-unsafe fold) negatives",
-            MissingDiscriminator: "positional/list sub-patterns remain unraised; non-integral relational sub-patterns are deliberately declined (float ordered/unordered compares disagree on NaN; unsigned compares disagree with signed relational patterns) rather than folded"),
+            MissingDiscriminator: "positional/list sub-patterns and recursive property declaration sub-patterns (`{ P: T t }`) remain unraised; non-integral relational sub-patterns are deliberately declined (float ordered/unordered compares disagree on NaN; unsigned compares disagree with signed relational patterns) rather than folded"),
     ];
 }


### PR DESCRIPTION
Part of #1045.

## Summary
- Minimized the runtime `LocalDataFlow` recursive property declaration pattern shape into `CfgSampleClass.RecursivePropertyPatternBinding`.
- Added an `IsPatternPassTests` frontier assertion showing current output stays as nested null/as tests and does not claim `{ PublicProperty: string str }`.
- Updated `IsPatternRecoveryFacts` to record recursive property declaration subpatterns (`{ P: T t }`) as an unraised frontier.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IsPatternPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
