### PR TITLE
Upload daily corpus snapshots

### DIFF
--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -63,8 +63,18 @@ jobs:
         shell: bash
         run: |
           mapfile -t assemblies < corpus-assemblies.txt
+          mkdir -p artifacts/decompiler-daily
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --emit-corpus-snapshot artifacts/decompiler-daily/corpus-snapshot.json \
             --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
             --compile-cap 25 \
             --corpus-fidelity-cap 3 \
             --max-examples 3
+
+      - name: Upload corpus snapshot
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: decompiler-corpus-snapshot
+          path: artifacts/decompiler-daily/corpus-snapshot.json
+          if-no-files-found: warn

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -168,6 +168,8 @@ static class FidelityCheck
         foreach (var assemblyPath in assemblies)
         {
             var assemblyResults = new List<CompileBackResult>();
+            int attempts = 0;
+            int attemptCap = perAssemblyCap * 10;
             PEReader pe;
             try { pe = new PEReader(File.OpenRead(assemblyPath)); }
             catch { continue; }
@@ -185,9 +187,12 @@ static class FidelityCheck
                     var references = RuntimeReferences(assemblyPath);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {
-                        if (assemblyResults.Count >= perAssemblyCap)
+                        if (assemblyResults.Count >= perAssemblyCap || attempts >= attemptCap)
                             break;
-                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, assemblyResults, perAssemblyCap - assemblyResults.Count);
+                        var typeResults = new List<CompileBackResult>();
+                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, Math.Min(8, attemptCap - attempts));
+                        attempts += typeResults.Count;
+                        assemblyResults.AddRange(typeResults.Where(IsUsefulCorpusSample).Take(perAssemblyCap - assemblyResults.Count));
                     }
                 }
             }
@@ -195,6 +200,9 @@ static class FidelityCheck
         }
         return results;
     }
+
+    static bool IsUsefulCorpusSample(CompileBackResult result)
+        => result.Status is CompileBackStatus.Exact or CompileBackStatus.OpcodeDiff;
 
     /// <summary>One method ready to compile back: its decompiled body and the original opcode stream to match.</summary>
     sealed record Entry(

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -55,7 +55,7 @@ static class Program
         bool typeCheck = false;
         bool bindCheck = false;
         bool classifyDec0009 = false;
-        string? emitCorpusBaseline = null;
+        string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
         int corpusFidelityCap = 0;
         bool json = false;
@@ -107,7 +107,8 @@ static class Program
                 case "--bind-check": bindCheck = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
                 case "--dec0009-shapes": classifyDec0009 = true; break;
-                case "--emit-corpus-baseline": emitCorpusBaseline = args[++i]; break;
+                case "--emit-corpus-baseline": emitCorpusSnapshot = args[++i]; break;
+                case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
                 case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
                 case "--json": json = true; break;
@@ -144,8 +145,8 @@ static class Program
         if (classifyDec0009)
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
-        if (emitCorpusBaseline is not null || diffCorpusBaseline is not null)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusBaseline, diffCorpusBaseline);
+        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null)
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1103,6 +1104,8 @@ static class Program
           --dec0009-shapes       alias for --classify-dec0009.
           --emit-corpus-baseline <f>     run the real-world corpus sensor and write
                                 the current JSON baseline to <f>.
+          --emit-corpus-snapshot <f>     alias for --emit-corpus-baseline; intended
+                                for daily artifact snapshots.
           --diff-corpus-baseline <f>     run the real-world corpus sensor and fail
                                 if current metrics regress beyond the tolerances
                                 in baseline <f>.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -25,13 +25,18 @@ Decompiler Daily workflow tracks fully-raised rate,
 (`cond-target-past-region` + `forward-branch-not-region-exit`), Full malformed
 output, semantic validity defects, compile-back fidelity defects, and pass bugs.
 The validity and fidelity caps are per assembly so the sensor samples every
-corpus member at bounded cost without adding that cost to every PR.
+corpus member at bounded cost without adding that cost to every PR. The fidelity
+sample records useful compile-back outcomes (`Exact`/`OpcodeDiff`) rather than
+mostly recording methods whose generated shell does not recompile. Each daily run
+uploads the current JSON snapshot as the `decompiler-corpus-snapshot` artifact so
+trends can be compared without scraping logs.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
 bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
 mapfile -t assemblies < /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-corpus-snapshot /tmp/corpus-snapshot.json \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
   --compile-cap 25 \
   --corpus-fidelity-cap 3 \
