### PR TITLE
Raise property target tuple deconstruction

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -203,6 +203,93 @@ public class DeconstructionAssignmentPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void ValueTupleFieldStoresWithPropertyTarget_RaiseToDeconstruction()
+    {
+        var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: false);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Equal(2, deconstruction.Targets.Length);
+        Assert.Contains(deconstruction.Targets, target => target.Kind == DeconstructionTargetKind.Property && target.PropertyName == "Count");
+        Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), field => field.Field.Name is "Item1" or "Item2");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void PrintRaised_RendersPropertyTargetDeconstruction()
+    {
+        var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: false);
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("(int x, node.Count) = pair;", output);
+        Assert.Contains("return x + node.Count;", output);
+        Assert.DoesNotContain(".Item", output);
+    }
+
+    [Fact]
+    public void SourcePropertyTarget_RaisesToDeconstruction()
+    {
+        var function = Raised(nameof(DeconstructionAdversarialSamples.PropertyTarget), typeof(DeconstructionAdversarialSamples));
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Contains(deconstruction.Targets, target => target.Kind == DeconstructionTargetKind.Property && target.PropertyName == "Count");
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("(int x, node.Count) = pair;", output);
+        Assert.DoesNotContain(".Item", output);
+    }
+
+    [Fact]
+    public void SourceNamedTupleTempPropertyTarget_IsNotRaised()
+    {
+        var function = Raised(nameof(DeconstructionAdversarialSamples.ManualTupleTempPropertyTarget), typeof(DeconstructionAdversarialSamples));
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<StoreProperty>(), store => store.PropertyName == "Count");
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name is "Item1" or "Item2");
+    }
+
+    [Fact]
+    public void SourceSideEffectingPropertyReceiver_IsNotRaised()
+    {
+        var function = Raised(nameof(DeconstructionAdversarialSamples.SideEffectingPropertyTarget), typeof(DeconstructionAdversarialSamples));
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<StoreProperty>(), store => store.PropertyName == "Count");
+    }
+
+    [Fact]
+    public void ValueTupleFieldStoresWithSourceNamedTupleTemp_IsNotRaised()
+    {
+        var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: true);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<StoreProperty>(), store => store.PropertyName == "Count");
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item1");
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name == "Item2");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ValueTupleFieldStoresWithSideEffectingPropertyReceiver_IsNotRaised()
+    {
+        var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: false, sideEffectingReceiver: true);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        Assert.Contains(function.Descendants.OfType<StoreProperty>(), store => store.PropertyName == "Count");
+        function.CheckInvariant();
+    }
+
     static IrFunction BuildDeconstructCallWithParameterTarget()
     {
         var intType = TypeRef.CoreLib("System", "Int32");
@@ -287,6 +374,45 @@ public class DeconstructionAssignmentPassTests
             body);
     }
 
