### PR TITLE
Render generic constraints in whole-type source

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -121,6 +121,56 @@ public class TypeSourceCheckTests
         Assert.Empty(TypeSourceCheck.CompareType(type, source));
     }
 
+    [Fact]
+    public void GenericConstraints_MatchMetadata()
+    {
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "C`2",
+            Kind = "class",
+            TypeParameters =
+            [
+                new TypeParameter { Name = "TKey", Constraints = ["class"] },
+                new TypeParameter { Name = "TValue", Constraints = ["System.IDisposable", "new()"] },
+            ],
+            Members = [Member("Foo", "method")],
+        };
+        string source = """
+            namespace N;
+            public class C<TKey, TValue> where TKey : class where TValue : System.IDisposable, new()
+            {
+                public void Foo() { }
+            }
+            """;
+
+        Assert.Empty(TypeSourceCheck.CompareType(type, source));
+    }
+
+    [Fact]
+    public void DroppedGenericConstraint_IsCaught()
+    {
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "C`1",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "T", Constraints = ["struct"] }],
+            Members = [Member("Foo", "method")],
+        };
+        string source = """
+            namespace N;
+            public class C<T>
+            {
+                public void Foo() { }
+            }
+            """;
+
+        var deltas = TypeSourceCheck.CompareType(type, source);
+        Assert.Contains(deltas, d => d.Kind == TypeSourceCheck.Deltas.GenericConstraintDropped
+            && d.Detail == "T : struct");
+    }
+
     [Theory]
     [InlineData("System.ArgIterator", "public ref struct ArgIterator")]
     [InlineData("System.DateTime", "public readonly struct DateTime")]
@@ -137,6 +187,22 @@ public class TypeSourceCheckTests
 
         var deltas = TypeSourceCheck.CompareType(type, source);
         Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.ModifierDropped);
+    }
+
+    [Fact]
+    public void Evaluate_OnExtractorFixture_DoesNotReportGenericConstraintDeltas()
+    {
+        string path = typeof(int).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == "System.Nullable`1");
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+        Assert.Contains("where T : struct", source);
+
+        var deltas = TypeSourceCheck.CompareType(type, source);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.GenericConstraintDropped);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.GenericConstraintExtra);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -138,6 +138,7 @@ public static class TypeSourceComposer
         bases.AddRange(type.Interfaces);
         if (bases.Count > 0)
             sb.Append($" : {string.Join(", ", bases)}");
+        AppendTypeParameterConstraints(sb, type.TypeParameters);
         return sb.ToString();
     }
 
@@ -150,6 +151,15 @@ public static class TypeSourceComposer
         if (type.TypeParameters.Count > 0)
             name += $"<{string.Join(", ", type.TypeParameters.Select(p => p.Name))}>";
         return name;
+    }
+
+    static void AppendTypeParameterConstraints(StringBuilder sb, IReadOnlyList<TypeParameter> typeParameters)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            if (typeParameter.ConstraintsSummary is { } constraints)
+                sb.Append($" where {typeParameter.Name} : {constraints}");
+        }
     }
 
     static void ComposeEnumValues(StringBuilder sb, ApiType type, ref bool any)

--- a/tools/DecompilerHarness/TypeSourceCheck.cs
+++ b/tools/DecompilerHarness/TypeSourceCheck.cs
@@ -40,6 +40,8 @@ static class TypeSourceCheck
         public const string TypeKind = "type-kind";
         public const string ModifierDropped = "modifier-dropped";
         public const string ModifierExtra = "modifier-extra";
+        public const string GenericConstraintDropped = "generic-constraint-dropped";
+        public const string GenericConstraintExtra = "generic-constraint-extra";
         public const string MemberMissing = "member-missing";
     }
 
@@ -199,12 +201,57 @@ static class TypeSourceCheck
                 deltas.Add(new TypeArtifactDelta(fullType, Deltas.ModifierExtra, modifier));
         }
 
+        CompareGenericConstraints(type, typeDecl, fullType, deltas);
+
         // Member surface: every metadata member must have a matching declaration.
         // Extra syntax declarations (e.g. non-public context fields the composer
         // adds) are not flagged — this is a missing-member oracle.
         CompareMembers(type, typeDecl, fullType, deltas);
 
         return deltas;
+    }
+
+    static void CompareGenericConstraints(ApiType type, MemberDeclarationSyntax typeDecl, string fullType,
+        List<TypeArtifactDelta> deltas)
+    {
+        if (typeDecl is not TypeDeclarationSyntax td)
+            return;
+
+        var declared = td.ConstraintClauses.ToDictionary(
+            clause => clause.Name.Identifier.Text,
+            clause => clause.Constraints.Select(c => c.ToString()).ToHashSet(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+
+        foreach (var typeParameter in type.TypeParameters)
+        {
+            var expected = typeParameter.Constraints.ToHashSet(StringComparer.Ordinal);
+            declared.TryGetValue(typeParameter.Name, out var actual);
+            actual ??= [];
+
+            foreach (var constraint in expected)
+            {
+                if (!actual.Contains(constraint))
+                    deltas.Add(new TypeArtifactDelta(fullType, Deltas.GenericConstraintDropped,
+                        $"{typeParameter.Name} : {constraint}"));
+            }
+
+            foreach (var constraint in actual)
+            {
+                if (!expected.Contains(constraint))
+                    deltas.Add(new TypeArtifactDelta(fullType, Deltas.GenericConstraintExtra,
+                        $"{typeParameter.Name} : {constraint}"));
+            }
+        }
+
+        var knownParameters = type.TypeParameters.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+        foreach (var (name, constraints) in declared)
+        {
+            if (knownParameters.Contains(name))
+                continue;
+            foreach (var constraint in constraints)
+                deltas.Add(new TypeArtifactDelta(fullType, Deltas.GenericConstraintExtra,
+                    $"{name} : {constraint}"));
+        }
     }
 
     static void CompareMembers(ApiType type, MemberDeclarationSyntax typeDecl, string fullType,


### PR DESCRIPTION
## Summary

- Appends type-level generic `where` clauses in `TypeSourceComposer` from `ApiType.TypeParameters[].Constraints`.
- Extends the whole-type source oracle to report dropped or extra generic constraints.
- Adds coverage for matching constraints, dropped constraints, and a real `System.Nullable<T>` source listing.

## Root Cause

`ApiSurfaceExtractor` already captured type parameter constraints such as `struct`, `class`, `new()`, and type/interface constraints, but `TypeSourceComposer.TypeDeclaration` stopped after the type name and base/interface list. Whole-type `Decompiled Source` therefore lost constraint clauses even when the metadata surface had the data.

## Scope Note

This fixes rendering for constraints already present in `ApiType.TypeParameters[].Constraints`. `where T : notnull` is not a CLR generic-parameter constraint flag; recovering it from nullable metadata is tracked separately in #1143. This PR intentionally does not infer `notnull`.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypeSourceCheckTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- CLI smoke: `dotnet run --project src/dotnet-inspect -c Release -- type 'Nullable\`1' --platform System.Private.CoreLib -S "Decompiled Source" --raw`
- `git diff --check`

Refs #1140.
Follow-up: #1143.
