### PR TITLE
Consume two-type catch filter regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -23,6 +23,7 @@ public class EhStructuringPassTests
     static readonly TypeRef ExceptionHandling = TypeRef.CoreLib("System", "ExceptionHandling");
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
+    static readonly TypeRef OutOfMemoryException = TypeRef.CoreLib("System", "OutOfMemoryException");
     static readonly TypeRef InvalidOperationExceptionType = TypeRef.CoreLib("System", "InvalidOperationException");
     static readonly TypeRef CustomNamedException = TypeRef.Definition("Synthetic", "Synthetic", "FakeException");
     static readonly MethodRef PredicateMethod = new(Holder, "Predicate", Bool, [], HasThis: false);
@@ -360,6 +361,90 @@ public class EhStructuringPassTests
                     TryOffset: 0x0010,
                     TryLength: 0x0010,
                     HandlerOffset: 0x0030,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction TwoTypeExceptionFilterRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0060));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(ExceptionType, new CaughtException(null))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, ExceptionType)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, ExceptionType), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0048));
+        body.Add(falseArm);
+
+        var typedException = new Block(0x0030);
+        typedException.Add(new StoreLocal(0, ExceptionType, new LoadStackSlot(0, ExceptionType)));
+        typedException.Add(new ConditionalBranch(new IsInstance(IOException, new LoadLocal(0, ExceptionType)), 0x0040));
+        body.Add(typedException);
+
+        var alternateTest = new Block(0x0038);
+        alternateTest.Add(new StoreStackSlot(
+            2,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new IsInstance(OutOfMemoryException, new LoadLocal(0, ExceptionType)),
+                new Constant(null, ExceptionType))));
+        alternateTest.Add(new Branch(0x0044));
+        body.Add(alternateTest);
+
+        var directMatch = new Block(0x0040);
+        directMatch.Add(new StoreStackSlot(2, new Constant(1, Int32)));
+        body.Add(directMatch);
+
+        var join = new Block(0x0044);
+        join.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadStackSlot(2, Int32),
+                new Constant(0, Int32))));
+        body.Add(join);
+
+        var endFilter = new Block(0x0048);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Int32)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0050);
+        handler.Add(new ExpressionStatement(new CaughtException(null)));
+        handler.Add(new StoreLocal(1, ExceptionType, new LoadLocal(0, ExceptionType)));
+        handler.Add(new Leave(0x0060));
+        body.Add(handler);
+
+        var tail = new Block(0x0060);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [ExceptionType, ExceptionType],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0050,
                     HandlerLength: 0x0010,
                     FilterOffset: 0x0020,
                     CatchType: null),
@@ -1778,6 +1863,27 @@ public class EhStructuringPassTests
 
         var output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("catch when (handle)", output);
