### PR TITLE
Harden EH leave target structuring

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -8,10 +8,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>throw</c>/<c>return</c>-only block not reached by any goto) inline a copy
 /// of T's statements, dissolving shared-terminator joins that otherwise break
 /// strict nesting. The pass is two-phase: the whole function is validated
-/// against the slice (forward branches only — loops, switch, and EH stay
-/// flat) before any mutation, so a function either structures completely or
-/// keeps the always-correct flat form. Conditions render the fallthrough
-/// arm first, matching the current emitter's guard style.
+/// against the slice (forward branches plus explicit EH path terminators;
+/// loops and switch stay flat) before any mutation, so a function either
+/// structures completely or keeps the always-correct flat form. Conditions
+/// render the fallthrough arm first, matching the current emitter's guard style.
 /// </summary>
 public sealed class StructuringPass : IIrPass
 {
@@ -23,8 +23,8 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>
     /// Per-container facts precomputed before any mutation: the block list and
-    /// offset map, the offsets reached by an unconditional <c>goto</c> (so an
-    /// inlined terminator never erases a label some goto still needs), the
+    /// offset map, the offsets reached by explicit control transfers (so an
+    /// inlined terminator never erases a label some goto/leave still needs), the
     /// blocks dropped from the linear walk after being cloned or inlined
     /// into a guard, and a snapshot of each inlinable terminator's statements
     /// (taken before <see cref="BuildRegion"/> detaches anything, so the
@@ -74,28 +74,24 @@ public sealed class StructuringPass : IIrPass
         // leave-to-finally-continuation can disappear before the outer container
         // decides whether that target block still needs a printable label.
         foreach (var container in function.Descendants.OfType<BlockContainer>().OrderByDescending(Depth).ToList())
-        {
-            var leaveTargets = function.Descendants.OfType<Leave>()
-                .Select(leave => leave.TargetOffset)
-                .ToHashSet();
-            Structure(container, leaveTargets, context);
-        }
+            Structure(container, context);
     }
 
-    static void Structure(BlockContainer container, HashSet<int> leaveTargets, PassContext context)
+    static void Structure(BlockContainer container, PassContext context)
     {
         var blocks = container.Blocks;
         if (blocks.Count <= 1)
             return;
-        if (leaveTargets.Count > 0 && blocks.Any(b => leaveTargets.Contains(b.StartOffset)))
-        {
-            context.StructuringDiagnostics?.RecordStop("leave-target-in-container");
-            return;
-        }
 
         var offsetToIndex = new Dictionary<int, int>();
         for (int i = 0; i < blocks.Count; i++)
             offsetToIndex[blocks[i].StartOffset] = i;
+
+        if (HasBackwardOrSelfLeaveTarget(blocks, offsetToIndex))
+        {
+            context.StructuringDiagnostics?.RecordStop("leave-target-in-container");
+            return;
+        }
 
         // A label is needed only for an unconditional goto: conditional guards
         // to a terminator are inlined, so they impose no label. Count the
@@ -115,6 +111,10 @@ public sealed class StructuringPass : IIrPass
                     unconditionalTargets.Add(branch.TargetOffset);
                     branchTargets.Add(branch.TargetOffset);
                 }
+                else if (child is Leave leave)
+                {
+                    branchTargets.Add(leave.TargetOffset);
+                }
                 else if (child is ConditionalBranch conditional)
                 {
                     conditionalTargetCounts[conditional.TargetOffset] =
@@ -130,6 +130,9 @@ public sealed class StructuringPass : IIrPass
                     }
                 }
             }
+
+            foreach (var leave in block.Descendants.OfType<Leave>())
+                branchTargets.Add(leave.TargetOffset);
         }
 
         // A terminator whose only predecessors are inlined guards (no goto
@@ -265,17 +268,14 @@ public sealed class StructuringPass : IIrPass
                     // enclosing construct's continuation, not a block here) ends
                     // its path like a return/break: control leaves the region and
                     // the printer still emits the same `goto IL_xxxx; // leave`.
