### PR TITLE
Pin filter-entangled EH branch decline

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -46,6 +46,23 @@ public class CompletenessTests
     }
 
     [Fact]
+    public void ExceptionFilter_RemainsFilterEhEntangledResidual()
+    {
+        // #1089 row 7: catch/filter-entangled branches are the highest-risk EH
+        // slice. Until filter structuring lands, the filter's endfilter/leaves
+        // must stay as honest Partial residuals, classified as the `filter`
+        // subshape rather than consumed by a branch rewrite that crosses handler
+        // boundaries.
+        var function = Raised(nameof(CfgSampleClass.FilteredLength));
+
+        Assert.Equal("structuring: conditional-branch", Completeness.Residual(function));
+        Assert.Equal("eh-entangled", ConditionalBranchShapeClassifier.Classify(function));
+        Assert.Equal("filter", EhShapeClassifier.Classify(function));
+        Assert.NotEmpty(function.Descendants.OfType<EndFilter>());
+        Assert.NotEmpty(function.Descendants.OfType<Leave>());
+    }
+
+    [Fact]
     public void CommonExitGotos_RecoveredByRegionExitDiamond()
     {
         // GotoCommonExitGuardedMerge's inner arms both branch to the enclosing

--- a/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExceptionFilterFidelityTests.cs
@@ -33,13 +33,13 @@ public class ExceptionFilterFidelityTests
     [Fact]
     public void FilterMethod_PreservesEhTerminatorsThroughPipeline()
     {
-        // #1081 eh-entangled conditional-branch audit. A try/catch-when filter
+        // #1089 row 7 catch/filter-entangled audit. A try/catch-when filter
         // (FilteredLength) stays honestly Partial because the filter region is not
         // structured, so the surrounding conditional branches stay flat too. The
-        // audit invariant: no pass illegally consumes or reorders the EH terminators
-        // — dropping the endfilter or a leave across the protected region would
-        // change which handler runs. The endfilter and the leaves survive the full
-        // pipeline unchanged (no illegal EH transform).
+        // audit invariant: no pass illegally consumes or reorders the EH
+        // terminators — dropping the endfilter or a leave across the protected
+        // region would change which handler runs. The endfilter and the leaves
+        // survive the full pipeline unchanged (no illegal EH transform).
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.FilteredLength));
         Assert.NotNull(function);

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -50,6 +50,8 @@
              Link="Completeness.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ConditionalBranchShapeClassifier.cs"
              Link="ConditionalBranchShapeClassifier.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\EhShapeClassifier.cs"
+             Link="EhShapeClassifier.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ShellNoise.cs"
              Link="ShellNoise.cs" />
   </ItemGroup>


### PR DESCRIPTION
Addresses #1089 row 7.

## Summary
- Link `EhShapeClassifier` into the decompiler test project.
- Pin `FilteredLength` as `structuring: conditional-branch` -> `eh-entangled` -> `filter`.
- Strengthen the filter fidelity guardrail comment to row 7: `endfilter` and `leave` terminators must survive until filter-aware structuring lands.

This is a documented-decline/guardrail slice, not a structuring change. Row 7 is the highest EH-legality-risk bucket; the safe outcome for now is to keep filter-entangled branches honest and Partial rather than accidentally consuming filter boundaries.

## Measurement
Current CoreLib `--gaps --by-shape`:

```text
eh-entangled bucket by EH subshape:
  18 filter
  17 prologue-epilogue-guard
  12 leave-retry-loop
   2 region-internal
   2 eh-unstructured
```

Pass bugs: 0.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 20`
