### PR TITLE
Expose correctness coverage in quality cards

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -422,12 +422,19 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --max-examples 3
 ```
 
+For risky raise or structuring PRs, add `--quality-card-risky`. It keeps the
+card generated from the same snapshots, but adds a thin-coverage warning when the
+semantic validity sample is below 1.00% of methods or the compile-back fidelity
+sample is below 0.10%. That warning means the aggregate card is not enough by
+itself; add method-level improved examples and still-flat near misses.
+
 The tool emits a block like:
 
 ```md
 ### Decompiler quality diff
 
 Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,907 methods
+Correctness coverage: validity sampled 350 / 87,907 (0.40%); fidelity sampled 6 / 87,907 (0.01%)
 
 | Metric | Baseline | PR | Delta |
 | --- | ---: | ---: | ---: |
@@ -435,8 +442,8 @@ Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies
 | Conditional-branch residual | 2,298 (2.61%) | 2,298 (2.61%) | 0 |
 | Forward-merge stops | 2,290 (2.61%) | 2,290 (2.61%) | 0 |
 | Full malformed | 165 | 165 | 0 |
-| Semantic defects | 4/350 | 4/350 | 0 |
-| Fidelity diffs | 1/6 | 1/6 | 0 |
+| Semantic defects | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 87,907 (0.40%) | 0 |
+| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | 0 |
 | Pass bugs | 0 | 0 | 0 |
 
 Verdict: corpus sensor matched baseline tolerances.
@@ -453,6 +460,10 @@ Still-flat near miss:
 - Type::Other — declined because the discriminator is missing / readability
   failed / fidelity would regress.
 ```
+
+Full malformed rows should be root-cause bucketed in a linked library report,
+validity-defect report, or issue when they are relevant to the PR. The generated
+card intentionally stays short; the linked report carries the long tail.
 
 Read movement as correctness evidence, not a JIT-style tradeoff budget.
 Acceptable movement is: completeness improves while validity/fidelity stay flat,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -9,6 +9,8 @@ namespace ILInspector.DecompilerHarness;
 internal static class CorpusSensor
 {
     const string ConditionalBranchBucket = "structuring: conditional-branch";
+    const int RiskyValidityCoverageFloorBasisPoints = 100; // 1.00%
+    const int RiskyFidelityCoverageFloorBasisPoints = 10;  // 0.10%
     static readonly string[] ForwardMergeStopReasons =
     [
         "cond-target-past-region",
@@ -23,6 +25,7 @@ internal static class CorpusSensor
         string? emitBaseline,
         string? diffBaseline,
         bool qualityDiffCard = false,
+        bool qualityCardRisky = false,
         int methodCap = int.MaxValue)
     {
         if (assemblies.Count == 0)
@@ -66,7 +69,7 @@ internal static class CorpusSensor
         var regressions = Compare(baseline, current);
         if (qualityDiffCard)
         {
-            PrintQualityDiffCard(baseline, current, regressions);
+            PrintQualityDiffCard(baseline, current, regressions, qualityCardRisky);
             return regressions.Length == 0 ? 0 : 1;
         }
 
@@ -343,13 +346,17 @@ internal static class CorpusSensor
     static void PrintQualityDiffCard(
         CorpusSensorSnapshot baseline,
         CorpusSensorSnapshot current,
-        IReadOnlyList<string> regressions)
+        IReadOnlyList<string> regressions,
+        bool risky)
     {
         Console.WriteLine("### Decompiler quality diff");
         Console.WriteLine();
         Console.WriteLine($"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods");
         if (current.MethodCap is { } cap)
             Console.WriteLine($"Sample: hash-stable {Number(cap)} methods per assembly");
+        Console.WriteLine($"Correctness coverage: {CoverageSummary(current)}");
+        if (risky)
+            PrintRiskyCoverageGuidance(current);
         Console.WriteLine();
         Console.WriteLine("| Metric | Baseline | PR | Delta |");
         Console.WriteLine("| --- | ---: | ---: | ---: |");
@@ -382,8 +389,8 @@ internal static class CorpusSensor
                 Delta(current.Metrics.FullMalformedMethods - baseline.Metrics.FullMalformedMethods));
             PrintMetric(
                 "Semantic defects",
-                Fraction(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods),
-                Fraction(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods),
+                FractionWithCoverage(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods, baseline.Metrics.TotalMethods),
+                FractionWithCoverage(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods, current.Metrics.TotalMethods),
                 Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
         }
         if (current.FidelityCompileCap <= 0)
@@ -394,8 +401,8 @@ internal static class CorpusSensor
         {
             PrintMetric(
                 "Fidelity diffs",
-                Fraction(baseline.Metrics.Fidelity.OpcodeDiffMethods, baseline.Metrics.Fidelity.CheckedMethods),
-                Fraction(current.Metrics.Fidelity.OpcodeDiffMethods, current.Metrics.Fidelity.CheckedMethods),
+                FidelityWithCoverage(baseline.Metrics.Fidelity, baseline.Metrics.TotalMethods),
+                FidelityWithCoverage(current.Metrics.Fidelity, current.Metrics.TotalMethods),
                 Delta(current.Metrics.Fidelity.OpcodeDiffMethods - baseline.Metrics.Fidelity.OpcodeDiffMethods));
         }
         PrintMetric(
@@ -419,11 +426,53 @@ internal static class CorpusSensor
     static void PrintMetric(string metric, string baseline, string current, string delta)
         => Console.WriteLine($"| {metric} | {baseline} | {current} | {delta} |");
 
+    static string CoverageSummary(CorpusSensorSnapshot snapshot)
+    {
+        var validity = snapshot.ValidityCompileCap <= 0
+            ? "validity not run"
+            : $"validity sampled {Coverage(snapshot.Metrics.SemanticCheckedMethods, snapshot.Metrics.TotalMethods)}";
+        var fidelity = snapshot.FidelityCompileCap <= 0
+            ? "fidelity not run"
+            : $"fidelity sampled {Coverage(snapshot.Metrics.Fidelity.CheckedMethods, snapshot.Metrics.TotalMethods)}";
+        return $"{validity}; {fidelity}";
+    }
+
+    static void PrintRiskyCoverageGuidance(CorpusSensorSnapshot snapshot)
+    {
+        List<string> warnings = [];
+        if (snapshot.ValidityCompileCap <= 0)
+            warnings.Add("validity not run");
+        else if (RateBasisPoints(snapshot.Metrics.SemanticCheckedMethods, snapshot.Metrics.TotalMethods) < RiskyValidityCoverageFloorBasisPoints)
+            warnings.Add($"validity below {FormatBps(RiskyValidityCoverageFloorBasisPoints)} floor");
+
+        if (snapshot.FidelityCompileCap <= 0)
+            warnings.Add("fidelity not run");
+        else if (RateBasisPoints(snapshot.Metrics.Fidelity.CheckedMethods, snapshot.Metrics.TotalMethods) < RiskyFidelityCoverageFloorBasisPoints)
+            warnings.Add($"fidelity below {FormatBps(RiskyFidelityCoverageFloorBasisPoints)} floor");
+
+        if (warnings.Count > 0)
+        {
+            Console.WriteLine($"Risk warning: thin correctness coverage ({string.Join("; ", warnings)}). Add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
+            return;
+        }
+
+        Console.WriteLine("Risk guidance: add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
+    }
+
     static string CountPercent(int count, int basisPoints)
         => $"{Number(count)} ({FormatBps(basisPoints)})";
 
     static string Fraction(int numerator, int denominator)
         => $"{Number(numerator)}/{Number(denominator)}";
+
+    static string FractionWithCoverage(int numerator, int denominator, int total)
+        => $"{Fraction(numerator, denominator)} — sampled {Coverage(denominator, total)}";
+
+    static string FidelityWithCoverage(FidelitySensorMetrics metrics, int total)
+        => $"opcode-diff {Fraction(metrics.OpcodeDiffMethods, metrics.CheckedMethods)}, exact {Number(metrics.ExactMethods)}, recompile-failed {Number(metrics.RecompileFailMethods)}, context-failed {Number(metrics.ContextFailMethods)}; sampled {Coverage(metrics.CheckedMethods, total)}";
+
+    static string Coverage(int checkedMethods, int totalMethods)
+        => $"{Number(checkedMethods)} / {Number(totalMethods)} ({FormatBps(RateBasisPoints(checkedMethods, totalMethods))})";
 
     static string AssemblyCount(int count)
         => $"{Number(count)} assembl{(count == 1 ? "y" : "ies")}";

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -58,6 +58,7 @@ static class Program
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
         bool qualityDiffCard = false;
+        bool qualityCardRisky = false;
         int corpusFidelityCap = 0;
         int corpusMethodCap = int.MaxValue;
         bool json = false;
@@ -113,6 +114,7 @@ static class Program
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
                 case "--quality-diff-card": qualityDiffCard = true; break;
+                case "--quality-card-risky": qualityDiffCard = true; qualityCardRisky = true; break;
                 case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
                 case "--corpus-method-cap": corpusMethodCap = int.Parse(args[++i]); break;
                 case "--json": json = true; break;
@@ -150,7 +152,7 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, corpusMethodCap);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, qualityCardRisky, corpusMethodCap);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1118,6 +1120,9 @@ static class Program
           --quality-diff-card  with --diff-corpus-baseline: emit a Markdown
                                 Decompiler quality diff card generated from the
                                 baseline/current corpus snapshots.
+          --quality-card-risky with --quality-diff-card: include thin-coverage
+                                warnings and targeted-example guidance for risky
+                                raise/structuring PRs.
           --corpus-fidelity-cap <n>      with corpus baseline modes: cap methods
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -45,8 +45,15 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 ```
 
 Add `--quality-diff-card` to emit a Markdown PR block generated directly from
