### PR TITLE
Document comparison-tree range-search blocker

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -418,21 +418,22 @@ only when the post-dominator machinery is proven.
    comparisons — switch raising, not this track), 21 `range-search-tree` (a
    relational `if (x > c)` binary search over clustered cases, e.g.
    `HttpClientFactory::IsNonPublic`), and ~0 genuine flat equality cascades (those
-   already raise). A minimal fixture isolates the blocker: a clustered-`int`
-   `switch` whose every arm is a straight-line `return <const>` **already raises
-   today** (the dispatch is a clean nested diamond once the leaves inline); the
-   *same* dispatch with arms that compute a bool before returning — `0 => true,
-   100 => y is >= 64 and <= 127, …` — stays flat. csc lowers each such arm to a
-   slot diamond (`if (y < 64) goto F; S = y <= 127; goto J; F: S = false;
-   J: …`) that converges with the other arms on a single shared `J: return S`.
-   That shared `return S` is exactly the deferred return-tail merge above. The
-   deadlock is structural: `BooleanFoldingPass` would fold each arm to
-   `return y >= 64 && y <= 127` (a straight-line terminator that then inlines),
-   but it runs **after** structuring and matches tree nodes, while structuring is
-   all-or-nothing and bails on the unfolded arms — so neither fires. Teaching the
-   guard combiner to defer to a genuine shared return-tail merge (the `String::Trim`
-   follow-up) is therefore the same unlock for the `range-search-tree` slice; it is
-   not separate work.
+   already raise). The #1081 audit pinned `HttpClientFactory::IsNonPublic` on
+   `origin/main` (`0d14d8e`) as Full fidelity with one shared false return block
+   reached by six guarded range-test predecessors; `CfgSampleClass.ByteRangeSearchTree`
+   is the local fixture for that exact residual. A clustered switch whose every arm
+   is a straight-line `return <const>` **already raises today** (the dispatch is a
+   clean nested diamond once the leaves inline); the same dispatch with guarded
+   range arms — `100 => b[1] is >= 64 and <= 127, …` — stays flat. csc lowers each
+   range arm to conditionals that converge with the other arms on one shared
+   `return false` tail. That shared return tail is exactly the deferred
+   return-tail merge above. The deadlock is structural: the boolean/range fold
+   that would turn each arm into a straight-line terminator runs **after**
+   structuring and matches tree nodes, while structuring is all-or-nothing and
+   bails on the unfolded arms — so neither fires. Teaching the guard combiner to
+   defer to a genuine shared return-tail merge (the `String::Trim` follow-up) is
+   therefore the same unlock for the `range-search-tree` slice; it is not separate
+   work.
 
    *Stepper audit — branch-target and switch-dispatch invariants.* The #1011
    branch-target/switch audit stepped `Interop::GetExceptionForIoErrno` and

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -867,6 +867,28 @@ public class CfgSampleClass
         _ => false,
     };
 
+    // The HttpClientFactory::IsNonPublic comparison-tree residual: clustered
+    // sparse-switch dispatch over a byte, with guarded range arms that all branch
+    // to one shared false return tail. Unlike SlotDiamondDispatch, the range
+    // arms are not reduced to straight-line returns before structuring, so the
+    // comparison tree still stays flat.
+    public static bool ByteRangeSearchTree(byte[] b)
+    {
+        byte first = b[0];
+        return first switch
+        {
+            0 => true,
+            10 => true,
+            127 => true,
+            169 when b[1] == 254 => true,
+            172 when b[1] >= 16 && b[1] <= 31 => true,
+            192 when b[1] == 168 => true,
+            100 when b[1] >= 64 && b[1] <= 127 => true,
+            >= 224 => true,
+            _ => false,
+        };
+    }
+
     public static string UnsignedBoundsBranch(int index, int[] array)
     {
         if ((uint)index >= (uint)array.Length)

--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -33,6 +33,19 @@ public class CompletenessTests
     }
 
     [Fact]
+    public void ByteRangeSearchTree_RemainsComparisonTreeResidual()
+    {
+        // ByteRangeSearchTree isolates the HttpClientFactory::IsNonPublic row from
+        // #1081: the sparse byte dispatch itself is recognizable, but guarded
+        // range arms still share one false return tail, so the strict structurer
+        // keeps the comparison tree flat until a dedicated follow-up handles it.
+        var function = Raised(nameof(CfgSampleClass.ByteRangeSearchTree));
+
+        Assert.Equal("structuring: conditional-branch", Completeness.Residual(function));
+        Assert.Equal("comparison-tree", ConditionalBranchShapeClassifier.Classify(function));
+    }
+
+    [Fact]
     public void CommonExitGotos_RecoveredByRegionExitDiamond()
     {
         // GotoCommonExitGuardedMerge's inner arms both branch to the enclosing

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -34,6 +34,10 @@ public class FidelityGateTests
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
+        // ByteRangeSearchTree is the #1081 comparison-tree blocker fixture:
+        // valid Full-fidelity output, but the shared false return tail leaves a
+        // flat range-search tree that recompiles to different branch structure.
+        "ByteRangeSearchTree",
         "GotoCommonExit",
         "NeitherOr",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -48,6 +48,8 @@
              Link="VolatileFieldDetector.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\Completeness.cs"
              Link="Completeness.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ConditionalBranchShapeClassifier.cs"
+             Link="ConditionalBranchShapeClassifier.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ShellNoise.cs"
              Link="ShellNoise.cs" />
   </ItemGroup>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -28,6 +28,10 @@ public class LoweredFidelityGateTests
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
         "BothPositive",
+        // ByteRangeSearchTree is the #1081 comparison-tree blocker fixture:
+        // valid Full-fidelity output, but the shared false return tail leaves a
+        // flat range-search tree that recompiles to different branch structure.
+        "ByteRangeSearchTree",
         "GotoCommonExit",
         "NeitherOr",
         "ReverseCopy",


### PR DESCRIPTION
## Summary

- add `CfgSampleClass.ByteRangeSearchTree` as a local fixture for the `HttpClientFactory::IsNonPublic` comparison-tree residual
- pin the fixture as a `structuring: conditional-branch` / `comparison-tree` known gap in completeness coverage
- record the #1081 audit in the control-flow structuring design note and baseline the fixture in both fidelity gates

Follow-up: #1084

## Verification

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll --gaps --by-shape`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll --dump 'DotnetInspector.Core.HttpClientFactory::IsNonPublic' --remarks`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --gaps --by-shape`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `npx markdownlint-cli docs/design/control-flow-structuring.md`
