### PR TITLE
Consume three-type catch filter regions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -17,6 +17,7 @@ public class EhStructuringPassTests
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef ArgumentException = TypeRef.CoreLib("System", "ArgumentException");
     static readonly TypeRef ExceptionType = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
@@ -25,6 +26,7 @@ public class EhStructuringPassTests
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
     static readonly TypeRef OutOfMemoryException = TypeRef.CoreLib("System", "OutOfMemoryException");
+    static readonly TypeRef UnauthorizedAccessException = TypeRef.CoreLib("System", "UnauthorizedAccessException");
     static readonly TypeRef InvalidOperationExceptionType = TypeRef.CoreLib("System", "InvalidOperationException");
     static readonly TypeRef CustomNamedException = TypeRef.Definition("Synthetic", "Synthetic", "FakeException");
     static readonly MethodRef PredicateMethod = new(Holder, "Predicate", Bool, [], HasThis: false);
@@ -446,6 +448,98 @@ public class EhStructuringPassTests
                     TryOffset: 0x0010,
                     TryLength: 0x0010,
                     HandlerOffset: 0x0050,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction ThreeTypeExceptionFilterWithTempVerdictRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0070));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(ExceptionType, new CaughtException(Object))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, ExceptionType)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, ExceptionType), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0058));
+        body.Add(falseArm);
+
+        var firstTest = new Block(0x0030);
+        firstTest.Add(new StoreLocal(0, ExceptionType, new LoadStackSlot(0, ExceptionType)));
+        firstTest.Add(new ConditionalBranch(new IsInstance(ArgumentException, new LoadLocal(0, ExceptionType)), 0x0048));
+        body.Add(firstTest);
+
+        var secondTest = new Block(0x0038);
+        secondTest.Add(new ConditionalBranch(new IsInstance(IOException, new LoadLocal(0, ExceptionType)), 0x0048));
+        body.Add(secondTest);
+
+        var thirdTest = new Block(0x0040);
+        thirdTest.Add(new ConditionalBranch(
+            new LogicalNot(new IsInstance(UnauthorizedAccessException, new LoadLocal(0, ExceptionType))),
+            0x0050));
+        body.Add(thirdTest);
+
+        var trueVerdict = new Block(0x0048);
+        trueVerdict.Add(new StoreLocal(1, Bool, new Constant(true, Bool)));
+        trueVerdict.Add(new Branch(0x0054));
+        body.Add(trueVerdict);
+
+        var falseVerdict = new Block(0x0050);
+        falseVerdict.Add(new StoreLocal(1, Bool, new Constant(false, Bool)));
+        body.Add(falseVerdict);
+
+        var join = new Block(0x0054);
+        join.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadLocal(1, Bool),
+                new Constant(false, Bool))));
+        body.Add(join);
+
+        var endFilter = new Block(0x0058);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Int32)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0060);
+        handler.Add(new ExpressionStatement(new CaughtException(Object)));
+        handler.Add(new StoreLocal(2, Bool, new Constant(false, Bool)));
+        handler.Add(new Leave(0x0078));
+        body.Add(handler);
+
+        var success = new Block(0x0070);
+        success.Add(new Return(new Constant(true, Bool)));
+        body.Add(success);
+
+        var failure = new Block(0x0078);
+        failure.Add(new Return(new LoadLocal(2, Bool)));
+        body.Add(failure);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Bool, [], HasThis: false, GenericParameterCount: 0),
+            [ExceptionType, Bool, Bool],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0060,
                     HandlerLength: 0x0010,
                     FilterOffset: 0x0020,
                     CatchType: null),
@@ -1954,6 +2048,27 @@ public class EhStructuringPassTests
         Assert.Contains("V_0 is IOException", output);
         Assert.Contains("V_0 is OutOfMemoryException", output);
         Assert.Contains("||", output);
+    }
+
+    [Fact]
+    public void ThreeTypeExceptionFilterWithTempVerdictRegion_RaisesToCatchWhen()
+    {
+        var function = ThreeTypeExceptionFilterWithTempVerdictRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when", output);
+        Assert.Contains("V_0 is ArgumentException", output);
+        Assert.Contains("V_0 is IOException", output);
+        Assert.Contains("V_0 is UnauthorizedAccessException", output);
+        Assert.DoesNotContain("bool V_1", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -643,6 +643,19 @@ public sealed class EhStructuringPass : IIrPass
             }
             return twoTypeFilter;
         }
+        if (TryBuildThreeTypeExceptionFilter(blocks, handler, filterBlocks) is { } threeTypeFilter)
+        {
+            if (preferredVariable is not null && threeTypeFilter.VariableIndex != preferredVariable)
+                return null;
+            if (preferredVariableType is not null && !threeTypeFilter.ExceptionType.Equals(preferredVariableType))
+                return null;
+            if (threeTypeFilter.VariableIndex is { } threeTypeVariable
+                && LocalReferencedOutsideFilterHandler(blocks, handler, threeTypeVariable))
+            {
+                return null;
+            }
+            return threeTypeFilter;
+        }
 
         return TryBuildTypedExceptionFilter(
             function,
@@ -1081,6 +1094,150 @@ public sealed class EhStructuringPass : IIrPass
         var direct = new IsInstance(directTestedType, new LoadLocal(variableIndex, exceptionType));
         var alternate = new IsInstance(alternateTestedType, new LoadLocal(variableIndex, exceptionType));
         return new FilterInfo(exceptionType, variableIndex, new LogicalBinary(LogicalKind.Or, direct, alternate));
+    }
+
+    static FilterInfo? TryBuildThreeTypeExceptionFilter(
+        IReadOnlyList<Block> blocks,
+        HandlerRegion handler,
+        IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var firstTest,
+                var secondTest,
+                var thirdTest,
+                var trueVerdict,
+                var falseVerdict,
+                var join,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var firstTestOffset },
+            ]
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || firstTestOffset != firstTest.StartOffset
+            || !IsSupportedCatchFilterType(exceptionType))
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (firstTest.Children is not
+            [
+                StoreLocal { Index: var variableIndex, Type: var storedExceptionType, Value: LoadStackSlot storedException },
+                ConditionalBranch { Condition: IsInstance { Type: var firstType, Operand: LoadLocal firstOperand }, TargetOffset: var firstTrueOffset },
+            ]
+            || storedException.Slot != copiedExceptionSlot
+            || !storedExceptionType.Equals(exceptionType)
+            || firstOperand.Index != variableIndex
+            || firstTrueOffset != trueVerdict.StartOffset
+            || !IsSupportedExceptionTypeTest(firstType))
+        {
+            return null;
+        }
+
+        if (secondTest.Children is not
+            [
+                ConditionalBranch { Condition: IsInstance { Type: var secondType, Operand: LoadLocal secondOperand }, TargetOffset: var secondTrueOffset },
+            ]
+            || secondOperand.Index != variableIndex
+            || secondTrueOffset != trueVerdict.StartOffset
+            || !IsSupportedExceptionTypeTest(secondType))
+        {
+            return null;
+        }
+
+        if (thirdTest.Children is not
+            [
+                ConditionalBranch
+                {
+                    Condition: LogicalNot { Operand: IsInstance { Type: var thirdType, Operand: LoadLocal thirdOperand } },
+                    TargetOffset: var falseOffset,
+                },
+            ]
+            || thirdOperand.Index != variableIndex
+            || falseOffset != falseVerdict.StartOffset
+            || !IsSupportedExceptionTypeTest(thirdType))
+        {
+            return null;
+        }
+
+        if (firstType.Equals(secondType) || firstType.Equals(thirdType) || secondType.Equals(thirdType))
+            return null;
+
+        if (trueVerdict.Children is not
+            [
+                StoreLocal { Index: var verdictLocal, Type: var verdictLocalType, Value: Constant { Value: true or 1 } },
+                Branch { TargetOffset: var joinOffset },
+            ]
+            || joinOffset != join.StartOffset)
+        {
+            return null;
+        }
+
+        if (falseVerdict.Children is not
+            [
+                StoreLocal { Index: var falseVerdictLocal, Type: var falseVerdictLocalType, Value: Constant { Value: false or 0 } },
+            ]
+            || falseVerdictLocal != verdictLocal
+            || !falseVerdictLocalType.Equals(verdictLocalType)
+            || LocalReferencedOutsideFilterHandler(blocks, handler, verdictLocal))
+        {
+            return null;
+        }
+
+        if (join.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var joinedVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: LoadLocal joinedResult,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || joinedVerdictSlot != verdictSlot
+            || joinedResult.Index != verdictLocal)
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        var first = new IsInstance(firstType, new LoadLocal(variableIndex, exceptionType));
+        var second = new IsInstance(secondType, new LoadLocal(variableIndex, exceptionType));
+        var third = new IsInstance(thirdType, new LoadLocal(variableIndex, exceptionType));
+        return new FilterInfo(
+            exceptionType,
+            variableIndex,
+            new LogicalBinary(LogicalKind.Or, new LogicalBinary(LogicalKind.Or, first, second), third));
     }
 
     static FilterInfo? TryBuildTypedExceptionFilter(


### PR DESCRIPTION
Continues #1135 with the remaining filter lane, represented by `System.IO.Path::Exists`.

Changes:
- recognize generated catch filters that normalize a three-exception OR chain through a temporary bool verdict local;
- raise the filter as `catch (Exception ex) when (ex is A || ex is B || ex is C)`;
- keep exact guards for block layout, distinct corelib exception types, local-scope safety for the exception variable and verdict temp, and the existing handler/leave checks.

Measured impact on current `origin/main` (`102a38b1`):
- `--structuring-stops`: `unconsumed-regions` 9 -> 8.
- EH-entangled filter subshape shrinks from 2 -> 1; remaining filter representative is `System.IO.Strategies.BufferedFileStreamStrategy::Dispose`.
- `System.IO.Path::Exists` reaches Full fidelity.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs same-main baseline: no regressed defect codes.