### PR TITLE
Fix bool-array element materialization (#1031)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -409,6 +409,13 @@ public class CfgSampleClass
 
     public static void SetCharElement(char[] a, int v) => a[0] = (char)v;
 
+    public static int BoolArrayVisited(int index)
+    {
+        bool[] visited = new bool[index + 1];
+        visited[index] = true;
+        return visited[index] ? 1 : 0;
+    }
+
     // A static abstract interface member invoked through a type parameter:
     // `constrained. T; call INumberBase<T>::IsNegative`. C#'s spelling is the type
     // parameter itself — `T.IsNegative(value)` — not the declaring interface

--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -39,4 +39,40 @@ public class TypedConstantsPassTests
         Assert.Contains("flag = true;", output);
         Assert.DoesNotContain("flag = 1;", output);
     }
+
+    [Fact]
+    public void BoolArrayElementTraffic_RendersAsBool()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.BoolArrayVisited))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("[index] = true;", output);
+        Assert.Contains("return S_256[index] ? 1 : 0;", output);
+        Assert.DoesNotContain("visited[index] = 1;", output);
+        Assert.DoesNotContain("visited[index] == 0", output);
+    }
+
+    [Fact]
+    public void ConstantOnlyBoolSpill_RendersAsBool()
+    {
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new Constant(1, intType)));
+        block.Add(new StoreLocal(0, boolType, new LoadStackSlot(0, intType)));
+        block.Add(new Return(new LoadLocal(0, boolType)));
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [boolType], container);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var slotStore = Assert.Single(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Equal(true, Assert.IsType<Constant>(slotStore.Value).Value);
+        var localStore = Assert.Single(function.Descendants.OfType<StoreLocal>());
+        var slotLoad = Assert.IsType<LoadStackSlot>(localStore.Value);
+        Assert.NotNull(slotLoad.Type);
+        Assert.Equal("Boolean", slotLoad.Type.Name);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -19,19 +19,65 @@ public sealed class BooleanFoldingPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (FoldOnce(function, context.Stepper) || MaterializeBooleanSlots(function, context.Stepper))
+        while (MaterializeBooleanElementAccesses(function, context.Stepper)
+            || FoldOnce(function, context.Stepper)
+            || MaterializeBooleanSlots(function, context.Stepper))
         {
         }
     }
 
     /// <summary>
