### PR TITLE
Emit per-method corpus delta artifacts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -40,6 +40,8 @@
   <ItemGroup>
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMetadata.cs"
              Link="CorpusMetadata.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodIdentity.cs"
+             Link="CorpusMethodIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"

--- a/tools/DecompilerHarness/CorpusMethodIdentity.cs
+++ b/tools/DecompilerHarness/CorpusMethodIdentity.cs
@@ -5,7 +5,10 @@ namespace ILInspector.DecompilerHarness;
 static class CorpusMethodIdentity
 {
     public static string SignatureText(MethodSignature signature)
-        => $"({string.Join(", ", signature.Parameters.Select(p => TypeText(p.Type)))}) -> {TypeText(signature.ReturnType)}";
+    {
+        string arity = signature.GenericParameterCount == 0 ? "" : $"`{signature.GenericParameterCount}";
+        return $"{arity}({string.Join(", ", signature.Parameters.Select(p => TypeText(p.Type)))}) -> {TypeText(signature.ReturnType)}";
+    }
 
     static string TypeText(TypeRef type) => type.Kind switch
     {

--- a/tools/DecompilerHarness/CorpusMethodIdentity.cs
+++ b/tools/DecompilerHarness/CorpusMethodIdentity.cs
@@ -1,0 +1,38 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+static class CorpusMethodIdentity
+{
+    public static string SignatureText(MethodSignature signature)
+        => $"({string.Join(", ", signature.Parameters.Select(p => TypeText(p.Type)))}) -> {TypeText(signature.ReturnType)}";
+
+    static string TypeText(TypeRef type) => type.Kind switch
+    {
+        TypeRefKind.Definition => NamedTypeText(type),
+        TypeRefKind.GenericInstance => $"{TypeText(type.ElementType!)}<{string.Join(", ", type.TypeArguments.Select(TypeText))}>",
+        TypeRefKind.SzArray => $"{TypeText(type.ElementType!)}[]",
+        TypeRefKind.Array => $"{TypeText(type.ElementType!)}[{new string(',', type.Rank - 1)}]",
+        TypeRefKind.ByRef => $"ref {TypeText(type.ElementType!)}",
+        TypeRefKind.Pointer => $"{TypeText(type.ElementType!)}*",
+        TypeRefKind.Pinned => $"pinned {TypeText(type.ElementType!)}",
+        TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
+        TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+        TypeRefKind.FunctionPointer => FunctionPointerText(type),
+        TypeRefKind.Unsupported => $"<unsupported:{type.UnsupportedReason}>",
+        _ => type.ToDisplayString(),
+    };
+
+    static string NamedTypeText(TypeRef type)
+    {
+        string ns = type.Namespace.Length == 0 ? "" : $"{type.Namespace}.";
+        return $"{type.Assembly}:{ns}{type.Name}";
+    }
+
+    static string FunctionPointerText(TypeRef type)
+    {
+        var parts = type.TypeArguments.Select(TypeText).Append(TypeText(type.ElementType!));
+        string convention = type.CallingConvention.Length == 0 ? "" : $" {type.CallingConvention}";
+        return $"delegate*{convention}<{string.Join(", ", parts)}>";
+    }
+}

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -24,6 +24,7 @@ internal static class CorpusSensor
         int maxExamples,
         string? emitBaseline,
         string? diffBaseline,
+        string? emitDelta,
         bool qualityDiffCard = false,
         bool qualityCardRisky = false,
         int methodCap = int.MaxValue)
@@ -43,6 +44,11 @@ internal static class CorpusSensor
         if (qualityDiffCard && diffBaseline is null)
         {
             Console.Error.WriteLine("--quality-diff-card requires --diff-corpus-baseline <file>.");
+            return 1;
+        }
+        if (emitDelta is not null && diffBaseline is null)
+        {
+            Console.Error.WriteLine("--emit-corpus-delta requires --diff-corpus-baseline <file>.");
             return 1;
         }
 
@@ -67,9 +73,23 @@ internal static class CorpusSensor
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
             ?? throw new InvalidOperationException($"Could not read corpus baseline '{diffBaseline}'.");
         var regressions = Compare(baseline, current);
+        if (emitDelta is not null)
+        {
+            EmitMethodDelta(emitDelta, baseline, current);
+            if (!qualityDiffCard)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Wrote per-method corpus delta: {emitDelta}");
+            }
+        }
         if (qualityDiffCard)
         {
             PrintQualityDiffCard(baseline, current, regressions, qualityCardRisky);
+            if (emitDelta is not null)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Per-method delta artifact: `{emitDelta}`");
+            }
             return regressions.Length == 0 ? 0 : 1;
         }
 
