### PR TITLE
Render enum optional defaults as enum literals

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -680,7 +681,7 @@ public static class ApiSurfaceExtractor
 
             if (hasDefault)
             {
-                paramStr += $" = {FormatDefaultValue(defaultValue, AcceptsNullDefault(paramTypes[i]))}";
+                paramStr += $" = {FormatDefaultValue(reader, defaultValue, type, AcceptsNullDefault(paramTypes[i]))}";
             }
 
             parameters.Add(paramStr);
@@ -760,7 +761,7 @@ public static class ApiSurfaceExtractor
         => node.IsReferenceType
             || node.Render().StartsWith("System.Nullable<", StringComparison.Ordinal);
 
-    private static string FormatDefaultValue(object? value, bool acceptsNullDefault)
+    private static string FormatDefaultValue(MetadataReader reader, object? value, string typeName, bool acceptsNullDefault)
     {
         // A null constant is `default(T)` for a non-nullable value-type parameter
         // (the only legal spelling — `T x = null` is CS1750), and a genuine `null`
@@ -769,6 +770,9 @@ public static class ApiSurfaceExtractor
         // (ELEMENT_TYPE_VALUETYPE), already on the decoded type node.
         if (value == null)
             return acceptsNullDefault ? "null" : "default";
+
+        if (TryFormatEnumDefaultValue(reader, value, typeName) is { } enumValue)
+            return enumValue;
 
         return value switch
         {
@@ -805,6 +809,107 @@ public static class ApiSurfaceExtractor
         }
         sb.Append('"');
         return sb.ToString();
+    }
+
+    private static string? TryFormatEnumDefaultValue(MetadataReader reader, object value, string typeName)
+    {
+        if (!TryConvertEnumConstant(value, out var defaultValue))
+            return null;
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!IsEnum(reader, typeDef))
+                continue;
+
+            var enumTypeName = TypeResolver.GetFullName(reader, typeDef);
+            if (!string.Equals(typeName, enumTypeName, StringComparison.Ordinal))
+                continue;
+
+            foreach (var fieldHandle in typeDef.GetFields())
+            {
+                var field = reader.GetFieldDefinition(fieldHandle);
+                if ((field.Attributes & FieldAttributes.Literal) == 0)
+                    continue;
+                var constantHandle = field.GetDefaultValue();
+                if (constantHandle.IsNil)
+                    continue;
+                var constant = reader.GetConstant(constantHandle);
+                if (TryReadEnumConstant(reader, constant, out var memberValue)
+                    && memberValue == defaultValue)
+                {
+                    return $"{typeName}.{reader.GetString(field.Name)}";
+                }
+            }
+
+            return $"({typeName}){defaultValue.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        return null;
+    }
+
+    private static bool IsEnum(MetadataReader reader, TypeDefinition typeDef)
+        => TypeResolver.GetTypeName(reader, typeDef.BaseType) == "System.Enum";
+
+    private static bool TryReadEnumConstant(MetadataReader reader, Constant constant, out decimal value)
+    {
+        var blob = reader.GetBlobReader(constant.Value);
+        switch (constant.TypeCode)
+        {
+            case ConstantTypeCode.SByte:
+                return TryConvertEnumConstant(blob.ReadSByte(), out value);
+            case ConstantTypeCode.Byte:
+                return TryConvertEnumConstant(blob.ReadByte(), out value);
+            case ConstantTypeCode.Int16:
+                return TryConvertEnumConstant(blob.ReadInt16(), out value);
+            case ConstantTypeCode.UInt16:
+                return TryConvertEnumConstant(blob.ReadUInt16(), out value);
+            case ConstantTypeCode.Int32:
+                return TryConvertEnumConstant(blob.ReadInt32(), out value);
+            case ConstantTypeCode.UInt32:
+                return TryConvertEnumConstant(blob.ReadUInt32(), out value);
+            case ConstantTypeCode.Int64:
+                return TryConvertEnumConstant(blob.ReadInt64(), out value);
+            case ConstantTypeCode.UInt64:
+                return TryConvertEnumConstant(blob.ReadUInt64(), out value);
+            default:
+                value = 0;
+                return false;
+        }
+    }
+
+    private static bool TryConvertEnumConstant(object value, out decimal converted)
+    {
+        switch (value)
+        {
+            case sbyte v:
+                converted = v;
+                return true;
+            case byte v:
+                converted = v;
+                return true;
+            case short v:
+                converted = v;
+                return true;
+            case ushort v:
+                converted = v;
+                return true;
+            case int v:
+                converted = v;
+                return true;
+            case uint v:
+                converted = v;
+                return true;
+            case long v:
+                converted = v;
+                return true;
+            case ulong v:
+                converted = v;
+                return true;
+            default:
+                converted = 0;
+                return false;
+        }
     }
 
     private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext, bool includeAll = false)
