### PR TITLE
Clarify hot-start burndown row ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ The current decompiler priority is high-value hardening:
   clearly negative.
 - Use `docs/decompiler-burndown-curator.md` for burndown queue hygiene: stale
   rows, merged PR state, merge conflicts, CI breaks, rebaseline triggers, and
-  safe subagent delegation.
+  safe subagent delegation. Claimed burndown rows are hot-start work: drive to a
+  PR, explicit blocker, or pivot issue.
 - Use PR-intent-informed adversarial reviewer passes for recent or broad raises:
   reconstruct the raise claim from the PR and current code, then falsify the
   discriminator with near-miss negative fixtures.

--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -58,6 +58,65 @@ gh issue view 1081 --json body -q .body > /tmp/issue-1081.md
 gh issue edit 1081 --body-file /tmp/issue-1081.md
 ```
 
+## Hot-start row ownership
+
+Burndown rows are **hot-start work**. Claiming a row means the agent starts
+immediately and drives to a concrete terminal state, normally a PR. It is not a
+reservation system.
+
+A claimed implementation/audit/curation row should proceed in one sitting as far
+as possible:
+
+1. create or reuse a dedicated worktree based on current `origin/main`;
+2. inspect the issue row and relevant code/tests;
+3. implement the narrow slice, audit fixture, or curation edit;
+4. run the row's validation commands;
+5. commit, push, and open a PR;
+6. update the burndown row to `In review — #PR`.
+
+The unacceptable states are:
+
+- `In progress` with no work started;
+- stopping at an internal milestone that does not produce a PR, pivot issue, or
+  explicit blocker;
+- leaving uncommitted local work with no PR and no clear handoff;
+- waiting for a human to notice that the row stalled.
+
+It is OK to pause and ask for clarity. A real blocking question should be
+concrete: name the design/taste decision, show the evidence, and state the
+options. If no answer is needed, keep going to PR. If the row proves too large,
+pivot it into one or more focused issues and update the row to `Pivoted`.
+
+For mechanical curator work, the PR may be documentation/test-metadata only. For
+code rows, "done locally" is not done; the row is not in review until the PR
+exists.
+
+## Multi-slice work
+
+Some burndowns intentionally decompose one family into sequential slices. Do not
+idle just because an earlier slice is awaiting merge if the next slice can start
+with high confidence that it will not conflict.
+
+Start the next slice when:
+
+- it touches disjoint files or an additive fixture/helper path;
+- the previous PR's public contract is stable enough to build against;
+- a rebase/merge conflict is unlikely or clearly mechanical;
+- the next slice has its own measured signal and done criteria.
+
+Wait instead when:
+
+- the next slice depends on unresolved design feedback from the previous PR;
+- both slices edit the same hotspot (`IrPasses`, `StructuringPass`,
+  `CSharpPrinter`, `LoweringCoverage`, sidecar facts, scorecard,
+  `CfgSampleClass`) in incompatible ways;
+- the previous PR may be rejected, narrowed, or pivoted;
+- a fresh rebaseline is required to choose the next measured row.
+
+When starting a safe next slice before the prior PR merges, say so in the row or
+comment, and keep the slice isolated in its own worktree/branch. If the earlier
+PR changes under it, resync before opening the next PR.
+
 ## Stale PRs
 
 A stale PR is one that has not moved recently, has merge conflicts, or has broken

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -224,6 +224,9 @@ Operational burndown queue hygiene — stale rows, merged PR status, merge
 conflicts, CI breaks, rebaseline triggers, and subagent delegation — is the
 **Decompiler Burndown Curator** role. Its protocol lives in
 [decompiler-burndown-curator.md](decompiler-burndown-curator.md).
+Burndown row ownership is hot-start work: a claimed row should proceed to a PR,
+explicit blocker, or pivot issue rather than waiting or stopping at an internal
+milestone.
 
 ### PR-intent-informed adversarial review
 


### PR DESCRIPTION
## Summary

- clarify that claimed burndown rows are hot-start work, not reservations
- require claimed rows to drive toward a PR, explicit blocker, or pivot issue
- document unacceptable stalled states like claim-and-wait and uncommitted local work with no PR
- clarify when multi-slice agents should start the next slice instead of waiting for a prior PR to merge

## Validation

- `npx markdownlint-cli AGENTS.md docs/decompiler-burndown-curator.md docs/decompiler-quality.md`
