### PR TITLE
Suggest commands for bare router typos

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -282,6 +282,20 @@ public class CommandExecutionTests
         Assert.DoesNotContain("Library: System.CommandLine.dll | Types:", output);
     }
 
+    [Fact]
+    public async Task BareName_CommandTypo_SuggestsCommandWithoutNuGetLookup()
+    {
+        var (exit, output, error) = await RunAppAsync("packag", "--tips", "q");
+
+        Assert.NotEqual(0, exit);
+        Assert.Empty(output);
+        Assert.Contains("Error: Unknown command 'packag'.", error);
+        Assert.Contains("Did you mean:", error);
+        Assert.Contains("  package", error);
+        Assert.DoesNotContain("Package 'packag' not found", error);
+        Assert.DoesNotContain("Network traffic", error);
+    }
+
     // ── api command ──────────────────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.CommandLine;
 
@@ -40,6 +41,15 @@ public static class RouterCommandDefinition
                 return 0;
             }
 
+            if (TryGetCommandTypoSuggestion(tokens[0]) is { } suggestion)
+            {
+                Console.Error.WriteLine($"Error: Unknown command '{tokens[0]}'.");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Did you mean:");
+                Console.Error.WriteLine($"  {suggestion}");
+                return 1;
+            }
+
             RequestTelemetry.Breadcrumb("router-hit", string.Join(' ', tokens));
             var rewritten = await RouterTokenRewriter.RewriteAsync(tokens);
             RequestTelemetry.Breadcrumb(
@@ -56,6 +66,51 @@ public static class RouterCommandDefinition
         });
 
         return routerCommand;
+    }
+
+    private static readonly string[] CommandSuggestionNames =
+    [
+        PackageCommand.Name,
+        ProjectCommand.Name,
+        "library",
+        TypeCommand.Name,
+        MemberCommand.Name,
+        DiffCommand.Name,
+        FindCommand.Name,
+        SourceCommand.Name,
+        "extensions",
+        "implements",
+        "depends",
+        "cache",
+        "completion",
+        "skill"
+    ];
+
+    private static string? TryGetCommandTypoSuggestion(string token)
+    {
+        if (token.Length < 4
+            || token.Contains('.')
+            || token.Contains('@')
+            || token.Contains('/')
+            || token.Contains('\\'))
+        {
+            return null;
+        }
+
+        var normalized = token.ToLowerInvariant();
+        return CommandSuggestionNames
+            .Select(command => new
+            {
+                Command = command,
+                Distance = StringDistance.EditDistance(normalized, command.ToLowerInvariant()),
+                Similarity = StringDistance.Similarity(normalized, command.ToLowerInvariant())
+            })
+            .Where(candidate => candidate.Distance <= 2 && candidate.Similarity >= 0.70)
+            .OrderByDescending(candidate => candidate.Similarity)
+            .ThenBy(candidate => candidate.Distance)
+            .ThenBy(candidate => candidate.Command, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => candidate.Command)
+            .FirstOrDefault();
     }
 
     private static class RouterTokenRewriter

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -33,6 +33,7 @@
 ### Bare-name routing
 
 - Keeps exact platform libraries such as `System.Text.Json` on the library view while routing exact NuGet-only package IDs such as `System.CommandLine` to package inspection.
+- Suggests likely command names for bare-token typos such as `packag` before falling through to NuGet package lookup.
 
 ## v0.10.5
 


### PR DESCRIPTION
## Summary

- Add a local bare-router typo guard for unknown first tokens that closely match command names.
- Make `packag` fail fast with a `Did you mean: package` suggestion before any NuGet lookup.
- Keep real bare package/library/type routes unchanged.

## Validation

- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- focused bare-router tests
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandLineTests
- smoke: `dotnet-inspect packag` emits a local command suggestion and no network traffic

Note: the full suite currently has unrelated platform-version failures in this preview SDK environment; the focused router and command-line tests pass.
