### PR TITLE
Add Source Files section to type output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type filters. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. |
-| Source mapping | `library`/`package -S "Source Files"`, `member -S "Original Source"` | SourceLink URLs, member line numbers, source fetching, URL verification, token+IL-offset to source-line resolution. |
+| Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Original Source"` | SourceLink URLs, member line numbers, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -19,7 +19,7 @@ dnx dotnet-inspect -y -- <command>
 | Find an API | `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
-| Source/implementation | `member Type Name:1 -S @Source`; `library/package Foo -S "Source Files"` |
+| Source/implementation | `type Type -S "Source Files"`; `member Type Name:1 -S @Source`; `library/package Foo -S "Source Files"` |
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden/extra members. |
 | Compare APIs | `diff --package Foo@old..new --breaking`; use `--additive` for new APIs. |
 | Inspect packages | `package Foo -S Signals`, `-S "Library Files"`, `--library` |

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1418,6 +1418,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("| Method Groups | section |", output);
+        Assert.Contains("| Source Files | section (opt-in) |", output);
         Assert.DoesNotContain("| Fields | section |", output);
     }
 
@@ -1443,6 +1444,19 @@ public class CommandExecutionTests
         Assert.DoesNotContain("| Decompiled Source | section |", output);
         Assert.DoesNotContain("| Original Source | section |", output);
         Assert.DoesNotContain("| IL | section |", output);
+    }
+
+    [Fact]
+    public async Task Type_SingleType_SourceFilesSection_RendersTypeSourceUrls()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializer", "-S", "Source Files", "--tips", "q", "-n", "28");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Files", output);
+        Assert.Contains("| Url |", output);
+        Assert.Contains("JsonSerializer.Write.String.cs", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1143,7 +1143,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(20, pipeline.AllSectionNames.Length);
+        Assert.Equal(21, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -1173,6 +1173,7 @@ public class SectionPipelineTests
         Assert.Contains("Explicit Interface Implementations", names);
         Assert.Contains("Extension Methods", names);
         Assert.Contains("Events", names);
+        Assert.Contains("Source Files", names);
         Assert.Contains("IL", names);
         Assert.Contains("Decompiled Source", names);
         Assert.Contains("Original Source", names);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -217,6 +217,19 @@ public static class TypeCommand
                         return ApiCommand.ExecuteEffectiveDiscovery(apiType, memberPipeline, effectiveOptions);
                     }
 
+                    if (effectiveOptions.DllPath is { } sourceFilesDllPath
+                        && ApiCommand.GetRequestedMemberSections(apiType, effectiveOptions)
+                            .Contains(SectionNames.SourceFiles))
+                    {
+                        await SourceEnricher.EnrichTypeWithSourceInfoAsync(
+                            apiType,
+                            apiType.FullName,
+                            sourceFilesDllPath,
+                            effectiveOptions,
+                            logger,
+                            context.HttpClient);
+                    }
+
                     bool hasProjection = effectiveOptions.Columns is { Length: > 0 } || effectiveOptions.Fields is { Length: > 0 };
                     bool tabularProjection = hasProjection
                         && !effectiveOptions.JsonOutput

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -388,6 +388,8 @@ public static class ApiOutputFormatter
             Package = topFieldsOnly ? packageName : null,
             Version = topFieldsOnly ? packageVersion : null,
             Source = topFieldsOnly ? apiSource : null,
+            SourceUrl = type.SourceUrl,
+            AdditionalSourceFiles = type.AdditionalSourceFiles,
             Tfm = topFieldsOnly ? selectedTfm : null,
             SamplesInfo = topFieldsOnly ? samplesInfo : null,
             // Member stats for quiet verbosity

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -92,6 +92,7 @@ public static class ApiMemberSectionDescriptors
             .Add<Events>()
             .Add<MethodAttributes>()
             .Add<UnsafeMembers>()
+            .Add<SourceFiles>()
             .Add<DecompiledSource>()
             .Add<OriginalSource>()
             .Add<ILBody>()
@@ -260,6 +261,18 @@ public static class ApiMemberSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(IsMethodLike);
+    }
+
+    public sealed class SourceFiles : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.SourceFiles;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => !string.IsNullOrWhiteSpace(model.FullName);
     }
 
     // ===== Expensive sections (decompiler output) =====

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -87,6 +87,9 @@ public static class SectionNames
     /// <summary>Section for original method source code resolved via SourceLink.</summary>
     public const string OriginalSource = "Original Source";
 
+    /// <summary>Section for SourceLink source file URLs for a type.</summary>
+    public const string SourceFiles = "Source Files";
+
     /// <summary>Section for the raw IL disassembly.</summary>
     public const string IL = "IL";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -40,6 +40,14 @@ public class TypeView
     [MarkoutSkipNull] public string? Version { get; set; }
     [MarkoutSkipNull] public string? Source { get; set; }
 
+    [MarkoutIgnore]
+    [JsonIgnore]
+    public string? SourceUrl { get; set; }
+
+    [MarkoutIgnore]
+    [JsonIgnore]
+    public List<PartialSourceFileInfo>? AdditionalSourceFiles { get; set; }
+
     [MarkoutSkipNull]
     [MarkoutPropertyName("TFM")]
     public string? Tfm { get; set; }
@@ -180,11 +188,26 @@ public class TypeView
     [JsonIgnore]
     public List<UnsafeMemberRow>? UnsafeMemberRows { get; set; }
 
+    [MarkoutSection(Name = "Source Files", EmptyText = "No SourceLink source files found for this type.")]
+    [JsonIgnore]
+    public List<TypeSourceFileRow>? SourceFileRows => TypeSourceFiles();
+
     // Member code sections (populated by member command only, serialized separately)
     [MarkoutIgnore]
     [JsonIgnore]
     public MemberCodeView? MemberCode { get; set; }
 
+    private List<TypeSourceFileRow>? TypeSourceFiles()
+    {
+        List<TypeSourceFileRow> rows = [];
+        if (SourceUrl != null)
+            rows.Add(new TypeSourceFileRow(SourceUrl));
+        if (AdditionalSourceFiles is { Count: > 0 })
+            rows.AddRange(AdditionalSourceFiles
+                .Where(file => file.SourceUrl != null)
+                .Select(file => new TypeSourceFileRow(file.SourceUrl!)));
+        return rows.Count > 0 ? rows : null;
+    }
 }
 
 [MarkoutSerializable(AutoFields = false)]
@@ -432,6 +455,9 @@ public record MemberIndexRow(
     [property: MarkoutIgnore] string Digest);
 
 [MarkoutSerializable]
+public record TypeSourceFileRow(string Url);
+
+[MarkoutSerializable]
 public record MemberSignatureRow(
     string Signature,
     [property: MarkoutSkipNull] string? Description);
@@ -608,6 +634,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(CallerSiteRow))]
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(FactRow))]
+[MarkoutContext(typeof(TypeSourceFileRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
 [MarkoutContext(typeof(MemberRow))]

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -5,7 +5,7 @@
 ### Package documentation and project grounding
 
 - Adds package file and documentation views for the best package README, Markdown files, explicit file listings, scoped content, and frontmatter/body extraction.
-- Adds opt-in `Source Files` sections to `library` and `package` for SourceLink type-to-URL rows.
+- Adds opt-in `Source Files` sections to `type`, `library`, and `package` for SourceLink type-to-URL rows.
 - Verifies portable PDB identity before using SourceLink rows so multi-TFM package symbol PDBs cannot be paired with the wrong assembly.
 - Extends package README/content output with JSON/JSONL and frontmatter/body-scoped modes.
 - Supports multi-package `package` surveys with package/version provenance and optional `--skip-empty`.


### PR DESCRIPTION
## Summary

- Add an opt-in Source Files section to single-type output.
- Make `type <Type> -D` advertise Source Files as an opt-in section.
- Populate type Source Files only when selected, using existing SourceLink/PDB enrichment.
- Update README, SKILL.md, release notes, and tests.

## Validation

- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- focused type Source Files tests
- npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md src/dotnet-inspect/release-notes.md
- smoke: `System.Text.Json.JsonSerializer -D` lists `Source Files`; `-S "Source Files"` renders SourceLink URL rows

Note: the full suite currently has unrelated platform-version failures in this preview SDK environment; focused tests pass.
