### PR TITLE
Document SourceLink exposure policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Bare `-S` Default View](design/info-view.md) | Bullseye questions and section profiles for curated high-density default views. |
 | [Platform Components](platform-components.md) | Accessing SDK libraries vs NuGet packages. |
 | [Signals](assembly-audit.md) | Understanding Signals output and network scope flags. |
+| [SourceLink Exposure](sourcelink-exposure.md) | Where SourceLink appears in package/library/type/member flows and how PDB/network costs are controlled. |
 | [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved. |
 | [Sample References](sample-references.md) | Extracting code samples from XML docs. |
 | [Reading IR Dumps](decompiler-ir-dumps.md) | How maintainers read DecompilerHarness per-pass IR dumps to diagnose decompiled output. |

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -11,6 +11,9 @@ dotnet-inspect package System.Text.Json -S Signals
 
 Cost is governed by verbosity (the cost ceiling) and explicit section selection. `library X -S Signals` reports metadata/provenance signals and acquires a missing library PDB to resolve SourceLink. The per-source-file reachability pass (the `SourceLink Availability` and `SourceLink Missing Files` sections, which issue one HTTP HEAD per tracked source URL) is selected explicitly via `-S`. It does not run in a plain `library X -v:d` flow, because its cost scales with source-file count. The exhaustive content check — downloading every tracked source file and comparing its hash to the PDB checksum — is the opt-in `SourceLink Integrity` section, selected explicitly via `library X -S "SourceLink Integrity"`; it never runs in a default flow and exits non-zero on a checksum mismatch. For packages, `Signals` is opt-in and includes registry-backed signals.
 
+See [SourceLink Exposure](sourcelink-exposure.md) for the product surfaces,
+PDB dependency, and network policy behind these sections.
+
 ## Build Audit Fields
 
 ### Deterministic

--- a/docs/design/member-index.md
+++ b/docs/design/member-index.md
@@ -13,6 +13,14 @@ provides terse, copyable selectors.
 | `Stable` | Durable selector, such as `Serialize~1dc14dd1fb`. It is based on the canonical signature digest. |
 | `Canonical Signature` | Printed source string used to compute the stable selector digest. |
 
+These are the identity columns. When SourceLink location enrichment is selected
+and a verified PDB is available, `Member Index` is also the preferred
+member-level place to add file/URL/line columns. The enrichment applies both to a
+member group, where each overload row can carry its own location, and to a
+selected member signature, where the row can point to source without fetching the
+full `Original Source` body. Missing or ambiguous mappings leave the SourceLink
+fields empty rather than guessing.
+
 Example:
 
 ```text

--- a/docs/design/member-index.md
+++ b/docs/design/member-index.md
@@ -13,13 +13,10 @@ provides terse, copyable selectors.
 | `Stable` | Durable selector, such as `Serialize~1dc14dd1fb`. It is based on the canonical signature digest. |
 | `Canonical Signature` | Printed source string used to compute the stable selector digest. |
 
-These are the identity columns. When SourceLink location enrichment is selected
-and a verified PDB is available, `Member Index` is also the preferred
-member-level place to add file/URL/line columns. The enrichment applies both to a
-member group, where each overload row can carry its own location, and to a
-selected member signature, where the row can point to source without fetching the
-full `Original Source` body. Missing or ambiguous mappings leave the SourceLink
-fields empty rather than guessing.
+These are the identity columns. `Member Index` should stay focused on the query
+pattern and not grow SourceLink file/URL/line columns. Member source locations
+belong in a separate `Source*` section available on both member-group and
+selected-signature views.
 
 Example:
 

--- a/docs/pdb-acquisition.md
+++ b/docs/pdb-acquisition.md
@@ -119,6 +119,7 @@ When PDB acquisition fails, we report the reason:
 
 ## Related Resources
 
+- [SourceLink Exposure](sourcelink-exposure.md)
 - [Portable PDB Specification](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md)
 - [Symbol Server Protocol](https://github.com/dotnet/symstore)
 - [SourceLink](https://github.com/dotnet/sourcelink)

--- a/docs/sample-references.md
+++ b/docs/sample-references.md
@@ -1,7 +1,10 @@
 # Sample References in XML Doc Comments
 
-The `source` command can surface code sample references from XML documentation comments (`///`) at detailed verbosity.
+The current `source` command can surface code sample references from XML documentation comments (`///`) at detailed verbosity.
 This document describes the supported formats and known repositories with examples.
+The long-term section shape should be a table of sample names/descriptions and
+URLs. Fetching or printing sample source bodies is out of scope for this path;
+the URL table is the useful artifact.
 
 ## Supported Formats
 
@@ -199,7 +202,7 @@ This format is not currently surfaced by the SourceLink sample-reference path.
 
 **Multi-language examples are common** (C#, VB.NET, F#, C++).
 
-## Testing sample references with `source`
+## Testing sample references with current `source`
 
 ### Newtonsoft.Json
 
@@ -211,13 +214,14 @@ This format is not currently surfaced by the SourceLink sample-reference path.
 ### Markout
 
 ```bash
-# Show sample references discovered from SourceLink/XML docs
+# Show sample-reference names and URLs discovered from SourceLink/XML docs
 dotnet-inspect source TreeNode --package Markout -v:d -S Samples --tips q
 ```
 
 ## Notes
 
 1. **Path normalization**: Backslashes are converted to forward slashes automatically
-2. **Region extraction**: The tool extracts content between `#region Name` and `#endregion` markers
+2. **Region names**: Region values identify a target within a sample file; the
+   section should report URLs, not print extracted region bodies
 3. **URL resolution**: Relative paths are resolved to raw GitHub URLs using SourceLink information
 4. **HTTP URLs ignored**: `<seealso href="https://...">` links are not treated as sample references

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -8,9 +8,9 @@ so the tool stays fast by default.
 
 This follows the section-bias direction from
 [issue #1163](https://github.com/richlander/dotnet-inspect/issues/1163):
-SourceLink inventories belong on `package`, `library`, and `type` sections; the
-standalone `source` command is transitional compatibility, not the long-term
-home for new SourceLink surfaces.
+SourceLink inventories belong on `package`, `library`, `type`, and member
+sections; the standalone `source` command is transitional compatibility, not the
+long-term home for new SourceLink surfaces.
 
 ## Model
 
@@ -20,6 +20,7 @@ SourceLink answers three related questions:
 | --- | --- |
 | Does this binary have trustworthy source provenance? | `library` / `package` `Signals`, `Symbols`, and `SourceLink *` sections |
 | Which source files map to this target? | `Source Files` sections on `library` / `package` / `type` |
+| Where do these member signatures live in source? | `Member Index` SourceLink location columns for file/URL/line when a verified PDB is available |
 | What is the source for this exact member or IL offset? | selected `member` source sections, or a narrow point query / parameterized section while the `source` command remains |
 
 The command model should prefer sections over new flags. SourceLink URL listings
@@ -63,6 +64,7 @@ Selected member output already exposes source evidence:
 | Section | Purpose |
 | --- | --- |
 | `Original Source` | SourceLink-backed original source text for one selected overload |
+| `Member Index` | overload/member-group selectors, with SourceLink file/URL/line as the target enrichment |
 | `Decompiled Source` | readable C# reconstructed from IL |
 | `Annotated Source` | C# plus hidden-fact comments and IL evidence |
 | `IL` | raw IL disassembly |
@@ -70,6 +72,14 @@ Selected member output already exposes source evidence:
 Single-type `Source Files` is the natural section home for type-to-URL rows when
 a user is already in a `type` flow. The standalone `source` command remains for
 type URL lookup compatibility and point symbolication.
+
+`Member Index` should also be a SourceLink location surface. It already maps a
+member group to exact overload signatures, so it is the right place to show the
+file/URL/line for each signature when a verified PDB supplies a sequence point.
+For a selected member signature, the same location evidence should be available
+without requiring the user to fetch the full `Original Source` body. For a member
+group, rows should carry per-overload locations so users can choose the right
+signature and source location in one table.
 
 ### Source command
 
@@ -121,6 +131,7 @@ use the network only when the selected section justifies it.
 | HEAD every source URL | explicit `SourceLink Availability` / `SourceLink Missing Files` |
 | Download every source body | explicit `SourceLink Integrity` |
 | Fetch one original member source body | explicit selected-member `Original Source` / `@Source` |
+| Resolve member file/line locations | explicit member SourceLink location section/columns; may acquire one missing PDB but should not fetch source bodies |
 
 The section pipeline encodes this with capabilities:
 
@@ -165,3 +176,6 @@ but it still depends on a verified PDB identity.
 8. When unsure, show no SourceLink rows instead of showing possibly wrong rows.
 9. Do not expand `source` with new section-shaped capabilities; move those to
    their package/library/type/member homes.
+10. Treat `Member Index` as the member-level URL/location index; prefer
+    file/URL/line columns over fetching source bodies when the user needs a
+    source pointer rather than content.

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -8,9 +8,9 @@ so the tool stays fast by default.
 
 This follows the section-bias direction from
 [issue #1163](https://github.com/richlander/dotnet-inspect/issues/1163):
-SourceLink inventories belong on `package`, `library`, `type`, and member
-sections; the standalone `source` command is transitional compatibility, not the
-long-term home for new SourceLink surfaces.
+SourceLink inventories belong on `package`, `library`, `type`, and dedicated
+member source sections; the standalone `source` command is planned for removal,
+not a long-term home for new SourceLink surfaces.
 
 ## Model
 
@@ -20,7 +20,7 @@ SourceLink answers three related questions:
 | --- | --- |
 | Does this binary have trustworthy source provenance? | `library` / `package` `Signals`, `Symbols`, and `SourceLink *` sections |
 | Which source files map to this target? | `Source Files` sections on `library` / `package` / `type` |
-| Where do these member signatures live in source? | `Member Index` SourceLink location columns for file/URL/line when a verified PDB is available |
+| Where do these member signatures live in source? | A dedicated member `Source Locations` section for file/URL/line when a verified PDB is available |
 | What is the source for this exact member or IL offset? | selected `member` source sections, or a narrow point query / parameterized section while the `source` command remains |
 
 The command model should prefer sections over new flags. SourceLink URL listings
@@ -64,32 +64,57 @@ Selected member output already exposes source evidence:
 | Section | Purpose |
 | --- | --- |
 | `Original Source` | SourceLink-backed original source text for one selected overload |
-| `Member Index` | overload/member-group selectors, with SourceLink file/URL/line as the target enrichment |
+| `Source Locations` | file/URL/line rows for a member group or selected signature |
 | `Decompiled Source` | readable C# reconstructed from IL |
 | `Annotated Source` | C# plus hidden-fact comments and IL evidence |
 | `IL` | raw IL disassembly |
 
 Single-type `Source Files` is the natural section home for type-to-URL rows when
-a user is already in a `type` flow. The standalone `source` command remains for
-type URL lookup compatibility and point symbolication.
+a user is already in a `type` flow. The standalone `source` command currently
+remains for type URL lookup compatibility and point symbolication.
 
-`Member Index` should also be a SourceLink location surface. It already maps a
-member group to exact overload signatures, so it is the right place to show the
-file/URL/line for each signature when a verified PDB supplies a sequence point.
-For a selected member signature, the same location evidence should be available
-without requiring the user to fetch the full `Original Source` body. For a member
-group, rows should carry per-overload locations so users can choose the right
-signature and source location in one table.
+Member source locations should not be added to `Member Index`. That section must
+stay focused on the query pattern: terse selectors, stable selectors, and
+canonical signatures. SourceLink file/URL/line belongs in a separate `Source*`
+section, currently described as `Source Locations`.
+
+`Source Locations` should exist on both member-group and selected-signature
+views so the experience progressively narrows. A member-group view can show one
+row per overload with enough selector/signature context to identify the row. A
+selected-signature view can show the same file/URL/line evidence for one
+signature without fetching the full `Original Source` body.
 
 ### Source command
 
-`source` is legacy / transitional. Most of its output is section-shaped and
-should migrate into `type`, `library`, and `package`. Issue #1163 records the
+`source` is transitional and planned for removal. Most of its output is
+section-shaped and should migrate into `type`, `library`, and `package`. Issue
+[#1163](https://github.com/richlander/dotnet-inspect/issues/1163) records the
 long-term removal path: source inventories become `Source Files` sections,
 source-body retrieval follows existing content retrieval patterns, availability
 checks fold into `SourceLink Integrity`, URL shape is a format concern, and IL
-offset symbolication becomes the remaining narrow point-query/parameterized
+offset symbolication becomes the remaining narrow point query / parameterized
 section rather than a broad command.
+
+The URL-inventory part of `source` should move cleanly to `package`, `library`,
+and `type`. Member-level locations should move to `Source Locations`. Sample
+URLs are less direct: they may need one-or-more URL rows from real package or
+documentation metadata rather than calculated links, because some sample URL
+schemes are odd and some application firewalls block model-constructed URLs.
+
+### Adjacent member documentation and safety sections
+
+Not every source-adjacent member feature is SourceLink. Member signatures should
+also have sections for documentation and safety evidence:
+
+| Section | Purpose |
+| --- | --- |
+| `Documentation` | the full XML documentation comment (`///`) block for a selected member signature |
+| `Signals` | signature-level evidence such as visibility, safety documentation presence, and safety classification |
+| `Samples` | one or more sample URLs when package/docs metadata can provide trustworthy links |
+
+`Signals` can report visibility (`private`, `protected`, `internal`, `public`)
+and a safety row such as `safe`, `unsafe boundary`, or `unsafe`. Safety comments
+should come from the documentation block, not SourceLink URL inference.
 
 ## PDB dependency
 
@@ -131,7 +156,7 @@ use the network only when the selected section justifies it.
 | HEAD every source URL | explicit `SourceLink Availability` / `SourceLink Missing Files` |
 | Download every source body | explicit `SourceLink Integrity` |
 | Fetch one original member source body | explicit selected-member `Original Source` / `@Source` |
-| Resolve member file/line locations | explicit member SourceLink location section/columns; may acquire one missing PDB but should not fetch source bodies |
+| Resolve member file/line locations | explicit member `Source Locations` section; may acquire one missing PDB but should not fetch source bodies |
 
 The section pipeline encodes this with capabilities:
 
@@ -176,6 +201,9 @@ but it still depends on a verified PDB identity.
 8. When unsure, show no SourceLink rows instead of showing possibly wrong rows.
 9. Do not expand `source` with new section-shaped capabilities; move those to
    their package/library/type/member homes.
-10. Treat `Member Index` as the member-level URL/location index; prefer
-    file/URL/line columns over fetching source bodies when the user needs a
+10. Keep `Member Index` focused on query/selectors; do not add URL/file/line
+    columns to it.
+11. Put member file/URL/line evidence in a dedicated `Source*` section on both
+    member-group and selected-signature views.
+12. Prefer file/URL/line rows over fetching source bodies when the user needs a
     source pointer rather than content.

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -1,0 +1,155 @@
+# SourceLink Exposure
+
+SourceLink is not a first-class artifact like a package manifest or assembly
+metadata table. It is source provenance hidden behind debug symbols, so its CLI
+home is less obvious. This document records where dotnet-inspect should expose
+SourceLink, how those surfaces depend on PDBs, and how network work is bounded
+so the tool stays fast by default.
+
+## Model
+
+SourceLink answers three related questions:
+
+| Question | Best home |
+| --- | --- |
+| Does this binary have trustworthy source provenance? | `library` / `package` `Signals`, `Symbols`, and `SourceLink *` sections |
+| Which source files map to this target? | `Source Files` sections on `library` / `package` / `type` |
+| What is the source for this exact member or IL offset? | selected `member` source sections, or a narrow point-query while the `source` command remains |
+
+The command model should prefer sections over new flags. SourceLink URL listings
+are document sections, not standalone verbs. Point queries, such as method-token
+plus IL offset symbolication, are the exception because they do not naturally
+produce a section-shaped inventory.
+
+## Current product surfaces
+
+### Library
+
+`library` is the natural home for assembly-level SourceLink evidence.
+
+| Section | Purpose | Network posture |
+| --- | --- | --- |
+| `Symbols` | PDB format/location, SourceLink presence, symbol server, builder hints | may acquire one missing PDB when authorized |
+| `Signals` | summary evidence including SourceLink/provenance signals | opt-in; may acquire one missing PDB |
+| `Source Files` | type-to-SourceLink URL rows for the selected library | opt-in; may acquire one missing PDB |
+| `SourceLink Availability` | per-source-file reachability via HTTP HEAD | opt-in; one request per source file |
+| `SourceLink Missing Files` | files not reachable or embedded | opt-in; derived from availability pass |
+| `SourceLink Integrity` | downloads source bodies and checks PDB checksums | opt-in; slowest and exits non-zero on mismatch |
+
+### Package
+
+`package` owns package-level aggregation. It should not force users to pivot to
+another command merely to continue a package inspection.
+
+| Section | Purpose |
+| --- | --- |
+| `Signals` | package and dependency evidence, plus binary/source provenance summaries |
+| `Source Files` | SourceLink URL rows aggregated from package libraries, with library provenance |
+
+The package `Source Files` section defaults to the same library selection rules
+as other package-library views: compatible/highest TFM unless a TFM selector says
+otherwise. This keeps the section scoped and avoids exploding output by default.
+
+### Type and member
+
+Selected member output already exposes source evidence:
+
+| Section | Purpose |
+| --- | --- |
+| `Original Source` | SourceLink-backed original source text for one selected overload |
+| `Decompiled Source` | readable C# reconstructed from IL |
+| `Annotated Source` | C# plus hidden-fact comments and IL evidence |
+| `IL` | raw IL disassembly |
+
+Single-type `Source Files` is the natural section home for type-to-URL rows when
+a user is already in a `type` flow. The standalone `source` command remains for
+type URL lookup compatibility and point symbolication.
+
+### Source command
+
+`source` is legacy / transitional. Most of its output is section-shaped and
+should migrate into `type`, `library`, and `package`. The genuinely verb-shaped
+residue is point lookup, especially `--il-offset` symbolication.
+
+## PDB dependency
+
+SourceLink requires a readable portable PDB. The assembly alone is not enough.
+PDB acquisition proceeds in this order:
+
+1. Embedded portable PDB in the assembly.
+2. Adjacent standalone `.pdb`.
+3. NuGet symbol package (`.snupkg`) for package assemblies.
+4. Symbol servers, keyed by the assembly's CodeView PDB identity.
+
+Windows PDBs are detected but not read by this tool. If no matching portable PDB
+is available, SourceLink sections should degrade to absent/empty evidence rather
+than guessing.
+
+### Identity is mandatory
+
+Portable PDB metadata is row-aligned with the exact assembly build. A PDB from
+another TFM or build can contain the same source files and still map method rows
+to the wrong documents. Therefore:
+
+- External portable PDBs must match the assembly CodeView GUID before use.
+- Symbol-package cache keys include PDB identity, not just package/version/file
+  name.
+- If identity does not match, treat the PDB as unavailable for that assembly.
+- SourceLink Integrity cannot replace identity checking: content hashes can
+  verify source files while method-row mappings are still wrong.
+
+This is a fail-closed rule: missing SourceLink is better than wrong SourceLink.
+
+## Network and performance policy
+
+dotnet-inspect should stay fast and local by default. SourceLink is allowed to
+use the network only when the selected section justifies it.
+
+| Work | When allowed |
+| --- | --- |
+| Acquire one missing PDB | explicit SourceLink/source/provenance section, or detailed library provenance where already documented |
+| HEAD every source URL | explicit `SourceLink Availability` / `SourceLink Missing Files` |
+| Download every source body | explicit `SourceLink Integrity` |
+| Fetch one original member source body | explicit selected-member `Original Source` / `@Source` |
+
+The section pipeline encodes this with capabilities:
+
+- `MayDownloadPdb`: a section may acquire symbols.
+- `MayAuditSources`: a section may issue per-file HEAD requests.
+- `MayFetchSources`: a section may download source bodies.
+
+Detailed verbosity can authorize some lighter provenance enrichment, but it must
+not silently authorize bulk SourceLink URL checks or source-body downloads. Bulk
+work remains explicit.
+
+## Caching
+
+Caching is required because SourceLink can otherwise turn one command into many
+network requests.
+
+- Version/package metadata caches prevent repeated NuGet lookups.
+- PDB caches avoid repeated symbol downloads.
+- Symbol-package PDB caches are identity-keyed to avoid multi-TFM collisions.
+- Effective-section caches may summarize what sections are renderable, but must
+  be invalidated when section semantics change.
+
+Cache reuse must never bypass PDB identity validation.
+
+## URL safety
+
+SourceLink URLs come from package or PDB data and are not inherently trusted.
+Operations that contact those URLs should use the untrusted-fetch HTTP path and
+remain opt-in. Rendering URLs as rows is lower risk than fetching their bodies,
+but it still depends on a verified PDB identity.
+
+## Design rules for new SourceLink features
+
+1. Prefer sections over new commands or flags when output is a table/list.
+2. Put assembly-scoped evidence under `library`.
+3. Put package-aggregate evidence under `package`.
+4. Put type-scoped evidence under `type`; selected-member source belongs under
+   `member`.
+5. Keep point queries narrow; do not make inventories masquerade as verbs.
+6. Do not add default network fan-out.
+7. Verify PDB identity before trusting method/type-to-document mappings.
+8. When unsure, show no SourceLink rows instead of showing possibly wrong rows.

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -97,9 +97,11 @@ section rather than a broad command.
 
 The URL-inventory part of `source` should move cleanly to `package`, `library`,
 and `type`. Member-level locations should move to `Source Locations`. Sample
-URLs are less direct: they may need one-or-more URL rows from real package or
-documentation metadata rather than calculated links, because some sample URL
-schemes are odd and some application firewalls block model-constructed URLs.
+URLs are less direct: they should be URL rows from real package or documentation
+metadata rather than calculated links, because some sample URL schemes are odd
+and some application firewalls block model-constructed URLs.
+Printing a table of sample names and URLs is the useful default; fetching or
+printing sample source bodies is overkill and should be avoided or removed.
 
 ### Adjacent member documentation and safety sections
 
@@ -110,7 +112,7 @@ also have sections for documentation and safety evidence:
 | --- | --- |
 | `Documentation` | the full XML documentation comment (`///`) block for a selected member signature |
 | `Signals` | signature-level evidence such as visibility, safety documentation presence, and safety classification |
-| `Samples` | one or more sample URLs when package/docs metadata can provide trustworthy links |
+| `Samples` | sample name/description plus URL rows when package/docs metadata can provide trustworthy links |
 
 `Signals` can report visibility (`private`, `protected`, `internal`, `public`)
 and a safety row such as `safe`, `unsafe boundary`, or `unsafe`. Safety comments

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -6,6 +6,12 @@ home is less obvious. This document records where dotnet-inspect should expose
 SourceLink, how those surfaces depend on PDBs, and how network work is bounded
 so the tool stays fast by default.
 
+This follows the section-bias direction from
+[issue #1163](https://github.com/richlander/dotnet-inspect/issues/1163):
+SourceLink inventories belong on `package`, `library`, and `type` sections; the
+standalone `source` command is transitional compatibility, not the long-term
+home for new SourceLink surfaces.
+
 ## Model
 
 SourceLink answers three related questions:
@@ -14,7 +20,7 @@ SourceLink answers three related questions:
 | --- | --- |
 | Does this binary have trustworthy source provenance? | `library` / `package` `Signals`, `Symbols`, and `SourceLink *` sections |
 | Which source files map to this target? | `Source Files` sections on `library` / `package` / `type` |
-| What is the source for this exact member or IL offset? | selected `member` source sections, or a narrow point-query while the `source` command remains |
+| What is the source for this exact member or IL offset? | selected `member` source sections, or a narrow point query / parameterized section while the `source` command remains |
 
 The command model should prefer sections over new flags. SourceLink URL listings
 are document sections, not standalone verbs. Point queries, such as method-token
@@ -68,8 +74,12 @@ type URL lookup compatibility and point symbolication.
 ### Source command
 
 `source` is legacy / transitional. Most of its output is section-shaped and
-should migrate into `type`, `library`, and `package`. The genuinely verb-shaped
-residue is point lookup, especially `--il-offset` symbolication.
+should migrate into `type`, `library`, and `package`. Issue #1163 records the
+long-term removal path: source inventories become `Source Files` sections,
+source-body retrieval follows existing content retrieval patterns, availability
+checks fold into `SourceLink Integrity`, URL shape is a format concern, and IL
+offset symbolication becomes the remaining narrow point-query/parameterized
+section rather than a broad command.
 
 ## PDB dependency
 
@@ -153,3 +163,5 @@ but it still depends on a verified PDB identity.
 6. Do not add default network fan-out.
 7. Verify PDB identity before trusting method/type-to-document mappings.
 8. When unsure, show no SourceLink rows instead of showing possibly wrong rows.
+9. Do not expand `source` with new section-shaped capabilities; move those to
+   their package/library/type/member homes.

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -116,6 +116,13 @@ also have sections for documentation and safety evidence:
 and a safety row such as `safe`, `unsafe boundary`, or `unsafe`. Safety comments
 should come from the documentation block, not SourceLink URL inference.
 
+`--raw` is the right output shape when a caller wants section content without a
+heading, table, or Markdown decoration. Today it is used by type/member code
+sections such as `Decompiled Source`, `Annotated Source`, `Original Source`, and
+`IL`. If `Documentation` returns the complete `///` block, it should follow the
+same single-section raw contract so users can redirect the exact comment block
+or feed it to downstream tools without Markout framing.
+
 ## PDB dependency
 
 SourceLink requires a readable portable PDB. The assembly alone is not enough.


### PR DESCRIPTION
## Summary
- document where SourceLink appears across package, library, type, member, and legacy source flows
- tie the policy to the section-bias/source-folding design in #1163 and the plan to remove `source`
- keep Member Index query-focused and move member file/URL/line evidence to a separate `Source Locations` section on member group/signature views
- capture adjacent member `Documentation`, `Signals`, and `Samples` section direction for safety docs and sample URLs
- record that `Samples` should be a table of sample names/descriptions and URLs, not fetched/printed sample bodies
- record that full `///` documentation sections should support the existing single-section `--raw` undecorated-output contract
- capture the PDB identity dependency and fail-closed behavior for SourceLink mappings
- describe network/performance policy for PDB acquisition, URL checks, and source downloads

## Related
- Refs #1163

## Validation
- npx markdownlint-cli docs/sourcelink-exposure.md docs/sample-references.md docs/design/member-index.md docs/README.md docs/pdb-acquisition.md docs/assembly-audit.md