### PR TITLE
Pin collection-spread-in-iterator frontier interaction (#1142)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -308,11 +308,23 @@ public class IteratorReconstructionPassTests
     {
         var function = Raised(nameof(CfgSampleClass.YieldCollectionExpressionSpread));
 
+        // The iterator layer reconstructs the single yield, but the yielded
+        // spread collection expression (`[.. arch, true]`) stays at the lowered
+        // inline-array/CopyTo/Slice altitude: the spread collection-target frontier
+        // is unraised (see CollectionExpression ledger), so this composes two
+        // independent frontiers rather than recovering the source idiom. The
+        // reconstruction is still Full fidelity — honest, just lower altitude.
         Assert.Single(function.Descendants.OfType<YieldReturn>());
         Assert.Empty(function.Descendants.OfType<CollectionExpression>());
         Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
 
+        // Pin the exact lowered spread shape so an array-spread raise cannot reach
+        // into the iterator interaction without an explicit fixture proving it safe.
         var output = Print(nameof(CfgSampleClass.YieldCollectionExpressionSpread));
+        Assert.Contains("new bool[1 + ", output);
+        Assert.Contains(".CopyTo(", output);
+        Assert.Contains(".Slice(", output);
         Assert.Contains("yield return", output);
         Assert.DoesNotContain("[..", output);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
@@ -11,7 +11,7 @@ internal sealed class IteratorRecoveryFacts : ILoweringFactProvider
                 new FactPrimitive("generated.iterator-state-machine", "GeneratedCodeIdentity.IsIteratorStateMachineConstructor"),
             ],
             PositiveCoverage: "IteratorReconstructionPassTests linear, yield-nothing, counting-loop, conditional, multi-yield, nested-loop, and foreach-delegation iterator fixtures",
-            AdversarialCoverage: "IteratorReconstructionPassTests parameter-referencing empty iterator and IteratorAcknowledgmentPassTests state-machine-name lookalike",
-            MissingDiscriminator: "captured iterator shapes and deeper state-machine/PDB correlation remain owed"),
+            AdversarialCoverage: "IteratorReconstructionPassTests parameter-referencing empty iterator, state-machine-name lookalike (IteratorAcknowledgmentPassTests), and collection-spread yield body that reconstructs the iterator while leaving the spread lowered (CollectionExpressionSpreadIterator_ReconstructsYieldButNotSpread)",
+            MissingDiscriminator: "captured iterator shapes and deeper state-machine/PDB correlation remain owed; a reconstructed iterator can still contain lowered scaffolding from an unraised inner frontier — e.g. a yielded spread collection expression (`yield return [.. arch, true];`) keeps its inline-array/CopyTo/Slice lowering because the spread collection-target frontier is unraised (see CollectionExpression)"),
     ];
 }


### PR DESCRIPTION
## What

Burndown row from #1142: **Collection expression in iterator/yield**.

The positive frontier-tracking fixture (`YieldCollectionExpressionSpread`) and a basic test already landed in #1059. This PR hardens that into a precise pin:

- The yielded spread collection expression `yield return [.. arch, true];` reconstructs the iterator at **Full** fidelity but keeps the spread element at the lowered `new bool[1 + ...]` / `CopyTo` / `Slice` altitude — two independent frontiers compose honestly rather than recovering the source idiom.
- Sharpened `CollectionExpressionSpreadIterator_ReconstructsYieldButNotSpread` from a loose `no [..` check into a regression guard on the exact lowered spread shape plus Full fidelity. This protects the iterator interaction against the in-review array-spread raise (#1151) reaching in without an explicit fixture.
- Cross-referenced the interaction from the iterator ledger sidecar (`IteratorRecoveryFacts`): a reconstructed iterator can still contain lowered scaffolding from an unraised inner frontier.

## Evidence

Current decompiled output (Full fidelity):

```csharp
bool[] V_3 = new bool[1 + V_1.Length];
ReadOnlySpan<bool> V_4 = new ReadOnlySpan<bool>(V_1);
Span<bool> V_5 = new Span<bool>(V_3);
V_4.CopyTo(V_5.Slice(V_2, V_4.Length));
V_2 += V_4.Length;
V_3[V_2] = true;
yield return V_3;
```

## Tests

`dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — all 1035 pass.

No raise added (guardrail: spread-in-iterator has no reliable discriminator; pin instead of guess). SRM-only, no inspected-assembly loading.

Closes the iterator/yield row in #1142.