### PR TITLE
Fold shared-forward slot-store diamonds

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2323,6 +2323,15 @@ public class CfgSampleClass
     public static IEnumerable<int> CachedDelegateChain(IEnumerable<int> items)
         => items.Where(x => x > 0).Select(x => x * 2);
 
+    static string CacheMethodGroupIdentity(string value) => value;
+
+    // Static method groups use Roslyn's <>O holder and <N>__Method cache fields,
+    // not the <>c/<>9__ lambda cache shape. LambdaCachePass should strip that
+    // cache too so LINQ chains with method groups do not stay as shared-forward
+    // merge goto soup.
+    public static System.Collections.Generic.IEnumerable<string> CachedStaticMethodGroup(System.Collections.Generic.IEnumerable<string> items)
+        => System.Linq.Enumerable.Select(items, CacheMethodGroupIdentity);
+
     // A same-assembly user extension method, called in instance form. csc lowers it
     // to the static call `ExtensionMethodSamples.Doubled(n)`; the [Extension] mark is
     // read from the same-assembly MethodDef, so it should render back as `n.Doubled()`.

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1784,7 +1784,8 @@ public class RaisingPassTests
 
         Assert.Contains("bool S_0", output);
         Assert.DoesNotContain("int S_0", output);
-        Assert.Contains(": false", output);
+        Assert.Contains("false", output);
+        Assert.DoesNotContain("? 0", output);
         Assert.DoesNotContain(": 0", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
@@ -21,6 +21,7 @@ public class LambdaCachePassTests
     static void AssertCacheCollapsed(string output)
     {
         Assert.DoesNotContain("<>9__", output);
+        Assert.DoesNotContain(">__", output);
         Assert.DoesNotContain("is null", output);
     }
 
@@ -44,5 +45,51 @@ public class LambdaCachePassTests
         Assert.Contains("x => x * 2", output);
         Assert.Contains("Where", output);
         Assert.Contains("Select", output);
+    }
+
+    [Fact]
+    public void StaticMethodGroupCache_Collapses()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CachedStaticMethodGroup));
+
+        AssertCacheCollapsed(output);
+        Assert.Contains("CacheMethodGroupIdentity", output);
+        Assert.Contains("Select", output);
+    }
+
+    [Fact]
+    public void FlatStaticMethodGroupCache_CollapsesBeforeStructuring()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var funcType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`2"), [stringType, stringType]);
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var cacheHolder = TypeRef.Definition("Synthetic", "Samples", "Owner+<>O");
+        var cacheField = new FieldRef(cacheHolder, "<0>__Identity", funcType);
+        var identity = new MethodRef(owner, "Identity", stringType, [stringType], HasThis: false);
+
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new StoreStackSlot(0, new LoadField(cacheField, null)));
+        head.Add(new StoreStackSlot(1, new LoadArgument(0, "items", TypeRef.CoreLib("System", "Object"))));
+        head.Add(new StoreStackSlot(2, new LoadStackSlot(0, funcType)));
+        head.Add(new ConditionalBranch(new LoadStackSlot(0, funcType), 8));
+        var create = new Block(4);
+        create.Add(new StoreStackSlot(3, new DelegateCreation(funcType, identity, isVirtual: false, new Constant(null, objectType))));
+        create.Add(new StoreField(cacheField, null, new LoadStackSlot(3, funcType)));
+        create.Add(new StoreStackSlot(2, new LoadStackSlot(3, funcType)));
+        var join = new Block(8);
+        join.Add(new Return(new LoadStackSlot(2, funcType)));
+        foreach (var block in (Block[])[head, create, join])
+            container.Add(block);
+        var function = new IrFunction("M", owner, new MethodSignature(funcType, [new Parameter("items", TypeRef.CoreLib("System", "Object"))], HasThis: false, GenericParameterCount: 0), [], container);
+
+        new LambdaCachePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Empty(function.Descendants.OfType<LoadField>());
+        Assert.Empty(function.Descendants.OfType<StoreField>());
+        Assert.Single(function.Descendants.OfType<DelegateCreation>());
+        Assert.Equal(2, function.Body.Blocks.Count);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -1,0 +1,62 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class SlotStoreDiamondPassTests
+{
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    [Fact]
+    public void FoldsNestedNullableBoolDiamondAheadOfSharedTrueArm()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var any = new MethodRef(owner, "Any", Bool, [Object, Object], HasThis: false);
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "show", Bool), 16));
+        var nullableHead = new Block(4);
+        nullableHead.Add(new StoreStackSlot(0, new LoadArgument(1, "columns", Object)));
+        nullableHead.Add(new ConditionalBranch(new LoadStackSlot(0, Object), 12));
+        var nullArm = new Block(8);
+        nullArm.Add(new StoreStackSlot(1, new Constant(false, Bool)));
+        nullArm.Add(new Branch(20));
+        var trueSetup = new Block(12);
+        trueSetup.Add(new StoreStackSlot(2, new LoadArgument(2, "predicate", Object)));
+        var trueValue = new Block(14);
+        trueValue.Add(new StoreStackSlot(1, new Call(any, isVirtual: false, [new LoadStackSlot(0, Object), new LoadStackSlot(2, Object)])));
+        trueValue.Add(new Branch(20));
+        var sharedTrue = new Block(16);
+        sharedTrue.Add(new StoreStackSlot(1, new Constant(true, Bool)));
+        var merge = new Block(20);
+        merge.Add(new ConditionalBranch(new LoadStackSlot(1, Bool), 28));
+        var falseText = new Block(24);
+        falseText.Add(new StoreStackSlot(3, new Constant(null, Object)));
+        falseText.Add(new Branch(32));
+        var trueText = new Block(28);
+        trueText.Add(new StoreStackSlot(3, new LoadArgument(3, "summary", Object)));
+        var done = new Block(32);
+        done.Add(new Return(new LoadStackSlot(3, Object)));
+        foreach (var block in (Block[])[head, nullableHead, nullArm, trueSetup, trueValue, sharedTrue, merge, falseText, trueText, done])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(Object, [
+                new Parameter("show", Bool),
+                new Parameter("columns", Object),
+                new Parameter("predicate", Object),
+                new Parameter("summary", Object),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        Assert.Equal(5, function.Body.Blocks.Count);
+        Assert.Equal(2, function.Descendants.OfType<Conditional>().Count());
+        Assert.Single(function.Descendants.OfType<Branch>());
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 2);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -133,6 +133,12 @@ public static class IrPasses
         // EH-entangled (issue #1089, slice 4) — must run before StructuringPass,
         // which declines the whole container for leave-target-in-container.
         new PrologueGuardReturnPass(),
+        // Collapse flat lazy delegate-cache artifacts before shared slot-store
+        // diamonds try to inline their true-arm temporaries.
+        new LambdaCachePass(),
+        // Fold shared-forward slot diamonds into one conditional store so a
+        // later merge can structure instead of carrying the slot through gotos.
+        new SlotStoreDiamondPass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -33,6 +33,10 @@ public sealed class LambdaCachePass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        while (FoldFlatCache(function, context.Stepper))
+        {
+        }
+
         foreach (var ifStmt in function.Descendants.OfType<IfStatement>().ToList())
         {
             if (ifStmt.Parent is not Block block || ifStmt.HasElse || ifStmt.ChildIndex < 2)
@@ -48,7 +52,7 @@ public sealed class LambdaCachePass : IIrPass
                     StoreStackSlot { Value: LoadStackSlot resultCarrier } resultStore,
                 ])
                 continue;
-            if (!IsClosureCacheField(cacheField))
+            if (!IsDelegateCacheField(cacheField))
                 continue;
             int carrierSlot = createStore.Slot;
             if (fieldCarrier.Slot != carrierSlot || resultCarrier.Slot != carrierSlot)
@@ -93,10 +97,139 @@ public sealed class LambdaCachePass : IIrPass
         }
     }
 
+    static bool FoldFlatCache(IrFunction function, Stepper stepper)
+    {
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            if (TryFoldFlatCache(container, leaveTargets, stepper))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryFoldFlatCache(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        for (int i = 0; i + 1 < blocks.Count; i++)
+        {
+            var block = blocks[i];
+            if (block.Children.Count == 0
+                || block.Children[^1] is not ConditionalBranch { Condition: LoadStackSlot cacheRead } branch)
+            {
+                continue;
+            }
+            if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int joinIndex)
+                || joinIndex != i + 2
+                || leaveTargets.Contains(blocks[i + 1].StartOffset))
+            {
+                continue;
+            }
+
+            var createBlock = blocks[i + 1];
+            if (createBlock.Children is not
+                [
+                    StoreStackSlot { Value: DelegateCreation delegateCreation } createStore,
+                    StoreField { Field: { } cacheField, Instance: null, Value: LoadStackSlot fieldCarrier },
+                    StoreStackSlot { Value: LoadStackSlot resultCarrier } resultStore,
+                ])
+            {
+                continue;
+            }
+            if (!IsDelegateCacheField(cacheField))
+                continue;
+            int carrierSlot = createStore.Slot;
+            if (fieldCarrier.Slot != carrierSlot || resultCarrier.Slot != carrierSlot)
+                continue;
+
+            if (FindSeedAndLoad(block, cacheRead.Slot, resultStore.Slot, cacheField) is not { } prior)
+                continue;
+            if (HasExternalEntry(blocks, i + 1))
+                continue;
+
+            delegateCreation.Detach();
+            var replacement = new StoreStackSlot(resultStore.Slot, delegateCreation);
+            replacement.InheritSourceOffset(createStore);
+            stepper.StepOver($"collapse flat lazy delegate cache {cacheField.Name}", branch);
+            branch.Detach();
+            prior.Seed.Detach();
+            prior.CacheLoad.Detach();
+            block.Add(replacement);
+            createBlock.Detach();
+            return true;
+        }
+        return false;
+    }
+
+    sealed record PriorStores(StoreStackSlot Seed, StoreStackSlot CacheLoad);
+
+    static PriorStores? FindSeedAndLoad(Block block, int cacheSlot, int resultSlot, FieldRef cacheField)
+    {
+        StoreStackSlot? seed = null;
+        for (int j = block.Children.Count - 2; j >= 0; j--)
+        {
+            if (seed is null)
+            {
+                if (block.Children[j] is StoreStackSlot { Slot: var seedSlot, Value: LoadStackSlot from }
+                    && seedSlot == resultSlot && from.Slot == cacheSlot)
+                {
+                    seed = (StoreStackSlot)block.Children[j];
+                    continue;
+                }
+                if (ReferencesSlot(block.Children[j], cacheSlot))
+                    return null;
+                continue;
+            }
+
+            if (block.Children[j] is StoreStackSlot { Slot: var loadedSlot, Value: LoadField { Field: { } loadedField, Instance: null } } candidate
+                && loadedSlot == cacheSlot && loadedField == cacheField)
+            {
+                return new PriorStores(seed, candidate);
+            }
+            if (ReferencesSlot(block.Children[j], cacheSlot))
+                return null;
+        }
+        return null;
+    }
+
+    static bool HasExternalEntry(IReadOnlyList<Block> blocks, int targetIndex)
+    {
+        int targetOffset = blocks[targetIndex].StartOffset;
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (i == targetIndex - 1 || i == targetIndex)
+                continue;
+            foreach (var node in blocks[i].Children)
+                foreach (int target in Targets(node))
+                    if (target == targetOffset)
+                        return true;
+        }
+        return false;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        Leave leave => [leave.TargetOffset],
+        _ => [],
+    };
+
     // The compiler names the per-lambda cache field <>9__N_M (on the static <>c
-    // closure holder); the name is the unique anchor for the whole idiom.
-    static bool IsClosureCacheField(FieldRef field)
-        => field.Name.StartsWith("<>9__", StringComparison.Ordinal);
+    // closure holder) and static method-group cache fields <N>__MethodName (on
+    // the <>O holder); the generated field name is the anchor for the idiom.
+    static bool IsDelegateCacheField(FieldRef field)
+        => field.Name.StartsWith("<>9__", StringComparison.Ordinal)
+            || (field.DeclaringType.Name.EndsWith("+<>O", StringComparison.Ordinal)
+                && field.Name.StartsWith("<", StringComparison.Ordinal)
+                && field.Name.Contains(">__", StringComparison.Ordinal));
 
     // Whether the statement reads or writes the given stack slot anywhere in its
     // subtree — the guard for what may be interleaved ahead of the cache load.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -55,6 +55,8 @@ internal static class NativePasses
     public static SlotDiamondPass SlotDiamond => new();
     [Native(NativeCategory.EmitArtifact, "comparison-tree bool guard arms folded to straight-line bool returns so structuring can consume the surrounding dispatch")]
     public static ComparisonTreeBoolArmPass ComparisonTreeBoolArm => new();
+    [Native(NativeCategory.EmitArtifact, "a shared-forward slot-store diamond folded to one conditional store so structuring can consume the surrounding merge")]
+    public static SlotStoreDiamondPass SlotStoreDiamond => new();
     [Native(NativeCategory.EmitArtifact, "generic null-conditional invocation (recv?.M() ?? x — the default(T)-box two-stage null test) folded so structuring can consume it")]
     public static NullConditionalCoalescePass NullConditionalCoalesce => new();
     [Native(NativeCategory.EmitArtifact, "branch-to-adjacent / dead branches removed before structuring")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -1,0 +1,351 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a flat stack-slot diamond into one conditional store before structuring.
+/// This is the non-returning sibling of <see cref="SlotDiamondPass"/>: csc often
+/// lowers <c>S = c ? T : F</c> as a shared-forward merge, then uses <c>S</c> in a
+/// later condition or assignment. The structurer cannot name the shared merge
+/// while it is still split across gotos, but a single <see cref="Conditional"/>
+/// store preserves the evaluation order and lets the surrounding container raise.
+/// </summary>
+public sealed class SlotStoreDiamondPass : IIrPass
+{
+    public string Name => "slot-store-diamond";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            var blocks = container.Blocks;
+            var offsetToIndex = new Dictionary<int, int>();
+            for (int i = 0; i < blocks.Count; i++)
+                offsetToIndex[blocks[i].StartOffset] = i;
+
+            for (int p = 0; p + 2 < blocks.Count; p++)
+            {
+                if (Match(function, blocks, offsetToIndex, leaveTargets, p) is { } shape)
+                {
+                    Fold(container, blocks, p, shape, stepper);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    sealed record Shape(
+        int FalseIndex,
+        int TrueStart,
+        int TrueEnd,
+        int MergeIndex,
+        int ResultSlot,
+        TypeRef? ResultType,
+        IrExpression Condition,
+        IrExpression WhenTrue,
+        IrExpression WhenFalse);
+
+    static Shape? Match(
+        IrFunction function,
+        IReadOnlyList<Block> blocks,
+        Dictionary<int, int> offsetToIndex,
+        HashSet<int> leaveTargets,
+        int p)
+    {
+        var head = blocks[p];
+        if (head.Children.Count == 0 || head.Children[^1] is not ConditionalBranch branch)
+            return null;
+        for (int s = 0; s < head.Children.Count - 1; s++)
+            if (IsControlFlow(head.Children[s]))
+                return null;
+
+        int falseIndex = p + 1;
+        if (blocks[falseIndex].Children is not [StoreStackSlot falseStore, Branch falseExit]
+            || !offsetToIndex.TryGetValue(falseExit.TargetOffset, out int mergeIndex)
+            || !offsetToIndex.TryGetValue(branch.TargetOffset, out int trueStart)
+            || trueStart <= falseIndex
+            || trueStart >= mergeIndex)
+        {
+            return null;
+        }
+
+        if (FindTrueRegion(blocks, trueStart, mergeIndex) is not { } trueRegion)
+            return null;
+        if (trueRegion.Store.Slot != falseStore.Slot)
+            return null;
+
+        var prefixStores = trueRegion.Prefix.OfType<StoreStackSlot>().ToList();
+        if (prefixStores.Count != trueRegion.Prefix.Count
+            || !PrefixSlotsDeadOutside(function, blocks, trueStart, trueRegion.EndIndex, prefixStores.Select(store => store.Slot).ToHashSet()))
+        {
+            return null;
+        }
+
+        var whenTrue = (IrExpression)trueRegion.Store.Value.Clone();
+        if (!SubstitutePrefixStores(whenTrue, prefixStores, trueRegion.Store.Slot, out whenTrue))
+            return null;
+        var whenFalse = (IrExpression)falseStore.Value.Clone();
+        var condition = (IrExpression)branch.Condition.Clone();
+        if (condition is LogicalNot negated)
+        {
+            condition = (IrExpression)negated.Operand.Clone();
+            (whenTrue, whenFalse) = (whenFalse, whenTrue);
+        }
+        if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
+            return null;
+
+        if (!NoExternalEntry(blocks, p, falseIndex, trueStart, trueRegion.EndIndex, leaveTargets))
+            return null;
+
+        return new Shape(
+            falseIndex,
+            trueStart,
+            trueRegion.EndIndex,
+            mergeIndex,
+            falseStore.Slot,
+            whenTrue.ResultType ?? whenFalse.ResultType,
+            condition,
+            whenTrue,
+            whenFalse);
+    }
+
+    static bool NormalizeArmTypes(ref IrExpression whenTrue, ref IrExpression whenFalse)
+    {
+        var trueType = whenTrue.ResultType;
+        var falseType = whenFalse.ResultType;
+        if (trueType is null
+            || falseType is null
+            || trueType.Equals(falseType)
+            || whenTrue is Constant { Value: null }
+            || whenFalse is Constant { Value: null })
+        {
+            return true;
+        }
+
+        if (IsBool(trueType) && TryBoolConstant(whenFalse, out var falseBool))
+        {
+            whenFalse = falseBool;
+            return true;
+        }
+        if (IsBool(falseType) && TryBoolConstant(whenTrue, out var trueBool))
+        {
+            whenTrue = trueBool;
+            return true;
+        }
+        return false;
+    }
+
+    static bool IsBool(TypeRef type) => type.Equals(TypeRef.CoreLib("System", "Boolean"));
+
+    static bool TryBoolConstant(IrExpression expression, out IrExpression normalized)
+    {
+        if (expression is Constant { Value: int value } constant && (value == 0 || value == 1))
+        {
+            normalized = new Constant(value != 0, TypeRef.CoreLib("System", "Boolean"));
+            normalized.InheritSourceOffset(constant);
+            return true;
+        }
+        normalized = expression;
+        return false;
+    }
+
+    sealed record TrueRegionShape(int EndIndex, IReadOnlyList<IrNode> Prefix, StoreStackSlot Store);
+
+    static TrueRegionShape? FindTrueRegion(IReadOnlyList<Block> blocks, int trueStart, int mergeIndex)
+    {
+        var statements = new List<IrNode>();
+        for (int i = trueStart; i < blocks.Count && i <= mergeIndex; i++)
+        {
+            if (i == mergeIndex)
+                return null;
+            var children = blocks[i].Children;
+            if (children.Count == 0)
+                return null;
+
+            bool exitsToMerge = false;
+            int statementCount = children.Count;
+            if (children[^1] is Branch branch)
+            {
+                if (branch.TargetOffset != blocks[mergeIndex].StartOffset)
+                    return null;
+                exitsToMerge = true;
+                statementCount--;
+            }
+            else if (i + 1 == mergeIndex)
+            {
+                exitsToMerge = true;
+            }
+
+            for (int s = 0; s < statementCount; s++)
+            {
+                if (IsControlFlow(children[s]))
+                    return null;
+                statements.Add(children[s]);
+            }
+            if (!exitsToMerge)
+                continue;
+
+            if (statements.Count == 0 || statements[^1] is not StoreStackSlot store)
+                return null;
+            return new TrueRegionShape(i, statements.Take(statements.Count - 1).ToList(), store);
+        }
+        return null;
+    }
+
+    static bool SubstitutePrefixStores(
+        IrExpression initial,
+        IReadOnlyList<StoreStackSlot> prefixStores,
+        int resultSlot,
+        out IrExpression substituted)
+    {
+        substituted = initial;
+        for (int i = prefixStores.Count - 1; i >= 0; i--)
+        {
+            var store = prefixStores[i];
+            if (store.Slot == resultSlot)
+                return false;
+
+            var loads = substituted.Descendants.Prepend(substituted)
+                .OfType<LoadStackSlot>()
+                .Where(load => load.Slot == store.Slot)
+                .ToList();
+            if (loads.Count != 1)
+                return false;
+
+            var replacement = (IrExpression)store.Value.Clone();
+            if (ReferenceEquals(loads[0], substituted))
+            {
+                substituted = replacement;
+            }
+            else
+            {
+                loads[0].ReplaceWith(replacement);
+            }
+        }
+        return true;
+    }
+
+    static bool PrefixSlotsDeadOutside(
+        IrFunction function,
+        IReadOnlyList<Block> blocks,
+        int trueStart,
+        int trueEnd,
+        HashSet<int> prefixSlots)
+    {
+        if (prefixSlots.Count == 0)
+            return true;
+        var trueBlocks = blocks.Skip(trueStart).Take(trueEnd - trueStart + 1).ToHashSet();
+        foreach (var node in function.Descendants)
+        {
+            bool touches = node switch
+            {
+                LoadStackSlot load => prefixSlots.Contains(load.Slot),
+                StoreStackSlot store => prefixSlots.Contains(store.Slot),
+                _ => false,
+            };
+            if (touches && !InAnyBlock(node, trueBlocks))
+                return false;
+        }
+        return true;
+    }
+
+    static bool InAnyBlock(IrNode node, HashSet<Block> blocks)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (current is Block block && blocks.Contains(block))
+                return true;
+        return false;
+    }
+
+    static bool NoExternalEntry(
+        IReadOnlyList<Block> blocks,
+        int root,
+        int falseIndex,
+        int trueStart,
+        int trueEnd,
+        HashSet<int> leaveTargets)
+    {
+        var forbidden = new HashSet<int> { blocks[falseIndex].StartOffset };
+        for (int i = trueStart; i <= trueEnd; i++)
+            forbidden.Add(blocks[i].StartOffset);
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (i == root || i == falseIndex || (i >= trueStart && i <= trueEnd))
+                continue;
+            foreach (var node in blocks[i].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static void Fold(BlockContainer container, IReadOnlyList<Block> blocks, int p, Shape shape, Stepper stepper)
+    {
+        var ordered = container.Blocks.ToList();
+        var folded = new Block(ordered[p].StartOffset);
+        var rootChildren = ordered[p].DetachChildren();
+        for (int k = 0; k < rootChildren.Count - 1; k++)
+            folded.Add(rootChildren[k]);
+        var conditional = new Conditional(shape.Condition, shape.WhenTrue, shape.WhenFalse)
+        {
+            MergedType = shape.ResultType,
+        };
+        folded.Add(new StoreStackSlot(shape.ResultSlot, conditional));
+        if (NextKeptIndex(ordered.Count, shape) is { } next && next != shape.MergeIndex)
+            folded.Add(new Branch(ordered[shape.MergeIndex].StartOffset));
+
+        foreach (var block in ordered)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            if (i == p)
+            {
+                rebuilt.Add(folded);
+                continue;
+            }
+            if (i == shape.FalseIndex || (i >= shape.TrueStart && i <= shape.TrueEnd))
+                continue;
+            rebuilt.Add(ordered[i]);
+        }
+        stepper.StepOver("fold slot-store diamond into conditional store", container);
+        container.ReplaceWith(rebuilt);
+    }
+
+    static int? NextKeptIndex(int count, Shape shape)
+    {
+        for (int i = shape.FalseIndex; i < count; i++)
+            if (i != shape.FalseIndex && (i < shape.TrueStart || i > shape.TrueEnd))
+                return i;
+        return null;
+    }
+
+    static bool IsControlFlow(IrNode node)
+        => node is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter;
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        Leave leave => [leave.TargetOffset],
+        _ => [],
+    };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -17,6 +17,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        if (function.Descendants.OfType<EndFilter>().Any())
+            return;
+
         while (FoldOne(function, context.Stepper))
         {
         }


### PR DESCRIPTION
Refs #1081

## Summary
- add a pre-structuring `SlotStoreDiamondPass` that folds shared-forward stack-slot diamonds into a single conditional store
- run `LambdaCachePass` before structuring too, including flat `<>9__` / `<>O` delegate-cache shapes, so cached delegate temps can be consumed by the slot-store fold
- keep slot-store folding out of exception-filter methods and add focused regressions for static method-group caches and nullable-bool shared merges

## Measurement
- earlier latest `origin/main` product `--gaps --by-shape`: `shared-forward-merge` 144
- rebased branch product `--gaps --by-shape`: `shared-forward-merge` 141, 0 pass bugs

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- product `DecompilerHarness --gaps --by-shape --max-examples 10`
- product `DecompilerHarness --validity-check --compile-cap 10000`