### PR TITLE
Raise EH leave retry loops conservatively

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -533,6 +533,24 @@ public class CfgSampleClass
         finally { LastValue = x; }
     }
 
+    public static int TryFinallyRetryLoop(int x)
+    {
+        while (true)
+        {
+            try
+            {
+                if (x >= 3)
+                    return x;
+                x++;
+                continue;
+            }
+            finally
+            {
+                LastValue = x;
+            }
+        }
+    }
+
     public static int LastValue;
 
     public static int FilteredLength(string s)

--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -63,6 +63,57 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction LeaveRetryOutsideTryWithExit()
+    {
+        var body = new BlockContainer();
+
+        var retry = new Block(0x0000);
+        retry.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        body.Add(retry);
+
+        var tryEntry = new Block(0x0010);
+        tryEntry.Add(new ConditionalBranch(new LoadArgument(0, "done", TypeRef.CoreLib("System", "Boolean")), 0x0018));
+        body.Add(tryEntry);
+
+        var tryReturn = new Block(0x0014);
+        tryReturn.Add(new Return(null));
+        body.Add(tryReturn);
+
+        var tryRetry = new Block(0x0018);
+        tryRetry.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        tryRetry.Add(new Leave(0x0000));
+        body.Add(tryRetry);
+
+        var finallyBlock = new Block(0x0020);
+        finallyBlock.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        finallyBlock.Add(new EndFinally());
+        body.Add(finallyBlock);
+
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("done", TypeRef.CoreLib("System", "Boolean"))], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Finally,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
     static IrFunction LeaveIntoSameTry()
     {
         var body = new BlockContainer();
@@ -458,7 +509,7 @@ public class EhStructuringPassTests
     [Fact]
     public void LeaveRetryOutsideTry_StructuresRetryLoopAroundFinallyRegion()
     {
-        var function = LeaveRetryOutsideTry();
+        var function = LeaveRetryOutsideTryWithExit();
         var diagnostics = new StructuringDiagnostics();
 
         new EhStructuringPass().Run(function, PassContext.None);

--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -357,6 +357,31 @@ public class EhStructuringPassTests
     }
 
     [Fact]
+    public void LeaveRetryOutsideTry_StructuresRetryLoopAroundFinallyRegion()
+    {
+        var function = LeaveRetryOutsideTry();
+        var diagnostics = new StructuringDiagnostics();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        new StructuringPass().Run(function, new PassContext(new Stepper(enabled: false), diagnostics));
+        function.CheckInvariant();
+
+        var loop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.True(loop.Condition is Constant { Value: true });
+        Assert.Single(loop.Body.Descendants.OfType<TryFinally>());
+        Assert.Single(loop.Body.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.DoesNotContain("leave-target-in-container", diagnostics.Stops);
+
+        var output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+        Assert.Contains("while (true)", output);
+        Assert.Contains("try", output);
+        Assert.Contains("finally", output);
+        Assert.Contains("continue;", output);
+        Assert.DoesNotContain("// leave", output);
+    }
+
+    [Fact]
     public void LeaveIntoSameTry_KeepsRegionFlat()
     {
         var function = LeaveIntoSameTry();

--- a/src/ILInspector.Decompiler.Tests/InfiniteLoopStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InfiniteLoopStructuringTests.cs
@@ -116,4 +116,22 @@ public class InfiniteLoopStructuringTests
         Assert.Empty(function.Descendants.OfType<Branch>());
         Assert.DoesNotContain("goto", CSharpPrinter.Print(function).Output);
     }
+
+    [Fact]
+    public void TryFinallyRetryLoop_RaisesToWhileTrueWithContinue()
+    {
+        var function = Raised(nameof(CfgSampleClass.TryFinallyRetryLoop));
+
+        var loop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.True(IsWhileTrue(loop));
+        Assert.Single(loop.Body.Descendants.OfType<TryFinally>());
+        Assert.Single(loop.Body.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<Leave>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("while (true)", output);
+        Assert.Contains("continue;", output);
+        Assert.Contains("finally", output);
+        Assert.DoesNotContain("goto", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1352,6 +1352,7 @@ public sealed partial class CSharpPrinter
         Throw { Value: CaughtException } => "throw;",
         Throw t => $"throw {Expression(t.Value)};",
         Break => "break;",
+        Continue => "continue;",
         Branch b => $"goto IL_{b.TargetOffset:X4};",
         ConditionalBranch c => $"if ({Condition(c.Condition)}) goto IL_{c.TargetOffset:X4};",
         SwitchBranch s => $"switch ({Expression(s.Value)}) goto [{string.Join(", ", s.TargetOffsets.Select(t => $"IL_{t:X4}"))}];",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -256,8 +256,9 @@ public sealed class IrFunction : IrNode
     /// have to emit with no C# spelling, any residual runtime token with no C#
     /// expression spelling, any residual exception-filter boundary, any
     /// expression whose result type the pipeline does not know (null — e.g. a
-    /// join slot merged from conflicting types), or an un-raised <c>pinned
-    /// T&amp;</c> local (no faithful C# spelling) ⇒ at most
+    /// join slot merged from conflicting types), an EH-retry <c>continue</c>
+    /// whose source-like spelling is not currently opcode-exact, or an un-raised
+    /// <c>pinned</c> T&amp; local (no faithful C# spelling) ⇒ at most
     /// <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
@@ -268,6 +269,7 @@ public sealed class IrFunction : IrNode
             || n is NewObject { HasUnverifiedByRefArgument: true }
             || n is LoadToken { Kind: not RuntimeTokenKind.Type }
             || n is EndFilter
+            || n is Continue
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || CSharpSpellability.HasUnrepresentableMetadataName(n)
             || n is IrExpression { ResultType: null }
@@ -743,6 +745,16 @@ public sealed class ConditionalBranch : IrNode
 public sealed class Break : IrNode
 {
     public override string Describe() => "Break";
+}
+
+/// <summary>
+/// A C# <c>continue</c>: a loop back-edge raised from a branch or an EH
+/// <see cref="Leave"/> to the loop header. Childless terminator, like
+/// <see cref="Branch"/>.
+/// </summary>
+public sealed class Continue : IrNode
+{
+    public override string Describe() => "Continue";
 }
 
 public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -86,12 +86,6 @@ public sealed class StructuringPass : IIrPass
         var blocks = container.Blocks;
         if (blocks.Count <= 1)
             return;
-        if (leaveTargets.Count > 0 && blocks.Any(b => leaveTargets.Contains(b.StartOffset)))
-        {
-            context.StructuringDiagnostics?.RecordStop("leave-target-in-container");
-            return;
-        }
-
         var offsetToIndex = new Dictionary<int, int>();
         for (int i = 0; i < blocks.Count; i++)
             offsetToIndex[blocks[i].StartOffset] = i;
@@ -174,6 +168,17 @@ public sealed class StructuringPass : IIrPass
             Recorder = recorder,
         };
 
+        var leaveTargetIndices = blocks
+            .Select((block, index) => leaveTargets.Contains(block.StartOffset) ? index : -1)
+            .Where(index => index >= 0)
+            .ToList();
+        if (leaveTargetIndices.Count > 0
+            && leaveTargetIndices.Any(index => FindLeaveRetryLoopShape(ctx, index, blocks.Count) is null))
+        {
+            context.StructuringDiagnostics?.RecordStop("leave-target-in-container");
+            return;
+        }
+
         if (!Validate(ctx, 0, blocks.Count, joinIndex: blocks.Count, breakTarget: null, continueTarget: null))
         {
             context.StructuringDiagnostics?.RecordStop(recorder?.Reason ?? "unknown");
@@ -246,6 +251,11 @@ public sealed class StructuringPass : IIrPass
                 case Return or Throw or Break:
                     // A straight-line terminator: the loop pass already raised
                     // the break, so this block ends its region cleanly.
+                    i++;
+                    break;
+                case Leave leave when offsetToIndex.TryGetValue(leave.TargetOffset, out int leaveTarget)
+                    && continueTarget == leaveTarget
+                    && CanRaiseRetryLeave(leave):
                     i++;
                     break;
                 case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
@@ -348,7 +358,8 @@ public sealed class StructuringPass : IIrPass
                     }
                     if (target > stop)
                     {
-                        if (CanInlinePastRegionTarget(ctx, target))
+                        if (CanClonePastRegionTerminatorInLeaveRetryLoop(ctx, continueTarget, target)
+                            || CanInlinePastRegionTarget(ctx, target))
                         {
                             i++;
                             break;
@@ -477,16 +488,21 @@ public sealed class StructuringPass : IIrPass
     /// <summary>
     /// An infinite (<c>while (true)</c>) loop headed at <paramref name="head"/>:
     /// a single later block in <c>(head, stop)</c> ends with an unconditional
-    /// <see cref="Branch"/> back to the head, and that latch is the only block
-    /// branching to the head. Returns the latch index; the loop body is
-    /// <c>[head, latch]</c> and execution continues at <c>latch + 1</c>.
+    /// <see cref="Branch"/> back to the head, or one or more safe EH
+    /// <see cref="Leave"/> nodes target the head from a recovered protected
+    /// region. Returns the latch index; the loop body is <c>[head, latch]</c>
+    /// and execution continues at <c>latch + 1</c>.
     ///
     /// A conditional back-edge (a do-while, already raised, or a mid-body
-    /// <c>continue</c>) or a second back-edge keeps the container flat: this
-    /// slice models only the latch-terminated infinite loop whose exits are the
-    /// body's own <c>break</c>/<c>return</c>/<c>throw</c>.
+    /// <c>continue</c>) keeps the container flat. Ordinary branches still require
+    /// one latch; EH retry loops may have multiple retry leaves, all converted to
+    /// <c>continue</c> after the loop body is built.
     /// </summary>
     static int? FindInfiniteLoopShape(Ctx ctx, int head, int stop)
+        => FindBranchInfiniteLoopShape(ctx, head, stop)
+            ?? FindLeaveRetryLoopShape(ctx, head, stop);
+
+    static int? FindBranchInfiniteLoopShape(Ctx ctx, int head, int stop)
     {
         var blocks = ctx.Blocks;
         int headOffset = blocks[head].StartOffset;
@@ -514,6 +530,53 @@ public sealed class StructuringPass : IIrPass
             }
         }
         return latch == -1 ? null : latch;
+    }
+
+    static int? FindLeaveRetryLoopShape(Ctx ctx, int head, int stop)
+    {
+        var blocks = ctx.Blocks;
+        int headOffset = blocks[head].StartOffset;
+        if (CountBranchTargets(ctx, head) != 0)
+            return null;
+
+        int latch = -1;
+        for (int j = head + 1; j < stop; j++)
+        {
+            var retryLeaves = RetryLeavesTo(blocks[j], headOffset).ToList();
+            if (retryLeaves.Count == 0)
+                continue;
+            if (retryLeaves.Any(leave => !CanRaiseRetryLeave(leave)))
+                return null;
+            latch = j;
+        }
+
+        return latch == -1 ? null : latch;
+    }
+
+    static IEnumerable<Leave> RetryLeavesTo(Block block, int targetOffset)
+        => block.Descendants.OfType<Leave>().Where(leave => leave.TargetOffset == targetOffset);
+
+    static bool CanRaiseRetryLeave(Leave leave)
+        => HasAncestor<TryFinally>(leave)
+            && !HasAncestor<CatchClause>(leave)
+            && !IsInsideFinallyBody(leave);
+
+    static bool HasAncestor<T>(IrNode node) where T : IrNode
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is T)
+                return true;
+        return false;
+    }
+
+    static bool IsInsideFinallyBody(Leave leave)
+    {
+        for (var current = leave.Parent; current is not null; current = current.Parent)
+        {
+            if (current.Parent is TryFinally tryFinally && ReferenceEquals(current, tryFinally.FinallyBody))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>The <c>true</c> condition of a raised <c>while (true)</c> loop.</summary>
@@ -559,6 +622,33 @@ public sealed class StructuringPass : IIrPass
         => !ctx.UnconditionalTargets.Contains(ctx.Blocks[target].StartOffset)
             && !ctx.FallenInto.Contains(ctx.Blocks[target].StartOffset)
             && TryBuildPastRegionTarget(ctx, target, out _, out _);
+
+    static bool CanClonePastRegionTerminator(Ctx ctx, int target)
+        => TryClonePastRegionTerminator(ctx, target, out _);
+
+    static bool CanClonePastRegionTerminatorInLeaveRetryLoop(Ctx ctx, int? continueTarget, int target)
+        => continueTarget is { } head
+            && IsLeaveRetryLoopHead(ctx, head)
+            && CanClonePastRegionTerminator(ctx, target);
+
+    static bool IsLeaveRetryLoopHead(Ctx ctx, int head)
+        => FindLeaveRetryLoopShape(ctx, head, ctx.Blocks.Count) is not null;
+
+    static bool TryClonePastRegionTerminator(Ctx ctx, int target, out Block body)
+    {
+        body = null!;
+        if (target < 0 || target >= ctx.Blocks.Count)
+            return false;
+        if (!IsTerminatorBlock(ctx.Blocks[target]) || ContainsConstructorChainCall(ctx.Blocks[target]))
+            return false;
+
+        var inlineCtx = CreateInlineCtx([CloneBlock(ctx.Blocks[target])]);
+        if (!Validate(inlineCtx, 0, 1, joinIndex: 1, breakTarget: null, continueTarget: null))
+            return false;
+
+        body = BuildRegion(inlineCtx, 0, 1, joinIndex: 1, breakTarget: null, continueTarget: null);
+        return true;
+    }
 
     static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body, out int inlinedStop)
     {
@@ -811,6 +901,7 @@ public sealed class StructuringPass : IIrPass
             if (continueTarget != i && FindInfiniteLoopShape(ctx, i, stop) is { } latch)
             {
                 var loopBody = BuildRegion(ctx, i, latch + 1, joinIndex: latch + 1, breakTarget: latch + 1, continueTarget: i);
+                ReplaceRetryLeavesWithContinues(loopBody, blocks[i].StartOffset);
                 result.Add(new WhileLoop(TrueLiteral(), loopBody));
                 i = latch + 1;
                 continue;
@@ -833,6 +924,16 @@ public sealed class StructuringPass : IIrPass
                     result.Add(last);
                     i++;
                     break;
+                case Leave leave when offsetToIndex.TryGetValue(leave.TargetOffset, out int leaveTarget)
+                    && continueTarget == leaveTarget
+                    && CanRaiseRetryLeave(leave):
+                {
+                    var next = new Continue();
+                    next.InheritSourceOffset(leave);
+                    result.Add(next);
+                    i++;
+                    break;
+                }
                 case Leave leave when !offsetToIndex.ContainsKey(leave.TargetOffset):
                     // A container-exiting leave (mirrors Validate): emit it as the
                     // path terminator; the printer renders the `goto IL_xxxx`.
@@ -903,6 +1004,15 @@ public sealed class StructuringPass : IIrPass
                         i = stop;
                         break;
                     }
+                    if (target > stop
+                        && continueTarget is { } loopHead
+                        && IsLeaveRetryLoopHead(ctx, loopHead)
+                        && TryClonePastRegionTerminator(ctx, target, out var clonedTerminatorArm))
+                    {
+                        result.Add(new IfStatement(condition, clonedTerminatorArm, null));
+                        i++;
+                        break;
+                    }
                     if (target > stop && TryBuildPastRegionTarget(ctx, target, out var pastRegionArm, out int inlinedStop))
                     {
                         result.Add(new IfStatement(condition, pastRegionArm, null));
@@ -942,6 +1052,18 @@ public sealed class StructuringPass : IIrPass
             }
         }
         return result;
+    }
+
+    static void ReplaceRetryLeavesWithContinues(IrNode root, int targetOffset)
+    {
+        foreach (var leave in root.Descendants.OfType<Leave>()
+            .Where(leave => leave.TargetOffset == targetOffset && CanRaiseRetryLeave(leave))
+            .ToList())
+        {
+            var next = new Continue();
+            next.InheritSourceOffset(leave);
+            leave.ReplaceWith(next);
+        }
     }
 
     static IrExpression BuildWhileCondition(WhileShape loop)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -569,11 +569,23 @@ public sealed class StructuringPass : IIrPass
             latch = j;
         }
 
-        return latch == -1 ? null : latch;
+        bool hasLoopExit = latch >= 0
+            && Enumerable.Range(head, latch - head + 1).Any(index => HasLoopExit(blocks[index]));
+        return latch == -1 || !hasLoopExit ? null : latch;
     }
 
     static IEnumerable<Leave> RetryLeavesTo(Block block, int targetOffset)
         => block.Descendants.OfType<Leave>().Where(leave => leave.TargetOffset == targetOffset);
