### PR TITLE
Preserve bool return accumulators for fidelity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ElseReturnFoldTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ElseReturnFoldTests.cs
@@ -2,29 +2,37 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
-// FoldElseReturn: a boolean materialized through an if/else over a temp and then
-// returned — `if (c) { v = true; } else { v = false; } return v;` — collapses to
-// `return c;` (and the inverted arms to `return !c;`). A readability raise; see
-// the pass docs and #1047.
+// A boolean materialized through an if/else over a temp and then returned —
+// `if (c) { v = true; } else { v = false; } return v;` — must stay in that
+// accumulator form. Collapsing it to `return c;` is semantically equivalent but
+// does not round-trip opcode-exact for pattern-lowered bool returns (#1047).
 public class ElseReturnFoldTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
 
     [Fact]
-    public void IfElseBoolStoreReturn_FoldsToCondition()
+    public void IfElseBoolStoreReturn_StaysAccumulatorForm()
     {
         var output = Fold(thenValue: true, elseValue: false);
 
-        Assert.Equal("return c;", output);
+        Assert.Contains("if (c)", output);
+        Assert.Contains("V_0 = true;", output);
+        Assert.Contains("V_0 = false;", output);
+        Assert.Contains("return V_0;", output);
+        Assert.DoesNotContain("return c;", output);
     }
 
     [Fact]