+    static IrFunction BuildValueTupleFieldStoresWithPropertyTarget(bool sourceNamedTupleTemp, bool sideEffectingReceiver = false)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var tupleType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple`2"), [intType, intType]);
+        var nodeType = TypeRef.Definition("UserAssembly", "Samples", "Node");
+        var setCount = new MethodRef(nodeType, "set_Count", voidType, [intType], HasThis: true);
+        var getCount = new MethodRef(nodeType, "get_Count", intType, [], HasThis: true);
+        var makeNode = new MethodRef(TypeRef.Definition("UserAssembly", "Samples", "Factory"), "MakeNode", nodeType, [], HasThis: false);
+        IrExpression propertyReceiver = sideEffectingReceiver
+            ? new Call(makeNode, isVirtual: false, [])
+            : new LoadArgument(0, "node", nodeType);
+
+        var block = new Block();
+        block.Add(new StoreLocal(1, tupleType, new LoadArgument(1, "pair", tupleType)));
+        block.Add(new StoreLocal(0, intType, new LoadField(new FieldRef(tupleType, "Item1", intType), new LoadLocal(1, tupleType))));
+        block.Add(new StoreProperty(
+            setCount,
+            propertyReceiver,
+            [],
+            new LoadField(new FieldRef(tupleType, "Item2", intType), new LoadLocal(1, tupleType))));
+        block.Add(new Return(new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, intType),
+            new LoadProperty(getCount, new LoadArgument(0, "node", nodeType), []))));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Int32"), [new Parameter("node", nodeType), new Parameter("pair", tupleType)], HasThis: false, GenericParameterCount: 0),
+            [intType, tupleType],
+            body);
+        function.LocalNames = ["x", sourceNamedTupleTemp ? "tmp" : null];
+        return function;
+    }
+
     static IrFunction BuildMixedValueTupleTargets()
     {
         var intType = TypeRef.CoreLib("System", "Int32");
@@ -365,10 +491,39 @@ public class DeconstructionAssignmentPassTests
 
 public static class DeconstructionAdversarialSamples
 {
+    static readonly Node s_node = new();
+
+    public sealed class Node
+    {
+        public int Count { get; set; }
+    }
+
     public static int ManualTupleFields((int Sum, int Product) pair)
     {
         int sum = pair.Sum;
         int product = pair.Product;
         return sum + product;
     }
+
+    public static int PropertyTarget(Node node, (int X, int Count) pair)
+    {
+        (int x, node.Count) = pair;
+        return x + node.Count;
+    }
+
+    public static int ManualTupleTempPropertyTarget(Node node, (int X, int Count) pair)
+    {
+        var tmp = pair;
+        int x = tmp.X;
+        node.Count = tmp.Count;
+        return x + node.Count;
+    }
+
+    public static int SideEffectingPropertyTarget((int X, int Count) pair)
+    {
+        (int x, MakeNode().Count) = pair;
+        return x;
+    }
+
+    static Node MakeNode() => s_node;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/TupleRecoveryFacts.cs
@@ -20,10 +20,11 @@ internal sealed class TupleRecoveryFacts : ILoweringFactProvider
             [
                 new FactPrimitive("member.corelib-identity:System.ValueTuple", "MemberIdentity.IsSupportedValueTupleType"),
                 new FactPrimitive("place.stack-slot", "PlaceIdentity.SameStackSlot-equivalent slot ownership checks"),
+                new FactPrimitive("pdb.hidden-local", "LocalNames hidden tuple temp discriminator for local temp-copy property targets"),
             ],
-            PositiveCoverage: "DeconstructionAssignmentPassTests ValueTuple field-store, mixed fresh/existing local, and Deconstruct-method fixtures",
-            AdversarialCoverage: "DeconstructionAssignmentPassTests manual tuple field access, user ValueTuple lookalike, side-effecting Deconstruct receiver, non-local (parameter/field) target, and field-load (temp-copy) Deconstruct receiver negatives",
-            MissingDiscriminator: "nested/rest tuples still owed; non-local targets and non-trivial (field/temp-copy) receivers are confirmed to decline rather than over-match, so raising those forms is a future slice"),
+            PositiveCoverage: "DeconstructionAssignmentPassTests ValueTuple field-store, mixed fresh/existing local, simple property target, and Deconstruct-method fixtures",
+            AdversarialCoverage: "DeconstructionAssignmentPassTests manual tuple field access, named tuple temp, user ValueTuple lookalike, side-effecting Deconstruct/property receivers, parameter/field targets, and field-load (temp-copy) Deconstruct receiver negatives",
+            MissingDiscriminator: "nested/rest tuples, parameter/field targets, indexer property targets, and non-trivial receivers remain owed; named tuple temps and side-effecting property receivers are confirmed to decline rather than over-match"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.TupleBinaryOperator)),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1302,7 +1302,7 @@ public sealed partial class CSharpPrinter
         StoreLocal s => _declaringStores.Contains(s)
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
-        DeconstructionAssignment d => $"({string.Join(", ", d.LocalIndices.Select((index, i) => d.IsDeclared[i] ? $"{TypeText(d.LocalTypes[i])} {LocalName(index)}" : LocalName(index)))}) = {Expression(d.Source)};",
+        DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
         NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
@@ -1361,6 +1361,15 @@ public sealed partial class CSharpPrinter
         EndFinally => "// endfinally",
         EndFilter f => $"// endfilter({Expression(f.Value)})",
         _ => $"/* {node.Describe()} */",
+    };
+
+    string DeconstructionTargetText(DeconstructionTarget target) => target.Kind switch
+    {
+        DeconstructionTargetKind.Local => target.IsDeclared
+            ? $"{TypeText(target.Type)} {LocalName(target.LocalIndex)}"
+            : LocalName(target.LocalIndex),
+        DeconstructionTargetKind.Property => PropertyTarget(target.Accessor!, target.HasInstance ? target.Instance : null, target.IndexArguments, target.PropertyName, target.IsVirtual),
+        _ => $"/* {target.Describe()} */",
     };
 
     string Expression(IrExpression node) => node switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -250,8 +250,12 @@ static class DefiniteAssignment
                             break;
                         case DeconstructionAssignment deconstruction:
                             CheckReads(deconstruction.Source, running);
-                            foreach (int index in deconstruction.LocalIndices)
-                                running.Add(index);
+                            foreach (var target in deconstruction.Targets)
+                            {
+                                CheckReads(target, running);
+                                if (target.Kind == DeconstructionTargetKind.Local)
+                                    running.Add(target.LocalIndex);
+                            }
                             break;
                         case ForeachStatement foreachStatement:
                             CheckReads(foreachStatement.Collection, running);
@@ -292,8 +296,12 @@ static class DefiniteAssignment
                     return DefiniteFlow.FallThrough;
                 case DeconstructionAssignment deconstruction:
                     CheckReads(deconstruction.Source, assigned);
-                    foreach (int index in deconstruction.LocalIndices)
-                        assigned.Add(index);
+                    foreach (var target in deconstruction.Targets)
+                    {
+                        CheckReads(target, assigned);
+                        if (target.Kind == DeconstructionTargetKind.Local)
+                            assigned.Add(target.LocalIndex);
+                    }
                     return DefiniteFlow.FallThrough;
                 case InitObject { Address: LoadLocalAddress address }:
                     assigned.Add(address.Index);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1412,48 +1412,125 @@ public sealed class TupleBinaryExpression : IrExpression
     public override string Describe() => IsEquality ? "TupleBinary ==" : "TupleBinary !=";
 }
 
+public enum DeconstructionTargetKind
+{
+    Local,
+    Property,
+}
+
+/// <summary>A target inside a raised tuple deconstruction.</summary>
+public sealed class DeconstructionTarget : IrNode
+{
+    DeconstructionTarget(DeconstructionTargetKind kind, TypeRef type)
+    {
+        Kind = kind;
+        Type = type;
+    }
+
+    public static DeconstructionTarget Local(int index, TypeRef type, bool isDeclared)
+        => new(DeconstructionTargetKind.Local, type)
+        {
+            LocalIndex = index,
+            IsDeclared = isDeclared,
+        };
+
+    public static DeconstructionTarget Property(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, bool isVirtual)
+    {
+        var valueType = accessor.ParameterTypes.Length > 0
+            ? accessor.ParameterTypes[^1]
+            : TypeRef.CoreLib("System", "Void");
+        var target = new DeconstructionTarget(DeconstructionTargetKind.Property, valueType)
+        {
+            Accessor = accessor,
+            HasInstance = instance is not null,
+            IsVirtual = isVirtual,
+        };
+        if (instance is not null)
+            target.AddChild(instance);
+        foreach (var argument in indexArguments)
+            target.AddChild(argument);
+        return target;
+    }
+
+    public DeconstructionTargetKind Kind { get; }
+    public TypeRef Type { get; }
+    public int LocalIndex { get; private init; } = -1;
+    public bool IsDeclared { get; private init; }
+    public MethodRef? Accessor { get; private init; }
+    public bool HasInstance { get; private init; }
+    public bool IsVirtual { get; private init; }
+    public string PropertyName => Accessor?.Name["set_".Length..] ?? "";
+    public IrExpression? Instance => Kind == DeconstructionTargetKind.Property && HasInstance ? (IrExpression)Children[0] : null;
+    public IReadOnlyList<IrExpression> IndexArguments
+        => Kind == DeconstructionTargetKind.Property
+            ? Children.Skip(HasInstance ? 1 : 0).Cast<IrExpression>().ToList()
+            : [];
+    public override IEnumerable<TypeRef> DirectTypes
+        => Kind == DeconstructionTargetKind.Property && Accessor is { } accessor
+            ? accessor.ParameterTypes.Append(accessor.DeclaringType)
+            : [Type];
+
+    public override string Describe() => Kind switch
+    {
+        DeconstructionTargetKind.Local => IsDeclared
+            ? $"DeconstructionTarget local declaration {LocalIndex}"
+            : $"DeconstructionTarget local assignment {LocalIndex}",
+        DeconstructionTargetKind.Property => $"DeconstructionTarget property {Accessor!.DeclaringType.ToDisplayString()}.{PropertyName}",
+        _ => "DeconstructionTarget",
+    };
+}
+
 /// <summary>
 /// A raised tuple deconstruction, produced by
 /// <see cref="DeconstructionAssignmentPass"/> from the compiler's
 /// <c>ValueTuple</c> receiver spill followed by sequential <c>ItemN</c> stores.
-/// <see cref="IsDeclaration"/> distinguishes a deconstruction <em>declaration</em>
-/// (<c>(T1 a, T2 b) = tuple;</c>, the targets are fresh locals declared here)
-/// from a deconstruction <em>assignment</em> into pre-existing locals
-/// (<c>(a, b) = tuple;</c>, the targets are declared elsewhere).
+/// Local targets may be declarations or assignments; property targets are
+/// assignments into an existing place.
 /// </summary>
 public sealed class DeconstructionAssignment : IrNode
 {
     public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source, ImmutableArray<bool> isDeclared)
+        : this([.. localIndices.Select((index, i) => DeconstructionTarget.Local(index, localTypes[i], isDeclared[i]))], source)
     {
-        LocalIndices = localIndices;
-        LocalTypes = localTypes;
-        IsDeclared = isDeclared;
-        AddChild(source);
     }
 
-    public ImmutableArray<int> LocalIndices { get; }
-    public ImmutableArray<TypeRef> LocalTypes { get; }
+    public DeconstructionAssignment(ImmutableArray<DeconstructionTarget> targets, IrExpression source)
+    {
+        AddChild(source);
+        foreach (var target in targets)
+            AddChild(target);
+    }
+
+    public ImmutableArray<DeconstructionTarget> Targets
+        => [.. Children.Skip(1).Cast<DeconstructionTarget>()];
+
+    public ImmutableArray<int> LocalIndices
+        => [.. Targets.Where(target => target.Kind == DeconstructionTargetKind.Local).Select(target => target.LocalIndex)];
+
+    public ImmutableArray<TypeRef> LocalTypes
+        => [.. Targets.Where(target => target.Kind == DeconstructionTargetKind.Local).Select(target => target.Type)];
 
     /// <summary>
-    /// Per-target declaration flags, parallel to <see cref="LocalIndices"/>: a
+    /// Per-local declaration flags, parallel to <see cref="LocalIndices"/>: a
     /// target is <c>true</c> when it is a fresh local introduced here (rendered
     /// with its declared type) and <c>false</c> when it assigns into a pre-existing
     /// local (rendered as a bare name). A run may mix the two — <c>(int x, y) =</c>.
     /// </summary>
-    public ImmutableArray<bool> IsDeclared { get; }
+    public ImmutableArray<bool> IsDeclared
+        => [.. Targets.Where(target => target.Kind == DeconstructionTargetKind.Local).Select(target => target.IsDeclared)];
 
     /// <summary>True when every target is a fresh declaration (the uniform-declaration form).</summary>
-    public bool IsDeclaration => IsDeclared.All(declared => declared);
+    public bool IsDeclaration => Targets.Length > 0 && Targets.All(target => target.Kind == DeconstructionTargetKind.Local && target.IsDeclared);
 
     public IrExpression Source => (IrExpression)Children[0];
-    public override IEnumerable<TypeRef> DirectTypes => LocalTypes;
+    public override IEnumerable<TypeRef> DirectTypes => Targets.SelectMany(target => target.DirectTypes);
 
     public override string Describe()
     {
-        string shape = IsDeclared.All(d => d) ? "declaration"
+        string shape = IsDeclaration ? "declaration"
             : IsDeclared.Any(d => d) ? "mixed"
             : "assignment";
-        return $"DeconstructionAssignment ({LocalIndices.Length} locals, {shape})";
+        return $"DeconstructionAssignment ({Targets.Length} targets, {shape})";
     }
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -7,16 +7,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <code>
 /// S = tuple;
 /// T1 a = S.Item1;
-/// T2 b = S.Item2;
+/// target = S.Item2;
 /// </code>
 /// into <c>(T1 a, T2 b) = tuple;</c> when the targets are fresh locals declared
 /// here, <c>(a, b) = tuple;</c> when they assign into pre-existing locals, or a
-/// mix such as <c>(T1 a, b) = tuple;</c> — each target is classified independently
-/// as a declaration or an assignment. Scoped to direct <c>System.ValueTuple</c>
-/// fields, arities 2-7, with every target a local (parameter and field targets,
-/// which the importer spells as <c>StoreArgument</c>/<c>StoreField</c> rather than
-/// <c>StoreLocal</c>, fall outside the match). Nested/rest tuples and user-defined
-/// <c>Deconstruct</c> calls are later slices.
+/// mix such as <c>(T1 a, b) = tuple;</c> — each local target is classified
+/// independently as a declaration or an assignment. Scoped to direct
+/// <c>System.ValueTuple</c> fields, arities 2-7, with local targets and simple
+/// property targets over side-effect-free receivers. Parameter, field, indexer,
+/// nested/rest tuples, and user-defined <c>Deconstruct</c> calls with non-local
+/// targets are later slices.
 /// </summary>
 public sealed class DeconstructionAssignmentPass : IIrPass
 {
@@ -45,7 +45,7 @@ public sealed class DeconstructionAssignmentPass : IIrPass
     static bool TryRaiseValueTuple(IrFunction function, Block block, int i, PassContext context)
     {
         var children = block.Children;
-        if (children[i] is not StoreStackSlot seed
+        if (TryMatchTupleSeed(function, children[i]) is not { } seed
             || seed.Value.ResultType is not { } tupleType
             || !MemberIdentity.IsSupportedValueTupleType(tupleType, out var arity)
             || i + arity >= children.Count)
@@ -53,42 +53,32 @@ public sealed class DeconstructionAssignmentPass : IIrPass
             return false;
         }
 
-        var stores = new List<StoreLocal>(arity);
+        var targets = new List<TargetMatch>(arity);
         for (int j = 0; j < arity; j++)
         {
-            if (children[i + 1 + j] is not StoreLocal
-                {
-                    Value: LoadField
-                    {
-                        Field.Name: var fieldName,
-                        Instance: LoadStackSlot load,
-                    },
-                } store
-                || load.Slot != seed.Slot
-                || fieldName != $"Item{j + 1}")
+            if (TryMatchTarget(function, children[i + 1 + j], seed, j + 1) is not { } target)
             {
-                stores.Clear();
+                targets.Clear();
                 break;
             }
-            stores.Add(store);
+            targets.Add(target);
         }
 
-        if (stores.Count != arity
-            || !ReferencedOnlyWithin(function, seed.Slot, stores))
+        if (targets.Count != arity
+            || !ReferencedOnlyWithin(function, seed, [seed.Statement, .. targets.Select(target => target.Statement)]))
         {
             return false;
         }
 
-        var targets = stores.Select(store => (store.Index, store.Type, (IrNode)store));
-        if (ClassifyTargets(function, targets) is not { } resolved)
+        if (ClassifyTargets(function, seed, targets) is not { } resolved)
             return false;
 
-        var source = (IrExpression)seed.DetachChildren()[0];
-        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared);
-        context.Stepper.StepOver("raise ValueTuple field stores to deconstruction", seed);
-        seed.ReplaceWith(deconstruction);
-        foreach (var store in stores)
-            store.Detach();
+        var source = (IrExpression)seed.Statement.DetachChildren()[0];
+        var deconstruction = new DeconstructionAssignment([.. resolved], source);
+        context.Stepper.StepOver("raise ValueTuple field stores to deconstruction", seed.Statement);
+        seed.Statement.ReplaceWith(deconstruction);
+        foreach (var target in targets)
+            target.DetachConsumedStatement();
         return true;
     }
 
@@ -148,6 +138,106 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         _ => null,
     };
 
+    sealed record TupleSeed(IrNode Statement, IrExpression Value, int Index, bool IsLocal)
+    {
+        public bool Matches(IrExpression expression) => IsLocal
+            ? expression is LoadLocal local && local.Index == Index
+            : expression is LoadStackSlot slot && slot.Slot == Index;
+
+        public bool IsReference(IrNode node) => IsLocal
+            ? node switch
+            {
+                LoadLocal local => local.Index == Index,
+                StoreLocal local => local.Index == Index,
+                LoadLocalAddress address => address.Index == Index,
+                _ => false,
+            }
+            : node switch
+            {
+                LoadStackSlot slot => slot.Slot == Index,
+                StoreStackSlot slot => slot.Slot == Index,
+                _ => false,
+            };
+    }
+
+    sealed record TargetMatch(IrNode Statement, Func<DeconstructionTarget> BuildTarget)
+    {
+        public void DetachConsumedStatement() => Statement.Detach();
+    }
+
+    static TupleSeed? TryMatchTupleSeed(IrFunction function, IrNode node) => node switch
+    {
+        StoreStackSlot stack => new TupleSeed(stack, stack.Value, stack.Slot, IsLocal: false),
+        StoreLocal local when IsHiddenLocal(function, local.Index) => new TupleSeed(local, local.Value, local.Index, IsLocal: true),
+        _ => null,
+    };
+
+    static TargetMatch? TryMatchTarget(IrFunction function, IrNode statement, TupleSeed seed, int ordinal)
+    {
+        if (statement is StoreLocal
+            {
+                Value: LoadField
+                {
+                    Field.Name: var localFieldName,
+                    Instance: var localInstance,
+                },
+            } local
+            && localInstance is not null
+            && seed.Matches(localInstance)
+            && localFieldName == $"Item{ordinal}")
+        {
+            return new TargetMatch(local, () => DeconstructionTarget.Local(
+                local.Index,
+                local.Type,
+                IsFirstReference(function, local, local.Index)));
+        }
+
+        if (statement is StoreProperty
+            {
+                Value: LoadField
+                {
+                    Field.Name: var propertyFieldName,
+                    Instance: var propertyInstance,
+                },
+            } property
+            && propertyInstance is not null
+            && seed.Matches(propertyInstance)
+            && propertyFieldName == $"Item{ordinal}"
+            && IsSimplePropertyTarget(property, seed))
+        {
+            return new TargetMatch(property, () => BuildPropertyTarget(property));
+        }
+
+        return null;
+    }
+
+    static DeconstructionTarget BuildPropertyTarget(StoreProperty property)
+    {
+        int indexArgumentCount = property.Accessor.ParameterTypes.Length - 1;
+        var children = property.DetachChildren();
+        var instance = property.HasInstance ? (IrExpression?)children[0] : null;
+        var indexArguments = children
+            .Skip(property.HasInstance ? 1 : 0)
+            .Take(indexArgumentCount)
+            .Cast<IrExpression>()
+            .ToArray();
+        return DeconstructionTarget.Property(property.Accessor, instance, indexArguments, property.IsVirtual);
+    }
+
+    static bool IsSimplePropertyTarget(StoreProperty property, TupleSeed seed)
+    {
+        if (property.Accessor.ParameterTypes.Length == 0 || property.IndexArguments.Count != 0)
+            return false;
+
+        return property.Instance switch
+        {
+            null => true,
+            LoadArgument => true,
+            LoadLocal local => !(seed.IsLocal && local.Index == seed.Index),
+            _ => false,
+        };
+    }
+
     /// <summary>
     /// Resolves the deconstruction targets, classifying each independently as a
     /// fresh local introduced here (a declaration, its first reference is this
@@ -169,13 +259,42 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         return ([.. resolved.Select(target => target.index)], [.. resolved.Select(target => target.type)], isDeclared);
     }
 
-    static bool ReferencedOnlyWithin(IrFunction function, int slot, IReadOnlyList<StoreLocal> stores)
+    static ImmutableArray<DeconstructionTarget>? ClassifyTargets(
+        IrFunction function,
+        TupleSeed seed,
+        IReadOnlyList<TargetMatch> targets)
     {
-        foreach (var load in function.Descendants.OfType<LoadStackSlot>().Where(load => load.Slot == slot))
-            if (!stores.Any(store => IsInside(load, store)))
+        var localIndices = new HashSet<int>();
+        foreach (var local in targets.Select(target => target.Statement).OfType<StoreLocal>())
+        {
+            if (seed.IsLocal && local.Index == seed.Index)
+                return null;
+            if (!localIndices.Add(local.Index))
+                return null;
+        }
+
+        foreach (var property in targets.Select(target => target.Statement).OfType<StoreProperty>())
+            if (property.Instance is LoadLocal receiver && localIndices.Contains(receiver.Index))
+                return null;
+
+        var builder = ImmutableArray.CreateBuilder<DeconstructionTarget>(targets.Count);
+        foreach (var target in targets)
+            builder.Add(target.BuildTarget());
+        return builder.MoveToImmutable();
+    }
+
+    static bool ReferencedOnlyWithin(IrFunction function, TupleSeed seed, IReadOnlyList<IrNode> allowed)
+    {
+        foreach (var reference in function.Descendants.Where(seed.IsReference))
+            if (!allowed.Any(allowedNode => IsInside(reference, allowedNode)))
                 return false;
         return true;
     }
+
+    static bool IsHiddenLocal(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && function.LocalNames[index] is null;
 
     static bool IsFirstReference(IrFunction function, IrNode target, int index)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -56,9 +56,6 @@ public static class IrPasses
         // Runs after struct-constructor so in-place struct .ctor calls have
         // already been normalized to NewObject when they are spellable.
         new TupleCreationPass(),
-        // Raise ValueTuple receiver-spill + ItemN local stores back into a
-        // local tuple deconstruction declaration.
-        new DeconstructionAssignmentPass(),
         // Raise an anonymous-type constructor (new <>f__AnonymousTypeN(...)) back
         // into a new { Name = value, ... } literal, using the property names the
         // importer captured on the NewObject. Runs in the expression-sugar band
@@ -66,6 +63,9 @@ public static class IrPasses
         // flat form is invalid C#, so this also lifts fidelity to valid source.
         new AnonymousObjectPass(),
         new PropertySugarPass(),
+        // Raise ValueTuple receiver-spill + ItemN target stores back into tuple
+        // deconstruction after property-sugar has normalized setter calls.
+        new DeconstructionAssignmentPass(),
         // Raise the object/collection-initializer lowering (a NewObject threaded
         // through a dup chain and mutated by a run of member stores or Add calls)
         // back into new T { X = a, ... }. Runs after property-sugar so the member

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -63,7 +63,7 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Full)] public static BooleanFoldingPass ConditionalOperator => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static StructuringPass ContinueStatement => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative Conversion => default!;
-    [Completeness(CompletenessLevel.Partial, "local exact BCL ValueTuple deconstruction (arities 2-7) as a fresh-local declaration, existing-local assignment, or a mix of the two over locals ((int x, y) = ...), plus Deconstruct-method calls with a local/parameter receiver; non-local existing targets (parameters/fields) and the temp-then-copy receiver forms not raised")]
+    [Completeness(CompletenessLevel.Partial, "local exact BCL ValueTuple deconstruction (arities 2-7) as a fresh-local declaration, existing-local assignment, or a mix of locals and simple property targets over side-effect-free receivers ((int x, node.Count) = ...), plus Deconstruct-method calls with a local/parameter receiver; parameter, field, indexer, side-effecting property receiver, source-named temp-copy, and broader temp-then-copy forms not raised")]
     public static DeconstructionAssignmentPass DeconstructionAssignmentOperator => new();
     [Completeness(CompletenessLevel.Full)] public static DelegateConstructionPass DelegateCreationExpression => new();
     [Completeness(CompletenessLevel.Partial, "control flow — completeness tracked by --gaps")] public static DoWhileLoopPass DoStatement => new();


### PR DESCRIPTION
## Summary
- raises the simple ValueTuple temp-copy shape for `(int x, node.Count) = pair`
- generalizes deconstruction targets to local/property targets while keeping source-named temps and side-effecting receivers lowered
- updates deconstruction ledger/sidecar coverage and adds positive/negative fixtures

## Validation
- dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
- dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.DeconstructionAssignmentPassTests -noLogo
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.LoweringFactCatalogTests -class ILInspector.Decompiler.Tests.LoweringCoverageTests -class ILInspector.Decompiler.Tests.DataflowFactsTests -noLogo
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.FidelityGateTests -noLogo
- dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dotnet-inspect-frontier-fixtures/bin/Release/net11.0/FrontierFixtures.dll --dump FrontierEvidence.TupleDeconstructionCases::PropertyTarget

Fixes one row of #1142.