### PR TITLE
Raise catch-all EH regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -1481,6 +1481,7 @@ public class EhStructuringPassTests
         body.Add(tryBlock);
 
         var handlerBlock = new Block(0x0020);
+        handlerBlock.Add(new ExpressionStatement(new CaughtException(null)));
         handlerBlock.Add(new Leave(0x0030));
         body.Add(handlerBlock);
 
@@ -1493,6 +1494,104 @@ public class EhStructuringPassTests
             Holder,
             new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
             [],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Catch,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction CatchAllInsideFinallyRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0038));
+        body.Add(tryBlock);
+
+        var handlerBlock = new Block(0x0020);
+        handlerBlock.Add(new ExpressionStatement(new CaughtException(null)));
+        handlerBlock.Add(new Leave(0x0038));
+        body.Add(handlerBlock);
+
+        var sibling = new Block(0x0030);
+        sibling.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        body.Add(sibling);
+
+        var target = new Block(0x0038);
+        target.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        target.Add(new Leave(0x0050));
+        body.Add(target);
+
+        var finallyBlock = new Block(0x0040);
+        finallyBlock.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        finallyBlock.Add(new EndFinally());
+        body.Add(finallyBlock);
+
+        var tail = new Block(0x0050);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Finally,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0030,
+                    HandlerOffset: 0x0040,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+                new HandlerRegion(
+                    HandlerKind.Catch,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0020,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction CatchAllWithStoredExceptionRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0030));
+        body.Add(tryBlock);
+
+        var handlerBlock = new Block(0x0020);
+        handlerBlock.Add(new StoreLocal(0, Object, new CaughtException(null)));
+        handlerBlock.Add(new Leave(0x0030));
+        body.Add(handlerBlock);
+
+        var tail = new Block(0x0030);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Object],
             body)
         {
             Regions =
@@ -1873,9 +1972,45 @@ public class EhStructuringPassTests
     }
 
     [Fact]
