### PR TITLE
Fix stackalloc event data rendering

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -55,6 +55,15 @@ public static class UnsafeFixtures
         return s.Length;
     }
 
+    public static unsafe int StackAllocEventData(int eventId)
+    {
+        byte* payload = stackalloc byte[sizeof(int) * 2];
+        int* values = (int*)payload;
+        values[0] = eventId;
+        values[1] = eventId + 1;
+        return values[0] + values[1];
+    }
+
     // `fixed` is SAFE under the new rules, but the pointer element access
     // `p[i]` inside the loop is not. A minimal-scope emitter must wrap only the
     // unsafe access, not the whole `fixed` statement.

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -89,6 +89,22 @@ public static class UnsafeFixtures
         return s.Length;
     }
 
+    // Runtime-style event data often stages small payloads in a raw stack buffer
+    // and reinterprets that storage through a pointer. The stackalloc itself and
+    // the pointer element accesses require explicit unsafe contexts under the
+    // new rules; the pointer locals do not.
+    public static int StackAllocEventData(int eventId)
+    {
+        unsafe
+        {
+            byte* payload = stackalloc byte[sizeof(int) * 2];
+            int* values = (int*)payload;
+            values[0] = eventId;
+            values[1] = eventId + 1;
+            return values[0] + values[1];
+        }
+    }
+
     // `fixed` is safe; only the `p[i]` element access needs a context. The block
     // is scoped to that access inside the loop, not the whole `fixed` statement.
     public static int SumPinned(int[] data)

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 
 using ILInspector.Decompiler;
+using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 
 using Microsoft.CodeAnalysis;
@@ -59,6 +60,14 @@ public class UnsafeEmitterTests
 
     static string DecompileLegacySimulate(string method) =>
         DecompileSimulate(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
+
+    static (IrFunction Function, IReadOnlyList<Annotation> Annotations) ClassifyNew(string method)
+    {
+        var source = MetadataSource.Open(typeof(NewFixtures).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(NewFixtures).FullName!, method);
+        Assert.NotNull(function);
+        return (function!, AnnotationEngine.Default.ClassifyImported(function!));
+    }
 
     /// <summary>The body of the first <c>unsafe { }</c> block, by brace matching.</summary>
     static string FirstUnsafeBlockBody(string output)
@@ -234,6 +243,46 @@ public class UnsafeEmitterTests
         Assert.DoesNotContain("unsafe", DecompileLegacy(nameof(LegacyFixtures.StackAllocDefault)));
     }
 
+    [Fact]
+    public void NewRulesModule_StackAllocEventData_RendersRawStackallocInUnsafeBlock()
+    {
+        var output = DecompileNew(nameof(NewFixtures.StackAllocEventData));
+        var block = FirstUnsafeBlockBody(output);
+
+        Assert.Contains("byte* __stackalloc = stackalloc byte[", block);
+        Assert.Contains("int* values = (int*)__stackalloc;", block);
+        Assert.Contains("*values", block);
+        Assert.Contains("*(values + 4)", block);
+        Assert.DoesNotContain("Span", output);
+    }
+
+    [Fact]
+    public void LegacyModule_StackAllocEventData_EmitsNoUnsafeBlock()
+    {
+        var output = DecompileLegacy(nameof(LegacyFixtures.StackAllocEventData));
+
+        Assert.DoesNotContain("unsafe", output);
+        Assert.Contains("stackalloc byte[", output);
+        Assert.Contains("int* values = (int*)__stackalloc;", output);
+        Assert.Contains("*values", output);
+    }
+
+    [Fact]
+    public void StackAllocEventData_AnnotationSurvivesImportedClassificationAndRaising()
+    {
+        var (function, annotations) = ClassifyNew(nameof(NewFixtures.StackAllocEventData));
+
+        var stackAlloc = Assert.Single(annotations, a => a.Descriptor.Id == "unsafe.stackalloc");
+        Assert.Equal("byte*", stackAlloc.Detail);
+        Assert.True(stackAlloc.SourceOffset >= 0);
+        Assert.Single(function.Descendants.OfType<StackAllocate>());
+
+        var output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Contains("stackalloc byte[", output);
+        Assert.Single(function.Descendants.OfType<StackAllocate>());
+    }
+
     // ---- Optimistic ("simulate") mode: render new-rules contexts for legacy input ----
 
     [Fact]