@@ -95,9 +115,10 @@ internal static class CorpusSensor
         int methodCap)
     {
         var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap);
-        var validity = AnalyzeValidity(assemblies, validityCompileCap);
+        var methods = completeness.Methods.ToDictionary(MethodKey, StringComparer.Ordinal);
+        var validity = AnalyzeValidity(assemblies, validityCompileCap, methods);
         var structuring = AnalyzeStructuring(assemblies, methodCap);
-        var fidelity = AnalyzeFidelity(assemblies, fidelityCompileCap);
+        var fidelity = AnalyzeFidelity(assemblies, fidelityCompileCap, methods);
         var totalMethods = completeness.Assemblies.Sum(assembly => assembly.TotalMethods);
         var fullyRaisedMethods = completeness.FullyRaisedMethods;
         var conditionalBranchMethods = completeness.ResidualBuckets.GetValueOrDefault(ConditionalBranchBucket);
@@ -128,6 +149,7 @@ internal static class CorpusSensor
             MethodCap: methodCap == int.MaxValue ? null : methodCap,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: completeness.Assemblies,
+            Methods: methods.Values.OrderBy(MethodKey, StringComparer.Ordinal).ToImmutableArray(),
             Metrics: metrics);
     }
 
@@ -135,6 +157,7 @@ internal static class CorpusSensor
     {
         var residualBuckets = new Dictionary<string, int>(StringComparer.Ordinal);
         var assemblyReports = ImmutableArray.CreateBuilder<CorpusAssemblySnapshot>();
+        var methodReports = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>();
         int fullyRaised = 0, passBugs = 0;
 
         using var metadata = CorpusMetadata.Create(assemblies);
@@ -142,27 +165,49 @@ internal static class CorpusSensor
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             int methods = 0;
-            foreach (var (_, _, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
+            string portablePath = PortablePath(assemblyPath);
+            var overloads = new Dictionary<(string Type, string Method), int>();
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
             {
+                int overload = overloads.GetValueOrDefault((typeName, methodName));
+                overloads[(typeName, methodName)] = overload + 1;
                 methods++;
+                string? residual = null;
+                string? passBug = null;
                 try
                 {
                     IrPasses.Run(function);
                 }
-                catch
+                catch (Exception ex)
                 {
                     passBugs++;
-                    continue;
+                    passBug = ex.GetType().Name;
                 }
 
-                string? residual = Completeness.Residual(function)
-                    ?? (function.Fidelity != DecompilationFidelity.Full
-                        ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}"
-                        : null);
+                if (passBug is null)
+                {
+                    residual = Completeness.Residual(function)
+                        ?? (function.Fidelity != DecompilationFidelity.Full
+                            ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}"
+                            : null);
+                }
                 if (residual is null)
                     fullyRaised++;
                 else
                     residualBuckets[residual] = residualBuckets.GetValueOrDefault(residual) + 1;
+                methodReports.Add(new CorpusMethodSnapshot(
+                    source.AssemblyName,
+                    portablePath,
+                    typeName,
+                    methodName,
+                    overload,
+                    SignatureText(function),
+                    function.Fidelity.ToString(),
+                    residual is null && passBug is null,
+                    residual,
+                    passBug,
+                    Validity: "not-sampled",
+                    FidelityCheck: "not-sampled"));
             }
             assemblyReports.Add(new CorpusAssemblySnapshot(source.AssemblyName, PortablePath(assemblyPath), methods));
         }
@@ -171,15 +216,29 @@ internal static class CorpusSensor
             assemblyReports.ToImmutable(),
             fullyRaised,
             passBugs,
-            residualBuckets);
+            residualBuckets,
+            methodReports.ToImmutable());
     }
 
