### PR TITLE
Consume global exception-handler filter regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -18,6 +18,7 @@ public class EhStructuringPassTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
+    static readonly TypeRef ExceptionHandling = TypeRef.CoreLib("System", "ExceptionHandling");
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
 
@@ -374,6 +375,75 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction GlobalExceptionHandlerFilterRegion()
+    {
+        var body = new BlockContainer();
+        var isHandledByGlobalHandler = new MethodRef(
+            ExceptionHandling,
+            "IsHandledByGlobalHandler",
+            Boolean,
+            [Exception],
+            HasThis: false);
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0060));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(Exception, new CaughtException(null))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, Exception)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, Exception), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0040));
+        body.Add(falseArm);
+
+        var typedException = new Block(0x0030);
+        typedException.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new Call(isHandledByGlobalHandler, isVirtual: false, [new LoadStackSlot(0, Exception)]),
+                new Constant(false, Boolean))));
+        body.Add(typedException);
+
+        var endFilter = new Block(0x0040);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Boolean)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0050);
+        handler.Add(new ExpressionStatement(new CaughtException(null)));
+        handler.Add(new Leave(0x0060));
+        body.Add(handler);
+
+        var tail = new Block(0x0060);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0050,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
     static IrFunction CatchThenFilterRegion()
     {
         var body = new BlockContainer();
@@ -606,6 +676,23 @@ public class EhStructuringPassTests
 
         var output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("catch (Exception V_0) when (captureException)", output);
+    }
+
+    [Fact]
+    public void GlobalExceptionHandlerFilterRegion_RaisesToTypedCatchWhen()
+    {
+        var function = GlobalExceptionHandlerFilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when (ExceptionHandling.IsHandledByGlobalHandler(V_0))", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -16,6 +16,7 @@ public class EhStructuringPassTests
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
@@ -308,6 +309,71 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction ExceptionCaptureFilterRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0060));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(Exception, new CaughtException(null))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, Exception)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, Exception), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0040));
+        body.Add(falseArm);
+
+        var typedException = new Block(0x0030);
+        typedException.Add(new StoreLocal(0, Exception, new LoadStackSlot(0, Exception)));
+        typedException.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadArgument(0, "captureException", Boolean),
+                new Constant(false, Boolean))));
+        body.Add(typedException);
+
+        var endFilter = new Block(0x0040);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Boolean)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0050);
+        handler.Add(new ExpressionStatement(new CaughtException(null)));
+        handler.Add(new StoreLocal(1, Exception, new LoadLocal(0, Exception)));
+        handler.Add(new Leave(0x0060));
+        body.Add(handler);
+
+        var tail = new Block(0x0060);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("captureException", Boolean)], HasThis: false, GenericParameterCount: 0),
+            [Exception, Exception],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0050,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
     static IrFunction CatchThenFilterRegion()
     {
         var body = new BlockContainer();
@@ -523,6 +589,23 @@ public class EhStructuringPassTests
 
         var output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("catch when (handle)", output);
+    }
+
+    [Fact]
+    public void ExceptionCaptureFilterRegion_RaisesToTypedCatchWhen()
+    {
+        var function = ExceptionCaptureFilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when (captureException)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -10,12 +10,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// the always-correct flat form with <see cref="IrFunction.Regions"/> intact.
 /// On success the regions clear — the nesting in the tree is then the truth.
 ///
-/// The slice: catch and finally handlers, plus the narrow generated
-/// <c>catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)</c>
-/// filter shape; unsupported filters and faults stay flat. Every <c>leave</c>
-/// must target the continuation of an enclosing construct, every branch must
-/// stay inside its region segment, and <c>endfinally</c>/<c>endfilter</c> must
-/// close its handler/filter from the final block only. Bodies become nested
+/// The slice: catch and finally handlers, plus narrow generated filter shapes
+/// that can be re-spelled as C# <c>catch when</c> clauses. Unsupported filters
+/// and faults stay flat. Every <c>leave</c> must target the continuation of an
+/// enclosing construct, every branch must stay inside its region segment, and
+/// <c>endfinally</c>/<c>endfilter</c> must close its handler/filter from the final
+/// block only. Bodies become nested
 /// containers, which the later structuring pass raises independently — a
 /// goto-heavy try body stays honestly flat inside a structured try/catch shell.
 /// </summary>
@@ -515,6 +515,8 @@ public sealed class EhStructuringPass : IIrPass
             return simple;
         if (TryBuildExceptionCaptureFilter(filterBlocks) is { } capture)
             return capture;
+        if (TryBuildGlobalExceptionHandlerFilter(filterBlocks) is { } globalHandler)
+            return globalHandler;
 
         return TryBuildIOExceptionFilter(filterBlocks);
     }
@@ -634,6 +636,83 @@ public sealed class EhStructuringPass : IIrPass
         }
 
         return new FilterInfo(exceptionType, variableIndex, condition);
