### PR TITLE
Consume IO-related dispose catch filters

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -23,6 +23,7 @@ public class EhStructuringPassTests
     static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef ExceptionHandling = TypeRef.CoreLib("System", "ExceptionHandling");
     static readonly TypeRef FileNotFoundException = TypeRef.CoreLib("System.IO", "FileNotFoundException");
+    static readonly TypeRef FileStreamHelpers = TypeRef.CoreLib("System.IO.Strategies", "FileStreamHelpers");
     static readonly TypeRef FormatException = TypeRef.CoreLib("System", "FormatException");
     static readonly TypeRef IOException = TypeRef.CoreLib("System.IO", "IOException");
     static readonly TypeRef OutOfMemoryException = TypeRef.CoreLib("System", "OutOfMemoryException");
@@ -31,6 +32,7 @@ public class EhStructuringPassTests
     static readonly TypeRef CustomNamedException = TypeRef.Definition("Synthetic", "Synthetic", "FakeException");
     static readonly MethodRef PredicateMethod = new(Holder, "Predicate", Bool, [], HasThis: false);
     static readonly MethodRef MakeExceptionMethod = new(Holder, "MakeException", ExceptionType, [], HasThis: false);
+    static readonly MethodRef IsIoRelatedExceptionMethod = new(FileStreamHelpers, "IsIoRelatedException", Bool, [ExceptionType], HasThis: false);
 
     static IrFunction LeaveRetryOutsideTry()
     {
@@ -540,6 +542,85 @@ public class EhStructuringPassTests
                     TryOffset: 0x0010,
                     TryLength: 0x0010,
                     HandlerOffset: 0x0060,
+                    HandlerLength: 0x0010,
+                    FilterOffset: 0x0020,
+                    CatchType: null),
+            ],
+        };
+    }
+
+    static IrFunction IoRelatedDisposeFilterRegion()
+    {
+        var body = new BlockContainer();
+
+        var tryBlock = new Block(0x0010);
+        tryBlock.Add(new Leave(0x0060));
+        body.Add(tryBlock);
+
+        var typeTest = new Block(0x0020);
+        typeTest.Add(new StoreStackSlot(256, new IsInstance(ExceptionType, new CaughtException(Object))));
+        typeTest.Add(new StoreStackSlot(0, new LoadStackSlot(256, ExceptionType)));
+        typeTest.Add(new ConditionalBranch(new LoadStackSlot(256, ExceptionType), 0x0030));
+        body.Add(typeTest);
+
+        var falseArm = new Block(0x0028);
+        falseArm.Add(new StoreStackSlot(1, new Constant(0, Int32)));
+        falseArm.Add(new Branch(0x0048));
+        body.Add(falseArm);
+
+        var typedException = new Block(0x0030);
+        typedException.Add(new StoreLocal(0, ExceptionType, new LoadStackSlot(0, ExceptionType)));
+        typedException.Add(new ConditionalBranch(new LoadArgument(0, "disposing", Bool), 0x0040));
+        body.Add(typedException);
+
+        var helperCall = new Block(0x0038);
+        helperCall.Add(new StoreStackSlot(
+            2,
+            new Call(IsIoRelatedExceptionMethod, isVirtual: false, [new LoadLocal(0, ExceptionType)])));
+        helperCall.Add(new Branch(0x0044));
+        body.Add(helperCall);
+
+        var suppressed = new Block(0x0040);
+        suppressed.Add(new StoreStackSlot(2, new Constant(0, Int32)));
+        body.Add(suppressed);
+
+        var join = new Block(0x0044);
+        join.Add(new StoreStackSlot(
+            1,
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: true,
+                new LoadStackSlot(2, Int32),
+                new Constant(0, Int32))));
+        body.Add(join);
+
+        var endFilter = new Block(0x0048);
+        endFilter.Add(new EndFilter(new LoadStackSlot(1, Int32)));
+        body.Add(endFilter);
+
+        var handler = new Block(0x0050);
+        handler.Add(new ExpressionStatement(new CaughtException(Object)));
+        handler.Add(new Leave(0x0060));
+        body.Add(handler);
+
+        var tail = new Block(0x0060);
+        tail.Add(new Return(null));
+        body.Add(tail);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("disposing", Bool)], HasThis: false, GenericParameterCount: 0),
+            [ExceptionType],
+            body)
+        {
+            Regions =
+            [
+                new HandlerRegion(
+                    HandlerKind.Filter,
+                    TryOffset: 0x0010,
+                    TryLength: 0x0010,
+                    HandlerOffset: 0x0050,
                     HandlerLength: 0x0010,
                     FilterOffset: 0x0020,
                     CatchType: null),
@@ -2069,6 +2150,25 @@ public class EhStructuringPassTests
         Assert.Contains("V_0 is IOException", output);
         Assert.Contains("V_0 is UnauthorizedAccessException", output);
         Assert.DoesNotContain("bool V_1", output);
+    }
+
+    [Fact]
+    public void IoRelatedDisposeFilterRegion_RaisesToCatchWhen()
+    {
+        var function = IoRelatedDisposeFilterRegion();
+
+        new EhStructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Regions);
+        var clause = Assert.Single(Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses);
+        Assert.NotNull(clause.Filter);
+        Assert.Equal(0, clause.VariableIndex);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("catch (Exception V_0) when", output);
+        Assert.Contains("!disposing", output);
+        Assert.Contains("FileStreamHelpers.IsIoRelatedException(V_0)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -10,6 +10,7 @@ public static class MemberIdentity
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_char = TypeRef.CoreLib("System", "Char");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
@@ -149,6 +150,18 @@ public static class MemberIdentity
                 "AsyncHelpers",
                 "Await")
             && call.Callee.ParameterTypes.Length == 1
+            && call.Arguments.Count == 1;
+
+    public static bool IsFileStreamHelpersIsIoRelatedException(Call call)
+        => !call.IsVirtual
+            && IsStaticCoreLibraryMethod(
+                call.Callee,
+                "System.IO.Strategies",
+                "FileStreamHelpers",
+                "IsIoRelatedException")
+            && call.Callee.ReturnType.Equals(s_bool)
+            && call.Callee.ParameterTypes is [var exception]
+            && exception.Equals(s_exception)
             && call.Arguments.Count == 1;
 
     public static bool IsDefaultInterpolatedStringHandlerConstructor(NewObject newObject)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/EhStructuringPass.cs
@@ -656,6 +656,19 @@ public sealed class EhStructuringPass : IIrPass
             }
             return threeTypeFilter;
         }
