### PR TITLE
Run heavy decompiler checks daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
-      decompiler: ${{ steps.filter.outputs.decompiler }}
-      decompiler_corpus: ${{ steps.filter.outputs.decompiler_corpus }}
       ilroundtrip: ${{ steps.filter.outputs.ilroundtrip }}
     steps:
       - uses: actions/checkout@v6
@@ -39,8 +37,6 @@ jobs:
           fi
           CODE=false
           DOCS=false
-          DECOMPILER=false
-          DECOMPILER_CORPUS=false
           ILROUNDTRIP=false
           while IFS= read -r file; do
             case "$file" in
@@ -52,30 +48,6 @@ jobs:
             esac
             case "$file" in
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
-            esac
-            # The decompiler test suite is expensive (it decompiles the platform
-            # CoreLib). Only run it when the decompiler or its source dependencies
-            # change. Dependency chain: ILInspector.Decompiler ->
-            # ILInspector.Metadata -> { DotnetInspector.Core,
-            # ILInspector.MetadataPrimitives }. Global build files also force a
-            # run; workflow-only changes do not.
-            case "$file" in
-              src/ILInspector.Decompiler*) DECOMPILER=true ;;
-              src/ILInspector.Metadata*) DECOMPILER=true ;;
-              src/DotnetInspector.Core/*) DECOMPILER=true ;;
-              *.props|*.sln) DECOMPILER=true ;;
-            esac
-            # The real-world corpus sensor is a standing decompiler regression
-            # baseline. Run it when decompiler behavior can change, or when the
-            # sensor/manifest/baseline changes.
-            case "$file" in
-              src/ILInspector.Decompiler*) DECOMPILER_CORPUS=true ;;
-              src/ILInspector.Metadata*) DECOMPILER_CORPUS=true ;;
-              src/DotnetInspector.Core/*) DECOMPILER_CORPUS=true ;;
-              tools/DecompilerHarness/*) DECOMPILER_CORPUS=true ;;
-              tools/DecompilerHarness/corpus/*) DECOMPILER_CORPUS=true ;;
-              eng/prepare-decompiler-corpus.sh) DECOMPILER_CORPUS=true ;;
-              *.props|*.sln) DECOMPILER_CORPUS=true ;;
             esac
             # The IL round-trip oracle is also expensive (vendored ILAssembler
             # round-trip over a broad corpus). It depends on ILInspector.Metadata
@@ -91,12 +63,10 @@ jobs:
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "docs=$DOCS" >> "$GITHUB_OUTPUT"
-          echo "decompiler=$DECOMPILER" >> "$GITHUB_OUTPUT"
-          echo "decompiler_corpus=$DECOMPILER_CORPUS" >> "$GITHUB_OUTPUT"
           echo "ilroundtrip=$ILROUNDTRIP" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$FILES"
-          echo "code=$CODE docs=$DOCS decompiler=$DECOMPILER decompiler_corpus=$DECOMPILER_CORPUS ilroundtrip=$ILROUNDTRIP"
+          echo "code=$CODE docs=$DOCS ilroundtrip=$ILROUNDTRIP"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -166,30 +136,6 @@ jobs:
 
       - name: Run CLI tests
         run: dotnet run --project src/dotnet-inspect.Tests -c Release
-
-      # Decompiler tests decompile the platform CoreLib (chain/loop/spill
-      # regression tests, emit-all stress). They are expensive, so they only run
-      # when the decompiler or its source dependencies change (see the
-      # `decompiler` filter in the changes job). Cross-platform IL diversity is
-      # now only exercised at Publish time on the Windows/macOS build legs.
-      - name: Run decompiler tests
-        if: needs.changes.outputs.decompiler == 'true'
-        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
-
-      - name: Prepare decompiler real-world corpus
-        if: needs.changes.outputs.decompiler_corpus == 'true'
-        run: bash eng/prepare-decompiler-corpus.sh corpus-assemblies.txt
-
-      - name: Run decompiler real-world corpus sensor
-        if: needs.changes.outputs.decompiler_corpus == 'true'
-        shell: bash
-        run: |
-          mapfile -t assemblies < corpus-assemblies.txt
-          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
-            --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
-            --compile-cap 25 \
-            --corpus-fidelity-cap 3 \
-            --max-examples 3
 
       - name: Run metadata tests
         run: dotnet run --project tests/ILInspector.Metadata.Tests -c Release

--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -1,0 +1,70 @@
+name: Decompiler Daily
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_INSPECT_TIPS: q
+
+concurrency:
+  group: decompiler-daily-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  decompiler:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Build managed tool
+        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+
+      - name: Install ilasm/ildasm
+        continue-on-error: true
+        shell: bash
+        run: |
+          RID=linux-x64
+          VERSION=11.0.0-preview.1.26104.118
+          PACKAGES_DIR=$(mktemp -d)
+          PROJ_DIR=$(mktemp -d)
+          cat > "$PROJ_DIR/iltools.csproj" <<EOF
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
+            <ItemGroup>
+              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILAsm" Version="[${VERSION}]" />
+              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILDAsm" Version="[${VERSION}]" />
+            </ItemGroup>
+          </Project>
+          EOF
+          dotnet restore "$PROJ_DIR/iltools.csproj" --packages "$PACKAGES_DIR" --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
+          ILASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ilasm/$VERSION/runtimes/$RID/native"
+          ILDASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ildasm/$VERSION/runtimes/$RID/native"
+          chmod +x "$ILASM_DIR"/* "$ILDASM_DIR"/* 2>/dev/null || true
+          echo "$ILASM_DIR" >> "$GITHUB_PATH"
+          echo "$ILDASM_DIR" >> "$GITHUB_PATH"
+
+      - name: Run decompiler tests
+        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
+
+      - name: Prepare real-world corpus
+        run: bash eng/prepare-decompiler-corpus.sh corpus-assemblies.txt
+
+      - name: Run real-world corpus sensor
+        shell: bash
+        run: |
+          mapfile -t assemblies < corpus-assemblies.txt
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+            --compile-cap 25 \
+            --corpus-fidelity-cap 3 \
+            --max-examples 3

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -16,15 +16,16 @@ library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
 `--top-libraries N` limits the detailed library sections to the noisiest
 libraries, and `--json` emits the same data as structured JSON.
 
-**Real-world corpus sensor** (`--diff-corpus-baseline`): the continuous CI
+**Real-world corpus sensor** (`--diff-corpus-baseline`): the daily/manual
 baseline for #1166. It measures the fixed #1150 corpus — pinned NuGet assemblies
 plus dotnet-inspect's own assemblies — and compares the run against
-`tools/DecompilerHarness/corpus/real-world-baseline.json`. The default CI sensor
-tracks fully-raised rate, `structuring: conditional-branch`, forward-merge
-structuring stops (`cond-target-past-region` +
-`forward-branch-not-region-exit`), Full malformed output, semantic validity
-defects, compile-back fidelity defects, and pass bugs. The validity and fidelity
-caps are per assembly so the sensor samples every corpus member at bounded cost.
+`tools/DecompilerHarness/corpus/real-world-baseline.json`. The scheduled
+Decompiler Daily workflow tracks fully-raised rate,
+`structuring: conditional-branch`, forward-merge structuring stops
+(`cond-target-past-region` + `forward-branch-not-region-exit`), Full malformed
+output, semantic validity defects, compile-back fidelity defects, and pass bugs.
+The validity and fidelity caps are per assembly so the sensor samples every
+corpus member at bounded cost without adding that cost to every PR.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false


### PR DESCRIPTION
## Summary
- move expensive `ILInspector.Decompiler.Tests` out of per-PR/per-push CI
- move the real-world corpus sensor out of per-run CI into a scheduled/manual Decompiler Daily workflow
- keep regular CI focused on build, CLI tests, metadata/services tests, pack/smoke, and existing conditional IL roundtrip coverage

## Validation
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- `npx -y yaml-lint .github/workflows/ci.yml .github/workflows/decompiler-daily.yml`

Refs #1175.