### PR TITLE
Populate End Line for single-line source locations

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1664,6 +1664,27 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_Tsv_RepeatsStartLineForSingleLineMethods()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonConvert", "--package", "Newtonsoft.Json@13.0.4",
+            "-m", "SerializeObject", "-S", "Source Locations", "--tsv", "--no-headers", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        var rows = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Where(cells => cells.Length >= 5)
+            .ToDictionary(cells => cells[0], cells => (Line: cells[3], EndLine: cells[4]));
+
+        Assert.Equal(("532", "532"), rows["SerializeObject:1"]);
+        Assert.Equal(("548", "548"), rows["SerializeObject:2"]);
+        Assert.Equal(("581", "585"), rows["SerializeObject:4"]);
+    }
+
+    [Fact]
     public async Task Member_SourceLocations_Discovery_DoesNotAcquirePdb()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -828,11 +828,7 @@ public static class ApiOutputFormatter
                 continue;
 
             var signature = FormatMemberDeclaration(type, member, abbreviate: false);
-            int? endLine = member.SourceEndLineNumber is { } end
-                           && member.SourceLineNumber is { } start
-                           && end != start
-                ? end
-                : null;
+            int? endLine = member.SourceEndLineNumber ?? member.SourceLineNumber;
 
             rows.Add(new MemberSourceLocationRow(
                 detail ? null : indexRows[i].Selector,

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -9,6 +9,8 @@
 - Resolves SourceLink rows for unpinned NuGet packages whose symbols are only in
   `.snupkg` packages by reusing the resolved package version during PDB
   acquisition.
+- Repeats the start line in the `End Line` column for single-line member source
+  locations so blank cells only mean the end line is unknown.
 - Keeps `Member Index` focused on selector/query columns while moving
   source-location evidence to the dedicated source section.
 


### PR DESCRIPTION
## Summary
- always populate End Line in member Source Locations when a start line is known
- repeat the start line for single-line methods so blank only means unknown
- keep the merged unpinned snupkg Source Locations regression from #1198
- add a TSV regression with Newtonsoft.Json one-line and multi-line overloads
- update 0.14.0 release notes

## Related
- Fixes #1197

## Validation
- npx markdownlint-cli src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Tsv_RepeatsStartLineForSingleLineMethods -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_UnpinnedSnupkgPackage_ResolvesSourceRows -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Group_RendersSelectorsAndSourceRows -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_SelectedSignature_RendersWithoutSelectorColumn -method DotnetInspector.Tests.CommandExecutionTests.Member_SourceLocations_Discovery_DoesNotAcquirePdb
- dotnet run --project src/dotnet-inspect -c Release -- member JsonConvert --package Newtonsoft.Json@13.0.4 -m SerializeObject -S "Source Locations" --tsv --no-headers --tips q | awk -F"\t" 'NR<=5 {print $1 " Line=" $4 " End=" $5}'