### PR TITLE
Add member Source Locations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type filters. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. |
-| Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Original Source"` | SourceLink URLs, member line numbers, source fetching, URL verification, token+IL-offset to source-line resolution. |
+| Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory
@@ -139,6 +139,7 @@ dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize -S "Member Index"
+dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize -S "Source Locations"
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S @Source
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Calls
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S Callers

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -45,7 +45,7 @@ For package, library, and selected-overload member output, focused selected sect
 
 Bare `-S` is command/context-specific shorthand for `-S @Default`: package uses `Package Info` and `Library Files`; library uses `Library Info`; type and broad member list views use compact member summaries such as `Method Groups`; member-name views use `Methods` overload rows; selected member overloads use `Signature` and `Decompiled Source`. See [Bare `-S` default view](info-view.md) for the bullseye question each preset is meant to answer.
 
-For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments, and `Original Source` is SourceLink-backed source text for one method; both render via explicit `-S` (or `-S @Source`, which also includes `IL`). The structured dual of `Annotated Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
+For selected overloads, the default high-value section is `Signature`. Normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `IL` (raw IL). `Source Locations` is an explicit SourceLink file/line URL table that does not fetch source bodies. `Annotated Source` is the mixed C#+IL view with hidden-fact comments, and `Original Source` is SourceLink-backed source text for one method; both render via explicit `-S` (or `-S @Source`, which also includes `IL`). The structured dual of `Annotated Source`, `Facts` (a hidden-fact table), is opt-in via `-S "Facts"` / `--tsv`.
 
 ## Discovery
 

--- a/docs/llm-design.md
+++ b/docs/llm-design.md
@@ -47,10 +47,11 @@ For compact type overviews and overload counts, prefer type shape:
 dotnet-inspect type JsonSerializer --package System.Text.Json@10.0.0 --shape
 ```
 
-Use `member -m Name` when you need a specific overload inventory, docs, decompiled/lowered C#, SourceLink-backed original source, or IL. Use `-S "Member Index"` for a terse selector index with interactive `Name:N` selectors, durable `Name~digest` selectors, and the printed `Canonical Signature` used to compute each digest:
+Use `member -m Name` when you need a specific overload inventory, docs, SourceLink file/line locations, decompiled/lowered C#, SourceLink-backed original source, or IL. Use `-S "Member Index"` for a terse selector index with interactive `Name:N` selectors, durable `Name~digest` selectors, and the printed `Canonical Signature` used to compute each digest:
 
 ```bash
 dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize -S "Member Index"
+dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 -m Serialize -S "Source Locations"
 dotnet-inspect member JsonSerializer --package System.Text.Json@10.0.0 Serialize:1 -S "Decompiled Source"
 ```
 
@@ -71,6 +72,7 @@ Library signals describe assemblies: SourceLink presence/reachability, PDB/symbo
 ## Fidelity expectations
 
 - `Original Source` is SourceLink-backed original source when available.
+- `Source Locations` is SourceLink-backed file/line URL evidence without fetching source bodies.
 - `Decompiled Source` is raised C#, a best-effort readable reconstruction from IL; it may use PDB debug names when available.
 - `Annotated Source` is raised C# with hidden-fact comments and interleaved IL.
 - `@Source` selects `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`.

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -17,7 +17,7 @@ Verbosity levels:
 | Minimal (default) | (none) | H1, description, metadata field list, one section table | Yes |
 | Detailed | `-v:d` | H1, description, metadata field list, all sections | No |
 
-The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `IL` (raw IL). `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. `-S @Source` selects Decompiled, Annotated, Original, and IL evidence. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
+The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `IL` (raw IL). `Source Locations` is an explicit SourceLink file/line URL table that does not fetch source bodies. `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. `-S @Source` selects Decompiled, Annotated, Original, and IL evidence. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
 
 Section selection (`-S`, with lowercase `-s` as an alias) lists available sections or filters to specific ones. Tips are suppressed when sections are selected. `--count` with exactly one selected section returns a single integer.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.13.0
