### PR TITLE
Raise single-element string-array list patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1123,6 +1123,31 @@ public class CfgSampleClass
 
     public static bool IsPatternMultiPropertyMixed(object o) => o is PatternPoint { X: > 0, Y: 2 };
 
+    // Runtime-mined frontier: a single-element string-array list pattern lowers
+    // to a null/length guard, an element temp, an OR-chain of string equality
+    // tests, then a bool result slot.
+    public static int SingleElementStringArrayListPattern(string[] args)
+    {
+        if (args is ["--help" or "-h" or "/?" or "-?"])
+            return 1;
+        return 0;
+    }
+
+    // Near-miss: source manual guard with a named element temp. It is semantically
+    // equivalent, but not a compiler list-pattern lowering because the temp is
+    // source-authored and must remain available to source-level debugging/name
+    // recovery.
+    public static int ManualSingleElementStringArrayGuard(string[] args)
+    {
+        if (args is not null && args.Length == 1)
+        {
+            var arg = args[0];
+            if (arg == "--help" || arg == "-h" || arg == "/?" || arg == "-?")
+                return 1;
+        }
+        return 0;
+    }
+
     // Runtime-mined frontier shape: a recursive property pattern with a
     // declaration subpattern whose variable is used in the body. The decompiler
     // currently raises the outer type test only; `{ PublicProperty: string str }`

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecardTests.cs
@@ -47,6 +47,7 @@ public class IdiomShapeScorecardTests
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternPropertyGreater), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
         new("IsPatternPass", nameof(CfgSampleClass.IsPatternMultiProperty), SyntaxKind.PropertyPatternClause, [SyntaxKind.LogicalAndExpression]),
+        new("ListPatternPass", nameof(CfgSampleClass.SingleElementStringArrayListPattern), SyntaxKind.ListPattern, [SyntaxKind.GotoStatement]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.DoWhileLoop), SyntaxKind.DoStatement, [SyntaxKind.WhileStatement]),
         new("DoWhileLoopPass", nameof(CfgSampleClass.PartitionStyleNestedSelfLoops), SyntaxKind.DoStatement, [SyntaxKind.GotoStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.LoopWithBreak), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),

