### PR TITLE
Decline invalid unmanaged method addresses

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -705,8 +705,6 @@ public class CfgSampleClass
 
     public static void Overloaded(double x) { _ = x; }
 
-    public static void CallsPInvokeOverloaded() => Overloaded(1);
-
     public static int Add(int a, int b) => a + b;
 
     public static bool IsPositive(int x) => x > 0;

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -705,6 +705,8 @@ public class CfgSampleClass
 
     public static void Overloaded(double x) { _ = x; }
 
+    public static void CallsPInvokeOverloaded() => Overloaded(1);
+
     public static int Add(int a, int b) => a + b;
 
     public static bool IsPositive(int x) => x > 0;

--- a/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
@@ -41,6 +41,48 @@ public class FunctionPointerDiagnosticsPassTests
         Assert.DoesNotContain("ldvirtftn", diagnostic.Message);
     }
 
+    [Fact]
+    public void MethodAddress_PInvokeTarget_StaysDiagnosticResidual()
+    {
+        var method = new MethodRef(Owner, "NativeTarget", Void, [], HasThis: false)
+        {
+            IsPInvoke = MetadataFactState.Yes
+        };
+        var function = FunctionWith(new LoadFunctionPointer(method, isVirtual: false, instance: null));
+
+        new MethodAddressPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<LoadFunctionPointer>());
+        Assert.Empty(function.Descendants.OfType<AddressOfMethod>());
+
+        new FunctionPointerDiagnosticsPass().Run(function, PassContext.None);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedFunctionPointer, diagnostic.Id);
+        Assert.Contains("P/Invoke target", diagnostic.Message);
+        Assert.Contains("NativeTarget", diagnostic.Message);
+    }
+
+    [Fact]
+    public void MethodAddress_RuntimeAsyncTarget_StaysDiagnosticResidual()
+    {
+        var method = new MethodRef(Owner, "RuntimeAsyncTarget", Void, [], HasThis: false)
+        {
+            IsRuntimeAsync = MetadataFactState.Yes
+        };
+        var function = FunctionWith(new LoadFunctionPointer(method, isVirtual: false, instance: null));
+
+        new MethodAddressPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<LoadFunctionPointer>());
+        Assert.Empty(function.Descendants.OfType<AddressOfMethod>());
+
+        new FunctionPointerDiagnosticsPass().Run(function, PassContext.None);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedFunctionPointer, diagnostic.Id);
+        Assert.Contains("runtime-async", diagnostic.Message);
+        Assert.Contains("RuntimeAsyncTarget", diagnostic.Message);
+    }
+
     private static IrFunction FunctionWith(IrExpression expression)
     {
         var body = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -327,6 +327,17 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void PInvokeCall_ImportsTargetFact()
+    {
+        var function = ImportFixture(nameof(CfgSampleClass.CallsPInvokeOverloaded));
+
+        var call = Assert.Single(function.Descendants.OfType<Call>());
+        Assert.Equal("Overloaded", call.Callee.Name);
+        Assert.Equal(MetadataFactState.Yes, call.Callee.IsPInvoke);
+        Assert.Equal(MetadataFactState.No, call.Callee.IsRuntimeAsync);
+    }
+
+    [Fact]
     public void Shift_DropsRedundantWidthMask()
     {
         // C# masks a shift count by the operand width (int -> & 31, long -> & 63)

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -327,14 +328,25 @@ public class IrImporterTests
     }
 
     [Fact]
-    public void PInvokeCall_ImportsTargetFact()
+    public void PInvokeMethodDef_ImportsTargetFact()
     {
-        var function = ImportFixture(nameof(CfgSampleClass.CallsPInvokeOverloaded));
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var reader = source.Reader;
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetFullTypeName(reader.GetTypeDefinition(handle)) == typeof(CfgSampleClass).FullName);
+        var type = reader.GetTypeDefinition(typeHandle);
+        var methodHandle = type.GetMethods().Single(handle =>
+        {
+            var method = reader.GetMethodDefinition(handle);
+            return reader.GetString(method.Name) == "Overloaded"
+                && method.RelativeVirtualAddress == 0;
+        });
 
-        var call = Assert.Single(function.Descendants.OfType<Call>());
-        Assert.Equal("Overloaded", call.Callee.Name);
-        Assert.Equal(MetadataFactState.Yes, call.Callee.IsPInvoke);
-        Assert.Equal(MetadataFactState.No, call.Callee.IsRuntimeAsync);
+        var methodRef = IrImporter.ResolveMethod(reader, methodHandle, GenericScope.Empty);
+
+        Assert.Equal("Overloaded", methodRef.Name);
+        Assert.Equal(MetadataFactState.Yes, methodRef.IsPInvoke);
+        Assert.Equal(MetadataFactState.No, methodRef.IsRuntimeAsync);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1612,6 +1612,8 @@ public static class IrImporter
                     CompilerGenerated = FactState(methodCompilerGenerated),
                     DeclaringTypeCompilerGenerated = FactState(typeCompilerGenerated),
                     IsExtension = FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)),