-    static ValiditySensorMetrics AnalyzeValidity(IReadOnlyList<string> assemblies, int cap)
+    static ValiditySensorMetrics AnalyzeValidity(
+        IReadOnlyList<string> assemblies,
+        int cap,
+        Dictionary<string, CorpusMethodSnapshot> methods)
     {
         if (cap <= 0)
             return new ValiditySensorMetrics(0, 0, 0);
 
-        var results = assemblies.SelectMany(assembly => ValidityCheck.Evaluate(assembly, cap)).ToArray();
+        var results = new List<ValidityCheck.MethodResult>();
+        foreach (var assembly in assemblies)
+        {
+            var portablePath = PortablePath(assembly);
+            foreach (var result in ValidityCheck.Evaluate(assembly, cap))
+            {
+                results.Add(result);
+                foreach (var key in WeakMethodKeys(portablePath, result.TypeName, result.MethodName, methods))
+                    methods[key] = methods[key] with { Validity = ValidityStatus(result) };
+            }
+        }
         return new ValiditySensorMetrics(
             results.Count(result => result.IsFull && result.IsMalformed),
             results.Count(result => result.SemanticChecked),
@@ -226,9 +285,23 @@ internal static class CorpusSensor
         return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons);
     }
 
-    static FidelitySensorMetrics AnalyzeFidelity(IReadOnlyList<string> assemblies, int cap)
+    static FidelitySensorMetrics AnalyzeFidelity(
+        IReadOnlyList<string> assemblies,
+        int cap,
+        Dictionary<string, CorpusMethodSnapshot> methods)
     {
-        var results = FidelityCheck.Evaluate(assemblies, cap, lowered: false);
+        var results = new List<FidelityCheck.CompileBackResult>();
+        foreach (var assembly in assemblies)
+        {
+            var portablePath = PortablePath(assembly);
+            foreach (var result in FidelityCheck.Evaluate([assembly], cap, lowered: false))
+            {
+                results.Add(result);
+                string key = MethodKey(portablePath, result.Type, result.Method, result.Overload);
+                if (methods.TryGetValue(key, out var method))
+                    methods[key] = method with { FidelityCheck = result.Status.ToString() };
+            }
+        }
         return new FidelitySensorMetrics(
             results.Count,
             results.Count(result => result.Status == FidelityCheck.CompileBackStatus.Exact),
@@ -250,6 +323,40 @@ internal static class CorpusSensor
         }
         return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
+
+    static string SignatureText(IrFunction function)
+        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
+
+    static string MethodKey(CorpusMethodSnapshot method)
+        => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Overload);
+
+    static string MethodKey(string assemblyPath, string type, string method, int overload)
+        => $"{assemblyPath}!{type}::{method}#{overload}";
+
+    static IEnumerable<string> WeakMethodKeys(
+        string assemblyPath,
+        string type,
+        string method,
+        IReadOnlyDictionary<string, CorpusMethodSnapshot> methods)
+        => methods
+            .Where(kvp => kvp.Value.AssemblyPath == assemblyPath
+                && kvp.Value.Type == type
+                && kvp.Value.Method == method)
+            .Select(kvp => kvp.Key);
+
+    static string ValidityStatus(ValidityCheck.MethodResult result)
+    {
+        if (result.IsMalformed)
+            return $"{(result.IsFull ? "full" : "partial")}-malformed:{Codes(result.MalformedDiagnostics)}";
+        if (result.SemanticChecked)
+            return result.HasSemanticDefect
+                ? $"semantic-defect:{Codes(result.SemanticDiagnostics)}"
+                : "valid";
+        return "syntax-valid";
+    }
+
+    static string Codes(IEnumerable<ValidityCheck.ValidityDiagnostic> diagnostics)
+        => string.Join(",", diagnostics.Select(d => d.Id).Distinct().Order(StringComparer.Ordinal));
 
     static string PortablePath(string path)
     {
@@ -305,6 +412,72 @@ internal static class CorpusSensor
         }
 
         return failures.ToImmutable();
