### PR TITLE
Audit eh-entangled conditional branches; pin EH-terminator preservation (#1081)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
@@ -27,5 +28,30 @@ public class ExceptionFilterFidelityTests
             r => r.Code == DiagnosticIds.UnsupportedExceptionFilter);
         Assert.Equal(0x20, remark.Offset);
         Assert.Contains("endfilter", remark.Reason);
+    }
+
+    [Fact]
+    public void FilterMethod_PreservesEhTerminatorsThroughPipeline()
+    {
+        // #1081 eh-entangled conditional-branch audit. A try/catch-when filter
+        // (FilteredLength) stays honestly Partial because the filter region is not
+        // structured, so the surrounding conditional branches stay flat too. The
+        // audit invariant: no pass illegally consumes or reorders the EH terminators
+        // — dropping the endfilter or a leave across the protected region would
+        // change which handler runs. The endfilter and the leaves survive the full
+        // pipeline unchanged (no illegal EH transform).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.FilteredLength));
+        Assert.NotNull(function);
+        int endFiltersBefore = function!.Descendants.OfType<EndFilter>().Count();
+        int leavesBefore = function.Descendants.OfType<Leave>().Count();
+        Assert.True(endFiltersBefore > 0, "fixture must import with an endfilter");
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        Assert.Equal(endFiltersBefore, function.Descendants.OfType<EndFilter>().Count());
+        Assert.Equal(leavesBefore, function.Descendants.OfType<Leave>().Count());
     }
 }


### PR DESCRIPTION
#1081 row: **EH-entangled conditional branches** (27 product hits). Per the row's guardrail, a stepper semantic audit first — deliverable is a phase-contract note / illegal-transform pin, not a structuring rewrite.

## Audit

Two representatives:
- `IndexBuilder::MethodLabel` — `try`/`catch when` (exception **filter**).
- `SymbolPackageDownloader::ExtractPdbFromSymbolPackage` — **async** `try/finally` + `using` (await inside the protected region).

Both stay honestly **Partial** because their EH regions are **not structured** (filters and async-EH are left flat), so the surrounding conditional branches can't structure across the unstructured EH boundary. Comparing import vs post-pass trees, **every EH terminator (`leave`/`endfilter`/`endfinally`) and the surrounding control flow is preserved — no illegal transform.** That's the EH legality blocker for this shape: unstructured filters + async-EH, not a mis-transform.

## Deliverable

A regression test (`FilterMethod_PreservesEhTerminatorsThroughPipeline`) over the real `FilteredLength` filter method: it imports with an `endfilter` + leaves, stays Partial through the pipeline, and its EH terminators survive unchanged. A future pass that illegally consumes/reorders a filter leave or endfilter — which would change which handler runs — is caught. Complements the existing synthetic `ResidualEndFilter_DegradesToPartialAndReportsRemark`.

**Test-only; no product change.** 949 decompiler tests green (+1).

## Sub-finding (follow-up, not fixed here)

In the filter, the caught-exception `isinst` test renders a typeless reference stack slot as a bare `if (S_257)` rather than `is not null`. Tolerated here (the method is Partial → honest degradation), but a truthiness/slot-type gap that would be CS0019 in a Full method — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)