### PR TITLE
Pin generic function pointer calli rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2715,6 +2715,23 @@ public class CfgSampleClass
     // A void-returning function-pointer invocation renders as a statement.
     public static unsafe void InvokesVoidFunctionPointer(delegate*<int, void> callback, int value) => callback(value);
 
+    // Runtime GenericFunctionPointer-style specimen: a void* is cast to a
+    // generic unmanaged function-pointer signature, then invoked through calli.
+    // The generic return and argument types must stay on the CallIndirect
+    // signature instead of degrading to an unsupported function-pointer shape.
+    public static unsafe T InvokesGenericUnmanagedFunctionPointer<T, U>(void* callback, U value)
+    {
+        return ((delegate* unmanaged<U, T>)callback)(value);
+    }
+
+    // Same calli family, but with a byref argument. This pins the ref-kind
+    // preservation discriminator from the runtime specimen without pulling in
+    // UnmanagedCallersOnly or interop runtime behavior.
+    public static unsafe void InvokesUnmanagedFunctionPointerWithRef(void* callback, ref int value, float arg)
+    {
+        ((delegate* unmanaged<ref int, float, void>)callback)(ref value, arg);
+    }
+
     static unsafe delegate*<int, int> s_functionPointer;
     static int FunctionPointerTarget(int value) => value;
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -237,6 +237,50 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void Calli_GenericUnmanagedFunctionPointer_PreservesSignature()
+    {
+        // Minimized from runtime's GenericFunctionPointer test: a void* cast to a
+        // generic unmanaged delegate* then invoked through calli. The call-site
+        // signature, not the pointer's static void* type, carries the generic
+        // argument and return types.
+        var function = ImportFixture(nameof(CfgSampleClass.InvokesGenericUnmanagedFunctionPointer));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var call = Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Equal("T", call.ReturnType.ToDisplayString());
+        Assert.Equal("U", Assert.Single(call.ParameterTypes).ToDisplayString());
+        Assert.Single(call.Arguments);
+        Assert.Contains("delegate* unmanaged<U, T>", call.Pointer.ResultType!.ToDisplayString());
+
+        var raised = ImportFixture(nameof(CfgSampleClass.InvokesGenericUnmanagedFunctionPointer));
+        IrPasses.Run(raised);
+        string output = CSharpPrinter.PrintRaised(raised).Output!;
+        Assert.Contains("delegate* unmanaged<U, T>", output);
+        Assert.Contains("return V_0(value);", output);
+    }
+
+    [Fact]
+    public void Calli_UnmanagedFunctionPointerWithRef_PreservesRefArgument()
+    {
+        // The ref argument is part of the calli signature and must survive both
+        // import and rendering; dropping the ref-kind would turn the minimized
+        // runtime specimen into invalid or semantically different C#.
+        var function = ImportFixture(nameof(CfgSampleClass.InvokesUnmanagedFunctionPointerWithRef));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        var call = Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Equal("void", call.ReturnType.ToDisplayString());
+        Assert.Equal(["ref int", "float"], call.ParameterTypes.Select(t => t.ToDisplayString()).ToArray());
+        Assert.Equal(2, call.Arguments.Count);
+
+        var raised = ImportFixture(nameof(CfgSampleClass.InvokesUnmanagedFunctionPointerWithRef));
+        IrPasses.Run(raised);
+        string output = CSharpPrinter.PrintRaised(raised).Output!;
+        Assert.Contains("delegate* unmanaged<ref int, float, void>", output);
+        Assert.Contains("V_0(ref value, arg);", output);
+    }
+
+    [Fact]
     public void Ldftn_StaticMethodAddress_RaisesToAmpersandMethod()
     {
         // A static ldftn that feeds a delegate*-typed field store (not a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -171,6 +171,9 @@ public sealed partial class CSharpPrinter
     string Arguments(IEnumerable<IrExpression> arguments)
         => string.Join(", ", arguments.Select(Expression));
 
+    static ImmutableArray<ArgumentRefKind> CallIndirectRefKinds(CallIndirect call)
+        => [.. call.ParameterTypes.Select(t => t.Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value)];
+
     /// <summary>
     /// Arguments paired positionally with the callee's parameter types, casting
     /// each to its parameter type where C# needs it (CS0266) — the call-site

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1325,7 +1325,7 @@ public sealed partial class CSharpPrinter
             : $"{Operand(id.Target)}{(id.IsIncrement ? "++" : "--")}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
-        CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments)})",
+        CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci))})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -87,6 +87,9 @@ public sealed class ExpressionInliningPass : IIrPass
             if (store is StoreLocal { Value: LoadField { Instance: null } } && IsLockObject(load))
                 continue;  // keep copied static lock receivers; inlining can fail to bind in reconstructed shells
 
+            if (store is StoreLocal typedStore && !typedStore.Type.Equals(typedStore.Value.ResultType))
+                continue;  // the local declaration carries a required cast/type witness
+
             bool pure = IsPure(store is StoreLocal sl ? sl.Value : ((StoreStackSlot)store).Value, locals, argumentAddresses, function);
             if (!IsFirstEvaluatedLeaf(load, next) && !pure)
                 continue;  // inlining would move the computation past whatever evaluates before the load


### PR DESCRIPTION
## Summary

Resolves the #1045 `Generic function pointers / calli` row with a minimized runtime-inspired fixture and a narrow rendering fix.

The new fixtures model the runtime `GenericFunctionPointer` shapes without copying the runtime test wholesale:

- cast `void*` to a generic `delegate* unmanaged<U, T>` and invoke through `calli`
- cast `void*` to `delegate* unmanaged<ref int, float, void>` and invoke with a `ref` argument

The tests pin both the import invariants and the shipped raised output.

## Fix

Two small issues surfaced from the minimized specimen:

- `ExpressionInliningPass` could inline a local even when the local declaration carried required type evidence, such as `void*` stored into `delegate* unmanaged<...>`.
- `CallIndirect` rendering did not use the call-site parameter types, so byref calli arguments rendered without `ref`.

The fix keeps type-witness locals when the stored value type differs from the declared local type, and routes indirect-call arguments through the same typed/ref argument renderer used by direct calls.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build tools/DecompilerHarness -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` => 917 passed
- Harness dumps for both new fixtures show Full fidelity and raised output preserving `delegate* unmanaged<...>` plus `ref value`.
