### PR TITLE
Verify PDB identity before SourceLink mapping

### DIFF
--- a/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
+++ b/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Net;
+using System.Reflection.Metadata;
 using DotnetInspector.Core;
 
 namespace DotnetInspector.Packages;
@@ -66,7 +67,7 @@ public class SymbolPackageDownloader(HttpClient client)
         if (!string.IsNullOrEmpty(packageName) && !string.IsNullOrEmpty(packageVersion))
         {
             var snupkgResult = await TryLocateFromSymbolPackageAsync(
-                packageName, packageVersion, assemblyPath, log).ConfigureAwait(false);
+                packageName, packageVersion, assemblyPath, symbolKey, pdbGuid, log).ConfigureAwait(false);
             if (snupkgResult.PdbFilePath != null)
                 return snupkgResult;
             if (snupkgResult.WindowsPdbDetected)
@@ -150,7 +151,7 @@ public class SymbolPackageDownloader(HttpClient client)
     }
 
     private async Task<PdbDownloadResult> TryLocateFromSymbolPackageAsync(
-        string packageName, string packageVersion, string assemblyPath, Action<string>? log)
+        string packageName, string packageVersion, string assemblyPath, string symbolKey, Guid pdbGuid, Action<string>? log)
     {
         using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SymbolDownload);
         var normalizedName = packageName.ToLowerInvariant();
@@ -158,7 +159,7 @@ public class SymbolPackageDownloader(HttpClient client)
         bool windowsPdbDetected = false;
 
         // Check cache first
-        var cachedPdbPath = GetCachedPdbPath(normalizedName, normalizedVersion, assemblyPath);
+        var cachedPdbPath = GetCachedPdbPath(normalizedName, normalizedVersion, assemblyPath, symbolKey);
         if (cachedPdbPath != null && File.Exists(cachedPdbPath))
         {
             log?.Invoke($"Using cached PDB: {Path.GetFileName(cachedPdbPath)}");
@@ -197,7 +198,7 @@ public class SymbolPackageDownloader(HttpClient client)
 
                 log?.Invoke($"Found symbol package at: {snupkgUrl}");
                 var result = await ExtractPdbFromSymbolPackage(
-                    response, normalizedName, normalizedVersion, assemblyPath, windowsPdbDetected, log).ConfigureAwait(false);
+                    response, normalizedName, normalizedVersion, assemblyPath, symbolKey, pdbGuid, windowsPdbDetected, log).ConfigureAwait(false);
                 if (result.WindowsPdbDetected)
                     windowsPdbDetected = true;
                 return result;
@@ -215,7 +216,7 @@ public class SymbolPackageDownloader(HttpClient client)
     private async Task<PdbDownloadResult> ExtractPdbFromSymbolPackage(
         HttpResponseMessage response,
         string normalizedName, string normalizedVersion, string assemblyPath,
-        bool windowsPdbDetected, Action<string>? log)
+        string symbolKey, Guid pdbGuid, bool windowsPdbDetected, Action<string>? log)
     {
         var tempDir = Directory.CreateTempSubdirectory("snupkg").FullName;
 
@@ -239,8 +240,33 @@ public class SymbolPackageDownloader(HttpClient client)
                 return new PdbDownloadResult(null, windowsPdbDetected);
             }
 
-            var pdbFile = pdbFiles[0];
-            var cachePath = EnsureCachedPdbPath(normalizedName, normalizedVersion, assemblyPath);
+            string? pdbFile = null;
+            foreach (var candidate in pdbFiles.OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+            {
+                var candidateHeader = CheckPdbHeader(candidate);
+                if (candidateHeader == PdbHeaderKind.Windows)
+                {
+                    windowsPdbDetected = true;
+                    continue;
+                }
+
+                if (candidateHeader != PdbHeaderKind.Portable)
+                    continue;
+
+                if (PortablePdbMatchesGuid(candidate, pdbGuid, log))
+                {
+                    pdbFile = candidate;
+                    break;
+                }
+            }
+
+            if (pdbFile == null)
+            {
+                log?.Invoke("No matching Portable PDB identity found in symbol package");
+                return new PdbDownloadResult(null, windowsPdbDetected);
+            }
+
+            var cachePath = EnsureCachedPdbPath(normalizedName, normalizedVersion, assemblyPath, symbolKey);
             if (cachePath != null)
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
@@ -406,19 +432,47 @@ public class SymbolPackageDownloader(HttpClient client)
         }
     }
 
