### PR TITLE
Fix cross-method decompiler import recursion

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -150,6 +150,39 @@ public class LambdaRaisingPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void RecursiveLambdaImport_DeclinesInsteadOfReenteringPipeline()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Outer+<>c");
+        var lambdaMethod = new MethodRef(
+            holder,
+            "<M>b__0_0",
+            s_int,
+            [s_int],
+            HasThis: true)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var function = FunctionReturningDelegate(lambdaMethod);
+        int imports = 0;
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method =>
+            {
+                if (method != lambdaMethod)
+                    return null;
+                imports++;
+                return RecursiveLambdaBody(lambdaMethod);
+            });
+
+        new LambdaRaisingPass().Run(function, context);
+
+        Assert.Equal(1, imports);
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+        Assert.Single(function.Descendants.OfType<DelegateCreation>());
+        function.CheckInvariant();
+    }
+
     static IrFunction FunctionReturningDelegate(MethodRef method)
     {
         var block = new Block();
@@ -172,6 +205,25 @@ public class LambdaRaisingPassTests
     {
         var block = new Block();
         block.Add(new Return(new LoadArgument(1, "x", s_int)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            method.Name,
+            method.DeclaringType,
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction RecursiveLambdaBody(MethodRef method)
+    {
+        var block = new Block();
+        block.Add(new ExpressionStatement(new DelegateCreation(
+            s_func,
+            method,
+            isVirtual: false,
+            new Constant(null, TypeRef.CoreLib("System", "Object")))));
+        block.Add(new Return(new LoadArgument(0, "this", method.DeclaringType)));
         var body = new BlockContainer();
         body.Add(block);
         return new IrFunction(

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -4,6 +4,9 @@ namespace ILInspector.Decompiler.Tests;
 
 public class LocalFunctionRaisingPassTests
 {
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_func = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`2"), [s_int, s_int]);
+
     static string PrintRaised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -127,6 +130,56 @@ public class LocalFunctionRaisingPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void LambdaLocalFunctionImportCycle_DeclinesInsteadOfReenteringPipeline()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Owner+<>c");
+        var localMethod = new MethodRef(
+            owner,
+            "<M>g__Helper|0_0",
+            s_int,
+            [s_int],
+            HasThis: false)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+        };
+        var lambdaMethod = new MethodRef(
+            holder,
+            "<M>b__0_0",
+            s_int,
+            [s_int],
+            HasThis: true)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var function = FunctionReturningCall(localMethod, s_int);
+        int localImports = 0;
+        int lambdaImports = 0;
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method =>
+            {
+                if (method == localMethod)
+                {
+                    localImports++;
+                    return LocalFunctionBodyCreatingLambda(localMethod, lambdaMethod);
+                }
+                if (method == lambdaMethod)
+                {
+                    lambdaImports++;
+                    return LambdaBodyCallingLocalFunction(lambdaMethod, localMethod);
+                }
+                return null;
+            });
+
+        new LocalFunctionRaisingPass().Run(function, context);
+
+        Assert.Equal(1, localImports);
+        Assert.Equal(1, lambdaImports);
+        function.CheckInvariant();
+    }
+
     static int CountOccurrences(string haystack, string needle)
     {
         int count = 0, index = 0;
@@ -189,6 +242,42 @@ public class LocalFunctionRaisingPassTests
             method.Name,
             method.DeclaringType,
             new MethodSignature(method.ReturnType, [new Parameter("x", intType)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction LocalFunctionBodyCreatingLambda(MethodRef localMethod, MethodRef lambdaMethod)
+    {
+        var block = new Block();
+        block.Add(new ExpressionStatement(new DelegateCreation(
+            s_func,
+            lambdaMethod,
+            isVirtual: false,
+            new Constant(null, TypeRef.CoreLib("System", "Object")))));
+        block.Add(new Return(new LoadArgument(0, "x", s_int)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            localMethod.Name,
+            localMethod.DeclaringType,
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction LambdaBodyCallingLocalFunction(MethodRef lambdaMethod, MethodRef localMethod)
+    {
+        var block = new Block();
+        block.Add(new Return(new Call(
+            localMethod,
+            isVirtual: false,
+            [new LoadArgument(1, "x", s_int)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            lambdaMethod.Name,
+            lambdaMethod.DeclaringType,
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: true, GenericParameterCount: 0),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler/Pipeline/PassContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PassContext.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -10,6 +12,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public sealed class PassContext
 {
+    const int MaxCrossMethodPipelineDepth = 64;
+    readonly List<string> _activeCrossMethodPipelines = [];
+
     public PassContext(
         Stepper stepper,
         StructuringDiagnostics? structuringDiagnostics = null,
@@ -34,11 +39,99 @@ public sealed class PassContext
     /// (un-raised) body by reference, or null when the method is absent. The
     /// pipeline is otherwise per-method — a pass sees only its one function — so
     /// this is the single sanctioned way for a pass to reach another body.
-    /// <see cref="LambdaRaisingPass"/> uses it to pull in a lambda's synthesized
-    /// method. Null on runs that wired no source (stage dumps, direct pass tests,
-    /// the lowered view); a pass that needs it must no-op when it is null.
+    /// Cross-method passes use it to pull in synthesized companion methods
+    /// (lambdas, local functions, state machines). Null on runs that wired no
+    /// source (stage dumps, direct pass tests, the lowered view); a pass that
+    /// needs it must no-op when it is null. Passes that run a nested pipeline over
+    /// the imported body must use the guarded helpers below rather than invoking
+    /// this delegate directly.
     /// </summary>
     public Func<MethodRef, IrFunction?>? ImportMethodBody { get; }
+
+    /// <summary>
+    /// Imports a sibling body and runs a pass pipeline over it while marking that
+    /// method active. Cross-method raising is allowed to nest, but recursive or
+    /// pathologically deep sibling chains decline so one method cannot re-enter
+    /// the whole pipeline indefinitely.
+    /// </summary>
+    public bool TryImportAndRunMethodBody(MethodRef method, ImmutableArray<IIrPass> passes, out IrFunction? body)
+    {
+        body = null;
+        if (!TryEnterCrossMethodPipeline(method, out var scope))
+            return false;
+        using (scope)
+        {
+            body = scope.Import();
+            if (body is not null)
+                IrPasses.Run(body, passes, this);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Marks a sibling method active across any raw inspection and nested pass run
+    /// the caller needs. Use when a pass must inspect the imported body before
+    /// choosing which pipeline, if any, to run.
+    /// </summary>
+    public bool TryEnterCrossMethodPipeline(MethodRef method, out CrossMethodPipelineScope scope)
+    {
+        scope = null!;
+        if (ImportMethodBody is null)
+            return false;
+
+        var key = CrossMethodPipelineKey(method);
+        if (_activeCrossMethodPipelines.Contains(key)
+            || _activeCrossMethodPipelines.Count >= MaxCrossMethodPipelineDepth)
+            return false;
+
+        _activeCrossMethodPipelines.Add(key);
+        scope = new CrossMethodPipelineScope(this, method, key);
+        return true;
+    }
+
+    void ExitCrossMethodPipeline(string key)
+    {
+        var last = _activeCrossMethodPipelines.Count - 1;
+        if (last >= 0 && _activeCrossMethodPipelines[last] == key)
+            _activeCrossMethodPipelines.RemoveAt(last);
+        else
+            _activeCrossMethodPipelines.Remove(key);
+    }
+
+    public sealed class CrossMethodPipelineScope : IDisposable
+    {
+        readonly PassContext _context;
+        readonly MethodRef _method;
+        readonly string _key;
+        bool _disposed;
+
+        internal CrossMethodPipelineScope(PassContext context, MethodRef method, string key)
+        {
+            _context = context;
+            _method = method;
+            _key = key;
+        }
+
+        public IrFunction? Import() => _context.ImportMethodBody!(_method);
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _context.ExitCrossMethodPipeline(_key);
+        }
+    }
+
+    static string CrossMethodPipelineKey(MethodRef method)
+    {
+        var parameters = string.Join(",", method.ParameterTypes.Select(static p => p.ToDisplayString()));
+        var typeArguments = method.TypeArguments.IsDefaultOrEmpty
+            ? ""
+            : $"<{string.Join(",", method.TypeArguments.Select(static t => t.ToDisplayString()))}>";
+        var receiver = method.HasThis ? "instance" : "static";
+        return $"{method.DeclaringType.ToDisplayString()}::{method.Name}{typeArguments}({parameters})->{method.ReturnType.ToDisplayString()}:{receiver}";
+    }
 
     /// <summary>A context with stepping disabled — the default for normal runs and for tests that drive a pass directly.</summary>
     public static PassContext None { get; } = new(new Stepper(enabled: false));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClassicAsyncReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClassicAsyncReconstructionPass.cs
@@ -23,19 +23,18 @@ public sealed class ClassicAsyncReconstructionPass : IIrPass
         if (!TryGetKickoff(function, out var kickoff))
             return;
 
-        var moveNext = context.ImportMethodBody(new MethodRef(
+        var moveNextMethod = new MethodRef(
             kickoff.StateMachineType,
             "MoveNext",
             TypeRef.CoreLib("System", "Void"),
             [],
-            HasThis: true));
-        if (moveNext is null)
-            return;
-
+            HasThis: true);
         var moveNextPasses = IrPasses.Default
             .Where(static pass => pass is not ClassicAsyncReconstructionPass)
             .ToImmutableArray();
-        IrPasses.Run(moveNext, moveNextPasses, context);
+        if (!context.TryImportAndRunMethodBody(moveNextMethod, moveNextPasses, out var moveNext)
+            || moveNext is null)
+            return;
 
         if (!TryReconstruct(moveNext, function, kickoff, out var body, out var locals, out var localNames))
             return;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -61,20 +61,17 @@ public sealed class IteratorReconstructionPass : IIrPass
         if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return;
 
-        var moveNext = context.ImportMethodBody(handoff.Constructor with { Name = "MoveNext" });
-        if (moveNext is null)
+        var moveNextMethod = handoff.Constructor with { Name = "MoveNext" };
+        if (!context.TryImportAndRunMethodBody(moveNextMethod, IrPasses.Default, out var moveNext)
+            || moveNext is null)
             return;
-
-        // Raise the MoveNext body with the same pipeline so its state dispatch
-        // lands at the altitude this pass recognizes.
-        IrPasses.Run(moveNext, IrPasses.Default, context);
 
         if (!TryReconstruct(moveNext, function, handoff, out var statements))
         {
             // The structured matchers above all declined. Fall back to the general
             // transform-then-restructure path: strip the state scaffolding from a fresh
             // raw import to make the CFG reducible, then let the structurer raise it.
-            var raw = context.ImportMethodBody(handoff.Constructor with { Name = "MoveNext" });
+            var raw = context.ImportMethodBody(moveNextMethod);
             if (raw is null)
                 return;  // leave for IteratorAcknowledgmentPass
 
@@ -88,7 +85,7 @@ public sealed class IteratorReconstructionPass : IIrPass
             // A foreach-delegation iterator carries an exception region (the enumerator's
             // disposal), so the reducible path declines; strip the disposal idiom too and
             // recover the foreach.
-            var rawForeach = context.ImportMethodBody(handoff.Constructor with { Name = "MoveNext" });
+            var rawForeach = context.ImportMethodBody(moveNextMethod);
             if (rawForeach is not null
                 && ForeachIteratorReconstruction.TryReconstruct(rawForeach, function, handoff, context, out var foreachBody))
             {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -243,10 +243,9 @@ public sealed class LambdaRaisingPass : IIrPass
     // seam). Null when the body is absent.
     static IrFunction? RaisedBody(DelegateCreation creation, PassContext context)
     {
-        var body = context.ImportMethodBody!(creation.Method);
-        if (body is null)
+        if (!context.TryImportAndRunMethodBody(creation.Method, IrPasses.Default, out var body)
+            || body is null)
             return null;
-        IrPasses.Run(body, IrPasses.Default, context);
         return body;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -60,59 +60,64 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             if (environment is null && method.ParameterTypes.Any(IsDisplayClassParameter))
                 continue;
 
-            var body = context.ImportMethodBody(method);
-            if (body is null)
+            if (!context.TryEnterCrossMethodPipeline(method, out var importScope))
                 continue;
-            // Keep the import non-recursive: a body that calls a local function
-            // (itself, mutually, or nested) is out of this slice.
-            if (body.Descendants.OfType<Call>().Any(c => GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee)))
-                continue;
-
-            IrPasses.Run(body, IrPasses.Default, context);
-
-            if (environment is not null && !SubstituteEnvironment(body, environment))
-                continue;
-            bool allowLocals = environment is null;
-            if (!allowLocals && !body.Locals.IsEmpty
-                || body.Descendants.OfType<UnsupportedNode>().Any()
-                || !IsPrintableBody(body, allowLocals))
-                continue;
-
-            string name = CSharpNaming.MethodName(method.Name);
-            // The environment parameter is the last one; drop it from the source signature.
-            var parameters = environment is null
-                ? body.Signature.Parameters
-                : body.Signature.Parameters.RemoveAt(body.Signature.Parameters.Length - 1);
-
-            var container = body.Body;
-            container.Detach();
-            // The body is another method's; clear its offsets so they cannot collide
-            // with the host's offset-keyed annotations and interleaved IL.
-            foreach (var node in Self(container))
-                node.SetSourceOffset(-1);
-
-            foreach (var call in calls)
+            using (importScope)
             {
-                context.Stepper.StepOver($"raise local function {name}", call);
-                var arguments = call.DetachChildren().Cast<IrExpression>().ToList();
-                if (environment is not null)
-                    arguments.RemoveAt(arguments.Count - 1);   // drop the ref-env argument
-                call.ReplaceWith(new LocalFunctionInvocation(name, method.ReturnType, arguments));
+                var body = importScope.Import();
+                if (body is null)
+                    continue;
+                // Keep the import non-recursive: a body that calls a local function
+                // (itself, mutually, or nested) is out of this slice.
+                if (body.Descendants.OfType<Call>().Any(c => GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee)))
+                    continue;
+
+                IrPasses.Run(body, IrPasses.Default, context);
+
+                if (environment is not null && !SubstituteEnvironment(body, environment))
+                    continue;
+                bool allowLocals = environment is null;
+                if (!allowLocals && !body.Locals.IsEmpty
+                    || body.Descendants.OfType<UnsupportedNode>().Any()
+                    || !IsPrintableBody(body, allowLocals))
+                    continue;
+
+                string name = CSharpNaming.MethodName(method.Name);
+                // The environment parameter is the last one; drop it from the source signature.
+                var parameters = environment is null
+                    ? body.Signature.Parameters
+                    : body.Signature.Parameters.RemoveAt(body.Signature.Parameters.Length - 1);
+
+                var container = body.Body;
+                container.Detach();
+                // The body is another method's; clear its offsets so they cannot collide
+                // with the host's offset-keyed annotations and interleaved IL.
+                foreach (var node in Self(container))
+                    node.SetSourceOffset(-1);
+
+                foreach (var call in calls)
+                {
+                    context.Stepper.StepOver($"raise local function {name}", call);
+                    var arguments = call.DetachChildren().Cast<IrExpression>().ToList();
+                    if (environment is not null)
+                        arguments.RemoveAt(arguments.Count - 1);   // drop the ref-env argument
+                    call.ReplaceWith(new LocalFunctionInvocation(name, method.ReturnType, arguments));
+                }
+                // A capturing local function cannot be `static` (CS8421); the
+                // synthesized method is static only because the environment is passed
+                // explicitly by ref, which the recovered source form does not show.
+                declarations.Add(new LocalFunctionStatement(
+                    name,
+                    method.ReturnType,
+                    parameters,
+                    isStatic: environment is null,
+                    body.Locals,
+                    body.LocalNames,
+                    body.UsesUpdatedMemorySafetyRules,
+                    body.SkipLocalsInit,
+                    container));
+                environment?.Elide();
             }
-            // A capturing local function cannot be `static` (CS8421); the
-            // synthesized method is static only because the environment is passed
-            // explicitly by ref, which the recovered source form does not show.
-            declarations.Add(new LocalFunctionStatement(
-                name,
-                method.ReturnType,
-                parameters,
-                isStatic: environment is null,
-                body.Locals,
-                body.LocalNames,
-                body.UsesUpdatedMemorySafetyRules,
-                body.SkipLocalsInit,
-                container));
-            environment?.Elide();
         }
 
         if (declarations.Count == 0)


### PR DESCRIPTION
## Summary

- Add a guarded cross-method pipeline scope to `PassContext` keyed by stable method identity, with cycle detection and a bounded nesting depth.
- Route lambda, local-function, iterator, and classic-async nested pipeline imports through the guard while preserving local-function raw-body recursion checks.
- Add synthetic regression coverage for a self-recursive lambda import and a lambda/local-function import cycle.

Fixes #1203.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,061 methods
Correctness coverage: validity sampled 350 / 88,061 (0.40%); fidelity sampled 6 / 88,061 (0.01%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,376 (88.02%) | 77,513 (88.02%) | +137 |
| Conditional-branch residual | 2,298 (2.61%) | 2,294 (2.61%) | -4 |
| Forward-merge stops | 2,290 (2.61%) | 2,287 (2.60%) | -3 |
| Full malformed | 165 | 165 | 0 |
| Semantic defects | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 88,061 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 88,061 (0.01%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

## Focused validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LambdaRaisingPassTests -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --no-restore --nologo`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- ~/.nuget/packages/microsoft.codeanalysis.common/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.dll --library-report --json --compile-cap 0 --top-patterns 200 --max-examples 200` → exit 0, PassBugs 0
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- ~/.nuget/packages/microsoft.codeanalysis.csharp/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.CSharp.dll --library-report --json --compile-cap 0 --top-patterns 200 --max-examples 200` → exit 0, PassBugs 0
