### PR TITLE
Route exact bare NuGet package IDs to package

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -246,6 +246,42 @@ public class CommandExecutionTests
         });
     }
 
+    // ── bare router ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BareName_PlatformLibrary_RoutesToLibrary()
+    {
+        var (exit, output, error) = await RunAppAsync("System.Text.Json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("# System.Text.Json.dll", output);
+        Assert.Contains("## Library Info", output);
+    }
+
+    [Fact]
+    public async Task BareName_PlatformNamespacePrefix_RoutesToTypePrefixBrowse()
+    {
+        var (exit, output, error) = await RunAppAsync("System.Text", "--tips", "q", "-n", "12");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Showing best-effort platform prefix matches for 'System.Text'", error);
+        Assert.Contains("# System.Text", output);
+        Assert.Contains("Source: Platform", output);
+    }
+
+    [Fact]
+    public async Task BareName_ExactNuGetPackageId_RoutesToPackage()
+    {
+        var (exit, output, error) = await RunAppAsync("System.CommandLine", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("# System.CommandLine", output);
+        Assert.Contains("## Package Info", output);
+        Assert.DoesNotContain("Library: System.CommandLine.dll | Types:", output);
+    }
+
     // ── api command ──────────────────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -176,7 +176,12 @@ public static class RouterCommandDefinition
             }
 
             if (PlatformResolver.IsPlatformCandidate(target))
+            {
+                if (await PackageExistsAsync(target, context))
+                    return ["package", .. tokens];
+
                 return ["type", target, .. tail];
+            }
 
             return ["package", .. tokens];
         }
@@ -187,6 +192,29 @@ public static class RouterCommandDefinition
 
         private static string[] FrameworkArgs(string source)
             => string.IsNullOrWhiteSpace(source) ? [] : ["--framework", source];
+
+        private static async Task<bool> PackageExistsAsync(string packageName, CommandContext context)
+        {
+            if (NuGetCache.TryGetLatestCachedVersion(packageName) != null)
+                return true;
+
+            try
+            {
+                var versions = await PackageExtractor.GetVersionsAsync(
+                    context.HttpClient,
+                    packageName,
+                    includePrerelease: true,
+                    limit: 1,
+                    log: context.Logger.Log,
+                    sourceOptions: NuGetSourceOptions.Default);
+                return versions is { Count: > 0 };
+            }
+            catch (Exception ex)
+            {
+                context.Logger.Log($"Could not query package versions for '{packageName}': {ex.Message}");
+                return false;
+            }
+        }
 
         private static async Task<bool> IsExactPlatformTypeAsync(
             SourceResolver.LocalProbeResult probe,

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -9,6 +9,10 @@
 - Keeps one readable decompiled C# section and makes `@Source` include `Recovered IL`.
 - Documents the source-view model in repo docs and the embedded skill guidance.
 
+### Bare-name routing
+
+- Keeps exact platform libraries such as `System.Text.Json` on the library view while routing exact NuGet-only package IDs such as `System.CommandLine` to package inspection.
+
 ## v0.10.5
 
 ### Library workflows


### PR DESCRIPTION
## Summary
- Keep bare exact platform libraries like System.Text.Json on the library view.
- Preserve platform namespace-prefix browsing for names like System.Text.
- Route exact NuGet-only package IDs like System.CommandLine to package inspection instead of the package type inventory.
- Add routing regression tests for those edge cases.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- targeted bare-route methods
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandLineTests
- dotnet run --project src/dotnet-inspect.Tests -c Release
- npx markdownlint-cli src/dotnet-inspect/release-notes.md