### PR TITLE
Add perf cues to member call graphs

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -35,6 +35,18 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void DirectCalls_MarksCallsInsideLoopRegions()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var call = Assert.Single(index.DirectCalls.Where(c =>
+            c.Caller.Name == nameof(CallSiteFixtures.CallsConsoleWriteLineInLoop)
+            && c.Callee.Name == nameof(CallSiteFixtures.CallsConsoleWriteLine)));
+
+        Assert.True(call.InLoop);
+    }
+
+    [Fact]
     public void MemberReferences_InstantiateGenericDeclaringTypeArguments()
     {
         var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
@@ -426,6 +438,12 @@ public class CallTreeTests
 public static class CallSiteFixtures
 {
     public static void CallsConsoleWriteLine() => Console.WriteLine("hello");
+
+    public static void CallsConsoleWriteLineInLoop(int iterations)
+    {
+        for (int i = 0; i < iterations; i++)
+            CallsConsoleWriteLine();
+    }
 
     public static string? CallsVirtualToString(object value) => value.ToString();
 

--- a/src/ILInspector.Analysis/CallTree.cs
+++ b/src/ILInspector.Analysis/CallTree.cs
@@ -32,4 +32,8 @@ public sealed record CallTreeNode(
     MemberRef Member,
     CallKind? Kind,
     CallTreeStatus Status,
-    ImmutableArray<CallTreeNode> Children);
+    ImmutableArray<CallTreeNode> Children,
+    CallTreePerf? Perf = null);
+
+/// <summary>Perf-triage cues surfaced for a call-graph node.</summary>
+public sealed record CallTreePerf(int Fanout, int Fanin, int MaxDepth, bool InLoop, string? LoopHint = null);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -127,16 +127,24 @@ public sealed class LibraryBodyIndex
                 : 0;
         }
 
-        CallTreeNode Build(MemberRef member, CallKind? kind, int token, int depth)
+        var incomingCounts = DirectCalls
+            .GroupBy(call => ResolveCallee(call))
+            .Where(group => group.Key != 0)
+            .ToDictionary(group => group.Key, group => group.Count(), EqualityComparer<int>.Default);
+
+        CallTreeNode Build(MemberRef member, CallKind? kind, int token, int depth, bool inLoop = false)
         {
             if (token == 0 || !callsByCaller.TryGetValue(token, out var edges))
-                return new CallTreeNode(member, kind, token == 0 && depth > 0 ? CallTreeStatus.External : CallTreeStatus.Leaf, []);
+            {
+                var leafStatus = token == 0 && depth > 0 ? CallTreeStatus.External : CallTreeStatus.Leaf;
+                return new CallTreeNode(member, kind, leafStatus, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incoming) ? incoming : 0, 1, inLoop, inLoop ? "loop" : null));
+            }
 
             if (depth >= maxDepth)
-                return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, []);
+                return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incomingDepth) ? incomingDepth : 0, 1, inLoop, inLoop ? "loop" : null));
 
             if (!expanded.Add(token))
-                return new CallTreeNode(member, kind, CallTreeStatus.AlreadyShown, []);
+                return new CallTreeNode(member, kind, CallTreeStatus.AlreadyShown, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incomingShown) ? incomingShown : 0, 1, inLoop, inLoop ? "loop" : null));
 
             var children = ImmutableArray.CreateBuilder<CallTreeNode>();
             bool truncated = false;
@@ -148,13 +156,16 @@ public sealed class LibraryBodyIndex
                     break;
                 }
                 created++;
-                children.Add(Build(edge.Callee, edge.Kind, ResolveCallee(edge), depth + 1));
+                children.Add(Build(edge.Callee, edge.Kind, ResolveCallee(edge), depth + 1, edge.InLoop));
             }
 
             var status = truncated
                 ? CallTreeStatus.Truncated
                 : children.Count == 0 ? CallTreeStatus.Leaf : CallTreeStatus.Expanded;
-            return new CallTreeNode(member, kind, status, children.ToImmutable());
+            var fanout = children.Count;
+            var maxTreeDepth = children.Count == 0 ? 1 : 1 + children.Max(child => child.Perf?.MaxDepth ?? 1);
+            var fanin = incomingCounts.TryGetValue(token, out var count) ? count : 0;
+            return new CallTreeNode(member, kind, status, children.ToImmutable(), new CallTreePerf(fanout, fanin, maxTreeDepth, inLoop, inLoop ? "loop" : null));
         }
 
         return Build(rootMember, null, rootMethodToken, 0);
