### PR TITLE
Add decompiler quality diff PR card guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,10 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --max-examples 3
 ```
 
+Summarize decompiler-affecting PRs with the compact quality-diff card in
+`docs/decompiler-quality.md`; do not paste raw `--dump --steps` walls into PR
+bodies unless linked drill-down is required.
+
 Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if not installed.
 
 `DotnetInspector.ILRoundtrip.Tests` requires the vendored managed ILAssembler

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,14 +94,16 @@ bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
 mapfile -t assemblies < /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --quality-diff-card \
   --compile-cap 25 \
   --corpus-fidelity-cap 3 \
   --max-examples 3
 ```
 
-Summarize decompiler-affecting PRs with the compact quality-diff card in
-`docs/decompiler-quality.md`; do not paste raw `--dump --steps` walls into PR
-bodies unless linked drill-down is required.
+Summarize decompiler-affecting PRs with the tool-generated quality-diff card in
+`docs/decompiler-quality.md`; paste the harness output rather than constructing
+the table by hand, and do not paste raw `--dump --steps` walls into PR bodies
+unless linked drill-down is required.
 
 Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if not installed.
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -380,6 +380,68 @@ These keep a review fast and the proof legible:
   the sidecar's `MissingDiscriminator` and into `AdversarialCoverage` so the next
   reviewer reads it as proven rather than still owed.
 
+### Decompiler quality diff PR card
+
+Decompiler PRs should include a compact **Decompiler quality diff** card when
+they can affect raising, structuring, validity, fidelity, or corpus behaviour.
+Use the real-world corpus sensor (`--diff-corpus-baseline`) for the aggregate
+rows, then add method-level examples only when the PR intentionally changes
+behaviour. The card is reviewer-sized evidence, not a dump-stage artifact; keep
+`--dump --steps` output in linked diagnosis notes only when reviewers need the
+drill-down.
+
+For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
+sensor values are enough:
+
+```md
+### Decompiler quality diff
+
+Corpus: #1174 real-world corpus, 14 assemblies, 87,894 methods
+
+| Metric | Baseline | PR | Delta |
+| --- | ---: | ---: | ---: |
+| Fully raised | 77,373 (88.03%) | 77,373 (88.03%) | 0 |
+| Conditional-branch residual | 2,292 | 2,292 | 0 |
+| Forward-merge stops | 2,284 | 2,284 | 0 |
+| Full malformed | 165 | 165 | 0 |
+| Semantic defects | 4/350 | 4/350 | 0 |
+| Fidelity diffs | 1/42 | 1/42 | 0 |
+| Pass bugs | 0 | 0 | 0 |
+
+Verdict: no corpus movement expected; refactor is behavior-preserving.
+```
+
+Run the sensor with the same command documented in the harness README:
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
+mapfile -t assemblies < /tmp/corpus-assemblies.txt
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --compile-cap 25 \
+  --corpus-fidelity-cap 3 \
+  --max-examples 3
+```
+
+For raise or deliberate behaviour PRs, keep the table and add targeted examples:
+
+```md
+Improved examples:
+- Type::Method — `structuring: conditional-branch` -> Full
+
+Still-flat near miss:
+- Type::Other — declined because the discriminator is missing / readability
+  failed / fidelity would regress.
+```
+
+Read movement as correctness evidence, not a JIT-style tradeoff budget.
+Acceptable movement is: completeness improves while validity/fidelity stay flat,
+validity/fidelity defects shrink, or a Full -> Partial change is an explicit
+honesty correction that stops overclaiming. Do not normalize new pass bugs, new
+Full malformed/bound defects, new fidelity opcode diffs, or broad "correct but
+uglier" output without an explicit design approval and readability gate.
+
 For compiler/runtime expert review, optimize the code and tests for legible
 proof obligations:
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -384,34 +384,20 @@ These keep a review fast and the proof legible:
 
 Decompiler PRs should include a compact **Decompiler quality diff** card when
 they can affect raising, structuring, validity, fidelity, or corpus behaviour.
-Use the real-world corpus sensor (`--diff-corpus-baseline`) for the aggregate
-rows, then add method-level examples only when the PR intentionally changes
-behaviour. The card is reviewer-sized evidence, not a dump-stage artifact; keep
-`--dump --steps` output in linked diagnosis notes only when reviewers need the
-drill-down.
+Generate the aggregate rows with the real-world corpus sensor
+(`--diff-corpus-baseline --quality-diff-card`) and paste the harness output into
+the PR. Do not ask an agent to construct or re-key the table: that is wasteful,
+open to hallucination, and harder for a reviewer to validate. Method-level
+examples are the only hand-authored addendum, and only when the PR intentionally
+changes behaviour. The card is reviewer-sized evidence, not a dump-stage
+artifact; keep `--dump --steps` output in linked diagnosis notes only when
+reviewers need the drill-down.
 
 For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
 sensor values are enough:
 
-```md
-### Decompiler quality diff
-
-Corpus: #1174 real-world corpus, 14 assemblies, 87,894 methods
-
-| Metric | Baseline | PR | Delta |
-| --- | ---: | ---: | ---: |
-| Fully raised | 77,373 (88.03%) | 77,373 (88.03%) | 0 |
-| Conditional-branch residual | 2,292 | 2,292 | 0 |
-| Forward-merge stops | 2,284 | 2,284 | 0 |
-| Full malformed | 165 | 165 | 0 |
-| Semantic defects | 4/350 | 4/350 | 0 |
-| Fidelity diffs | 1/42 | 1/42 | 0 |
-| Pass bugs | 0 | 0 | 0 |
-
-Verdict: no corpus movement expected; refactor is behavior-preserving.
-```
-
-Run the sensor with the same command documented in the harness README:
+Run the sensor with the same command documented in the harness README. The
+`--quality-diff-card` flag is what emits the PR-ready Markdown block:
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
@@ -419,12 +405,34 @@ bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
 mapfile -t assemblies < /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --quality-diff-card \
   --compile-cap 25 \
   --corpus-fidelity-cap 3 \
   --max-examples 3
 ```
 