-    public void IfElseBoolStoreReturn_InvertedArms_FoldsToNegatedCondition()
+    public void IfElseBoolStoreReturn_InvertedArms_StaysAccumulatorForm()
     {
         var output = Fold(thenValue: false, elseValue: true);
 
-        Assert.Equal("return !c;", output);
+        Assert.Contains("if (c)", output);
+        Assert.Contains("V_0 = false;", output);
+        Assert.Contains("V_0 = true;", output);
+        Assert.Contains("return V_0;", output);
+        Assert.DoesNotContain("return !c;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
@@ -1,0 +1,96 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ReturnSinkingPassTests
+{
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    [Fact]
+    public void ExplicitElseBoolAccumulator_StaysAccumulatorForFidelity()
+    {
+        var condition = new LoadArgument(0, "condition", Bool);
+        var thenBlock = new Block(1);
+        thenBlock.Add(new StoreLocal(0, Bool, new Constant(true, Bool)));
+        var elseBlock = new Block(2);
+        elseBlock.Add(new StoreLocal(0, Bool, new Constant(false, Bool)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(condition, thenBlock, elseBlock));
+        entry.Add(new Return(new LoadLocal(0, Bool)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Object"),
+            new MethodSignature(Bool, [new Parameter("condition", Bool)], HasThis: false, GenericParameterCount: 0),
+            [Bool],
+            container);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Contains(function.Descendants.OfType<IfStatement>(), _ => true);
+        Assert.Equal(2, function.Descendants.OfType<StoreLocal>().Count());
+        var ret = Assert.Single(function.Body.Blocks[0].Children.OfType<Return>());
+        Assert.IsType<LoadLocal>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ExplicitElseInvertedBoolAccumulator_StaysAccumulatorForFidelity()
+    {
+        var condition = new LoadArgument(0, "condition", Bool);
+        var thenBlock = new Block(1);
+        thenBlock.Add(new StoreLocal(0, Bool, new Constant(false, Bool)));
+        var elseBlock = new Block(2);
+        elseBlock.Add(new StoreLocal(0, Bool, new Constant(true, Bool)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(condition, thenBlock, elseBlock));
+        entry.Add(new Return(new LoadLocal(0, Bool)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Object"),
+            new MethodSignature(Bool, [new Parameter("condition", Bool)], HasThis: false, GenericParameterCount: 0),
+            [Bool],
+            container);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Contains(function.Descendants.OfType<IfStatement>(), _ => true);
+        Assert.Equal(2, function.Descendants.OfType<StoreLocal>().Count());
+        var ret = Assert.Single(function.Body.Blocks[0].Children.OfType<Return>());
+        Assert.IsType<LoadLocal>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ExplicitElseWithPriorArmStatement_StaysStructured()
+    {
+        var thenBlock = new Block(1);
+        thenBlock.Add(new ExpressionStatement(new Call(
+            new MethodRef(TypeRef.CoreLib("System", "GC"), "KeepAlive", TypeRef.CoreLib("System", "Void"), [TypeRef.CoreLib("System", "Object")], HasThis: false),
+            isVirtual: false,
+            [new Constant(null, TypeRef.CoreLib("System", "Object"))])));
+        thenBlock.Add(new StoreLocal(0, Bool, new Constant(true, Bool)));
+        var elseBlock = new Block(2);
+        elseBlock.Add(new StoreLocal(0, Bool, new Constant(false, Bool)));
+        var entry = new Block(0);
+        entry.Add(new IfStatement(new LoadArgument(0, "condition", Bool), thenBlock, elseBlock));
+        entry.Add(new Return(new LoadLocal(0, Bool)));
+        var container = new BlockContainer();
+        container.Add(entry);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Object"),
+            new MethodSignature(Bool, [new Parameter("condition", Bool)], HasThis: false, GenericParameterCount: 0),
+            [Bool],
+            container);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Contains(function.Descendants.OfType<IfStatement>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<Return>(), r => r.Value is Constant { Value: true });
+        function.CheckInvariant();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -504,43 +504,12 @@ public sealed class BooleanFoldingPass : IIrPass
     /// </summary>
     static bool FoldElseReturn(IrFunction function, IfStatement guard, Stepper stepper)
     {
-        if (guard.Else is not { } elseArm || guard.Parent is not Block container)
-            return false;
-        if (guard.Then.Children is not [StoreLocal { Index: var local, Value: Constant { Value: bool thenBool } }]
-            || elseArm.Children is not [StoreLocal { Index: var elseLocal, Value: Constant { Value: bool elseBool } }]
-            || local != elseLocal
-            || thenBool == elseBool)
-        {
-            return false;
-        }
-        if (guard.ChildIndex + 1 >= container.Children.Count
-            || container.Children[guard.ChildIndex + 1] is not Return { Value: LoadLocal { Index: var returnLocal } } tailReturn
-            || returnLocal != local)
-        {
-            return false;
-        }
-        // The temp must be exactly these two stores and this one read across the
-        // whole function — otherwise it is a real local whose value other code
-        // depends on, and collapsing would drop a needed store.
-        int loads = 0, stores = 0;
-        foreach (var node in function.Descendants)
-        {
-            if (node is LoadLocal load && load.Index == local)
-                loads++;
-            else if (node is StoreLocal store && store.Index == local)
-                stores++;
-            else if (node is LoadLocalAddress address && address.Index == local)
-                return false;
-        }
-        if (loads != 1 || stores != 2)
-            return false;
-
-        var condition = guard.Condition;
-        condition.Detach();
-        tailReturn.Detach();
-        stepper.StepOver("fold if/else bool store into return", guard);
-        guard.ReplaceWith(new Return(thenBool ? condition : Conditions.Negate(condition)));
-        return true;
+        // Explicit if/else stores into a single bool return accumulator are the
+        // compiler's materialized bool-return lowering for patterns such as
+        // `s is null or { Length: 0 }`. Collapsing them to `return condition;`
+        // is semantically equivalent but not opcode-exact, so leave them for the
+        // printer as the faithful local/branch shape.
+        return false;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnSinkingPass.cs
@@ -154,8 +154,34 @@ public sealed class ReturnSinkingPass : IIrPass
         // a return but was missed.
         if (consumed.Count != indexStores.Count)
             return null;
+        if (IsExplicitElseBoolAccumulator(folds))
+            return null;
 
         return new Plan(folds, returns);
+    }
+
+    static bool IsExplicitElseBoolAccumulator(List<(StoreLocal Store, Break? Break)> folds)
+    {
+        if (folds is not [(var thenStore, null), (var elseStore, null)])
+            return false;
+        if (BoolConstant(thenStore.Value) is not { } thenBool
+            || BoolConstant(elseStore.Value) is not { } elseBool
+            || thenBool == elseBool)
+        {
+            return false;
+        }
+        if (thenStore.Parent is not Block thenBlock
+            || elseStore.Parent is not Block elseBlock
+            || thenBlock.Children is not [StoreLocal]
+            || elseBlock.Children is not [StoreLocal]
+            || thenBlock.Parent is not IfStatement ifStatement
+            || !ReferenceEquals(elseBlock.Parent, ifStatement)
+            || !ReferenceEquals(ifStatement.Then, thenBlock)
+            || !ReferenceEquals(ifStatement.Else, elseBlock))
+        {
+            return false;
+        }
+        return true;
     }
 
     static void Apply(Plan plan, Stepper stepper)
@@ -170,6 +196,13 @@ public sealed class ReturnSinkingPass : IIrPass
         foreach (var ret in plan.Returns)
             ret.Detach();
     }
+
+    static bool? BoolConstant(IrExpression expression) => expression switch
+    {
+        Constant { Value: bool value } => value,
+        Constant { Value: int value } when value is 0 or 1 => value == 1,
+        _ => null,
+    };
 
     /// <summary>
     /// The terminal fall-through stores of <paramref name="index"/> a trailing


### PR DESCRIPTION
Fixes #1047.

## Summary
- Preserve explicit bool return-accumulator if/else shapes instead of folding them to direct bool returns.
- Update the existing bool else-return tests to assert the fidelity-preserving accumulator form.
- Add ReturnSinkingPass coverage for both normal and inverted bool accumulator arms.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- Minimized #1047 fixture library: dotnet run --project tools/DecompilerHarness -c Release -- /tmp/issue1047lib/bin/Release/net11.0/issue1047lib.dll --fidelity-check --compile-cap 1000
  - exact opcode match: 2/2
  - opcode diff (Full): 0

Note: a full CoreLib fidelity sweep was attempted but ran for over 20 minutes without output, so I stopped it and used the targeted minimized fidelity repro plus the repository fidelity gate instead.