+version: 0.14.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, and API version diffs.
 ---
 
@@ -19,7 +19,7 @@ dnx dotnet-inspect -y -- <command>
 | Find an API | `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
-| Source/implementation | `type Type -S "Source Files"`; `member Type Name:1 -S @Source`; `library/package Foo -S "Source Files"` |
+| Source/implementation | `type Type -S "Source Files"`; `member Type -m Name -S "Source Locations"`; `member Type Name:1 -S @Source`; `library/package Foo -S "Source Files"` |
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden/extra members. |
 | Compare APIs | `diff --package Foo@old..new --breaking`; use `--additive` for new APIs. |
 | Inspect packages | `package Foo -S Signals`, `-S "Library Files"`, `--library` |
@@ -43,7 +43,7 @@ dnx dotnet-inspect -y -- member string IndexOf:7 -S Callers --caller-package Sys
 
 Selector syntax: first run `member Type --platform Lib -m Name -S "Member Index"` (or the package/library source `find` reported). Then pass either `Name:N` (1-based, for the current index) or `Name~digest` (stable, from the `Stable` column) as the positional member selector. `Canonical Signature` is the printed digest input. Prefer `Name~digest` in notes, scripts, issues, and handoffs; use `Name:N` for immediate drill-in. `--show-index` is an alias for `-S "Member Index"`.
 
-A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`. Use `-S @Source` for source and IL evidence: `Decompiled Source` (raised C#), `Annotated Source` (C# with hidden-fact comments and interleaved IL), `Original Source`, and `IL`. Use `Annotated Source` or `IL` when exact opcodes, offsets, branches, tokens, or calls matter.
+A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`. Use `-S "Source Locations"` for member file/line URLs without fetching source bodies. Use `-S @Source` for source and IL evidence: `Decompiled Source` (raised C#), `Annotated Source` (C# with hidden-fact comments and interleaved IL), `Original Source`, and `IL`. Use `Annotated Source` or `IL` when exact opcodes, offsets, branches, tokens, or calls matter.
 
 Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (widen with `--bin`, `--project`, or `--caller-package`), `-S "Call Graph"` for a bounded outbound tree, `-S "Unsafe Operations"` for unsafe evidence, and `-S Facts --tsv` for structured hidden facts.
 

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -322,7 +322,13 @@ public class ApiMember
     public string? EnumValueLiteral { get; set; }
 
     // Source information (populated with --source-url)
+    public string? SourceFilePath { get; set; }
+
+    public string? SourceUrl { get; set; }
+
     public int? SourceLineNumber { get; set; }
+
+    public int? SourceEndLineNumber { get; set; }
 
     // Documentation (populated with --docs)
     public DocComment Documentation { get; set; } = new();

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1649,6 +1649,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_Discovery_DoesNotAcquirePdb()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "--platform", "System.Text.Json",
+            "-m", "Serialize", "-D", "Source Locations", "--verbose", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("| File | column |", output);
+        Assert.Contains("| Line | column |", output);
+        Assert.DoesNotContain("Loaded PDB", error);
+        Assert.DoesNotContain("MSDL symbol", error);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_DefaultShowsSignatureOnly()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1617,6 +1617,38 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_Group_RendersSelectorsAndSourceRows()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "--platform", "System.Text.Json",
+            "-m", "Serialize", "-S", "Source Locations", "--rows", "-n", "6", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Locations", output);
+        Assert.Contains("| Selector | Signature | File | Line | End Line | Url |", output);
+        Assert.Contains("`Serialize:1`", output);
+        Assert.Contains("JsonSerializer.Write.String.cs", output);
+        Assert.Contains("raw.githubusercontent.com", output);
+        Assert.DoesNotContain("## Member Index", output);
+    }
+
+    [Fact]
+    public async Task Member_SourceLocations_SelectedSignature_RendersWithoutSelectorColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "--platform", "System.Text.Json",
+            "Serialize:1", "-S", "Source Locations", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Locations", output);
+        Assert.Contains("| Signature | File | Line | End Line | Url |", output);
+        Assert.DoesNotContain("| Selector |", output);
+        Assert.Contains("JsonSerializer.Write.String.cs", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_DefaultShowsSignatureOnly()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1285,13 +1285,23 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void ApiMemberPipeline_Sources_RemovedWithSourceCommand()
+    public void ApiMemberPipeline_SourceLocations_AreMemberGroupAndDetailOnly()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
         var names = pipeline.AllSectionNames;
 
-        // Remote Source section was removed — source info lives in the source command now
+        // Remote Source section was removed; SourceLink location rows live on the
+        // member group/detail pipelines instead of the broad type/member-list view.
         Assert.DoesNotContain("Remote Source", names);
+        Assert.DoesNotContain(SectionNames.SourceLocations, names);
+
+        var overloadPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+        Assert.Contains(SectionNames.SourceLocations, overloadPipeline.AllSectionNames);
+        Assert.Equal("opt-in", Assert.Contains(SectionNames.SourceLocations, overloadPipeline.GetCostAnnotations()));
+
+        var detailPipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
+        Assert.Contains(SectionNames.SourceLocations, detailPipeline.AllSectionNames);
+        Assert.Equal("opt-in", Assert.Contains(SectionNames.SourceLocations, detailPipeline.GetCostAnnotations()));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -612,6 +612,9 @@ public class ApiCommand
                 }
             }
 
+            if (ShouldRenderSourceLocations(options))
+                ApiOutputFormatter.PopulateMemberSourceLocations(view, type, options);
+
             // --index: populate code sections and custom attributes
             // Can be called with a specific overload for all sections, or without an overload
             // for Callers-only mode (aggregates across all overloads).
@@ -927,6 +930,9 @@ public class ApiCommand
                 }
             }
 
+            if (ShouldRenderSourceLocations(renderOptions))
+                ApiOutputFormatter.PopulateMemberSourceLocations(view, type, renderOptions);
+
             if (renderOptions is MemberOptions { DllPath: not null } memberOptions
                 && (memberOptions.OverloadIndex.HasValue || memberOptions.HasCallerScope))
             {
@@ -1019,6 +1025,9 @@ public class ApiCommand
         => options.IncludeSections?.Contains(SectionNames.MemberIndex) == true
            || options is MemberOptions { ShowMemberIndex: true };
 
+    private static bool ShouldRenderSourceLocations(ApiOptions options)
+        => options.IncludeSections?.Contains(SectionNames.SourceLocations) == true;
+
     /// <summary>
     /// Maps each member section name to the predicate that selects its members.
     /// </summary>
@@ -1035,6 +1044,7 @@ public class ApiCommand
             [SectionNames.ExtensionMethods] = m => m.Kind == "extension-method",
             [SectionNames.Constructors] = m => m.Kind == "constructor",
             [SectionNames.Events] = m => m.Kind == "event",
+            [SectionNames.SourceLocations] = ApiMemberSectionDescriptors.IsMethodLike,
         };
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -208,7 +208,7 @@ public static class MemberCommand
                     SourceEnricher.EnrichFromLocalXmlDocs(apiType, dllPath, effectiveOptions, logger);
             }
 
-            if (apiDllPath != null && NeedsMemberSourceLocationResolution(apiType, effectiveOptions))
+            if (apiDllPath != null && NeedsMemberSourceLocationResolution(effectiveOptions))
             {
                 var locationDllPath = apiType.SourceAssemblyPath ?? pdbLookupPath;
                 var pdbPath = await MemberSourceLocationCollector.EnrichAsync(
@@ -474,7 +474,6 @@ public static class MemberCommand
                    || sections.Contains(SectionNames.Facts));
     }
 
-    private static bool NeedsMemberSourceLocationResolution(ApiType apiType, MemberOptions options)
-        => ApiCommand.GetRequestedMemberSections(apiType, options)
-            .Contains(SectionNames.SourceLocations);
+    private static bool NeedsMemberSourceLocationResolution(MemberOptions options)
+        => options.IncludeSections?.Contains(SectionNames.SourceLocations) == true;
 }

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -208,6 +208,15 @@ public static class MemberCommand
                     SourceEnricher.EnrichFromLocalXmlDocs(apiType, dllPath, effectiveOptions, logger);
             }
 
+            if (apiDllPath != null && NeedsMemberSourceLocationResolution(apiType, effectiveOptions))
+            {
+                var locationDllPath = apiType.SourceAssemblyPath ?? pdbLookupPath;
+                var pdbPath = await MemberSourceLocationCollector.EnrichAsync(
+                    apiType, locationDllPath, effectiveOptions, context.HttpClient, logger);
+                if (pdbPath != null)
+                    effectiveOptions = effectiveOptions with { PdbPath = pdbPath };
+            }
+
             // Resolve PDB/source only when selected detail sections need them.
             if (effectiveOptions.OverloadIndex.HasValue && apiDllPath != null
                 && NeedsMemberSourceResolution(apiType, effectiveOptions))
@@ -464,4 +473,8 @@ public static class MemberCommand
                    || sections.Contains(SectionNames.AnnotatedSource)
                    || sections.Contains(SectionNames.Facts));
     }
+
+    private static bool NeedsMemberSourceLocationResolution(ApiType apiType, MemberOptions options)
+        => ApiCommand.GetRequestedMemberSections(apiType, options)
+            .Contains(SectionNames.SourceLocations);
 }

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -1,0 +1,103 @@
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Sections;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+internal static class MemberSourceLocationCollector
+{
+    public static async Task<string?> EnrichAsync(
+        ApiType apiType,
+        string assemblyPath,
+        MemberOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        try
+        {
+            using var service = SourceLinkService.Open(assemblyPath, logger.Log);
+            var context = service.Context;
+            if (!context.HasMetadata)
+                return null;
+
+            if (context.NeedsPdb)
+            {
+                var (packageName, packageVersion) = !string.IsNullOrEmpty(options.PackagePath)
+                    ? PackageExtractor.ParsePackageReference(options.PackagePath)
+                    : (null, null);
+
+                await SourceEnricher.AcquirePdbAsync(context, httpClient,
+                    packageName, packageVersion,
+                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+            }
+
+            var pdbPath = context.PortablePdbPath;
+            if (!service.HasPdb || !service.HasSourceLink)
+                return pdbPath;
+
+            foreach (var member in GetTargetMembers(apiType, options))
+            {
+                var typeName = string.IsNullOrWhiteSpace(member.DeclaringType)
+                    ? apiType.FullName
+                    : member.DeclaringType!;
+                var overloadIndex = GetSourceOverloadIndex(apiType, member, options);
+                if (overloadIndex < 0)
+                    continue;
+
+                var publicOnly = !options.IncludeAll
+                                 && member.Kind != "explicit-interface-implementation";
+                var info = service.ResolveMethodSource(typeName, member.Name, overloadIndex, publicOnly);
+                if (info is null)
+                    continue;
+
+                member.SourceFilePath = info.FilePath;
+                member.SourceUrl = info.SourceUrl;
+                member.SourceLineNumber = info.StartLine;
+                member.SourceEndLineNumber = info.EndLine;
+            }
+
+            return pdbPath;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Failed to resolve member source locations for {apiType.FullName}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static IEnumerable<ApiMember> GetTargetMembers(ApiType apiType, MemberOptions options)
+    {
+        var members = apiType.Members
+            .Where(ApiMemberSectionDescriptors.IsMethodLike)
+            .Where(m => !MemberFilters.IsCompilerGenerated(m.Name));
+
+        if (options.MemberFilter.Count > 0)
+            members = members.Where(m => TypeMatcher.MatchesMemberFilter(m.Name, options.MemberFilter));
+
+        if (options.KindFilter.Count > 0)
+            members = members.Where(m => options.KindFilter.Contains(m.Kind));
+
+        if (options.UnsafeOnly)
+            members = members.Where(m => m.IsUnsafe);
+
+        return members;
+    }
+
+    private static int GetSourceOverloadIndex(ApiType apiType, ApiMember member, MemberOptions options)
+    {
+        if (member.DeclaringOverloadIndex is { } declaringOverload)
+            return declaringOverload - 1;
+
+        if (options.OverloadIndex is { } selectedOverload && apiType.Members.Count == 1)
+            return selectedOverload - 1;
+
+        var sameName = apiType.Members
+            .Where(m => string.Equals(m.Name, member.Name, StringComparison.Ordinal))
+            .Where(ApiMemberSectionDescriptors.IsMethodLike)
+            .ToList();
+
+        return sameName.IndexOf(member);
+    }
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -803,6 +803,49 @@ public static class ApiOutputFormatter
         view.Rows = BuildMemberIndexRows(type, allMembers);
     }
 
+    internal static void PopulateMemberSourceLocations(TypeView view, ApiType type, ApiOptions options)
+    {
+        var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
+        var members = grouped
+            .SelectMany(g => g.Value)
+            .Where(ApiMemberSectionDescriptors.IsMethodLike)
+            .OrderBy(m => GetMemberSortOrder(m.Kind))
+            .ThenBy(m => m.Name, StringComparer.Ordinal)
+            .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
+            .ToList();
+
+        if (options.Limit.HasValue && options.Limit.Value < members.Count)
+            members = members.Take(options.Limit.Value).ToList();
+
+        bool detail = options is MemberOptions { OverloadIndex: not null } && type.Members.Count == 1;
+        List<MemberIndexRow> indexRows = detail ? [] : BuildMemberIndexRows(type, members);
+        List<MemberSourceLocationRow> rows = [];
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            var member = members[i];
+            if (member.SourceFilePath is null && member.SourceUrl is null && member.SourceLineNumber is null)
+                continue;
+
+            var signature = FormatMemberDeclaration(type, member, abbreviate: false);
+            int? endLine = member.SourceEndLineNumber is { } end
+                           && member.SourceLineNumber is { } start
+                           && end != start
+                ? end
+                : null;
+
+            rows.Add(new MemberSourceLocationRow(
+                detail ? null : indexRows[i].Selector,
+                string.IsNullOrWhiteSpace(signature) ? null : MarkoutInline.Code(signature),
+                member.SourceFilePath is null ? null : MarkoutInline.Code(member.SourceFilePath),
+                member.SourceLineNumber,
+                endLine,
+                member.SourceUrl));
+        }
+
+        view.SourceLocationRows = rows;
+    }
+
     internal static List<MemberIndexRow> BuildMemberIndexRows(ApiType type, IReadOnlyList<ApiMember> members)
     {
         var overloadCounts = members

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -263,6 +263,18 @@ public static class ApiMemberSectionDescriptors
             => model.Members.Any(IsMethodLike);
     }
 
+    public sealed class SourceLocations : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.SourceLocations;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(IsMethodLike);
+    }
+
     public sealed class SourceFiles : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.SourceFiles;
@@ -367,6 +379,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.Signature>()
             .Add<Methods>()
             .Add<ApiMemberSectionDescriptors.MemberIndex>()
+            .Add<ApiMemberSectionDescriptors.SourceLocations>()
             .Add<ApiMemberSectionDescriptors.Operators>()
             .Add<ApiMemberSectionDescriptors.ExplicitInterfaceImplementations>()
             .Add<ApiMemberSectionDescriptors.ExtensionMethods>()
@@ -405,6 +418,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<DecompiledSource>()
             .Add<AnnotatedSource>()
             .Add<OriginalSource>()
+            .Add<SourceLocations>()
             .Add<Calls>()
             .Add<Callers>()
             .Add<CallGraph>()
@@ -477,6 +491,19 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class SourceLocations : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.SourceLocations;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Count == 1
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -90,6 +90,9 @@ public static class SectionNames
     /// <summary>Section for SourceLink source file URLs for a type.</summary>
     public const string SourceFiles = "Source Files";
 
+    /// <summary>Section for SourceLink source locations for member signatures.</summary>
+    public const string SourceLocations = "Source Locations";
+
     /// <summary>Section for the raw IL disassembly.</summary>
     public const string IL = "IL";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -192,6 +192,14 @@ public class TypeView
     [JsonIgnore]
     public List<TypeSourceFileRow>? SourceFileRows => TypeSourceFiles();
 
+    [MarkoutSection(Name = SectionNames.SourceLocations, EmptyText = "No SourceLink source locations found for the selected member(s).")]
+    [MarkoutIgnoreColumnWhen(nameof(SourceLocationSelectorIsEmpty), nameof(MemberSourceLocationRow.Selector))]
+    [JsonIgnore]
+    public List<MemberSourceLocationRow>? SourceLocationRows { get; set; }
+
+    public static bool SourceLocationSelectorIsEmpty(List<MemberSourceLocationRow>? rows)
+        => rows is null || rows.All(row => string.IsNullOrEmpty(row.Selector));
+
     // Member code sections (populated by member command only, serialized separately)
     [MarkoutIgnore]
     [JsonIgnore]
@@ -458,6 +466,16 @@ public record MemberIndexRow(
 public record TypeSourceFileRow(string Url);
 
 [MarkoutSerializable]
+public record MemberSourceLocationRow(
+    [property: MarkoutSkipNull] string? Selector,
+    [property: MarkoutSkipNull] string? Signature,
+    [property: MarkoutSkipNull] string? File,
+    [property: MarkoutSkipNull] int? Line,
+    [property: MarkoutPropertyName("End Line")]
+    [property: MarkoutSkipNull] int? EndLine,
+    [property: MarkoutSkipNull] string? Url);
+
+[MarkoutSerializable]
 public record MemberSignatureRow(
     string Signature,
     [property: MarkoutSkipNull] string? Description);
@@ -635,6 +653,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(FactRow))]
 [MarkoutContext(typeof(TypeSourceFileRow))]
+[MarkoutContext(typeof(MemberSourceLocationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]
 [MarkoutContext(typeof(ForwarderSummaryRow))]
 [MarkoutContext(typeof(MemberRow))]

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.14.0
+
+### SourceLink member locations
+
+- Adds a `Source Locations` section for member groups and selected signatures,
+  reporting SourceLink-backed file/line/URL rows without fetching source bodies.
+- Keeps `Member Index` focused on selector/query columns while moving
+  source-location evidence to the dedicated source section.
+
 ## v0.13.0
 
 ### Package documentation and project grounding


### PR DESCRIPTION
## Summary
- add explicit member Source Locations sections for member-group and selected-signature views
- resolve SourceLink-backed file/line/URL rows from verified PDBs without fetching source bodies
- keep Member Index query-focused and update docs/SKILL/release notes for 0.14.0
- keep Source Locations discovery structural/cheap so -D does not acquire PDBs

## Validation
- npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md docs/llm-design.md docs/design/progressive-disclosure.md docs/workflows/getting-started/verbosity-and-tips.md src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.SectionPipelineTests.ApiMemberPipeline_SourceLocations_AreMemberGroupAndDetailOnly -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Group_RendersSelectorsAndSourceRows -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_SelectedSignature_RendersWithoutSelectorColumn -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Discovery_DoesNotAcquirePdb
- dotnet run --project src/dotnet-inspect -c Release --no-build -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Source Locations" --tsv --no-headers --tips q -n 1
- dotnet run --project src/dotnet-inspect -c Release -- member JsonSerializer --platform System.Text.Json -m Serialize -D "Source Locations" --verbose --tips q

## Note
- Full dotnet run --project src/dotnet-inspect.Tests -c Release still hits the existing preview-runtime environment failures in VersionDisplayTests.PlatformVersion_MatchesRuntimeDirectory, PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies, and CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute.