### PR TITLE
Filter validity-shell static simple-name collisions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
@@ -22,8 +22,7 @@ public class DefaultParameterValidityTests
             .ToDictionary(m => m.Name, CompileSignature, StringComparer.Ordinal);
 
         AssertInvalid(results, nameof(DefaultParameterFixtures.CharControlDefault));
-        AssertInvalid(results, nameof(DefaultParameterFixtures.DecimalDefault), "SIGDEFAULT");
-
+        AssertClean(results, nameof(DefaultParameterFixtures.DecimalDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.ValueTypeStructDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.EnumNonZeroDefault));
         AssertClean(results, nameof(DefaultParameterFixtures.EnumZeroDefault));
@@ -46,7 +45,6 @@ public class DefaultParameterValidityTests
         Assert.Equal(
             [
                 nameof(DefaultParameterFixtures.CharControlDefault),
-                nameof(DefaultParameterFixtures.DecimalDefault),
             ],
             invalid);
     }

--- a/src/ILInspector.Decompiler.Tests/ShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShellNoiseTests.cs
@@ -24,6 +24,12 @@ public class ShellNoiseTests
     static TypeRef NonGenericComparison =>
         TypeRef.Definition("ILInspector.Decompiler", "ILInspector.Decompiler.Pipeline.Ir", "Comparison");
 
+    static TypeRef NonGenericConvert =>
+        TypeRef.Definition("ILInspector.Decompiler", "ILInspector.Decompiler.Pipeline", "Convert");
+
+    static TypeRef NestedEnvironment =>
+        TypeRef.Definition("ILInspector.Decompiler", "ILInspector.Decompiler.Pipeline", "LocalFunctionRaisingPass+Environment");
+
     [Fact]
     public void GenericInstance_IsRecognizedByItsSimpleName()
     {
@@ -81,6 +87,27 @@ public class ShellNoiseTests
         // CS0305 is the import collision and is filtered.
         var withCollision = Function(locals: [NonGenericComparison]);
         Assert.False(ShellNoise.ReferencesGenericTypeNamed(withCollision, "Comparison"));
+    }
+
+    [Fact]
+    public void ReferencesNonGenericTypeNamed_FindsLocalSiblingTypeCollision()
+    {
+        var withCollision = Function(locals: [NonGenericConvert]);
+        Assert.True(ShellNoise.ReferencesNonGenericTypeNamed(withCollision, "Convert"));
+    }
+
+    [Fact]
+    public void ReferencesNonGenericTypeNamed_FindsNestedSiblingTypeCollision()
+    {
+        var withCollision = Function(locals: [NestedEnvironment]);
+        Assert.True(ShellNoise.ReferencesNonGenericTypeNamed(withCollision, "Environment"));
+    }
+
+    [Fact]
+    public void ReferencesNonGenericTypeNamed_DoesNotHideGenericDefects()
+    {
+        var withGeneric = Function(locals: [ListOfInt]);
+        Assert.False(ShellNoise.ReferencesNonGenericTypeNamed(withGeneric, "List"));
     }
 
     static IrFunction Function(ImmutableArray<TypeRef> locals) =>

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -175,6 +175,7 @@ internal static class LibraryReport
                     .Where(d => !ValidityCheck.BindingNoise.Contains(d.Id))
                     .Where(d => !ValidityCheck.IsShellArtifact(d))
                     .Where(d => !ValidityCheck.IsGenericArityCollisionNoise(d, tree, function))
+                    .Where(d => !ValidityCheck.IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
                     .ToList();
                 if (defects.Count == 0)
                 {

--- a/tools/DecompilerHarness/ShellNoise.cs
+++ b/tools/DecompilerHarness/ShellNoise.cs
@@ -32,6 +32,23 @@ internal static class ShellNoise
     }
 
     /// <summary>
+    /// Does the decompiler's own model for <paramref name="function"/> reference a
+    /// non-generic type whose simple name is <paramref name="simpleName"/>? Used to
+    /// identify the sibling-free-shell collision where a valid local/sibling type
+    /// (for example the decompiler's IR node <c>Convert</c>) is wrapped in a shell
+    /// with blanket <c>using System;</c>, and Roslyn binds the bare name to the
+    /// imported static type <c>System.Convert</c> instead.
+    /// </summary>
+    internal static bool ReferencesNonGenericTypeNamed(IrFunction function, string simpleName)
+    {
+        foreach (var node in function.Descendants.Prepend(function))
+            foreach (var type in node.DirectTypes)
+                if (ContainsNonGenericTypeNamed(type, simpleName))
+                    return true;
+        return false;
+    }
+
+    /// <summary>
     /// Whether <paramref name="type"/> — or any type nested inside it (array element,
     /// by-ref/pointer pointee, or a type argument) — is a generic type whose simple
     /// name is <paramref name="simpleName"/>. Both a generic instantiation
@@ -51,6 +68,18 @@ internal static class ShellNoise
         return false;
     }
 
+    internal static bool ContainsNonGenericTypeNamed(TypeRef type, string simpleName)
+    {
+        if (IsNonGenericNamed(type, simpleName))
+            return true;
+        if (type.ElementType is { } element && ContainsNonGenericTypeNamed(element, simpleName))
+            return true;
+        foreach (var argument in type.TypeArguments)
+            if (ContainsNonGenericTypeNamed(argument, simpleName))
+                return true;
+        return false;
+    }
+
     static bool IsGenericNamed(TypeRef type, string simpleName) => type.Kind switch
     {
         // A generic instantiation: the simple name lives on the open definition.
@@ -63,20 +92,27 @@ internal static class ShellNoise
         _ => false,
     };
 
