### PR TITLE
Recover nullable-aware generic constraints

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -206,6 +206,26 @@ public class TypeSourceCheckTests
     }
 
     [Fact]
+    public void Evaluate_OnNullableConstraintFixture_RendersRecoveredConstraints()
+    {
+        string path = typeof(TypeSourceNullableConstraintMatrix<,,,>).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourceNullableConstraintMatrix<,,,>).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        Assert.Contains("where TNotNull : notnull", source);
+        Assert.Contains("where TClassNullable : class?", source);
+        Assert.Contains("where TUnmanaged : unmanaged", source);
+        Assert.Contains("where TNullableInterface : IDisposable?", source);
+
+        var deltas = TypeSourceCheck.CompareType(type, source);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.GenericConstraintDropped);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.GenericConstraintExtra);
+    }
+
+    [Fact]
     public void WrongTypeKind_IsCaught()
     {
         var type = Type("N", "C", "struct", Member("Foo", "method"));
@@ -273,4 +293,13 @@ public class TypeSourceCheckTests
         var deltas = TypeSourceCheck.Evaluate(path);
         Assert.NotNull(deltas);
     }
+}
+
+public class TypeSourceNullableConstraintMatrix<TNotNull, TClassNullable, TUnmanaged, TNullableInterface>
+    where TNotNull : notnull
+    where TClassNullable : class?
+    where TUnmanaged : unmanaged
+    where TNullableInterface : System.IDisposable?
+{
+    public int Value => 0;
 }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -114,17 +114,22 @@ public static class ApiSurfaceExtractor
                     else if ((attrs & GenericParameterAttributes.Contravariant) != 0)
                         typeParam.Variance = "in";
 
