### PR TITLE
Structure finally leave common exits

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -4,6 +4,11 @@ namespace ILInspector.Decompiler.Tests;
 
 public class StructuringDiagnosticsTests
 {
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+
     static StructuringDiagnostics RunWithDiagnostics(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -11,6 +16,13 @@ public class StructuringDiagnosticsTests
         Assert.NotNull(function);
         var diagnostics = new StructuringDiagnostics();
         IrPasses.Run(function, IrPasses.Default, new PassContext(new Stepper(enabled: false), diagnostics));
+        return diagnostics;
+    }
+
+    static StructuringDiagnostics RunStructuringOnly(IrFunction function)
+    {
+        var diagnostics = new StructuringDiagnostics();
+        new StructuringPass().Run(function, new PassContext(new Stepper(enabled: false), diagnostics));
         return diagnostics;
     }
 
@@ -165,30 +177,28 @@ public class StructuringDiagnosticsTests
     }
 
     [Fact]
-    public void EarlyBreakFromInnerTry_StructuresTryBody_NoTerminatorSurvivorStop()
+    public void EarlyBreakFromInnerTry_StructuresThroughCommonExit_NoLeaveTargetStop()
     {
         // A nested foreach whose inner loop early-`break`s lowers to a non-tail
         // `leave` that exits the inner try (the enumerator-dispose finally) to the
         // `if (!matched)` continuation — the surviving-leave shape of
-        // HashSetEqualityComparer::Equals. The structuring pass treats a leave
-        // that exits its container as a clean path terminator, so the inner try
-        // body raises into `while (...) { if (...) { ...; goto ...; } }` instead
-        // of bailing flat with `eh-terminator-survivor`. The outer body keeps the
-        // leave's target label, so it stays flat (leave-target-in-container) — the
-        // remaining, deliberately conservative, stop.
+        // HashSetEqualityComparer::Equals. The row-5 slice consumes the leave when
+        // it targets the recovered finally's normal continuation, so both the
+        // inner body and the post-try continuation can structure without keeping a
+        // label alive.
         var diag = RunWithDiagnostics(nameof(CfgSampleClass.AllOuterMatchInner));
 
         Assert.DoesNotContain("eh-terminator-survivor", diag.Stops);
         Assert.True(diag.Structured > 0);
-        Assert.Equal("leave-target-in-container", Assert.Single(diag.Stops));
+        Assert.Empty(diag.Stops);
     }
 
     [Fact]
-    public void EarlyBreakFromInnerTry_RaisesWhileLoopOverFlatGotoSoup()
+    public void EarlyBreakFromInnerTry_RaisesWithoutLeaveGoto()
     {
-        // The readability win: the inner try body is a structured `while` whose
-        // early exit is the surviving `goto ...; // leave`, not a flat chain of
-        // gotos. Fidelity stays Full (the leave still renders the same goto).
+        // The readability win: the inner try body and its post-finally
+        // continuation structure without either flat goto soup or a surviving
+        // `goto ...; // leave`.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.AllOuterMatchInner));
         Assert.NotNull(function);
@@ -199,6 +209,101 @@ public class StructuringDiagnosticsTests
 
         var output = result.Output!.ReplaceLineEndings("\n");
         Assert.Contains("while (", output);
-        Assert.Contains("// leave", output);
+        Assert.DoesNotContain("// leave", output);
+    }
+
+    [Fact]
+    public void LeaveToCommonExit_StructuresAfterRecoveredTryFinally()
+    {
+        var function = BuildTryFinallyWithLeaveToCommonExit();
+
+        var diag = RunStructuringOnly(function);
+        function.CheckInvariant();
+
+        Assert.True(diag.Structured >= 2);
+        Assert.Empty(diag.Stops);
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+
+        var output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+        Assert.Contains("try", output);
+        Assert.Contains("finally", output);
+        Assert.DoesNotContain("// leave", output);
+    }
+
+    [Fact]
+    public void LeaveRetryLoop_KeepsOuterContinuationLabel()
+    {
+        var function = BuildTryFinallyWithLeaveRetryLoop();
+
+        var diag = RunStructuringOnly(function);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants, node => node is Leave { TargetOffset: 0x0000 });
+        Assert.Equal("leave-target-in-container", Assert.Single(diag.Stops));
+    }
+
+    static IrFunction BuildTryFinallyWithLeaveToCommonExit()
+    {
+        var tryBody = new BlockContainer();
+        var guard = new Block(0x0010);
+        guard.Add(new ConditionalBranch(new LoadArgument(0, "flag", Boolean), 0x0018));
+        var exit = new Block(0x0014);
+        exit.Add(new Leave(0x0030));
+        var body = new Block(0x0018);
+        body.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        body.Add(new Leave(0x0030));
+        foreach (var block in (Block[])[guard, exit, body])
+            tryBody.Add(block);
+
+        var finallyBody = new BlockContainer();
+        var finallyBlock = new Block(0x0020);
+        finallyBlock.Add(new StoreLocal(1, Int32, new Constant(2, Int32)));
+        finallyBody.Add(finallyBlock);
+
+        var root = new BlockContainer();
+        var holder = new Block(0x0010);
+        holder.Add(new TryFinally(tryBody, finallyBody));
+        var tail = new Block(0x0030);
+        tail.Add(new Return(new LoadLocal(0, Int32)));
+        root.Add(holder);
+        root.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("flag", Boolean)], HasThis: false, GenericParameterCount: 0),
+            [Int32, Int32],
+            root);
+    }
+
+    static IrFunction BuildTryFinallyWithLeaveRetryLoop()
+    {
+        var tryBody = new BlockContainer();
+        var body = new Block(0x0010);
+        body.Add(new Leave(0x0000));
+        tryBody.Add(body);
+
+        var finallyBody = new BlockContainer();
+        var finallyBlock = new Block(0x0020);
+        finallyBlock.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        finallyBody.Add(finallyBlock);
+
+        var root = new BlockContainer();
+        var retry = new Block(0x0000);
+        retry.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        var holder = new Block(0x0010);
+        holder.Add(new TryFinally(tryBody, finallyBody));
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        foreach (var block in (Block[])[retry, holder, tail])
+            root.Add(block);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            root);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -41,6 +41,7 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
         public required bool IsComparisonTree { get; init; }
