### PR TITLE
Fix whole-type operator declarations

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -327,6 +327,28 @@ public class TypeSourceCheckTests
     }
 
     [Fact]
+    public void Evaluate_OnOperatorFixture_RendersCSharpOperatorDeclarations()
+    {
+        string path = typeof(TypeSourceOperatorFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourceOperatorFixture).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        Assert.Contains("public static TypeSourceOperatorFixture operator +(TypeSourceOperatorFixture left, TypeSourceOperatorFixture right)", source);
+        Assert.Contains("public static bool operator ==(TypeSourceOperatorFixture left, TypeSourceOperatorFixture right)", source);
+        Assert.Contains("public static implicit operator int(TypeSourceOperatorFixture value)", source);
+        Assert.Contains("public static explicit operator TypeSourceOperatorFixture(int value)", source);
+        Assert.Contains("public static explicit operator long(TypeSourceOperatorFixture value)", source);
+        Assert.Contains("public static explicit operator byte(TypeSourceOperatorFixture value)", source);
+        Assert.DoesNotContain(" op_", source);
+
+        var deltas = TypeSourceCheck.CompareType(type, source);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.MemberMissing);
+    }
+
+    [Fact]
     public void WrongTypeKind_IsCaught()
     {
         var type = Type("N", "C", "struct", Member("Foo", "method"));
@@ -403,4 +425,17 @@ public class TypeSourceNullableConstraintMatrix<TNotNull, TClassNullable, TUnman
     where TNullableInterface : System.IDisposable?
 {
     public int Value => 0;
+}
+
+public readonly struct TypeSourceOperatorFixture
+{
+    public static TypeSourceOperatorFixture operator +(TypeSourceOperatorFixture left, TypeSourceOperatorFixture right) => default;
+    public static bool operator ==(TypeSourceOperatorFixture left, TypeSourceOperatorFixture right) => true;
+    public static bool operator !=(TypeSourceOperatorFixture left, TypeSourceOperatorFixture right) => false;
+    public static implicit operator int(TypeSourceOperatorFixture value) => 0;
+    public static explicit operator TypeSourceOperatorFixture(int value) => default;
+    public static explicit operator long(TypeSourceOperatorFixture value) => 0;
+    public static explicit operator byte(TypeSourceOperatorFixture value) => 0;
+    public override bool Equals(object? obj) => obj is TypeSourceOperatorFixture;
+    public override int GetHashCode() => 0;
 }

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -416,6 +416,8 @@ public static class TypeSourceComposer
                 signature = signature[5..];
             return $"public {signature.Replace(".ctor", ctorName)}";
         }
+        if (member.Kind == "operator")
+            return OperatorDeclaration(member);
 
         // Explicit interface implementations take no modifiers.
         if (member.Kind == "explicit-interface-implementation")
@@ -432,6 +434,33 @@ public static class TypeSourceComposer
         }
         parts.Add(signature);
         return string.Join(" ", parts);
+    }
+
+    static string OperatorDeclaration(ApiMember member)
+    {
+        string signature = member.Signature ?? member.Name;
+        int parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        int nameIndex = signature.LastIndexOf(member.Name, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        string returnType = signature[..nameIndex].TrimEnd();
+        string parameters = signature[parenStart..];
+
+        if (member.Name.StartsWith("op_Checked", StringComparison.Ordinal)
+            && OperatorNames.MapBinaryOrUnary(member.Name["op_Checked".Length..]) is { } checkedSymbol)
+            return $"public static {returnType} operator checked {checkedSymbol}{parameters}";
+
+        return member.Name switch
+        {
+            "op_Implicit" => $"public static implicit operator {returnType}{parameters}",
+            "op_Explicit" => $"public static explicit operator {returnType}{parameters}",
+            "op_CheckedExplicit" => $"public static explicit operator checked {returnType}{parameters}",
+            _ => $"public static {returnType} {OperatorNames.FormatDisplayName(member.Name)}{parameters}"
+        };
     }
 
     static void AppendMember(StringBuilder sb, string signature, string? body, string? constructorChain = null)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -757,7 +757,30 @@ static class FidelityCheck
             ? "async "
             : "";
         string unsafeModifier = asyncModifier.Length == 0 ? "unsafe " : "";
+        if (name.StartsWith("op_", StringComparison.Ordinal)
+            && OperatorDeclaration(name, returnType, parameters) is { } operatorDeclaration)
+        {
+            sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
+            return;
+        }
         sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}) {{{body}}}");
+    }
+
+    static string? OperatorDeclaration(string name, string returnType, string parameters)
+    {
+        if (name.StartsWith("op_Checked", StringComparison.Ordinal)
+            && OperatorNames.MapBinaryOrUnary(name["op_Checked".Length..]) is { } checkedSymbol)
+            return $"{returnType} operator checked {checkedSymbol}({parameters})";
+
+        return name switch
+        {
+            "op_Implicit" => $"implicit operator {returnType}({parameters})",
+            "op_Explicit" => $"explicit operator {returnType}({parameters})",
+            "op_CheckedExplicit" => $"explicit operator checked {returnType}({parameters})",
+            _ => OperatorNames.FormatDisplayName(name) is { } display && display.StartsWith("operator ", StringComparison.Ordinal)
+                ? $"{returnType} {display}({parameters})"
+                : null,
+        };
     }
 
     static bool CanBeAsync(string returnType)

--- a/tools/DecompilerHarness/TypeSourceCheck.cs
+++ b/tools/DecompilerHarness/TypeSourceCheck.cs
@@ -308,9 +308,10 @@ static class TypeSourceCheck
             {
                 case MethodDeclarationSyntax method:
                     declaredNames.Add(method.Identifier.Text);
-                    // The composer renders operators with their raw metadata
-                    // name (op_Equality), so they parse as methods, not operator
-                    // syntax — count them as operators either way.
+                    // Older or malformed listings can render operators with
+                    // their raw metadata name (op_Equality), so count those as
+                    // operators too; correct listings hit the operator arms
+                    // below.
                     if (method.Identifier.Text.StartsWith("op_", StringComparison.Ordinal))
                         declaredOperators++;
                     break;


### PR DESCRIPTION
## Summary

Fixes #1152.

Whole-type decompiled source was rendering user-defined operators with their raw metadata names, such as `op_Implicit`, `op_Explicit`, and `op_Addition`. That produced invalid C# for conversion operators because methods cannot be overloaded only by return type.

This updates `TypeSourceComposer` to render operator members as C# operator declarations, including conversion operators and checked operators. It also adds a focused type-source fixture covering arithmetic/equality operators plus multiple explicit conversions with the same parameter list.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypeSourceCheckTests`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- Smoke: `System.Decimal` whole-type decompiled source renders conversion and overload operators without raw `op_` member declarations

Note: the Release build emitted a transient MSBuild file-copy retry warning while another process had an artifact open, then completed successfully.
