### PR TITLE
Preserve nested-type suffix in generic instantiations (#1154)

### DIFF
--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -64,14 +64,14 @@ internal sealed class NamedTypeNode(string name, bool isReferenceType) : TypeNod
 }
 
 /// <summary>Generic instantiations (Dictionary&lt;K,V&gt;, Task&lt;T&gt;, etc.).</summary>
-internal sealed class GenericTypeNode(string baseName, bool isReferenceType, ImmutableArray<TypeNode> arguments) : TypeNode
+internal sealed class GenericTypeNode(string baseName, bool isReferenceType, ImmutableArray<TypeNode> arguments, string nestedSuffix = "") : TypeNode
 {
     public override bool IsReferenceType => isReferenceType;
 
     public override string Render()
     {
         var argsStr = string.Join(", ", arguments.Select(a => a.Render()));
-        var result = $"{baseName}<{argsStr}>";
+        var result = $"{baseName}<{argsStr}>{nestedSuffix}";
         return IsReferenceType && IsNullableAnnotated ? $"{result}?" : result;
     }
 

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -51,11 +51,21 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
 
     public TypeNode GetGenericInstantiation(TypeNode genericType, ImmutableArray<TypeNode> typeArguments)
     {
-        // Strip .NET arity suffix (e.g., List`1 -> List)
         string rawName = genericType is NamedTypeNode n ? n.Name : genericType.Render();
         var backtickIndex = rawName.IndexOf('`');
-        var baseName = backtickIndex >= 0 ? rawName[..backtickIndex] : rawName;
-        return new GenericTypeNode(baseName, genericType.IsReferenceType, typeArguments);
+        if (backtickIndex < 0)
+            return new GenericTypeNode(rawName, genericType.IsReferenceType, typeArguments);
+
+        // Strip only the arity digits at the first backtick, keeping any trailing
+        // nested-type segment (Dictionary`2.Enumerator -> base "Dictionary",
+        // suffix ".Enumerator") so the instantiation renders Dictionary<…>.Enumerator
+        // rather than collapsing to Dictionary<…>.
+        var baseName = rawName[..backtickIndex];
+        var suffixStart = backtickIndex + 1;
+        while (suffixStart < rawName.Length && char.IsDigit(rawName[suffixStart]))
+            suffixStart++;
+        var nestedSuffix = TypeResolver.FormatDisplayName(rawName[suffixStart..]);
+        return new GenericTypeNode(baseName, genericType.IsReferenceType, typeArguments, nestedSuffix);
     }
 
     public TypeNode GetGenericMethodParameter(GenericContext? context, int index)

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -62,12 +62,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     public string GetPointerType(string elementType) => $"{elementType}*";
     
     public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
-    {
-        // Strip .NET arity suffix (e.g., List`1 -> List)
-        var backtickIndex = genericType.IndexOf('`');
-        var cleanName = backtickIndex >= 0 ? genericType[..backtickIndex] : genericType;
-        return $"{cleanName}<{string.Join(", ", typeArguments)}>";
-    }
+        => TypeResolver.ApplyGenericArguments(genericType, typeArguments);
 
     public string GetGenericMethodParameter(GenericContext? context, int index)
     {

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -70,6 +70,64 @@ public static class TypeResolver
     }
 
     /// <summary>
+    /// Renders a generic instantiation by substituting the supplied type arguments
+    /// at each <c>`N</c> arity marker in the open type name, preserving the
+    /// surrounding text — crucially any trailing nested-type segment such as the
+    /// <c>.Enumerator</c> in <c>Dictionary`2.Enumerator</c>. Arguments are consumed
+    /// in order across arity markers (so <c>Outer`1.Inner`1</c> with two arguments
+    /// becomes <c>Outer&lt;A&gt;.Inner&lt;B&gt;</c>). When the name carries no arity
+    /// marker the arguments are appended once, matching the simple
+    /// <c>Name&lt;args&gt;</c> form.
+    /// </summary>
+    public static string ApplyGenericArguments(string genericTypeName, IReadOnlyList<string> typeArguments)
+    {
+        if (!genericTypeName.Contains('`'))
+        {
+            return typeArguments.Count == 0
+                ? genericTypeName
+                : $"{genericTypeName}<{string.Join(", ", typeArguments)}>";
+        }
+
+        var result = new System.Text.StringBuilder(genericTypeName.Length + 16);
+        var argIndex = 0;
+        for (var i = 0; i < genericTypeName.Length; i++)
+        {
+            if (genericTypeName[i] != '`')
+            {
+                result.Append(genericTypeName[i]);
+                continue;
+            }
+
+            var digitStart = i + 1;
+            var digitEnd = digitStart;
+            while (digitEnd < genericTypeName.Length && char.IsDigit(genericTypeName[digitEnd]))
+                digitEnd++;
+
+            if (digitEnd == digitStart
+                || !int.TryParse(genericTypeName.AsSpan(digitStart, digitEnd - digitStart), out var arity)
+                || arity <= 0)
+            {
+                result.Append('`');
+                continue;
+            }
+
+            var take = Math.Min(arity, typeArguments.Count - argIndex);
+            result.Append('<');
+            for (var k = 0; k < take; k++)
+            {
+                if (k > 0)
+                    result.Append(", ");
+                result.Append(typeArguments[argIndex + k]);
+            }
+            result.Append('>');
+            argIndex += take;
+            i = digitEnd - 1;
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
     /// Formats raw metadata type names for display by replacing CLR generic arity suffixes
     /// with readable type parameter placeholders.
     /// </summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2262,6 +2262,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_GenericInstantiation_PreservesNestedTypeSuffix()
+    {
+        // #1154: an instantiated nested type (Dictionary`2.Enumerator) must keep
+        // its nested segment instead of collapsing to Dictionary<TKey, TValue>.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Collections.Generic.Dictionary`2", "--platform", "System.Private.CoreLib",
+            "-S", "Methods");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Dictionary<TKey, TValue>.Enumerator GetEnumerator()", output);
+        Assert.DoesNotContain("Dictionary<TKey, TValue> GetEnumerator()", output);
+    }
+
+    [Fact]
     public async Task Type_DecompiledSource_UsesExpressionBodiedSyntaxForOneLineMembers()
     {
         var (exit, output, error) = await RunAppAsync(


### PR DESCRIPTION
Fixes #1154.

## Problem

Generic-instantiated nested types lost their nested-type suffix. Both
generic-instantiation renderers stripped the CLR arity suffix by truncating
from the **first** backtick to end-of-string. For a nested type under a generic
parent the backtick is mid-name (`…Dictionary\`2.Enumerator`), so `.Enumerator`
was discarded — producing non-compiling C# such as
`Dictionary<TKey, TValue> GetEnumerator()` (CS0029) instead of
`Dictionary<TKey, TValue>.Enumerator`. Affected `--json` signatures and
`-S "Decompiled Source"`.

## Fix

- New `TypeResolver.ApplyGenericArguments(string, IReadOnlyList<string>)`:
  substitutes the real type arguments at each `` `N `` arity marker while
  preserving all surrounding text (including any trailing `.Nested` segment),
  distributing arguments in order across multiple arity points.
- `SignatureDecoder.GetGenericInstantiation` (string path) routes through the
  new helper.
- `GenericTypeNode` gains an optional `nestedSuffix`; `TypeNodeProvider`
  computes it by splitting the raw name at the first backtick's digit run, so
  the structured-node path renders `Base<args>.Nested`.

## Verification

- `Dictionary<,>` → `…Enumerator`, `…KeyCollection`, `…ValueCollection` ✔
- `List<>.GetEnumerator()` → `List<T>.Enumerator` ✔
- Non-nested generics unchanged ✔
- Tests: dotnet-inspect.Tests 1223 pass (1 new regression test),
  ILInspector.Metadata.Tests 215 pass, ILInspector.Decompiler.Tests 1035 pass;
  product builds clean.
