### PR TITLE
Normalize foreach struct collection receivers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -419,6 +419,26 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void EnumeratorUsingLoop_WithStructCollectionAddressReceiver_RendersValueCollection()
+    {
+        var function = BuildStructCollectionEnumeratorUsingWhile();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        var collection = Assert.IsType<LoadLocal>(foreachStatement.Collection);
+        Assert.Equal(2, collection.Index);
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("foreach (int value in items)", output);
+        Assert.DoesNotContain("foreach (int value in ref items)", output);
+        Assert.DoesNotContain(" in ref ", output);
+    }
+
+    [Fact]
     public void EnumeratorUsingLoop_WithCopiedCurrentReceiver_StaysUsingWhile()
     {
         var function = BuildEnumeratorUsingWhileWithCopiedCurrentReceiver();
@@ -499,6 +519,42 @@ public class ForeachStatementPassTests
             new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("items", collectionType)], HasThis: false, GenericParameterCount: 0),
             [enumeratorType, intType],
             body);
+    }
+
+    static IrFunction BuildStructCollectionEnumeratorUsingWhile()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var collectionType = TypeRef.Definition("UserAssembly", "Samples", "StructCollection", ValueTypeHint.ValueType);
+        var enumeratorType = TypeRef.Definition("UserAssembly", "Samples", "StructEnumerator", ValueTypeHint.ValueType);
+        var getEnumerator = new MethodRef(collectionType, "GetEnumerator", enumeratorType, [], HasThis: true);
+        var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var loopBody = new Block();
+        loopBody.Add(new StoreLocal(1, intType, new LoadProperty(current, new LoadLocalAddress(0, enumeratorType), [])));
+
+        var usingBody = new BlockContainer();
+        var usingBlock = new Block();
+        usingBlock.Add(new WhileLoop(new Call(moveNext, isVirtual: false, [new LoadLocalAddress(0, enumeratorType)]), loopBody));
+        usingBody.Add(usingBlock);
+
+        var entry = new Block();
+        entry.Add(new StoreLocal(2, collectionType, new LoadArgument(0, "source", collectionType)));
+        entry.Add(new UsingStatement(0, enumeratorType, new Call(getEnumerator, isVirtual: false, [new LoadLocalAddress(2, collectionType)]), usingBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("source", collectionType)], HasThis: false, GenericParameterCount: 0),
+            [enumeratorType, intType, collectionType],
+            body);
+        function.LocalNames = [null, "value", "items"];
+        return function;
     }
 
     static IrFunction BuildPatternEnumeratorLoop(TypeRef moveNextReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -208,7 +208,7 @@ public sealed class ForeachStatementPass : IIrPass
         if (loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
             return null;
 
-        return new EnumeratorMatch(getEnumerator.Arguments[0], loop, currentStore);
+        return new EnumeratorMatch(CollectionValue(getEnumerator.Arguments[0]), loop, currentStore);
     }
 
     sealed record PatternMatch(IrExpression Collection, StoreLocal EnumeratorStore, WhileLoop Loop, StoreLocal CurrentStore);


### PR DESCRIPTION
Fixes #1202.

Changes:
- normalize the accepted using-enumerator collection receiver with the existing `CollectionValue` helper, matching the pattern-enumerator path;
- add a focused synthetic regression where a struct collection receiver is passed as `LoadLocalAddress` to `GetEnumerator`;
- keep all existing foreach discriminators unchanged: hidden enumerator proof, MoveNext/Current ownership, and no residual enumerator scaffold references.

Representative check:
- `ILInspector.Metadata.ApiSurfaceExtractor::Extract` now renders `foreach (TypeDefinitionHandle typeDefHandle in V_3)`, not `in ref V_3`.

Corpus quality diff (#1166/#1150 corpus, 14 assemblies, 88,050 methods):

```text
| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,376 (88.02%) | 77,505 (88.02%) | +129 |
| Conditional-branch residual | 2,298 (2.61%) | 2,294 (2.61%) | -4 |
| Forward-merge stops | 2,290 (2.61%) | 2,286 (2.60%) | -4 |
| Full malformed | 165 | 33 | -132 |
| Semantic defects | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 88,050 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 88,050 (0.01%) | 0 |
| Pass bugs | 0 | 0 | 0 |
```

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo -p:PublishAot=false`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- targeted `DecompilerHarness --dump ILInspector.Metadata.ApiSurfaceExtractor::Extract` grep for foreach headers
- `eng/prepare-decompiler-corpus.sh` + `DecompilerHarness --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3`