@@ -233,8 +244,10 @@ public sealed class LibraryBodyIndex
                         var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
                         var il = body.GetILBytes() ?? [];
                         bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
+                        var loopRegions = CollectLoopRegions(il);
                         ScanBody(il, caller, scope, calls, unsafeEvidence,
-                            includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals);
+                            includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals,
+                            loopRegions);
                     }
                     catch (Exception ex) when (IsRecoverableMethodFailure(ex))
                     {
@@ -386,7 +399,8 @@ public sealed class LibraryBodyIndex
         void ScanBody(byte[] il, MethodIdentity caller, GenericScope callerScope,
             ImmutableArray<DirectCall>.Builder calls,
             ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence,
-            bool includeIndirectOpcodes)
+            bool includeIndirectOpcodes,
+            IReadOnlyList<(int Start, int End)> loopRegions)
         {
             int position = 0;
             while (position < il.Length)
@@ -403,7 +417,8 @@ public sealed class LibraryBodyIndex
                     {
                         int token = ReadInt32(il, ref position, offset);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
-                        calls.Add(new DirectCall(caller, callee, offset, token, ToCallKind(opcode)));
+                        bool inLoop = IsInLoopRegion(offset, loopRegions);
+                        calls.Add(new DirectCall(caller, callee, offset, token, ToCallKind(opcode), inLoop));
                         if (IsUnsafeCall(callee))
                         {
                             unsafeEvidence.Add(new UnsafeEvidence(
@@ -419,7 +434,7 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Calli:
                     {
                         int token = ReadInt32(il, ref position, offset);
-                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, token, CallKind.CallIndirect));
+                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, token, CallKind.CallIndirect, IsInLoopRegion(offset, loopRegions)));
                         unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", "calli", "calli", offset, token));
                         break;
                     }
@@ -429,6 +444,60 @@ public sealed class LibraryBodyIndex
                         SkipOperand(il, opcode, ref position, offset);
                         break;
                 }
+            }
+        }
+
+        IReadOnlyList<(int Start, int End)> CollectLoopRegions(byte[] il)
+        {
+            try
+            {
+                var regions = new List<(int Start, int End)>();
+                int position = 0;
+                while (position < il.Length)
+                {
+                    int offset = position;
+                    var opcode = ReadOpcode(il, ref position);
+                    if (TryReadBranchTarget(opcode, il, ref position, offset, out int target) && target < offset)
+                        regions.Add((target, offset));
+                    else
+                        SkipOperand(il, opcode, ref position, offset);
+                }
+                return regions;
+            }
+            catch (BadImageFormatException)
+            {
+                return [];
+            }
+        }
+
+        static bool IsInLoopRegion(int offset, IReadOnlyList<(int Start, int End)> regions)
+            => regions.Any(region => offset >= region.Start && offset <= region.End);
+
+        bool TryReadBranchTarget(ILOpCode opcode, byte[] il, ref int position, int offset, out int target)
+        {
+            target = -1;
+            switch (opcode)
+            {
+                case ILOpCode.Br_s:
+                    target = offset + 2 + (sbyte)ReadByte(il, ref position, offset);
+                    return true;
+                case ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s
+                    or ILOpCode.Bge_s or ILOpCode.Bgt_s or ILOpCode.Ble_s or ILOpCode.Blt_s
+                    or ILOpCode.Bne_un_s or ILOpCode.Bge_un_s or ILOpCode.Bgt_un_s
+                    or ILOpCode.Ble_un_s or ILOpCode.Blt_un_s or ILOpCode.Leave_s:
+                    target = offset + 2 + (sbyte)ReadByte(il, ref position, offset);
+                    return true;
+                case ILOpCode.Br:
+                    target = offset + 5 + ReadInt32(il, ref position, offset);
+                    return true;
+                case ILOpCode.Brfalse or ILOpCode.Brtrue or ILOpCode.Beq
+                    or ILOpCode.Bge or ILOpCode.Bgt or ILOpCode.Ble or ILOpCode.Blt
+                    or ILOpCode.Bne_un or ILOpCode.Bge_un or ILOpCode.Bgt_un
+                    or ILOpCode.Ble_un or ILOpCode.Blt_un or ILOpCode.Leave:
+                    target = offset + 5 + ReadInt32(il, ref position, offset);
+                    return true;
+                default:
+                    return false;
             }
         }
 
