### PR TITLE
Consolidate member source sections

### DIFF
--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -45,7 +45,7 @@ For package, library, and selected-overload member output, focused selected sect
 
 Bare `-S` is command/context-specific shorthand for `-S @Default`: package uses `Package Info` and `Library Files`; library uses `Library Info`; type and broad member list views use compact member summaries such as `Method Groups`; member-name views use `Methods` overload rows; selected member overloads use `Signature` and `Decompiled Source`. See [Bare `-S` default view](info-view.md) for the bullseye question each preset is meant to answer.
 
-For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments, and `Original Source` is SourceLink-backed source text for one method; both render via explicit `-S` (or `-S @Source` for source views). The structured dual of `Annotated Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
+For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments, and `Original Source` is SourceLink-backed source text for one method; both render via explicit `-S` (or `-S @Source`, which also includes `Recovered IL`). The structured dual of `Annotated Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
 
 ## Discovery
 

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -73,6 +73,7 @@ Library signals describe assemblies: SourceLink presence/reachability, PDB/symbo
 - `Original Source` is SourceLink-backed original source when available.
 - `Decompiled Source` is raised C#, a best-effort readable reconstruction from IL; it may use PDB debug names when available.
 - `Annotated Source` is raised C# with hidden-fact comments and interleaved IL.
+- `@Source` selects `Decompiled Source`, `Annotated Source`, `Original Source`, and `Recovered IL`.
 - `Recovered IL` and `Annotated Source` are the highest-fidelity views for exact instructions, offsets, branches, tokens, and calls.
 
 ## Skill guidance

--- a/docs/workflows/core/member-lookup-docs-code.md
+++ b/docs/workflows/core/member-lookup-docs-code.md
@@ -145,7 +145,7 @@ Tips:
 
 ## 3. View member implementation code
 
-> Goal: When selecting a specific member, discover and select implementation sections: raised C# (`Decompiled Source`), mixed C#+IL (`Annotated Source`), SourceLink-backed source (`Original Source`), and IL.
+> Goal: When selecting a specific member, discover and select implementation sections: raised C# (`Decompiled Source`), mixed C#+IL (`Annotated Source`), SourceLink-backed source (`Original Source`), and raw IL (`Recovered IL`). `-S @Source` selects those four evidence views.
 
 ### 3a. Single member (no overloads)
 

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -17,7 +17,7 @@ Verbosity levels:
 | Minimal (default) | (none) | H1, description, metadata field list, one section table | Yes |
 | Detailed | `-v:d` | H1, description, metadata field list, all sections | No |
 
