### PR TITLE
Render value-type optional-parameter defaults as = default, not = null (#1113 slice 2)

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -679,7 +679,7 @@ public static class ApiSurfaceExtractor
 
             if (hasDefault)
             {
-                paramStr += $" = {FormatDefaultValue(defaultValue, type)}";
+                paramStr += $" = {FormatDefaultValue(defaultValue, AcceptsNullDefault(paramTypes[i]))}";
             }
 
             parameters.Add(paramStr);
@@ -752,10 +752,22 @@ public static class ApiSurfaceExtractor
         };
     }
 
-    private static string FormatDefaultValue(object? value, string typeName)
+    // `null` is a legal default only for a reference type or a Nullable<T> (a
+    // value type that nonetheless accepts the `null` literal). A non-nullable
+    // value type must spell its null constant `default`.
+    private static bool AcceptsNullDefault(TypeNode node)
+        => node.IsReferenceType
+            || node.Render().StartsWith("System.Nullable<", StringComparison.Ordinal);
+
+    private static string FormatDefaultValue(object? value, bool acceptsNullDefault)
     {
+        // A null constant is `default(T)` for a non-nullable value-type parameter
+        // (the only legal spelling — `T x = null` is CS1750), and a genuine `null`
+        // for reference types and Nullable<T> (both accept `null` as a literal
+        // default). value-vs-reference comes from the signature's element type
+        // (ELEMENT_TYPE_VALUETYPE), already on the decoded type node.
         if (value == null)
-            return "null";
+            return acceptsNullDefault ? "null" : "default";
 
         return value switch
         {
@@ -863,7 +875,7 @@ public static class ApiSurfaceExtractor
             var modifier = isParams ? "params" : refKind;
             var parameter = modifier is null ? $"{paramType} {paramName}" : $"{modifier} {paramType} {paramName}";
             if (hasDefault)
-                parameter += $" = {FormatDefaultValue(defaultValue, paramType)}";
+                parameter += $" = {FormatDefaultValue(defaultValue, AcceptsNullDefault(paramTypes[i]))}";
             indexerParameters.Add(parameter);
         }
 

--- a/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+#nullable enable
+
+/// <summary>
+/// Slice 2 of #1113: a non-nullable value-type optional parameter encodes its
+/// `= default` as a null constant, which the renderer printed as `= null`
+/// (CS1750). The fix renders `= default` for value types while keeping `= null`
+/// for reference types and Nullable&lt;T&gt; (both accept the null literal). Uses
+/// this test assembly as the subject, like <see cref="NullabilityTests"/>.
+/// </summary>
+public sealed class DefaultValueRenderingTests
+{
+    static readonly ApiSurface Surface;
+
+    static DefaultValueRenderingTests()
+    {
+        using var stream = File.OpenRead(typeof(DefaultValueRenderingTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    static string Signature(string method) => Surface.Types
+        .First(t => t.Name == nameof(DefaultValueFixtures))
+        .Members.First(m => m.Name == method).Signature;
+
+    [Fact]
+    public void ValueTypeStruct_Default_RendersDefaultNotNull()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.ValueTypeStructDefault));
+        Assert.Contains("ct = default", sig);
+        Assert.DoesNotContain("ct = null", sig);
+    }
+
+    [Fact]
+    public void CustomStruct_Default_RendersDefault()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.CustomStructDefault));
+        Assert.Contains("s = default", sig);
+        Assert.DoesNotContain("s = null", sig);
+    }
+
+    // --- regression canaries: these must stay `= null` / unchanged ---
+
+    [Fact]
+    public void RefType_Null_StaysNull()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.RefTypeNull));
+        Assert.Contains("r = null", sig);
+        Assert.DoesNotContain("= default", sig);
+    }
+
+    [Fact]
+    public void NullableValue_Null_StaysNull()
+    {
+        // Nullable<T> is a value type but accepts the null literal as its default.
+        var sig = Signature(nameof(DefaultValueFixtures.NullableValueNull));
+        Assert.Contains("n = null", sig);
+        Assert.DoesNotContain("n = default", sig);
+    }
+
+    [Fact]
+    public void Int_Default_Unchanged()
+        => Assert.Contains("i = 5", Signature(nameof(DefaultValueFixtures.IntDefault)));
+
+    [Fact]
+    public void Bool_Default_Unchanged()
+        => Assert.Contains("b = true", Signature(nameof(DefaultValueFixtures.BoolDefault)));
+}
+
+public class DefaultValueFixtures
+{
+    public struct PlainStruct { public int X; }
+
+    public void ValueTypeStructDefault(System.Threading.CancellationToken ct = default) { }
+    public void CustomStructDefault(PlainStruct s = default) { }
+    public void RefTypeNull(string? r = null) { }
+    public void NullableValueNull(int? n = null) { }
+    public void IntDefault(int i = 5) { }
+    public void BoolDefault(bool b = true) { }
+}


### PR DESCRIPTION
## Summary
Slice 2 of #1113 (the dominant defect). A non-nullable value-type optional parameter encodes its `= default` as a **null constant**, and `FormatDefaultValue` printed every null constant as `= null`. For a value type that is **CS1750** (`CancellationToken ct = null` — no standard conversion from `<null>`), so every async overload with an optional cancellation token rendered a non-compiling signature header (shared by `-S Signature` and the Decompiled Source header).

## Fix
Render a null constant as `default` for value types, keeping `null` for reference types and `Nullable<T>` (both accept the `null` literal). The value-vs-reference discriminator is already on the decoded type node — `TypeNode.IsReferenceType`, set from the signature's `ELEMENT_TYPE_VALUETYPE` — so no extra resolution is needed. `FormatDefaultValue`'s unused `typeName` arg becomes an `acceptsNullDefault` flag.

Scope held to the value/null branch only — enum, char, string, decimal shapes are their own slices (per "one default shape per PR").

## Fixtures + canaries (`DefaultValueRenderingTests`, this assembly as subject)
- ✅ cross-assembly `CancellationToken ct = default`
- ✅ custom struct `PlainStruct s = default`
- 🛡️ `string? r = null` stays `null`
- 🛡️ `int? n = null` (Nullable<T>) stays `null`
- 🛡️ `int i = 5`, `bool b = true` unchanged

## Validation
- `tests/ILInspector.Metadata.Tests` — **211**, 0 failed (incl. 6 new).
- `src/dotnet-inspect.Tests` — **1218**, 0 failed (exercises real JsonSerializer signatures; reference-type `options = null` unaffected).
- The slice-1 validity matrix (#1113 row 1) will confirm CS1750 → 0 for this shape once it lands.

Addresses #1113 slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)