### PR TITLE
Use resolved package version for Source Locations

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1649,6 +1649,21 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_UnpinnedSnupkgPackage_ResolvesSourceRows()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonConvert", "--package", "Newtonsoft.Json",
+            "-m", "SerializeObject", "-S", "Source Locations", "--rows", "-n", "6", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Locations", output);
+        Assert.Contains("`SerializeObject:1`", output);
+        Assert.Contains("JsonConvert.cs", output);
+        Assert.Contains("raw.githubusercontent.com/JamesNK/Newtonsoft.Json", output);
+    }
+
+    [Fact]
     public async Task Member_SourceLocations_Discovery_DoesNotAcquirePdb()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -212,7 +212,8 @@ public static class MemberCommand
             {
                 var locationDllPath = apiType.SourceAssemblyPath ?? pdbLookupPath;
                 var pdbPath = await MemberSourceLocationCollector.EnrichAsync(
-                    apiType, locationDllPath, effectiveOptions, context.HttpClient, logger);
+                    apiType, locationDllPath, packageName, packageVersion,
+                    effectiveOptions, context.HttpClient, logger);
                 if (pdbPath != null)
                     effectiveOptions = effectiveOptions with { PdbPath = pdbPath };
             }

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -1,6 +1,5 @@
 using DotnetInspector.Options;
 using DotnetInspector.Output;
-using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using ILInspector.Metadata;
 
@@ -11,6 +10,8 @@ internal static class MemberSourceLocationCollector
     public static async Task<string?> EnrichAsync(
         ApiType apiType,
         string assemblyPath,
+        string? packageName,
+        string? packageVersion,
         MemberOptions options,
         HttpClient httpClient,
         VerboseLogger logger)
@@ -24,10 +25,6 @@ internal static class MemberSourceLocationCollector
 
             if (context.NeedsPdb)
             {
-                var (packageName, packageVersion) = !string.IsNullOrEmpty(options.PackagePath)
-                    ? PackageExtractor.ParsePackageReference(options.PackagePath)
-                    : (null, null);
-
                 await SourceEnricher.AcquirePdbAsync(context, httpClient,
                     packageName, packageVersion,
                     isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,6 +6,9 @@
 
 - Adds a `Source Locations` section for member groups and selected signatures,
   reporting SourceLink-backed file/line/URL rows without fetching source bodies.
+- Resolves SourceLink rows for unpinned NuGet packages whose symbols are only in
+  `.snupkg` packages by reusing the resolved package version during PDB
+  acquisition.
 - Keeps `Member Index` focused on selector/query columns while moving
   source-location evidence to the dedicated source section.
 


### PR DESCRIPTION
## Summary
- pass the already-resolved package id/version into member Source Locations PDB acquisition
- stop reparsing the raw --package argument, preserving unpinned package versions for snupkg downloads
- add a Newtonsoft.Json unpinned regression for snupkg-only symbols
- update 0.14.0 release notes

## Related
- Fixes #1196

## Validation
- npx markdownlint-cli src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_UnpinnedSnupkgPackage_ResolvesSourceRows -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Group_RendersSelectorsAndSourceRows -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_SelectedSignature_RendersWithoutSelectorColumn -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Discovery_DoesNotAcquirePdb
- dotnet run --project src/dotnet-inspect -c Release -- member JsonConvert --package Newtonsoft.Json -m SerializeObject -S "Source Locations" --rows -n 6 --tips q