-                    // The target block lives in an enclosing container, which the
-                    // leave-target-in-container guard (Structure) keeps flat, so
-                    // its label always survives — safe to structure around here.
                     i++;
                     break;
                 case Leave or EndFinally or EndFilter:
-                    // Survivors of the EH pass (an early exit through outer
-                    // constructs) keep their container flat: structure would
-                    // erase the label their goto needs.
-                    ctx.Recorder?.Record("eh-terminator-survivor");
-                    return false;
+                    // EH terminators end the current path. Leave targets are
+                    // tracked as branch targets so labels survive when the target
+                    // remains inside this container.
+                    i++;
+                    break;
                 case Branch branch:
                 {
                     if (!offsetToIndex.TryGetValue(branch.TargetOffset, out int branchTarget))
@@ -609,6 +609,17 @@ public sealed class StructuringPass : IIrPass
     static bool EndsWithTerminator(Block block)
         => block.Children.Count > 0 && block.Children[^1] is Return or Throw;
 
+    static bool HasBackwardOrSelfLeaveTarget(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex)
+    {
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            foreach (var leave in blocks[i].Descendants.OfType<Leave>())
+                if (offsetToIndex.TryGetValue(leave.TargetOffset, out int target) && target <= i)
+                    return true;
+        }
+        return false;
+    }
+
     static Block CloneBlock(Block source)
     {
         var clone = new Block(source.StartOffset);
@@ -635,6 +646,10 @@ public sealed class StructuringPass : IIrPass
                     unconditionalTargets.Add(branch.TargetOffset);
                     branchTargets.Add(branch.TargetOffset);
                 }
+                else if (child is Leave leave)
+                {
+                    branchTargets.Add(leave.TargetOffset);
+                }
                 else if (child is ConditionalBranch conditional)
                 {
                     conditionalTargetCounts[conditional.TargetOffset] =
@@ -650,6 +665,9 @@ public sealed class StructuringPass : IIrPass
                     }
                 }
             }
+
+            foreach (var leave in block.Descendants.OfType<Leave>())
+                branchTargets.Add(leave.TargetOffset);
         }
 
         var fallenInto = new HashSet<int>();
@@ -878,6 +896,10 @@ public sealed class StructuringPass : IIrPass
                     }
                     // A container-exiting leave (mirrors Validate): emit it as the
                     // path terminator; the printer renders the `goto IL_xxxx`.
+                    result.Add(last);
+                    i++;
+                    break;
+                case Leave or EndFinally or EndFilter:
                     result.Add(last);
                     i++;
                     break;


### PR DESCRIPTION
## Summary

- Allow forward in-container EH `leave` targets to structure by treating `leave` targets as label-preserved branch targets.
- Keep backward/self `leave` targets flat as `leave-target-in-container`, preserving the leave-retry-loop floor now tracked separately.
- Let surviving EH terminators (`leave`, `endfinally`, `endfilter`) validate and build as explicit path terminators instead of forcing a broad EH survivor stop.

Follow-up hardening for #1089 after the row-4 and row-5 work already on `main`; this PR keeps the retry-loop decline intact while relaxing the overly broad label-preservation gate for forward EH exits.

## Measurement

On current `origin/main` after intervening #1089 work:

- `--structuring-stops`: 11211 containers structured; 741 left flat; `leave-target-in-container` remains only for 14 backward/self cases.
- `--gaps --by-shape`: 1494 real gaps; 29 EH-entangled conditional residuals split as 17 filter, 10 leave-retry-loop, 2 eh-unstructured.
- The remaining hard cases are isolated to `System.Gen2GcCallback::Finalize` and `System.Globalization.CultureInfo::CreateSpecificCulture` under `eh-unstructured`.

## Validation

- `dotnet build src/dotnet-inspect -c Release -m:1`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` (974 passed)
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops --max-examples 8`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 8`
- `dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 4000` (Full malformed: 0)