-The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
+The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `Recovered IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. `-S @Source` selects Decompiled, Annotated, Original, and IL evidence. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
 
 Section selection (`-S`, with lowercase `-s` as an alias) lists available sections or filters to specific ones. Tips are suppressed when sections are selected. `--count` with exactly one selected section returns a single integer.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -118,7 +118,7 @@ dnx dotnet-inspect -y -- diff --platform System.Runtime@9.0.0..10.0.0 --additive
 
 ## Source and implementation workflow
 
-Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S @Source` when you want all source views for a selected overload: `Decompiled Source` (best-effort raised C# without IL comments), `Annotated Source` (the same raised C# with hidden-fact comments and IL interleaved beneath each statement), `Lowered Source` (de-sugared SharpLab-style C# without IL comments), and `Original Source` (SourceLink-backed source text when available). Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (defaults to the member's own assembly, widen with `--bin <dir>` / `--project <proj>` / `--caller-package <pkg>`), `-S "Call Graph"` for the bounded outbound call tree, `-S "Unsafe*"` for unsafe API-member and operation evidence, `-S "Recovered IL"` for raw IL, or `-S "Facts"` for hidden facts as a structured table (`--tsv` for agents).
+Use `source` for SourceLink URLs, source text, or token/IL-offset mapping. Use `member Type Member:N -S @Source` when you want source and IL evidence for a selected overload: `Decompiled Source` (best-effort raised C# without IL comments), `Annotated Source` (the same raised C# with hidden-fact comments and IL interleaved beneath each statement), `Original Source` (SourceLink-backed source text when available), and `Recovered IL` (raw IL). Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (defaults to the member's own assembly, widen with `--bin <dir>` / `--project <proj>` / `--caller-package <pkg>`), `-S "Call Graph"` for the bounded outbound call tree, `-S "Unsafe*"` for unsafe API-member and operation evidence, or `-S "Facts"` for hidden facts as a structured table (`--tsv` for agents).
 
 ```bash
 dnx dotnet-inspect -y -- source JsonSerializer --package System.Text.Json
@@ -131,7 +131,7 @@ dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json Serial
 dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
 ```
 
-A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `@Source`, `Annotated Source`, `Original Source`, or `Recovered IL` when you need specific implementation evidence. The code views are `Decompiled Source` (raised C# without IL comments), `Annotated Source` (raised C# with hidden-fact comments and interleaved IL), `Lowered Source` (de-sugared SharpLab-style C# without IL comments), `Recovered IL` (raw IL), and `Original Source` (SourceLink-backed original C#).
+A selected overload defaults to `Signature`; use bare `-S` for `Signature` plus `Decompiled Source`, or select `@Source`, `Annotated Source`, `Original Source`, or `Recovered IL` when you need specific implementation evidence. The code views are `Decompiled Source` (raised C# without IL comments), `Annotated Source` (raised C# with hidden-fact comments and interleaved IL), `Recovered IL` (raw IL), and `Original Source` (SourceLink-backed original C#).
 
 When `Decompiled Source` looks wrong and you need to see *how* the decompiler raised IL to C#, dump the per-pass IR pipeline (JitDump-style) with `--dump-stages` (or `-S "IR (Stages)"`): it prints the typed IR tree after import and after each raising pass, so you can spot which pass introduced a defect. Like the other code sections it needs a selected overload (`Name:N` or `Name~digest` from Member Index), and it is a deep decompiler-debugging view — not a normal lookup path. To learn how to read the dump, see [Reading IR Dumps](https://github.com/richlander/dotnet-inspect/blob/main/docs/decompiler-ir-dumps.md).
 
@@ -145,7 +145,7 @@ To read a whole type instead of one member, use `type Name -S "Decompiled Source
 dnx dotnet-inspect -y -- type Stack --platform System.Collections -S "Decompiled Source" --raw > Stack.cs
 ```
 
-Fidelity expectations: `Original Source` is SourceLink-backed original source when available. `Decompiled Source` is a best-effort readable C# reconstruction from IL, idiomatically raised, that helps explain intent; it may use PDB local names but is not guaranteed to match original syntax or compiler transformations. `Lowered Source` is the same reconstruction with cosmetic statement-sugar passes declined. `Annotated Source` and `Recovered IL` are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
+Fidelity expectations: `Original Source` is SourceLink-backed original source when available. `Decompiled Source` is a best-effort readable C# reconstruction from IL, idiomatically raised, that helps explain intent; it may use PDB local names but is not guaranteed to match original syntax or compiler transformations. `Annotated Source` and `Recovered IL` are the highest-fidelity displays for exact opcodes, offsets, branches, tokens, and member calls; use them to confirm behavior when precision matters.
 
 For crash/stack diagnostics that include a MethodDef token plus IL offset, `source --il-offset 0x06000001+0x5` can map the offset to source. This is a niche deep-debugging path; do not start there for normal API lookup.
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1781,6 +1781,21 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectedOverload_SourceCategory_IncludesIlAndNoLoweredSource()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "Overloaded:2", "-S", "@Source", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Decompiled Source", output);
+        Assert.Contains("## Annotated Source", output);
+        Assert.Contains("## Recovered IL", output);
+        Assert.DoesNotContain("## Lowered Source", output);
+    }
+
+    [Fact]
     public async Task Member_SelectDecompiledSource_RequestTrace_RecordsDecompileOutcome()
     {
         // The app converts the decompiler's telemetry-free trace shape into a
@@ -1900,60 +1915,6 @@ public class CommandExecutionTests
         Assert.Contains("WriteElement", output);
         Assert.DoesNotContain("## Original Source", output);
         Assert.Contains("public static System.Text.Json.JsonElement SerializeToElement<TValue>(TValue value, System.Text.Json.JsonSerializerOptions? options = null)", output);
-    }
-
-    [Fact]
-    public async Task Member_SelectedOverload_SelectLoweredSource_RendersDesugaredCSharp()
-    {
-        // Issue #636: the "Lowered Source" section renders the de-sugared
-        // (SharpLab-style) shape — the statement-sugar passes (for-loop, lock,
-        // ++/--) are declined, so a `for` raised in Decompiled Source surfaces
-        // here as the underlying `while` + explicit increment.
-        var options = new MemberOptions
-        {
-            PlatformAssembly = "System.Private.CoreLib",
-            TypeName = "Array",
-            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ForEach" },
-            OverloadIndex = 1,
-            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lowered Source" }
-        };
-
-        var (exit, output, _) = await ConsoleCapture.RunAsync(
-            () => MemberCommand.ExecuteAsync(options));
-
-        Assert.Equal(0, exit);
-        Assert.Contains("## Lowered Source", output);
-        Assert.Contains("public static void ForEach<T>", output);
-        // The for-loop is de-sugared to a while loop at the lowered altitude.
-        Assert.Contains("while (", output);
-        Assert.DoesNotContain("for (", output);
-        Assert.DoesNotContain("## Decompiled Source", output);
-    }
-
-    [Fact]
-    public async Task Member_SelectedOverload_DecompiledVsLoweredSource_DifferInSugar()
-    {
-        // The same method, raised vs lowered: Decompiled Source keeps the `for`
-        // sugar; Lowered Source does not. Guards that the two sections render
-        // through distinct altitudes of the same pipeline.
-        static MemberOptions ForSection(string section) => new()
-        {
-            PlatformAssembly = "System.Private.CoreLib",
-            TypeName = "Array",
-            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ForEach" },
-            OverloadIndex = 1,
-            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section }
-        };
-
-        var (decExit, decompiled, _) = await ConsoleCapture.RunAsync(
-            () => MemberCommand.ExecuteAsync(ForSection("Decompiled Source")));
-        var (lowExit, lowered, _) = await ConsoleCapture.RunAsync(
-            () => MemberCommand.ExecuteAsync(ForSection("Lowered Source")));
-
-        Assert.Equal(0, decExit);
-        Assert.Equal(0, lowExit);
-        Assert.Contains("for (", decompiled);
-        Assert.DoesNotContain("for (", lowered);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -30,6 +30,16 @@ public class MemberCallsSectionTests
     }
 
     [Fact]
+    public async Task CallsSection_SelectedSecondOverload_UsesSelectedMethod()
+    {
+        var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.Overloaded), overloadIndex: 2);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Calls", result.Output);
+        Assert.Contains("`System.Console.WriteLine(string)`", result.Output);
+    }
+
+    [Fact]
     public async Task CallsSection_TsvUsesPlainNormalizedValues()
     {
         var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsWriteLineTwice), tsv: true);