@@ -541,9 +610,10 @@ public sealed class LibraryBodyIndex
                 case ILOpCode.Switch:
                 {
                     int count = ReadInt32(il, ref position, offset);
-                    if (count < 0 || position + checked(count * 4) > il.Length)
+                    int operandBytes = count * 4;
+                    if (count < 0 || operandBytes < 0 || position + operandBytes > il.Length)
                         throw new BadImageFormatException($"Malformed switch at IL_{offset:X4} in method body from {_path}");
-                    position += count * 4;
+                    position += operandBytes;
                     break;
                 }
                 case ILOpCode.Br_s or ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -89,7 +89,8 @@ public sealed record DirectCall(
     MemberRef Callee,
     int ILOffset,
     int OperandToken,
-    CallKind Kind);
+    CallKind Kind,
+    bool InLoop = false);
 
 public sealed record UnsafeEvidence(
     MethodIdentity Member,

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -23,6 +23,19 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task CallGraphSection_RendersPerfCuesForFanoutDepthAndLoopingCalls()
+    {
+        var result = await RunCallGraphAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.LoopHeavyCall));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Call Graph", result.Output);
+        Assert.Contains("fanout", result.Output);
+        Assert.Contains("depth", result.Output);
+        Assert.Contains("loop", result.Output);
+    }
+
+    [Fact]
     public async Task CallGraphSection_RendersEmptyStateNote_WhenNoOutboundCalls()
     {
         var result = await RunCallGraphAsync(
@@ -92,6 +105,12 @@ public static class MemberCallGraphFixture
     public static void Mid() => Inner();
 
     public static void Inner() => Console.WriteLine("leaf");
+
+    public static void LoopHeavyCall()
+    {
+        for (int i = 0; i < 2; i++)
+            RootCall();
+    }
 
     public static void NoCalls()
     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1293,13 +1293,36 @@ public static class ApiOutputFormatter
     static string FormatCallGraphLabel(Analysis.CallTreeNode node)
     {
         string member = FormatCallee(node.Member);
-        return node.Status switch
+        var suffixes = new List<string>();
+
+        switch (node.Status)
         {
-            Analysis.CallTreeStatus.External => $"{member} (external)",
-            Analysis.CallTreeStatus.AlreadyShown => $"{member} (shown above)",
-            Analysis.CallTreeStatus.DepthLimited => $"{member} (…)",
-            _ => member,
-        };
+            case Analysis.CallTreeStatus.External:
+                suffixes.Add("external");
+                break;
+            case Analysis.CallTreeStatus.AlreadyShown:
+                suffixes.Add("shown above");
+                break;
+            case Analysis.CallTreeStatus.DepthLimited:
+                suffixes.Add("…");
+                break;
+        }
+
+        if (node.Perf is { } perf)
+        {
+            if (perf.Fanout > 0)
+                suffixes.Add($"fanout {perf.Fanout}");
+            if (perf.Fanin > 0)
+                suffixes.Add($"fanin {perf.Fanin}");
+            if (perf.MaxDepth > 1)
+                suffixes.Add($"depth {perf.MaxDepth}");
+            else if (perf.Fanout == 0 && perf.Fanin == 0 && suffixes.Count == 0)
+                suffixes.Add("depth 1");
+            if (perf.InLoop)
+                suffixes.Add(perf.LoopHint ?? "loop");
+        }
+
+        return suffixes.Count > 0 ? $"{member} ({string.Join(", ", suffixes)})" : member;
     }
 
     internal static void PopulateUnsafeMembers(TypeView view, ApiType type, string dllPath)


### PR DESCRIPTION
## Summary
- add loop-aware perf metadata for member call-tree nodes
- surface fanout/fanin/depth/loop cues in member call graphs
- add regression coverage for the analysis and CLI rendering paths

## Testing
- dotnet run --project src/ILInspector.Analysis.Tests -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.MemberCallGraphSectionTests"
- dotnet build src/dotnet-inspect -c Release

Fixes #1207