+    }
+
+    static void EmitMethodDelta(string path, CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".");
+        var baselineMethods = (baseline.Methods ?? []).ToDictionary(MethodKey, StringComparer.Ordinal);
+        var currentMethods = (current.Methods ?? []).ToDictionary(MethodKey, StringComparer.Ordinal);
+        var rows = ImmutableArray.CreateBuilder<CorpusMethodDeltaRow>();
+        foreach (var key in baselineMethods.Keys.Union(currentMethods.Keys).Order(StringComparer.Ordinal))
+        {
+            baselineMethods.TryGetValue(key, out var before);
+            currentMethods.TryGetValue(key, out var after);
+            var deltas = MethodDeltas(before, after);
+            if (deltas.Length == 0)
+                continue;
+            rows.Add(new CorpusMethodDeltaRow(
+                Method: after?.DisplayMethod ?? before?.DisplayMethod ?? key,
+                Assembly: after?.Assembly ?? before?.Assembly ?? "",
+                AssemblyPath: after?.AssemblyPath ?? before?.AssemblyPath ?? "",
+                Type: after?.Type ?? before?.Type ?? "",
+                MethodName: after?.Method ?? before?.Method ?? "",
+                Overload: after?.Overload ?? before?.Overload ?? 0,
+                Signature: after?.Signature ?? before?.Signature ?? "",
+                Baseline: before,
+                Current: after,
+                Deltas: deltas));
+        }
+        var artifact = new CorpusMethodDeltaArtifact(
+            SchemaVersion: 1,
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            BaselineGeneratedUtc: baseline.GeneratedUtc,
+            CurrentGeneratedUtc: current.GeneratedUtc,
+            BaselineHasMethodDetails: baseline.Methods is not null,
+            CurrentHasMethodDetails: current.Methods is not null,
+            ChangedMethods: rows.ToImmutable());
+        File.WriteAllText(path, JsonSerializer.Serialize(artifact, JsonOptions()));
+    }
+
+    static ImmutableArray<string> MethodDeltas(CorpusMethodSnapshot? before, CorpusMethodSnapshot? after)
+    {
+        if (before is null && after is null)
+            return [];
+        var deltas = ImmutableArray.CreateBuilder<string>();
+        if (before is null)
+        {
+            deltas.Add("added");
+            return deltas.ToImmutable();
+        }
+        if (after is null)
+        {
+            deltas.Add("removed");
+            return deltas.ToImmutable();
+        }
+        Add("fidelity", before.Fidelity, after.Fidelity);
+        Add("fullyRaised", before.FullyRaised, after.FullyRaised);
+        Add("residual", before.Residual, after.Residual);
+        Add("validity", before.Validity, after.Validity);
+        Add("fidelityCheck", before.FidelityCheck, after.FidelityCheck);
+        Add("passBug", before.PassBug, after.PassBug);
+        return deltas.ToImmutable();
+
+        void Add<T>(string name, T? oldValue, T? newValue)
+        {
+            if (!EqualityComparer<T?>.Default.Equals(oldValue, newValue))
+                deltas.Add(name);
+        }
     }
 
     static void AddCountRegression(ImmutableArray<string>.Builder failures, string name, int baseline, int current, int tolerance)
@@ -505,6 +678,7 @@ internal sealed record CorpusSensorSnapshot(
     int? MethodCap,
     CorpusSensorTolerances? Tolerances,
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,
+    IReadOnlyList<CorpusMethodSnapshot>? Methods,
     CorpusSensorMetrics Metrics);
 
 internal sealed record CorpusAssemblySnapshot(string Assembly, string Path, int TotalMethods);
@@ -513,7 +687,46 @@ internal sealed record CompletenessSensorMetrics(
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,
     int FullyRaisedMethods,
     int PassBugs,
-    IReadOnlyDictionary<string, int> ResidualBuckets);
+    IReadOnlyDictionary<string, int> ResidualBuckets,
+    IReadOnlyList<CorpusMethodSnapshot> Methods);
+
+internal sealed record CorpusMethodSnapshot(
+    string Assembly,
+    string AssemblyPath,
+    string Type,
+    string Method,
+    int Overload,
+    string Signature,
+    string Fidelity,
+    bool FullyRaised,
+    string? Residual,
+    string? PassBug,
+    string Validity,
+    string FidelityCheck)
+{
+    public string DisplayMethod => $"{Assembly}!{Type}::{Method}#{Overload}";
+}
+
+internal sealed record CorpusMethodDeltaArtifact(
+    int SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    DateTimeOffset BaselineGeneratedUtc,
+    DateTimeOffset CurrentGeneratedUtc,
+    bool BaselineHasMethodDetails,
+    bool CurrentHasMethodDetails,
+    IReadOnlyList<CorpusMethodDeltaRow> ChangedMethods);
+
+internal sealed record CorpusMethodDeltaRow(
+    string Method,
+    string Assembly,
+    string AssemblyPath,
+    string Type,
+    string MethodName,
+    int Overload,
+    string Signature,
+    CorpusMethodSnapshot? Baseline,
+    CorpusMethodSnapshot? Current,
+    IReadOnlyList<string> Deltas);
 
 internal sealed record ValiditySensorMetrics(
     int FullMalformedMethods,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -235,8 +235,9 @@ internal static class CorpusSensor
             foreach (var result in ValidityCheck.Evaluate(assembly, cap))
             {
                 results.Add(result);
-                foreach (var key in WeakMethodKeys(portablePath, result.TypeName, result.MethodName, methods))
-                    methods[key] = methods[key] with { Validity = ValidityStatus(result) };
+                string key = MethodKey(portablePath, result.TypeName, result.MethodName, result.Signature);
+                if (methods.TryGetValue(key, out var method))
+                    methods[key] = method with { Validity = ValidityStatus(result) };
             }
         }
         return new ValiditySensorMetrics(
@@ -297,7 +298,7 @@ internal static class CorpusSensor
             foreach (var result in FidelityCheck.Evaluate([assembly], cap, lowered: false))
             {
                 results.Add(result);
-                string key = MethodKey(portablePath, result.Type, result.Method, result.Overload);
+                string key = MethodKey(portablePath, result.Type, result.Method, result.Signature);
                 if (methods.TryGetValue(key, out var method))
                     methods[key] = method with { FidelityCheck = result.Status.ToString() };
             }
@@ -328,21 +329,10 @@ internal static class CorpusSensor
         => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static string MethodKey(CorpusMethodSnapshot method)
-        => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Overload);
+        => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Signature);
 