-    public void FilterlessCatchRegion_KeepsRegionFlat()
+    public void FilterlessCatchRegion_RaisesToBareCatch()
     {
         var function = FilterlessCatchRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.Equal(Object, clause.ExceptionType);
+        Assert.Null(clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch", output);
+        Assert.DoesNotContain("catch (", output);
+    }
+
+    [Fact]
+    public void CatchAllInsideFinallyRegion_RaisesSiblingLeaveTarget()
+    {
+        var function = CatchAllInsideFinallyRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Single(function.Descendants.OfType<TryCatch>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch", output);
+        Assert.Contains("finally", output);
+        Assert.Contains("goto IL_0038;", output);
+    }
+
+    [Fact]
+    public void CatchAllWithStoredExceptionRegion_KeepsRegionFlat()
+    {
+        var function = CatchAllWithStoredExceptionRegion();
 
         new EhStructuringPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -1608,6 +1608,67 @@ public class EhStructuringPassTests
         };
     }
 
+    static IrFunction LeaveToSiblingLeaveOnlyBlock()
+    {
+        var body = new BlockContainer();
+
+        var outerTry = new Block(0x0000);
+        outerTry.Add(new Leave(0x0040));
+        body.Add(outerTry);
+
+        var outerCatchEntry = new Block(0x0010);
+        outerCatchEntry.Add(new ExpressionStatement(new CaughtException(FormatException)));
+        body.Add(outerCatchEntry);
+
+        var innerTry = new Block(0x0020);
+        innerTry.Add(new Leave(0x0038));
+        body.Add(innerTry);
+
+        var innerCatch = new Block(0x0030);
+        innerCatch.Add(new Throw(new CaughtException(null)));
+        body.Add(innerCatch);
+
+        var sibling = new Block(0x0034);
+        sibling.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        body.Add(sibling);
+
+        var leaveOnlyTarget = new Block(0x0038);
+        leaveOnlyTarget.Add(new Leave(0x0040));
+        body.Add(leaveOnlyTarget);
+
+        var tail = new Block(0x0040);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Catch,
+                    TryOffset: 0x0000,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0010,
+                    HandlerLength: 0x0030,
+                    FilterOffset: 0,
+                    CatchType: FormatException),
+                new HandlerRegion(
+                    HandlerKind.Catch,
+                    TryOffset: 0x0020,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0030,
+                    HandlerLength: 0x0004,
+                    FilterOffset: 0,
+                    CatchType: FormatException),
+            ],
+        };
+    }
+
     [Fact]
     public void LeaveRetryOutsideTry_ConsumesFinallyRegion()
     {
@@ -2011,6 +2072,17 @@ public class EhStructuringPassTests
     public void CatchAllWithStoredExceptionRegion_KeepsRegionFlat()
     {
         var function = CatchAllWithStoredExceptionRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+
+        Assert.NotEmpty(function.Regions);
+        Assert.Empty(function.Descendants.OfType<TryCatch>());
+    }
+
+    [Fact]
+    public void LeaveToSiblingLeaveOnlyBlock_KeepsRegionFlat()
+    {
+        var function = LeaveToSiblingLeaveOnlyBlock();
 
         new EhStructuringPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -22,6 +22,7 @@ namespace ILInspector.Decompiler.Pipeline;
 public sealed class EhStructuringPass : IIrPass
 {
     public string Name => "eh-structuring";
+    static TypeRef CatchAllType => TypeRef.CoreLib("System", "Object");
 
     /// <summary>One try with its contiguous handlers: a TryCatch's clauses share the protected range; a finally is always sole.</summary>
     sealed class Construct
@@ -44,8 +45,6 @@ public sealed class EhStructuringPass : IIrPass
         if (function.Regions.IsEmpty)
             return;
         if (function.Regions.Any(r => r.Kind is HandlerKind.Fault))
-            return;
-        if (function.Regions.Any(r => r.Kind is HandlerKind.Catch && r.CatchType is null))
             return;
 
         var blocks = function.Body.Blocks;
@@ -241,6 +240,7 @@ public sealed class EhStructuringPass : IIrPass
                         // idiom the build phase inlines back into the body.
                         if (!targetsContinuation
                             && !TargetsOutsideContainingConstructs(all, offset, leave.TargetOffset)
+                            && !TargetsWithinEnclosingSegment(all, offset, leave.TargetOffset)
                             && !IsInlineableReturn(blocks, offsetToIndex, leave.TargetOffset))
                             return false;
                         break;
@@ -337,14 +337,17 @@ public sealed class EhStructuringPass : IIrPass
             {
                 var statement = block.Children[s];
                 bool isEntry = handler is not null && block.StartOffset == handler.HandlerOffset && s == 0;
-                bool entryConsumption = isEntry && statement switch
-                {
-                    StoreLocal { Value: CaughtException } => true,
-                    ExpressionStatement { Expression: CaughtException } => true,
-                    _ => false,
-                };
-                if (entryConsumption)
+                bool catchAll = handler is { Kind: HandlerKind.Catch, CatchType: null };
+                bool entryDiscard = isEntry && statement is ExpressionStatement { Expression: CaughtException };
+                if (entryDiscard)
                     continue;
+                bool entryStore = isEntry && statement is StoreLocal { Value: CaughtException };
+                if (entryStore)
+                {
+                    if (catchAll)
+                        return false;
+                    continue;
+                }
                 if (statement is Throw { Value: CaughtException { Type: null } } && handler is not null)
                     continue;  // rethrow
                 foreach (var node in statement.Descendants.Prepend(statement))
@@ -353,6 +356,8 @@ public sealed class EhStructuringPass : IIrPass
                         continue;
                     // A CaughtException outside any catch handler cannot be spelled.
                     if (handler is null)
+                        return false;
+                    if (catchAll)
                         return false;
                     inlineUses[handler.HandlerOffset] = inlineUses.GetValueOrDefault(handler.HandlerOffset) + 1;
                 }
@@ -420,6 +425,27 @@ public sealed class EhStructuringPass : IIrPass
     }
 
     /// <summary>
+    /// True when a leave exits an inner construct but lands in the same try/catch
+    /// segment of an enclosing construct, without entering a sibling region. C#
+    /// can spell this as a goto to a label after/before the nested try statement.
+    /// </summary>
+    static bool TargetsWithinEnclosingSegment(List<Construct> all, int offset, int targetOffset)
+    {
+        var source = Zone(all, offset);
+        var target = Zone(all, targetOffset);
+        if (source.Construct is null
+            || target.Construct is null
+            || ReferenceEquals(source.Construct, target.Construct)
+            || source.Construct.Contains(targetOffset)
+            || !target.Construct.Contains(offset))
+        {
+            return false;
+        }
+
+        return SegmentWithin(target.Construct, offset) == target.Segment;
+    }
+
+    /// <summary>
     /// True when both offsets sit in the same segment of the same innermost
     /// construct — branches never cross a region boundary in the slice.
     /// </summary>
@@ -445,6 +471,19 @@ public sealed class EhStructuringPass : IIrPass
                 return (best, h);
         }
         return (best, -2);
+    }
+
+    static int SegmentWithin(Construct construct, int offset)
+    {
+        if (offset >= construct.TryStart && offset < construct.TryEnd)
+            return -1;
+        for (int h = 0; h < construct.Handlers.Count; h++)
+        {
+            var handler = construct.Handlers[h];
+            if (offset >= handler.HandlerOffset && offset < handler.HandlerOffset + handler.HandlerLength)
+                return h;
+        }
+        return -2;
     }
 
     /// <summary>Phase 2: rebuilds a block range as a container, nesting each construct into its statement node. Shapes were already proven.</summary>