@@ -49,12 +59,13 @@ public class MemberCallsSectionTests
         Assert.Contains("Calls\tsection", result.Output);
     }
 
-    static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false)
+    static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false, int? overloadIndex = null)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
             TypeName = typeof(MemberCallsFixture).FullName,
             AssemblyPath = typeof(MemberCallsFixture).Assembly.Location,
             MemberFilter = [memberName],
+            OverloadIndex = overloadIndex,
             IncludeSections = [SectionNames.Calls],
             TipLevel = TipLevel.Quiet,
             Discover = discover ? [] : null,
@@ -87,4 +98,13 @@ public static class MemberCallsFixture
     }
 
     public static int CallsInterfaceItem(IList<int> values) => values[0];
+
+    public static void Overloaded(int value)
+    {
+    }
+
+    public static void Overloaded(string value)
+    {
+        Console.WriteLine(value);
+    }
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1142,7 +1142,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(21, pipeline.AllSectionNames.Length);
+        Assert.Equal(20, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -1363,8 +1363,8 @@ public class SectionPipelineTests
             [
                 SectionNames.DecompiledSource,
                 SectionNames.AnnotatedSource,
-                SectionNames.LoweredSource,
-                SectionNames.OriginalSource
+                SectionNames.OriginalSource,
+                SectionNames.IL
             ],
             categories[SectionCategoryNames.Source]);
     }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -674,7 +674,6 @@ public class ApiCommand
                 {
                     SectionNames.DecompiledSource => view.MemberCode?.DecompiledSourceCode.Content,
                     SectionNames.AnnotatedSource => view.MemberCode?.AnnotatedSourceCode.Content,
-                    SectionNames.LoweredSource => view.MemberCode?.LoweredSourceCode.Content,
                     SectionNames.OriginalSource => view.MemberCode?.OriginalSourceCode.Content,
                     SectionNames.IL => view.MemberCode?.ILCode.Content,
                     SectionNames.IRStages => view.MemberCode?.IRStages.Content,
@@ -684,7 +683,7 @@ public class ApiCommand
             if (raw is null)
             {
                 Console.Error.WriteLine(
-                    "Error: --raw requires a single -S code section with content (Decompiled Source, Annotated Source, Lowered Source, Recovered IL, Original Source).");
+                    "Error: --raw requires a single -S code section with content (Decompiled Source, Annotated Source, Recovered IL, Original Source).");
                 return;
             }
             sink.WriteLine(raw.TrimEnd());

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -462,7 +462,6 @@ public static class MemberCommand
         return pdbAuthorized
                && (sections.Contains(SectionNames.DecompiledSource)
                    || sections.Contains(SectionNames.AnnotatedSource)
-                   || sections.Contains(SectionNames.LoweredSource)
                    || sections.Contains(SectionNames.Facts));
     }
 }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -16,7 +16,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Stages = false, bool Facts = false, bool LoweredSource = false);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Stages = false, bool Facts = false);
 
     /// <summary>
     /// Code content for one member. Body and diagnostic are mutually
