### PR TITLE
Collapse if/else bool-store return into the bare condition (readability)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ElseReturnFoldTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ElseReturnFoldTests.cs
@@ -1,0 +1,78 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// FoldElseReturn: a boolean materialized through an if/else over a temp and then
+// returned — `if (c) { v = true; } else { v = false; } return v;` — collapses to
+// `return c;` (and the inverted arms to `return !c;`). A readability raise; see
+// the pass docs and #1047.
+public class ElseReturnFoldTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    [Fact]
+    public void IfElseBoolStoreReturn_FoldsToCondition()
+    {
+        var output = Fold(thenValue: true, elseValue: false);
+
+        Assert.Equal("return c;", output);
+    }
+
+    [Fact]
+    public void IfElseBoolStoreReturn_InvertedArms_FoldsToNegatedCondition()
+    {
+        var output = Fold(thenValue: false, elseValue: true);
+
+        Assert.Equal("return !c;", output);
+    }
+
+    [Fact]
+    public void IfElseBoolStoreReturn_TempReadElsewhere_StaysStatementForm()
+    {
+        // A second read of the temp means it is a real local, not the boolean's
+        // materialization, so the fold must decline.
+        var block = new Block(0);
+        block.Add(Diamond(thenValue: true, elseValue: false));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(Holder, "Use", TypeRef.CoreLib("System", "Void"), [Bool], HasThis: false),
+            isVirtual: false,
+            [new LoadLocal(0, Bool)])));
+        block.Add(new Return(new LoadLocal(0, Bool)));
+
+        var output = Print(block);
+
+        Assert.Contains("if (c)", output);
+        Assert.DoesNotContain("return c;", output);
+    }
+
+    static string Fold(bool thenValue, bool elseValue)
+    {
+        var block = new Block(0);
+        block.Add(Diamond(thenValue, elseValue));
+        block.Add(new Return(new LoadLocal(0, Bool)));
+        return Print(block);
+    }
+
+    static IfStatement Diamond(bool thenValue, bool elseValue)
+    {
+        var then = new Block(0);
+        then.Add(new StoreLocal(0, Bool, new Constant(thenValue, Bool)));
+        var @else = new Block(0);
+        @else.Add(new StoreLocal(0, Bool, new Constant(elseValue, Bool)));
+        return new IfStatement(new LoadArgument(0, "c", Bool), then, @else);
+    }
+
+    static string Print(Block block)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M", Holder,
+            new MethodSignature(Bool, [new Parameter("c", Bool)], HasThis: false, GenericParameterCount: 0),
+            [Bool],
+            body);
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -190,6 +190,7 @@ public sealed class BooleanFoldingPass : IIrPass
             bool folded = node switch
             {
                 IfStatement statement => FoldNestedGuard(statement, stepper) || FoldGuardReturn(statement, stepper)
+                    || FoldElseReturn(function, statement, stepper)
                     || FoldTernaryReturn(statement, stepper)
                     || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(statement, stepper),
                 Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
@@ -418,6 +419,65 @@ public sealed class BooleanFoldingPass : IIrPass
         tailReturn.Detach();
         stepper.StepOver("fold guarded return into short-circuit", guard);
         guard.ReplaceWith(new Return(folded));
+        return true;
+    }
+
+    /// <summary>
+    /// A boolean materialized through an if/else over a temp, then returned:
+    /// <c>if (c) { v = true; } else { v = false; } return v;</c> ≡ <c>return c;</c>
+    /// (and the inverted arms ≡ <c>return !c;</c>). Without this, <c>return-sinking</c>
+    /// later pushes the return into the arms (<c>if (c) return true; else return
+    /// false;</c>) — a verbose, low-altitude spelling of a bare boolean. This is a
+    /// readability raise, not a fidelity fix: the shape comes from a branch
+    /// materialization (e.g. an unraised <c>or</c>/property pattern) whose opcodes
+    /// neither spelling reproduces, so the recompiled stream is unchanged by this
+    /// fold (it only matches that already-non-round-tripping shape). The faithful
+    /// recovery is to raise the pattern itself; see #1047.
+    ///
+    /// The arms must each be a single store of an opposite <c>bool</c> constant to
+    /// one temp, and the if's next sibling the sole read of that temp — so the
+    /// store is genuinely the boolean's materialization, not a real local. Equal
+    /// arms are left alone (collapsing would drop the condition's side effects on
+    /// one path).
+    /// </summary>
+    static bool FoldElseReturn(IrFunction function, IfStatement guard, Stepper stepper)
+    {
+        if (guard.Else is not { } elseArm || guard.Parent is not Block container)
+            return false;
+        if (guard.Then.Children is not [StoreLocal { Index: var local, Value: Constant { Value: bool thenBool } }]
+            || elseArm.Children is not [StoreLocal { Index: var elseLocal, Value: Constant { Value: bool elseBool } }]
+            || local != elseLocal
+            || thenBool == elseBool)
+        {
+            return false;
+        }
+        if (guard.ChildIndex + 1 >= container.Children.Count
+            || container.Children[guard.ChildIndex + 1] is not Return { Value: LoadLocal { Index: var returnLocal } } tailReturn
+            || returnLocal != local)
+        {
+            return false;
+        }
+        // The temp must be exactly these two stores and this one read across the
+        // whole function — otherwise it is a real local whose value other code
+        // depends on, and collapsing would drop a needed store.
+        int loads = 0, stores = 0;
+        foreach (var node in function.Descendants)
+        {
+            if (node is LoadLocal load && load.Index == local)
+                loads++;
+            else if (node is StoreLocal store && store.Index == local)
+                stores++;
+            else if (node is LoadLocalAddress address && address.Index == local)
+                return false;
+        }
+        if (loads != 1 || stores != 2)
+            return false;
+
+        var condition = guard.Condition;
+        condition.Detach();
+        tailReturn.Detach();
+        stepper.StepOver("fold if/else bool store into return", guard);
+        guard.ReplaceWith(new Return(thenBool ? condition : Conditions.Negate(condition)));
         return true;
     }
 


### PR DESCRIPTION
## Summary
A boolean materialized through an if/else over a temp and then returned —
```csharp
if (c) { v = true; } else { v = false; }
return v;
```
— now folds to `return c;` (and the inverted arms to `return !c;`). Without it, the later `return-sinking` pass pushes the return into the arms (`if (c) return true; else return false;`), a verbose low-altitude spelling of a bare boolean.

## Not a fidelity fix (scope note)
This is a **readability raise**, surfaced while investigating #1047. The shape comes from a branch materialization (e.g. an unraised `or`/property pattern such as `s is null or { Length: 0 }`) whose opcodes **neither** spelling reproduces, so the recompiled stream is unchanged by this fold — it only rewrites the already-non-round-tripping shape. Faithfully recovering that IL needs the **pattern itself raised** (tracked in #1047, corrected there); this just improves the rendering meanwhile, and is fidelity-neutral.

## Soundness
The arms must each be a single store of an **opposite** `bool` constant to one temp, and the if's next sibling the **sole** read of that temp (checked across the whole function — no address-of, exactly two stores and one load), so the store is genuinely the boolean's materialization, not a real local. The condition is evaluated by `return c`, preserving its side effects. Equal arms are left alone.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — **918 tests, 0 failed**, including the fixture **fidelity gate** (no fidelity regression).
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps` — **0 pass bugs** across CoreLib.
- New synthetic-IR tests: positive (`return c` / `return !c`) and the temp-read-elsewhere decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)