### PR TITLE
Curate decompiler sidecar facts

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ForeachRecoveryFacts.cs
@@ -12,11 +12,11 @@ internal sealed class ForeachRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("enumerator-call-shape", "ForeachStatementPass GetEnumerator/MoveNext/Current shape checks"),
                 new FactPrimitive("dataflow.enumerator-local-consumed", "ForeachStatementPass ReferencesEnumerator residual-use guard"),
                 new FactPrimitive("member.corelib-identity:string.Length/string.Chars", "MemberIdentity.IsStringLengthGetter/IsStringCharsGetter"),
-                new FactPrimitive("mdarray-bounds-and-get-shape", "ForeachStatementPass rank-2 GetLowerBound/GetUpperBound/Get shape checks"),
+                new FactPrimitive("mdarray-bounds-and-get-shape", "ForeachStatementPass rank-N GetLowerBound/GetUpperBound/Get shape checks"),
                 new FactPrimitive("pdb.hidden-pattern-enumerator-local", "ForeachStatementPass HasLocalNameSlot + HasSourceLocalName guard"),
             ],
-            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, strings, rank-2 rectangular arrays, and PDB-discriminated custom pattern enumerators",
-            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop, copied Current receiver, hand-written indexed array/string/rectangular-array loops, and no-symbols/manual pattern enumerator loops",
-            MissingDiscriminator: "higher-rank arrays, no-symbol custom pattern enumerators, and broader collection/extension GetEnumerator shapes not raised"),
+            PositiveCoverage: "ForeachStatementPassTests foreach over IEnumerable with and without symbols, single-dimensional arrays, strings, rank-N rectangular arrays, and PDB-discriminated custom pattern enumerators",
+            AdversarialCoverage: "ForeachStatementPassTests source-named/no-symbols hand-written enumerator using/while loop, copied Current receiver, hand-written indexed array/string/rank-N rectangular-array loops, and no-symbols/manual pattern enumerator loops",
+            MissingDiscriminator: "no-symbol custom pattern enumerators and broader collection/extension GetEnumerator shapes not raised"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IsPatternRecoveryFacts.cs
@@ -11,8 +11,8 @@ internal sealed class IsPatternRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("place.local-scope", "IsPatternPass.ReferencedOnlyWithin"),
                 new FactPrimitive("property-subpattern-comparison", "CSharpPrinter.TryPropertySubpattern"),
             ],
-            PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures",
-            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, duplicate-property, unsigned relational-property, and floating-point relational sub-pattern (NaN-unsafe fold) negatives",
-            MissingDiscriminator: "positional/list sub-patterns and recursive property declaration sub-patterns (`{ P: T t }`) remain unraised; non-integral relational sub-patterns are deliberately declined (float ordered/unordered compares disagree on NaN; unsigned compares disagree with signed relational patterns) rather than folded"),
+            PositiveCoverage: "IsPatternPassTests type, property, relational, and multi-property pattern fixtures; ListPatternPassTests single-element string-array list pattern with constant OR alternatives",
+            AdversarialCoverage: "IsPatternPassTests binding-use, side-effecting-value, variable-bound, local-use manual-as, duplicate-property, unsigned relational-property, and floating-point relational sub-pattern (NaN-unsafe fold) negatives; ListPatternPassTests manual single-element string-array guard negative",
+            MissingDiscriminator: "positional sub-patterns, general list patterns beyond the single-element string-array constant-OR slice, and recursive property declaration sub-patterns (`{ P: T t }`) remain unraised; non-integral relational sub-patterns are deliberately declined (float ordered/unordered compares disagree on NaN; unsigned compares disagree with signed relational patterns) rather than folded"),
     ];
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -10,9 +10,9 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
             [
                 new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsValueTupleConstructor"),
             ],
-            PositiveCoverage: "TupleCreationPassTests ValueTuple constructor fixture",
-            AdversarialCoverage: "TupleCreationPassTests user ValueTuple lookalike and expression-statement negative fixtures",
-            MissingDiscriminator: "nested/rest tuples and tuple element names not recovered"),
+            PositiveCoverage: "TupleCreationPassTests ValueTuple constructor and RestTuple eight-or-more nested-TRest fixtures",
+            AdversarialCoverage: "TupleCreationPassTests user ValueTuple lookalike, expression-statement, and non-inline rest tuple negative fixtures",
+            MissingDiscriminator: "tuple element names not recovered"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.DeconstructionAssignmentOperator)),


### PR DESCRIPTION
## Summary
- refresh tuple creation sidecar coverage for the recovered rest-tuple literal slice
- update foreach sidecar wording from rank-2/higher-rank stale text to rank-N coverage
- update pattern sidecar wording for the single-element string-array list-pattern slice and its manual guard negative

Fixes #1114

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LoweringCoverageTests -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.IdiomShapeScorecardTests -reporter quiet
- git diff --check