### PR TITLE
Prefer expression-bodied decompiler one-liners

### DIFF
--- a/src/ILInspector.Decompiler/CSharpExpressionBody.cs
+++ b/src/ILInspector.Decompiler/CSharpExpressionBody.cs
@@ -1,0 +1,83 @@
+namespace ILInspector.Decompiler;
+
+/// <summary>
+/// Converts a rendered single-statement body to the expression used by C#
+/// expression-bodied members, when the statement form is known to be legal.
+/// </summary>
+public static class CSharpExpressionBody
+{
+    public static string? FromSingleStatement(string body)
+    {
+        var line = body.Trim();
+        if (line.Length == 0
+            || line.Contains('\n')
+            || !line.EndsWith(';')
+            || line.StartsWith("//", StringComparison.Ordinal)
+            || line.StartsWith("/*", StringComparison.Ordinal))
+            return null;
+
+        line = line[..^1].TrimEnd();
+        if (line.StartsWith("return ", StringComparison.Ordinal))
+        {
+            var expression = line["return ".Length..].TrimStart();
+            return expression.Length == 0 ? null : expression;
+        }
+        if (line is "return")
+            return null;
+        if (line.StartsWith("throw ", StringComparison.Ordinal))
+            return line;
+        return IsStatementExpression(line) ? line : null;
+    }
+
+    static bool IsStatementExpression(string expression)
+    {
+        if (expression.StartsWith("await ", StringComparison.Ordinal))
+        {
+            var awaited = expression["await ".Length..].TrimStart();
+            return awaited.Length > 0
+                && !awaited.StartsWith("using ", StringComparison.Ordinal)
+                && !awaited.StartsWith("foreach ", StringComparison.Ordinal);
+        }
+        if (expression.StartsWith("new ", StringComparison.Ordinal))
+            return true;
+        if (expression.EndsWith("++", StringComparison.Ordinal)
+            || expression.EndsWith("--", StringComparison.Ordinal)
+            || expression.StartsWith("++", StringComparison.Ordinal)
+            || expression.StartsWith("--", StringComparison.Ordinal))
+            return true;
+
+        if (TryFindAssignmentOperator(expression, out var operatorIndex))
+        {
+            var target = expression[..operatorIndex].Trim();
+            return target.Length > 0
+                && (!target.Contains(' ', StringComparison.Ordinal) || target.StartsWith('('));
+        }
+
+        var paren = expression.IndexOf('(');
+        if (paren <= 0)
+            return false;
+
+        var receiver = expression[..paren].TrimEnd();
+        return receiver.Length > 0
+            && !receiver.Contains(' ', StringComparison.Ordinal)
+            && receiver is not ("if" or "for" or "while" or "switch" or "using" or "lock");
+    }
+
+    static bool TryFindAssignmentOperator(string expression, out int index)
+    {
+        foreach (var op in new[]
+        {
+            " ??= ", " <<= ", " >>= ",
+            " += ", " -= ", " *= ", " /= ", " %= ", " &= ", " |= ", " ^= ",
+            " = "
+        })
+        {
+            index = expression.IndexOf(op, StringComparison.Ordinal);
+            if (index > 0)
+                return true;
+        }
+
+        index = -1;
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -274,7 +274,7 @@ public static class TypeSourceComposer
                         {
                             sb.AppendLine(head);
                             sb.AppendLine("    {");
-                            if (ExpressionOf(body) is { } setExpr)
+                            if (CSharpExpressionBody.FromSingleStatement(body) is { } setExpr)
                                 sb.AppendLine($"        set => {setExpr};");
                             else
                             {
@@ -285,7 +285,7 @@ public static class TypeSourceComposer
                             }
                             sb.AppendLine("    }");
                         }
-                        else if (ExpressionOf(body) is { } getExpr)
+                        else if (CSharpExpressionBody.FromSingleStatement(body) is { } getExpr)
                         {
                             sb.AppendLine($"{head} => {getExpr};");
                         }
@@ -403,6 +403,11 @@ public static class TypeSourceComposer
             sb.AppendLine($"    {head};");
             return;
         }
+        if (CSharpExpressionBody.FromSingleStatement(body) is { } expression)
+        {
+            sb.AppendLine($"    {head} => {expression};");
+            return;
+        }
         sb.AppendLine($"    {head}");
         sb.AppendLine("    {");
         AppendIndented(sb, body, "        ");
@@ -481,7 +486,7 @@ public static class TypeSourceComposer
         // (csharp_style_expression_bodied_properties/accessors = true):
         // a lone getter returning one expression is 'head => expr;', and any
         // single-statement accessor is 'get/set => ...;'.
-        if (accessors is [("get", { } loneGet)] && ExpressionOf(loneGet) is { } propExpr)
+        if (accessors is [("get", { } loneGet)] && CSharpExpressionBody.FromSingleStatement(loneGet) is { } propExpr)
         {
             sb.AppendLine($"    {head} => {propExpr};");
             return;
@@ -498,7 +503,7 @@ public static class TypeSourceComposer
                 sb.AppendLine($"        {keyword};");
                 continue;
             }
-            if (ExpressionOf(body) is { } accessorExpr)
+            if (CSharpExpressionBody.FromSingleStatement(body) is { } accessorExpr)
             {
                 sb.AppendLine($"        {keyword} => {accessorExpr};");
                 continue;
@@ -515,19 +520,6 @@ public static class TypeSourceComposer
     /// The expression of a single-statement body suitable for '=>':
     /// 'return X;' yields X; a lone statement yields itself without ';'.
     /// </summary>
-    static string? ExpressionOf(string body)
-    {
-        string line = body.Trim();
-        if (line.Contains('\n') || !line.EndsWith(';'))
-            return null;
-        line = line[..^1];
-        if (line.StartsWith("return ", StringComparison.Ordinal))
-            return line[7..];
-        if (line is "return")
-            return null;
-        return line;
-    }
-
     static string? DecompileBody(
         Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1954,6 +1954,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectDecompiledSource_UsesExpressionBodiedSyntaxForOneLineReturn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "CallsInterfaceItem", "-S", "Decompiled Source", "--raw");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public static int CallsInterfaceItem(System.Collections.Generic.IList<int> values) => values[0];", output);
+        Assert.DoesNotContain("{", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOperator_SelectDecompiledSource_RendersCSharpOperatorDeclaration()
     {
         var options = new MemberOptions
@@ -2229,6 +2242,19 @@ public class CommandExecutionTests
         // not their accessor methods.
         Assert.Contains("bool ICollection.IsSynchronized => false;", output);
         Assert.DoesNotContain("get_IsSynchronized", output);
+    }
+
+    [Fact]
+    public async Task Type_DecompiledSource_UsesExpressionBodiedSyntaxForOneLineMembers()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "-S", "Decompiled Source", "--raw");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public static int CallsInterfaceItem(IList<int> values) => values[0];", output);
+        Assert.Contains("    public static void CallsWriteLineTwice()\n    {", output.ReplaceLineEndings("\n"));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1173,7 +1173,13 @@ public static class ApiOutputFormatter
                 string source;
                 try
                 {
-                    source = FormatSourceWithDeclaration(type, member, code.MethodGenericParameters, lowered, code.RequiresAsyncDeclaration);
+                    source = FormatSourceWithDeclaration(
+                        type,
+                        member,
+                        code.MethodGenericParameters,
+                        lowered,
+                        code.RequiresAsyncDeclaration,
+                        preferExpressionBodied: true);
                 }
                 catch (Exception ex)
                 {
@@ -1391,7 +1397,8 @@ public static class ApiOutputFormatter
         ApiMember member,
         IReadOnlyList<string>? methodGenericParameters,
         string lowered,
-        bool requiresAsyncDeclaration = false)
+        bool requiresAsyncDeclaration = false,
+        bool preferExpressionBodied = false)
     {
         var declaration = FormatMemberDeclaration(type, member, abbreviate: false, methodGenericParameters);
         if (requiresAsyncDeclaration && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
@@ -1413,6 +1420,9 @@ public static class ApiOutputFormatter
 
         if (string.IsNullOrWhiteSpace(declaration))
             return body;
+
+        if (preferExpressionBodied && Decompiler.CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
+            return $"{declaration} => {expressionBody};";
 
         var indentedBody = string.Join(
             Environment.NewLine,


### PR DESCRIPTION
Closes #1079.

## Summary
- render eligible one-statement decompiled members as expression-bodied members
- share the single-statement-to-expression detector between member output and whole-type source composition
- keep annotated source block-bodied so comments and IL annotations stay anchored

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/dotnet-inspect -c Release -- member System.CommandLine.Command --package System.CommandLine Add:1 -S "Decompiled Source" --raw --tips q` → `public void Add(System.CommandLine.Argument argument) => Arguments.Add(argument);`