### PR TITLE
Activate corpus sensor validity and fidelity samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
           mapfile -t assemblies < corpus-assemblies.txt
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
             --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
-            --compile-cap 0 \
-            --corpus-fidelity-cap 0 \
+            --compile-cap 25 \
+            --corpus-fidelity-cap 3 \
             --max-examples 3
 
       - name: Run metadata tests

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -145,7 +145,7 @@ internal static class CorpusSensor
         if (cap <= 0)
             return new ValiditySensorMetrics(0, 0, 0);
 
-        var results = ValidityCheck.Evaluate(assemblies, cap);
+        var results = assemblies.SelectMany(assembly => ValidityCheck.Evaluate(assembly, cap)).ToArray();
         return new ValiditySensorMetrics(
             results.Count(result => result.IsFull && result.IsMalformed),
             results.Count(result => result.SemanticChecked),
@@ -233,6 +233,15 @@ internal static class CorpusSensor
     {
         var failures = ImmutableArray.CreateBuilder<string>();
         var tolerance = baseline.Tolerances ?? CorpusSensorTolerances.Default;
+
+        if (current.ValidityCompileCap < baseline.ValidityCompileCap)
+            failures.Add($"validity cap lower than baseline (baseline {baseline.ValidityCompileCap}, current {current.ValidityCompileCap})");
+        if (current.FidelityCompileCap < baseline.FidelityCompileCap)
+            failures.Add($"fidelity cap lower than baseline (baseline {baseline.FidelityCompileCap}, current {current.FidelityCompileCap})");
+        if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
+            failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
+        if (current.Metrics.Fidelity.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
+            failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {current.Metrics.Fidelity.CheckedMethods})");
 
         int fullyRaisedDrop = baseline.Metrics.FullyRaisedBasisPoints - current.Metrics.FullyRaisedBasisPoints;
         if (fullyRaisedDrop > tolerance.FullyRaisedDropBasisPoints)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -153,9 +153,9 @@ static class FidelityCheck
         return results;
     }
 
-    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int cap, bool lowered)
+    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered)
     {
-        if (cap <= 0)
+        if (perAssemblyCap <= 0)
             return [];
 
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
@@ -167,8 +167,7 @@ static class FidelityCheck
         var results = new List<CompileBackResult>();
         foreach (var assemblyPath in assemblies)
         {
-            if (results.Count >= cap)
-                break;
+            var assemblyResults = new List<CompileBackResult>();
             PEReader pe;
             try { pe = new PEReader(File.OpenRead(assemblyPath)); }
             catch { continue; }
@@ -186,14 +185,15 @@ static class FidelityCheck
                     var references = RuntimeReferences(assemblyPath);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {
-                        if (results.Count >= cap)
+                        if (assemblyResults.Count >= perAssemblyCap)
                             break;
-                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results);
+                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, assemblyResults, perAssemblyCap - assemblyResults.Count);
                     }
                 }
             }
+            results.AddRange(assemblyResults.Take(perAssemblyCap));
         }
-        return results.Count <= cap ? results : results.Take(cap).ToArray();
+        return results;
     }
 
     /// <summary>One method ready to compile back: its decompiled body and the original opcode stream to match.</summary>
@@ -258,10 +258,15 @@ static class FidelityCheck
     static void EvaluateType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
         ImmutableArray<MetadataReference> references, CSharpParseOptions parseOptions,
-        CSharpCompilationOptions compileOptions, Func<IrFunction, DecompilerResult> render, List<CompileBackResult> results)
+        CSharpCompilationOptions compileOptions, Func<IrFunction, DecompilerResult> render, List<CompileBackResult> results,
+        int maxEntries = int.MaxValue)
     {
+        if (maxEntries <= 0)
+            return;
         if (CollectType(reader, pe, source, typeHandle, render) is not var (fullType, entries) || entries.Count == 0)
             return;
+        if (entries.Count > maxEntries)
+            entries = entries.Take(maxEntries).ToList();
         results.AddRange(EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries));
     }
 

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1106,9 +1106,11 @@ static class Program
           --diff-corpus-baseline <f>     run the real-world corpus sensor and fail
                                 if current metrics regress beyond the tolerances
                                 in baseline <f>.