@@ -315,6 +364,15 @@ public class UnsafeEmitterTests
         Assert.Contains("scoped Span<int> s", body);
 
         var diagnostics = Recompile("[SkipLocalsInit] static int M(int n)", body);
+        AssertNoWarningsOrErrors(diagnostics, body);
+    }
+
+    [Fact]
+    public void NewRulesModule_StackAllocEventData_RecompilesWithoutWarning()
+    {
+        var body = DecompileNew(nameof(NewFixtures.StackAllocEventData));
+
+        var diagnostics = Recompile("static int M(int eventId)", body);
         AssertNoWarningsOrErrors(diagnostics, body);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -722,6 +722,8 @@ public sealed partial class CSharpPrinter
             {
                 if (!HasUnsafeOperation(store.Value) || !LocalIsRead(function, store.Index))
                     continue;
+                if (LocalReadsStayInsideUnsafeRun(function, store))
+                    continue;
                 _declaringStores.Remove(store);
                 // A stackalloc-initialized span loses its inline `scoped`
                 // inference when split from its declaration, so the hoisted
@@ -738,6 +740,43 @@ public sealed partial class CSharpPrinter
         => DescendantsOutsideNestedFunctions(function).Any(n =>
             (n is LoadLocal load && load.Index == index)
             || (n is LoadLocalAddress address && address.Index == index));
+
+    bool LocalReadsStayInsideUnsafeRun(IrFunction function, StoreLocal store)
+    {
+        if (store.Parent is not Block container)
+            return false;
+        int start = store.ChildIndex;
+        if (start < 0 || start >= container.Children.Count)
+            return false;
+
+        int end = start;
+        while (end + 1 < container.Children.Count && HasUnsafeOperation(container.Children[end + 1]))
+            end++;
+
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        {
+            if (node is LoadLocal load && load.Index == store.Index
+                || node is LoadLocalAddress address && address.Index == store.Index)
+            {
+                bool insideRun = false;
+                for (int i = start; i <= end; i++)
+                    insideRun |= IsDescendantOrSelf(node, container.Children[i]);
+                if (!insideRun)
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    static bool IsDescendantOrSelf(IrNode node, IrNode ancestor)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, ancestor))
+                return true;
+        }
+        return false;
+    }
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
@@ -857,6 +896,30 @@ public sealed partial class CSharpPrinter
                 ? localName
                 : $"({TypeText(returnPointer)}){localName}";
             sb.Append(pad).Append("return ").Append(value).AppendLine(";");
+            return;
+        }
+        if (node is StoreLocal { Value: StackAllocate storeStackAllocate, Type.Kind: TypeRefKind.Pointer } store
+            && store.Type is { } storeType
+            && storeStackAllocate.ResultType is { } stackAllocType
+            && !storeType.Equals(stackAllocType))
+        {
+            string localName = FreshSyntheticLocalName("__stackalloc");
+            sb.Append(pad)
+                .Append(TypeText(stackAllocType))
+                .Append(' ')
+                .Append(localName)
+                .Append(" = ")
+                .Append(Expression(storeStackAllocate))
+                .AppendLine(";");
+            sb.Append(pad);
+            if (_declaringStores.Contains(store))
+                sb.Append(TypeText(storeType)).Append(' ');
+            sb.Append(LocalName(store.Index))
+                .Append(" = (")
+                .Append(TypeText(storeType))
+                .Append(')')
+                .Append(localName)
+                .AppendLine(";");
             return;
         }
         if (node is ForLoop forLoop)
@@ -1096,6 +1159,7 @@ public sealed partial class CSharpPrinter
     bool IsUnsafeOperation(IrNode node) => node switch
     {
         CallIndirect => true,
+        StackAllocate => true,
         // A stackalloc-backed Span (raised to `stackalloc T[n]` by
         // StackAllocSpanPass) is governed by the stackalloc rule — unsafe only
         // under [SkipLocalsInit], where the stack space is uninitialized.


### PR DESCRIPTION
## Summary

- Add new/legacy unsafe fixtures for runtime-style stackalloc event data.
- Render raw `stackalloc byte[...]` assigned to a differently typed pointer through a synthetic `byte*` local before casting.
- Keep new-rules pointer stackalloc declarations inside the coalesced `unsafe` block when all reads stay in that block, and preserve imported `unsafe.stackalloc` annotation coverage through raising.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.UnsafeEmitterTests -stopOnFail`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -longRunning 30 -maxThreads 1`

Fixes the Stackalloc/unsafe event data row in #1045.