### PR TITLE
Fold EH-entangled prologue guards (#1089 slice 4)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrologueGuardReturnPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrologueGuardReturnPassTests.cs
@@ -1,0 +1,120 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// <see cref="PrologueGuardReturnPass"/> folds a leading <c>if (c) goto L;
+/// return X; L:</c> prologue guard that <see cref="StructuringPass"/> leaves flat
+/// only because the rest of the body is EH-entangled (a surviving <c>Leave</c>
+/// makes a later block a leave-target). The fold must touch only the pristine
+/// prologue and stand down whenever the arm could reach into the EH residue.
+/// </summary>
+public class PrologueGuardReturnPassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Str = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    enum Arm { Return, FallsThrough, Branch }
+
+    static IrFunction Build(Arm arm = Arm.Return, bool survivingLeave = true)
+    {
+        var body = new BlockContainer();
+
+        // Prologue guard: V_0 = …; if (V_0 == null) goto IL_0018; return V_0;
+        var entry = new Block(0x0000);
+        entry.Add(new StoreLocal(0, Str, new Constant(null, Str)));
+        entry.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, false, new LoadLocal(0, Str), new Constant(null, Str)),
+            0x0018));
+        body.Add(entry);
+
+        var armBlock = new Block(0x0008);
+        switch (arm)
+        {
+            case Arm.Return:
+                armBlock.Add(new Return(new LoadLocal(0, Str)));
+                break;
+            case Arm.FallsThrough:
+                armBlock.Add(new StoreLocal(1, Int32, new Constant(0, Int32)));
+                break;
+            case Arm.Branch:
+                armBlock.Add(new Branch(0x0018));
+                break;
+        }
+        body.Add(armBlock);
+
+        // EH-entangled residue: a loop header reached by a surviving Leave
+        // back-edge, exactly the leave-target-in-container StructuringPass stop.
+        var loopHeader = new Block(0x0018);
+        loopHeader.Add(new StoreLocal(1, Int32, new Constant(1, Int32)));
+        body.Add(loopHeader);
+
+        var loopBody = new Block(0x0020);
+        loopBody.Add(new StoreLocal(1, Int32, new Constant(2, Int32)));
+        loopBody.Add(survivingLeave ? new Leave(0x0018) : new Return(new LoadLocal(0, Str)));
+        body.Add(loopBody);
+
+        return new IrFunction(
+            "M", Holder,
+            new MethodSignature(Str, [], HasThis: false, GenericParameterCount: 0),
+            [Str, Int32],
+            body);
+    }
+
+    [Fact]
+    public void PrologueGuard_InEhEntangledBody_Folds()
+    {
+        var function = Build();
+
+        new PrologueGuardReturnPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        // Arm consumed into the guard; the leave-target loop header stays flat.
+        Assert.DoesNotContain(function.Body.Blocks, b => b.StartOffset == 0x0008);
+        Assert.Contains(function.Body.Blocks, b => b.StartOffset == 0x0018);
+        Assert.NotEmpty(function.Descendants.OfType<Leave>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("if (V_0 is not null)", output);
+        Assert.DoesNotContain("goto", output.Split("if (V_0 is not null)")[0]);
+    }
+
+    [Fact]
+    public void NoSurvivingLeave_StandsDown()
+    {
+        // Without a leave-target the container is StructuringPass's to own.
+        var function = Build(survivingLeave: false);
+
+        new PrologueGuardReturnPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.Contains(function.Body.Blocks, b => b.StartOffset == 0x0008);
+    }
+
+    [Fact]
+    public void ArmFallsIntoResidue_StandsDown()
+    {
+        // The arm does not terminate, so folding it would change which code runs
+        // when the guard is not taken — it must decline.
+        var function = Build(arm: Arm.FallsThrough);
+
+        new PrologueGuardReturnPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.Contains(function.Body.Blocks, b => b.StartOffset == 0x0008);
+    }
+
+    [Fact]
+    public void ArmWithControlFlow_StandsDown()
+    {
+        // A branch inside the arm is out of the straight-line prologue slice.
+        var function = Build(arm: Arm.Branch);
+
+        new PrologueGuardReturnPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.Contains(function.Body.Blocks, b => b.StartOffset == 0x0008);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -125,6 +125,10 @@ public static class IrPasses
         // `recv?.M() ?? x` store the structuring pass can consume. The sibling of
         // the or-chain folds for the shared-true-arm-with-prologue case.
         new NullConditionalCoalescePass(),
+        // Fold a prologue guard left flat only because the method body is
+        // EH-entangled (issue #1089, slice 4) — must run before StructuringPass,
+        // which declines the whole container for leave-target-in-container.
+        new PrologueGuardReturnPass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -41,6 +41,8 @@ internal static class NativePasses
     public static ReturnMergePass ReturnMerge => new();
     [Native(NativeCategory.EmitArtifact, "whole-method flat guard return dispatch collapsed to ordered guard returns")]
     public static ReturnDispatchPass ReturnDispatch => new();
+    [Native(NativeCategory.EmitArtifact, "a prologue if (c) goto L; return X; guard folded to a structured if even when the rest of the body stays EH-entangled-flat")]
+    public static PrologueGuardReturnPass PrologueGuardReturn => new();
     [Native(NativeCategory.EmitArtifact, "return-accumulator temp spilled across an EH/lock region eliminated")]
     public static ReturnSinkingPass ReturnSinking => new();
     [Native(NativeCategory.EmitArtifact, "short-circuit OR-guard chains folded so structuring can consume them")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PrologueGuardReturnPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PrologueGuardReturnPass.cs
@@ -1,0 +1,136 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a leading prologue guard — <c>if (c) goto L; …return/throw arm…; L:</c>
+/// at the very start of a method body — into the structured guard
+/// <c>if (!c) { …arm… }</c> when the rest of the container stays flat only
+/// because it is EH-entangled.
+///
+/// <para>
+/// <see cref="StructuringPass"/> is two-phase and all-or-nothing per container:
+/// a container holding the target of a surviving <c>Leave</c> (the
+/// <c>leave-target-in-container</c> stop) keeps its <em>entire</em> flat form,
+/// so an otherwise-trivial prologue guard sitting in front of an EH/loop residue
+/// never folds (issue #1089, slice 4; specimen <c>Interop.Sys::GetCwd()</c>).
+/// This pass recovers just that pristine prologue without touching the recovered
+/// <c>try</c>/<c>catch</c>/<c>finally</c> nodes or relocating any block across an
+/// EH boundary.
+/// </para>
+///
+/// <para>
+/// The fold is gated to be EH-safe by construction: it fires only on a container
+/// that <see cref="StructuringPass"/> declines for <c>leave-target-in-container</c>,
+/// and only when the guard's fallthrough arm is a straight-line block sequence
+/// terminating in <c>return</c>/<c>throw</c> that lies <em>entirely before</em> the
+/// first leave-target — i.e. in the prologue, never crossing into a region. The
+/// negation mirrors <see cref="StructuringPass"/>'s blessed fallthrough-first
+/// guard shape (<see cref="Conditions.Negate"/>), so a folded prologue is
+/// opcode-identical to the same guard structured in a non-EH method.
+/// </para>
+/// </summary>
+public sealed class PrologueGuardReturnPass : IIrPass
+{
+    public string Name => "prologue-guard-return";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Surviving leaves are the cross-container early exits the EH pass left
+        // flat; their target blocks are why StructuringPass keeps the container
+        // flat. No leaves means StructuringPass already owns this method.
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        if (leaveTargets.Count == 0)
+            return;
+
+        var container = function.Body;
+        var blocks = container.Blocks;
+        if (blocks.Count < 3)
+            return;
+
+        // Only fire when StructuringPass declines this container for the exact
+        // leave-target-in-container reason — otherwise the prologue would fold
+        // through the normal structurer and this pass must not double-handle it.
+        if (!blocks.Any(b => leaveTargets.Contains(b.StartOffset)))
+            return;
+
+        var entry = blocks[0];
+        if (entry.Children.Count == 0 || entry.Children[^1] is not ConditionalBranch guard)
+            return;
+
+        int targetIndex = container.IndexOfOffset(guard.TargetOffset);
+        if (targetIndex < 2)
+            return;  // need at least one arm block strictly before the target
+
+        // The arm is every block between the guard and its target. It must be a
+        // straight-line return/throw island that no other edge enters and that
+        // ends before the first leave-target — so folding it relocates nothing
+        // across an EH boundary and erases no label a goto still needs.
+        var branchTargets = CollectBranchTargets(function);
+        for (int i = 1; i < targetIndex; i++)
+        {
+            var armBlock = blocks[i];
+            if (leaveTargets.Contains(armBlock.StartOffset))
+                return;  // the arm reaches into the EH residue — not a prologue
+            if (branchTargets.Contains(armBlock.StartOffset))
+                return;  // another edge enters the arm — dropping it is unsafe
+            foreach (var child in armBlock.Children)
+                if (child is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                    return;  // control flow inside the arm is out of this slice
+        }
+
+        if (blocks[targetIndex - 1].Children is not [.., Return or Throw])
+            return;  // the arm must terminate, else it would fall into the target
+
+        // The entry's own statements before the guard must be straight-line: a
+        // branch there would mean the entry is itself a structuring region.
+        for (int s = 0; s < entry.Children.Count - 1; s++)
+            if (entry.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return;
+
+        var condition = guard.Condition;
+        condition.Detach();
+        guard.Detach();
+
+        var armBody = new Block(blocks[1].StartOffset);
+        for (int i = 1; i < targetIndex; i++)
+            foreach (var child in blocks[i].DetachChildren())
+                armBody.Add(child);
+
+        var ifStatement = new IfStatement(Conditions.Negate(condition), armBody, null);
+        ifStatement.InheritSourceOffset(guard);
+        entry.Add(ifStatement);
+
+        for (int i = targetIndex - 1; i >= 1; i--)
+            blocks[i].Detach();
+
+        context.Stepper.StepOver(
+            $"fold prologue guard at IL_{entry.StartOffset:X4} (EH-entangled body stays flat)",
+            container);
+    }
+
+    static HashSet<int> CollectBranchTargets(IrFunction function)
+    {
+        var targets = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case Branch branch:
+                    targets.Add(branch.TargetOffset);
+                    break;
+                case ConditionalBranch conditional:
+                    targets.Add(conditional.TargetOffset);
+                    break;
+                case Leave leave:
+                    targets.Add(leave.TargetOffset);
+                    break;
+                case SwitchBranch switchBranch:
+                    foreach (int target in switchBranch.TargetOffsets)
+                        targets.Add(target);
+                    break;
+            }
+        }
+        return targets;
+    }
+}


### PR DESCRIPTION
Closes a row in #1089 (slice 4: **Prologue/epilogue forward guards in EH methods**).

## Problem

A leading prologue guard `if (c) goto L; return X;` stays flat whenever the method body is EH-entangled. `StructuringPass` is two-phase and all-or-nothing per container: a container holding the target of a surviving `Leave` (the `leave-target-in-container` stop) keeps its **entire** flat form, so even a trivial prologue guard sitting in front of an EH/loop residue never folds.

Specimen: `Interop.Sys::GetCwd()` — its container also holds `IL_001E`, the target of the retry `Leave`, so the whole container (including the pristine prologue) is declined.

## Fix

`PrologueGuardReturnPass` — a narrow pass that recovers just the prologue guard, registered before `StructuringPass`.

It fires only on a container `StructuringPass` declines for `leave-target-in-container`, and only when the guard's fallthrough arm is a straight-line `return`/`throw` island lying **entirely before** the first leave-target — never crossing a region. The negation mirrors `StructuringPass`'s blessed fallthrough-first guard shape (`Conditions.Negate`), so a folded prologue is opcode-identical to the same guard in a non-EH method. No `try`/`catch`/`finally` node moves.

### `Interop.Sys::GetCwd()` before → after

Before:

```csharp
string V_0 = Sys.GetCwdHelper(stackalloc byte[256], 256);
if (V_0 is null) goto IL_0018;
return V_0;
IL_0018:
V_1 = 256;
IL_001E:
...  // EH leave-retry residue
```

After:

```csharp
string V_0 = Sys.GetCwdHelper(stackalloc byte[256], 256);
if (V_0 is not null)
{
    return V_0;
}
V_1 = 256;
IL_001E:
...  // EH leave-retry residue — byte-for-byte identical
```

The entire `try`/`finally` + leave-retry loop below the prologue is unchanged.

## Safety

Safe by construction: the pass only touches **Partial EH methods** with surviving `Leave` nodes. Full-fidelity methods have no `Leave`, so the pass never runs on them — Full% cannot regress.

Confirmed empirically: CoreLib inventory Full count is **identical before/after** (`40208/41012`, 98.04%), with identical stop reasons.

## Tests

4 tests in `PrologueGuardReturnPassTests`: 1 positive (GetCwd-shaped prologue in an EH-entangled body), 3 adversarial negatives (no surviving leave → stands down; arm falls into the residue → stands down; arm has internal control flow → stands down). Full decompiler suite green; `LoweringCoverageTests` register satisfied (pass classified in `NativePasses`, EmitArtifact).