+    }
+
+    static FilterInfo? TryBuildGlobalExceptionHandlerFilter(IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var typedException,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var typedExceptionOffset },
+            ]
+            || !exceptionType.Equals(TypeRef.CoreLib("System", "Exception"))
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || typedExceptionOffset != typedException.StartOffset)
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (typedException.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var trueVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: Call
+                        {
+                            Callee: var callee,
+                            IsVirtual: var isVirtual,
+                            Arguments: [LoadStackSlot handledException],
+                        } call,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || trueVerdictSlot != verdictSlot
+            || handledException.Slot != copiedExceptionSlot
+            || call.ConstrainedTo is not null
+            || isVirtual
+            || callee.Name != "IsHandledByGlobalHandler"
+            || callee.DeclaringType.Name != "ExceptionHandling"
+            || !callee.ReturnType.Equals(TypeRef.CoreLib("System", "Boolean")))
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        var condition = new Call(callee, isVirtual: false, [new CaughtException(exceptionType)]);
+        return new FilterInfo(exceptionType, null, condition);
     }
 
     static FilterInfo? TryBuildIOExceptionFilter(IReadOnlyList<Block> filterBlocks)
@@ -847,10 +926,11 @@ public sealed class EhStructuringPass : IIrPass
     };
 
     /// <summary>
-    /// Binds a catch variable for a handler that uses the caught exception as a
+    /// Binds a catch variable for a clause that uses the caught exception as a
     /// value without an entry store. Release leaves a <em>once-used</em> catch
-    /// variable on the stack — <c>catch (E ex) { throw new TIE(ex); }</c> imports as
-    /// a single bare <see cref="CaughtException"/> in value position, with no
+    /// variable on the stack — <c>catch (E ex) { throw new TIE(ex); }</c> and
+    /// filter-only uses such as <c>catch (E ex) when (F(ex))</c> import as a
+    /// single bare <see cref="CaughtException"/> in value position, with no
     /// <c>E ex = …</c> to fold. C# has no spelling for the stack exception, so
     /// synthesize a local, make it the clause's variable, and rewrite that one use
     /// to read it. Recompiling re-elides the store, so the round trip is
@@ -871,7 +951,7 @@ public sealed class EhStructuringPass : IIrPass
         {
             if (clause.VariableIndex is not null)
                 continue;
-            var uses = clause.Body.Descendants.OfType<CaughtException>()
+            var uses = clause.Descendants.OfType<CaughtException>()
                 .Where(caught => InnermostCatchClause(caught) == clause && !IsBareRethrow(caught))
                 .ToList();
             if (uses.Count != 1)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -513,6 +513,8 @@ public sealed class EhStructuringPass : IIrPass
         var filterBlocks = blocks.Skip(filterStart).Take(handlerStart - filterStart).ToArray();
         if (TryBuildSimpleCatchAllFilter(filterBlocks) is { } simple)
             return simple;
+        if (TryBuildExceptionCaptureFilter(filterBlocks) is { } capture)
+            return capture;
 
         return TryBuildIOExceptionFilter(filterBlocks);
     }
@@ -564,6 +566,75 @@ public sealed class EhStructuringPass : IIrPass
         Constant constant => new Constant(constant.Value, constant.Type),
         _ => null,
     };
+
+    static FilterInfo? TryBuildExceptionCaptureFilter(IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var typedException,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var typedExceptionOffset },
+            ]
+            || !exceptionType.Equals(TypeRef.CoreLib("System", "Exception"))
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || typedExceptionOffset != typedException.StartOffset)
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (typedException.Children is not
+            [
+                StoreLocal { Index: var variableIndex, Type: var storedExceptionType, Value: LoadStackSlot storedException },
+                StoreStackSlot
+                {
+                    Slot: var trueVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: var conditionValue,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || storedException.Slot != copiedExceptionSlot
+            || !storedExceptionType.Equals(exceptionType)
+            || trueVerdictSlot != verdictSlot
+            || BoolFilterCondition(conditionValue) is not { } condition)
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        return new FilterInfo(exceptionType, variableIndex, condition);
+    }
 
     static FilterInfo? TryBuildIOExceptionFilter(IReadOnlyList<Block> filterBlocks)
     {


### PR DESCRIPTION
Stacked on #1109 so this #913 slice can be reviewed before #1109 merges. After #1109 merges, this PR can be retargeted to `main`.

Continues #913 with a narrow EH filter slice for the `System.GC::RunFinalizers` shape.

Changes:
- recognize filters that type-test the caught object as `System.Exception` and pass it to `ExceptionHandling.IsHandledByGlobalHandler`;
- synthesize a catch variable for exactly one filter-only caught-exception use so the output is valid C# (`catch (Exception V_n) when (ExceptionHandling.IsHandledByGlobalHandler(V_n))`);
- add a synthetic EH structuring fixture for this exact stack-slot/filter shape.

Measured impact on top of #1109:
- `--structuring-stops`: `unconsumed-regions` 26 -> 23; representative moves from `System.GC::RunFinalizers` to `System.Gen2GcCallback::Finalize`.
- `System.GC::RunFinalizers` reaches Full fidelity.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs parent (#1109) baseline: no regressed defect codes.