@@ -36,12 +36,7 @@ internal static class MemberCodeProvider
         string? StagesDiagnostic = null,
         IReadOnlyList<Decompiler.Annotations.Annotation>? Facts = null,
         Decompiler.DecompilerTrace? DecompileTrace = null,
-        // The lowered C# view (issue #636) — the de-sugared render. Distinct from
-        // LoweredBody above, which is the (misnamed) fully-raised decompiled body.
-        string? LoweredSourceBody = null,
-        string? LoweredSourceDiagnostic = null,
-        bool RequiresAsyncDeclaration = false,
-        bool LoweredSourceRequiresAsyncDeclaration = false);
+        bool RequiresAsyncDeclaration = false);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -128,20 +123,6 @@ internal static class MemberCodeProvider
                     annotatedDiagnostic = DiagnosticComment(result);
             }
 
-            // Lowered C# view (issue #636): plain C# at the lowered altitude —
-            // the cosmetic statement-sugar passes are declined, surfacing the
-            // de-sugared shape without annotation or IL comments.
-            string? loweredSourceBody = null, loweredSourceDiagnostic = null;
-            if (request.LoweredSource && pipelineSource is not null)
-            {
-                var result = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Lowered, lookupOverloadIndex, publicOnly);
-                decompileTrace ??= new Decompiler.DecompilerTrace(result.Fidelity, pipelineSource.Symbols, result.Diagnostics);
-                if (result.Output is { } loweredText)
-                    loweredSourceBody = loweredText.TrimEnd();
-                else
-                    loweredSourceDiagnostic = DiagnosticComment(result);
-            }
-
             string? ilText = null, ilDiagnostic = null;
             if (request.IL)
             {
@@ -197,10 +178,7 @@ internal static class MemberCodeProvider
                 stagesDiagnostic,
                 facts,
                 decompileTrace,
-                loweredSourceBody,
-                loweredSourceDiagnostic,
-                RequiresAsyncDeclaration: ContainsAwaitKeyword(loweredBody),
-                LoweredSourceRequiresAsyncDeclaration: ContainsAwaitKeyword(loweredSourceBody))));
+                RequiresAsyncDeclaration: ContainsAwaitKeyword(loweredBody))));
         }
 
         return results;
@@ -274,7 +252,7 @@ internal static class MemberCodeProvider
     /// </summary>
     static Decompiler.Pipeline.MetadataSource? OpenPipelineSource(Request request, string dllPath, string? pdbPath)
     {
-        if (!request.DecompiledSource && !request.AnnotatedSource && !request.LoweredSource && !request.Stages && !request.Facts)
+        if (!request.DecompiledSource && !request.AnnotatedSource && !request.Stages && !request.Facts)
             return null;
         try
         {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -975,8 +975,7 @@ public static class ApiOutputFormatter
             CallGraph: requestedSections.Contains(SectionNames.CallGraph),
             UnsafeOperations: requestedSections.Contains(SectionNames.UnsafeOperations),
             Stages: requestedSections.Contains(SectionNames.IRStages),
-            Facts: requestedSections.Contains(SectionNames.Facts),
-            LoweredSource: requestedSections.Contains(SectionNames.LoweredSource));
+            Facts: requestedSections.Contains(SectionNames.Facts));
 
         // An index-backed section that is explicitly selected (via -S or a category like
         // @Audit) renders an empty-state note instead of vanishing when it yields no rows.