-    private string? GetCachedPdbPath(string packageName, string packageVersion, string assemblyPath)
+    private static bool PortablePdbMatchesGuid(string pdbPath, Guid expectedGuid, Action<string>? log)
+    {
+        try
+        {
+            using var stream = File.OpenRead(pdbPath);
+            using var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
+            var reader = provider.GetMetadataReader();
+            var id = reader.DebugMetadataHeader?.Id;
+            if (id is not { Length: >= 16 })
+                return false;
+
+            Span<byte> guidBytes = stackalloc byte[16];
+            id.Value.AsSpan(0, 16).CopyTo(guidBytes);
+            var actualGuid = new Guid(guidBytes);
+            if (actualGuid == expectedGuid)
+                return true;
+
+            log?.Invoke($"Skipping mismatched PDB from symbol package: expected {expectedGuid:D}; found {actualGuid:D}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Could not read PDB identity from {Path.GetFileName(pdbPath)}: {ex.Message}");
+            return false;
+        }
+    }
+
+    private string? GetCachedPdbPath(string packageName, string packageVersion, string assemblyPath, string symbolKey)
     {
         NuGetCache.ValidatePathComponent(packageName, "package name");
         NuGetCache.ValidatePathComponent(packageVersion, "package version");
+        NuGetCache.ValidatePathComponent(symbolKey, "PDB identity");
 
         var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-        var cachePath = Path.Combine(_cachePath, packageName, packageVersion, $"{assemblyName}.pdb");
+        var cachePath = Path.Combine(_cachePath, packageName, packageVersion, symbolKey, $"{assemblyName}.pdb");
         return cachePath;
     }
 
-    private string? EnsureCachedPdbPath(string packageName, string packageVersion, string assemblyPath)
+    private string? EnsureCachedPdbPath(string packageName, string packageVersion, string assemblyPath, string symbolKey)
     {
-        return GetCachedPdbPath(packageName, packageVersion, assemblyPath);
+        return GetCachedPdbPath(packageName, packageVersion, assemblyPath, symbolKey);
     }
 
     private string GetSymbolServerCachePath(string pdbName, string symbolKey)

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -153,7 +153,6 @@ public class PdbContext : IDisposable
         try
         {
             var stream = File.OpenRead(pdbFilePath);
-            _disposables.Add(stream);
 
             // Check for Portable PDB magic header (BSJB)
             byte[] header = new byte[4];
@@ -169,13 +168,24 @@ public class PdbContext : IDisposable
                     PdbFormat = "Windows";
                     _log?.Invoke("Windows PDB detected (not supported)");
                 }
+                stream.Dispose();
                 return;
             }
 
             var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
+            var reader = provider.GetMetadataReader();
+            if (!PdbMatchesAssembly(reader))
+            {
+                provider.Dispose();
+                stream.Dispose();
+                _log?.Invoke($"Portable PDB identity mismatch: {Path.GetFileName(pdbFilePath)} does not match {Path.GetFileName(_assemblyPath)}");
+                return;
+            }
+
+            _disposables.Add(stream);
             _disposables.Add(provider);
             _pdbProvider = provider;
-            _pdbReader = provider.GetMetadataReader();
+            _pdbReader = reader;
 
             HasPdb = true;
             PdbFormat = "Portable";
@@ -522,5 +532,27 @@ public class PdbContext : IDisposable
 
         // It's a Portable PDB — open it
         LoadPdbFromFile(pdbPath, "Standalone");
+    }
+
+    private bool PdbMatchesAssembly(MetadataReader pdbReader)
+    {
+        if (PdbId is not { IsPortable: true } expected)
+            return true;
+
+        var id = pdbReader.DebugMetadataHeader?.Id;
+        if (id is not { Length: >= 16 })
+        {
+            _log?.Invoke("PDB identity missing or too short to verify");
+            return false;
+        }
+
+        Span<byte> guidBytes = stackalloc byte[16];
+        id.Value.AsSpan(0, 16).CopyTo(guidBytes);
+        var actual = new Guid(guidBytes);
+        if (actual == expected.Guid)
+            return true;
+
+        _log?.Invoke($"PDB GUID mismatch: assembly expects {expected.Guid:D}; PDB has {actual:D}");
+        return false;
     }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4684,6 +4684,34 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_SourceFilesSection_NewtonsoftJson_DoesNotBleedJTokenRowsAcrossTypes()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "Newtonsoft.Json",
