### PR TITLE
Add PR quick decompiler corpus artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               src/*) CODE=true ;;
               tools/DecompilerHarness/*) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
+              eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               *.props|*.sln) CODE=true ;;
               .github/workflows/*) CODE=true ;;
             esac
@@ -109,6 +110,43 @@ jobs:
 
       - name: Build
         run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+
+      - name: Prepare PR decompiler corpus
+        run: |
+          mkdir -p artifacts/decompiler-pr-corpus
+          bash eng/prepare-decompiler-pr-corpus.sh artifacts/decompiler-pr-corpus/assemblies.txt
+
+      - name: Run PR decompiler corpus sensor
+        id: decompiler_pr_corpus
+        continue-on-error: true
+        shell: bash
+        run: |
+          mapfile -t assemblies < artifacts/decompiler-pr-corpus/assemblies.txt
+          set +e
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --emit-corpus-snapshot artifacts/decompiler-pr-corpus/snapshot.json \
+            --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
+            --quality-diff-card \
+            --corpus-method-cap 100 \
+            --compile-cap 0 \
+            --corpus-fidelity-cap 0 \
+            --max-examples 3 \
+            | tee artifacts/decompiler-pr-corpus/quality-diff-card.md
+          status=${PIPESTATUS[0]}
+          echo "$status" > artifacts/decompiler-pr-corpus/exit-code.txt
+          exit "$status"
+
+      - name: Upload PR decompiler corpus artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: decompiler-pr-corpus
+          path: artifacts/decompiler-pr-corpus/
+          if-no-files-found: error
+
+      - name: Check PR decompiler corpus result
+        if: steps.decompiler_pr_corpus.outcome == 'failure'
+        run: exit 1
 
       - name: Install ilasm/ildasm
         continue-on-error: true

--- a/eng/prepare-decompiler-pr-corpus.sh
+++ b/eng/prepare-decompiler-pr-corpus.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Restores a PR-sized decompiler corpus and emits one managed assembly path per
+# line. This is intentionally broader than a unit fixture and smaller than the
+# daily real-world corpus: SPC, representative pinned 1P/3P packages, and the
+# dotnet-inspect product assemblies built by CI.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+out="${1:-}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/corpus.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
+    <PackageReference Include="NuGet.Versioning" Version="7.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+  </ItemGroup>
+</Project>
+EOF
+
+dotnet restore "$tmp/corpus.csproj" --verbosity quiet >/dev/null
+
+runtime_version="$(dotnet --list-runtimes | awk '$1 == "Microsoft.NETCore.App" { print $2 }' | tail -n 1)"
+runtime_dir="$(dotnet --list-runtimes | awk '$1 == "Microsoft.NETCore.App" { print $NF }' | tail -n 1 | sed 's/^\[//; s/\]$//')"
+if [ ! -f "$runtime_dir/System.Private.CoreLib.dll" ] && [ -n "$runtime_version" ]; then
+  runtime_dir="$runtime_dir/$runtime_version"
+fi
+if [ -z "$runtime_dir" ] || [ ! -f "$runtime_dir/System.Private.CoreLib.dll" ]; then
+  echo "Could not locate System.Private.CoreLib.dll from dotnet --list-runtimes." >&2
+  exit 1
+fi
+
+packages="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+declare -a assemblies=(
+  "$runtime_dir/System.Private.CoreLib.dll"
+  "$packages/newtonsoft.json/13.0.4/lib/net6.0/Newtonsoft.Json.dll"
+  "$packages/microsoft.codeanalysis.common/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.dll"
+  "$packages/microsoft.codeanalysis.csharp/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.CSharp.dll"
+  "$packages/system.commandline/3.0.0-preview.5.26302.115/lib/net10.0/System.CommandLine.dll"
+  "$packages/nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll"
+  "$packages/microsoft.applicationinsights/2.23.0/lib/netstandard2.0/Microsoft.ApplicationInsights.dll"
+)
+
+declare -a self_assemblies=(
+  "$root/artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll"
+  "$root/artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.Metadata.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.MetadataPrimitives.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Analysis.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll"
+)
+
+for assembly in "${self_assemblies[@]}"; do
+  if [ -f "$assembly" ]; then
+    assemblies+=("$assembly")
+  fi
+done
+
+for assembly in "${assemblies[@]}"; do
+  if [ ! -f "$assembly" ]; then
+    echo "Missing PR corpus assembly: $assembly" >&2
+    exit 1
+  fi
+done
+
+if [ -n "$out" ]; then
+  printf '%s\n' "${assemblies[@]}" > "$out"
+else
+  printf '%s\n' "${assemblies[@]}"
+fi

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -185,6 +185,107 @@ public static class IrImporter
         }
     }
 
+    /// <summary>
+    /// Imports a deterministic hash-ranked sample of method bodies from the
+    /// assembly. Unlike "first N" metadata order, the selected set is stable
+    /// under unrelated method insertions unless the new method hashes into the
+    /// sample itself.
+    /// </summary>
+    public static IEnumerable<(string TypeName, string MethodName, IrFunction Function)> ImportAssemblyStableSample(MetadataSource source, int sampleSize)
+    {
+        if (sampleSize <= 0)
+            yield break;
+        if (sampleSize == int.MaxValue)
+        {
+            foreach (var imported in ImportAssembly(source))
+                yield return imported;
+            yield break;
+        }
+
+        var reader = source.Reader;
+        var candidates = new List<MethodCandidate>();
+        int sequence = 0;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string typeName = reader.GetFullTypeName(typeDef);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (method.RelativeVirtualAddress == 0)
+                    continue;
+                string memberName = reader.GetString(method.Name);
+                string key = StableSampleKey(reader, typeDef, method, typeName, memberName);
+                candidates.Add(new MethodCandidate(
+                    typeDefHandle,
+                    methodHandle,
+                    typeName,
+                    memberName,
+                    sequence++,
+                    StableHash(key),
+                    key));
+            }
+        }
+
+        foreach (var candidate in candidates
+            .OrderBy(c => c.Hash)
+            .ThenBy(c => c.Key, StringComparer.Ordinal)
+            .Take(sampleSize)
+            .OrderBy(c => c.Sequence))
+        {
+            IrFunction function;
+            try
+            {
+                var typeDef = reader.GetTypeDefinition(candidate.TypeDefHandle);
+                var method = reader.GetMethodDefinition(candidate.MethodHandle);
+                function = Build(
+                    source,
+                    MethodImporter.Import(source, candidate.TypeDefHandle, candidate.MethodHandle),
+                    CallerScope(reader, typeDef, method));
+            }
+            catch (Exception ex)
+            {
+                function = CrashFunction(candidate.MethodName, candidate.TypeName, ex);
+            }
+            yield return (candidate.TypeName, candidate.MethodName, function);
+        }
+    }
+
+    static string StableSampleKey(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, string typeName, string methodName)
+    {
+        var signature = method.DecodeSignature(TypeRefDecoder.Instance, CallerScope(reader, typeDef, method));
+        return string.Join("|",
+            typeName,
+            methodName,
+            signature.ReturnType.ToDisplayString(),
+            signature.Header.IsInstance ? "instance" : "static",
+            string.Join(",", signature.ParameterTypes.Select(type => type.ToDisplayString())));
+    }
+
+    static ulong StableHash(string text)
+    {
+        const ulong offset = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        ulong hash = offset;
+        foreach (char ch in text)
+        {
+            hash ^= (byte)ch;
+            hash *= prime;
+            hash ^= (byte)(ch >> 8);
+            hash *= prime;
+        }
+        return hash;
+    }
+
+    sealed record MethodCandidate(
+        TypeDefinitionHandle TypeDefHandle,
+        MethodDefinitionHandle MethodHandle,
+        string TypeName,
+        string MethodName,
+        int Sequence,
+        ulong Hash,
+        string Key);
+
     static IrFunction CrashFunction(string methodName, string typeName, Exception ex)
     {
         var block = new Block(0);

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -22,11 +22,18 @@ internal static class CorpusSensor
         int maxExamples,
         string? emitBaseline,
         string? diffBaseline,
-        bool qualityDiffCard = false)
+        bool qualityDiffCard = false,
+        int methodCap = int.MaxValue)
     {
         if (assemblies.Count == 0)
         {
             Console.Error.WriteLine("No assemblies supplied for the corpus sensor.");
+            return 1;
+        }
+
+        if (methodCap <= 0)
+        {
+            Console.Error.WriteLine("--corpus-method-cap must be greater than zero.");
             return 1;
         }
 
@@ -36,7 +43,7 @@ internal static class CorpusSensor
             return 1;
         }
 
-        var current = Capture(assemblies, validityCompileCap, fidelityCompileCap, maxExamples);
+        var current = Capture(assemblies, validityCompileCap, fidelityCompileCap, maxExamples, methodCap);
         if (!qualityDiffCard)
             PrintSummary(current);
 
@@ -44,8 +51,11 @@ internal static class CorpusSensor
         {
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitBaseline)) ?? ".");
             File.WriteAllText(emitBaseline, JsonSerializer.Serialize(current, JsonOptions()));
-            Console.WriteLine();
-            Console.WriteLine($"Wrote corpus baseline: {emitBaseline}");
+            if (!qualityDiffCard)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Wrote corpus baseline: {emitBaseline}");
+            }
         }
 
         if (diffBaseline is null)
@@ -74,11 +84,16 @@ internal static class CorpusSensor
         return 1;
     }
 
-    static CorpusSensorSnapshot Capture(IReadOnlyList<string> assemblies, int validityCompileCap, int fidelityCompileCap, int maxExamples)
+    static CorpusSensorSnapshot Capture(
+        IReadOnlyList<string> assemblies,
+        int validityCompileCap,
+        int fidelityCompileCap,
+        int maxExamples,
+        int methodCap)
     {
-        var completeness = AnalyzeCompleteness(assemblies, maxExamples);
+        var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap);
         var validity = AnalyzeValidity(assemblies, validityCompileCap);
-        var structuring = AnalyzeStructuring(assemblies);
+        var structuring = AnalyzeStructuring(assemblies, methodCap);
         var fidelity = AnalyzeFidelity(assemblies, fidelityCompileCap);
         var totalMethods = completeness.Assemblies.Sum(assembly => assembly.TotalMethods);
         var fullyRaisedMethods = completeness.FullyRaisedMethods;
@@ -107,12 +122,13 @@ internal static class CorpusSensor
             GeneratedUtc: DateTimeOffset.UtcNow,
             ValidityCompileCap: validityCompileCap,
             FidelityCompileCap: fidelityCompileCap,
+            MethodCap: methodCap == int.MaxValue ? null : methodCap,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: completeness.Assemblies,
             Metrics: metrics);
     }
 
-    static CompletenessSensorMetrics AnalyzeCompleteness(IReadOnlyList<string> assemblies, int maxExamples)
+    static CompletenessSensorMetrics AnalyzeCompleteness(IReadOnlyList<string> assemblies, int maxExamples, int methodCap)
     {
         var residualBuckets = new Dictionary<string, int>(StringComparer.Ordinal);
         var assemblyReports = ImmutableArray.CreateBuilder<CorpusAssemblySnapshot>();
@@ -125,6 +141,8 @@ internal static class CorpusSensor
             int methods = 0;
             foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
             {
+                if (methods >= methodCap)
+                    break;
                 methods++;
                 try
                 {
@@ -167,7 +185,7 @@ internal static class CorpusSensor
             results.Count(result => result.HasSemanticDefect));
     }
 
-    static StructuringSensorMetrics AnalyzeStructuring(IReadOnlyList<string> assemblies)
+    static StructuringSensorMetrics AnalyzeStructuring(IReadOnlyList<string> assemblies, int methodCap)
     {
         long total = 0, crashes = 0, structured = 0, stoppedContainers = 0, methodsWithStop = 0;
         var reasons = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -176,8 +194,12 @@ internal static class CorpusSensor
         foreach (var assemblyPath in assemblies)
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            int assemblyMethods = 0;
             foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
             {
+                if (assemblyMethods >= methodCap)
+                    break;
+                assemblyMethods++;
                 total++;
                 var diagnostics = new StructuringDiagnostics();
                 var context = new PassContext(new Stepper(enabled: false), diagnostics);
@@ -253,6 +275,8 @@ internal static class CorpusSensor
             failures.Add($"validity cap lower than baseline (baseline {baseline.ValidityCompileCap}, current {current.ValidityCompileCap})");
         if (current.FidelityCompileCap < baseline.FidelityCompileCap)
             failures.Add($"fidelity cap lower than baseline (baseline {baseline.FidelityCompileCap}, current {current.FidelityCompileCap})");
+        if (current.MethodCap != baseline.MethodCap)
+            failures.Add($"method cap differs from baseline (baseline {CapText(baseline.MethodCap)}, current {CapText(current.MethodCap)})");
         if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
             failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
         if (current.Metrics.Fidelity.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
@@ -298,13 +322,26 @@ internal static class CorpusSensor
         Console.WriteLine();
         Console.WriteLine($"Assemblies: {snapshot.Assemblies.Count}");
         Console.WriteLine($"Methods: {metrics.TotalMethods}");
+        if (snapshot.MethodCap is { } cap)
+            Console.WriteLine($"Sample: first {Number(cap)} methods per assembly");
         Console.WriteLine($"Fully raised: {metrics.FullyRaisedMethods} ({FormatBps(metrics.FullyRaisedBasisPoints)})");
         Console.WriteLine($"Conditional-branch residual: {metrics.ConditionalBranchMethods} ({FormatBps(metrics.ConditionalBranchBasisPoints)})");
         Console.WriteLine($"Forward-merge stops: {metrics.ForwardMergeStoppedContainers} ({FormatBps(metrics.ForwardMergeBasisPoints)} of methods)");
-        Console.WriteLine($"Full malformed: {metrics.FullMalformedMethods}");
-        Console.WriteLine($"Semantic defects: {metrics.SemanticDefectMethods}/{metrics.SemanticCheckedMethods}");
+        if (snapshot.ValidityCompileCap <= 0)
+        {
+            Console.WriteLine("Full malformed: not run");
+            Console.WriteLine("Semantic defects: not run");
+        }
+        else
+        {
+            Console.WriteLine($"Full malformed: {metrics.FullMalformedMethods}");
+            Console.WriteLine($"Semantic defects: {metrics.SemanticDefectMethods}/{metrics.SemanticCheckedMethods}");
+        }
         Console.WriteLine($"Pass bugs: {metrics.PassBugs}");
-        Console.WriteLine($"Fidelity: {metrics.Fidelity.ExactMethods} exact, {metrics.Fidelity.OpcodeDiffMethods} opcode diffs, {metrics.Fidelity.RecompileFailMethods} recompile failures over {metrics.Fidelity.CheckedMethods} checked");
+        if (snapshot.FidelityCompileCap <= 0)
+            Console.WriteLine("Fidelity: not run");
+        else
+            Console.WriteLine($"Fidelity: {metrics.Fidelity.ExactMethods} exact, {metrics.Fidelity.OpcodeDiffMethods} opcode diffs, {metrics.Fidelity.RecompileFailMethods} recompile failures over {metrics.Fidelity.CheckedMethods} checked");
     }
 
     static void PrintQualityDiffCard(
@@ -315,6 +352,8 @@ internal static class CorpusSensor
         Console.WriteLine("### Decompiler quality diff");
         Console.WriteLine();
         Console.WriteLine($"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods");
+        if (current.MethodCap is { } cap)
+            Console.WriteLine($"Sample: first {Number(cap)} methods per assembly");
         Console.WriteLine();
         Console.WriteLine("| Metric | Baseline | PR | Delta |");
         Console.WriteLine("| --- | ---: | ---: | ---: |");
@@ -333,21 +372,36 @@ internal static class CorpusSensor
             CountPercent(baseline.Metrics.ForwardMergeStoppedContainers, baseline.Metrics.ForwardMergeBasisPoints),
             CountPercent(current.Metrics.ForwardMergeStoppedContainers, current.Metrics.ForwardMergeBasisPoints),
             Delta(current.Metrics.ForwardMergeStoppedContainers - baseline.Metrics.ForwardMergeStoppedContainers));
-        PrintMetric(
-            "Full malformed",
-            Number(baseline.Metrics.FullMalformedMethods),
-            Number(current.Metrics.FullMalformedMethods),
-            Delta(current.Metrics.FullMalformedMethods - baseline.Metrics.FullMalformedMethods));
-        PrintMetric(
-            "Semantic defects",
-            Fraction(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods),
-            Fraction(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods),
-            Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
-        PrintMetric(
-            "Fidelity diffs",
-            Fraction(baseline.Metrics.Fidelity.OpcodeDiffMethods, baseline.Metrics.Fidelity.CheckedMethods),
-            Fraction(current.Metrics.Fidelity.OpcodeDiffMethods, current.Metrics.Fidelity.CheckedMethods),
-            Delta(current.Metrics.Fidelity.OpcodeDiffMethods - baseline.Metrics.Fidelity.OpcodeDiffMethods));
+        if (current.ValidityCompileCap <= 0)
+        {
+            PrintMetric("Full malformed", "not run", "not run", "-");
+            PrintMetric("Semantic defects", "not run", "not run", "-");
+        }
+        else
+        {
+            PrintMetric(
+                "Full malformed",
+                Number(baseline.Metrics.FullMalformedMethods),
+                Number(current.Metrics.FullMalformedMethods),
+                Delta(current.Metrics.FullMalformedMethods - baseline.Metrics.FullMalformedMethods));
+            PrintMetric(
+                "Semantic defects",
+                Fraction(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods),
+                Fraction(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods),
+                Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
+        }
+        if (current.FidelityCompileCap <= 0)
+        {
+            PrintMetric("Fidelity diffs", "not run", "not run", "-");
+        }
+        else
+        {
+            PrintMetric(
+                "Fidelity diffs",
+                Fraction(baseline.Metrics.Fidelity.OpcodeDiffMethods, baseline.Metrics.Fidelity.CheckedMethods),
+                Fraction(current.Metrics.Fidelity.OpcodeDiffMethods, current.Metrics.Fidelity.CheckedMethods),
+                Delta(current.Metrics.Fidelity.OpcodeDiffMethods - baseline.Metrics.Fidelity.OpcodeDiffMethods));
+        }
         PrintMetric(
             "Pass bugs",
             Number(baseline.Metrics.PassBugs),
@@ -378,6 +432,9 @@ internal static class CorpusSensor
     static string AssemblyCount(int count)
         => $"{Number(count)} assembl{(count == 1 ? "y" : "ies")}";
 
+    static string CapText(int? cap)
+        => cap is { } value ? Number(value) : "uncapped";
+
     static string Delta(int value)
         => value > 0 ? $"+{Number(value)}" : Number(value);
 
@@ -400,6 +457,7 @@ internal sealed record CorpusSensorSnapshot(
     DateTimeOffset GeneratedUtc,
     int ValidityCompileCap,
     int FidelityCompileCap,
+    int? MethodCap,
     CorpusSensorTolerances? Tolerances,
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,
     CorpusSensorMetrics Metrics);

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -139,10 +139,8 @@ internal static class CorpusSensor
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             int methods = 0;
-            foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
+            foreach (var (_, _, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
             {
-                if (methods >= methodCap)
-                    break;
                 methods++;
                 try
                 {
@@ -195,10 +193,8 @@ internal static class CorpusSensor
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             int assemblyMethods = 0;
-            foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
+            foreach (var (_, _, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
             {
-                if (assemblyMethods >= methodCap)
-                    break;
                 assemblyMethods++;
                 total++;
                 var diagnostics = new StructuringDiagnostics();
@@ -323,7 +319,7 @@ internal static class CorpusSensor
         Console.WriteLine($"Assemblies: {snapshot.Assemblies.Count}");
         Console.WriteLine($"Methods: {metrics.TotalMethods}");
         if (snapshot.MethodCap is { } cap)
-            Console.WriteLine($"Sample: first {Number(cap)} methods per assembly");
+            Console.WriteLine($"Sample: hash-stable {Number(cap)} methods per assembly");
         Console.WriteLine($"Fully raised: {metrics.FullyRaisedMethods} ({FormatBps(metrics.FullyRaisedBasisPoints)})");
         Console.WriteLine($"Conditional-branch residual: {metrics.ConditionalBranchMethods} ({FormatBps(metrics.ConditionalBranchBasisPoints)})");
         Console.WriteLine($"Forward-merge stops: {metrics.ForwardMergeStoppedContainers} ({FormatBps(metrics.ForwardMergeBasisPoints)} of methods)");
@@ -353,7 +349,7 @@ internal static class CorpusSensor
         Console.WriteLine();
         Console.WriteLine($"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods");
         if (current.MethodCap is { } cap)
-            Console.WriteLine($"Sample: first {Number(cap)} methods per assembly");
+            Console.WriteLine($"Sample: hash-stable {Number(cap)} methods per assembly");
         Console.WriteLine();
         Console.WriteLine("| Metric | Baseline | PR | Delta |");
         Console.WriteLine("| --- | ---: | ---: | ---: |");

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1122,9 +1122,9 @@ static class Program
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).
           --corpus-method-cap <n>        with corpus baseline modes: cap the
-                                completeness/structuring scan to the first n
-                                imported methods per assembly. Intended for PR
-                                quick-corpus artifact runs.
+                                completeness/structuring scan to a deterministic
+                                hash-ranked sample of n methods per assembly.
+                                Intended for PR quick-corpus artifact runs.
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -59,6 +59,7 @@ static class Program
         string? diffCorpusBaseline = null;
         bool qualityDiffCard = false;
         int corpusFidelityCap = 0;
+        int corpusMethodCap = int.MaxValue;
         bool json = false;
         int topPatterns = 10;
         int? topLibraries = null;
@@ -113,6 +114,7 @@ static class Program
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
                 case "--quality-diff-card": qualityDiffCard = true; break;
                 case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
+                case "--corpus-method-cap": corpusMethodCap = int.Parse(args[++i]); break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
@@ -148,7 +150,7 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, corpusMethodCap);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1119,6 +1121,10 @@ static class Program
           --corpus-fidelity-cap <n>      with corpus baseline modes: cap methods
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).
+          --corpus-method-cap <n>        with corpus baseline modes: cap the
+                                completeness/structuring scan to the first n
+                                imported methods per assembly. Intended for PR
+                                quick-corpus artifact runs.
           --top-patterns <n>     with --library-report: show top n patterns
                                 overall and per library (default 10).
           --top-libraries <n>    with --library-report: show top n libraries by

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -53,11 +53,13 @@ with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.
 
 **PR quick corpus** (`tools/DecompilerHarness/corpus/pr-quick-baseline.json`):
 CI also runs a small artifact-producing corpus sensor after the managed tool
-build. It samples the first 100 imported methods per assembly across a mixed
-15-assembly set: System.Private.CoreLib, the pinned package libraries used by the
-daily corpus, and dotnet-inspect's managed product assemblies. The run skips the
-expensive semantic validity and compile-back fidelity oracles so it stays small;
-the daily workflow remains the authoritative full-corpus signal.
+build. It takes a deterministic hash-ranked sample of 100 methods per assembly
+across a mixed 15-assembly set: System.Private.CoreLib, the pinned package
+libraries used by the daily corpus, and dotnet-inspect's managed product
+assemblies. The hash-ranked sample avoids the order churn of "first N" metadata
+rows while still staying small. The run skips the expensive semantic validity
+and compile-back fidelity oracles so it stays small; the daily workflow remains
+the authoritative full-corpus signal.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -51,6 +51,32 @@ evidence; do not re-key the table by hand.
 To deliberately rebaseline after reviewed corpus movement, run the same command
 with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.
 
+**PR quick corpus** (`tools/DecompilerHarness/corpus/pr-quick-baseline.json`):
+CI also runs a small artifact-producing corpus sensor after the managed tool
+build. It samples the first 100 imported methods per assembly across a mixed
+15-assembly set: System.Private.CoreLib, the pinned package libraries used by the
+daily corpus, and dotnet-inspect's managed product assemblies. The run skips the
+expensive semantic validity and compile-back fidelity oracles so it stays small;
+the daily workflow remains the authoritative full-corpus signal.
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies.txt
+mapfile -t assemblies < /tmp/pr-corpus-assemblies.txt
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
+  --quality-diff-card \
+  --corpus-method-cap 100 \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 0 \
+  --max-examples 3
+```
+
+The CI artifact (`decompiler-pr-corpus`) contains the assembly list, generated
+snapshot JSON, generated Markdown quality card, and exit code. It is useful as a
+fast smoke/regression slice over real assemblies and for reviewer download, but
+it is intentionally too small to prove broad corpus quality by itself.
+
 **Unsupported nodes** (`--unsupported-nodes`): a focused view of the
 `fidelity: unsupported-node` bucket. It runs the normal raising pipeline, walks
 the finished tree for every `UnsupportedNode`, and groups sites by opcode and

--- a/tools/DecompilerHarness/corpus/pr-quick-baseline.json
+++ b/tools/DecompilerHarness/corpus/pr-quick-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
-  "generatedUtc": "2026-06-23T16:53:11.5809934+00:00",
+  "generatedUtc": "2026-06-23T17:10:17.4011776+00:00",
   "validityCompileCap": 0,
   "fidelityCompileCap": 0,
   "methodCap": 100,
@@ -95,31 +95,33 @@
   ],
   "metrics": {
     "totalMethods": 1461,
-    "fullyRaisedMethods": 1203,
-    "fullyRaisedBasisPoints": 8234,
-    "conditionalBranchMethods": 7,
-    "conditionalBranchBasisPoints": 48,
-    "forwardMergeStoppedContainers": 7,
-    "forwardMergeBasisPoints": 48,
+    "fullyRaisedMethods": 1215,
+    "fullyRaisedBasisPoints": 8316,
+    "conditionalBranchMethods": 38,
+    "conditionalBranchBasisPoints": 260,
+    "forwardMergeStoppedContainers": 33,
+    "forwardMergeBasisPoints": 226,
     "fullMalformedMethods": 0,
     "semanticCheckedMethods": 0,
     "semanticDefectMethods": 0,
     "passBugs": 0,
     "residualBuckets": {
-      "fidelity: (typed)": 234,
-      "structuring: conditional-branch": 7,
-      "fidelity: unsupported-node": 16,
-      "eh: leave/endfinally": 1
+      "structuring: conditional-branch": 38,
+      "fidelity: (typed)": 180,
+      "eh: leave/endfinally": 4,
+      "fidelity: unsupported-node": 24
     },
     "structuring": {
       "totalMethods": 1461,
-      "structuredContainers": 565,
-      "stoppedContainers": 7,
-      "methodsWithStops": 7,
+      "structuredContainers": 595,
+      "stoppedContainers": 41,
+      "methodsWithStops": 41,
       "passBugs": 0,
       "stopReasons": {
-        "forward-branch-not-region-exit": 4,
-        "cond-target-past-region": 3
+        "cond-target-past-region": 22,
+        "forward-branch-not-region-exit": 11,
+        "cond-backward-branch": 1,
+        "unconsumed-regions": 7
       }
     },
     "fidelity": {

--- a/tools/DecompilerHarness/corpus/pr-quick-baseline.json
+++ b/tools/DecompilerHarness/corpus/pr-quick-baseline.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": 1,
+  "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
+  "generatedUtc": "2026-06-23T16:53:11.5809934+00:00",
+  "validityCompileCap": 0,
+  "fidelityCompileCap": 0,
+  "methodCap": 100,
+  "tolerances": {
+    "fullyRaisedDropBasisPoints": 10,
+    "conditionalBranchIncreaseBasisPoints": 10,
+    "forwardMergeIncreaseBasisPoints": 10,
+    "fullMalformedIncrease": 0,
+    "semanticDefectIncrease": 0,
+    "passBugIncrease": 0,
+    "fidelityOpcodeDiffIncrease": 0,
+    "fidelityRecompileFailIncrease": 0,
+    "fidelityContextFailIncrease": 0
+  },
+  "assemblies": [
+    {
+      "assembly": "System.Private.CoreLib",
+      "path": "System.Private.CoreLib.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "Newtonsoft.Json",
+      "path": "nuget:newtonsoft.json/13.0.4/lib/net6.0/Newtonsoft.Json.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis",
+      "path": "nuget:microsoft.codeanalysis.common/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis.CSharp",
+      "path": "nuget:microsoft.codeanalysis.csharp/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.CSharp.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "System.CommandLine",
+      "path": "nuget:system.commandline/3.0.0-preview.5.26302.115/lib/net10.0/System.CommandLine.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "NuGet.Versioning",
+      "path": "nuget:nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "Microsoft.ApplicationInsights",
+      "path": "nuget:microsoft.applicationinsights/2.23.0/lib/netstandard2.0/Microsoft.ApplicationInsights.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "DotnetInspector.Core",
+      "path": "artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "DotnetInspector.Packages",
+      "path": "artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "DotnetInspector.Services",
+      "path": "artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "ILInspector.Metadata",
+      "path": "artifacts/bin/DotnetInspector.Services/release/ILInspector.Metadata.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "ILInspector.MetadataPrimitives",
+      "path": "artifacts/bin/DotnetInspector.Services/release/ILInspector.MetadataPrimitives.dll",
+      "totalMethods": 61
+    },
+    {
+      "assembly": "dotnet-inspect",
+      "path": "artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "ILInspector.Analysis",
+      "path": "artifacts/bin/dotnet-inspect/release/ILInspector.Analysis.dll",
+      "totalMethods": 100
+    },
+    {
+      "assembly": "ILInspector.Decompiler",
+      "path": "artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll",
+      "totalMethods": 100
+    }
+  ],
+  "metrics": {
+    "totalMethods": 1461,
+    "fullyRaisedMethods": 1203,
+    "fullyRaisedBasisPoints": 8234,
+    "conditionalBranchMethods": 7,
+    "conditionalBranchBasisPoints": 48,
+    "forwardMergeStoppedContainers": 7,
+    "forwardMergeBasisPoints": 48,
+    "fullMalformedMethods": 0,
+    "semanticCheckedMethods": 0,
+    "semanticDefectMethods": 0,
+    "passBugs": 0,
+    "residualBuckets": {
+      "fidelity: (typed)": 234,
+      "structuring: conditional-branch": 7,
+      "fidelity: unsupported-node": 16,
+      "eh: leave/endfinally": 1
+    },
+    "structuring": {
+      "totalMethods": 1461,
+      "structuredContainers": 565,
+      "stoppedContainers": 7,
+      "methodsWithStops": 7,
+      "passBugs": 0,
+      "stopReasons": {
+        "forward-branch-not-region-exit": 4,
+        "cond-target-past-region": 3
+      }
+    },
+    "fidelity": {
+      "checkedMethods": 0,
+      "exactMethods": 0,
+      "opcodeDiffMethods": 0,
+      "recompileFailMethods": 0,
+      "contextFailMethods": 0,
+      "notFullMethods": 0
+    }
+  }
+}

--- a/tools/DecompilerHarness/corpus/pr-quick-baseline.json
+++ b/tools/DecompilerHarness/corpus/pr-quick-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
-  "generatedUtc": "2026-06-23T17:10:17.4011776+00:00",
+  "generatedUtc": "2026-06-23T17:12:27.9031461+00:00",
   "validityCompileCap": 0,
   "fidelityCompileCap": 0,
   "methodCap": 100,
@@ -95,8 +95,8 @@
   ],
   "metrics": {
     "totalMethods": 1461,
-    "fullyRaisedMethods": 1215,
-    "fullyRaisedBasisPoints": 8316,
+    "fullyRaisedMethods": 1213,
+    "fullyRaisedBasisPoints": 8303,
     "conditionalBranchMethods": 38,
     "conditionalBranchBasisPoints": 260,
     "forwardMergeStoppedContainers": 33,
@@ -107,7 +107,7 @@
     "passBugs": 0,
     "residualBuckets": {
       "structuring: conditional-branch": 38,
-      "fidelity: (typed)": 180,
+      "fidelity: (typed)": 182,
       "eh: leave/endfinally": 4,
       "fidelity: unsupported-node": 24
     },


### PR DESCRIPTION
Follow-up to #1187 / #1188.

## Summary
- add a PR-sized decompiler corpus prep script with 15 mixed assemblies: System.Private.CoreLib, pinned package libraries, and dotnet-inspect managed product assemblies
- add `--corpus-method-cap` so the corpus sensor can sample a deterministic hash-ranked set of 100 methods per assembly for PR runs
- add `tools/DecompilerHarness/corpus/pr-quick-baseline.json` and run the quick corpus in CI after the managed build
- upload `decompiler-pr-corpus` with `assemblies.txt`, `snapshot.json`, `quality-diff-card.md`, and `exit-code.txt`

## Scope / tradeoff
- local hash-stable cap-100 quick corpus run: ~3.6-4.9s over 15 assemblies / 1,461 sampled methods
- cap-250 over the same 15 assemblies exceeded 5 minutes locally and was stopped
- one semantic-validity sample per assembly took ~196s locally, so PR quick corpus skips semantic validity and compile-back fidelity; the daily full corpus remains the authoritative broad correctness signal
- the PR artifact is a real-assembly smoke/regression slice and reviewer-download artifact, not a replacement for the 30-minute daily corpus
- the capped sample is hash-ranked by method identity instead of "first N" metadata order, so unrelated method-order churn is less likely to change the sampled set

## Validation
- `dotnet build tools/DecompilerHarness -c Release --no-restore --nologo`
- local PR artifact flow generated clean `quality-diff-card.md`, `snapshot.json`, `assemblies.txt`, and `exit-code.txt`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- old baseline compatibility check: a baseline without `methodCap` deserializes and reports a method-cap mismatch against capped runs
- after switching to hash-stable sampling, refreshed `pr-quick-baseline.json` from the CI artifact because the GitHub Actions runner produced two fewer fully raised methods than local; local comparison against that CI baseline is a +2 improvement
- CI passed on the latest push; downloaded the latest `decompiler-pr-corpus` artifact and verified the generated card reports `Sample: hash-stable 100 methods per assembly` with 0 delta