### PR TITLE
Preserve unmanaged method-address witnesses

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2772,6 +2772,19 @@ public class CfgSampleClass
         ((delegate* unmanaged<ref int, float, void>)callback)(ref value, arg);
     }
 
+    [System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvStdcall)])]
+    public static int UnmanagedStdcallTarget(int value) => value;
+
+    // Runtime UnmanagedCallersOnly-style specimen: ldftn for a target with an
+    // unmanaged calling convention is stored through a delegate* local and then
+    // invoked through calli. The local's function-pointer type is the convention
+    // witness the decompiler must preserve.
+    public static unsafe int InvokesUnmanagedCallersOnlyStdcallTarget(int value)
+    {
+        delegate* unmanaged[Stdcall]<int, int> callback = &UnmanagedStdcallTarget;
+        return callback(value);
+    }
+
     static unsafe delegate*<int, int> s_functionPointer;
     static int FunctionPointerTarget(int value) => value;
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -281,6 +281,34 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness()
+    {
+        // Minimized from runtime's UnmanagedCallersOnly tests: a static ldftn for
+        // an UnmanagedCallersOnly target is assigned to a delegate* local whose
+        // type carries the unmanaged calling convention, then invoked through
+        // calli. The local type is the source-level convention witness.
+        var function = ImportFixture(nameof(CfgSampleClass.InvokesUnmanagedCallersOnlyStdcallTarget));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var functionPointerLocal = Assert.Single(function.Locals.Where(t => t.Kind == TypeRefKind.FunctionPointer));
+        Assert.Equal("delegate* unmanaged[Stdcall]<int, int>", functionPointerLocal.ToDisplayString());
+
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<LoadFunctionPointer>());
+        var address = Assert.Single(function.Descendants.OfType<AddressOfMethod>());
+        Assert.Equal("UnmanagedStdcallTarget", address.Method.Name);
+        Assert.Equal("delegate* unmanaged[Stdcall]<int, int>", address.ResultType!.ToDisplayString());
+        var call = Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Equal("int", call.ReturnType.ToDisplayString());
+        Assert.Equal(["int"], call.ParameterTypes.Select(t => t.ToDisplayString()).ToArray());
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Contains("return (&UnmanagedStdcallTarget)(value);", output);
+    }
+
+    [Fact]
     public void Ldftn_StaticMethodAddress_RaisesToAmpersandMethod()
     {
         // A static ldftn that feeds a delegate*-typed field store (not a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1389,7 +1389,7 @@ public sealed partial class CSharpPrinter
             : $"{Operand(id.Target)}{(id.IsIncrement ? "++" : "--")}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
-        CallIndirect ci => $"{Operand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci))})",
+        CallIndirect ci => $"{FunctionPointerOperand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci))})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),
@@ -1567,6 +1567,9 @@ public sealed partial class CSharpPrinter
             || node is Call call && !IsOperatorCall(call);
         return atomic ? text : $"({text})";
     }
+
+    string FunctionPointerOperand(IrExpression pointer)
+        => pointer is AddressOfMethod ? $"({Expression(pointer)})" : Operand(pointer);
 
     /// <summary>
     /// The C# place a load/store-indirect reads or writes. Dereferencing a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1595,17 +1595,23 @@ public sealed class LoadFunctionPointer : IrExpression
 /// constructor: it feeds a <c>calli</c>, a native-callback argument, or a
 /// <c>delegate*</c>-typed field. Raised from a surviving
 /// <see cref="LoadFunctionPointer"/> by <see cref="MethodAddressPass"/>; its
-/// result type is the managed function-pointer type of the method's signature.
+/// result type is the contextual function-pointer type when available, falling
+/// back to the managed function-pointer type of the method's signature.
 /// </summary>
 public sealed class AddressOfMethod : IrExpression
 {
-    public AddressOfMethod(MethodRef method) => Method = method;
+    public AddressOfMethod(MethodRef method, TypeRef? functionPointerType = null)
+    {
+        Method = method;
+        FunctionPointerType = functionPointerType;
+    }
 
     public MethodRef Method { get; }
+    public TypeRef? FunctionPointerType { get; }
     public override TypeRef? ResultType
-        => TypeRef.FunctionPointer(Method.ReturnType, Method.ParameterTypes, "");
+        => FunctionPointerType ?? TypeRef.FunctionPointer(Method.ReturnType, Method.ParameterTypes, "");
     public override IEnumerable<TypeRef> DirectTypes
-        => Method.ParameterTypes.Append(Method.DeclaringType).Append(Method.ReturnType).Concat(Method.TypeArguments);
+        => Method.ParameterTypes.Append(Method.DeclaringType).Append(Method.ReturnType).Concat(Method.TypeArguments).Concat(FunctionPointerType is null ? [] : [FunctionPointerType]);
 
     public override string Describe()
         => $"AddressOfMethod {Method.DeclaringType.ToDisplayString()}.{Method.Name}";

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
@@ -21,7 +21,20 @@ public sealed class MethodAddressPass : IIrPass
             if (pointer.Parent is null || pointer.IsVirtual)
                 continue;
             context.Stepper.StepOver($"raise ldftn to &{pointer.Method.Name}", pointer);
-            pointer.ReplaceWith(new AddressOfMethod(pointer.Method));
+            pointer.ReplaceWith(new AddressOfMethod(pointer.Method, ContextualFunctionPointerType(function, pointer)));
         }
+    }
+
+    static TypeRef? ContextualFunctionPointerType(IrFunction function, LoadFunctionPointer pointer)
+    {
+        TypeRef? type = pointer.Parent switch
+        {
+            StoreLocal store when ReferenceEquals(store.Value, pointer) => store.Type,
+            StoreField store when ReferenceEquals(store.Value, pointer) => store.Field.Type,
+            Return ret when ReferenceEquals(ret.Value, pointer) => function.Signature.ReturnType,
+            _ => null,
+        };
+
+        return type?.Kind == TypeRefKind.FunctionPointer ? type : null;
     }
 }


### PR DESCRIPTION
## Summary

- add a minimized `UnmanagedCallersOnly` Stdcall method-address fixture from #1064
- preserve contextual `delegate* unmanaged[Stdcall]<...>` evidence on raised `AddressOfMethod` nodes
- render direct function-pointer calls through method addresses as `(&Target)(args)` after expression inlining

Resolves the valid Stdcall method-address audit slice in #1064.

## Verification

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method ILInspector.Decompiler.Tests.IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness -method ILInspector.Decompiler.Tests.IrImporterTests.Calli_UnmanagedFunctionPointerWithRef_PreservesRefArgument -method ILInspector.Decompiler.Tests.IrImporterTests.Ldftn_StaticMethodAddress_RaisesToAmpersandMethod`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IrImporterTests`
- `dotnet build src/dotnet-inspect -c Release`

Note: I also started the full `src/ILInspector.Decompiler.Tests` executable, but stopped it after it did not return promptly; no failure summary was emitted before cancellation.