+            "-S", "Source Files", "--tsv", "--no-headers", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        var rows = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Where(cells => cells.Length >= 3)
+            .Select(cells => (Library: cells[0], Type: cells[1], Url: cells[2]))
+            .ToList();
+
+        var jTokenRows = rows.Where(row => row.Type == "Newtonsoft.Json.Linq.JToken").ToArray();
+        Assert.NotEmpty(jTokenRows);
+        Assert.All(jTokenRows, row => Assert.Contains("/Linq/JToken", row.Url));
+        Assert.DoesNotContain(jTokenRows, row => row.Url.Contains("JTokenReader.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(jTokenRows, row => row.Url.Contains("JValue.cs", StringComparison.OrdinalIgnoreCase));
+
+        var jTokenReaderRows = rows.Where(row => row.Type == "Newtonsoft.Json.Linq.JTokenReader").ToArray();
+        Assert.NotEmpty(jTokenReaderRows);
+        Assert.All(jTokenReaderRows, row => Assert.Contains("/Linq/JTokenReader.cs", row.Url));
+    }
+
+    [Fact]
     public async Task Package_BareSelect_RendersInfoPreset()
     {
         var (packagePath, tempDir) = CreateLocalLibPackage();

--- a/src/dotnet-inspect.Tests/PdbIdentityTests.cs
+++ b/src/dotnet-inspect.Tests/PdbIdentityTests.cs
@@ -1,0 +1,60 @@
+using DotnetInspector.Core;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public class PdbIdentityTests
+{
+    [Fact]
+    public void LoadPdbFromFile_AcceptsMatchingPortablePdb()
+    {
+        var (assemblyCopy, tempDir) = CopyAssemblyWithoutPdb(typeof(PdbIdentityTests).Assembly.Location);
+        var pdbPath = Path.ChangeExtension(typeof(PdbIdentityTests).Assembly.Location, ".pdb");
+        try
+        {
+            Assert.True(File.Exists(pdbPath), $"Expected test PDB at {pdbPath}");
+            using var context = PdbContext.Open(assemblyCopy);
+            Assert.False(context.HasPdb);
+
+            context.LoadPdbFromFile(pdbPath);
+
+            Assert.True(context.HasPdb);
+            Assert.Equal(pdbPath, context.PortablePdbPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadPdbFromFile_RejectsMismatchedPortablePdb()
+    {
+        var (assemblyCopy, tempDir) = CopyAssemblyWithoutPdb(typeof(PdbIdentityTests).Assembly.Location);
+        var mismatchedPdb = Path.ChangeExtension(typeof(CoreCache).Assembly.Location, ".pdb");
+        try
+        {
+            Assert.True(File.Exists(mismatchedPdb), $"Expected mismatched PDB at {mismatchedPdb}");
+            using var context = PdbContext.Open(assemblyCopy);
+            Assert.False(context.HasPdb);
+
+            context.LoadPdbFromFile(mismatchedPdb);
+
+            Assert.False(context.HasPdb);
+            Assert.Null(context.PortablePdbPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (string AssemblyCopy, string TempDir) CopyAssemblyWithoutPdb(string assemblyPath)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"pdb-identity-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var assemblyCopy = Path.Combine(tempDir, Path.GetFileName(assemblyPath));
+        File.Copy(assemblyPath, assemblyCopy);
+        return (assemblyCopy, tempDir);
+    }
+}

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,6 +6,7 @@
 
 - Adds package file and documentation views for the best package README, Markdown files, explicit file listings, scoped content, and frontmatter/body extraction.
 - Adds opt-in `Source Files` sections to `library` and `package` for SourceLink type-to-URL rows.
+- Verifies portable PDB identity before using SourceLink rows so multi-TFM package symbol PDBs cannot be paired with the wrong assembly.
 - Extends package README/content output with JSON/JSONL and frontmatter/body-scoped modes.
 - Supports multi-package `package` surveys with package/version provenance and optional `--skip-empty`.
 - Adds `project [path] --agents-index` for direct dependency grounding manifests and `project [path] --readme <package-id>` for version-resolved dependency docs.


### PR DESCRIPTION
## Summary

- Reject external portable PDBs whose content ID GUID does not match the assembly CodeView GUID.
- Select the matching PDB inside multi-TFM symbol packages instead of copying the first same-named PDB.
- Key symbol-package PDB cache entries by PDB identity to avoid cross-TFM collisions.
- Add PDB identity unit tests and a Newtonsoft.Json Source Files regression for JToken/JTokenReader bleed.

Fixes #1170.

## Validation

- dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
- dotnet run --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -class DotnetInspector.Tests.PdbIdentityTests
- dotnet run --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method DotnetInspector.Tests.CommandExecutionTests.Package_SourceFilesSection_NewtonsoftJson_DoesNotBleedJTokenRowsAcrossTypes
- smoke: package Newtonsoft.Json -S "Source Files" shows JToken rows only for JToken.cs/JToken.Async.cs and JTokenReader only for JTokenReader.cs

Note: local validation used PublishAot=false because this machine's preview SDK requests a runtime pack version that is not available from NuGet for AOT restore.
