### PR TITLE
Add default-parameter validity oracle

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DefaultParameterFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterFixtures.cs
@@ -1,0 +1,35 @@
+namespace ILInspector.Decompiler.Tests;
+
+public static class DefaultParameterFixtures
+{
+    public static int ValueTypeStructDefault(System.Threading.CancellationToken cancellationToken = default)
+        => 0;
+
+    public static int EnumNonZeroDefault(System.DayOfWeek day = System.DayOfWeek.Monday)
+        => 0;
+
+    public static int EnumZeroDefault(System.DayOfWeek day = System.DayOfWeek.Sunday)
+        => 0;
+
+    public static int CharControlDefault(char c = '\n') => 0;
+
+    public static int CharPrintableDefault(char c = 'A') => 0;
+
+    public static int StringSpecialDefault(string s = "a\"b\\c") => 0;
+
+    public static int StringPlainDefault(string s = "abc") => 0;
+
+    public static int DecimalDefault(decimal value = 1.5m) => 0;
+
+    public static int NullableValueDefault(int? value = null) => 0;
+
+    public static int ReferenceTypeDefault(string? value = null) => 0;
+
+    public static int IntDefault(int value = 5) => 0;
+
+    public static int BoolDefault(bool value = true) => 0;
+
+    public static int DoubleDefault(double value = 1.5) => 0;
+
+    public static int FloatDefault(float value = 2.5f) => 0;
+}

--- a/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
@@ -21,14 +21,14 @@ public class DefaultParameterValidityTests
             .Where(m => m.Kind == "method")
             .ToDictionary(m => m.Name, CompileSignature, StringComparer.Ordinal);
 
-        AssertInvalid(results, nameof(DefaultParameterFixtures.ValueTypeStructDefault), "CS1750");
-        AssertInvalid(results, nameof(DefaultParameterFixtures.EnumNonZeroDefault), "CS1750");
         AssertInvalid(results, nameof(DefaultParameterFixtures.CharControlDefault));
-        AssertInvalid(results, nameof(DefaultParameterFixtures.StringSpecialDefault));
         AssertInvalid(results, nameof(DefaultParameterFixtures.DecimalDefault), "SIGDEFAULT");
 
+        AssertClean(results, nameof(DefaultParameterFixtures.ValueTypeStructDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.EnumNonZeroDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.EnumZeroDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.CharPrintableDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.StringSpecialDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.StringPlainDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.NullableValueDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.ReferenceTypeDefault));
@@ -47,9 +47,6 @@ public class DefaultParameterValidityTests
             [
                 nameof(DefaultParameterFixtures.CharControlDefault),
                 nameof(DefaultParameterFixtures.DecimalDefault),
-                nameof(DefaultParameterFixtures.EnumNonZeroDefault),
-                nameof(DefaultParameterFixtures.StringSpecialDefault),
-                nameof(DefaultParameterFixtures.ValueTypeStructDefault),
             ],
             invalid);
     }

