### PR TITLE
Pin CultureInfo EH-unstructured residual

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -85,22 +85,4 @@ public class CompletenessTests
         Assert.Null(Completeness.Residual(Raised(nameof(CfgSampleClass.DiamondArmEarlyExitGuardedMerge))));
     }
 
-    [Fact]
-    public void CultureInfoCreateSpecificCulture_RemainsEhUnstructuredPivot()
-    {
-        // #1135 pivot: CreateSpecificCulture has two adjacent filterless catch
-        // islands and EH structuring stays fully flat. This is not a narrow
-        // StructuringPass lane; it needs broader EH-region support before the
-        // outer conditionals can be productively raised.
-        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
-        var function = IrImporter.Import(source, "System.Globalization.CultureInfo", "CreateSpecificCulture");
-        Assert.NotNull(function);
-
-        IrPasses.Run(function!);
-
-        Assert.Equal("structuring: conditional-branch", Completeness.Residual(function!));
-        Assert.Equal("eh-unstructured", EhShapeClassifier.Classify(function!));
-        Assert.Empty(function!.Descendants.OfType<TryCatch>());
-        Assert.Contains(function.Descendants, node => node is Leave);
-    }
 }

--- a/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompletenessTests.cs
@@ -84,4 +84,23 @@ public class CompletenessTests
         // no residual control flow survives.
         Assert.Null(Completeness.Residual(Raised(nameof(CfgSampleClass.DiamondArmEarlyExitGuardedMerge))));
     }
+
+    [Fact]
+    public void CultureInfoCreateSpecificCulture_RemainsEhUnstructuredPivot()
+    {
+        // #1135 pivot: CreateSpecificCulture has two adjacent filterless catch
+        // islands and EH structuring stays fully flat. This is not a narrow
+        // StructuringPass lane; it needs broader EH-region support before the
+        // outer conditionals can be productively raised.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.Globalization.CultureInfo", "CreateSpecificCulture");
+        Assert.NotNull(function);
+
+        IrPasses.Run(function!);
+
+        Assert.Equal("structuring: conditional-branch", Completeness.Residual(function!));
+        Assert.Equal("eh-unstructured", EhShapeClassifier.Classify(function!));
+        Assert.Empty(function!.Descendants.OfType<TryCatch>());
+        Assert.Contains(function.Descendants, node => node is Leave);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/CultureInfoEhResidualTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CultureInfoEhResidualTests.cs
@@ -1,0 +1,26 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CultureInfoEhResidualTests
+{
+    [Fact]
+    public void CreateSpecificCulture_RemainsEhUnstructuredPivot()
+    {
+        // #1135 pivot: CreateSpecificCulture has two adjacent filterless catch
+        // islands and EH structuring stays fully flat. This is not a narrow
+        // StructuringPass lane; it needs broader EH-region support before the
+        // outer conditionals can be productively raised.
+        using var source = MetadataSource.Open(typeof(object).Assembly.Location);
+        var function = IrImporter.Import(source, "System.Globalization.CultureInfo", "CreateSpecificCulture");
+        Assert.NotNull(function);
+
+        IrPasses.Run(function!);
+
+        Assert.Equal("structuring: conditional-branch", Completeness.Residual(function!));
+        Assert.Equal("eh-unstructured", EhShapeClassifier.Classify(function!));
+        Assert.Empty(function!.Descendants.OfType<TryCatch>());
+        Assert.Contains(function.Descendants, node => node is Leave);
+    }
+}


### PR DESCRIPTION
## Summary

- pin `CultureInfo::CreateSpecificCulture` as the remaining #1135 EH-unstructured pivot
- document in a focused test that EH structuring stays fully flat for the two adjacent filterless catch islands
- avoid a speculative product rewrite; this residual needs broader EH-region support before StructuringPass can productively raise the outer conditionals

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- --dump 'System.Globalization.CultureInfo::CreateSpecificCulture' --remarks`\n\nUpdates #1135.