+                    IsPInvoke = FactState(MethodDefinitionFacts.IsPInvoke(method)),
+                    IsRuntimeAsync = FactState(MethodDefinitionFacts.IsRuntimeAsync(method)),
                 };
             }
             case HandleKind.MemberReference:

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -83,6 +83,22 @@ public sealed record MethodRef(
     public MetadataFactState IsExtension { get; init; } = MetadataFactState.Unknown;
 
     /// <summary>
+    /// Metadata PInvokeImpl / <c>[DllImport]</c> evidence on this method. Taking
+    /// such a target as <c>&amp;Method</c> is not a source-equivalent
+    /// UnmanagedCallersOnly callback address, so method-address raising declines
+    /// it when this fact is positively known.
+    /// </summary>
+    public MetadataFactState IsPInvoke { get; init; } = MetadataFactState.Unknown;
+
+    /// <summary>
+    /// Metadata runtime-async evidence (<c>MethodImplAttributes.Async</c>, flag
+    /// <c>0x2000</c>) on this method. Runtime-async methods are not valid native
+    /// callback targets; method-address raising declines them when this fact is
+    /// positively known.
+    /// </summary>
+    public MetadataFactState IsRuntimeAsync { get; init; } = MetadataFactState.Unknown;
+
+    /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
     /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
     /// resolved as a MemberReference (cross-assembly, or a same-assembly call on

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -48,6 +48,15 @@ internal static class MethodDefinitionFacts
     internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)
         => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices", "ExtensionAttribute");
 
+    internal static bool IsPInvoke(MethodDefinition method)
+        => (method.Attributes & System.Reflection.MethodAttributes.PinvokeImpl) != 0;
+
+    internal static bool IsRuntimeAsync(MethodDefinition method)
+    {
+        const System.Reflection.MethodImplAttributes AsyncImplFlag = (System.Reflection.MethodImplAttributes)0x2000;
+        return (method.ImplAttributes & AsyncImplFlag) != 0;
+    }
+
     internal static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
     {
         if (handles.Count == 0)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
@@ -24,6 +24,10 @@ public sealed class FunctionPointerDiagnosticsPass : IIrPass
                 DiagnosticIds.UnsupportedFunctionPointer,
                 pointer.IsVirtual
                     ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} requires a receiver; C# cannot spell a virtual method address as a delegate* target"
+                    : pointer.Method.IsPInvoke == MetadataFactState.Yes
+                        ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is a P/Invoke target; C# &Method would claim an unsupported native callback target is faithful"
+                    : pointer.Method.IsRuntimeAsync == MetadataFactState.Yes
+                        ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is runtime-async; C# &Method would claim an unsupported native callback target is faithful"
                     : $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is not a delegate construction and was not raised to &Method"));
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
@@ -20,10 +20,16 @@ public sealed class MethodAddressPass : IIrPass
         {
             if (pointer.Parent is null || pointer.IsVirtual)
                 continue;
+            if (IsInvalidNativeCallbackTarget(pointer.Method))
+                continue;
             context.Stepper.StepOver($"raise ldftn to &{pointer.Method.Name}", pointer);
             pointer.ReplaceWith(new AddressOfMethod(pointer.Method, ContextualFunctionPointerType(function, pointer)));
         }
     }
+
+    static bool IsInvalidNativeCallbackTarget(MethodRef method)
+        => method.IsPInvoke == MetadataFactState.Yes
+            || method.IsRuntimeAsync == MetadataFactState.Yes;
 
     static TypeRef? ContextualFunctionPointerType(IrFunction function, LoadFunctionPointer pointer)
     {


### PR DESCRIPTION
## Summary

- add SRM-backed method facts for P/Invoke and runtime-async MethodDefs
- keep invalid native callback targets as residual `LoadFunctionPointer` nodes instead of raising them to `&Method`
- make the DEC0006 function-pointer diagnostic name P/Invoke/runtime-async targets explicitly
- add tests for P/Invoke fact import and pass-level P/Invoke/runtime-async method-address declines

Addresses the invalid-target audit path from #1064. The valid Stdcall path remains covered by #1071.

## Verification

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method ILInspector.Decompiler.Tests.FunctionPointerDiagnosticsPassTests.MethodAddress_PInvokeTarget_StaysDiagnosticResidual -method ILInspector.Decompiler.Tests.FunctionPointerDiagnosticsPassTests.MethodAddress_RuntimeAsyncTarget_StaysDiagnosticResidual -method ILInspector.Decompiler.Tests.IrImporterTests.PInvokeCall_ImportsTargetFact -method ILInspector.Decompiler.Tests.IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` reported `Total: 958, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`; note the process was interrupted as it finished and returned cancellation exit code 58 despite the no-failure summary.
