### PR TITLE
Clarify annotated IL stack state

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
@@ -48,7 +48,7 @@ public class AnnotatedIlFactTests
         var output = Render(nameof(AllocSampleClass.BoxInt));
         var line = output.Split('\n').Single(l => l.Contains(": box"));
         int fact = line.IndexOf("alloc.box", StringComparison.Ordinal);
-        int stack = line.IndexOf("[object]", StringComparison.Ordinal);
+        int stack = line.IndexOf("stack: [object]", StringComparison.Ordinal);
         Assert.True(fact >= 0 && stack >= 0 && fact < stack);
     }
 

--- a/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IlProjectionTests.cs
@@ -41,8 +41,9 @@ public class IlProjectionTests
         // LengthOf is `s.Length`: ldarg.0 leaves [string], get_Length leaves [int].
         // The types come from the importer's stack simulation via the trace hook.
         var output = Project(nameof(CfgSampleClass.LengthOf), IlProjectionDepth.Typed);
-        Assert.Contains("// [string]", output);
-        Assert.Contains("// [int]", output);
+        Assert.Contains("// stack: [string]", output);
+        Assert.Contains("// stack: [int]", output);
+        Assert.Contains("// stack: []", output);
     }
 
     [Fact]
@@ -155,7 +156,21 @@ public class IlProjectionTests
         // ldarg.0 (string s) then call get_Length leaves [int] on the stack.
         // (The stack annotation follows any variable-name annotation on the line.)
         var output = Project(nameof(CfgSampleClass.LengthOf), IlProjectionDepth.Annotated);
-        Assert.Contains("[string]", output);
-        Assert.Contains("[int]", output);
+        Assert.Contains("stack: [string]", output);
+        Assert.Contains("stack: [int]", output);
+        Assert.Contains("stack: []", output);
+    }
+
+    [Fact]
+    public void Annotated_AlignsInstructionCommentsForOneMethod()
+    {
+        var output = Project(nameof(CfgSampleClass.LengthOf), IlProjectionDepth.Annotated);
+        var commentColumns = output.Split('\n')
+            .Where(line => line.Contains("IL_", StringComparison.Ordinal) && line.Contains("//", StringComparison.Ordinal))
+            .Select(line => line.IndexOf("//", StringComparison.Ordinal))
+            .Distinct()
+            .ToArray();
+
+        Assert.Single(commentColumns);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -47,6 +47,8 @@ public enum IlProjectionDepth
 /// </summary>
 public static class IlProjection
 {
+    const int MaxAnnotatedCommentColumn = 72;
+
     public static DecompilerResult Project(
         MetadataSource source, string typeFullName, string methodName,
         IlProjectionDepth depth, int overloadIndex = 0, bool publicOnly = false)
@@ -85,7 +87,7 @@ public static class IlProjection
         foreach (var i in instructions)
         {
             string types = typesByOffset.TryGetValue(i.Offset, out var stack)
-                ? $"  // [{string.Join(", ", stack.Select(t => t?.ToDisplayString() ?? "?"))}]"
+                ? $"  // {StackAnnotation(stack)}"
                 : "";
             sb.AppendLine(Format(i) + types);
         }
@@ -331,6 +333,8 @@ public static class IlProjection
         }
 
         BuildRegionMarkers(body.Handlers, out var regionStarts, out var regionEnds);
+        var annotatedLines = AnnotatedInstrLines(imported, instructions, factsByOffset, stackByOffset)
+            .ToDictionary(line => line.Offset);
 
         var sb = new StringBuilder();
         AnnotatedHeader(sb, imported);
@@ -362,7 +366,7 @@ public static class IlProjection
             }
 
             WriteIndent(sb, indent + 1);
-            sb.AppendLine(FormatAnnotatedInstr(imported, i, factsByOffset, stackByOffset));
+            sb.AppendLine(annotatedLines[i.Offset].Text);
         }
 
         while (indent > 1)
@@ -376,18 +380,18 @@ public static class IlProjection
 
     /// <summary>
     /// Formats one instruction as it appears in the annotated IL view:
-    /// <c>IL_xxxx: name operand  // facts; local; [stack types]</c>. Shared by the
-    /// flat annotated-IL view and the mixed source view, so an instruction reads
-    /// identically whether shown on its own or interleaved beneath C#.
+    /// <c>IL_xxxx: name operand  // facts; local; stack: [types]</c>. Shared by
+    /// the flat annotated-IL view and the mixed source view, so an instruction
+    /// reads identically whether shown on its own or interleaved beneath C#.
     /// </summary>
-    static string FormatAnnotatedInstr(ImportedMethod imported, Instr i,
+    static AnnotatedInstrPart FormatAnnotatedInstrPart(ImportedMethod imported, Instr i,
         Dictionary<int, List<Annotations.Annotation>> factsByOffset,
         Dictionary<int, ImmutableArray<TypeRef?>> stackByOffset)
     {
-        var sb = new StringBuilder();
-        sb.Append($"IL_{i.Offset:X4}: {i.Name,-12}");
+        var instruction = new StringBuilder();
+        instruction.Append($"IL_{i.Offset:X4}: {i.Name,-12}");
         if (i.Operand.Length > 0)
-            sb.Append(' ').Append(i.Operand);
+            instruction.Append(' ').Append(i.Operand);
 
         List<string> annotations = [];
         if (factsByOffset.TryGetValue(i.Offset, out var facts))
@@ -396,11 +400,44 @@ public static class IlProjection
         if (VariableAnnotation(imported, i) is { } variable)
             annotations.Add(variable);
         if (stackByOffset.TryGetValue(i.Offset, out var stack))
-            annotations.Add($"[{string.Join(", ", stack.Select(t => t?.ToDisplayString() ?? "?"))}]");
-        if (annotations.Count > 0)
-            sb.Append("  // ").Append(string.Join("; ", annotations));
-        return sb.ToString();
+            annotations.Add(StackAnnotation(stack));
+        return new AnnotatedInstrPart(i.Offset, instruction.ToString(), string.Join("; ", annotations));
     }
+
+    static IReadOnlyList<AnnotatedInstrLine> AnnotatedInstrLines(
+        ImportedMethod imported,
+        IReadOnlyList<Instr> instructions,
+        Dictionary<int, List<Annotations.Annotation>> factsByOffset,
+        Dictionary<int, ImmutableArray<TypeRef?>> stackByOffset)
+    {
+        var parts = instructions
+            .Select(i => FormatAnnotatedInstrPart(imported, i, factsByOffset, stackByOffset))
+            .ToList();
+        int commentColumn = CommentColumn(parts);
+        return [.. parts.Select(part => new AnnotatedInstrLine(part.Offset, FormatAnnotatedInstr(part, commentColumn)))];
+    }
+
+    static int CommentColumn(IReadOnlyList<AnnotatedInstrPart> parts)
+    {
+        var annotated = parts.Where(part => part.Annotation.Length > 0).ToList();
+        if (annotated.Count == 0)
+            return 0;
+        int naturalColumn = annotated.Max(part => part.Instruction.Length) + 2;
+        return Math.Min(naturalColumn, MaxAnnotatedCommentColumn);
+    }
+
+    static string FormatAnnotatedInstr(AnnotatedInstrPart part, int commentColumn)
+    {
+        if (part.Annotation.Length == 0)
+            return part.Instruction;
+        int padding = Math.Max(2, commentColumn - part.Instruction.Length);
+        return $"{part.Instruction}{new string(' ', padding)}// {part.Annotation}";
+    }
+
+    static string StackAnnotation(ImmutableArray<TypeRef?> stack)
+        => $"stack: [{string.Join(", ", stack.Select(t => t?.ToDisplayString() ?? "?"))}]";
+
+    readonly record struct AnnotatedInstrPart(int Offset, string Instruction, string Annotation);
 
     /// <summary>One instruction's IL offset and its annotated text, for the mixed view.</summary>
     internal readonly record struct AnnotatedInstrLine(int Offset, string Text);
@@ -436,8 +473,7 @@ public static class IlProjection
             list.Add(fact);
         }
 
-        return [.. instructions.Select(i =>
-            new AnnotatedInstrLine(i.Offset, FormatAnnotatedInstr(imported, i, factsByOffset, stackByOffset)))];
+        return AnnotatedInstrLines(imported, instructions, factsByOffset, stackByOffset);
     }
 
     static void AnnotatedHeader(StringBuilder sb, ImportedMethod imported)


### PR DESCRIPTION
## Summary
- render evaluation-stack state as `stack: [...]` so `stack: []` clearly means empty stack, not void
- align annotated IL comments per method with a bounded comment column, while letting long operands fall back to normal spacing
- share the formatted annotated instruction lines between the standalone annotated IL view and the mixed Annotated Source view

## Verification
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release
- spot-check: `LengthOf` typed IL now renders `ret  // stack: []`
