### PR TITLE
Consume exception-capture filter regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -16,6 +16,7 @@ public class EhStructuringPassTests
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
@@ -308,6 +309,71 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction ExceptionCaptureFilterRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0060));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(Exception, new CaughtException(null))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, Exception)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, Exception), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0040));
+        body.Add(falseArm);
+
+        var typedException = new Block(0x0030);
+        typedException.Add(new StoreLocal(0, Exception, new LoadStackSlot(0, Exception)));
+        typedException.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadArgument(0, "captureException", Boolean),
+                new Constant(false, Boolean))));
+        body.Add(typedException);
+
+        var endFilter = new Block(0x0040);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Boolean)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0050);
+        handler.Add(new ExpressionStatement(new CaughtException(null)));
+        handler.Add(new StoreLocal(1, Exception, new LoadLocal(0, Exception)));
+        handler.Add(new Leave(0x0060));
+        body.Add(handler);
+
+        var tail = new Block(0x0060);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("captureException", Boolean)], HasThis: false, GenericParameterCount: 0),
+            [Exception, Exception],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0050,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
     static IrFunction CatchThenFilterRegion()
     {
         var body = new BlockContainer();
@@ -523,6 +589,23 @@ public class EhStructuringPassTests
 
         var output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("catch when (handle)", output);
+    }
+
+    [Fact]
+    public void ExceptionCaptureFilterRegion_RaisesToTypedCatchWhen()
+    {
+        var function = ExceptionCaptureFilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when (captureException)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -513,6 +513,8 @@ public sealed class EhStructuringPass : IIrPass
         var filterBlocks = blocks.Skip(filterStart).Take(handlerStart - filterStart).ToArray();
         if (TryBuildSimpleCatchAllFilter(filterBlocks) is { } simple)
             return simple;
+        if (TryBuildExceptionCaptureFilter(filterBlocks) is { } capture)
+            return capture;
 
         return TryBuildIOExceptionFilter(filterBlocks);
     }
@@ -564,6 +566,75 @@ public sealed class EhStructuringPass : IIrPass
         Constant constant => new Constant(constant.Value, constant.Type),
         _ => null,
     };
+
+    static FilterInfo? TryBuildExceptionCaptureFilter(IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var typedException,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var typedExceptionOffset },
+            ]
+            || !exceptionType.Equals(TypeRef.CoreLib("System", "Exception"))
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || typedExceptionOffset != typedException.StartOffset)
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (typedException.Children is not
+            [
+                StoreLocal { Index: var variableIndex, Type: var storedExceptionType, Value: LoadStackSlot storedException },
+                StoreStackSlot
+                {
+                    Slot: var trueVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: var conditionValue,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || storedException.Slot != copiedExceptionSlot
+            || !storedExceptionType.Equals(exceptionType)
+            || trueVerdictSlot != verdictSlot
+            || BoolFilterCondition(conditionValue) is not { } condition)
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        return new FilterInfo(exceptionType, variableIndex, condition);
+    }
 
     static FilterInfo? TryBuildIOExceptionFilter(IReadOnlyList<Block> filterBlocks)
     {


### PR DESCRIPTION
Continues #913 with a narrow EH filter slice for the `System.Environment::CallEntryPoint` shape.

Changes:
- recognize filters that first type-test the caught object as `System.Exception`, capture it in the catch variable, and use a boolean filter verdict such as `captureException`;
- emit the structured form as `catch (Exception V_n) when (captureException)`;
- add a synthetic EH structuring fixture covering the exact stack-slot/filter shape.

Measured impact on current `origin/main` (`d08bd084`):
- `--structuring-stops`: `unconsumed-regions` 30 -> 26; representative moves from `System.Environment::CallEntryPoint` to `System.GC::RunFinalizers`.
- `System.Environment::CallEntryPoint` reaches Full fidelity.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs same-main baseline: no regressed defect codes.