+    }
+
+    [Fact]
+    public void TwoTypeExceptionFilterRegion_RaisesToCatchWhen()
+    {
+        var function = TwoTypeExceptionFilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+        Assert.Contains(clause.Body.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when", output);
+        Assert.Contains("V_0 is IOException", output);
+        Assert.Contains("V_0 is OutOfMemoryException", output);
+        Assert.Contains("||", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -630,6 +630,19 @@ public sealed class EhStructuringPass : IIrPass
             }
             return ioFilter;
         }
+        if (TryBuildTwoTypeExceptionFilter(filterBlocks) is { } twoTypeFilter)
+        {
+            if (preferredVariable is not null && twoTypeFilter.VariableIndex != preferredVariable)
+                return null;
+            if (preferredVariableType is not null && !twoTypeFilter.ExceptionType.Equals(preferredVariableType))
+                return null;
+            if (twoTypeFilter.VariableIndex is { } twoTypeVariable
+                && LocalReferencedOutsideFilterHandler(blocks, handler, twoTypeVariable))
+            {
+                return null;
+            }
+            return twoTypeFilter;
+        }
 
         return TryBuildTypedExceptionFilter(
             function,
@@ -954,6 +967,122 @@ public sealed class EhStructuringPass : IIrPass
         return new FilterInfo(exceptionType, variableIndex, new LogicalBinary(LogicalKind.Or, direct, inner));
     }
 
+    static FilterInfo? TryBuildTwoTypeExceptionFilter(IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var typedException,
+                var alternateTypeTest,
+                var directMatch,
+                var join,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var typedExceptionOffset },
+            ]
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || typedExceptionOffset != typedException.StartOffset
+            || !IsSupportedCatchFilterType(exceptionType))
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (typedException.Children is not
+            [
+                StoreLocal { Index: var variableIndex, Type: var storedExceptionType, Value: LoadStackSlot storedException },
+                ConditionalBranch { Condition: IsInstance { Type: var directTestedType, Operand: LoadLocal directOperand }, TargetOffset: var directMatchOffset },
+            ]
+            || storedException.Slot != copiedExceptionSlot
+            || !storedExceptionType.Equals(exceptionType)
+            || directOperand.Index != variableIndex
+            || directMatchOffset != directMatch.StartOffset
+            || !IsSupportedExceptionTypeTest(directTestedType))
+        {
+            return null;
+        }
+
+        if (alternateTypeTest.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var alternateResultSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: IsInstance { Type: var alternateTestedType, Operand: LoadLocal alternateOperand },
+                        Right: Constant { Value: null },
+                    },
+                },
+                Branch { TargetOffset: var joinOffset },
+            ]
+            || alternateOperand.Index != variableIndex
+            || joinOffset != join.StartOffset
+            || !IsSupportedExceptionTypeTest(alternateTestedType))
+        {
+            return null;
+        }
+
+        if (directMatch.Children is not
+            [
+                StoreStackSlot { Slot: var directResultSlot, Value: Constant { Value: true or 1 } },
+            ]
+            || directResultSlot != alternateResultSlot)
+        {
+            return null;
+        }
+
+        if (join.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var joinedVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: LoadStackSlot joinedResult,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || joinedVerdictSlot != verdictSlot
+            || joinedResult.Slot != alternateResultSlot)
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        var direct = new IsInstance(directTestedType, new LoadLocal(variableIndex, exceptionType));
+        var alternate = new IsInstance(alternateTestedType, new LoadLocal(variableIndex, exceptionType));
+        return new FilterInfo(exceptionType, variableIndex, new LogicalBinary(LogicalKind.Or, direct, alternate));
+    }
+
     static FilterInfo? TryBuildTypedExceptionFilter(
         IrFunction? function,
         IReadOnlyList<Block> blocks,
@@ -1166,6 +1295,12 @@ public sealed class EhStructuringPass : IIrPass
             && type.Namespace == "System"
             && type.DeclaredValueTypeHint != ValueTypeHint.ValueType
             && (type.Name == "Exception" || type.Name.EndsWith("Exception", StringComparison.Ordinal));
+
+    static bool IsSupportedExceptionTypeTest(TypeRef type)
+        => type.Kind == TypeRefKind.Definition
+            && type.Assembly == TypeRef.CoreLibrary
+            && type.DeclaredValueTypeHint != ValueTypeHint.ValueType
+            && type.Name.EndsWith("Exception", StringComparison.Ordinal);
 
     static bool ContainsExceptionAliasLoad(IrNode node, HashSet<int> aliases)
         => node is LoadStackSlot load && aliases.Contains(load.Slot)


### PR DESCRIPTION
Continues #913 with a narrow filter slice represented by `System.TimeZoneInfo::TryGetTimeZoneFromLocalMachineCore`.

Changes:
- recognize generated exception filters that type-test the caught `Exception` against two exception types and normalize through a boolean stack slot;
- raise them as a single `catch (Exception ex) when (ex is A || ex is B)` clause;
- keep the existing preferred-variable and local-scope guards so filter locals that escape outside the filter/handler remain flat.

Measured impact on current `origin/main` (`0abdc4de`):
- `--structuring-stops`: `unconsumed-regions` 12 -> 11.
- representative moves from `System.TimeZoneInfo::TryGetTimeZoneFromLocalMachineCore` to `System.Resources.ResourceReader::UseReflectionToGetType`.
- `TryGetTimeZoneFromLocalMachineCore` reaches Full fidelity.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs same-main baseline: no regressed defect codes.