### PR TITLE
Discover library SourceLink audit sections structurally

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3243,6 +3243,28 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_DiscoverEffective_ListsSourceLinkAuditSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--package", "Newtonsoft.Json", "-D", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Tip:", error);
+        Assert.Contains("SourceLink Availability", output);
+        Assert.Contains("SourceLink Missing Files", output);
+        Assert.Contains("SourceLink Integrity", output);
+
+        var (allExit, allOutput, allError) = await RunAppAsync(
+            "library", "--package", "Newtonsoft.Json", "-D", "@All", "--table", "--tips", "q");
+
+        Assert.Equal(0, allExit);
+        Assert.DoesNotContain("Tip:", allError);
+        Assert.Contains("SourceLink Availability", allOutput);
+        Assert.Contains("SourceLink Missing Files", allOutput);
+        Assert.Contains("SourceLink Integrity", allOutput);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DiscoverSchema_GroupsOptInSections()
     {
         var (exit, output, _) = await RunAppAsync("library", "System.Text.Json", "-D", "--schema");

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -301,6 +301,27 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void LibraryPipeline_SourceLinkAuditDiscovery_UsesStructuralApplicability()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            PdbPath = "Library.pdb"
+        };
+
+        var applicable = pipeline.GetApplicableSections(model);
+        var renderable = pipeline.GetAvailableSections(model);
+
+        Assert.Contains("SourceLink Availability", applicable);
+        Assert.Contains("SourceLink Missing Files", applicable);
+        Assert.Contains("SourceLink Integrity", applicable);
+        Assert.DoesNotContain("SourceLink Availability", renderable);
+        Assert.DoesNotContain("SourceLink Missing Files", renderable);
+        Assert.DoesNotContain("SourceLink Integrity", renderable);
+    }
+
+    [Fact]
     public void LibraryPipeline_SourceIntegrityAuthorizedOnlyByExplicitSelection()
     {
         var pipeline = LibrarySections.CreatePipeline();

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -303,8 +303,10 @@ public class LibraryCommand
     private static int WriteEffectiveSections(string assemblyPath, LibraryInspection inspection,
         LibraryOptions options, SectionPipeline<LibraryInspection> pipeline, Verbosity userVerbosity = Verbosity.Minimal)
     {
-        // Compute all target-available sections for caching, including opt-in sections.
-        var allEffective = pipeline.GetAvailableSections(inspection);
+        // Compute all structurally applicable sections for discovery/caching,
+        // including opt-in sections whose renderability depends on the section's
+        // own work (for example SourceLink audit sections).
+        var allEffective = pipeline.GetApplicableSections(inspection);
         var schemaMap = InspectionContext.Default.GetSchemaInfo<LibraryInspectionView>()!.ToDocumentSchema();
 
         // Field-level filtering on ALL effective sections (unfiltered) for caching
@@ -324,7 +326,7 @@ public class LibraryCommand
 
     // ── Effective sections cache ──
 
-    private const string EffectiveCategory = "effective-v7";
+    private const string EffectiveCategory = "effective-v8";
 
     static LibraryCommand()
     {

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -31,9 +31,9 @@ public static class LibrarySections
         return new SectionPipeline<LibraryInspection>()
             .Add<LibraryInfo>()
             .Add<SourceFiles>()
-            .Add<SourceLinkAudit>()
-            .Add<MissingSourceFiles>()
-            .Add<SourceIntegrity>()
+            .Add<SourceLinkAudit>(SourceLinkAuditApplicable)
+            .Add<MissingSourceFiles>(SourceLinkAuditApplicable)
+            .Add<SourceIntegrity>(SourceLinkAuditApplicable)
             .Add<Symbols>()
             .Add<Signals>()
             .Add<Switches>()
@@ -290,6 +290,12 @@ public static class LibrarySections
     }
 
     // ===== Opt-in SourceLink sections =====
+
+    private static bool SourceLinkAuditApplicable(LibraryInspection model)
+        => model.AssemblyInfo != null
+           && (model.HasSourceLink
+               || model.HasEmbeddedPdb
+               || !string.IsNullOrWhiteSpace(model.PdbPath));
 
     public sealed class SourceLinkAudit : ISectionDescriptor<LibraryInspection>
     {

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -15,6 +15,7 @@ public sealed class SectionEntry<TModel>
     public bool ProbeEffectiveness { get; init; } = true;
     public SectionCapabilities Capabilities { get; init; }
     public required string? ScannerKey { get; init; }
+    public required Func<TModel, bool> IsApplicable { get; init; }
     public required Func<TModel, bool> CanRender { get; init; }
 }
 
@@ -46,7 +47,8 @@ public sealed class SectionPipeline<TModel>
     /// Registers a section descriptor. The descriptor type is never instantiated —
     /// only its static members are accessed.
     /// </summary>
-    public SectionPipeline<TModel> Add<TDescriptor>() where TDescriptor : ISectionDescriptor<TModel>
+    public SectionPipeline<TModel> Add<TDescriptor>(
+        Func<TModel, bool>? isApplicable = null) where TDescriptor : ISectionDescriptor<TModel>
     {
         if (!TDescriptor.ProbeEffectiveness && !TDescriptor.ExplicitOnly)
             throw new InvalidOperationException(
@@ -61,6 +63,7 @@ public sealed class SectionPipeline<TModel>
             ProbeEffectiveness = TDescriptor.ProbeEffectiveness,
             Capabilities = TDescriptor.Capabilities,
             ScannerKey = TDescriptor.ScannerKey,
+            IsApplicable = isApplicable ?? TDescriptor.CanRender,
             CanRender = TDescriptor.CanRender,
         });
         return this;
@@ -160,6 +163,26 @@ public sealed class SectionPipeline<TModel>
             if (include is { Count: > 0 } && !include.Contains(entry.Name))
                 continue;
             if (entry.CanRender(model))
+                result.Add(entry.Name);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns sections that are structurally applicable for this target,
+    /// independent of whether their post-execution data has been collected.
+    /// Discovery uses this over-rendering direction so selectable sections do not
+    /// disappear just because their <see cref="SectionEntry{TModel}.CanRender"/>
+    /// predicate depends on the section's own work.
+    /// </summary>
+    public List<string> GetApplicableSections(TModel model, HashSet<string>? include = null)
+    {
+        List<string> result = [];
+        foreach (var entry in _entries)
+        {
+            if (include is { Count: > 0 } && !include.Contains(entry.Name))
+                continue;
+            if (entry.IsApplicable(model))
                 result.Add(entry.Name);
         }
         return result;

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -27,6 +27,8 @@
   acquisition.
 - Repeats the start line in the `End Line` column for single-line member source
   locations so blank cells only mean the end line is unknown.
+- Keeps library SourceLink audit sections discoverable via `-D` when their
+  render data is produced only after the section runs.
 - Keeps `Member Index` focused on selector/query columns while moving
   source-location evidence to the dedicated source section.
 


### PR DESCRIPTION
## Summary
- split library section discovery applicability from render-time `CanRender` for result-dependent sections
- make `library -D` / `-D @All` list SourceLink Availability, SourceLink Missing Files, and SourceLink Integrity when a library structurally has PDB/SourceLink evidence
- keep those sections opt-in and render-suppressed until their audit/integrity data is produced
- bump the effective-section cache key and add regression coverage

## Related
- Fixes #1201

## Validation
- npx markdownlint-cli src/dotnet-inspect/release-notes.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.SectionPipelineTests.LibraryPipeline_SourceLinkAuditDiscovery_UsesStructuralApplicability -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_DiscoverEffective_ListsSourceLinkAuditSections
- dotnet run --project src/dotnet-inspect -c Release --no-build -- library --package Newtonsoft.Json -D @All --table --tips q | grep SourceLink