+                                Uses --compile-cap as a per-assembly semantic
+                                validity cap.
           --corpus-fidelity-cap <n>      with corpus baseline modes: cap methods
-                                checked by the expensive compile-back fidelity
-                                oracle (default 0, not run).
+                                checked per assembly by the expensive compile-back
+                                fidelity oracle (default 0, not run).
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -22,11 +22,9 @@ plus dotnet-inspect's own assemblies — and compares the run against
 `tools/DecompilerHarness/corpus/real-world-baseline.json`. The default CI sensor
 tracks fully-raised rate, `structuring: conditional-branch`, forward-merge
 structuring stops (`cond-target-past-region` +
-`forward-branch-not-region-exit`), Full malformed output, and pass bugs. The
-semantic validity and compile-back fidelity oracles are available via caps but
-are currently disabled in CI (`--compile-cap 0`, `--corpus-fidelity-cap 0`) so
-the first standing sensor stays affordable; raising either cap turns those
-defect counts into part of the same baseline diff.
+`forward-branch-not-region-exit`), Full malformed output, semantic validity
+defects, compile-back fidelity defects, and pass bugs. The validity and fidelity
+caps are per assembly so the sensor samples every corpus member at bounded cost.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
@@ -34,8 +32,8 @@ bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
 mapfile -t assemblies < /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
-  --compile-cap 0 \
-  --corpus-fidelity-cap 0 \
+  --compile-cap 25 \
+  --corpus-fidelity-cap 3 \
   --max-examples 3
 ```
 

--- a/tools/DecompilerHarness/corpus/real-world-baseline.json
+++ b/tools/DecompilerHarness/corpus/real-world-baseline.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
-  "generatedUtc": "2026-06-22T23:33:17.706627+00:00",
-  "validityCompileCap": 0,
-  "fidelityCompileCap": 0,
+  "generatedUtc": "2026-06-23T03:17:47.1986677+00:00",
+  "validityCompileCap": 25,
+  "fidelityCompileCap": 3,
   "tolerances": {
     "fullyRaisedDropBasisPoints": 10,
     "conditionalBranchIncreaseBasisPoints": 10,
@@ -95,9 +95,9 @@
     "conditionalBranchBasisPoints": 262,
     "forwardMergeStoppedContainers": 2289,
     "forwardMergeBasisPoints": 261,
-    "fullMalformedMethods": 0,
-    "semanticCheckedMethods": 0,
-    "semanticDefectMethods": 0,
+    "fullMalformedMethods": 165,
+    "semanticCheckedMethods": 350,
+    "semanticDefectMethods": 4,
     "passBugs": 0,
     "residualBuckets": {
       "structuring: conditional-branch": 2298,
@@ -125,10 +125,10 @@
       }
     },
     "fidelity": {
-      "checkedMethods": 0,
-      "exactMethods": 0,
-      "opcodeDiffMethods": 0,
-      "recompileFailMethods": 0,
+      "checkedMethods": 42,
+      "exactMethods": 1,
+      "opcodeDiffMethods": 1,
+      "recompileFailMethods": 40,
       "contextFailMethods": 0,
       "notFullMethods": 0
     }


### PR DESCRIPTION
## Summary
- make the #1174 corpus sensor run bounded non-zero validity and fidelity samples per assembly
- regenerate `real-world-baseline.json` with active validity/fidelity counts
- fail corpus comparisons if a future run lowers the validity/fidelity cap or checks fewer methods than the baseline

## Validation
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- active corpus diff: `--compile-cap 25 --corpus-fidelity-cap 3` matched the regenerated baseline
- negative check: `--compile-cap 0 --corpus-fidelity-cap 0` failed with lower-cap/lower-coverage regressions

Unblocks #1175 evidence requirement #4.