### PR TITLE
Escape char defaults in API signatures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
@@ -21,15 +21,14 @@ public class DefaultParameterValidityTests
             .Where(m => m.Kind == "method")
             .ToDictionary(m => m.Name, CompileSignature, StringComparer.Ordinal);
 
-        AssertInvalid(results, nameof(DefaultParameterFixtures.CharControlDefault));
-        AssertInvalid(results, nameof(DefaultParameterFixtures.DecimalDefault), "SIGDEFAULT");
-
         AssertClean(results, nameof(DefaultParameterFixtures.ValueTypeStructDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.EnumNonZeroDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.EnumZeroDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.CharControlDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.CharPrintableDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.StringSpecialDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.StringPlainDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.DecimalDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.NullableValueDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.ReferenceTypeDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.IntDefault));
@@ -44,10 +43,7 @@ public class DefaultParameterValidityTests
             .ToArray();
 
         Assert.Equal(
-            [
-                nameof(DefaultParameterFixtures.CharControlDefault),
-                nameof(DefaultParameterFixtures.DecimalDefault),
-            ],
+            [],
             invalid);
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -761,12 +761,29 @@ public static class ApiSurfaceExtractor
         {
             bool b => b ? "true" : "false",
             string s => $"\"{s}\"",
-            char c => $"'{c}'",
+            char c => $"'{EscapeCharLiteral(c)}'",
             float f => f.ToString("G") + "f",
             double d => d.ToString("G"),
             _ => value.ToString() ?? "default"
         };
     }
+
+    private static string EscapeCharLiteral(char c) => c switch
+    {
+        '\\' => "\\\\",
+        '\'' => "\\'",
+        '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\v' => "\\v",
+        '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)c:x4}",
+        _ when char.IsControl(c) => $"\\u{(int)c:x4}",
+        _ => c.ToString()
+    };
 
     private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext, bool includeAll = false)
     {

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -98,6 +98,31 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_EscapesCharDefaultValuesInMethodSignatures()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
+        Assert.NotNull(testType);
+
+        var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithCharDefaults");
+        Assert.NotNull(method);
+
+        var expected =
+            """void MethodWithCharDefaults(char nul = '\0', """ +
+            """char newline = '\n', """ +
+            """char tab = '\t', """ +
+            """char quote = '\'', """ +
+            """char nonPrintable = '\u0001', """ +
+            """char letter = 'A')""";
+        Assert.Equal(expected, method.Signature);
+    }
+
+    [Fact]
     public void Extract_ShowsGenericInterfaceNamesWithTypeParameters()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -494,6 +519,13 @@ public class SampleClassForTesting
     public void MethodWithParameters(int count, string name) { }
     public void MethodWithNoParameters() { }
     public void GenericMethod<T>(T item) { }
+    public void MethodWithCharDefaults(
+        char nul = '\0',
+        char newline = '\n',
+        char tab = '\t',
+        char quote = '\'',
+        char nonPrintable = '\u0001',
+        char letter = 'A') { }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Escapes `char` optional-parameter default values when rendering API signatures.
- Covers null, newline, tab, single quote, non-printable, and printable char defaults in `ApiSurfaceExtractorTests`.

## Root Cause

`ApiSurfaceExtractor.FormatDefaultValue` interpolated `char` constants directly into single quotes. Control characters and `'` could therefore render invalid or line-breaking C# literals such as an empty-looking `''` or a literal newline inside the signature.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- `git diff --check`

Fixes row 4 of #1113.