+    static bool IsNonGenericNamed(TypeRef type, string simpleName) => type.Kind switch
+    {
+        TypeRefKind.Definition =>
+            !HasArity(type.Name) && SimpleName(type.Name) == simpleName,
+        _ => false,
+    };
+
     /// <summary>The C# simple name of a metadata type name: innermost nested
     /// segment, with the generic-arity suffix stripped (<c>Outer+List`1</c> → <c>List</c>).</summary>
-    static string SimpleName(string metadataName)
+    internal static string SimpleName(string metadataName)
     {
-        int nested = metadataName.LastIndexOf('+');
-        string innermost = nested < 0 ? metadataName : metadataName[(nested + 1)..];
+        int qualifier = Math.Max(metadataName.LastIndexOf('+'), metadataName.LastIndexOf('.'));
+        string innermost = qualifier < 0 ? metadataName : metadataName[(qualifier + 1)..];
         int tick = innermost.IndexOf('`');
         return tick < 0 ? innermost : innermost[..tick];
     }
 
     static bool HasArity(string metadataName)
     {
-        int nested = metadataName.LastIndexOf('+');
-        string innermost = nested < 0 ? metadataName : metadataName[(nested + 1)..];
+        int qualifier = Math.Max(metadataName.LastIndexOf('+'), metadataName.LastIndexOf('.'));
+        string innermost = qualifier < 0 ? metadataName : metadataName[(qualifier + 1)..];
         int tick = innermost.IndexOf('`');
         return tick >= 0 && int.TryParse(innermost[(tick + 1)..], out int arity) && arity > 0;
     }

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -211,6 +211,7 @@ static class ValidityCheck
                         .Where(d => !BindingNoise.Contains(d.Id))
                         .Where(d => !IsShellArtifact(d))
                         .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
+                        .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
                     results.Add(new MethodResult(typeName, methodName, full, [], SemanticChecked: true, defects));
@@ -620,6 +621,54 @@ static class ValidityCheck
         // generic of that name, i.e. the bare name is genuinely a non-generic type
         // (or non-type) that merely collides with an imported generic.
         return !ShellNoise.ReferencesGenericTypeNamed(function, name.Identifier.ValueText);
+    }
+
+    /// <summary>
+    /// Static-type misuse diagnostics on a bare simple-name type that the
+    /// decompiler model knows as a non-generic local/sibling type. In the real
+    /// whole-type output, the current namespace type wins over blanket imports;
+    /// only the standalone validity shell can mis-bind it to imported static types
+    /// such as <c>System.Convert</c> or <c>System.Environment</c>.
+    /// </summary>
+    internal static bool IsSimpleNameStaticTypeCollisionNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function)
+    {
+        if (diagnostic.Id is not ("CS0712" or "CS0721" or "CS0722" or "CS0723"))
+            return false;
+        if (diagnostic.Location.SourceTree != tree)
+            return false;
+
+        string? simpleName = SimpleNameAtDiagnosticLocation(diagnostic, tree)
+            ?? SimpleNameFromDiagnosticMessage(diagnostic);
+        if (simpleName is null)
+            return false;
+
+        return ShellNoise.ReferencesNonGenericTypeNamed(function, simpleName)
+            && !ShellNoise.ReferencesGenericTypeNamed(function, simpleName);
+    }
+
+    static string? SimpleNameAtDiagnosticLocation(Diagnostic diagnostic, SyntaxTree tree)
+    {
+        var node = tree.GetRoot().FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        if (node.FirstAncestorOrSelf<IdentifierNameSyntax>() is { } name)
+            return name.Identifier.ValueText;
+        if (node.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>() is { Type: IdentifierNameSyntax objectType })
+            return objectType.Identifier.ValueText;
+        return null;
+    }
+
+    static string? SimpleNameFromDiagnosticMessage(Diagnostic diagnostic)
+    {
+        var message = diagnostic.GetMessage();
+        int start = message.IndexOf('\'');
+        if (start < 0)
+            return null;
+        int end = message.IndexOf('\'', start + 1);
+        if (end <= start + 1)
+            return null;
+        var quoted = message[(start + 1)..end];
+        if (quoted.Any(c => !(char.IsLetterOrDigit(c) || c is '_' or '.' or '+')))
+            return null;
+        return ShellNoise.SimpleName(quoted);
     }
 
     internal static ImmutableArray<MetadataReference> RuntimeReferences()


### PR DESCRIPTION
Refs #1017

## Summary
- classify validity-shell static type collisions (`CS0712`, `CS0721`, `CS0722`, `CS0723`) as shell noise when the decompiler model references a same-named non-generic local/sibling type
- apply the same filter in `--library-report` validity buckets
- add ShellNoise coverage for `Convert` and nested `Environment` sibling-name collisions without hiding generic defects
- sync the default-parameter validity matrix expectation after the decimal default fix merged

This addresses the measurement-accuracy side of #1017; the separate product-side work for detectable CS0104-style collisions remains open.

## Measurement
`ILInspector.Decompiler.dll --validity-check --compile-cap 10000` on current `origin/main` before this branch:
- semantic defect methods: 25
- `CS0723`: 12
- `CS0721`: 9
- `CS0712`/`CS0722`: 1 each

After this branch:
- semantic defect methods: 7
- `CS0712`/`CS0721`/`CS0722`/`CS0723`: 0

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/obj/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --validity-check --compile-cap 10000 --emit-validity-defects /tmp/issue1017-decompiler-defects-final.txt`