+        public int? RegionExitLeaveTarget { get; init; }
 
         /// <summary>
         /// First-wins recorder for the deepest direct stop reason, populated only
@@ -67,18 +68,18 @@ public sealed class StructuringPass : IIrPass
             context.StructuringDiagnostics?.RecordStop("unconsumed-regions");
             return;  // unconsumed regions: the flat form is still the truth
         }
-        // Surviving leaves are the one cross-container goto (an early exit
-        // through outer constructs); their target blocks must keep printing
-        // a label, so their containers stay flat.
-        var leaveTargets = function.Descendants.OfType<Leave>()
-            .Select(leave => leave.TargetOffset)
-            .ToHashSet();
         // Containers are independent regions: the function body plus every
         // try/catch/finally body the EH pass nested. Each structures (or
-        // stays flat) on its own — a goto-heavy handler does not flatten
-        // the rest of the method.
-        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        // stays flat) on its own. Walk inner containers first so a consumed
+        // leave-to-finally-continuation can disappear before the outer container
+        // decides whether that target block still needs a printable label.
+        foreach (var container in function.Descendants.OfType<BlockContainer>().OrderByDescending(Depth).ToList())
+        {
+            var leaveTargets = function.Descendants.OfType<Leave>()
+                .Select(leave => leave.TargetOffset)
+                .ToHashSet();
             Structure(container, leaveTargets, context);
+        }
     }
 
     static void Structure(BlockContainer container, HashSet<int> leaveTargets, PassContext context)
@@ -171,6 +172,7 @@ public sealed class StructuringPass : IIrPass
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
             IsComparisonTree = isComparisonTree,
+            RegionExitLeaveTarget = NormalEhContinuationTarget(container),
             Recorder = recorder,
         };
 
@@ -249,6 +251,16 @@ public sealed class StructuringPass : IIrPass
                     i++;
                     break;
                 case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
+                    if (IsRegionExitLeave(ctx, leave))
+                    {
+                        if (i + 1 != stop)
+                        {
+                            ctx.Recorder?.Record("leave-region-exit-not-region-end");
+                            return false;
+                        }
+                        i = stop;
+                        break;
+                    }
                     // A leave that exits this container (its target is an
                     // enclosing construct's continuation, not a block here) ends
                     // its path like a return/break: control leaves the region and
@@ -331,6 +343,14 @@ public sealed class StructuringPass : IIrPass
                         ctx.Recorder?.Record("cond-backward-branch");
                         return false;  // backward = loop (later slice)
                     }
+                    int falseStart = i + 1;
+                    if (falseStart + 1 == target
+                        && IsRegionExitTerminator(ctx, falseStart)
+                        && Validate(ctx, target, stop, joinIndex, breakTarget, continueTarget))
+                    {
+                        i = stop;
+                        break;
+                    }
                     // A conditional that jumps to this region's own merge — its
                     // post-dominator, tracked as joinIndex — is an early exit to
                     // the join: `if (c) goto JOIN` selects the merge, the
@@ -359,7 +379,6 @@ public sealed class StructuringPass : IIrPass
                     // Guard: if (c) goto M with M ending this region's view.
                     // Diamond: the fallthrough arm ends with goto M past the
                     // true arm.