-                    // Get special constraints
-                    if ((attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
-                        typeParam.Constraints.Add("class");
-                    if ((attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+                    var nullable = GetEffectiveNullable(reader, param.GetCustomAttributes(), typeNullableContext);
+                    var hasReferenceTypeConstraint = (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+                    var hasValueTypeConstraint = (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+                    var hasDefaultConstructorConstraint = (attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+                    var isUnmanaged = AttributeReader.HasAttribute(reader, param.GetCustomAttributes(),
+                        KnownAttributeNames.IsUnmanagedAttribute);
+
+                    // Get primary constraints.
+                    if (hasReferenceTypeConstraint)
+                        typeParam.Constraints.Add(nullable == 2 ? "class?" : "class");
+                    else if (isUnmanaged)
+                        typeParam.Constraints.Add("unmanaged");
+                    else if (hasValueTypeConstraint)
                         typeParam.Constraints.Add("struct");
-                    if ((attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0 &&
-                        (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0)
-                        // new() is implied by struct constraint, only show if not struct
-                        typeParam.Constraints.Add("new()");
-                    if ((attrs & GenericParameterAttributes.AllowByRefLike) != 0)
-                        typeParam.Constraints.Add("allows ref struct");
+                    else if (nullable == 1)
+                        typeParam.Constraints.Add("notnull");
 
                     // Get type constraints (interfaces and base class)
                     foreach (var constraintHandle in param.GetConstraints())
@@ -135,9 +140,14 @@ public static class ApiSurfaceExtractor
                         {
                             // Skip System.ValueType (shown as 'struct' above) and System.Object
                             if (constraintTypeName != "System.ValueType" && constraintTypeName != "System.Object")
-                                typeParam.Constraints.Add(constraintTypeName);
+                                typeParam.Constraints.Add(FormatConstraintType(reader, constraint, constraintTypeName, typeNullableContext));
                         }
                     }
+
+                    if (hasDefaultConstructorConstraint && !hasValueTypeConstraint)
+                        typeParam.Constraints.Add("new()");
+                    if ((attrs & GenericParameterAttributes.AllowByRefLike) != 0)
+                        typeParam.Constraints.Add("allows ref struct");
 
                     apiType.TypeParameters.Add(typeParam);
                 }
@@ -457,6 +467,24 @@ public static class ApiSurfaceExtractor
         }
 
         return surface;
+    }
+
+    private static byte? GetEffectiveNullable(
+        MetadataReader reader, CustomAttributeHandleCollection attributes, byte nullableContext)
+    {
+        var bytes = NullabilityReader.GetNullableBytes(reader, attributes);
+        if (bytes is { Length: > 0 })
+            return bytes[0];
+        return nullableContext != 0 ? nullableContext : null;
+    }
+
+    private static string FormatConstraintType(
+        MetadataReader reader, GenericParameterConstraint constraint, string constraintTypeName, byte nullableContext)
+    {
+        var nullable = GetEffectiveNullable(reader, constraint.GetCustomAttributes(), nullableContext);
+        return nullable == 2 && !constraintTypeName.EndsWith("?", StringComparison.Ordinal)
+            ? $"{constraintTypeName}?"
+            : constraintTypeName;
     }
 
     private static (string? Namespace, string Name) GetApiTypeNameParts(MetadataReader reader, TypeDefinition typeDef)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -300,9 +300,60 @@ public class ApiSurfaceExtractorTests
         
         var param = testType.TypeParameters[0];
         Assert.Equal("T", param.Name);
-        Assert.Contains("class", param.Constraints);
-        Assert.Contains("System.IDisposable", param.Constraints);
-        Assert.Contains("new()", param.Constraints);
+        Assert.Equal(["class", "System.IDisposable", "new()"], param.Constraints);
+    }
+
+    [Fact]
+    public void Extract_DistinguishesNullableAwareGenericConstraintShapes()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        AssertConstraints(surface, "SampleUnconstrainedConstraint`1", []);
+        AssertConstraints(surface, "SampleNotNullConstraint`1", ["notnull"]);
+        AssertConstraints(surface, "SampleClassConstraint`1", ["class"]);
+        AssertConstraints(surface, "SampleClassNullableConstraint`1", ["class?"]);
+        AssertConstraints(surface, "SampleStructConstraint`1", ["struct"]);
+        AssertConstraints(surface, "SampleUnmanagedConstraint`1", ["unmanaged"]);
+        AssertConstraints(surface, "SampleInterfaceConstraint`1", ["System.IDisposable"]);
+        AssertConstraints(surface, "SampleInterfaceNullableConstraint`1", ["System.IDisposable?"]);
+        AssertConstraints(surface, "SampleInterfaceNewConstraint`1", ["System.IDisposable", "new()"]);
+        AssertConstraints(surface, "SampleNotNullInterfaceNewConstraint`1", ["notnull", "System.IDisposable", "new()"]);
+    }
+
+    [Fact]
+    public void Extract_DistinguishesMixedGenericParameterNullableOverrides()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleMixedNullableConstraints`4");
+        Assert.NotNull(testType);
+        Assert.Collection(testType.TypeParameters,
+            p =>
+            {
+                Assert.Equal("TNotNull", p.Name);
+                Assert.Equal(["notnull"], p.Constraints);
+            },
+            p =>
+            {
+                Assert.Equal("TUnconstrained", p.Name);
+                Assert.Empty(p.Constraints);
+            },
+            p =>
+            {
+                Assert.Equal("TClass", p.Name);
+                Assert.Equal(["class"], p.Constraints);
+            },
+            p =>
+            {
+                Assert.Equal("TClassNullable", p.Name);
+                Assert.Equal(["class?"], p.Constraints);
+            });
     }
 
     [Fact]
@@ -381,6 +432,14 @@ public class ApiSurfaceExtractorTests
         };
 
         Assert.Null(param.ConstraintsSummary);
+    }
+
+    private static void AssertConstraints(ApiSurface surface, string typeName, string[] expected)
+    {
+        var testType = surface.Types.FirstOrDefault(t => t.Name == typeName);
+        Assert.NotNull(testType);
+        var param = Assert.Single(testType.TypeParameters);
+        Assert.Equal(expected, param.Constraints);
     }
 
     [Fact]
@@ -665,6 +724,16 @@ public class SampleGenericClass<T> : IEnumerable<T>
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new NotImplementedException();
 }
 
+public class SampleUnconstrainedConstraint<T>
+{
+    public T? Maybe { get; set; }
+}
+
+public class SampleNotNullConstraint<T> where T : notnull
+{
+    public T Value { get; set; } = default!;
+}
+
 /// <summary>
 /// Sample generic class with class constraint for testing constraint extraction.
 /// </summary>
@@ -673,10 +742,20 @@ public class SampleClassConstraint<T> where T : class
     public T? Value { get; set; }
 }
 
+public class SampleClassNullableConstraint<T> where T : class?
+{
+    public T Value { get; set; } = default!;
+}
+
 /// <summary>
 /// Sample generic class with struct constraint for testing constraint extraction.
 /// </summary>
 public class SampleStructConstraint<T> where T : struct
+{
+    public T Value { get; set; }
+}
+
+public class SampleUnmanagedConstraint<T> where T : unmanaged
 {
     public T Value { get; set; }
 }
@@ -695,6 +774,32 @@ public class SampleNewConstraint<T> where T : new()
 public class SampleInterfaceConstraint<T> where T : IDisposable
 {
     public void Use(T item) => item.Dispose();
+}
+
+public class SampleInterfaceNullableConstraint<T> where T : IDisposable?
+{
+    public void Use(T? item) => item?.Dispose();
+}
+
+public class SampleInterfaceNewConstraint<T> where T : IDisposable, new()
+{
+    public T Create() => new();
+}
+
+public class SampleNotNullInterfaceNewConstraint<T> where T : notnull, IDisposable, new()
+{
+    public T Create() => new();
+}
+
+public class SampleMixedNullableConstraints<TNotNull, TUnconstrained, TClass, TClassNullable>
+    where TNotNull : notnull
+    where TClass : class
+    where TClassNullable : class?
+{
+    public TNotNull Value { get; set; } = default!;
+    public TUnconstrained? Maybe { get; set; }
+    public TClass ClassValue { get; set; } = default!;
+    public TClassNullable ClassMaybe { get; set; } = default!;
 }
 
 /// <summary>

--- a/tools/DecompilerHarness/TypeSourceCheck.cs
+++ b/tools/DecompilerHarness/TypeSourceCheck.cs
@@ -230,14 +230,14 @@ static class TypeSourceCheck
 
             foreach (var constraint in expected)
             {
-                if (!actual.Contains(constraint))
+                if (!actual.Any(declared => ConstraintMatches(constraint, declared)))
                     deltas.Add(new TypeArtifactDelta(fullType, Deltas.GenericConstraintDropped,
                         $"{typeParameter.Name} : {constraint}"));
             }
 
             foreach (var constraint in actual)
             {
-                if (!expected.Contains(constraint))
+                if (!expected.Any(metadata => ConstraintMatches(metadata, constraint)))
                     deltas.Add(new TypeArtifactDelta(fullType, Deltas.GenericConstraintExtra,
                         $"{typeParameter.Name} : {constraint}"));
             }
@@ -253,6 +253,26 @@ static class TypeSourceCheck
                     $"{name} : {constraint}"));
         }
     }
+
+    static bool ConstraintMatches(string metadataConstraint, string declaredConstraint)
+    {
+        if (metadataConstraint == declaredConstraint)
+            return true;
+
+        var (metadataType, metadataNullable) = SplitNullableSuffix(metadataConstraint);
+        var (declaredType, declaredNullable) = SplitNullableSuffix(declaredConstraint);
+        if (metadataNullable != declaredNullable)
+            return false;
+
+        return metadataType == declaredType
+            || metadataType.EndsWith($".{declaredType}", StringComparison.Ordinal)
+            || declaredType.EndsWith($".{metadataType}", StringComparison.Ordinal);
+    }
+
+    static (string Type, bool Nullable) SplitNullableSuffix(string constraint)
+        => constraint.EndsWith("?", StringComparison.Ordinal)
+            ? (constraint[..^1], true)
+            : (constraint, false);
 
     static void CompareMembers(ApiType type, MemberDeclarationSyntax typeDecl, string fullType,
         List<TypeArtifactDelta> deltas)


### PR DESCRIPTION
## Summary

- Adds a fixture matrix for nullable-aware type generic constraint shapes before recovery.
- Recovers type-level `notnull`, `class?`, nullable interface/base constraints, and `unmanaged` from SRM metadata.
- Emits constraints in C# ordering so `new()` follows type/interface constraints.
- Teaches the whole-type source oracle to compare fully qualified metadata constraints against shortened rendered constraints while preserving nullable suffixes.

## Root Cause

`ApiSurfaceExtractor` only read CLR generic-parameter flags and raw constraint rows. C# constraints such as `notnull`, `class?`, and nullable interface constraints are represented through nullable metadata (`NullableAttribute` / `NullableContextAttribute`) rather than ordinary CLR constraint flags. `unmanaged` is represented by `IsUnmanagedAttribute`, but the extractor previously rendered it as `struct`.

## Scope Note

This PR handles type generic parameters, where `ApiType.TypeParameters` already models constraints. Method generic parameter constraints are not included because `ApiMember` does not currently expose method type-parameter constraints; that is separate model/rendering work.

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.ApiSurfaceExtractorTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypeSourceCheckTests`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
- Earlier full-suite checks before the final rebase:
  - `dotnet run --project src/dotnet-inspect.Tests -c Release`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `git diff --check`

Fixes #1143.
