### PR TITLE
Sub-classify the eh-entangled conditional-branch bucket by EH subshape (#1089)

### DIFF
--- a/tools/DecompilerHarness/EhShapeClassifier.cs
+++ b/tools/DecompilerHarness/EhShapeClassifier.cs
@@ -1,0 +1,64 @@
+using ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Sub-classifies a method already in the <c>eh-entangled</c> conditional-branch
+/// bucket (<see cref="ConditionalBranchShapeClassifier"/>) into the subshapes of
+/// the EH-aware structuring burndown (#1089). The EH regions are already
+/// recovered as <see cref="TryFinally"/>/<see cref="TryCatch"/> nodes; what stays
+/// flat is the branch/leave interacting with them. Returns the single
+/// most-blocking subshape per method, hardest first (so a method's bucket names
+/// the work that must land for it to fully raise):
+/// <list type="bullet">
+/// <item><c>filter</c> — a surviving <see cref="EndFilter"/>: an exception filter
+///   the structurer left flat. Highest EH-legality risk (slice 7).</item>
+/// <item><c>leave-retry-loop</c> — a surviving <see cref="Leave"/> whose target is
+///   at or before its own block: a backward leave (a retry loop around the
+///   region, e.g. <c>Interop.Sys::GetCwd</c>). Overlaps loop-residue (slice 6).</item>
+/// <item><c>handler-internal</c> — a residual <see cref="ConditionalBranch"/> inside
+///   a <see cref="CatchClause"/> body (handler-scope risk, slice 7).</item>
+/// <item><c>region-internal</c> — a residual branch inside a try/finally body but
+///   not crossing out: the safest reduction (slice 3).</item>
+/// <item><c>prologue-epilogue-guard</c> — every residual branch lies outside every
+///   recovered region (prologue/epilogue of an EH-bearing method, slice 4).</item>
+/// <item><c>leave-exit-merge</c> — the remainder: forward leaves to a common
+///   post-region merge (slice 5).</item>
+/// </list>
+/// </summary>
+static class EhShapeClassifier
+{
+    public static string Classify(IrFunction function)
+    {
+        if (function.Descendants.OfType<EndFilter>().Any())
+            return "filter";
+
+        foreach (var leave in function.Descendants.OfType<Leave>())
+            if (EnclosingBlockOffset(leave) is { } from && leave.TargetOffset <= from)
+                return "leave-retry-loop";
+
+        var residualBranches = function.Descendants.OfType<ConditionalBranch>().ToList();
+        if (residualBranches.Any(branch => HasAncestor<CatchClause>(branch)))
+            return "handler-internal";
+        if (residualBranches.Any(branch => HasAncestor<TryFinally>(branch) || HasAncestor<TryCatch>(branch)))
+            return "region-internal";
+        if (residualBranches.Count > 0)
+            return "prologue-epilogue-guard";
+
+        return "leave-exit-merge";
+    }
+
+    static int? EnclosingBlockOffset(IrNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is Block block)
+                return block.StartOffset;
+        return null;
+    }
+
+    static bool HasAncestor<T>(IrNode node) where T : IrNode
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is T)
+                return true;
+        return false;
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -189,6 +189,7 @@ static class Program
         // conditional-branch bucket by the shape around its residual guard (#921).
         var switchShapes = new Dictionary<string, (long Count, List<string> Examples)>();
         var conditionalShapes = new Dictionary<string, (long Count, List<string> Examples)>();
+        var ehShapes = new Dictionary<string, (long Count, List<string> Examples)>();
 
         void Record(string bucket, string method)
         {
@@ -245,7 +246,15 @@ static class Program
                     // The residual conditional survives in the finished tree, so
                     // classify the post-pass function rather than the pre-pass clone.
                     if (byShape && bucket == "structuring: conditional-branch")
-                        RecordShape(conditionalShapes, ConditionalBranchShapeClassifier.Classify(function), id);
+                    {
+                        string shape = ConditionalBranchShapeClassifier.Classify(function);
+                        RecordShape(conditionalShapes, shape, id);
+                        // The eh-entangled bucket is itself a product of branch
+                        // position x EH construct; sub-split it for the EH-aware
+                        // structuring burndown (#1089).
+                        if (shape == "eh-entangled")
+                            RecordShape(ehShapes, EhShapeClassifier.Classify(function), id);
+                    }
                 }
             }
         }
