### PR TITLE
Pin state-machine scaffold preservation (#1011 state-machine row)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -71,6 +71,34 @@ public class IteratorAcknowledgmentPassTests
     }
 
     [Fact]
+    public void StateMachineMoveNext_PreservesStateFieldWrites()
+    {
+        // #1011 stepper-audit invariant (state-machine scaffolds): the MoveNext body
+        // is decompiled honestly (Partial) rather than reconstructed, and no pass may
+        // delete a state-field write — including the `<>1__state = N` written right
+        // before a yield/await suspend `return`, which looks dead within a single
+        // MoveNext call but is observable on the next. Enumerated by shape (a
+        // `>d__` state-machine type's MoveNext with state writes), so it covers
+        // every iterator/async fixture in the test assembly without a brittle name.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        int audited = 0;
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName != "MoveNext" || !typeName.Contains(">d__"))
+                continue;
+            int before = function.Descendants.OfType<StoreField>().Count(s => s.Field.Name.Contains("__state"));
+            if (before == 0)
+                continue;
+            IrPasses.Run(function);
+            function.CheckInvariant();
+            int after = function.Descendants.OfType<StoreField>().Count(s => s.Field.Name.Contains("__state"));
+            Assert.Equal(before, after);   // every state write survives — no illegal scaffold deletion
+            audited++;
+        }
+        Assert.True(audited > 0, "expected at least one state-machine MoveNext fixture to audit");
+    }
+
+    [Fact]
     public void StateMachineNameLookalikeWithoutCompilerGeneratedMetadata_IsNotAcknowledged()
     {
         var function = BuildStateMachineNameLookalike();


### PR DESCRIPTION
The last open row of #1011 (Stepper Semantic Auditor): **State-machine scaffolds**.

## Audit

Stepped iterator (`Range`) and async (`AddAsync`) `MoveNext` bodies through the full pipeline and compared the import tree against the post-pass tree. Every scaffold element is **preserved across all passes**:

- **Iterator**: `<>1__state` dispatch + writes (including `<>1__state = 1` right before `return true`), `<>2__current`, hoisted `<i>5__N` locals.
- **Async**: `<>1__state` writes (including before each await-suspend `return`), `<>u__1` awaiter, and the `<>t__builder` calls — `AwaitUnsafeOnCompleted` / `SetResult` / `SetException`.

The subtle risk — a dead-store pass dropping a `<>1__state = N` write that's dead within one `MoveNext` call but observable on the next — does **not** occur. `MoveNext` degrades honestly to `Partial` fidelity rather than being mis-reconstructed.

## Outcome: no bug; invariant pinned

Per the row's done criteria (no bug → record the invariant the trace proves), this adds a regression test (`StateMachineMoveNext_PreservesStateFieldWrites`) that enumerates every `>d__` state-machine `MoveNext` in the test assembly (by shape, robust to generated names) and asserts its state-field write count survives the pipeline. A future pass that dead-store-eliminates a state write is caught. The test's doc comment is the contract note.

**Test-only; no product change.** 946 decompiler tests green (+1).

This closes the last open row in #1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)