-    static string MethodKey(string assemblyPath, string type, string method, int overload)
-        => $"{assemblyPath}!{type}::{method}#{overload}";
-
-    static IEnumerable<string> WeakMethodKeys(
-        string assemblyPath,
-        string type,
-        string method,
-        IReadOnlyDictionary<string, CorpusMethodSnapshot> methods)
-        => methods
-            .Where(kvp => kvp.Value.AssemblyPath == assemblyPath
-                && kvp.Value.Type == type
-                && kvp.Value.Method == method)
-            .Select(kvp => kvp.Key);
+    static string MethodKey(string assemblyPath, string type, string method, string signature)
+        => $"{assemblyPath}!{type}::{method}{signature}";
 
     static string ValidityStatus(ValidityCheck.MethodResult result)
     {

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -191,10 +191,14 @@ internal static class CorpusSensor
                             ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}"
                             : null);
                 }
-                if (residual is null)
+                if (passBug is null && residual is null)
+                {
                     fullyRaised++;
-                else
+                }
+                else if (residual is not null)
+                {
                     residualBuckets[residual] = residualBuckets.GetValueOrDefault(residual) + 1;
+                }
                 methodReports.Add(new CorpusMethodSnapshot(
                     source.AssemblyName,
                     portablePath,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -201,7 +201,7 @@ internal static class CorpusSensor
                     typeName,
                     methodName,
                     overload,
-                    SignatureText(function),
+                    CorpusMethodIdentity.SignatureText(function.Signature),
                     function.Fidelity.ToString(),
                     residual is null && passBug is null,
                     residual,
@@ -324,9 +324,6 @@ internal static class CorpusSensor
         }
         return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
-
-    static string SignatureText(IrFunction function)
-        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static string MethodKey(CorpusMethodSnapshot method)
         => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Signature);

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -110,7 +110,7 @@ static class FidelityCheck
 
     /// <summary>One method's fidelity check result, with both opcode streams for diagnostics.</summary>
     public sealed record CompileBackResult(
-        string Type, string Method, int Overload, CompileBackStatus Status,
+        string Type, string Method, int Overload, string Signature, CompileBackStatus Status,
         string OriginalOpcodes, string RecompiledOpcodes, string? Detail);
 
     /// <summary>
@@ -206,7 +206,7 @@ static class FidelityCheck
 
     /// <summary>One method ready to compile back: its decompiled body and the original opcode stream to match.</summary>
     sealed record Entry(
-        MethodDefinitionHandle Handle, string Name, int Overload, TargetBody Target,
+        MethodDefinitionHandle Handle, string Name, int Overload, string Signature, TargetBody Target,
         IReadOnlyList<(string Field, string Value)> FieldInits,
         string OrigText, IReadOnlyList<string> OrigOps, bool IsFull);
 