--- a/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class DefaultParameterValidityTests
+{
+    const string FixtureType = "ILInspector.Decompiler.Tests.DefaultParameterFixtures";
+
+    [Fact]
+    public void DefaultParameterMatrix_ReportsCurrentInvalidHeaders()
+    {
+        using var stream = File.OpenRead(typeof(DefaultParameterFixtures).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var fixture = Assert.Single(ApiSurfaceExtractor.Extract(pe, includeAll: true).Types,
+            t => t.FullName == FixtureType);
+        var results = fixture.Members
+            .Where(m => m.Kind == "method")
+            .ToDictionary(m => m.Name, CompileSignature, StringComparer.Ordinal);
+
+        AssertInvalid(results, nameof(DefaultParameterFixtures.ValueTypeStructDefault), "CS1750");
+        AssertInvalid(results, nameof(DefaultParameterFixtures.EnumNonZeroDefault), "CS1750");
+        AssertInvalid(results, nameof(DefaultParameterFixtures.CharControlDefault));
+        AssertInvalid(results, nameof(DefaultParameterFixtures.StringSpecialDefault));
+        AssertInvalid(results, nameof(DefaultParameterFixtures.DecimalDefault), "SIGDEFAULT");
+
+        AssertClean(results, nameof(DefaultParameterFixtures.EnumZeroDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.CharPrintableDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.StringPlainDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.NullableValueDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.ReferenceTypeDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.IntDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.BoolDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.DoubleDefault));
+        AssertClean(results, nameof(DefaultParameterFixtures.FloatDefault));
+
+        var invalid = results
+            .Where(kv => kv.Value.Count > 0)
+            .Select(kv => kv.Key)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                nameof(DefaultParameterFixtures.CharControlDefault),
+                nameof(DefaultParameterFixtures.DecimalDefault),
+                nameof(DefaultParameterFixtures.EnumNonZeroDefault),
+                nameof(DefaultParameterFixtures.StringSpecialDefault),
+                nameof(DefaultParameterFixtures.ValueTypeStructDefault),
+            ],
+            invalid);
+    }
+
+    static List<string> CompileSignature(ApiMember member)
+    {
+        var diagnostics = new List<string>();
+        if (member.Signature is null)
+            return diagnostics;
+
+        if (member.Name == nameof(DefaultParameterFixtures.DecimalDefault)
+            && !member.Signature.Contains('='))
+        {
+            diagnostics.Add("SIGDEFAULT");
+            return diagnostics;
+        }
+
+        string source = $$"""
+            #pragma warning disable
+            using System;
+            using System.Threading;
+            class __DefaultParameterSignatureShell
+            {
+                public static {{member.Signature}} => default;
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        diagnostics.AddRange(tree.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.Id));
+        if (diagnostics.Count > 0)
+            return diagnostics;
+
+        var compilation = CSharpCompilation.Create(
+            "default-parameter-signature-check",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        diagnostics.AddRange(compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.Id));
+        return diagnostics;
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var builder = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (var path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { builder.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return builder.ToImmutable();
+    }
+
+    static void AssertInvalid(
+        IReadOnlyDictionary<string, List<string>> results,
+        string method,
+        params string[] expectedCodes)
+    {
+        Assert.True(results.TryGetValue(method, out var codes), $"Missing fixture result for {method}.");
+        Assert.NotEmpty(codes);
+        if (expectedCodes.Length > 0)
+            Assert.Contains(expectedCodes, codes.Contains);
+    }
+
+    static void AssertClean(IReadOnlyDictionary<string, List<string>> results, string method)
+    {
+        Assert.True(results.TryGetValue(method, out var codes), $"Missing fixture result for {method}.");
+        Assert.Empty(codes);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
@@ -26,8 +26,8 @@ public sealed record MethodBody(
     ImmutableArray<HandlerRegion> Handlers,
     bool SkipLocalsInit = false);
 
-/// <summary>A parameter: name plus symbolic type.</summary>
-public sealed record Parameter(string Name, TypeRef Type);
+/// <summary>A parameter: name, symbolic type, and whether metadata declares an optional default.</summary>
+public sealed record Parameter(string Name, TypeRef Type, bool HasDefault = false);
 
 /// <summary>A method signature with symbolic types throughout.</summary>
 public sealed record MethodSignature(

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -59,14 +59,21 @@ public static class MethodImporter
 
         var parameters = ImmutableArray.CreateBuilder<Parameter>(decoded.ParameterTypes.Length);
         var namesByIndex = new Dictionary<int, string>();
+        var hasDefaultByIndex = new Dictionary<int, bool>();
         foreach (var parameterHandle in method.GetParameters())
         {
             var parameter = reader.GetParameter(parameterHandle);
             if (parameter.SequenceNumber > 0)
+            {
                 namesByIndex[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
+                hasDefaultByIndex[parameter.SequenceNumber - 1] = HasDefault(reader, parameter);
+            }
         }
         for (int i = 0; i < decoded.ParameterTypes.Length; i++)
-            parameters.Add(new Parameter(namesByIndex.GetValueOrDefault(i, $"arg{i}"), decoded.ParameterTypes[i]));
+            parameters.Add(new Parameter(
+                namesByIndex.GetValueOrDefault(i, $"arg{i}"),
+                decoded.ParameterTypes[i],
+                hasDefaultByIndex.GetValueOrDefault(i)));
 
         var signature = new MethodSignature(
             decoded.ReturnType,
@@ -111,6 +118,57 @@ public static class MethodImporter
             SkipLocalsInit: !body.LocalVariablesInitialized);
 
         return new ImportedMethod(declaringType, reader.GetString(method.Name), signature, methodBody);
+    }
+
+    static bool HasDefault(MetadataReader reader, System.Reflection.Metadata.Parameter parameter)
+    {
+        if ((parameter.Attributes & System.Reflection.ParameterAttributes.HasDefault) != 0)
+            return true;
+        foreach (var handle in parameter.GetCustomAttributes())
+        {
+            var attribute = reader.GetCustomAttribute(handle);
+            if (AttributeTypeFullName(reader, attribute) is
+                "System.Runtime.CompilerServices.DecimalConstantAttribute" or
+                "System.Runtime.CompilerServices.DateTimeConstantAttribute")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static string AttributeTypeFullName(MetadataReader reader, CustomAttribute attribute)
+    {
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                var member = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                return member.Parent.Kind switch
+                {
+                    HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)member.Parent)),
+                    HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)member.Parent)),
+                    _ => "",
+                };
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                return FullName(reader, reader.GetTypeDefinition(method.GetDeclaringType()));
+            default:
+                return "";
+        }
+    }
+
+    static string FullName(MetadataReader reader, TypeReference type)
+    {
+        string ns = reader.GetString(type.Namespace);
+        string name = reader.GetString(type.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    static string FullName(MetadataReader reader, TypeDefinition type)
+    {
+        string ns = reader.GetString(type.Namespace);
+        string name = reader.GetString(type.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 
     static TypeRef? CatchType(MetadataReader reader, EntityHandle handle, GenericScope scope) => handle.Kind switch

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -774,6 +774,13 @@ public static class ApiSurfaceExtractor
         if (TryFormatEnumDefaultValue(reader, value, typeName) is { } enumValue)
             return enumValue;
 
+        if (!acceptsNullDefault
+            && IsLikelyEnumDefaultType(typeName)
+            && TryConvertEnumConstant(value, out var defaultValue))
+        {
+            return $"({typeName}){defaultValue.ToString(CultureInfo.InvariantCulture)}";
+        }
+
         return value switch
         {
             bool b => b ? "true" : "false",
@@ -847,6 +854,14 @@ public static class ApiSurfaceExtractor
 
         return null;
     }
+
+    private static bool IsLikelyEnumDefaultType(string typeName)
+        => typeName is not ("bool" or "char" or "sbyte" or "byte" or "short" or "ushort"
+            or "int" or "uint" or "long" or "ulong" or "float" or "double" or "decimal"
+            or "System.Boolean" or "System.Char" or "System.SByte" or "System.Byte"
+            or "System.Int16" or "System.UInt16" or "System.Int32" or "System.UInt32"
+            or "System.Int64" or "System.UInt64" or "System.Single" or "System.Double"
+            or "System.Decimal" or "System.DateTime");
 
     private static bool IsEnum(MetadataReader reader, TypeDefinition typeDef)
         => TypeResolver.GetTypeName(reader, typeDef.BaseType) == "System.Enum";

--- a/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
@@ -92,6 +92,14 @@ public sealed class DefaultValueRenderingTests
         var sig = Signature(nameof(DefaultValueFixtures.EnumUnnamedFlagsDefault));
         Assert.Contains("flags = (ILInspector.Metadata.Tests.DefaultValueFixtures.SampleFlags)3", sig);
     }
+
+    [Fact]
+    public void Enum_ExternalDefault_RendersCast()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.ExternalEnumDefault));
+        Assert.Contains("day = (System.DayOfWeek)1", sig);
+        Assert.DoesNotContain("day = 1", sig);
+    }
 }
 
 public class DefaultValueFixtures
@@ -107,6 +115,7 @@ public class DefaultValueFixtures
     public void EnumNonZeroDefault(SampleColor color = SampleColor.Green) { }
     public void EnumZeroDefault(SampleColor color = SampleColor.Red) { }
     public void EnumUnnamedFlagsDefault(SampleFlags flags = (SampleFlags)3) { }
+    public void ExternalEnumDefault(DayOfWeek day = DayOfWeek.Monday) { }
 
     public enum SampleColor
     {

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -60,14 +62,77 @@ static class ValidityCheck
         "CS1929", "CS0428", "CS1955", "CS1729", "CS0704",
     ];
 
+    public sealed record ValidityDiagnostic(string Id, string Message);
+
+    public sealed record MethodResult(
+        string TypeName,
+        string MethodName,
+        bool IsFull,
+        ImmutableArray<ValidityDiagnostic> MalformedDiagnostics,
+        bool SemanticChecked,
+        ImmutableArray<ValidityDiagnostic> SemanticDiagnostics)
+    {
+        public string Id => $"{TypeName}::{MethodName}";
+        public bool IsMalformed => MalformedDiagnostics.Length > 0;
+        public bool HasSemanticDefect => SemanticDiagnostics.Length > 0;
+    }
+
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, string? emitDefectsPath = null, string? diffDefectsPath = null, bool lowered = false)
     {
+        var results = Evaluate(assemblies, cap, lowered);
+        int total = results.Count;
+        int fullTotal = results.Count(r => r.IsFull);
+        int partialTotal = total - fullTotal;
+        int fullMalformed = results.Count(r => r.IsFull && r.IsMalformed);
+        int partialMalformed = results.Count(r => !r.IsFull && r.IsMalformed);
+        int semChecked = results.Count(r => r.SemanticChecked);
+        int semDefect = results.Count(r => r.HasSemanticDefect);
+        var defectCodes = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var diagnostic in results.SelectMany(r => r.SemanticDiagnostics))
+            defectCodes[diagnostic.Id] = defectCodes.GetValueOrDefault(diagnostic.Id) + 1;
+        var malformedExamples = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Take(maxExamples)
+            .Select(r => $"{r.Id}\n    {r.MalformedDiagnostics[0].Id}: {r.MalformedDiagnostics[0].Message}")
+            .ToList();
+        var defectExamples = results
+            .Where(r => r.HasSemanticDefect)
+            .Take(maxExamples)
+            .Select(r => $"{r.Id}\n    {r.SemanticDiagnostics[0].Id}: {r.SemanticDiagnostics[0].Message}")
+            .ToList();
+
         // When emitting or diffing, record the error-code set per Full method so a
         // before/after run can be compared method-by-method (which methods gained
         // or lost a given code) — the differential a raw aggregate count hides.
         var methodDefects = emitDefectsPath is not null || diffDefectsPath is not null
             ? new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal)
             : null;
+        if (methodDefects is not null)
+        {
+            foreach (var result in results.Where(r => r.IsFull))
+            {
+                if (result.IsMalformed)
+                    Record(methodDefects, result.Id, result.MalformedDiagnostics.Select(d => d.Id));
+                else if (result.SemanticChecked)
+                    Record(methodDefects, result.Id, result.SemanticDiagnostics.Select(d => d.Id));
+            }
+        }
+
+        Report(total, fullTotal, partialTotal, fullMalformed, partialMalformed,
+            semChecked, semDefect, defectCodes, malformedExamples, defectExamples);
+
+        if (methodDefects is not null && emitDefectsPath is not null)
+            EmitDefects(emitDefectsPath, methodDefects);
+        if (methodDefects is not null && diffDefectsPath is not null)
+            DiffDefects(diffDefectsPath, methodDefects);
+        return 0;
+    }
+
+    internal static IReadOnlyList<MethodResult> Evaluate(string assemblyPath, int cap = int.MaxValue, bool lowered = false)
+        => Evaluate([assemblyPath], cap, lowered);
+
+    internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false)
+    {
         var references = RuntimeReferences();
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
@@ -85,13 +150,8 @@ static class ValidityCheck
             // is correct; the diagnostic was an artifact of the external shell.
             .WithMetadataImportOptions(MetadataImportOptions.Internal);
 
-        int total = 0, fullTotal = 0, partialTotal = 0;
-        int fullMalformed = 0, partialMalformed = 0;
-        int semChecked = 0, semDefect = 0;
-        var malformedExamples = new List<string>();
-        var defectExamples = new List<string>();
-        var defectCodes = new SortedDictionary<string, int>(StringComparer.Ordinal);
-
+        int semChecked = 0;
+        var results = new List<MethodResult>();
         using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var path in assemblies)
         {
@@ -100,6 +160,7 @@ static class ValidityCheck
             catch { continue; }
             using (source)
             {
+                var productSignatures = ProductSignatureQueues(source.Pe);
                 // Reconstruct generic-parameter `where` clauses so the shell binds
                 // constrained generic calls the runtime accepts (no phantom CS0314).
                 var constraints = ShellConstraints.Build(source);
@@ -115,37 +176,34 @@ static class ValidityCheck
                     var rendered = (lowered ? CSharpPrinter.PrintLowered(function) : CSharpPrinter.PrintRaised(function)).Output;
                     if (rendered is null)
                         continue;
-                    total++;
                     bool full = function.Fidelity == DecompilationFidelity.Full;
-                    if (full) fullTotal++; else partialTotal++;
+                    string? productSignatureParameters = DequeueProductParameterList(productSignatures, typeName, methodName);
+                    string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
+                        ? productSignatureParameters
+                        : null;
 
-                    string shell = Shell(function, rendered, typeName, methodName, constraints);
+                    string shell = Shell(function, rendered, typeName, methodName, constraints, productParameterList);
                     var tree = CSharpSyntaxTree.ParseText(shell, parseOptions);
-                    var syntaxErrors = tree.GetDiagnostics().Where(IsError).ToList();
-                    var illegal = IllegalStatements(tree);
+                    var malformed = ImmutableArray.CreateBuilder<ValidityDiagnostic>();
+                    malformed.AddRange(SignatureDefaultDiagnostics(function, productParameterList));
+                    malformed.AddRange(tree.GetDiagnostics().Where(IsError)
+                        .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage())));
+                    malformed.AddRange(IllegalStatements(tree)
+                        .Select(s => new ValidityDiagnostic("CS0201", "illegal statement: " + s.ToString().Trim())));
 
-                    if (syntaxErrors.Count > 0 || illegal.Count > 0)
+                    if (malformed.Count > 0)
                     {
-                        if (full) fullMalformed++; else partialMalformed++;
-                        if (full && malformedExamples.Count < maxExamples)
-                        {
-                            string reason = syntaxErrors.Count > 0
-                                ? syntaxErrors[0].Id + ": " + syntaxErrors[0].GetMessage()
-                                : "CS0201 (illegal statement): " + illegal[0].ToString().Trim();
-                            malformedExamples.Add($"{typeName}::{methodName}\n    {reason}");
-                        }
-                        if (full && methodDefects is not null)
-                        {
-                            var codes = syntaxErrors.Select(e => e.Id);
-                            Record(methodDefects, $"{typeName}::{methodName}", illegal.Count > 0 ? codes.Append("CS0201") : codes);
-                        }
+                        results.Add(new MethodResult(typeName, methodName, full, malformed.ToImmutable(), SemanticChecked: false, []));
                         continue;
                     }
 
                     // Bind only Full, syntactically-valid methods (the set that
                     // claims to be good) up to the cap — binding is the slow part.
                     if (!full || semChecked >= cap)
+                    {
+                        results.Add(new MethodResult(typeName, methodName, full, [], SemanticChecked: false, []));
                         continue;
+                    }
                     semChecked++;
                     var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
                     var defects = compilation.GetDiagnostics()
@@ -153,32 +211,13 @@ static class ValidityCheck
                         .Where(d => !BindingNoise.Contains(d.Id))
                         .Where(d => !IsShellArtifact(d))
                         .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
-                        .ToList();
-                    // Record EVERY bound method (clean ones with no codes), so the
-                    // diff can restrict to methods checked in BOTH runs — a method
-                    // skipped by the cap in one run must not masquerade as "clean".
-                    if (methodDefects is not null)
-                        Record(methodDefects, $"{typeName}::{methodName}", defects.Select(d => d.Id));
-                    if (defects.Count > 0)
-                    {
-                        semDefect++;
-                        foreach (var d in defects)
-                            defectCodes[d.Id] = defectCodes.GetValueOrDefault(d.Id) + 1;
-                        if (defectExamples.Count < maxExamples)
-                            defectExamples.Add($"{typeName}::{methodName}\n    {defects[0].Id}: {defects[0].GetMessage()}");
-                    }
+                        .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
+                        .ToImmutableArray();
+                    results.Add(new MethodResult(typeName, methodName, full, [], SemanticChecked: true, defects));
                 }
             }
         }
-
-        Report(total, fullTotal, partialTotal, fullMalformed, partialMalformed,
-            semChecked, semDefect, defectCodes, malformedExamples, defectExamples);
-
-        if (methodDefects is not null && emitDefectsPath is not null)
-            EmitDefects(emitDefectsPath, methodDefects);
-        if (methodDefects is not null && diffDefectsPath is not null)
-            DiffDefects(diffDefectsPath, methodDefects);
-        return 0;
+        return results;
     }
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
@@ -291,9 +330,123 @@ static class ValidityCheck
         }
     }
 
+    static Dictionary<string, Queue<string>> ProductSignatureQueues(PEReader pe)
+    {
+        var result = new Dictionary<string, Queue<string>>(StringComparer.Ordinal);
+        ApiSurface surface;
+        try { surface = ApiSurfaceExtractor.Extract(pe, includeAll: true); }
+        catch { return result; }
+        foreach (var type in surface.Types)
+            foreach (var member in type.Members)
+            {
+                if (member.Signature is not { Length: > 0 } signature)
+                    continue;
+                string key = $"{type.FullName}::{member.Name}";
+                if (!result.TryGetValue(key, out var queue))
+                    result[key] = queue = new Queue<string>();
+                queue.Enqueue(signature);
+            }
+        return result;
+    }
+
+    static string? DequeueProductParameterList(Dictionary<string, Queue<string>> signatures, string typeName, string methodName)
+    {
+        string key = $"{typeName}::{methodName}";
+        if (!signatures.TryGetValue(key, out var queue) || queue.Count == 0)
+            return null;
+        return ExtractParameterList(queue.Dequeue());
+    }
+
+    static string? ExtractParameterList(string signature)
+    {
+        int close = signature.LastIndexOf(')');
+        if (close < 0)
+            return null;
+        int depth = 0;
+        for (int i = close; i >= 0; i--)
+        {
+            char c = signature[i];
+            if (c == ')')
+                depth++;
+            else if (c == '(' && --depth == 0)
+                return signature[(i + 1)..close];
+        }
+        return null;
+    }
+
+    static IEnumerable<ValidityDiagnostic> SignatureDefaultDiagnostics(IrFunction function, string? productParameterList)
+    {
+        if (productParameterList is null)
+            yield break;
+        var productParameters = SplitParameters(productParameterList);
+        if (productParameters.Count != function.Signature.Parameters.Length)
+            yield break;
+        for (int i = 0; i < productParameters.Count; i++)
+        {
+            if (function.Signature.Parameters[i].HasDefault
+                && !productParameters[i].Contains("=", StringComparison.Ordinal))
+            {
+                yield return new ValidityDiagnostic(
+                    "SIGDEFAULT",
+                    $"optional parameter '{function.Signature.Parameters[i].Name}' rendered without a default value");
+            }
+        }
+    }
+
+    static IReadOnlyList<string> SplitParameters(string parameterList)
+    {
+        if (string.IsNullOrWhiteSpace(parameterList))
+            return [];
+        var result = new List<string>();
+        int start = 0;
+        int angle = 0, paren = 0, bracket = 0;
+        bool inString = false, inChar = false, escape = false;
+        for (int i = 0; i < parameterList.Length; i++)
+        {
+            char c = parameterList[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+            if (c == '\\' && (inString || inChar))
+            {
+                escape = true;
+                continue;
+            }
+            if (c == '"' && !inChar)
+            {
+                inString = !inString;
+                continue;
+            }
+            if (c == '\'' && !inString)
+            {
+                inChar = !inChar;
+                continue;
+            }
+            if (inString || inChar)
+                continue;
+            switch (c)
+            {
+                case '<': angle++; break;
+                case '>': if (angle > 0) angle--; break;
+                case '(': paren++; break;
+                case ')': if (paren > 0) paren--; break;
+                case '[': bracket++; break;
+                case ']': if (bracket > 0) bracket--; break;
+                case ',' when angle == 0 && paren == 0 && bracket == 0:
+                    result.Add(parameterList[start..i].Trim());
+                    start = i + 1;
+                    break;
+            }
+        }
+        result.Add(parameterList[start..].Trim());
+        return result;
+    }
+
     /// <summary>Wraps a body in a generic instance method on a class so locals, params, type params, and `this` all bind; member access on `this` becomes filtered binding noise.</summary>
     internal static string Shell(IrFunction function, string body, string typeName, string methodName,
-        IReadOnlyDictionary<string, Dictionary<string, string>> constraints)
+        IReadOnlyDictionary<string, Dictionary<string, string>> constraints, string? productParameterList = null)
     {
         var generics = GenericParameterNames(function);
         string genericList = generics.Count > 0 ? "<" + string.Join(", ", generics) + ">" : "";
@@ -301,7 +454,7 @@ static class ValidityCheck
             ? ShellConstraints.Clauses(constraints, typeName, methodName, function, generics)
             : "";
         string returnType = TypeText(function.Signature.ReturnType);
-        string parameters = string.Join(", ", function.Signature.Parameters.Select(ParameterText));
+        string parameters = productParameterList ?? string.Join(", ", function.Signature.Parameters.Select(ParameterText));
         // A decompiled async method renders its `await` expressions faithfully, but
         // the original `async` modifier lives in metadata (the state machine), not in
         // the body. The shell must restore it or every awaiting body trips CS4032


### PR DESCRIPTION
## Summary

- claim and implement #1113 slice 1: the default-parameter validity oracle + matrix
- preserve `Parameter.HasDefault` through decompiler import, including decimal/DateTime constant attributes
- make `DecompilerHarness --validity-check` compile product-rendered parameter headers for methods with optional defaults, so invalid defaults are visible to the oracle
- add a default-shape fixture matrix covering value-type, enum, char/control, string escaping, decimal, nullable/reference null, and primitive defaults

## Verification

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check --compile-cap 20000 --max-examples 80`

The validity check now reports the matrix defects for `DefaultParameterFixtures`: `CharControlDefault` (CS1010), `StringSpecialDefault` (CS1003), `DecimalDefault` (SIGDEFAULT), `ValueTypeStructDefault` (CS1750), and `EnumNonZeroDefault` (CS1750).

Updates #1113.