--- a/src/ILInspector.Decompiler.Tests/ListPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ListPatternPassTests.cs
@@ -1,0 +1,69 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ListPatternPassTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void SingleElementStringArrayListPattern_RaisesToListPattern()
+    {
+        var function = Raised(nameof(CfgSampleClass.SingleElementStringArrayListPattern));
+
+        var pattern = Assert.Single(function.Descendants.OfType<SingleElementListPattern>());
+        Assert.Equal(["--help", "-h", "/?", "-?"], pattern.Alternatives.Select(a => Assert.IsType<string>(a.Value)));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("if (args is [\"--help\" or \"-h\" or \"/?\" or \"-?\"])", output);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("V_0", output);
+        Assert.DoesNotContain("V_1", output);
+        Assert.DoesNotContain("args.Length != 1", output);
+    }
+
+    [Fact]
+    public void ManualSingleElementStringArrayGuard_StaysSourceGuard()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualSingleElementStringArrayGuard));
+
+        Assert.Empty(function.Descendants.OfType<SingleElementListPattern>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("if (args is not null && args.Length == 1)", output);
+        Assert.Contains("arg = args[0];", output);
+        Assert.Contains("if (arg == \"--help\" || arg == \"-h\" || arg == \"/?\" || arg == \"-?\")", output);
+        Assert.DoesNotContain("args is [", output);
+    }
+
+    [Fact]
+    public void Stepper_RecordsListPatternRaise()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.SingleElementStringArrayListPattern));
+        Assert.NotNull(function);
+
+        var stepper = IrPasses.RunWithSteps(function!);
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+
+        Assert.Contains("raise single-element string-array list pattern", descriptions);
+    }
+
+    static IEnumerable<Step> Flatten(IEnumerable<Step> steps)
+    {
+        foreach (var step in steps)
+        {
+            yield return step;
+            foreach (var child in Flatten(step.Children))
+                yield return child;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1418,6 +1418,7 @@ public sealed partial class CSharpPrinter
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
+        SingleElementListPattern p => $"{Operand(p.Value)} is [{ListPatternAlternativesText(p)}]",
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
         UnboxAny u => $"({TypeText(u.Type)}){UnboxAnyOperand(u.Operand)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
@@ -1815,6 +1816,9 @@ public sealed partial class CSharpPrinter
             && property.Instance is LoadLocal local
             && local.Index == patternLocal
             && property.IndexArguments.Count == 0;
+
+    string ListPatternAlternativesText(SingleElementListPattern pattern)
+        => string.Join(" or ", pattern.Alternatives.Select(ConstantText));
 
     /// <summary>
     /// A return statement. A method that returns by reference (<c>ref T</c>) ends

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2027,6 +2027,32 @@ public sealed class IsPattern : IrExpression
     public override string Describe() => $"IsPattern {Type.ToDisplayString()} V_{LocalIndex}";
 }
 
+/// <summary>
+/// A raised single-element list pattern over a string array:
+/// <c>value is ["a" or "b"]</c>. Produced by <see cref="ListPatternPass"/> from
+/// csc's null/length/element-temp/equality-chain lowering when the element temp
+/// and bool result slot are compiler-generated and do not escape.
+/// </summary>
+public sealed class SingleElementListPattern : IrExpression
+{
+    public SingleElementListPattern(IrExpression value, IReadOnlyList<Constant> alternatives)
+    {
+        AddChild(value);
+        foreach (var alternative in alternatives)
+            AddChild(alternative);
+    }
+
+    /// <summary>The list-pattern input expression.</summary>
+    public IrExpression Value => (IrExpression)Children[0];
+
+    /// <summary>The constant alternatives for element zero.</summary>
+    public IReadOnlyList<Constant> Alternatives => Children.Skip(1).Cast<Constant>().ToList();
+
+    public override TypeRef? ResultType => TypeRef.CoreLib("System", "Boolean");
+
+    public override string Describe() => $"SingleElementListPattern ({Alternatives.Count} alternatives)";
+}
+
 public sealed class CastClass : IrExpression
 {
     public CastClass(TypeRef type, IrExpression operand)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -105,6 +105,10 @@ public static class IrPasses
         // of or-chain-guard for the else-arm case; runs last so it folds the final
         // normalized shape just before structuring.
         new OrChainDiamondPass(),
+        // Raise csc's single-element string-array list-pattern lowering after
+        // the OR-chain folds expose its null/length guard, equality chain, and
+        // bool-result diamond as one pre-structuring run.
+        new ListPatternPass(),
         // Fold a flat slot diamond whose arms return one slot (`if (c) goto F;
         // S = b; goto J; F: S = a; J: return S`) into `return c ? a : b`, so a
         // bool-computing arm of a csc range/equality dispatch becomes a straight-

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ListPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ListPatternPass.cs
@@ -1,0 +1,272 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises csc's single-element string-array list-pattern lowering back to
+/// <c>args is ["a" or "b"]</c>. The compiler shape is a pre-structuring run:
+/// null/length guards to the false arm, an unnamed element-zero temp, an
+/// exact-BCL <c>string.op_Equality</c> OR chain, then an unnamed bool result
+/// diamond consumed by a following branch.
+/// </summary>
+public sealed class ListPatternPass : IIrPass
+{
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+
+    public string Name => "list-pattern";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            var blocks = container.Blocks;
+            for (int p = 0; p + 6 < blocks.Count; p++)
+            {
+                if (TryMatch(function, blocks, p, out var match)
+                    && NoExternalEntry(blocks, p, consumedCount: 7))
+                {
+                    Fold(container, blocks, p, match, stepper);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static bool TryMatch(IrFunction function, IReadOnlyList<Block> blocks, int p, out Match match)
+    {
+        match = default!;
+
+        if (blocks[p].Children is not [ConditionalBranch lengthGuard]
+            || !TryNullOrLengthFailure(lengthGuard.Condition, out var array)
+            || blocks[p + 1].Children is not [StoreLocal elementStore, ConditionalBranch equalityGuard]
+            || lengthGuard.TargetOffset != equalityGuard.TargetOffset
+            || !TryElementZeroStore(function, elementStore, array, out int elementLocal)
+            || equalityGuard.Condition is not LogicalNot equalityNot)
+        {
+            return false;
+        }
+
+        var alternatives = new List<Constant>();
+        if (!TryCollectStringEqualityAlternatives(equalityNot.Operand, elementLocal, alternatives)
+            || alternatives.Count < 2)
+        {
+            return false;
+        }
+
+        if (blocks[p + 2].Children is not [StoreLocal trueStore, Branch trueBranch]
+            || blocks[p + 3].StartOffset != lengthGuard.TargetOffset
+            || blocks[p + 3].Children is not [StoreLocal falseStore]
+            || blocks[p + 4].StartOffset != trueBranch.TargetOffset
+            || blocks[p + 4].Children is not [ConditionalBranch resultGuard]
+            || resultGuard.Condition is not LogicalNot { Operand: LoadLocal resultLoad }
+            || blocks[p + 5].Children is not [Return trueReturn]
+            || blocks[p + 6].StartOffset != resultGuard.TargetOffset
+            || blocks[p + 6].Children is not [Return falseReturn]
+            || !TryBoolStore(function, trueStore, value: true, out int resultLocal)
+            || !TryBoolStore(function, falseStore, value: false, out int falseLocal)
+            || falseLocal != resultLocal
+            || resultLoad.Index != resultLocal
+            || !ReferencedOnlyWithin(function, elementLocal, [elementStore, equalityGuard.Condition])
+            || !ReferencedOnlyWithin(function, resultLocal, [trueStore, falseStore, resultGuard.Condition]))
+        {
+            return false;
+        }
+
+        match = new Match(array, alternatives, trueReturn, falseReturn);
+        return true;
+    }
+
+    static bool TryNullOrLengthFailure(IrExpression condition, out IrExpression array)
+    {
+        array = null!;
+        return condition is LogicalBinary { Kind: LogicalKind.Or } logical
+            && TryNullFailure(logical.Left, out array)
+            && TryLengthNotOneFailure(logical.Right, array);
+    }
+
+    static bool TryNullFailure(IrExpression condition, out IrExpression array)
+    {
+        array = null!;
+        if (condition is LogicalNot { Operand: LoadArgument or LoadLocal } not)
+        {
+            array = not.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    static bool TryLengthNotOneFailure(IrExpression condition, IrExpression array)
+        => condition is Comparison
+        {
+            Kind: ComparisonKind.NotEqual,
+            IsUnsigned: false,
+            Left: ArrayLength length,
+            Right: Constant { Value: 1, Type: var type },
+        }
+        && type.Equals(s_int)
+        && PlaceIdentity.SameVariable(length.Array, array);
+
+    static bool TryElementZeroStore(IrFunction function, StoreLocal store, IrExpression array, out int elementLocal)
+    {
+        elementLocal = -1;
+        if (HasSourceLocalName(function, store.Index)
+            || !store.Type.Equals(s_string)
+            || store.Value is not LoadElement
+            {
+                Array: var elementArray,
+                Index: Constant { Value: 0, Type: var indexType },
+                ResultType: var elementType,
+            }
+            || !indexType.Equals(s_int)
+            || elementType is null
+            || !elementType.Equals(s_string)
+            || !PlaceIdentity.SameVariable(elementArray, array))
+        {
+            return false;
+        }
+
+        elementLocal = store.Index;
+        return true;
+    }
+
+    static bool TryCollectStringEqualityAlternatives(IrExpression condition, int elementLocal, List<Constant> alternatives)
+    {
+        if (condition is LogicalBinary { Kind: LogicalKind.Or } logical)
+        {
+            return TryCollectStringEqualityAlternatives(logical.Left, elementLocal, alternatives)
+                && TryCollectStringEqualityAlternatives(logical.Right, elementLocal, alternatives);
+        }
+
+        if (condition is Call { Arguments: var args } call
+            && MemberIdentity.IsStringEquality(call))
+        {
+            if (args[0] is LoadLocal left && left.Index == elementLocal && args[1] is Constant { Value: string } right)
+            {
+                alternatives.Add((Constant)right.Clone());
+                return true;
+            }
+
+            if (args[1] is LoadLocal rightLoad && rightLoad.Index == elementLocal && args[0] is Constant { Value: string } leftConstant)
+            {
+                alternatives.Add((Constant)leftConstant.Clone());
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryBoolStore(IrFunction function, StoreLocal store, bool value, out int local)
+    {
+        local = -1;
+        if (HasSourceLocalName(function, store.Index)
+            || !store.Type.Equals(s_bool)
+            || store.Value is not Constant { Value: bool actual }
+            || actual != value)
+        {
+            return false;
+        }
+
+        local = store.Index;
+        return true;
+    }
+
+    static bool ReferencedOnlyWithin(IrFunction function, int index, IrNode[] allowed)
+    {
+        foreach (var node in function.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == index,
+                StoreLocal store => store.Index == index,
+                LoadLocalAddress address => address.Index == index,
+                _ => false,
+            };
+            if (references && !allowed.Any(root => IsInside(node, root)))
+                return false;
+        }
+        return true;
+    }
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, root))
+                return true;
+        }
+        return false;
+    }
+
+    static bool HasSourceLocalName(IrFunction function, int index)
+        => index >= 0
+        && index < function.LocalNames.Length
+        && !string.IsNullOrEmpty(function.LocalNames[index]);
+
+    static bool NoExternalEntry(IReadOnlyList<Block> blocks, int p, int consumedCount)
+    {
+        var consumedInnerOffsets = blocks
+            .Skip(p + 1)
+            .Take(consumedCount - 1)
+            .Select(block => block.StartOffset)
+            .ToHashSet();
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (i >= p && i < p + consumedCount)
+                continue;
+
+            foreach (var node in blocks[i].Descendants.Prepend(blocks[i]))
+                foreach (int target in Targets(node))
+                    if (consumedInnerOffsets.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        Leave leave => [leave.TargetOffset],
+        _ => [],
+    };
+
+    static void Fold(BlockContainer container, IReadOnlyList<Block> blocks, int p, Match match, Stepper stepper)
+    {
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i < p; i++)
+            rebuilt.Add((Block)blocks[i].Clone());
+
+        var raised = new Block(blocks[p].StartOffset);
+        var then = new Block(blocks[p + 5].StartOffset);
+        then.Add(new Return(match.TrueReturn.Value is null ? null : (IrExpression)match.TrueReturn.Value.Clone()));
+        raised.Add(new IfStatement(
+            new SingleElementListPattern((IrExpression)match.Array.Clone(), match.Alternatives),
+            then,
+            elseArm: null));
+        raised.Add(new Return(match.FalseReturn.Value is null ? null : (IrExpression)match.FalseReturn.Value.Clone()));
+        rebuilt.Add(raised);
+
+        for (int i = p + 7; i < blocks.Count; i++)
+            rebuilt.Add((Block)blocks[i].Clone());
+
+        stepper.StepOver("raise single-element string-array list pattern", container);
+        container.ReplaceWith(rebuilt);
+    }
+
+    sealed record Match(
+        IrExpression Array,
+        IReadOnlyList<Constant> Alternatives,
+        Return TrueReturn,
+        Return FalseReturn);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -82,7 +82,7 @@ internal static class LoweringCoverage
     public static IndexFromEndPass Index => new();
     [Completeness(CompletenessLevel.Full)] public static PropertySugarPass IndexerAccess => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative IsOperator => default!;
-    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression) and property-pattern equality/relational sub-patterns, including same-local multi-property conjunctions (`value is T { P: constant, Q: > constant }`); positional/list sub-patterns not raised, and float relational sub-patterns deliberately declined (ordered/unordered compares disagree on NaN)")]
+    [Completeness(CompletenessLevel.Partial, "type pattern `value is T t` (statement guard and && expression), property-pattern equality/relational sub-patterns including same-local multi-property conjunctions (`value is T { P: constant, Q: > constant }`), and the single-element string-array list pattern with constant OR alternatives (`args is [\"a\" or \"b\"]`); positional sub-patterns and general list patterns are not raised, and float relational sub-patterns are deliberately declined (ordered/unordered compares disagree on NaN)")]
     public static IsPatternPass IsPatternOperator => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative LabeledStatement => default!;
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Literal => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -47,6 +47,8 @@ internal static class NativePasses
     public static OrChainGuardPass OrChainGuard => new();
     [Native(NativeCategory.EmitArtifact, "short-circuit OR chain selecting a diamond's two arms folded so structuring can consume it")]
     public static OrChainDiamondPass OrChainDiamond => new();
+    [Native(NativeCategory.EmitArtifact, "single-element string-array list-pattern lowering collapsed after OR-chain folding exposes the compiler bool diamond")]
+    public static ListPatternPass ListPattern => new();
     [Native(NativeCategory.EmitArtifact, "a spilled-to-slot conditional result (flat slot diamond returning one slot) folded to a conditional return so structuring can consume the surrounding dispatch")]
     public static SlotDiamondPass SlotDiamond => new();
     [Native(NativeCategory.EmitArtifact, "generic null-conditional invocation (recv?.M() ?? x — the default(T)-box two-stage null test) folded so structuring can consume it")]


### PR DESCRIPTION
## Summary
- add a narrow pre-structuring ListPatternPass for csc's single-element string-array list-pattern lowering
- render the recovered IR as `args is ["a" or "b"]`
- add positive fixture coverage, manual-guard near-miss coverage, stepper coverage, and scorecard/ledger wiring

Closes #1053.

## Verification
- `dotnet build src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` (939 passed)
- `dotnet build src/dotnet-inspect -c Release`