@@ -39,8 +44,7 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 ```
 
 To deliberately rebaseline after reviewed corpus movement, run the same command
-with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`
-instead of `--diff-corpus-baseline`.
+with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.
 
 **Unsupported nodes** (`--unsupported-nodes`): a focused view of the
 `fidelity: unsupported-node` bucket. It runs the normal raising pipeline, walks

--- a/tools/DecompilerHarness/corpus/real-world-baseline.json
+++ b/tools/DecompilerHarness/corpus/real-world-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
-  "generatedUtc": "2026-06-23T03:17:47.1986677+00:00",
+  "generatedUtc": "2026-06-23T15:06:00.5422037+00:00",
   "validityCompileCap": 25,
   "fidelityCompileCap": 3,
   "tolerances": {
@@ -74,7 +74,7 @@
     {
       "assembly": "dotnet-inspect",
       "path": "artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll",
-      "totalMethods": 12335
+      "totalMethods": 12392
     },
     {
       "assembly": "ILInspector.Analysis",
@@ -84,16 +84,16 @@
     {
       "assembly": "ILInspector.Decompiler",
       "path": "artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll",
-      "totalMethods": 4955
+      "totalMethods": 4961
     }
   ],
   "metrics": {
-    "totalMethods": 87844,
-    "fullyRaisedMethods": 77337,
-    "fullyRaisedBasisPoints": 8804,
+    "totalMethods": 87907,
+    "fullyRaisedMethods": 77376,
+    "fullyRaisedBasisPoints": 8802,
     "conditionalBranchMethods": 2298,
-    "conditionalBranchBasisPoints": 262,
-    "forwardMergeStoppedContainers": 2289,
+    "conditionalBranchBasisPoints": 261,
+    "forwardMergeStoppedContainers": 2290,
     "forwardMergeBasisPoints": 261,
     "fullMalformedMethods": 165,
     "semanticCheckedMethods": 350,
@@ -101,34 +101,33 @@
     "passBugs": 0,
     "residualBuckets": {
       "structuring: conditional-branch": 2298,
-      "fidelity: (typed)": 7351,
+      "fidelity: (typed)": 7374,
       "structuring: switch-branch": 136,
       "fidelity: (join-type):": 53,
       "structuring: unconditional-branch": 21,
       "eh: leave/endfinally": 41,
-      "fidelity: unsupported-node": 557,
+      "fidelity: unsupported-node": 558,
       "fidelity: type unspellable C# type name \u0027\u003CPrivateImplementationDetails\u003E\u0027": 50
     },
     "structuring": {
-      "totalMethods": 87844,
-      "structuredContainers": 29143,
+      "totalMethods": 87907,
+      "structuredContainers": 29156,
       "stoppedContainers": 2507,
       "methodsWithStops": 2464,
       "passBugs": 0,
       "stopReasons": {
-        "cond-target-past-region": 1443,
+        "cond-target-past-region": 1444,
         "forward-branch-not-region-exit": 846,
         "cond-backward-branch": 82,
         "unconsumed-regions": 134,
-        "leave-target-in-container": 1,
         "cond-target-external": 1
       }
     },
     "fidelity": {
-      "checkedMethods": 42,
-      "exactMethods": 1,
+      "checkedMethods": 6,
+      "exactMethods": 5,
       "opcodeDiffMethods": 1,
-      "recompileFailMethods": 40,
+      "recompileFailMethods": 0,
       "contextFailMethods": 0,
       "notFullMethods": 0
     }


### PR DESCRIPTION
## Summary
- upload the Decompiler Daily corpus snapshot JSON as an Actions artifact
- add `--emit-corpus-snapshot` as a clearer alias for daily snapshot emission
- make corpus fidelity sampling record useful compile-back outcomes (`Exact`/`OpcodeDiff`) instead of mostly recompile failures
- regenerate the real-world baseline with useful fidelity data: 5 exact, 1 opcode diff, 0 recompile failures

## Validation
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- `npx -y yaml-lint .github/workflows/decompiler-daily.yml .github/workflows/ci.yml`
- active corpus diff with snapshot emission matched baseline
- zero-cap corpus diff failed on lower coverage as expected

Refs #1175.