@@ -989,8 +988,12 @@ public static class ApiOutputFormatter
 
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.
-        var singleMethod = overloadIndex.HasValue && overloadIndex.Value < methods.Count 
-            ? methods[overloadIndex.Value]
+        var singleMethod = overloadIndex.HasValue
+            ? methods.Count == 1
+                ? methods[0]
+                : overloadIndex.Value < methods.Count
+                    ? methods[overloadIndex.Value]
+                    : null
             : null;
         var singleMethodList = singleMethod != null ? new List<ApiMember> { singleMethod } : new List<ApiMember>();
 
@@ -1142,7 +1145,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.DecompiledSource || request.AnnotatedSource || request.LoweredSource || request.IL || request.Attributes || request.Stages || request.Facts)
+        if (request.DecompiledSource || request.AnnotatedSource || request.IL || request.Attributes || request.Stages || request.Facts)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
         foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath))
@@ -1160,7 +1163,7 @@ public static class ApiOutputFormatter
                 string source;
                 try
                 {
-                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered, code.RequiresAsyncDeclaration);
+                    source = FormatSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered, code.RequiresAsyncDeclaration);
                 }
                 catch (Exception ex)
                 {
@@ -1182,7 +1185,7 @@ public static class ApiOutputFormatter
                 string source;
                 try
                 {
-                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, annotated);
+                    source = FormatSourceWithDeclaration(type, member, code.MethodGenericParameters, annotated);
                 }
                 catch (Exception ex)
                 {
@@ -1195,28 +1198,6 @@ public static class ApiOutputFormatter
             {
                 EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
                 memberCode.AnnotatedSourceCode = new CodeSection("csharp", annotatedDiagnostic);
-                hasCode = true;
-            }
-
-            if (code.LoweredSourceBody is { } loweredSource)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                string source;
-                try
-                {
-                    source = FormatLoweredSourceWithDeclaration(type, member, code.MethodGenericParameters, loweredSource, code.LoweredSourceRequiresAsyncDeclaration);
-                }
-                catch (Exception ex)
-                {
-                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
-                }
-                memberCode.LoweredSourceCode = new CodeSection("csharp", source);
-                hasCode = true;
-            }
-            else if (code.LoweredSourceDiagnostic is { } loweredSourceDiagnostic)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                memberCode.LoweredSourceCode = new CodeSection("csharp", loweredSourceDiagnostic);
                 hasCode = true;
             }
 
@@ -1395,7 +1376,7 @@ public static class ApiOutputFormatter
         RequestTelemetry.Breadcrumb(stage, detail);
     }
 
-    private static string FormatLoweredSourceWithDeclaration(
+    private static string FormatSourceWithDeclaration(
         ApiType type,
         ApiMember member,
         IReadOnlyList<string>? methodGenericParameters,

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -93,7 +93,6 @@ public static class ApiMemberSectionDescriptors
             .Add<MethodAttributes>()
             .Add<UnsafeMembers>()
             .Add<DecompiledSource>()
-            .Add<LoweredSource>()
             .Add<OriginalSource>()
             .Add<ILBody>()
             .Add<Facts>()
@@ -276,19 +275,6 @@ public static class ApiMemberSectionDescriptors
             => model.Members.Any(IsMethodLike) || model.Kind == "enum";
     }
 
-    // The de-sugared lowered C# view (issue #636). Opt-in only — no `Info` and
-    // marked expensive (a second decompile at the lowered altitude), so it stays
-    // out of the default and Normal views per the output verbosity contract; a
-    // reader reaches it via -v:d or an explicit -S "Lowered Source".
-    public sealed class LoweredSource : ISectionDescriptor<ApiType>
-    {
-        public static string Name => SectionNames.LoweredSource;
-        public static bool IsExpensive => true;
-        public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model)
-            => model.Members.Any(IsMethodLike) || model.Kind == "enum";
-    }
-
     public sealed class ILBody : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.IL;
@@ -374,7 +360,6 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Events>()
             .Add<ApiMemberSectionDescriptors.MethodAttributes>()
             .Add<ApiMemberSectionDescriptors.DecompiledSource>()