-the baseline/current snapshots. Paste that block as the PR's aggregate corpus
-evidence; do not re-key the table by hand.
+the baseline/current snapshots. The card includes a correctness-coverage line
+and per-row sampled denominators for semantic validity and compile-back fidelity
+so reviewers can tell when evidence is strong or thin. Paste that block as the
+PR's aggregate corpus evidence; do not re-key the table by hand.
+
+For risky raise/structuring PRs, add `--quality-card-risky`. It keeps the same
+card shape but warns when semantic validity coverage is below 1.00% or
+compile-back fidelity coverage is below 0.10%, and reminds authors to add
+targeted improved examples plus still-flat near misses.
 
 To deliberately rebaseline after reviewed corpus movement, run the same command
 with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.


### PR DESCRIPTION
## Summary
- add correctness coverage to generated decompiler quality diff cards
- show semantic/fidelity sampled denominators in rows so thin samples are visible
- expand fidelity row to show opcode-diff, exact, recompile-failed, and context-failed outcomes
- add --quality-card-risky for risky raise/structuring PRs, with documented coverage floors and targeted-example guidance
- document the generated-card workflow and root-cause link expectation for Full malformed rows

## Related
- Refs #1194

## Validation
- dotnet build tools/DecompilerHarness -c Release
- npx markdownlint-cli docs/decompiler-quality.md tools/DecompilerHarness/README.md
- generated a same-assembly quality card with --quality-card-risky, --compile-cap 1, and --corpus-fidelity-cap 1
- generated a skipped-validity/fidelity risky card and verified the thin-coverage warning
