### PR TITLE
Recover ref struct / readonly struct type modifiers (#1066)

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -180,6 +180,16 @@ public class ApiType
     public bool IsAbstract { get; set; }
     public bool IsStatic { get; set; }
 
+    /// <summary>
+    /// A byref-like struct (<c>ref struct</c>) — carries <c>[IsByRefLike]</c>, which
+    /// is suppressed from the attribute list as compiler-synthesized syntax, so the
+    /// modifier is reconstructed here instead.
+    /// </summary>
+    public bool IsByRefLike { get; set; }
+
+    /// <summary>A <c>readonly struct</c> — carries the likewise-suppressed <c>[IsReadOnly]</c>.</summary>
+    public bool IsReadOnly { get; set; }
+
     public string? BaseType { get; set; }
     public List<string> Interfaces { get; set; } = [];
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -69,6 +69,17 @@ public static class ApiSurfaceExtractor
 
             apiType.IsStatic = apiType.IsSealed && apiType.IsAbstract;
 
+            // The ref struct / readonly struct modifiers. Their [IsByRefLike] /
+            // [IsReadOnly] attributes are compiler-synthesized from syntax and so
+            // suppressed from the attribute list (AttributeReader.IsReEmitted), so
+            // the modifier is reconstructed here from the still-present attribute.
+            if (apiType.Kind == "struct")
+            {
+                var typeAttributes = typeDef.GetCustomAttributes();
+                apiType.IsByRefLike = AttributeReader.HasAttribute(reader, typeAttributes, KnownAttributeNames.IsByRefLikeAttribute);
+                apiType.IsReadOnly = AttributeReader.HasAttribute(reader, typeAttributes, KnownAttributeNames.IsReadOnlyAttribute);
+            }
+
             // Check if this is an extension class (static class with [Extension] attribute)
             bool isExtensionClass = apiType.IsStatic && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes());
 

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -31,6 +31,35 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_RecoversRefAndReadonlyStructModifiers()
+    {
+        // #1066: [IsByRefLike]/[IsReadOnly] are suppressed from the attribute list as
+        // compiler-synthesized syntax, so the ref/readonly struct modifier must be
+        // reconstructed onto the type model (and surfaced as a type modifier), not lost.
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var refStruct = surface.Types.FirstOrDefault(t => t.Name == "SampleRefStruct");
+        Assert.NotNull(refStruct);
+        Assert.Equal("struct", refStruct.Kind);
+        Assert.True(refStruct.IsByRefLike);
+        Assert.False(refStruct.IsReadOnly);
+
+        var readOnlyStruct = surface.Types.FirstOrDefault(t => t.Name == "SampleReadOnlyStruct");
+        Assert.NotNull(readOnlyStruct);
+        Assert.True(readOnlyStruct.IsReadOnly);
+        Assert.False(readOnlyStruct.IsByRefLike);
+
+        var plainStruct = surface.Types.FirstOrDefault(t => t.Name == "SamplePlainStruct");
+        Assert.NotNull(plainStruct);
+        Assert.False(plainStruct.IsByRefLike);
+        Assert.False(plainStruct.IsReadOnly);
+    }
+
+    [Fact]
     public void Extract_HandlesMethodWithNoParameters()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -490,6 +519,16 @@ public class SampleRequiredHost
 }
 
 public ref struct SampleRefStruct
+{
+    public int Value;
+}
+
+public readonly struct SampleReadOnlyStruct
+{
+    public readonly int Value;
+}
+
+public struct SamplePlainStruct
 {
     public int Value;
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -272,7 +272,13 @@ public static class ApiOutputFormatter
         var view = BuildShapeView(type, foundIn, packageName, packageVersion, memberFilter, kindFilter, verbosity);
         if (view.Members is { Count: > 0 })
         {
-            Console.WriteLine(view.FullName);
+            // Lead with a declaration-style header when the type carries modifiers
+            // (ref/readonly struct, static/sealed/abstract class) so the spelling is
+            // not silently dropped (#1066); a plain type keeps its bare name header.
+            string header = view.Modifiers is { Length: > 0 } modifiers
+                ? $"{modifiers.Replace(", ", " ")} {view.Kind} {view.FullName}"
+                : view.FullName;
+            Console.WriteLine(header);
             var writer = new MarkoutWriter(Console.Out, new MarkdownFormatter());
             writer.WriteTree([.. view.Members]);
         }
@@ -307,6 +313,8 @@ public static class ApiOutputFormatter
         if (type.IsStatic) modifiers.Add("static");
         if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
         if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
+        if (type.IsReadOnly && type.Kind == "struct") modifiers.Add("readonly");
+        if (type.IsByRefLike && type.Kind == "struct") modifiers.Add("ref");
 
         // Base type (filter out trivial bases)
         string? baseType = null;
@@ -561,6 +569,8 @@ public static class ApiOutputFormatter
         if (type.IsStatic) modifiers.Add("static");
         if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
         if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
+        if (type.IsReadOnly && type.Kind == "struct") modifiers.Add("readonly");
+        if (type.IsByRefLike && type.Kind == "struct") modifiers.Add("ref");
 
         var packageInfo = packageName != null && packageVersion != null
             ? $" ({packageName} {packageVersion})"


### PR DESCRIPTION
Closes #1066.

## The gap

`[IsByRefLike]`/`[IsReadOnly]` are correctly suppressed from the attribute list (compiler-synthesized syntax, `AttributeReader.IsReEmitted`), but the replacing syntax was never emitted — so every `ref struct` / `readonly struct` was spelled as a plain `struct`, in both the JSON model and the `--shape` markdown header.

## Fix (per the agreed basis — surface via the modifiers/`Modifiers` mechanism, not the kind-grouped tables)

- **`ApiType`**: add `IsByRefLike` / `IsReadOnly`, serialized like the existing `IsSealed`/`IsAbstract` bools.
- **`ApiSurfaceExtractor`**: reconstruct both from the still-present (list-suppressed) `IsByRefLikeAttribute`/`IsReadOnlyAttribute`, struct-only.
- **`ApiOutputFormatter`**: add `readonly`/`ref` (C# order) to the type modifiers list; and lead the `--shape` markdown header with a declaration-style `{modifiers} {kind} {name}` when modifiers are present (a plain type keeps its bare-name header).

## Result

```
type Rs.ByRefLikeSample   --shape  →  ref struct Rs.ByRefLikeSample
type Rs.ReadOnlySample    --shape  →  readonly struct Rs.ReadOnlySample
type Rs.ReadOnlyRefSample --shape  →  readonly ref struct Rs.ReadOnlyRefSample
type Rs.PlainSample       --shape  →  Rs.PlainSample              (unchanged)
--json  →  "is_by_ref_like": true / "is_read_only": true          (discriminators)
```

The same mechanism now also surfaces `static`/`sealed`/`abstract` class modifiers in the `--shape` header (previously computed but dropped) — the same silent-loss class, fixed consistently. Kind-grouped tables are unchanged, per scope.

## Validation

- **1213 `dotnet-inspect.Tests` + 205 `ILInspector.Metadata.Tests` green**, +1 regression test (`Extract_RecoversRefAndReadonlyStructModifiers`). **No snapshot churn**, no JSON schema doc to update (these fields aren't enumerated in docs).

## Note / possible follow-up

`ApiDiffAnalyzer` does not yet report `ref`/`readonly` *changes* between versions (it detects `sealed` changes). Out of scope for #1066 (spelling, not diff); flagging as a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)