-For raise or deliberate behaviour PRs, keep the table and add targeted examples:
+The tool emits a block like:
+
+```md
+### Decompiler quality diff
+
+Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,907 methods
+
+| Metric | Baseline | PR | Delta |
+| --- | ---: | ---: | ---: |
+| Fully raised | 77,376 (88.02%) | 77,376 (88.02%) | 0 |
+| Conditional-branch residual | 2,298 (2.61%) | 2,298 (2.61%) | 0 |
+| Forward-merge stops | 2,290 (2.61%) | 2,290 (2.61%) | 0 |
+| Full malformed | 165 | 165 | 0 |
+| Semantic defects | 4/350 | 4/350 | 0 |
+| Fidelity diffs | 1/6 | 1/6 | 0 |
+| Pass bugs | 0 | 0 | 0 |
+
+Verdict: corpus sensor matched baseline tolerances.
+```
+
+For raise or deliberate behaviour PRs, keep the generated table and add targeted
+examples:
 
 ```md
 Improved examples:

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -384,6 +384,17 @@ These keep a review fast and the proof legible:
 
 Decompiler PRs should include a compact **Decompiler quality diff** card when
 they can affect raising, structuring, validity, fidelity, or corpus behaviour.
+The model is the current dotnet/runtime JIT review posture: evidence is
+tool-driven (`jit-diff`, SPMI/PMI diff jobs, benchmark artifacts, or linked
+EgorBot benchmark runs), with small before/after codegen excerpts when a local
+shape matters. Newer JIT PRs do not always paste a full table into the body; they
+often link the generated diff job and summarize the verdict. The invariant is
+that the numbers come from a reproducible tool artifact, not from a reviewer or
+agent re-keying measurements. Roslyn performance PRs are similar in spirit but
+less uniform: they use BenchmarkDotNet tables, Speedometer/PR-validation links,
+allocation/trace snippets, and reviewer-requested reruns rather than one
+standard card.
+
 Generate the aggregate rows with the real-world corpus sensor
 (`--diff-corpus-baseline --quality-diff-card`) and paste the harness output into
 the PR. Do not ask an agent to construct or re-key the table: that is wasteful,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text.Json;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -20,7 +21,8 @@ internal static class CorpusSensor
         int fidelityCompileCap,
         int maxExamples,
         string? emitBaseline,
-        string? diffBaseline)
+        string? diffBaseline,
+        bool qualityDiffCard = false)
     {
         if (assemblies.Count == 0)
         {
@@ -28,8 +30,15 @@ internal static class CorpusSensor
             return 1;
         }
 
+        if (qualityDiffCard && diffBaseline is null)
+        {
+            Console.Error.WriteLine("--quality-diff-card requires --diff-corpus-baseline <file>.");
+            return 1;
+        }
+
         var current = Capture(assemblies, validityCompileCap, fidelityCompileCap, maxExamples);
-        PrintSummary(current);
+        if (!qualityDiffCard)
+            PrintSummary(current);
 
         if (emitBaseline is not null)
         {
@@ -45,6 +54,12 @@ internal static class CorpusSensor
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
             ?? throw new InvalidOperationException($"Could not read corpus baseline '{diffBaseline}'.");
         var regressions = Compare(baseline, current);
+        if (qualityDiffCard)
+        {
+            PrintQualityDiffCard(baseline, current, regressions);
+            return regressions.Length == 0 ? 0 : 1;
+        }
+
         if (regressions.Length == 0)
         {
             Console.WriteLine();
@@ -291,6 +306,83 @@ internal static class CorpusSensor
         Console.WriteLine($"Pass bugs: {metrics.PassBugs}");
         Console.WriteLine($"Fidelity: {metrics.Fidelity.ExactMethods} exact, {metrics.Fidelity.OpcodeDiffMethods} opcode diffs, {metrics.Fidelity.RecompileFailMethods} recompile failures over {metrics.Fidelity.CheckedMethods} checked");
     }
+
+    static void PrintQualityDiffCard(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current,
+        IReadOnlyList<string> regressions)
+    {
+        Console.WriteLine("### Decompiler quality diff");
+        Console.WriteLine();
+        Console.WriteLine($"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods");
+        Console.WriteLine();
+        Console.WriteLine("| Metric | Baseline | PR | Delta |");
+        Console.WriteLine("| --- | ---: | ---: | ---: |");
+        PrintMetric(
+            "Fully raised",
+            CountPercent(baseline.Metrics.FullyRaisedMethods, baseline.Metrics.FullyRaisedBasisPoints),
+            CountPercent(current.Metrics.FullyRaisedMethods, current.Metrics.FullyRaisedBasisPoints),
+            Delta(current.Metrics.FullyRaisedMethods - baseline.Metrics.FullyRaisedMethods));
+        PrintMetric(
+            "Conditional-branch residual",
+            CountPercent(baseline.Metrics.ConditionalBranchMethods, baseline.Metrics.ConditionalBranchBasisPoints),
+            CountPercent(current.Metrics.ConditionalBranchMethods, current.Metrics.ConditionalBranchBasisPoints),
+            Delta(current.Metrics.ConditionalBranchMethods - baseline.Metrics.ConditionalBranchMethods));
+        PrintMetric(
+            "Forward-merge stops",
+            CountPercent(baseline.Metrics.ForwardMergeStoppedContainers, baseline.Metrics.ForwardMergeBasisPoints),
+            CountPercent(current.Metrics.ForwardMergeStoppedContainers, current.Metrics.ForwardMergeBasisPoints),
+            Delta(current.Metrics.ForwardMergeStoppedContainers - baseline.Metrics.ForwardMergeStoppedContainers));
+        PrintMetric(
+            "Full malformed",
+            Number(baseline.Metrics.FullMalformedMethods),
+            Number(current.Metrics.FullMalformedMethods),
+            Delta(current.Metrics.FullMalformedMethods - baseline.Metrics.FullMalformedMethods));
+        PrintMetric(
+            "Semantic defects",
+            Fraction(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods),
+            Fraction(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods),
+            Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
+        PrintMetric(
+            "Fidelity diffs",
+            Fraction(baseline.Metrics.Fidelity.OpcodeDiffMethods, baseline.Metrics.Fidelity.CheckedMethods),
+            Fraction(current.Metrics.Fidelity.OpcodeDiffMethods, current.Metrics.Fidelity.CheckedMethods),
+            Delta(current.Metrics.Fidelity.OpcodeDiffMethods - baseline.Metrics.Fidelity.OpcodeDiffMethods));
+        PrintMetric(
+            "Pass bugs",
+            Number(baseline.Metrics.PassBugs),
+            Number(current.Metrics.PassBugs),
+            Delta(current.Metrics.PassBugs - baseline.Metrics.PassBugs));
+        Console.WriteLine();
+        Console.WriteLine(regressions.Count == 0
+            ? "Verdict: corpus sensor matched baseline tolerances."
+            : "Verdict: corpus sensor reported regressions; review before merging.");
+        if (regressions.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Regressions:");
+            foreach (var regression in regressions)
+                Console.WriteLine($"- {regression}");
+        }
+    }
+
+    static void PrintMetric(string metric, string baseline, string current, string delta)
+        => Console.WriteLine($"| {metric} | {baseline} | {current} | {delta} |");
+
+    static string CountPercent(int count, int basisPoints)
+        => $"{Number(count)} ({FormatBps(basisPoints)})";
+
+    static string Fraction(int numerator, int denominator)
+        => $"{Number(numerator)}/{Number(denominator)}";
+
+    static string AssemblyCount(int count)
+        => $"{Number(count)} assembl{(count == 1 ? "y" : "ies")}";
+
+    static string Delta(int value)
+        => value > 0 ? $"+{Number(value)}" : Number(value);
+
+    static string Number(int value)
+        => value.ToString("N0", CultureInfo.InvariantCulture);
 
     static int RateBasisPoints(int part, int whole)
         => whole <= 0 ? 0 : (int)Math.Round(10_000.0 * part / whole, MidpointRounding.AwayFromZero);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -57,6 +57,7 @@ static class Program
         bool classifyDec0009 = false;
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
+        bool qualityDiffCard = false;
         int corpusFidelityCap = 0;
         bool json = false;
         int topPatterns = 10;
@@ -110,6 +111,7 @@ static class Program
                 case "--emit-corpus-baseline": emitCorpusSnapshot = args[++i]; break;
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
+                case "--quality-diff-card": qualityDiffCard = true; break;
                 case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
@@ -145,8 +147,8 @@ static class Program
         if (classifyDec0009)
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
-        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline);
+        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1111,6 +1113,9 @@ static class Program
                                 in baseline <f>.
                                 Uses --compile-cap as a per-assembly semantic
                                 validity cap.
+          --quality-diff-card  with --diff-corpus-baseline: emit a Markdown
+                                Decompiler quality diff card generated from the
+                                baseline/current corpus snapshots.
           --corpus-fidelity-cap <n>      with corpus baseline modes: cap methods
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -38,10 +38,15 @@ mapfile -t assemblies < /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --emit-corpus-snapshot /tmp/corpus-snapshot.json \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --quality-diff-card \
   --compile-cap 25 \
   --corpus-fidelity-cap 3 \
   --max-examples 3
 ```