@@ -257,7 +257,7 @@ static class FidelityCheck
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
-            entries.Add(new Entry(mh, name, overload, new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
+            entries.Add(new Entry(mh, name, overload, SignatureText(function), new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
         }
         return (fullType, entries);
@@ -347,7 +347,7 @@ static class FidelityCheck
     {
         string unit;
         try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.FieldInits); }
-        catch { return new(fullType, e.Name, e.Overload, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
+        catch { return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
 
         var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
         var comp = CSharpCompilation.Create("cb", [tree], references, compileOptions);
@@ -356,21 +356,24 @@ static class FidelityCheck
         if (!emit.Success)
         {
             var err = emit.Diagnostics.FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
-            return new(fullType, e.Name, e.Overload, CompileBackStatus.RecompileFail, e.OrigText, "", err?.Id);
+            return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.RecompileFail, e.OrigText, "", err?.Id);
         }
         ms.Position = 0;
         using var rpe = new PEReader(ms);
         var rOps = FindAndDisassemble(rpe, fullType, e.Name, e.Overload)?.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
         return rOps is null
-            ? new(fullType, e.Name, e.Overload, CompileBackStatus.ContextFail, e.OrigText, "", "method-not-found")
+            ? new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "method-not-found")
             : Classify(fullType, e, rOps);
     }
 
     static CompileBackResult Classify(string fullType, Entry e, IReadOnlyList<string> rOps) =>
-        new(fullType, e.Name, e.Overload,
+        new(fullType, e.Name, e.Overload, e.Signature,
             e.OrigOps.SequenceEqual(rOps) ? CompileBackStatus.Exact
                 : e.IsFull ? CompileBackStatus.OpcodeDiff : CompileBackStatus.NotFull,
             e.OrigText, string.Join(" ", rOps), null);
+
+    static string SignatureText(IrFunction function)
+        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static void RunType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -257,7 +257,7 @@ static class FidelityCheck
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
-            entries.Add(new Entry(mh, name, overload, SignatureText(function), new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
+            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
         }
         return (fullType, entries);
@@ -371,9 +371,6 @@ static class FidelityCheck
             e.OrigOps.SequenceEqual(rOps) ? CompileBackStatus.Exact
                 : e.IsFull ? CompileBackStatus.OpcodeDiff : CompileBackStatus.NotFull,
             e.OrigText, string.Join(" ", rOps), null);
-
-    static string SignatureText(IrFunction function)
-        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static void RunType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -57,6 +57,7 @@ static class Program
         bool classifyDec0009 = false;
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
+        string? emitCorpusDelta = null;
         bool qualityDiffCard = false;
         bool qualityCardRisky = false;
         int corpusFidelityCap = 0;
@@ -113,6 +114,7 @@ static class Program
                 case "--emit-corpus-baseline": emitCorpusSnapshot = args[++i]; break;
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
+                case "--emit-corpus-delta": emitCorpusDelta = args[++i]; break;
                 case "--quality-diff-card": qualityDiffCard = true; break;
                 case "--quality-card-risky": qualityDiffCard = true; qualityCardRisky = true; break;
                 case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
@@ -152,7 +154,7 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, qualityCardRisky, corpusMethodCap);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1117,6 +1119,9 @@ static class Program
                                 in baseline <f>.
                                 Uses --compile-cap as a per-assembly semantic
                                 validity cap.
+          --emit-corpus-delta <f>        with --diff-corpus-baseline: write
+                                changed per-method corpus rows as JSON for
+                                reviewer drill-down and targeted fidelity runs.
           --quality-diff-card  with --diff-corpus-baseline: emit a Markdown
                                 Decompiler quality diff card generated from the
                                 baseline/current corpus snapshots.

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -153,7 +153,7 @@ static class Program
         if (classifyDec0009)
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
-        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
+        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || emitCorpusDelta is not null || qualityDiffCard)
             return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap);
 
         if (libraryReport)

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -50,6 +50,11 @@ and per-row sampled denominators for semantic validity and compile-back fidelity
 so reviewers can tell when evidence is strong or thin. Paste that block as the
 PR's aggregate corpus evidence; do not re-key the table by hand.
 
