### PR TITLE
Raise try-catch leave retry fallthrough loops

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -267,6 +267,27 @@ public class StructuringDiagnosticsTests
         Assert.DoesNotContain("goto IL_0010", output);
     }
 
+    [Fact]
+    public void TryCatchLeaveRetryLoop_WithFallthroughExit_RaisesRetryToContinueAndBreak()
+    {
+        var function = BuildTryCatchLeaveRetryLoopWithFallthroughExit();
+
+        var diag = RunStructuringOnly(function);
+        function.CheckInvariant();
+
+        Assert.True(diag.Structured > 0);
+        Assert.Empty(diag.Stops);
+        Assert.Single(function.Descendants.OfType<Continue>());
+        Assert.True(function.Descendants.OfType<Break>().Count() >= 2);
+
+        var output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+        Assert.Contains("while (true)", output);
+        Assert.Contains("continue;", output);
+        Assert.Contains("catch", output);
+        Assert.Contains("break;", output);
+        Assert.DoesNotContain("goto IL_0010", output);
+    }
+
     static IrFunction BuildTryFinallyWithLeaveToCommonExit()
     {
         var tryBody = new BlockContainer();
@@ -382,6 +403,39 @@ public class StructuringDiagnosticsTests
             "M",
             Holder,
             new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            root);
+    }
+
+    static IrFunction BuildTryCatchLeaveRetryLoopWithFallthroughExit()
+    {
+        var exception = TypeRef.CoreLib("System", "Exception");
+
+        var retryTryBody = new BlockContainer();
+        var retryTry = new Block(0x0020);
+        retryTry.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        retryTry.Add(new Leave(0x0010));
+        retryTryBody.Add(retryTry);
+
+        var retryCatchBody = new BlockContainer();
+        var retryCatch = new Block(0x0030);
+        retryCatch.Add(new ExpressionStatement(new CaughtException(exception)));
+        retryCatchBody.Add(retryCatch);
+
+        var root = new BlockContainer();
+        var head = new Block(0x0010);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "done", Boolean), 0x0040));
+        var holder = new Block(0x0020);
+        holder.Add(new TryCatch(retryTryBody, [new CatchClause(exception, retryCatchBody)]));
+        var tail = new Block(0x0040);
+        tail.Add(new Return(null));
+        foreach (var block in (Block[])[head, holder, tail])
+            root.Add(block);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("done", Boolean)], HasThis: false, GenericParameterCount: 0),
             [Int32],
             root);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -567,18 +567,25 @@ public sealed class StructuringPass : IIrPass
         }
 
         bool hasLoopExit = latch >= 0
-            && Enumerable.Range(head, latch - head + 1).Any(index => HasLoopExit(ctx, blocks[index], headOffset, head, latch));
+            && Enumerable.Range(head, latch - head + 1).Any(index => HasLoopExit(ctx, blocks[index], index, headOffset, head, latch));
         return latch == -1 || !hasLoopExit ? null : latch;
     }
 
     static IEnumerable<Leave> RetryLeavesTo(Block block, int targetOffset)
         => block.Descendants.OfType<Leave>().Where(leave => leave.TargetOffset == targetOffset);
 
