### PR TITLE
Clarify raw blob and bare output flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ configuration switches such as `FeatureSwitchDefinitionAttribute` and
 
 ## Output and querying
 
-Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--rows -n N` to cap rendered table rows, `--count` to count table rows in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
+Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload, `--rows -n N` to cap rendered table rows, `--count` for a bare row count in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
 
 Sections and fields are queryable without a template language:
 

--- a/docs/decompiler-ir-dumps.md
+++ b/docs/decompiler-ir-dumps.md
@@ -91,7 +91,7 @@ return value is null || value.Length == 0;
    names the culprit pass. Everything upstream of it is fine by construction.
 3. **Diff against the previous stage.** A pass that "did nothing" prints a tree
    identical to the stage above it — so a real change is visible as the delta
-   between two adjacent blocks. With `--raw` you can capture two runs (or two
+   between two adjacent blocks. With `--diff` you can capture two runs (or two
    methods) and diff them with your own tooling.
 4. **Check the fidelity footer.** `// fidelity: Full` means every construct was
    raised to representable C#. Anything lower means the tree carries an explicit

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -113,11 +113,11 @@ also have sections for documentation and safety evidence:
 and a safety row such as `safe`, `unsafe boundary`, or `unsafe`. Safety comments
 should come from the documentation block, not SourceLink URL inference.
 
-`--raw` is the right output shape when a caller wants section content without a
+`--bare` is the right output shape when a caller wants section content without a
 heading, table, or Markdown decoration. Today it is used by type/member code
 sections such as `Decompiled Source`, `Annotated Source`, `Original Source`, and
 `IL`. If `Documentation` returns the complete `///` block, it should follow the
-same single-section raw contract so users can redirect the exact comment block
+same single-section bare-output contract so users can redirect the exact comment block
 or feed it to downstream tools without Markout framing.
 
 ## PDB dependency

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -163,7 +163,7 @@
 | Persistent disk cache | aac88cc | 0.1.8 | Cache source content |
 | `--file` option | 1186bd7 | 0.4.4 | Retired with `samples --file` |
 | `--region` option | 1186bd7 | 0.4.4 | Retired with `samples --region` |
-| `--blob` | — | 0.15.0 | Use /blob/ URLs for browser viewing |
+| `--blob` | — | 0.13.0 | Use /blob/ URLs for browser viewing |
 | `--list` option | — | 0.2.x | Retired with `samples` |
 
 ## NuGet Sources
@@ -212,7 +212,7 @@
 | IL (Annotated) section | — | 0.3.x | IL with stack state annotations |
 | Decompiled Source mixed view | — | 0.11.x | Decompiled Source becomes a mixed C#+IL view with hidden-fact comments (allocations, unsafety, lifetime) |
 | Facts section | — | 0.11.x | Structured hidden-fact table for one method (`-S "Facts"` / `--tsv`) |