-            .Add<ApiMemberSectionDescriptors.LoweredSource>()
             .Add<ApiMemberSectionDescriptors.OriginalSource>()
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.Callers>()
@@ -406,7 +391,6 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
             .Add<AnnotatedSource>()
-            .Add<LoweredSource>()
             .Add<OriginalSource>()
             .Add<Calls>()
             .Add<Callers>()
@@ -418,8 +402,8 @@ public static class ApiMemberDetailSectionDescriptors
             .AddCategory(SectionCategoryNames.Source,
                 SectionNames.DecompiledSource,
                 SectionNames.AnnotatedSource,
-                SectionNames.LoweredSource,
-                SectionNames.OriginalSource);
+                SectionNames.OriginalSource,
+                SectionNames.IL);
     }
 
     public sealed class Summary : ISectionDescriptor<ApiType>
@@ -466,20 +450,6 @@ public static class ApiMemberDetailSectionDescriptors
         public static string Name => SectionNames.AnnotatedSource;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
-        public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
-    }
-
-    // The lowered C# view (issue #636). Opt-in only — no `Info` and marked
-    // expensive (a second decompile at the lowered altitude), so it stays out of
-    // the default and Normal member views per the output verbosity contract; a
-    // reader selects it explicitly (e.g. -S "Lowered Source") or via -v:d.
-    public sealed class LoweredSource : ISectionDescriptor<ApiType>
-    {
-        public static string Name => SectionNames.LoweredSource;
-        public static bool IsExpensive => true;
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -84,16 +84,6 @@ public static class SectionNames
     /// <summary>Section for the decompiled C# method body with hidden-fact annotations and interleaved IL.</summary>
     public const string AnnotatedSource = "Annotated Source";
 
-    /// <summary>
-    /// Section for the lowered C# view (issue #636): the method de-sugared — the
-    /// cosmetic statement-sugar passes declined — so explicit temps, goto/<c>while</c>
-    /// loops, and <c>Monitor.Enter</c>/<c>try…finally</c> (instead of <c>lock</c>)
-    /// are surfaced, the way SharpLab shows "lowered C#". Opt-in (not part of the
-    /// default member view); shares the fact-comment and interleaved-IL infra with
-    /// <see cref="DecompiledSource"/>.
-    /// </summary>
-    public const string LoweredSource = "Lowered Source";
-
     /// <summary>Section for original method source code resolved via SourceLink.</summary>
     public const string OriginalSource = "Original Source";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -556,9 +556,6 @@ public class MemberCodeView
     [MarkoutSection(Name = "Annotated Source")]
     public CodeSection AnnotatedSourceCode { get; set; }
 
-    [MarkoutSection(Name = "Lowered Source")]
-    public CodeSection LoweredSourceCode { get; set; }
-
     [MarkoutSection(Name = "Original Source")]
     public CodeSection OriginalSourceCode { get; set; }
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,6 +6,7 @@
 
 - Replaces selected-member `@Audit` with `@Source` for coherent source-view discovery.
 - Splits `Decompiled Source` into plain raised C# and `Annotated Source` into the mixed C#+IL view.
+- Keeps one readable decompiled C# section and makes `@Source` include `Recovered IL`.
 - Documents the source-view model in repo docs and the embedded skill guidance.
 
 ## v0.10.5
@@ -20,7 +21,6 @@
 
 - Keeps single-type verbosity in the tree-shaped type view, with `-v:n` and `-v:d` expanding overload leaves.
 - Adds whole-type decompiled source output and improves lowered C# readability for common compiler patterns.
-- Adds a `Lowered Source` member section that renders the de-sugared (SharpLab-style) C# — `for`/`lock`/`++` surface as their underlying `while`, `Monitor.Enter`/`try…finally`, and explicit-increment shapes. Opt-in via `-S "Lowered Source"` or `-v:d`.
 
 ## v0.10.4
 


### PR DESCRIPTION
## Summary
- Remove the public Lowered Source section so selected-member source evidence has one readable decompiled C# view.
- Make @Source expand to Decompiled Source, Annotated Source, Original Source, and Recovered IL.
- Fix selected-overload Calls rendering after member views narrow the type to one selected overload.
- Update docs, SKILL.md, release notes, and tests.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release
- npx markdownlint-cli on changed markdown files
- smoke: System.Text.Json.JsonSerializer.Serialize:2 -S Calls renders call rows
- smoke: selected member -S @Source renders Decompiled, Annotated, Original, and Recovered IL headings