### PR TITLE
Track collection spread iterator frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2532,6 +2532,11 @@ public class CfgSampleClass
         return [with(System.StringComparer.OrdinalIgnoreCase), "Hello", "HELLO", "hello"];
     }
 
+    public static IEnumerable<bool[]> YieldCollectionExpressionSpread(bool[] arch)
+    {
+        yield return [.. arch, true];
+    }
+
     public static int ReadOnlySpanCollectionExpression(int a)
     {
         ReadOnlySpan<int> values = [a, 42];

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -304,6 +304,20 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void CollectionExpressionSpreadIterator_ReconstructsYieldButNotSpread()
+    {
+        var function = Raised(nameof(CfgSampleClass.YieldCollectionExpressionSpread));
+
+        Assert.Single(function.Descendants.OfType<YieldReturn>());
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+
+        var output = Print(nameof(CfgSampleClass.YieldCollectionExpressionSpread));
+        Assert.Contains("yield return", output);
+        Assert.DoesNotContain("[..", output);
+    }
+
+    [Fact]
     public void ForeachDelegationIterator_ReconstructsForeach()
     {
         var function = Raised(nameof(CfgSampleClass.YieldEach));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -56,7 +56,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Block => default!;
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass BreakStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Call => default!;
-    [Completeness(CompletenessLevel.Full, "collection expressions in a span context; also raises a direct inline-array span conversion (`InlineArrayAsSpan`/`AsReadOnlySpan` over a field/parameter/array-element place) to the cast `(Span<T>)place`")] public static InlineArrayCollectionPass CollectionExpression => new();
+    [Completeness(CompletenessLevel.Partial, "span-target collection expressions lowered through compiler-synthesized inline-array buffers; direct inline-array span conversions (`InlineArrayAsSpan`/`AsReadOnlySpan` over a field/parameter/array-element place) to the cast `(Span<T>)place`; spread/general collection targets, including yielded spread collection expressions, are not raised")] public static InlineArrayCollectionPass CollectionExpression => new();
     [Completeness(CompletenessLevel.Partial, "value, array-element, field, property, indexer, and ref targets raised, including the checked-context form (`checked(x += v)` recovered as a `checked { x += v; }` block); nested-struct compound not raised")]
     public static IncrementDecrementPass CompoundAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static NullConditionalPass ConditionalAccess => new();


### PR DESCRIPTION
## Summary

- add a minimized runtime-inspired iterator fixture for `yield return [.. arch, true]`
- add a frontier test proving iterator reconstruction recovers the yield, but spread collection-expression recovery is not present
- tighten the collection-expression coverage ledger from broad `Full` to the actual span-target inline-array scope, with spread/general collection targets called out as not raised

Resolves the collection expressions with spread row in #1045.

## Verification

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IteratorReconstructionPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LoweringCoverageTests`
- `dotnet build src/dotnet-inspect -c Release`