+    /// Retypes bool-array element loads/stores from the array type itself.
+    /// IL spells bool-array traffic with the same byte-width opcodes used for
+    /// byte/sbyte arrays, so late sugar can still carry <c>ldelem.u1</c> or
+    /// <c>stelem.i1</c> as byte/sbyte even when the receiver is a <c>bool[]</c>.
+    /// The receiver's declared element type is authoritative; recover it before
+    /// boolean comparison folding so <c>visited[i] == 0</c> becomes
+    /// <c>!visited[i]</c> and stores print <c>true</c>/<c>false</c>.
+    /// </summary>
+    static bool MaterializeBooleanElementAccesses(IrFunction function, Stepper stepper)
+    {
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        foreach (var node in function.Descendants.ToList())
+        {
+            switch (node)
+            {
+                case LoadElement load when IsBool(ArrayElementType(load.Array)) && !IsBool(load.ResultType):
+                {
+                    var parts = load.DetachChildren();
+                    stepper.StepOver("retype bool-array element load", load);
+                    load.ReplaceWith(new LoadElement(boolType, (IrExpression)parts[0], (IrExpression)parts[1]));
+                    return true;
+                }
+                case StoreElement store when IsBool(ArrayElementType(store.Array))
+                    && (!IsBool(store.ElementType) || store.Value is Constant { Value: int storedInt } && storedInt is 0 or 1):
+                {
+                    var parts = store.DetachChildren();
+                    var value = (IrExpression)parts[2];
+                    if (value is Constant { Value: int intValue } && intValue is 0 or 1)
+                        value = new Constant(intValue == 1, boolType);
+                    stepper.StepOver("retype bool-array element store", store);
+                    store.ReplaceWith(new StoreElement(boolType, (IrExpression)parts[0], (IrExpression)parts[1], value));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static TypeRef? ArrayElementType(IrExpression array)
+        => array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } ? element : null;
+
+    /// <summary>
     /// Retypes a stack slot to <c>bool</c> when its stores prove it holds a
-    /// boolean: at least one store is a non-constant bool expression and every
-    /// other store is a bool or an <c>int</c> literal 0/1 (IL's spelling of
-    /// false/true). The 0/1 constant stores become bool literals and the slot's
-    /// loads retype, so a bool-returning method that returns the slot stops
-    /// declaring it <c>int</c> (CS0029). The non-constant bool store is the
-    /// proof — a genuine integer slot never receives one.
+    /// boolean: either at least one store is a non-constant bool expression, or
+    /// every load is consumed by a bool-only position, and every store is a bool
+    /// or an <c>int</c> literal 0/1 (IL's spelling of false/true). The 0/1
+    /// constant stores become bool literals and the slot's loads retype, so a
+    /// bool-returning method that returns the slot stops declaring it
+    /// <c>int</c> (CS0029). The proof is producer-side bool evidence or
+    /// consumer-side bool-only use; a genuine integer slot that flows into an
+    /// integer use is left alone.
     /// </summary>
     static bool MaterializeBooleanSlots(IrFunction function, Stepper stepper)
     {
@@ -52,15 +98,17 @@ public sealed class BooleanFoldingPass : IIrPass
                 .Where(s => IsZeroOne(s.Value) || IsBool(s.Value.ResultType))
                 .ToList();
             bool evidence = candidateStores.Any(s => s.Value is not Constant && IsBool(s.Value.ResultType));
-            if (!evidence)
-                continue;
             var loads = loadsBySlot.GetValueOrDefault(slot) ?? [];
             var candidateLoads = loads
                 .Where(load => IsBool(load.Type) || load.Type is { } type && TypeFamilies.IsIntegerLike(type))
                 .ToList();
+            bool allLoadsAcceptBool = candidateLoads.All(load => ConsumerAcceptsBool(function, load));
+            evidence = evidence || (candidateLoads.Count > 0 && allLoadsAcceptBool);
+            if (!evidence)
+                continue;
             if (!candidateStores.Any(s => IsZeroOne(s.Value)) && !candidateLoads.Any(l => !IsBool(l.Type)))
                 continue;  // nothing left to retype
-            if (!candidateLoads.All(load => ConsumerAcceptsBool(function, load)))
+            if (!allLoadsAcceptBool)
                 continue;  // a load is consumed as a non-bool; the slot is reused, not purely boolean
 
             var boolType = TypeRef.CoreLib("System", "Boolean");


### PR DESCRIPTION
Follow-up to #1056 for the #1031 `Join-type / bool-int-type audit follow-through` row. #1056 fixed the general `boolExpr == 0/1(int)` fold; this PR handles the adjacent residual shapes that were still visible in the product self-decompile validity rows.

## Changes

- Retype `bool[]` element loads/stores from the array element type when IL byte-width opcodes leave them as `byte`/`sbyte`.
- Allow all-constant 0/1 stack slots to materialize as bool when every load is consumed by a bool-only position.
- Add regressions for bool-array traffic and constant-only bool slot materialization.

## Product validity comparison

Same command on `origin/main` and this branch:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll \
  artifacts/bin/ILInspector.Metadata/release/ILInspector.Metadata.dll \
  artifacts/bin/ILInspector.Analysis/release/ILInspector.Analysis.dll \
  artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll \
  artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll \
  artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll \
  artifacts/bin/ILInspector.MetadataPrimitives/release/ILInspector.MetadataPrimitives.dll \
  --validity-check --compile-cap 10000 --max-examples 5 \
  --emit-validity-defects /tmp/issue1031-product-defects.txt
```

`origin/main` CS0019/CS0029 rows included:

- `BooleanFoldingPass::ComparisonSiblingAcceptsBool` — CS0029
- `BooleanFoldingPass::IsZeroOne` — CS0029
- `CSharpPrinter::LocalName` — CS0019,CS0029
- `PostDominators::Of` — CS0019,CS0029
- plus three older product CS0029 rows

This branch leaves only the three older product CS0029 rows:

- `RouterTokenRewriter::IsExactPlatformTypeAsync` — CS0029
- `TypeCommand::PackageExistsAsync` — CS0029
- `SourceEnricher::TryEnrichFromForwardedAssemblyAsync` — CS0029

The 80 Full malformed `ref` examples are present on both `origin/main` and this branch; this PR does not introduce them.

## Validation

- `dotnet build src/dotnet-inspect -c Release -m:1`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release -m:1`
- `dotnet run --no-build --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypedConstantsPassTests -parallel none`
- `dotnet run --no-build --project src/ILInspector.Decompiler.Tests -c Release -- -parallel none` — 932 tests, 0 failed before the final clean rebase; focused class rerun after rebase.

Note: I also attempted the popular six-library validity sweep after rebase, but several NuGet package DLLs were no longer present in the local cache, so I did not use that incomplete sweep as a six-library comparison.

🤖 Generated with Codex