-    static bool HasLoopExit(Ctx ctx, Block block, int headOffset, int head, int latch)
+    static bool HasLoopExit(Ctx ctx, Block block, int blockIndex, int headOffset, int head, int latch)
     {
+        if (blockIndex == latch && MayFallThroughAfterRetryReplacement(block, headOffset))
+            return true;
+
         foreach (var node in block.Descendants.Prepend(block))
         {
             if (node is Return or Throw or Break)
+                return true;
+            if (node is Branch branch && BranchExitsRetrySpan(ctx, branch.TargetOffset, head, latch))
+                return true;
+            if (node is ConditionalBranch conditional && BranchExitsRetrySpan(ctx, conditional.TargetOffset, head, latch))
                 return true;
             if (node is Leave leave
                 && leave.TargetOffset != headOffset
@@ -591,8 +598,31 @@ public sealed class StructuringPass : IIrPass
         return false;
     }
 
+    static bool BranchExitsRetrySpan(Ctx ctx, int targetOffset, int head, int latch)
+        => ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
+            && (target < head || target > latch);
+
+    static bool MayFallThroughAfterRetryReplacement(Block block, int retryTargetOffset)
+        => block.Children.Count == 0 || MayFallThroughAfterRetryReplacement(block.Children[^1], retryTargetOffset);
+
+    static bool MayFallThroughAfterRetryReplacement(IrNode node, int retryTargetOffset) => node switch
+    {
+        Return or Throw or Break or Branch or EndFinally or EndFilter => false,
+        Leave leave => !(leave.TargetOffset == retryTargetOffset && CanRaiseRetryLeave(leave)),
+        IfStatement branch => !branch.HasElse
+            || MayFallThroughAfterRetryReplacement(branch.Then, retryTargetOffset)
+            || MayFallThroughAfterRetryReplacement(branch.Else!, retryTargetOffset),
+        TryCatch tryCatch => MayFallThroughAfterRetryReplacement(tryCatch.TryBody, retryTargetOffset)
+            || tryCatch.Clauses.Any(clause => MayFallThroughAfterRetryReplacement(clause.Body, retryTargetOffset)),
+        TryFinally tryFinally => MayFallThroughAfterRetryReplacement(tryFinally.TryBody, retryTargetOffset),
+        _ => true,
+    };
+
+    static bool MayFallThroughAfterRetryReplacement(BlockContainer container, int retryTargetOffset)
+        => container.Blocks.Count == 0 || MayFallThroughAfterRetryReplacement(container.Blocks[^1], retryTargetOffset);
+
     static bool CanRaiseRetryLeave(Leave leave)
-        => HasAncestor<TryFinally>(leave)
+        => (HasAncestor<TryFinally>(leave) || HasAncestor<TryCatch>(leave))
             && !IsInsideFinallyBody(leave);
 
     static bool HasAncestor<T>(IrNode node) where T : IrNode
@@ -973,8 +1003,12 @@ public sealed class StructuringPass : IIrPass
             // implicit loop edge, dropped by the body's Branch case below.
             if (continueTarget != i && FindInfiniteLoopShape(ctx, i, stop) is { } latch)
             {
+                bool fallthroughExits = IsLeaveRetryLoopHead(ctx, i)
+                    && MayFallThroughAfterRetryReplacement(blocks[latch], blocks[i].StartOffset);
                 var loopBody = BuildRegion(ctx, i, latch + 1, joinIndex: latch + 1, breakTarget: latch + 1, continueTarget: i);
                 ReplaceRetryLeavesWithContinues(loopBody, blocks[i].StartOffset);
+                if (fallthroughExits)
+                    loopBody.Add(new Break());
                 result.Add(new WhileLoop(TrueLiteral(), loopBody));
                 i = latch + 1;
                 continue;


### PR DESCRIPTION
## Summary

- continue #1135 leave-retry-loop lane after merged #1158
- allow self-contained EH retry loops to use try/catch retry leaves, not only try/finally retry leaves
- preserve a retry latch fallthrough exit as an explicit `break;`, clearing `ThreadPoolWorkQueue::TransferAllLocalWorkItemsToHighPriorityGlobalQueue`

## Measured impact

Current origin/main (`7cf01ba3`) rebaseline before the slice:
- `leave-target-in-container`: 3
- EH-entangled leave-retry-loop subshape: 2 (`ThreadPoolWorkQueue::TransferAllLocalWorkItemsToHighPriorityGlobalQueue`, `EventProvider::EncodeObject`)

After this slice:
- `leave-target-in-container`: 1
- EH-entangled leave-retry-loop subshape: 1 (`EventProvider::EncodeObject`)
- `ThreadPoolWorkQueue::TransferAllLocalWorkItemsToHighPriorityGlobalQueue` structures without residual goto; catch fallthrough exits via `break;`

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --no-restore`
- `dotnet run --project tools/DecompilerHarness -c Release -- --structuring-stops --max-examples 10`
- `dotnet run --project tools/DecompilerHarness -c Release -- --gaps --by-shape --max-examples 10`

#1135