+Add `--emit-corpus-delta <file>` with `--diff-corpus-baseline` to write the
+changed per-method rows as JSON. The quality card stays compact and names the
+artifact path; reviewers and follow-up scripts can use the JSON to pick changed
+methods for targeted dump/fidelity checks.
+
 For risky raise/structuring PRs, add `--quality-card-risky`. It keeps the same
 card shape but warns when semantic validity coverage is below 1.00% or
 compile-back fidelity coverage is below 0.10%, and reminds authors to add

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -67,6 +67,7 @@ static class ValidityCheck
     public sealed record MethodResult(
         string TypeName,
         string MethodName,
+        string Signature,
         bool IsFull,
         ImmutableArray<ValidityDiagnostic> MalformedDiagnostics,
         bool SemanticChecked,
@@ -193,7 +194,7 @@ static class ValidityCheck
 
                     if (malformed.Count > 0)
                     {
-                        results.Add(new MethodResult(typeName, methodName, full, malformed.ToImmutable(), SemanticChecked: false, []));
+                        results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, malformed.ToImmutable(), SemanticChecked: false, []));
                         continue;
                     }
 
@@ -201,7 +202,7 @@ static class ValidityCheck
                     // claims to be good) up to the cap — binding is the slow part.
                     if (!full || semChecked >= cap)
                     {
-                        results.Add(new MethodResult(typeName, methodName, full, [], SemanticChecked: false, []));
+                        results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, [], SemanticChecked: false, []));
                         continue;
                     }
                     semChecked++;
@@ -214,12 +215,15 @@ static class ValidityCheck
                         .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
-                    results.Add(new MethodResult(typeName, methodName, full, [], SemanticChecked: true, defects));
+                    results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, [], SemanticChecked: true, defects));
                 }
             }
         }
         return results;
     }
+
+    static string SignatureText(IrFunction function)
+        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
     {

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -194,7 +194,7 @@ static class ValidityCheck
 
                     if (malformed.Count > 0)
                     {
-                        results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, malformed.ToImmutable(), SemanticChecked: false, []));
+                        results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, malformed.ToImmutable(), SemanticChecked: false, []));
                         continue;
                     }
 
@@ -202,7 +202,7 @@ static class ValidityCheck
                     // claims to be good) up to the cap — binding is the slow part.
                     if (!full || semChecked >= cap)
                     {
-                        results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, [], SemanticChecked: false, []));
+                        results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: false, []));
                         continue;
                     }
                     semChecked++;
@@ -215,15 +215,12 @@ static class ValidityCheck
                         .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
-                    results.Add(new MethodResult(typeName, methodName, SignatureText(function), full, [], SemanticChecked: true, defects));
+                    results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, defects));
                 }
             }
         }
         return results;
     }
-
-    static string SignatureText(IrFunction function)
-        => $"({string.Join(", ", function.Signature.Parameters.Select(p => p.Type.ToDisplayString()))}) -> {function.Signature.ReturnType.ToDisplayString()}";
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
     {


### PR DESCRIPTION
Fixes #1215.

Changes:
- add `--emit-corpus-delta <file>` for `--diff-corpus-baseline` runs;
- include per-method snapshot state in newly emitted corpus snapshots: assembly/path, type, method, overload, signature, fidelity, fully-raised state, residual, pass bug, validity sample state, and fidelity sample state;
- write a JSON delta artifact containing changed methods and their baseline/current states;
- keep `--quality-diff-card` compact and append only the artifact path when a delta file is emitted.

Smoke validation:
```bash
dotnet build tools/DecompilerHarness -c Release --nologo
asm=$(realpath artifacts/bin/ILInspector.MetadataPrimitives/release/ILInspector.MetadataPrimitives.dll)
dotnet run --project tools/DecompilerHarness -c Release -- "$asm" \
  --emit-corpus-snapshot /tmp/issue1215-baseline.json \
  --corpus-method-cap 5 --compile-cap 0 --corpus-fidelity-cap 0 --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release -- "$asm" \
  --diff-corpus-baseline /tmp/issue1215-baseline.json \
  --emit-corpus-delta /tmp/issue1215-delta.json \
  --quality-diff-card --corpus-method-cap 5 --compile-cap 0 --corpus-fidelity-cap 0 --max-examples 1
```

The smoke run wrote method details to the snapshot, wrote an empty changed-method delta for identical runs, and printed:

```text
Per-method delta artifact: `/tmp/issue1215-delta.json`
```

Validation:
- `dotnet build src/dotnet-inspect -c Release --nologo -p:PublishAot=false`
- `dotnet build tools/DecompilerHarness -c Release --nologo`
- `npx markdownlint-cli --fix tools/DecompilerHarness/README.md`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- `dotnet run --project tools/DecompilerHarness -c Release -- --help | grep emit-corpus-delta`