+
+    static bool HasLoopExit(Block block)
+    {
+        foreach (var node in block.Descendants.Prepend(block))
+        {
+            if (node is Return or Throw or Break)
+                return true;
+        }
+        return false;
+    }
 
     static bool CanRaiseRetryLeave(Leave leave)
         => HasAncestor<TryFinally>(leave)


### PR DESCRIPTION
Part of #1089 row 6.

## Summary
- Recognize safe EH retry-loop back-edges where a recovered `try`/`finally` contains a backward `Leave` to a pre-region loop header.
- Structure those regions as `while (true)` and replace the retry `Leave` with `continue`, without moving blocks across EH boundaries.
- Keep catch/filter-owned retry leaves declined for row 7, and mark EH-retry `continue` output as Partial because the source-like spelling is not currently opcode-exact.
- Add synthetic EH-region coverage plus a compiled `try`/`finally` retry-loop fixture.

## Measured impact
- `--gaps --by-shape`: `leave-retry-loop` drops **12 -> 2**; remaining examples are catch-owned (`TransferAllLocalWorkItemsToHighPriorityGlobalQueue`, `EncodeObject`) and should stay with row 7.
- `--structuring-stops`: `leave-target-in-container` drops **50 -> 39**.
- pass bugs: 0.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 30`
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops --max-examples 30`
- `dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 12000`