### PR TITLE
Decline expression tree lambda recovery

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -188,6 +188,23 @@ public class CfgSampleClass
     // lazy cache and LambdaRaisingPass recovers `x => x + 1`.
     public static System.Func<int, int> NonCapturingLambda() => x => x + 1;
 
+    // Expression-tree lambdas do not emit a generated closure method to import;
+    // ExpressionLambdaRewriter lowers the syntax directly to factory calls.
+    public static System.Linq.Expressions.Expression<System.Func<int, int>> SimpleExpressionTreeLambda()
+        => x => x + 1;
+
+    // Near-miss for expression-tree recovery: factory calls can be source-authored
+    // directly, with the same public Expression APIs that the compiler uses.
+    public static System.Linq.Expressions.Expression<System.Func<int, int>> ManualSimpleExpressionTreeFactory()
+    {
+        System.Linq.Expressions.ParameterExpression x;
+        return System.Linq.Expressions.Expression.Lambda<System.Func<int, int>>(
+            System.Linq.Expressions.Expression.Add(
+                x = System.Linq.Expressions.Expression.Parameter(typeof(int), "x"),
+                System.Linq.Expressions.Expression.Constant(1)),
+            x);
+    }
+
     // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
     // an instance method on that class. LambdaRaisingPass substitutes the body's
     // `this.n` read with the captured value and recovers `x => x + n`.

--- a/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
@@ -1,0 +1,44 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ExpressionTreeLambdaTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return function!;
+    }
+
+    [Fact]
+    public void SimpleExpressionTreeLambda_StaysFactoryCalls()
+    {
+        var function = Raised(nameof(CfgSampleClass.SimpleExpressionTreeLambda));
+
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("Expression.Lambda<Func<int, int>>", output);
+        Assert.Contains("Expression.Add", output);
+        Assert.Contains("Expression.Parameter(typeof(int), \"x\")", output);
+        Assert.DoesNotContain("=>", output);
+    }
+
+    [Fact]
+    public void ManualExpressionTreeFactory_StaysFactoryCalls()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualSimpleExpressionTreeFactory));
+
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("Expression.Lambda<Func<int, int>>", output);
+        Assert.Contains("Expression.Add", output);
+        Assert.Contains("Expression.Parameter(typeof(int), \"x\")", output);
+        Assert.DoesNotContain("=>", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringCoverageTests.cs
@@ -127,6 +127,7 @@ public class LoweringCoverageTests
             .ToHashSet();
 
         Assert.Contains("Query", declined);
+        Assert.Contains("ExpressionTreeLambda", declined);
         foreach (var name in declined)
             Assert.DoesNotContain(name, owed);
     }

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -26,6 +26,7 @@ public class LoweringFactCatalogTests
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.Lambda");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.LocalFunction");
         Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.CapturedClosure");
+        Assert.Contains(entries, e => e.Key.ToString() == "ClosureConversion.ExpressionTreeLambda");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ExpressionTreeRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ExpressionTreeRecoveryFacts.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class ExpressionTreeRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.ExpressionTreeLambda)),
+            typeof(Declined),
+            [
+                new FactPrimitive("no-generated-closure-method", "ExpressionLambdaRewriter emits System.Linq.Expressions factory calls instead of a delegate target body"),
+                new FactPrimitive("manual-factory-lookalike", "ExpressionTreeLambdaTests.ManualExpressionTreeFactory_StaysFactoryCalls"),
+            ],
+            PositiveCoverage: "ExpressionTreeLambdaTests simple arithmetic expression-tree lambda fixture remains visible as Expression.Parameter/Add/Lambda factory calls",
+            AdversarialCoverage: "ExpressionTreeLambdaTests manual Expression.Parameter/Add/Lambda factory-call lookalike remains factory calls",
+            MissingDiscriminator: "Expression-tree lambda syntax has no IL/PDB-independent discriminator from equivalent source-authored factory calls; keep the factory-call form unless a future source-syntax oracle is explicitly introduced"),
+    ];
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LambdaRecoveryFacts.cs
@@ -13,7 +13,7 @@ internal sealed class LambdaRecoveryFacts : ILoweringFactProvider
             ],
             PositiveCoverage: "LambdaRaisingPassTests non-capturing, capturing, non-capturing local-bodied, and parameter-capturing local-bodied fixtures",
             AdversarialCoverage: "LambdaRaisingPassTests generated-name lookalike without metadata and outer-local capturing local-bodied guard",
-            MissingDiscriminator: "outer-local capturing local-bound bodies and expression trees need additional closure/state facts"),
+            MissingDiscriminator: "outer-local capturing local-bound bodies need additional closure/state facts"),
 
         new(
             new LoweringFactKey(LoweringFactRegister.ClosureConversion, nameof(ClosureCoverage.CapturedClosure)),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -19,10 +19,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// zero-local capturing lambdas (a folded <c>&lt;&gt;c__DisplayClass</c>
 /// environment whose hoisted fields are substituted back into the body), and
 /// <see cref="LocalFunctionRaisingPass"/> recovers static non-capturing local
-/// functions. Capturing local-bound lambda bodies and expression trees are
-/// still owed, so they render as synthesized
-/// <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — an inferior-form gap
-/// the LocalRewriter register cannot show.</para>
+/// functions. Capturing local-bound lambda bodies are still owed, so they render
+/// as synthesized <c>&lt;&gt;c__DisplayClass</c> / <c>g__Local|</c> shapes — an
+/// inferior-form gap the LocalRewriter register cannot show. Expression-tree
+/// lambdas are tracked here too, but deliberately declined: ExpressionLambdaRewriter
+/// emits the same public factory-call shape that source can write by hand.</para>
 ///
 /// <para>Synced against dotnet/roslyn
 /// <c>src/Compilers/CSharp/Portable/Lowering/ClosureConversion/</c> @ main.</para>
@@ -38,6 +39,6 @@ internal static class ClosureCoverage
     [Completeness(CompletenessLevel.Partial, "a lambda's captured variables, substituted back from its <>c__DisplayClass environment — folded onto the delegate, or a local set up and shared across statements (allocation/stores elided); a class captured by a local function, or nested environments, still owed")]
     public static LambdaRaisingPass CapturedClosure => new();
 
-    [Completeness(CompletenessLevel.None, "Expression<Func<...>> built via Expression.Lambda/Call/... (ExpressionLambdaRewriter)")]
-    public static Unhandled ExpressionTreeLambda => default!;
+    [Completeness(CompletenessLevel.None, "Expression<Func<...>> syntax lowered by ExpressionLambdaRewriter to System.Linq.Expressions factory calls; no generated closure method or IL/PDB-independent discriminator separates it from equivalent source-authored Expression.Parameter/Add/Lambda calls, so the factory-call form is kept")]
+    public static Declined ExpressionTreeLambda => default!;
 }


### PR DESCRIPTION
Refs #1142

## Summary
- classify `ClosureCoverage.ExpressionTreeLambda` as a deliberate `Declined` row rather than owed `Unhandled` work
- add source expression-tree and manual `Expression.Parameter`/`Add`/`Lambda` factory fixtures that both stay in factory-call form
- add a sidecar entry documenting the missing discriminator and remove expression trees from the ordinary lambda missing-discriminator text

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --no-restore`