### PR TITLE
Add whole-type binding oracle (--bind-check) (#1137)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -56,6 +56,8 @@
              Link="ShellNoise.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\TypeSourceCheck.cs"
              Link="TypeSourceCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\TypeBindCheck.cs"
+             Link="TypeBindCheck.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Decompiler.Tests/TypeBindCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeBindCheckTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Fixtures for the whole-type source binding oracle (issue #1137). They drive
+/// the pure detector <see cref="TypeBindCheck.Collisions"/> so each behaviour is
+/// proven in isolation: a genuine cross-namespace ambiguity is caught, a clean
+/// type is silent, an unparseable/unbindable body is stubbed away (so it cannot
+/// manufacture a type-level collision), and the real composed
+/// <c>System.AppDomain</c> listing reproduces the #1137 collision the product
+/// path cannot detect without enumerating an external namespace.
+/// </summary>
+public class TypeBindCheckTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+    static ImmutableArray<MetadataReference> Refs => TypeBindCheck.ReferencesFor(CoreLibPath);
+
+    [Fact]
+    public void Detects_AmbiguousReference_AcrossTwoImportedNamespaces()
+    {
+        // Both System.Configuration.Assemblies and System.Reflection define
+        // AssemblyHashAlgorithm; the unqualified use is ambiguous (CS0104).
+        const string source = """
+            using System.Configuration.Assemblies;
+            using System.Reflection;
+
+            namespace T;
+
+            public class C
+            {
+                public void M(AssemblyHashAlgorithm a) { }
+            }
+            """;
+
+        var collisions = TypeBindCheck.Collisions("T.C", source, Refs);
+        Assert.Contains(collisions, c => c.SimpleName == "AssemblyHashAlgorithm");
+    }
+
+    [Fact]
+    public void CleanType_HasNoCollision()
+    {
+        const string source = """
+            using System.Text;
+
+            namespace T;
+
+            public class C
+            {
+                public void M(StringBuilder b) { }
+            }
+            """;
+
+        Assert.Empty(TypeBindCheck.Collisions("T.C", source, Refs));
+    }
+
+    [Fact]
+    public void UnbindableBody_IsStubbed_AndManufacturesNoCollision()
+    {
+        // A body riddled with synthesized names and undefined symbols would fail
+        // to bind; stubbing erases it before binding, so only type/signature-level
+        // ambiguities (here: none) can surface.
+        const string source = """
+            using System.Text;
+
+            namespace T;
+
+            public class C
+            {
+                public StringBuilder M() => new <Broken>d__0(undefined.Thing, 42);
+            }
+            """;
+
+        Assert.Empty(TypeBindCheck.Collisions("T.C", source, Refs));
+    }
+
+    [Fact]
+    public void ComposedAppDomain_ReproducesTheKnownCollision()
+    {
+        using var pe = new PEReader(File.OpenRead(CoreLibPath));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var appDomain = Assert.Single(surface.Types, t => t.FullName == "System.AppDomain");
+        var source = TypeSourceComposer.Compose(appDomain, CoreLibPath, pdbPath: null);
+        Assert.NotNull(source);
+
+        var collisions = TypeBindCheck.Collisions("System.AppDomain", source!, Refs);
+        Assert.Contains(collisions, c => c.SimpleName == "AssemblyHashAlgorithm");
+    }
+
+    [Fact]
+    public void KnownAppDomainArtifact_IsAllowlisted()
+    {
+        Assert.Contains(("System.AppDomain", "AssemblyHashAlgorithm"), TypeBindCheck.KnownArtifacts);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TypeBindGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeBindGateTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The whole-type binding gate (issue #1137): the breadth guard for the source
+/// the product <see cref="ILInspector.Decompiler.TypeSourceComposer"/> emits.
+/// It composes every public type in the running runtime's CoreLib, stubs bodies,
+/// and binds each listing against the platform reference set, failing on any
+/// <c>CS0104</c> ambiguous-reference collision outside
+/// <see cref="TypeBindCheck.KnownArtifacts"/>.
+///
+/// <para>
+/// A new collision is always a real, compile-breaking defect — the composed
+/// source would not bind — so it is gated absolutely. The single known artifact
+/// (<c>System.AppDomain.ExecuteAssembly</c>'s <c>AssemblyHashAlgorithm</c>
+/// parameter colliding with <c>System.Reflection.AssemblyHashAlgorithm</c>) is
+/// allowlisted: it cannot be fixed on the product path without enumerating an
+/// external namespace's contents, which the SRM-only, Roslyn-free product path
+/// must not do. The gate fails if a composer change introduces a new collision,
+/// and (because it is allowlisted, not pinned) stays green if a runtime shift
+/// removes the known one.
+/// </para>
+/// </summary>
+public class TypeBindGateTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    [Fact]
+    public void CoreLib_HasNoNewTypeSourceBindingCollisions()
+    {
+        var (typesChecked, collisions) = TypeBindCheck.EvaluateDetailed(CoreLibPath);
+
+        // Non-vacuous: the sweep must actually compose and bind a broad population,
+        // or a zero-collision result would prove nothing (a refactor that silently
+        // stops composing types must not pass this gate).
+        Assert.True(typesChecked > 500,
+            $"Expected a large CoreLib corpus; composed and bound only {typesChecked} types. "
+                + "A composer or extractor change may have silently stopped producing listings.");
+
+        Assert.True(collisions.Count == 0,
+            $"The composed source must bind without ambiguous-reference (CS0104) collisions, but "
+                + $"{collisions.Count} new one(s) surfaced — the listing would not compile. If a case is "
+                + "genuinely unfixable on the product path without external namespace enumeration, add it to "
+                + "TypeBindCheck.KnownArtifacts with justification:\n  "
+                + string.Join("\n  ", collisions.Select(c => $"{c.FullType} — {c.Detail}")));
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -53,6 +53,7 @@ static class Program
         bool libraryReport = false;
         bool unsupportedNodes = false;
         bool typeCheck = false;
+        bool bindCheck = false;
         bool classifyDec0009 = false;
         bool json = false;
         int topPatterns = 10;
@@ -100,6 +101,7 @@ static class Program
                 case "--library-report": libraryReport = true; break;
                 case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--type-check": typeCheck = true; break;
+                case "--bind-check": bindCheck = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
                 case "--dec0009-shapes": classifyDec0009 = true; break;
                 case "--json": json = true; break;
@@ -123,6 +125,9 @@ static class Program
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
+
+        if (bindCheck)
+            return TypeBindCheck.Run(assemblies, cap, maxExamples);
 
         if (gaps)
             return CompletenessScan(assemblies, maxExamples, byShape);
@@ -1052,6 +1057,12 @@ static class Program
                                 and compare its namespace, kind, modifiers, and member
                                 surface against metadata (syntactic, never binds, so
                                 method-body codegen is irrelevant). Issue #1112.
+          --bind-check          whole-type binding oracle — compose each public type,
+                                stub bodies, and bind against the platform refs; report
+                                new CS0104 ambiguous-reference collisions (the
+                                undetectable-without-namespace-enumeration class). Known
+                                artifacts are allowlisted; nonzero exit on a new one.
+                                Issue #1137.
           --gaps                self-contained real-gap view — methods whose
                                 raised tree still holds unstructured control flow
                                 (a surviving goto) or an unsupported node, bucketed

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -189,6 +189,10 @@ lowerings at once).
 
 *When to use it.* Reach for type-check when the question is **"is the whole-type file right,"** not "does a body mean the same thing" — after any change to `TypeSourceComposer`, the type-declaration rendering, or `ApiSurfaceExtractor`. Deltas are bucketed by kind (`namespace`, `type-kind`, `modifier-dropped`/`-extra`, `member-missing`, `type-decl-missing`) with examples. Over .NET 11 preview CoreLib its first standing finding is `modifier-dropped: readonly` / `ref` — the composer's `TypeDeclaration` does not yet emit the `readonly struct` / `ref struct` modifiers, a type-level artifact gap invisible to every method-body check. The pure comparison (`TypeSourceCheck.CompareType`) and the assembly driver (`TypeSourceCheck.Evaluate`) are covered by `TypeSourceCheckTests` in `ILInspector.Decompiler.Tests`, including a fixture proving an unparseable method body does not mask a sibling artifact.
 
+**Type-bind check** (`--bind-check`): the *whole-type binding* oracle ([issue #1137](https://github.com/richlander/dotnet-inspect/issues/1137)) — the binding companion to `--type-check`. Where type-check is purely syntactic, this one **compiles** each composed type against the platform reference set and reports the `CS0104` ambiguous-reference collisions that only a binder can see. A collision happens when the listing imports two namespaces that both define a simple name the source uses unqualified. The composer already keeps a name qualified when its *own* metadata shows two owners (the detectable case, #1017); the residue this oracle catches is the **undetectable** case — the competing type is not a TypeDef/TypeRef of the composed assembly, so the SRM-only product path, which must not enumerate external namespaces, cannot know it exists. Method bodies are stubbed (the same `StubMemberBodies` pass type-check uses) before binding, so a body-codegen defect can neither manufacture nor mask a type/signature-level collision. Roslyn lives only here in the oracle; the product path is unchanged.
+
+*When to use it.* Run after any change to `TypeSourceComposer`'s using-hoisting or signature rendering. The canonical artifact is `System.AppDomain.ExecuteAssembly`, whose `AssemblyHashAlgorithm` parameter (from `System.Configuration.Assemblies`) collides with `System.Reflection.AssemblyHashAlgorithm` once `System.Reflection` is imported for other members — its namespace is seeded by the *parameter type itself*, not by signature-text shortening, so it cannot be suppressed by a conservative-hoist policy without qualifying signature types wholesale. Known-unfixable artifacts are allowlisted in `TypeBindCheck.KnownArtifacts`; a *new* collision exits nonzero (the listing would not compile). The breadth gate is `TypeBindGateTests` in `ILInspector.Decompiler.Tests` (analog of `TypeSourceCheckTests`), which binds the whole running-runtime CoreLib and fails on any collision outside the allowlist.
+
 ## Usage
 
 ```bash
@@ -289,6 +293,10 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
 # Whole-type source oracle: namespace/kind/modifier/member deltas vs metadata
 dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/System.Private.CoreLib.dll --type-check --cap 2000 --max-examples 20
+
+# Whole-type binding oracle: new CS0104 ambiguous-reference collisions
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  /path/to/System.Private.CoreLib.dll --bind-check
 ```
 
 Inputs are assembly paths or directories (non-managed files are skipped).

--- a/tools/DecompilerHarness/TypeBindCheck.cs
+++ b/tools/DecompilerHarness/TypeBindCheck.cs
@@ -1,0 +1,229 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// The whole-type source <em>binding</em> oracle (issue #1137). Where
+/// <see cref="TypeSourceCheck"/> grades the composed listing syntactically — it
+/// never binds — this one compiles each composed type against the platform
+/// reference set and reports the type/signature-level <c>CS0104</c> ambiguous
+/// reference collisions that only a binder can see.
+///
+/// <para>
+/// A collision happens when the listing imports two namespaces that both define
+/// a simple name the source uses unqualified. The product
+/// <see cref="TypeSourceComposer"/> already keeps a name qualified when its own
+/// metadata shows two owners (the detectable case, #1017). The residue this
+/// oracle catches is the <em>undetectable</em> case: the competing type is not a
+/// TypeDef/TypeRef of the composed assembly, so the product — which must stay
+/// SRM-only and free of external namespace enumeration — cannot know it exists.
+/// The canonical example is <c>System.AppDomain.ExecuteAssembly</c>, whose
+/// <c>AssemblyHashAlgorithm</c> parameter (from <c>System.Configuration.Assemblies</c>)
+/// collides with <c>System.Reflection.AssemblyHashAlgorithm</c> once
+/// <c>System.Reflection</c> is imported for other members.
+/// </para>
+///
+/// <para>
+/// Method bodies are stubbed (via <see cref="TypeSourceCheck.StubMemberBodies"/>)
+/// before binding, so a body-codegen defect can neither manufacture nor mask a
+/// type/signature-level collision — the same isolation #1112 relies on. Roslyn
+/// lives only here in the developer/CI oracle; the product path is unchanged.
+/// </para>
+/// </summary>
+static class TypeBindCheck
+{
+    /// <summary>One ambiguous-reference (CS0104) collision in a composed type.</summary>
+    public sealed record BindCollision(string FullType, string SimpleName, string Detail);
+
+    /// <summary>
+    /// Collisions that are unfixable on the product path without enumerating an
+    /// external namespace's contents (the #1137 guardrail). Keyed by
+    /// (full type, ambiguous simple name). The gate accepts these and fails only
+    /// on collisions outside this set, so a regression that introduces a new
+    /// collision — or a composer change that resolves one of these — is caught.
+    /// </summary>
+    public static readonly ImmutableHashSet<(string FullType, string SimpleName)> KnownArtifacts =
+        ImmutableHashSet.Create(
+            ("System.AppDomain", "AssemblyHashAlgorithm"));
+
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
+    {
+        int typesChecked = 0, assembliesScanned = 0;
+        var collisions = new List<BindCollision>();
+        int known = 0;
+
+        foreach (var path in assemblies)
+        {
+            if (typesChecked >= cap)
+                break;
+            int before = typesChecked;
+            try
+            {
+                foreach (var c in Evaluate(path, cap, ref typesChecked))
+                {
+                    if (KnownArtifacts.Contains((c.FullType, c.SimpleName)))
+                        known++;
+                    else
+                        collisions.Add(c);
+                }
+            }
+            catch
+            {
+                continue;
+            }
+            if (typesChecked > before)
+                assembliesScanned++;
+        }
+
+        Console.WriteLine($"TYPE-BIND over {typesChecked} composed types ({assembliesScanned} assemblies)");
+        Console.WriteLine();
+        Console.WriteLine($"  known artifacts (allowlisted)   : {known}");
+        Console.WriteLine($"  new ambiguous-reference (CS0104): {collisions.Count}");
+        if (collisions.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  examples:");
+            foreach (var c in collisions.Take(maxExamples))
+                Console.WriteLine($"    {c.FullType} — {c.SimpleName} — {c.Detail}");
+            // Nonzero exit: a new collision is always a real, compile-breaking defect.
+            return 1;
+        }
+        Console.WriteLine();
+        Console.WriteLine("  no new type-source binding collisions.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Composes every public top-level type in <paramref name="assemblyPath"/>,
+    /// stubs bodies, binds against the platform reference set, and returns the
+    /// CS0104 collisions. Known artifacts are excluded unless
+    /// <paramref name="includeKnown"/> is set. Testable entry point.
+    /// </summary>
+    public static IReadOnlyList<BindCollision> Evaluate(
+        string assemblyPath, int cap = int.MaxValue, bool includeKnown = false)
+        => EvaluateDetailed(assemblyPath, cap, includeKnown).Collisions;
+
+    /// <summary>
+    /// As <see cref="Evaluate"/>, also reporting how many types were composed and
+    /// bound — so a gate can assert a non-vacuous population (a refactor that
+    /// silently stops composing types must not pass a zero-collision check).
+    /// </summary>
+    public static (int TypesChecked, IReadOnlyList<BindCollision> Collisions) EvaluateDetailed(
+        string assemblyPath, int cap = int.MaxValue, bool includeKnown = false)
+    {
+        int checkedCount = 0;
+        var all = Evaluate(assemblyPath, cap, ref checkedCount);
+        var collisions = includeKnown
+            ? all
+            : all.Where(c => !KnownArtifacts.Contains((c.FullType, c.SimpleName))).ToList();
+        return (checkedCount, collisions);
+    }
+
+    static IReadOnlyList<BindCollision> Evaluate(
+        string assemblyPath, int cap, ref int checkedCount)
+    {
+        var collisions = new List<BindCollision>();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            return collisions;
+
+        var references = ReferencesFor(assemblyPath);
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        foreach (var type in surface.Types)
+        {
+            if (checkedCount >= cap)
+                break;
+            if (type.Kind == "delegate")
+                continue;
+
+            var source = TypeSourceComposer.Compose(type, assemblyPath, pdbPath: null);
+            if (source is null)
+                continue;
+
+            checkedCount++;
+            collisions.AddRange(Collisions(type.FullName, source, references));
+        }
+        return collisions;
+    }
+
+    /// <summary>
+    /// The pure detector: bind <paramref name="composedSource"/> (with bodies
+    /// stubbed) against <paramref name="references"/> and return every CS0104
+    /// ambiguous-reference diagnostic as a collision. No other diagnostic class
+    /// is consulted — the duplicate-definition noise from referencing the
+    /// composed type's own defining assembly is irrelevant to an unqualified
+    /// name's ambiguity.
+    /// </summary>
+    public static IReadOnlyList<BindCollision> Collisions(
+        string fullType, string composedSource, ImmutableArray<MetadataReference> references)
+    {
+        var tree = CSharpSyntaxTree.ParseText(TypeSourceCheck.StubMemberBodies(composedSource));
+        var compilation = CSharpCompilation.Create(
+            "bind", [tree], references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var collisions = new List<BindCollision>();
+        foreach (var diagnostic in compilation.GetDiagnostics())
+        {
+            if (diagnostic.Id != "CS0104")
+                continue;
+            string message = diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture);
+            collisions.Add(new BindCollision(fullType, FirstQuoted(message) ?? "?", message));
+        }
+        return collisions;
+    }
+
+    /// <summary>The first single-quoted span of a CS0104 message is the ambiguous simple name.</summary>
+    static string? FirstQuoted(string message)
+    {
+        int open = message.IndexOf('\'');
+        if (open < 0)
+            return null;
+        int close = message.IndexOf('\'', open + 1);
+        return close < 0 ? null : message[(open + 1)..close];
+    }
+
+    /// <summary>
+    /// The platform reference set for binding a composed type: the running
+    /// runtime's trusted platform assemblies plus, if the target is not already
+    /// among them, the target and its sibling assemblies. Unlike
+    /// <c>FidelityCheck</c> (which reconstructs a body and so excludes the
+    /// target), this binds the type shell and therefore keeps the target so its
+    /// own types — and the competing same-named types in sibling assemblies —
+    /// are both visible.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> ReferencesFor(string assemblyPath)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var builder = ImmutableArray.CreateBuilder<MetadataReference>();
+
+        void Add(string path)
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                return;
+            if (!seen.Add(Path.GetFileNameWithoutExtension(path)))
+                return;
+            try { builder.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+
+        foreach (var path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+            Add(path);
+
+        Add(Path.GetFullPath(assemblyPath));
+        var dir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath));
+        if (dir is not null && Directory.Exists(dir))
+            foreach (var path in Directory.EnumerateFiles(dir, "*.dll"))
+                Add(path);
+
+        return builder.ToImmutable();
+    }
+}

--- a/tools/DecompilerHarness/TypeSourceCheck.cs
+++ b/tools/DecompilerHarness/TypeSourceCheck.cs
@@ -369,7 +369,7 @@ static class TypeSourceCheck
     /// is erased. The composer always emits a file-scoped namespace, so the
     /// type body opens at brace depth 1.
     /// </summary>
-    static string StubMemberBodies(string source)
+    internal static string StubMemberBodies(string source)
     {
         var sb = new System.Text.StringBuilder(source.Length);
         int depth = 0;            // brace depth before the current token


### PR DESCRIPTION
Addresses #1137 (direction 2 — oracle-only guard). See [my analysis comment](https://github.com/richlander/dotnet-inspect/issues/1137#issuecomment-4772393947) for why the product-side direction 1 is cost-without-benefit.

## TL;DR

The issue's whole-type `CS0104` is genuinely undetectable on the SRM-only product
path (the competing `System.Reflection.AssemblyHashAlgorithm` is not a TypeDef/TypeRef
of CoreLib). A faithful direction-1 "stop shortening signature-only names" policy
de-shortens **174/1099 (15.8%)** CoreLib type listings and fixes **0** collisions —
because the colliding namespace is seeded by the *parameter type itself*
(`CollectNamespaces`), not by signature-text shortening as the issue hypothesized.

So this PR keeps product behavior and adds the **binding oracle** the issue's
"stronger oracle-only policy" calls for.

## What

`--bind-check` (and `TypeBindCheck`) — the binding companion to the #1112 syntactic
`--type-check`. It compiles each composed whole-type listing against the platform
reference set (including the target, so a type and its same-named siblings are both
visible) and reports the `CS0104` ambiguous-reference collisions only a binder can see.

- **Body stubbing.** Reuses `TypeSourceCheck.StubMemberBodies`, so a body-codegen
  defect can neither manufacture nor mask a type/signature-level collision.
- **Detectable vs undetectable.** The composer already qualifies the #1017 case (two
  owners in its own metadata). This catches the undetectable residue, where the rival
  type is invisible to a single-assembly walk — the class the product path must not
  chase without enumerating external namespaces (the guardrail).
- **Allowlist.** `TypeBindCheck.KnownArtifacts` carries the one known case
  (`System.AppDomain` / `AssemblyHashAlgorithm`). A *new* collision exits nonzero — the
  listing would not compile.
- **Product path unchanged.** Roslyn lives only in the oracle (SRM-only,
  NativeAOT-friendly, Roslyn-free product path preserved).

## Tests

- `TypeBindCheckTests` (fast): cross-namespace ambiguity detected; clean type silent;
  an unbindable/synthesized-name body is stubbed away (no manufactured collision); the
  real composed `System.AppDomain` listing reproduces the #1137 collision; allowlist
  membership.
- `TypeBindGateTests` (breadth gate, analog of `AnnotationGateTests`): binds the whole
  running-runtime CoreLib (~1098 types, ~25s), asserts a non-vacuous population, and
  fails on any collision outside the allowlist. Currently: 1 known, 0 new.

Full decompiler suite green (1030 tests).

## Note on the branch name

Branch is `feature/issue-1137-conservative-hoist` from when I was testing direction 1;
the landed change is the direction-2 oracle. Happy to also pursue a product-side fix in
a follow-up if you'd accept the ~16% signature-qualification churn it requires.
