### PR TITLE
Pin expression-tree lambda fidelity frontier (#1142)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExpressionTreeFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionTreeFidelityTests.cs
@@ -1,0 +1,84 @@
+using System.Linq.Expressions;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the expression-tree lambda frontier (issue #1142). A C# expression-tree
+/// lambda (<c>Expression&lt;Func&lt;…&gt;&gt; f = x =&gt; …;</c>) lowers to a run of
+/// <c>System.Linq.Expressions</c> factory calls (<c>Expression.Parameter</c>,
+/// <c>Expression.Add</c>, <c>Expression.Lambda</c>, …). The decompiler renders
+/// those factory calls faithfully — it does <em>not</em> recover the original
+/// lambda syntax, which would require re-deriving the lambda from the tree it
+/// builds (a separate, design-gated effort).
+///
+/// The factory-call form is faithful, valid C# whenever every node it builds has
+/// a C# spelling, so a simple arithmetic lambda stays <c>Full</c>. A lambda that
+/// reads a member is different: the compiler captures the member with
+/// <c>ldtoken &lt;field/method&gt;</c> (passed to <c>GetFieldFromHandle</c>), and a
+/// member token has no C# expression spelling (unlike a type token, which is
+/// <c>typeof(T)</c>). That node degrades honestly to <c>DEC0010</c>, so a
+/// member-bodied expression-tree lambda is <c>Partial</c>. These tests lock that
+/// behavior in so neither the factory-call rendering nor the honest degradation
+/// can silently regress.
+/// </summary>
+public class ExpressionTreeFidelityTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(ExpressionTreeSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(ExpressionTreeSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void SimpleArithmeticLambda_RendersFactoryCalls_StaysFull()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.Simple));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        // Faithful factory-call rendering, not recovered `x => x + 1` lambda syntax.
+        Assert.Contains("Expression.Lambda<Func<int, int>>", output);
+        Assert.Contains("Expression.Add(", output);
+        Assert.DoesNotContain("=>", output);
+    }
+
+    [Fact]
+    public void MemberBodyLambda_DegradesToPartial_OnMemberToken()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.Member));
+
+        // The member access lowers to `ldtoken <field>` + GetFieldFromHandle, a
+        // runtime member token with no C# expression spelling, so the body is
+        // honestly Partial rather than a plausible-but-unspellable recovery.
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        Assert.Contains(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnsupportedRuntimeToken);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("GetFieldFromHandle", output);
+    }
+}
+
+public static class ExpressionTreeSamples
+{
+    public static Expression<Func<int, int>> Simple() => x => x + 1;
+
+    public static Expression<Func<ExpressionTreeNode, bool>> Member()
+        => n => n.Name != null && n.Count > 0;
+}
+
+public sealed class ExpressionTreeNode
+{
+    public string? Name;
+    public int Count;
+}


### PR DESCRIPTION
Refs #1142 — the two expression-tree lambda rows.

## Summary
- Add real-compiler fixtures for both expression-tree rows and pin the decompiler's current honest behavior with a fidelity test (test-only, no pass/printer changes).
- **Simple arithmetic lambda** (`x => x + 1`): lowers to `System.Linq.Expressions` factory calls (`Expression.Parameter`/`Expression.Add`/`Expression.Lambda`). The decompiler renders these faithfully and stays `Full`. It does **not** recover `x => x + 1` syntax.
- **Member-bodied lambda** (`n => n.Name != null && n.Count > 0`): captures the member with `ldtoken <field>` + `GetFieldFromHandle`. A member token has no C# expression spelling (unlike a type token, which is `typeof(T)`), so the body degrades honestly to `DEC0010` and is `Partial` — already modeled by `LoadToken`/`FidelityRemarks`; this adds end-to-end coverage from real csc output.

## Why a pin, not a raise
Recovering the original lambda from the factory-call tree (and giving member tokens a spelling via full tree to lambda recovery) is a separate, **design-gated** effort, exactly as the row notes flag. This PR locks current behavior so neither the factory-call rendering nor the honest degradation can silently regress, and leaves the scope decision (attempt expression-tree to lambda recovery?) open for @richlander.

## Notes from investigating #1142
- I originally claimed the **non-local deconstruction target: field** row, but found another active session already implementing that raise. Their scoping is sound: the local-target form spills the tuple to a *synthetic stack slot* (the discriminator the pass keys on), but the pure two-instance-field form spills to a real `.locals` temp that is **byte-identical** to a hand-written `var t = pair; this.f = t.Item1; this.g = t.Item2;` — no IL discriminator, so that `StoreLocal`-seed form must stay lowered (they correctly defer it). I backed out cleanly to avoid colliding and took an isolated row instead.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 1036 passed, 0 failed.
- `dotnet build src/dotnet-inspect -c Release` — clean.
