### PR TITLE
Distinguish region-internal-shared-merge from EH-safe region-internal (#1096)

### DIFF
--- a/tools/DecompilerHarness/EhShapeClassifier.cs
+++ b/tools/DecompilerHarness/EhShapeClassifier.cs
@@ -26,8 +26,11 @@ using ILInspector.Decompiler.Pipeline;
 ///   around the region, e.g. <c>Interop.Sys::GetCwd</c>). Overlaps loop-residue (slice 6).</item>
 /// <item><c>handler-internal</c> — a residual branch inside a <see cref="CatchClause"/>
 ///   body (handler-scope risk, slice 7).</item>
-/// <item><c>region-internal</c> — a residual branch inside a try/finally body, not
-///   crossing out: the safest reduction (slice 3).</item>
+/// <item><c>region-internal</c> — a residual branch inside a try/finally body whose
+///   region body is otherwise consumable: the genuine EH-safe reduction (slice 3).</item>
+/// <item><c>region-internal-shared-merge</c> — inside a region body too, but blocked
+///   by a non-EH shape (shared forward merge / cond-target-past-region), so it
+///   belongs with the shared-merge work (#1081), not an EH-safe reduction (#1096).</item>
 /// <item><c>prologue-epilogue-guard</c> — every residual branch lies outside every
 ///   recovered region (prologue/epilogue of an EH-bearing method, slice 4).</item>
 /// <item><c>leave-exit-merge</c> — the remainder: forward leaves to a common
@@ -53,12 +56,73 @@ static class EhShapeClassifier
         var residualBranches = function.Descendants.OfType<ConditionalBranch>().ToList();
         if (residualBranches.Any(branch => HasAncestor<CatchClause>(branch)))
             return "handler-internal";
-        if (residualBranches.Any(branch => HasAncestor<TryFinally>(branch) || HasAncestor<TryCatch>(branch)))
-            return "region-internal";
+        var regionBranches = residualBranches
+            .Where(branch => HasAncestor<TryFinally>(branch) || HasAncestor<TryCatch>(branch))
+            .ToList();
+        if (regionBranches.Count > 0)
+        {
+            // A branch inside a recovered region body is a pure EH-safe reduction
+            // (slice 3) only if the body is otherwise consumable. If its enclosing
+            // container carries a shared forward merge (>=2 branches to one forward
+            // target) or a branch targeting past the region, the real blocker is
+            // that non-EH shape — the same shared-forward-merge / cond-target-past-
+            // region work as #1081, not an EH boundary. Route it there instead of
+            // advertising a false EH-safe count (#1096).
+            bool nonEhBlocker = regionBranches.Any(branch =>
+                EnclosingContainer(branch) is { } container
+                && (HasSharedForwardMerge(container) || HasConditionalTargetPastContainer(container)));
+            return nonEhBlocker ? "region-internal-shared-merge" : "region-internal";
+        }
         if (residualBranches.Count > 0)
             return "prologue-epilogue-guard";
 
         return "leave-exit-merge";
+    }
+
+    /// <summary>The nearest <see cref="BlockContainer"/> ancestor — the region body the branch sits in.</summary>
+    static BlockContainer? EnclosingContainer(IrNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is BlockContainer container)
+                return container;
+        return null;
+    }
+
+    /// <summary>A forward target reached by two or more branches (the shared-merge signature, mirroring <see cref="ConditionalBranchShapeClassifier"/>).</summary>
+    static bool HasSharedForwardMerge(BlockContainer container)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+        var forwardPredecessors = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            foreach (int target in BranchTargets(blocks[i]))
+                if (offsetToIndex.TryGetValue(target, out int ti) && ti > i)
+                    forwardPredecessors[ti] = forwardPredecessors.GetValueOrDefault(ti) + 1;
+        return forwardPredecessors.Values.Any(count => count >= 2);
+    }
+
+    /// <summary>A conditional branch whose target is no block in this container — the cond-target-past-region shape.</summary>
+    static bool HasConditionalTargetPastContainer(BlockContainer container)
+    {
+        var offsets = container.Blocks.Select(block => block.StartOffset).ToHashSet();
+        return container.Blocks
+            .SelectMany(block => block.Children)
+            .OfType<ConditionalBranch>()
+            .Any(branch => !offsets.Contains(branch.TargetOffset));
+    }
+
+    static IEnumerable<int> BranchTargets(Block block)
+    {
+        foreach (var node in block.Children)
+            switch (node)
+            {
+                case Branch b: yield return b.TargetOffset; break;
+                case ConditionalBranch c: yield return c.TargetOffset; break;
+                case SwitchBranch sw: foreach (int t in sw.TargetOffsets) yield return t; break;
+                case Leave lv: yield return lv.TargetOffset; break;
+            }
     }
 
     static int? EnclosingBlockOffset(IrNode node)


### PR DESCRIPTION
## Summary
Follow-up to #1096 (audit of #1089 row 3). The sole CoreLib `region-internal` specimen — `EventSource.EventSourceHelpers::CreateManifestAndDescriptors` — is **not** blocked by an EH boundary: its conditional branches sit inside the recovered `TryCatch` body but are held by an ordinary shared-forward-merge / `cond-target-past-region` shape (the #1081 work). Counting it as a pure EH-safe reduction overstated slice 3.

A region-internal branch now stays `region-internal` only when its enclosing region body is otherwise consumable; if the body carries a shared forward merge (≥2 branches to one forward target) or a conditional branch targeting past the region, it's classified `region-internal-shared-merge` and routed to the shared-merge burndown (#1081).

## Result (.NET 11 CoreLib, eh-entangled still sums to 50)
`region-internal` 1 → **0**, new `region-internal-shared-merge` **1**. So #1089 slice 3 no longer advertises a false EH-safe count — the issue's done signal.

Tooling only; verified by the `--gaps --by-shape` corpus run. Closes #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)