### PR TITLE
Pin ref struct span layout import

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeSampleClass.cs
@@ -23,6 +23,23 @@ public static class LifetimeSampleClass
     // A ref struct parameter (Span<T>): cannot be boxed or put on the heap.
     public static int ReadSpan(Span<int> s) => s[0];
 
+    public ref struct SpanBackedView
+    {
+        private Span<int> _span;
+
+        public SpanBackedView(Span<int> span) => _span = span;
+
+        public int Length => _span.Length;
+
+        public int At(int index) => _span[index];
+    }
+
+    public static int ReadSpanBackedView(Span<int> span, int index)
+    {
+        var view = new SpanBackedView(span);
+        return view.At(index) + view.Length;
+    }
+
     // Returns a span borrowing from the input span.
     public static ReadOnlySpan<char> Tail(ReadOnlySpan<char> s) => s.Slice(1);
 

--- a/src/ILInspector.Decompiler.Tests/RefStructLayoutFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefStructLayoutFrontierTests.cs
@@ -1,0 +1,55 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class RefStructLayoutFrontierTests
+{
+    static IrFunction Import(Type type, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(LifetimeSampleClass).Assembly.Location);
+        string typeName = type.FullName!.Replace('+', '.');
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        return function!;
+    }
+
+    static IrFunction Raised(Type type, string methodName)
+    {
+        var function = Import(type, methodName);
+        IrPasses.Run(function);
+        function.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void RefStructWithSpanField_CallerImportsAndPrintsAtFullFidelity()
+    {
+        var function = Raised(typeof(LifetimeSampleClass), nameof(LifetimeSampleClass.ReadSpanBackedView));
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Diagnostics);
+        Assert.Contains("SpanBackedView view = new SpanBackedView(span);", output);
+        Assert.Contains("return view.At(index) + view.Length;", output);
+        Assert.DoesNotContain("IsByRefLike", output);
+        Assert.DoesNotContain("/*", output);
+    }
+
+    [Fact]
+    public void RefStructWithSpanField_MembersImportAndPrintAtFullFidelity()
+    {
+        var type = typeof(LifetimeSampleClass.SpanBackedView);
+
+        var ctor = Raised(type, ".ctor");
+        var at = Raised(type, nameof(LifetimeSampleClass.SpanBackedView.At));
+        var length = Raised(type, "get_Length");
+
+        Assert.Equal(DecompilationFidelity.Full, ctor.Fidelity);
+        Assert.Equal(DecompilationFidelity.Full, at.Fidelity);
+        Assert.Equal(DecompilationFidelity.Full, length.Fidelity);
+
+        Assert.Contains("_span = span;", CSharpPrinter.PrintRaised(ctor).Output);
+        Assert.Contains("return _span[index];", CSharpPrinter.PrintRaised(at).Output);
+        Assert.Contains("return _span.Length;", CSharpPrinter.PrintRaised(length).Output);
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -511,7 +511,11 @@ static class FidelityCheck
             return;
         }
 
-        string keyword = kind == TypeKind.Struct ? "struct" : "class";
+        // Byref-like stubs can legally contain Span<T> fields only when emitted
+        // as ref structs; otherwise the whole compile-back unit becomes invalid.
+        string keyword = kind == TypeKind.Struct
+            ? (IsByRefLike(reader, typeDef) ? "ref struct" : "struct")
+            : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
         // An [InlineArray(N)] struct must carry the attribute for its span
         // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
@@ -863,6 +867,17 @@ static class FidelityCheck
         return null;
     }
 
+    static bool IsByRefLike(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var ah in typeDef.GetCustomAttributes())
+        {
+            var attribute = reader.GetCustomAttribute(ah);
+            if (AttributeTypeFullName(reader, attribute) == "System.Runtime.CompilerServices.IsByRefLikeAttribute")
+                return true;
+        }
+        return false;
+    }
+
     /// <summary>The unqualified name of a custom attribute's type (its constructor's declaring type).</summary>
     static string AttributeTypeName(MetadataReader reader, CustomAttribute attribute)
     {
@@ -879,6 +894,26 @@ static class FidelityCheck
             case HandleKind.MethodDefinition:
                 var method = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
                 return reader.GetString(reader.GetTypeDefinition(method.GetDeclaringType()).Name);
+            default:
+                return "";
+        }
+    }
+
+    static string AttributeTypeFullName(MetadataReader reader, CustomAttribute attribute)
+    {
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                var member = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                return member.Parent.Kind switch
+                {
+                    HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)member.Parent)),
+                    HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)member.Parent)),
+                    _ => "",
+                };
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                return FullName(reader, reader.GetTypeDefinition(method.GetDeclaringType()));
             default:
                 return "";
         }


### PR DESCRIPTION
## Summary

Follow-up to the #1045 `Ref structs / byref-like layout` row and the #1066 pivot, focused on the decompiler/fidelity surface.

- Adds a `SpanBackedView` ref-struct fixture with a `Span<int>` field and pins caller/member import and raised C# output at full fidelity.
- Preserves `ref struct` in the fidelity compile-back skeleton when metadata carries `System.Runtime.CompilerServices.IsByRefLikeAttribute`, so byref-like stubs with span fields compile instead of invalidating unrelated gate entries.

## Validation

Latest base (`414ae61`):

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release -m:1 -nr:false /p:UseSharedCompilation=false`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -class ILInspector.Decompiler.Tests.RefStructLayoutFrontierTests -class ILInspector.Decompiler.Tests.LifetimeClassifierTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -class ILInspector.Decompiler.Tests.FidelityGateTests -class ILInspector.Decompiler.Tests.LoweredFidelityGateTests`
- `dotnet build src/dotnet-inspect -c Release -m:1 -nr:false /p:UseSharedCompilation=false`

Earlier full-suite validation before the final main rebase also passed: `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -maxThreads 1` (`938` tests, `0` failures).