@@ -270,6 +279,13 @@ static class Program
             Console.WriteLine();
             Console.WriteLine("conditional-branch bucket by structural shape (--by-shape):");
             foreach (var s in conditionalShapes.OrderByDescending(s => s.Value.Count))
+                Console.WriteLine($"  {s.Value.Count,8}  {s.Key,-38}  e.g. {string.Join(" | ", s.Value.Examples.Take(3))}");
+        }
+        if (byShape && ehShapes.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("eh-entangled bucket by EH subshape (--by-shape, hardest blocker per method):");
+            foreach (var s in ehShapes.OrderByDescending(s => s.Value.Count))
                 Console.WriteLine($"  {s.Value.Count,8}  {s.Key,-38}  e.g. {string.Join(" | ", s.Value.Examples.Take(3))}");
         }
         return crashes > 0 ? 1 : 0;
@@ -1034,7 +1050,9 @@ static class Program
           --by-shape            with --gaps: sub-classify the switch-branch and
                                 conditional-branch buckets by the structural shape
                                 of their residual control flow, so a bucket count
-                                becomes a per-shape slice docket.
+                                becomes a per-shape slice docket. The eh-entangled
+                                conditional shape is sub-split further by EH subshape
+                                (the #1089 burndown slices).
           --annotation-check      hidden-fact annotation check — the analyzer analog
                                 of --fidelity-check. Cross-checks each allocation/
                                 unsafety/lifetime annotation against the raw IL


### PR DESCRIPTION
## Summary
Slice 1 of the EH-aware conditional-branch structuring burndown (#1089): the measurement that gives the remaining slices real signals.

`--gaps --by-shape` split the conditional-branch bucket into loop-residue / shared-forward-merge / eh-entangled / comparison-tree / nonnested-forward-guards. The `eh-entangled` bucket is itself a product of **branch-position × EH-construct**, so `EhShapeClassifier` sub-splits it into the single hardest blocker per method:

- `filter` — a surviving `EndFilter` (exception filter left flat); highest risk.
- `leave-retry-loop` — a backward `Leave` (a retry loop around the region, e.g. `Interop.Sys::GetCwd`).
- `handler-internal` — a branch inside a `catch` body.
- `region-internal` — a branch inside a try/finally body (safest reduction).
- `prologue-epilogue-guard` — every branch outside any recovered region.
- `leave-exit-merge` — forward leaves to a common post-region merge.

## Result (.NET 11 CoreLib, sums to the 50 eh-entangled total)
```
eh-entangled bucket by EH subshape (--by-shape, hardest blocker per method):
   19  prologue-epilogue-guard   e.g. System.Gen2GcCallback::Finalize | System.TimeZoneInfo::GetSystemTimeZones
   18  filter                    e.g. System.Enum::TryParseRareTypeByValueOrName | System.Environment::CallEntryPoint
   12  leave-retry-loop          e.g. Interop.Sys::GetCwd | System.Threading.ThreadPoolWorkQueue::TransferAllLocalWorkItemsToHighPriorityGlobalQueue
    1  region-internal           e.g. ...EventSourceHelpers::CreateManifestAndDescriptors
```

## Scope
Tooling only — no structuring change, no product-path change. The EH regions are already recovered as `TryFinally`/`TryCatch` nodes; this classifies the branch/leave's relationship to them. Consistent with the existing `ConditionalBranchShapeClassifier`/`SwitchShapeClassifier` (internal, verified by the corpus `--gaps --by-shape` run rather than unit tests). #1089's slice table is updated with these signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)