+        if (TryBuildIoRelatedDisposeFilter(filterBlocks) is { } disposeFilter)
+        {
+            if (preferredVariable is not null && disposeFilter.VariableIndex != preferredVariable)
+                return null;
+            if (preferredVariableType is not null && !disposeFilter.ExceptionType.Equals(preferredVariableType))
+                return null;
+            if (disposeFilter.VariableIndex is { } disposeVariable
+                && LocalReferencedOutsideFilterHandler(blocks, handler, disposeVariable))
+            {
+                return null;
+            }
+            return disposeFilter;
+        }
 
         return TryBuildTypedExceptionFilter(
             function,
@@ -1238,6 +1251,117 @@ public sealed class EhStructuringPass : IIrPass
             exceptionType,
             variableIndex,
             new LogicalBinary(LogicalKind.Or, new LogicalBinary(LogicalKind.Or, first, second), third));
+    }
+
+    static FilterInfo? TryBuildIoRelatedDisposeFilter(IReadOnlyList<Block> filterBlocks)
+    {
+        if (filterBlocks is not
+            [
+                var typeTest,
+                var falseArm,
+                var typedException,
+                var helperCall,
+                var suppressed,
+                var join,
+                var end,
+            ])
+        {
+            return null;
+        }
+
+        if (typeTest.Children is not
+            [
+                StoreStackSlot { Slot: var exceptionSlot, Value: IsInstance { Type: var exceptionType, Operand: CaughtException } },
+                StoreStackSlot { Slot: var copiedExceptionSlot, Value: LoadStackSlot copiedException },
+                ConditionalBranch { Condition: LoadStackSlot testedException, TargetOffset: var typedExceptionOffset },
+            ]
+            || !exceptionType.Equals(TypeRef.CoreLib("System", "Exception"))
+            || copiedException.Slot != exceptionSlot
+            || testedException.Slot != exceptionSlot
+            || typedExceptionOffset != typedException.StartOffset)
+        {
+            return null;
+        }
+
+        if (falseArm.Children is not
+            [
+                StoreStackSlot { Slot: var verdictSlot, Value: Constant { Value: false or 0 } },
+                Branch { TargetOffset: var endOffset },
+            ]
+            || endOffset != end.StartOffset)
+        {
+            return null;
+        }
+
+        if (typedException.Children is not
+            [
+                StoreLocal { Index: var variableIndex, Type: var storedExceptionType, Value: LoadStackSlot storedException },
+                ConditionalBranch { Condition: var guardValue, TargetOffset: var suppressedOffset },
+            ]
+            || storedException.Slot != copiedExceptionSlot
+            || !storedExceptionType.Equals(exceptionType)
+            || suppressedOffset != suppressed.StartOffset
+            || BoolFilterCondition(guardValue) is not { } guard)
+        {
+            return null;
+        }
+
+        if (helperCall.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var helperResultSlot,
+                    Value: Call { Arguments: [LoadLocal helperArgument] } helper,
+                },
+                Branch { TargetOffset: var joinOffset },
+            ]
+            || helperArgument.Index != variableIndex
+            || joinOffset != join.StartOffset
+            || !MemberIdentity.IsFileStreamHelpersIsIoRelatedException(helper))
+        {
+            return null;
+        }
+
+        if (suppressed.Children is not
+            [
+                StoreStackSlot { Slot: var suppressedResultSlot, Value: Constant { Value: false or 0 } },
+            ]
+            || suppressedResultSlot != helperResultSlot)
+        {
+            return null;
+        }
+
+        if (join.Children is not
+            [
+                StoreStackSlot
+                {
+                    Slot: var joinedVerdictSlot,
+                    Value: Comparison
+                    {
+                        Kind: ComparisonKind.GreaterThan,
+                        IsUnsigned: true,
+                        Left: LoadStackSlot joinedResult,
+                        Right: Constant { Value: false or 0 },
+                    },
+                },
+            ]
+            || joinedVerdictSlot != verdictSlot
+            || joinedResult.Slot != helperResultSlot)
+        {
+            return null;
+        }
+
+        if (end.Children is not [EndFilter { Value: LoadStackSlot finalVerdict }]
+            || finalVerdict.Slot != verdictSlot)
+        {
+            return null;
+        }
+
+        var helperCondition = new Call(helper.Callee, isVirtual: false, [new LoadLocal(variableIndex, exceptionType)]);
+        return new FilterInfo(
+            exceptionType,
+            variableIndex,
+            new LogicalBinary(LogicalKind.And, new LogicalNot(guard), helperCondition));
     }
 
     static FilterInfo? TryBuildTypedExceptionFilter(


### PR DESCRIPTION
Continues #1135 with the final filter-lane representative, `System.IO.Strategies.BufferedFileStreamStrategy::Dispose`.

Changes:
- add an exact `MemberIdentity` predicate for `System.IO.Strategies.FileStreamHelpers.IsIoRelatedException(Exception)`;
- recognize the generated filter shape `!disposing && FileStreamHelpers.IsIoRelatedException(ex)`;
- raise it as `catch (Exception ex) when (!disposing && FileStreamHelpers.IsIoRelatedException(ex))`;
- keep exact block-shape, variable-scope, and member-identity guards.

Measured impact on current `origin/main` (`a44a4458`):
- `--structuring-stops`: `unconsumed-regions` 8 -> 7.
- EH-entangled filter subshape shrinks from 1 -> 0.
- `System.IO.Strategies.BufferedFileStreamStrategy::Dispose` reaches Full fidelity.

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `tools/DecompilerHarness --validity-check --compile-cap 10000 --diff-validity-defects` vs same-main baseline: no regressed defect codes.