### PR TITLE
Use applicability for effective discovery

### DIFF
--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -37,6 +37,8 @@ Vulnerabilities          section
 
 The major advantage of this system is that section queries / scoping pushes backpressure to the data generators. They are told the specific sections being requested. The model isn't "give me everything and I'll filter down". We do use after-the-fact filtering, but within the section scope. Sections are the contract boundary for most of this system.
 
+Effective discovery uses two predicates. The section pipeline's applicability gate answers whether a section is structurally selectable for the current target without doing the section's own work. `CanRender` answers whether collected data can actually produce output. Use explicit applicability gates to keep opt-in sections discoverable when their render data is populated only after selection; keep `CanRender` data-dependent so rendering and empty-section notes remain honest.
+
 Note: This content should itself be data and printable with any of the renderers using the same system as "actual data". I consider this view to be oneline + no-heading. One can imagine either of the following (which would include a heading).
 
 ```bash=

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -37,6 +37,14 @@ public class SectionPipelineTests
         public static bool CanRender(TestModel model) => model.Name != null;
     }
 
+    private sealed class StructurallyApplicableSection : ISectionDescriptor<TestModel>
+    {
+        public static string Name => "Structural";
+        public static bool IsExpensive => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(TestModel model) => model.Count > 0;
+    }
+
     private static SectionPipeline<TestModel> CreateTestPipeline() =>
         new SectionPipeline<TestModel>()
             .Add<AlwaysSection>()
@@ -96,6 +104,20 @@ public class SectionPipelineTests
         var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
 
         Assert.Equal(["Always"], effective);
+    }
+
+    [Fact]
+    public void GetApplicableSections_UsesRegistrationApplicability()
+    {
+        var pipeline = new SectionPipeline<TestModel>()
+            .Add<StructurallyApplicableSection>(model => model.Name != null);
+        var model = new TestModel("target", 0);
+
+        var applicable = pipeline.GetApplicableSections(model);
+        var available = pipeline.GetAvailableSections(model);
+
+        Assert.Equal(["Structural"], applicable);
+        Assert.Empty(available);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -799,29 +799,29 @@ public class ApiCommand
     {
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
-        var available = memberPipeline.GetAvailableSections(filteredType, options.IncludeSections);
-        available = DiscoverOutput.RestrictToSchemaSections(available, fullSchema);
+        var applicable = memberPipeline.GetApplicableSections(filteredType, options.IncludeSections);
+        applicable = DiscoverOutput.RestrictToSchemaSections(applicable, fullSchema);
         // Index-backed sections (Calls, Callers, Unsafe Operations) declare ProbeEffectiveness=false:
-        // they are listed structurally via CanRender and never rendered during discovery, so -D does
+        // they are listed structurally via IsApplicable and never rendered during discovery, so -D does
         // not open the whole-assembly IL index just to test them.
         var unprobed = memberPipeline.GetUnprobedSections();
         var bareDiscover = options.Discover is null or { Length: 0 };
         var discoveryRenderSections = bareDiscover
             ? options is MemberOptions { OverloadIndex: not null }
-                ? [.. available.Where(s => !unprobed.Contains(s))]
-                : [.. available.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
+                ? [.. applicable.Where(s => !unprobed.Contains(s))]
+                : [.. applicable.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
             : (IReadOnlyCollection<string>?)null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
-        var renderedKept = DiscoverOutput.RestrictToRenderedSections(available, fullSchema, rendered);
-        // Keep rendered sections plus any structural (unprobed) section that passed CanRender,
+        var renderedKept = DiscoverOutput.RestrictToRenderedSections(applicable, fullSchema, rendered);
+        // Keep rendered sections plus any structural (unprobed) section that passed IsApplicable,
         // preserving registration order.
         var keep = new HashSet<string>(renderedKept, StringComparer.OrdinalIgnoreCase);
-        foreach (var s in available)
+        foreach (var s in applicable)
         {
             if (unprobed.Contains(s))
                 keep.Add(s);
         }
-        var effective = available.Where(keep.Contains).ToList();
+        var effective = applicable.Where(keep.Contains).ToList();
         var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(effective, fullSchema, rendered);
         // Unprobed sections may render empty and must be opt-in by policy, so the
         // normal opt-in annotation is sufficient and avoids double labels.

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -408,7 +408,7 @@ public class PackageCommand
             // Output results
             if (effectiveDiscovery)
             {
-                var effective = pipeline.GetAvailableSections(result, options.IncludeSections);
+                var effective = pipeline.GetApplicableSections(result, options.IncludeSections);
                 var schemaMap = InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema();
                 var fullSchemaMap = schemaMap;
 

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -95,7 +95,7 @@ public static class TypeCommand
                 {
                     ApiCommand.ApplySurfaceFilters(api, options, options.TypeFilter);
                     var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
-                    var effective = typePipeline.GetAvailableSections(api, options.IncludeSections);
+                    var effective = typePipeline.GetApplicableSections(api, options.IncludeSections);
                     return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
                         tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine && !options.JsonOutput,
                         verbosity: (int)options.Verbosity,
@@ -467,7 +467,7 @@ public static class TypeCommand
         if (browseOptions.EffectiveDiscovery)
         {
             var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
-            var effective = typePipeline.GetAvailableSections(api, browseOptions.IncludeSections);
+            var effective = typePipeline.GetApplicableSections(api, browseOptions.IncludeSections);
             return DiscoverOutput.ExecuteEffective(browseOptions.Discover, effective, schema,
                 tree: browseOptions.Tree, json: browseOptions.JsonOutput, tsv: browseOptions.Tsv, jsonl: browseOptions.Jsonl, markdown: !browseOptions.OneLine && !browseOptions.JsonOutput,
                 verbosity: (int)browseOptions.Verbosity,

--- a/src/dotnet-inspect/Sections/ISectionDescriptor.cs
+++ b/src/dotnet-inspect/Sections/ISectionDescriptor.cs
@@ -35,7 +35,7 @@ public interface ISectionDescriptor<TModel>
 
     /// <summary>
     /// When false, effective discovery (<c>-D</c>) lists this section using only its
-    /// structural <see cref="CanRender"/> gate and never renders it to confirm it produces
+    /// section pipeline's structural applicability gate and never renders it to confirm it produces
     /// content. Use for sections whose content probe is heavy (e.g. opening a whole-assembly
     /// IL index): listing them structurally keeps them discoverable without paying the scan
     /// cost during discovery. The tradeoff is the section may render empty when queried.

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -117,7 +117,7 @@ public sealed class SectionPipeline<TModel>
     /// <summary>
     /// Names of sections whose effectiveness must not be content-probed during discovery
     /// (<see cref="ISectionDescriptor{TModel}.ProbeEffectiveness"/> is false). Effective
-    /// discovery lists these structurally via <c>CanRender</c> instead of rendering them,
+    /// discovery lists these structurally via <c>IsApplicable</c> instead of rendering them,
     /// avoiding heavy content probes (e.g. opening a whole-assembly IL index).
     /// </summary>
     public HashSet<string> GetUnprobedSections()


### PR DESCRIPTION
## Summary
- Route package, type, and member effective discovery through section applicability instead of render availability.
- Keep render/projection filtering data-dependent, so empty-section notes and rendered output remain honest.
- Document the applicability-vs-CanRender contract and add a SectionPipeline regression for registration-level applicability gates.

## Validation
- npx markdownlint-cli docs/design/section-model.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -noLogo -class DotnetInspector.Tests.SectionPipelineTests
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -noLogo -method DotnetInspector.Tests.CommandExecutionTests.LibraryCommand_DiscoverEffective_ListsSourceLinkAuditSections -method DotnetInspector.Tests.CommandExecutionTests.Package_Discover_DefaultsToEffectiveSchema -method DotnetInspector.Tests.CommandExecutionTests.Type_SingleType_DiscoverEffective_OnlyShowsSectionsWithData -method DotnetInspector.Tests.CommandExecutionTests.Type_SingleType_DiscoverEffective_ExcludesEmptyCustomAttributesSection
- dotnet run --project src/dotnet-inspect -c Release -- library --package Newtonsoft.Json -D @All --table --tips q

Full dotnet-inspect.Tests was also run; it only hit the known preview-runtime environment failures:
- PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies
- CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute