### PR TITLE
Relax OR-chain guard entry checks

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2853,6 +2853,101 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void OrChainGuard_AllowsSiblingArmBetweenOneBlockConsequenceAndJoin()
+    {
+        // A nested OR-chain guard inside a larger diamond: the one-block
+        // consequence branches to the join, while a sibling arm between that
+        // consequence and the join is reached from outside the chain.
+        //   V_0 = 0;
+        //   if (a == 0) goto IL_0010;  // sibling arm
+        //   if (b <= 0) goto IL_000C;  // → consequence
+        //   if (c > 0)  goto IL_0014;  // → join
+        //   IL_000C: V_0 = 1; goto IL_0014;
+        //   IL_0010: V_0 = 2; goto IL_0014;
+        //   IL_0014: return V_0;
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+        LoadArgument C() => new(2, "c", intType);
+        LoadLocal V0() => new(0, intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new StoreLocal(0, intType, new Constant(0, intType)));
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, A(), new Constant(0, intType)), 16));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThanOrEqual, false, B(), new Constant(0, intType)), 12));
+        var b2 = new Block(8);
+        b2.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, C(), new Constant(0, intType)), 20));
+        var consequence = new Block(12);
+        consequence.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        consequence.Add(new Branch(20));
+        var sibling = new Block(16);
+        sibling.Add(new StoreLocal(0, intType, new Constant(2, intType)));
+        sibling.Add(new Branch(20));
+        var join = new Block(20);
+        join.Add(new Return(V0()));
+        foreach (var block in (Block[])[b0, b1, b2, consequence, sibling, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType), new Parameter("c", intType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("if (b <= 0 || c <= 0)", output);
+        Assert.Contains("V_0 = 2;", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
+    [Fact]
+    public void OrChainGuard_RejectsExternalEntryIntoOneBlockConsequence()
+    {
+        // The relaxation above is only for sibling arms that remain as ordinary
+        // blocks. A sibling branch into the consequence itself must still block
+        // the fold, since the structurer may consume that consequence as the
+        // folded guard's arm.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        LoadArgument A() => new(0, "a", intType);
+        LoadArgument B() => new(1, "b", intType);
+        LoadArgument C() => new(2, "c", intType);
+        LoadLocal V0() => new(0, intType);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new StoreLocal(0, intType, new Constant(0, intType)));
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, A(), new Constant(0, intType)), 16));
+        var b1 = new Block(4);
+        b1.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThanOrEqual, false, B(), new Constant(0, intType)), 12));
+        var b2 = new Block(8);
+        b2.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, C(), new Constant(0, intType)), 20));
+        var consequence = new Block(12);
+        consequence.Add(new StoreLocal(0, intType, new Constant(1, intType)));
+        consequence.Add(new Branch(20));
+        var sibling = new Block(16);
+        sibling.Add(new Branch(12));
+        var join = new Block(20);
+        join.Add(new Return(V0()));
+        foreach (var block in (Block[])[b0, b1, b2, consequence, sibling, join])
+            container.Add(block);
+
+        var signature = new MethodSignature(intType,
+            [new Parameter("a", intType), new Parameter("b", intType), new Parameter("c", intType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+        var stepper = new Stepper(enabled: true);
+
+        new OrChainGuardPass().Run(function, new PassContext(stepper));
+
+        Assert.Equal(0, stepper.Count);
+    }
+
+    [Fact]
     public void PastRegionTerminatorTarget_InlinesAsGuardExit()
     {
         // A #1031 shared-forward-merge slice from Array.CopyImpl: an outer guard

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OrChainGuardPass.cs
@@ -69,7 +69,7 @@ public sealed class OrChainGuardPass : IIrPass
         for (int p = 0; p < blocks.Count; p++)
         {
             if (Chain(blocks, offsetToIndex, p) is { } chain
-                && NoExternalEntry(blocks, p, chain.JoinIndex, leaveTargets))
+                && NoExternalEntry(blocks, p, chain.SkipGuard, chain.JoinIndex, leaveTargets))
             {
                 Fold(container, p, chain.SkipGuard, chain.JoinOffset, stepper);
                 return true;
@@ -143,26 +143,47 @@ public sealed class OrChainGuardPass : IIrPass
     }
 
     /// <summary>
-    /// No block outside the chain-and-consequence span may branch into the
-    /// guards this fold removes or into the consequence it re-parents — those
-    /// targets would dangle or escape the guard arm. The chain entry (p) and
-    /// the join may be targeted freely; a leave from anywhere (collected
-    /// function-wide) into the span aborts the fold too.
+    /// No block outside the folded chain may branch into guards this fold removes
+    /// or into the consequence arm the structurer may consume next. Sibling arms
+    /// between a one-block consequence and the join remain real blocks with real
+    /// labels, so they do not need to reject external entries. The chain entry
+    /// (p) and the join may be targeted freely; a leave from anywhere (collected
+    /// function-wide) into a protected block aborts the fold too.
     /// </summary>
     static bool NoExternalEntry(
-        IReadOnlyList<Block> blocks, int p, int joinIndex, HashSet<int> leaveTargets)
+        IReadOnlyList<Block> blocks, int p, int skipGuard, int joinIndex, HashSet<int> leaveTargets)
     {
         var forbidden = new HashSet<int>();
-        for (int idx = p + 1; idx < joinIndex; idx++)
-            forbidden.Add(blocks[idx].StartOffset);
+        var internalIndices = new HashSet<int>();
+        for (int idx = p; idx <= skipGuard; idx++)
+        {
+            internalIndices.Add(idx);
+            if (idx > p)
+                forbidden.Add(blocks[idx].StartOffset);
+        }
+
+        int consequenceStart = skipGuard + 1;
+        if (IsSingleBlockConsequence(blocks[consequenceStart], blocks[joinIndex].StartOffset))
+        {
+            forbidden.Add(blocks[consequenceStart].StartOffset);
+            internalIndices.Add(consequenceStart);
+        }
+        else
+        {
+            for (int idx = consequenceStart; idx < joinIndex; idx++)
+            {
+                forbidden.Add(blocks[idx].StartOffset);
+                internalIndices.Add(idx);
+            }
+        }
 
         if (forbidden.Overlaps(leaveTargets))
             return false;
 
         for (int idx = 0; idx < blocks.Count; idx++)
         {
-            if (idx >= p && idx < joinIndex)
-                continue;   // inside the chain/consequence span — internal edges are fine
+            if (internalIndices.Contains(idx))
+                continue;   // inside the protected chain/consequence blocks — internal edges are fine
             foreach (var node in blocks[idx].Children)
                 foreach (int target in Targets(node))
                     if (forbidden.Contains(target))
@@ -170,6 +191,26 @@ public sealed class OrChainGuardPass : IIrPass
         }
         return true;
     }
+
+    static bool IsSingleBlockConsequence(Block block, int joinOffset)
+    {
+        if (block.Children.Count == 0)
+            return false;
+        for (int i = 0; i < block.Children.Count - 1; i++)
+        {
+            if (IsControlFlow(block.Children[i]))
+                return false;
+        }
+        return block.Children[^1] switch
+        {
+            Branch branch => branch.TargetOffset == joinOffset,
+            Return or Throw => true,
+            _ => false,
+        };
+    }
+
+    static bool IsControlFlow(IrNode node)
+        => node is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter;
 
     static IEnumerable<int> Targets(IrNode node) => node switch
     {


### PR DESCRIPTION
## Summary
- relax `OrChainGuardPass` entry checks for one-block consequences so sibling arms between the consequence and join may keep their labels
- keep protection for removed guard blocks and the consequence arm, including an adversarial external-entry fixture
- recovers the `SourceIntegrityService.NormalizeLineEndings` loop-residue subshape from #1081

## Verification
- `dotnet build src/dotnet-inspect -c Release -m:1 -nr:false /p:UseSharedCompilation=false`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build` — 960 tests, 0 failed
- `dotnet build tools/DecompilerHarness -c Release -m:1 -nr:false /p:UseSharedCompilation=false`
- `dotnet run --no-build --project tools/DecompilerHarness -c Release -- <8 product dlls> --gaps --by-shape --max-examples 20` — loop-residue 236, conditional-branch 468, 0 pass bugs
- `dotnet run --no-build --project tools/DecompilerHarness -c Release -- artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll --dump 'DotnetInspector.Services.SourceIntegrityService::NormalizeLineEndings' --remarks` — Full fidelity, no remarks

Fixes part of #1081.