-| `library --il-offset` | — | 0.15.0 | Map MethodDef token + IL offset to source file location |
+| `library --il-offset` | — | 0.13.0 | Map MethodDef token + IL offset to source file location |
 
 ## Plugin and Integration
 

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -218,7 +218,7 @@ JsonSerializer.Helpers.cs
 Fetch selected member source text when source content is the desired artifact:
 
 ```bash
-dotnet-inspect member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source" --raw -n 20
+dotnet-inspect member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source" --bare -n 20
 ```
 
 ```expect

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.15.0
+version: 0.13.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, and API version diffs.
 ---
 
@@ -49,7 +49,7 @@ Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (wi
 
 ## Query and output
 
-Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON object per row, `--json` for structured documents, and `--mermaid` for graph-shaped output.
+Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON object per row, `--json` for structured documents, `--bare` for one undecorated payload, `--count` for a bare row count, and `--mermaid` for graph-shaped output.
 
 Use `-D` to discover sections/columns, `-S Section` to select sections by name or wildcard, and `--columns`/`--fields` to project values. Discover first instead of guessing names.
 
@@ -86,7 +86,7 @@ Use `diff --package Foo@old..new --breaking` for migration work, `--additive` fo
 
 For unsafe audits, start with `library MyLib.dll -S @Audit`, then drill into `member Type Method:1 --library MyLib.dll -S "Unsafe Operations,IL"`.
 
-Use `type Name -S "Decompiled Source" --raw` for a whole-type C# listing. Use `library Foo --il-offset 0x06000001+0x5` for crash diagnostics with MethodDef token plus IL offset. If decompiled output looks wrong, capture `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`; maintainers diagnose pipeline state with DecompilerHarness.
+Use `type Name -S "Decompiled Source" --bare` for a whole-type C# listing. SourceLink URLs default to raw/fetchable form; add `--blob` for browser URLs. Use `library Foo --il-offset 0x06000001+0x5` for crash diagnostics with MethodDef token plus IL offset. If decompiled output looks wrong, capture `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`; maintainers diagnose pipeline state with DecompilerHarness.
 
 ## General tips
 

--- a/src/DotnetInspector.Services/GitHubUrlResolver.cs
+++ b/src/DotnetInspector.Services/GitHubUrlResolver.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace DotnetInspector.Services;
 
 /// <summary>
@@ -5,6 +7,10 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class GitHubUrlResolver
 {
+    private static readonly Regex GitHubFileUrlRegex = new(
+        @"https://github\.com/([^/\s)]+/[^/\s)]+)/(?<kind>blob|raw)/([^/\s)]+)/([^\s)]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     /// <summary>
     /// Resolves a relative sample path to a full URL based on the source file URL.
     /// </summary>
@@ -85,5 +91,33 @@ public static class GitHubUrlResolver
         }
 
         return url.Replace("/raw/", "/blob/", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Converts GitHub browser/raw URLs to raw.githubusercontent.com URLs for
+    /// agent-friendly content fetching.
+    /// </summary>
+    public static string ConvertBlobToRawUrl(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || !uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+            return url;
+
+        var parts = uri.AbsolutePath.TrimStart('/').Split('/', 5);
+        if (parts.Length == 5
+            && (parts[2].Equals("blob", StringComparison.OrdinalIgnoreCase)
+                || parts[2].Equals("raw", StringComparison.OrdinalIgnoreCase)))
+            return $"https://raw.githubusercontent.com/{parts[0]}/{parts[1]}/{parts[3]}/{parts[4]}";
+
+        return url;
+    }
+
+    /// <summary>
+    /// Normalizes GitHub file links in markdown/content from blob pages to raw
+    /// file URLs. This is safe for images because blob-to-raw improves fetchability.
+    /// </summary>
+    public static string NormalizeGitHubFileLinksToRaw(string content)
+    {
+        return GitHubFileUrlRegex.Replace(content, match => ConvertBlobToRawUrl(match.Value));
     }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -949,6 +949,17 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task BrowsableUrlsAlias_Removed()
+    {
+        var (exit, _, error) = await RunAppAsync(
+            "member", "JsonConvert", "--package", "Newtonsoft.Json@13.0.4",
+            "-m", "SerializeObject", "-S", "Source Locations", "--browsable-urls", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Unrecognized option '--browsable-urls'", error);
+    }
+
+    [Fact]
     public async Task Type_ExactPlatformAssembly_DoesNotUseWidePlatformPrefixBrowse()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -1605,6 +1616,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_RawOverridesBlob()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonConvert", "--package", "Newtonsoft.Json@13.0.4",
+            "-m", "SerializeObject", "-S", "Source Locations", "--blob", "--raw", "--tsv", "--no-headers", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("raw.githubusercontent.com/JamesNK/Newtonsoft.Json", output);
+        Assert.DoesNotContain("github.com/JamesNK/Newtonsoft.Json/blob/", output);
+    }
+
+    [Fact]
     public async Task Member_SourceLocations_Discovery_DoesNotAcquirePdb()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -2005,7 +2029,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
-            "CallsInterfaceItem", "-S", "Decompiled Source", "--raw");
+            "CallsInterfaceItem", "-S", "Decompiled Source", "--bare");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -2310,7 +2334,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "type", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
-            "-S", "Decompiled Source", "--raw");
+            "-S", "Decompiled Source", "--bare");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -2353,7 +2377,7 @@ public class CommandExecutionTests
         // defining assembly.
         var (exit, output, error) = await RunAppAsync(
             "type", "System.DayOfWeek", "--platform", "System.Runtime",
-            "-S", "Decompiled Source", "--raw");
+            "-S", "Decompiled Source", "--bare");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -2363,11 +2387,11 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_DecompiledSource_Raw_EmitsBareListing()
+    public async Task Type_DecompiledSource_Bare_EmitsBareListing()
     {
         var (exit, output, error) = await RunAppAsync(
             "type", "System.Collections.Generic.Stack", "--platform", "System.Collections",
-            "-S", "Decompiled Source", "--raw");
+            "-S", "Decompiled Source", "--bare");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -5050,6 +5074,50 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_Readme_DefaultNormalizesGithubBlobLinksToRaw()
+    {
+        const string readme = """
+            [code](https://github.com/owner/repo/blob/main/src/File.cs)
+            ![image](https://github.com/owner/repo/blob/main/images/logo.png)
+            """;
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Readme.RawLinks", "README.md", readme);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "--readme");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("https://raw.githubusercontent.com/owner/repo/main/src/File.cs", output);
+            Assert.Contains("https://raw.githubusercontent.com/owner/repo/main/images/logo.png", output);
+            Assert.DoesNotContain("github.com/owner/repo/blob", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_Readme_BlobLeavesMarkdownLinksVerbatim()
+    {
+        const string readme = "[code](https://github.com/owner/repo/blob/main/src/File.cs)";
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Readme.BlobLinks", "README.md", readme);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "--readme", "--blob");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("https://github.com/owner/repo/blob/main/src/File.cs", output);
+            Assert.DoesNotContain("raw.githubusercontent.com", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_ReadmeInfo_RecordsSelectedReadmeProvenance()
     {
         var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Info", "README.md", "readme", "agents");
@@ -5650,6 +5718,29 @@ public class CommandExecutionTests
             Assert.Empty(error);
             Assert.Contains("# Agent guidance", output);
             Assert.DoesNotContain("# README body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Project_Readme_NormalizesGithubBlobLinksToRaw()
+    {
+        const string agents = "See https://github.com/owner/repo/blob/main/docs/guide.md";
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.RawLinks", "1.0.0", "README.md", "readme", agents));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--readme", "Test.Project.RawLinks");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.Contains("https://raw.githubusercontent.com/owner/repo/main/docs/guide.md", output);
+            Assert.DoesNotContain("github.com/owner/repo/blob", output);
         }
         finally
         {

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -84,6 +84,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(typeFilterOption);
         typeCommand.Options.Add(opts.Json);
         typeCommand.Options.Add(compactOption);
+        typeCommand.Options.Add(opts.RawUrls);
         typeCommand.Options.Add(opts.BrowsableUrls);
         opts.AddTableOptionsTo(typeCommand);
         typeCommand.Options.Add(shapeOption);
@@ -94,7 +95,7 @@ public static class ApiCommandDefinitions
         opts.AddCountOptionTo(typeCommand);
         typeCommand.Options.Add(opts.Markdown);
         typeCommand.Options.Add(opts.PlainText);
-        typeCommand.Options.Add(opts.Raw);
+        typeCommand.Options.Add(opts.Bare);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 
@@ -209,6 +210,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(opts.Limit);
         memberCommand.Options.Add(opts.Json);
         memberCommand.Options.Add(compactOption);
+        memberCommand.Options.Add(opts.RawUrls);
         memberCommand.Options.Add(opts.BrowsableUrls);
         opts.AddTableOptionsTo(memberCommand);
         memberCommand.Options.Add(unsafeOption);
@@ -222,7 +224,7 @@ public static class ApiCommandDefinitions
         opts.AddCountOptionTo(memberCommand);
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
-        memberCommand.Options.Add(opts.Raw);
+        memberCommand.Options.Add(opts.Bare);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);
 

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -136,6 +136,7 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(asmTfmOption);
         assemblyCommand.Options.Add(typeFilterOption);
         assemblyCommand.Options.Add(ilOffsetOption);
+        assemblyCommand.Options.Add(opts.RawUrls);
         assemblyCommand.Options.Add(opts.BrowsableUrls);
         assemblyCommand.Options.Add(extractResourcesOption);
         opts.AddAllOptionsTo(assemblyCommand);
@@ -205,7 +206,8 @@ public static class InspectionCommandDefinitions
                 Tfm = parseResult.GetValue(asmTfmOption),
                 TypeFilter = typeFilter,
                 ILOffset = parseResult.GetValue(ilOffsetOption),
-                BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls),
+                BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
+                    && !parseResult.GetValue(opts.RawUrls),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 Markdown = parseResult.GetValue(opts.Markdown),
                 PlainText = parseResult.GetValue(opts.PlainText),

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -82,6 +82,7 @@ public static class PackageCommandDefinitions
         packageCommand.Options.Add(typeFilterOption);
         packageCommand.Options.Add(versionOption);
         packageCommand.Options.Add(latestVersionOption);
+        packageCommand.Options.Add(opts.RawUrls);
         packageCommand.Options.Add(opts.BrowsableUrls);
         packageCommand.Options.Add(outOption);
         opts.AddTableOptionsTo(packageCommand);

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -228,7 +228,8 @@ public static class MemberOptionsParser
             Limit = memberLimit,
             ShowDocs = true,  // Docs always on (local XML); use source command for SourceLink
             DocsExplicitlySet = false,
-            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls),
+            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
+                && !parseResult.GetValue(opts.RawUrls),
             JsonOutput = parseResult.GetValue(opts.Json),
             CompactJson = parseResult.GetValue(args.CompactOption),
             OneLine = opts.ResolveOneLine(parseResult),
@@ -237,7 +238,7 @@ public static class MemberOptionsParser
             OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             PlainText = parseResult.GetValue(opts.PlainText),
-            Raw = parseResult.GetValue(opts.Raw),
+            Bare = parseResult.GetValue(opts.Bare),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             UnsafeOnly = parseResult.GetValue(args.UnsafeOption),
             CtorOnly = ctorOnly,

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -145,7 +145,8 @@ public static class PackageOptionsParser
             OneLine = opts.ResolveOneLine(parseResult),
             Tsv = opts.ResolveTsv(parseResult),
             Jsonl = opts.ResolveJsonl(parseResult),
-            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls),
+            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
+                && !parseResult.GetValue(opts.RawUrls),
             OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             NoHeader = parseResult.GetValue(opts.NoHeaders),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -125,7 +125,8 @@ public static class TypeOptionsParser
             Limit = memberLimit ?? typeLimit,
             ShowDocs = false,  // Type command: docs off by default
             DocsExplicitlySet = false,
-            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls),
+            BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
+                && !parseResult.GetValue(opts.RawUrls),
             JsonOutput = parseResult.GetValue(opts.Json),
             CompactJson = parseResult.GetValue(args.CompactOption),
             OneLine = opts.ResolveOneLine(parseResult),
@@ -135,7 +136,7 @@ public static class TypeOptionsParser
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
             PlainText = parseResult.GetValue(opts.PlainText),
-            Raw = parseResult.GetValue(opts.Raw),
+            Bare = parseResult.GetValue(opts.Bare),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             ShapeOutput = parseResult.GetValue(args.ShapeOption),
             ShapeExplicitlySet = parseResult.GetResult(args.ShapeOption) is { Implicit: false },

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -668,9 +668,9 @@ public class ApiCommand
             }
         }
 
-        // --raw: only the selected code section's content — no heading, no
+        // --bare: only the selected code section's content — no heading, no
         // fence — suitable for redirecting to a .cs/.il file.
-        if (options.Raw)
+        if (options.Bare)
         {
             var raw = options.IncludeSections is { Count: 1 } included
                 ? included.First() switch
@@ -685,7 +685,7 @@ public class ApiCommand
             if (raw is null)
             {
                 Console.Error.WriteLine(
-                    "Error: --raw requires a single -S code section with content (Decompiled Source, Annotated Source, IL, Original Source).");
+                    "Error: --bare requires a single -S code section with content (Decompiled Source, Annotated Source, IL, Original Source).");
                 return;
             }
             sink.WriteLine(raw.TrimEnd());

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1104,7 +1104,13 @@ public class PackageCommand
             ? PackageFileLister.Filter(files, "@readme")
             : FilterPackageFiles(files, options);
         var contents = selectedFiles
-            .Select(file => ReadPackageFileContent(extractPath, packageName, version, file, options.ContentScope))
+            .Select(file => ReadPackageFileContent(
+                extractPath,
+                packageName,
+                version,
+                file,
+                options.ContentScope,
+                normalizeGithubLinksToRaw: !options.BrowsableUrls))
             .ToList();
         return new PackageFileContentSet(packageName, version, contents);
     }
@@ -1114,10 +1120,13 @@ public class PackageCommand
         string packageName,
         string version,
         PackageFile file,
-        PackageFileContentScope scope)
+        PackageFileContentScope scope,
+        bool normalizeGithubLinksToRaw)
     {
         var fullPath = Path.Combine(extractPath, file.Path.Replace('/', Path.DirectorySeparatorChar));
         var content = MarkdownContent.ApplyScope(File.ReadAllText(fullPath), scope);
+        if (normalizeGithubLinksToRaw)
+            content = GitHubUrlResolver.NormalizeGitHubFileLinksToRaw(content);
         return new PackageFileContent(packageName, version, file.Path, file.Size, Found: true, content);
     }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -261,7 +261,8 @@ public class ProjectCommand
         if (!File.Exists(fullPath))
             return null;
 
-        var content = MarkdownContent.ApplyScope(File.ReadAllText(fullPath), scope);
+        var content = GitHubUrlResolver.NormalizeGitHubFileLinksToRaw(
+            MarkdownContent.ApplyScope(File.ReadAllText(fullPath), scope));
         return new ProjectPackageDocument(
             dependency.PackageName,
             dependency.Version,

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -48,7 +48,7 @@ public partial record ApiOptions
 
     /// <summary>Print only the selected section's content with no heading,
     /// fence, or tips — suitable for redirecting code sections to files.</summary>
-    public bool Raw { get; init; }
+    public bool Bare { get; init; }
 
     /// <summary>
     /// True when the user explicitly chose an output format via CLI flags.
@@ -101,7 +101,7 @@ public partial record ApiOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public virtual bool IsRawOutput => Raw || JsonOutput || OneLine || Jsonl || NoHeader || Count;
+    public virtual bool IsRawOutput => Bare || JsonOutput || OneLine || Jsonl || NoHeader || Count;
 }
 
 /// <summary>
@@ -142,7 +142,7 @@ public record TypeOptions : ApiOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public override bool IsRawOutput => Raw || JsonOutput || OneLine || Jsonl || NoHeader || ShapeOutput || Count;
+    public override bool IsRawOutput => Bare || JsonOutput || OneLine || Jsonl || NoHeader || ShapeOutput || Count;
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -17,7 +17,8 @@ public class SharedOptions
     public Option<bool> Json { get; } = new("--json") { Description = "Output as JSON" };
     public Option<bool> Markdown { get; } = new("--markdown") { Description = "Output as markdown" };
     public Option<bool> PlainText { get; } = new("--plaintext") { Description = "Output as plain text" };
-    public Option<bool> Raw { get; } = new("--raw") { Description = "Print only the selected section's content, undecorated (single -S code section; e.g. redirect Decompiled Source to a .cs file)" };
+    public Option<bool> Bare { get; } = new("--bare") { Description = "Print only the selected payload, undecorated (single -S content section; e.g. redirect Decompiled Source to a .cs file)" };
+    public Option<bool> RawUrls { get; } = new("--raw") { Description = "Emit raw/fetchable GitHub URLs (default; pairs with --blob)" };
     public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Use GitHub /blob/ URLs for browser viewing (default: raw URLs for agents)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
@@ -108,7 +109,6 @@ public class SharedOptions
 
         NoHeaders.Aliases.Add("--no-header");
         NoHeaders.Aliases.Add("--nh");
-        BrowsableUrls.Aliases.Add("--browsable-urls");
     }
 
     /// <summary>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,9 +1,14 @@
 # Release Notes
 
-## v0.15.0
+## v0.13.0
 
 ### SourceLink section consolidation
 
+- Renames the undecorated single-section output mode from `--raw` to `--bare`;
+  `--raw` now names the default raw/fetchable GitHub URL shape and pairs with
+  `--blob`.
+- Normalizes GitHub file links in package README/content output from `blob` to
+  raw URLs in the default agent-friendly URL mode.
 - Removes the standalone `source` command. Use `package`, `library`, and `type`
   `-S "Source Files"` for type-to-SourceLink URL rows, and use `member -S
   "Source Locations"` / `member -S "Original Source"` for member-level source
@@ -12,8 +17,6 @@
   symbolication.
 - Adds `--blob` as the GitHub browser URL toggle for SourceLink URL sections.
 - Adds `-t` type filtering to `package`/`library -S "Source Files"`.
-
-## v0.14.0
 
 ### SourceLink member locations
 
@@ -26,8 +29,6 @@
   locations so blank cells only mean the end line is unknown.
 - Keeps `Member Index` focused on selector/query columns while moving
   source-location evidence to the dedicated source section.
-
-## v0.13.0
 
 ### Package documentation and project grounding
 


### PR DESCRIPTION
## Summary
- rename undecorated single-section output from `--raw` to `--bare`
- make `--raw` the default/fetchable GitHub URL shape and keep `--blob` for browser URLs
- remove the `--browsable-urls` alias
- normalize GitHub `blob` file links in package/project README content to raw URLs in default agent mode, while `--blob` leaves README content verbatim
- keep package version/SKILL version at `0.13.0` and update docs/release notes

## Related
- Refs #1211

## Validation
- npx markdownlint-cli README.md skills/dotnet-inspect/SKILL.md docs/sourcelink-exposure.md docs/workflows/getting-started/lap-around.md docs/decompiler-ir-dumps.md src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release
- focused dotnet-inspect.Tests methods for `--bare`, `--raw`/`--blob`, removed `--browsable-urls`, and README blob-to-raw normalization
- dotnet run --project src/dotnet-inspect.Tests -c Release (local environment still has the existing preview-runtime failures in `PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies` and `CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute`; no #1211 failures)
