### PR TITLE
Escape string optional parameter defaults

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Text;
 
 namespace ILInspector.Metadata;
 
@@ -760,12 +761,38 @@ public static class ApiSurfaceExtractor
         return value switch
         {
             bool b => b ? "true" : "false",
-            string s => $"\"{s}\"",
+            string s => StringLiteral(s),
             char c => $"'{c}'",
             float f => f.ToString("G") + "f",
             double d => d.ToString("G"),
             _ => value.ToString() ?? "default"
         };
+    }
+
+    private static string StringLiteral(string value)
+    {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            sb.Append(c switch
+            {
+                '"' => "\\\"",
+                '\\' => "\\\\",
+                '\0' => "\\0",
+                '\a' => "\\a",
+                '\b' => "\\b",
+                '\f' => "\\f",
+                '\n' => "\\n",
+                '\r' => "\\r",
+                '\t' => "\\t",
+                '\v' => "\\v",
+                _ when char.IsControl(c) => $"\\u{(int)c:X4}",
+                _ => c.ToString()
+            });
+        }
+        sb.Append('"');
+        return sb.ToString();
     }
 
     private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext, bool includeAll = false)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -98,6 +98,24 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_EscapesStringParameterDefaults()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
+        Assert.NotNull(testType);
+        var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithStringDefault");
+        Assert.NotNull(method);
+
+        Assert.Contains("string text = \"a\\\"b\\\\c\\n\\u0001\"", method.Signature);
+        Assert.DoesNotContain("a\"b\\c", method.Signature);
+    }
+
+    [Fact]
     public void Extract_ShowsGenericInterfaceNamesWithTypeParameters()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -494,6 +512,7 @@ public class SampleClassForTesting
     public void MethodWithParameters(int count, string name) { }
     public void MethodWithNoParameters() { }
     public void GenericMethod<T>(T item) { }
+    public void MethodWithStringDefault(string text = "a\"b\\c\n\u0001") { }
 }
 
 /// <summary>


### PR DESCRIPTION
Addresses #1113 row 5.

## Summary
- Escape string optional-parameter default values in the shared API signature renderer.
- Covers quotes, backslashes, newlines, standard control escapes, and other control chars via `\uXXXX`.
- Adds an API-surface fixture method whose default is `a"b\c\n\u0001`.

This shared path feeds both `-S Signature` and decompiled-source section headers.

## Validation
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