-                    int falseStart = i + 1;
                     if (FindRegionExitDiamond(ctx, falseStart, target, stop, joinIndex) is { } exitDiamond)
                     {
                         if (!Validate(ctx, falseStart, target, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget)
@@ -532,9 +551,9 @@ public sealed class StructuringPass : IIrPass
             return null;
         if (trueStart != falseStart + 1 || stop != trueStart + 1)
             return null;
-        if (!EndsWithBranchTo(ctx, trueStart - 1, joinIndex))
+        if (!EndsWithRegionExit(ctx, trueStart - 1, joinIndex))
             return null;
-        if (!EndsWithBranchTo(ctx, stop - 1, joinIndex))
+        if (!EndsWithRegionExit(ctx, stop - 1, joinIndex))
             return null;
         if (!IsStraightLineUntilFinalBranch(ctx.Blocks[trueStart - 1])
             || !IsStraightLineUntilFinalBranch(ctx.Blocks[stop - 1]))
@@ -649,9 +668,27 @@ public sealed class StructuringPass : IIrPass
             TerminatorSnapshots = new Dictionary<int, IReadOnlyList<IrNode>>(),
             FallenInto = fallenInto,
             IsComparisonTree = false,
+            RegionExitLeaveTarget = null,
             Recorder = null,
         };
     }
+
+    static bool EndsWithRegionExit(Ctx ctx, int blockIndex, int targetIndex)
+        => EndsWithBranchTo(ctx, blockIndex, targetIndex)
+            || IsRegionExitTerminator(ctx, blockIndex);
+
+    static bool IsRegionExitTerminator(Ctx ctx, int blockIndex)
+    {
+        if (blockIndex < 0 || blockIndex >= ctx.Blocks.Count)
+            return false;
+        var children = ctx.Blocks[blockIndex].Children;
+        return children.Count > 0
+            && children[^1] is Leave leave
+            && IsRegionExitLeave(ctx, leave);
+    }
+
+    static bool IsRegionExitLeave(Ctx ctx, Leave leave)
+        => ctx.RegionExitLeaveTarget == leave.TargetOffset;
 
     static bool EndsWithBranchTo(Ctx ctx, int blockIndex, int targetIndex)
     {
@@ -834,6 +871,11 @@ public sealed class StructuringPass : IIrPass
                     i++;
                     break;
                 case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
+                    if (IsRegionExitLeave(ctx, leave))
+                    {
+                        i = stop;
+                        break;
+                    }
                     // A container-exiting leave (mirrors Validate): emit it as the
                     // path terminator; the printer renders the `goto IL_xxxx`.
                     result.Add(last);
@@ -892,6 +934,14 @@ public sealed class StructuringPass : IIrPass
                         i++;
                         break;
                     }
+                    int falseStart = i + 1;
+                    if (falseStart + 1 == target && IsRegionExitTerminator(ctx, falseStart))
+                    {
+                        var takenArm = BuildRegion(ctx, target, stop, joinIndex, breakTarget, continueTarget);
+                        result.Add(new IfStatement(condition, takenArm, null));
+                        i = stop;
+                        break;
+                    }
                     // A conditional jumping to this region's merge (joinIndex) is
                     // an early exit to the join: raise it as a guard over the rest
                     // of the region, the negated condition selecting the
@@ -911,7 +961,6 @@ public sealed class StructuringPass : IIrPass
                         i++;
                         break;
                     }
-                    int falseStart = i + 1;
                     if (FindRegionExitDiamond(ctx, falseStart, target, stop, joinIndex) is { } exitDiamond)
                     {
                         var thenArm = BuildRegion(ctx, falseStart, target, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget);
@@ -956,4 +1005,31 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>Negation delegates to the shared type-aware duals (see <see cref="Conditions"/>).</summary>
     static IrExpression Negate(IrExpression condition) => Conditions.Negate(condition);
+
+    static int Depth(IrNode node)
+    {
+        int depth = 0;
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            depth++;
+        return depth;
+    }
+
+    static int? NormalEhContinuationTarget(BlockContainer container)
+    {
+        // Row #1089/5's conservative first cut: only the try body of a recovered
+        // finally. Try/catch async-dispose scaffolds keep their flat evidence for
+        // UsingStatementPass and later EH-specific rows can widen this gate.
+        IrNode? construct = container.Parent switch
+        {
+            TryFinally tryFinally when ReferenceEquals(tryFinally.TryBody, container) => tryFinally,
+            _ => null,
+        };
+        if (construct?.Parent is not Block holder || holder.Parent is not BlockContainer outer)
+            return null;
+
+        var blocks = outer.Blocks;
+        return holder.ChildIndex + 1 < blocks.Count
+            ? blocks[holder.ChildIndex + 1].StartOffset
+            : null;
+    }
 }


### PR DESCRIPTION
## Summary

- consume `Leave` terminators that target the normal continuation of a recovered `TryFinally` try body
- structure nested containers before their outer body so consumed leaves no longer force a `leave-target-in-container` stop
- keep retry-loop leaves and runtime-async `TryCatch` await-using scaffolds outside this slice

Fixes row 5 of #1089.

## Verification

- `dotnet build src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method 'ILInspector.Decompiler.Tests.StructuringDiagnosticsTests.*' -method 'ILInspector.Decompiler.Tests.UsingStatementPassTests.NestedRuntimeAsyncAwaitUsing_*' -method 'ILInspector.Decompiler.Tests.IdiomShapeScorecardTests.FixtureIdioms_RecoverExpectedSyntaxShapes'`\n- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --dump 'ILInspector.Decompiler.Tests.CfgSampleClass::AllOuterMatchInner' --remarks`\n- `dotnet build src/dotnet-inspect -c Release`