@@ -902,7 +1007,7 @@ public static class ApiSurfaceExtractor
             var modifier = isParams ? "params" : refKind;
             var parameter = modifier is null ? $"{paramType} {paramName}" : $"{modifier} {paramType} {paramName}";
             if (hasDefault)
-                parameter += $" = {FormatDefaultValue(defaultValue, AcceptsNullDefault(paramTypes[i]))}";
+                parameter += $" = {FormatDefaultValue(reader, defaultValue, paramType, AcceptsNullDefault(paramTypes[i]))}";
             indexerParameters.Add(parameter);
         }
 

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -103,7 +103,6 @@ public class ApiSurfaceExtractorTests
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
-
         var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
 
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
@@ -113,6 +112,31 @@ public class ApiSurfaceExtractorTests
 
         Assert.Contains("string text = \"a\\\"b\\\\c\\n\\u0001\"", method.Signature);
         Assert.DoesNotContain("a\"b\\c", method.Signature);
+    }
+
+    [Fact]
+    public void Extract_RendersEnumParameterDefaultsAsEnumLiterals()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleEnumDefaultHost));
+        Assert.NotNull(testType);
+
+        var green = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleEnumDefaultHost.Green));
+        Assert.NotNull(green);
+        Assert.Contains("DotnetInspector.Tests.SampleColor color = DotnetInspector.Tests.SampleColor.Green", green.Signature);
+
+        var zero = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleEnumDefaultHost.Zero));
+        Assert.NotNull(zero);
+        Assert.Contains("DotnetInspector.Tests.SampleColor color = DotnetInspector.Tests.SampleColor.Red", zero.Signature);
+
+        var unnamed = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleEnumDefaultHost.Unnamed));
+        Assert.NotNull(unnamed);
+        Assert.Contains("DotnetInspector.Tests.SampleFlags flags = (DotnetInspector.Tests.SampleFlags)3", unnamed.Signature);
     }
 
     [Fact]
@@ -513,6 +537,27 @@ public class SampleClassForTesting
     public void MethodWithNoParameters() { }
     public void GenericMethod<T>(T item) { }
     public void MethodWithStringDefault(string text = "a\"b\\c\n\u0001") { }
+}
+
+public enum SampleColor
+{
+    Red = 0,
+    Green = 1,
+    Blue = 2
+}
+
+[Flags]
+public enum SampleFlags
+{
+    One = 1,
+    Two = 2
+}
+
+public class SampleEnumDefaultHost
+{
+    public void Green(SampleColor color = SampleColor.Green) { }
+    public void Zero(SampleColor color = SampleColor.Red) { }
+    public void Unnamed(SampleFlags flags = (SampleFlags)3) { }
 }
 
 /// <summary>

--- a/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
@@ -69,6 +69,29 @@ public sealed class DefaultValueRenderingTests
     [Fact]
     public void Bool_Default_Unchanged()
         => Assert.Contains("b = true", Signature(nameof(DefaultValueFixtures.BoolDefault)));
+
+    [Fact]
+    public void Enum_NonZeroDefault_RendersMemberName()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.EnumNonZeroDefault));
+        Assert.Contains("color = ILInspector.Metadata.Tests.DefaultValueFixtures.SampleColor.Green", sig);
+        Assert.DoesNotContain("color = 1", sig);
+    }
+
+    [Fact]
+    public void Enum_ZeroDefault_RendersZeroMemberName()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.EnumZeroDefault));
+        Assert.Contains("color = ILInspector.Metadata.Tests.DefaultValueFixtures.SampleColor.Red", sig);
+        Assert.DoesNotContain("color = 0", sig);
+    }
+
+    [Fact]
+    public void Enum_UnnamedFlagsDefault_RendersCast()
+    {
+        var sig = Signature(nameof(DefaultValueFixtures.EnumUnnamedFlagsDefault));
+        Assert.Contains("flags = (ILInspector.Metadata.Tests.DefaultValueFixtures.SampleFlags)3", sig);
+    }
 }
 
 public class DefaultValueFixtures
@@ -81,4 +104,21 @@ public class DefaultValueFixtures
     public void NullableValueNull(int? n = null) { }
     public void IntDefault(int i = 5) { }
     public void BoolDefault(bool b = true) { }
+    public void EnumNonZeroDefault(SampleColor color = SampleColor.Green) { }
+    public void EnumZeroDefault(SampleColor color = SampleColor.Red) { }
+    public void EnumUnnamedFlagsDefault(SampleFlags flags = (SampleFlags)3) { }
+
+    public enum SampleColor
+    {
+        Red = 0,
+        Green = 1,
+        Blue = 2
+    }
+
+    [Flags]
+    public enum SampleFlags
+    {
+        One = 1,
+        Two = 2
+    }
 }


### PR DESCRIPTION
Refs #1113

## Summary
- render optional enum defaults as `EnumType.Member` when the value maps to a local enum field
- render unnamed enum/flags constants as explicit casts, e.g. `(EnumType)3`, instead of raw integer literals
- add enum cases to the #1113 default-value rendering matrix and extractor tests

## Validation
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`