+
+Add `--quality-diff-card` to emit a Markdown PR block generated directly from
+the baseline/current snapshots. Paste that block as the PR's aggregate corpus
+evidence; do not re-key the table by hand.
 
 To deliberately rebaseline after reviewed corpus movement, run the same command
 with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.


### PR DESCRIPTION
Fixes #1187

## Summary
- add `--quality-diff-card` to `tools/DecompilerHarness` so the Decompiler quality diff table is generated from baseline/current corpus snapshots
- document the tool-driven workflow in `docs/decompiler-quality.md`, `tools/DecompilerHarness/README.md`, and `AGENTS.md`
- keep targeted improved/near-miss examples as hand-authored addenda for behavior PRs, while forbidding re-keyed aggregate tables and dump-stage walls in PR bodies

## Runtime JIT / Roslyn reference check
- sampled newer dotnet/runtime JIT PRs from Egor/Andy (for example dotnet/runtime#128500, #127117, #124147, #127429, #129449): current practice is still tool-driven, but often via linked generated `jit-diff`/SPMI/PMI jobs, EgorBot benchmark issues, or compact codegen diffs rather than always pasting a full table
- sampled recent Roslyn perf PRs (for example dotnet/roslyn#83000, #82708, #82431, #83664, #82462): Roslyn has analogous evidence, but no single uniform card; they use BenchmarkDotNet tables, Speedometer/PR-validation links, allocation/trace snippets, and reviewer-requested reruns
- reflected this in the docs: our invariant is generated/reproducible aggregate data, not a hand-entered table

## Validation
- `dotnet build tools/DecompilerHarness -c Release --no-restore --nologo`
- generated a local corpus baseline and reran with `--diff-corpus-baseline /tmp/dotnet-inspect-card-baseline.json --quality-diff-card` to verify Markdown output
- `npx markdownlint-cli AGENTS.md docs/decompiler-quality.md tools/DecompilerHarness/README.md`