@@ -508,7 +547,7 @@ public sealed class EhStructuringPass : IIrPass
                 }
                 else
                 {
-                    clauses.Add(new CatchClause(handler.CatchType!, body) { VariableIndex = variable });
+                    clauses.Add(new CatchClause(handler.CatchType ?? CatchAllType, body) { VariableIndex = variable });
                 }
             }
             node = new TryCatch(tryBody, clauses);
@@ -1352,6 +1391,8 @@ public sealed class EhStructuringPass : IIrPass
         foreach (var clause in root.Descendants.OfType<CatchClause>())
         {
             if (clause.VariableIndex is not null)
+                continue;
+            if (clause.ExceptionType.Equals(CatchAllType))
                 continue;
             var uses = clause.Descendants.OfType<CaughtException>()
                 .Where(caught => InnermostCatchClause(caught) == clause && !IsBareRethrow(caught))

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -240,7 +240,7 @@ public sealed class EhStructuringPass : IIrPass
                         // idiom the build phase inlines back into the body.
                         if (!targetsContinuation
                             && !TargetsOutsideContainingConstructs(all, offset, leave.TargetOffset)
-                            && !TargetsWithinEnclosingSegment(all, offset, leave.TargetOffset)
+                            && !TargetsWithinEnclosingSegment(blocks, all, offsetToIndex, offset, leave.TargetOffset)
                             && !IsInlineableReturn(blocks, offsetToIndex, leave.TargetOffset))
                             return false;
                         break;
@@ -429,8 +429,19 @@ public sealed class EhStructuringPass : IIrPass
     /// segment of an enclosing construct, without entering a sibling region. C#
     /// can spell this as a goto to a label after/before the nested try statement.
     /// </summary>
-    static bool TargetsWithinEnclosingSegment(List<Construct> all, int offset, int targetOffset)
+    static bool TargetsWithinEnclosingSegment(
+        IReadOnlyList<Block> blocks,
+        List<Construct> all,
+        Dictionary<int, int> offsetToIndex,
+        int offset,
+        int targetOffset)
     {
+        if (!offsetToIndex.TryGetValue(targetOffset, out int targetIndex)
+            || !HasPrintableLandingStatement(blocks[targetIndex]))
+        {
+            return false;
+        }
+
         var source = Zone(all, offset);
         var target = Zone(all, targetOffset);
         if (source.Construct is null
@@ -444,6 +455,9 @@ public sealed class EhStructuringPass : IIrPass
 
         return SegmentWithin(target.Construct, offset) == target.Segment;
     }
+
+    static bool HasPrintableLandingStatement(Block block)
+        => block.Children.Any(statement => statement is not Leave);
 
     /// <summary>
     /// True when both offsets sit in the same segment of the same innermost


### PR DESCRIPTION
Continues #913 with a narrow catch-all EH structuring slice, represented by `System.Gen2GcCallback::Finalize`.

Changes:
- treat null catch-type EH regions as C# bare `catch` when the caught value is discarded;
- allow `leave` out of an inner EH construct to a label in the same enclosing try/catch segment, without entering a sibling region;
- keep catch-all handlers that store/use the caught exception flat because C# bare `catch` has no variable form;
- keep same-segment leave targets flat when the landing block has no printable statement, avoiding dangling goto labels after leave-only blocks are trimmed.

Measured impact on current `origin/main` (`6e412c5c`):
- `--structuring-stops`: `unconsumed-regions` 14 -> 12.
- representative moves from `System.Gen2GcCallback::Finalize` to `System.TimeZoneInfo::TryGetTimeZoneFromLocalMachineCore`.
- `System.Gen2GcCallback::Finalize` loses validity defect CS0250.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs same-main baseline: no regressed defect codes.