### PR TITLE
Pin hand-written inline-array span views are not over-raised (#1045)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2800,6 +2800,20 @@ public class CfgSampleClass
         return s[i];
     }
 
+    int _spanBacking;
+
+    // Adversarial negative (#1045, runtime specimen MyArray<T>.AsSpan in
+    // Loader/classloader/InlineArray/InlineArrayValid.cs): a HAND-WRITTEN span view
+    // via MemoryMarshal.CreateSpan, then indexed. This is NOT csc's
+    // <PrivateImplementationDetails>.InlineArrayAsSpan conversion — a name user code
+    // cannot declare — so InlineArrayCollectionPass must NOT raise the CreateSpan to
+    // a (Span<int>) cast: it renders faithfully as the CreateSpan call it is.
+    public int HandWrittenCreateSpan(int i)
+    {
+        System.Span<int> s = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(ref _spanBacking, 4);
+        return s[i];
+    }
+
     static void Tick() { }
     void Instance() { }
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -433,6 +433,23 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void HandWrittenCreateSpan_NotRaisedToInlineArrayCast()
+    {
+        // Adversarial negative (#1045, runtime MyArray<T>.AsSpan shape): a
+        // hand-written MemoryMarshal.CreateSpan view, then indexed, is NOT csc's
+        // <PrivateImplementationDetails>.InlineArrayAsSpan conversion (a name user
+        // code cannot declare). InlineArrayCollectionPass keys on that helper, so it
+        // must NOT raise the CreateSpan to a (Span<int>) cast — it renders faithfully.
+        var function = ImportFixture(nameof(CfgSampleClass.HandWrittenCreateSpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Empty(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains("CreateSpan", output);
+        Assert.DoesNotContain("(Span<int>)", output);
+    }
+
+    [Fact]
     public void CheckedCompound_RendersCheckedBlockWithCompoundSugar()
     {
         // `checked(x += v)` lowers to add.ovf; `checked(x += v);` is not a legal


### PR DESCRIPTION
#1045 runtime pattern-mining row **"Inline arrays and indexers"**, specimen `MyArray<T>` in `src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs`.

## Audit outcome: no over-match

The runtime specimen is a custom `[InlineArray]` struct exposing its span via `MemoryMarshal.CreateSpan(ref _element, Length)` and indexing through `this[i]` — **hand-written**, not csc's `<PrivateImplementationDetails>.InlineArrayAsSpan` lowering.

`InlineArrayCollectionPass` keys strictly on the `<PrivateImplementationDetails>.InlineArrayAsSpan`/`AsReadOnlySpan`/`ElementRef` helpers — a name **user code cannot declare** — so the discriminator is **unforgeable**. I minimized the specimen and decompiled it; the hand-written view renders faithfully:

```
AsSpan()  →  return MemoryMarshal.CreateSpan<T>(ref _e, 4);     // not raised to (Span<T>)
At(i)     →  Span<T> V_0 = AsSpan(); return V_0[i];             // faithful
```

No over-match, no cast over-raise — discriminator holds.

## Deliverable

A `CfgSampleClass.HandWrittenCreateSpan` fixture + an adversarial **negative** test (`HandWrittenCreateSpan_NotRaisedToInlineArrayCast`) pinning that a hand-written `MemoryMarshal.CreateSpan` view stays a faithful call (no `InlineArraySpanConversion`, no `(Span<int>)` cast). This complements the existing *positive* inline-array fixtures (`InlineArrayFieldAsSpan`, etc.) and catches any future broadening of the pass that would over-match hand-written code.

**Test-only; no product change.** 919 decompiler tests green (fidelity gates included; the fixture round-trips opcode-exact, so no `KnownDiffs` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)