### PR TITLE
List verbose Methods in effective discovery

### DIFF
--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -37,7 +37,7 @@ Vulnerabilities          section
 
 The major advantage of this system is that section queries / scoping pushes backpressure to the data generators. They are told the specific sections being requested. The model isn't "give me everything and I'll filter down". We do use after-the-fact filtering, but within the section scope. Sections are the contract boundary for most of this system.
 
-Effective discovery uses two predicates. The section pipeline's applicability gate answers whether a section is structurally selectable for the current target without doing the section's own work. `CanRender` answers whether collected data can actually produce output. Use explicit applicability gates to keep opt-in sections discoverable when their render data is populated only after selection; keep `CanRender` data-dependent so rendering and empty-section notes remain honest.
+Effective discovery uses two predicates. The section pipeline's applicability gate answers whether a section is structurally selectable for the current target without doing the section's own work. `CanRender` answers whether collected data can actually produce output. Use explicit applicability gates to keep opt-in or alternate-representation sections discoverable when their render data is populated only after selection, or when the default render pass chooses a compact alternate; keep `CanRender` data-dependent so rendering and empty-section notes remain honest. Discovery annotates explicit non-default alternates as `verbose`.
 
 Note: This content should itself be data and printable with any of the renderers using the same system as "actual data". I consider this view to be oneline + no-heading. One can imagine either of the following (which would include a heading).
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1350,6 +1350,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("| Method Groups | section |", output);
+        Assert.Contains("| Methods | section (verbose) |", output);
         Assert.Contains("| Source Files | section (opt-in) |", output);
         Assert.DoesNotContain("| Fields | section |", output);
     }
@@ -1511,6 +1512,24 @@ public class CommandExecutionTests
         // must not list it (regression: member effective used to leak it).
         Assert.DoesNotContain("| Select | column |", output);
         Assert.Contains("| Name | column |", output);
+    }
+
+    [Fact]
+    public async Task Member_DiscoverEffective_ListsMethodsAlternate()
+    {
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            Discover = []
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("| Method Groups | section |", output);
+        Assert.Contains("| Methods | section (verbose) |", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -115,9 +115,11 @@ public class SectionPipelineTests
 
         var applicable = pipeline.GetApplicableSections(model);
         var available = pipeline.GetAvailableSections(model);
+        var explicitlyApplicable = pipeline.GetExplicitlyApplicableSections(model);
 
         Assert.Equal(["Structural"], applicable);
         Assert.Empty(available);
+        Assert.Equal(["Structural"], explicitlyApplicable);
     }
 
     [Fact]
@@ -1357,6 +1359,32 @@ public class SectionPipelineTests
         Assert.Contains("Explicit Interface Implementations", pipeline.InfoSectionNames);
         Assert.Contains("Extension Methods", pipeline.InfoSectionNames);
         Assert.DoesNotContain("Methods", pipeline.InfoSectionNames);
+        Assert.Equal("verbose", Assert.Contains("Methods", pipeline.GetCostAnnotations()));
+    }
+
+    [Fact]
+    public void ApiMemberPipeline_AlternateMemberRows_UseExplicitApplicability()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var model = new ApiType
+        {
+            Name = "Sample",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Name = "Run", Kind = "method" },
+                new ApiMember { Name = "op_Equality", Kind = "operator" },
+                new ApiMember { Name = "IFoo.Bar", Kind = "explicit-interface-implementation" },
+                new ApiMember { Name = "Ext", Kind = "extension-method" }
+            ]
+        };
+
+        var explicitlyApplicable = pipeline.GetExplicitlyApplicableSections(model);
+
+        Assert.Contains("Methods", explicitlyApplicable);
+        Assert.Contains("Operators", explicitlyApplicable);
+        Assert.Contains("Explicit Interface Implementations", explicitlyApplicable);
+        Assert.Contains("Extension Methods", explicitlyApplicable);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -801,6 +801,7 @@ public class ApiCommand
         var filteredType = BuildFilteredTypeForSections(apiType, options);
         var applicable = memberPipeline.GetApplicableSections(filteredType, options.IncludeSections);
         applicable = DiscoverOutput.RestrictToSchemaSections(applicable, fullSchema);
+        var explicitlyApplicable = memberPipeline.GetExplicitlyApplicableSections(filteredType, options.IncludeSections);
         // Index-backed sections (Calls, Callers, Unsafe Operations) declare ProbeEffectiveness=false:
         // they are listed structurally via IsApplicable and never rendered during discovery, so -D does
         // not open the whole-assembly IL index just to test them.
@@ -813,12 +814,14 @@ public class ApiCommand
             : (IReadOnlyCollection<string>?)null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
         var renderedKept = DiscoverOutput.RestrictToRenderedSections(applicable, fullSchema, rendered);
-        // Keep rendered sections plus any structural (unprobed) section that passed IsApplicable,
-        // preserving registration order.
+        // Keep rendered sections plus sections that intentionally opted into structural discovery,
+        // preserving registration order. Explicit applicability covers sections whose default
+        // render pass may choose a compact alternate representation (for example Method Groups
+        // instead of Methods) even though the full section is selectable and content-producing.
         var keep = new HashSet<string>(renderedKept, StringComparer.OrdinalIgnoreCase);
         foreach (var s in applicable)
         {
-            if (unprobed.Contains(s))
+            if (unprobed.Contains(s) || explicitlyApplicable.Contains(s))
                 keep.Add(s);
         }
         var effective = applicable.Where(keep.Contains).ToList();

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -84,11 +84,11 @@ public static class ApiMemberSectionDescriptors
             .Add<Fields>()
             .Add<Properties>()
             .Add<MethodGroups>()
-            .Add<Methods>()
+            .Add<Methods>(HasMethods)
             .Add<MemberIndex>()
-            .Add<Operators>()
-            .Add<ExplicitInterfaceImplementations>()
-            .Add<ExtensionMethods>()
+            .Add<Operators>(HasOperators)
+            .Add<ExplicitInterfaceImplementations>(HasExplicitInterfaceImplementations)
+            .Add<ExtensionMethods>(HasExtensionMethods)
             .Add<Events>()
             .Add<MethodAttributes>()
             .Add<UnsafeMembers>()
@@ -181,7 +181,7 @@ public static class ApiMemberSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind == "method");
+            => HasMethods(model);
     }
 
     public sealed class MemberIndex : ISectionDescriptor<ApiType>
@@ -201,7 +201,7 @@ public static class ApiMemberSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind == "method");
+            => HasMethods(model);
     }
 
     public sealed class Events : ISectionDescriptor<ApiType>
@@ -221,7 +221,7 @@ public static class ApiMemberSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind == "operator");
+            => HasOperators(model);
     }
 
     public sealed class ExplicitInterfaceImplementations : ISectionDescriptor<ApiType>
@@ -231,7 +231,7 @@ public static class ApiMemberSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind == "explicit-interface-implementation");
+            => HasExplicitInterfaceImplementations(model);
     }
 
     public sealed class ExtensionMethods : ISectionDescriptor<ApiType>
@@ -241,7 +241,7 @@ public static class ApiMemberSectionDescriptors
         public static bool Info => true;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(m => m.Kind == "extension-method");
+            => HasExtensionMethods(model);
     }
 
     public sealed class MethodAttributes : ISectionDescriptor<ApiType>
@@ -334,6 +334,18 @@ public static class ApiMemberSectionDescriptors
 
     internal static bool IsMethodLike(ApiMember member) =>
         member.Kind is "method" or "constructor" or "operator" or "explicit-interface-implementation" or "extension-method";
+
+    private static bool HasMethods(ApiType model)
+        => model.Members.Any(m => m.Kind == "method");
+
+    private static bool HasOperators(ApiType model)
+        => model.Members.Any(m => m.Kind == "operator");
+
+    private static bool HasExplicitInterfaceImplementations(ApiType model)
+        => model.Members.Any(m => m.Kind == "explicit-interface-implementation");
+
+    private static bool HasExtensionMethods(ApiType model)
+        => model.Members.Any(m => m.Kind == "extension-method");
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -15,6 +15,7 @@ public sealed class SectionEntry<TModel>
     public bool ProbeEffectiveness { get; init; } = true;
     public SectionCapabilities Capabilities { get; init; }
     public required string? ScannerKey { get; init; }
+    public bool HasExplicitApplicability { get; init; }
     public required Func<TModel, bool> IsApplicable { get; init; }
     public required Func<TModel, bool> CanRender { get; init; }
 }
@@ -24,6 +25,7 @@ public sealed record SectionCategory(string Name, string[] Sections);
 public static class SectionAnnotations
 {
     public const string OptIn = "opt-in";
+    public const string Verbose = "verbose";
 }
 
 /// <summary>
@@ -63,6 +65,7 @@ public sealed class SectionPipeline<TModel>
             ProbeEffectiveness = TDescriptor.ProbeEffectiveness,
             Capabilities = TDescriptor.Capabilities,
             ScannerKey = TDescriptor.ScannerKey,
+            HasExplicitApplicability = isApplicable != null,
             IsApplicable = isApplicable ?? TDescriptor.CanRender,
             CanRender = TDescriptor.CanRender,
         });
@@ -101,7 +104,9 @@ public sealed class SectionPipeline<TModel>
     /// <summary>
     /// Maps each section name to a short annotation for discovery output:
     /// <c>"opt-in"</c> for <see cref="SectionEntry{TModel}.ExplicitOnly"/> sections (never shown
-    /// in a default flow). Default sections are omitted (no annotation).
+    /// in a default flow), and <c>"verbose"</c> for explicitly applicable alternate
+    /// sections that render only outside the compact <c>@Default</c> preset.
+    /// Default sections are omitted (no annotation).
     /// </summary>
     public Dictionary<string, string> GetCostAnnotations()
     {
@@ -109,7 +114,13 @@ public sealed class SectionPipeline<TModel>
         foreach (var e in _entries)
         {
             if (e.ExplicitOnly)
+            {
                 map[e.Name] = SectionAnnotations.OptIn;
+                continue;
+            }
+
+            if (e.HasExplicitApplicability && !e.Info)
+                map[e.Name] = SectionAnnotations.Verbose;
         }
         return map;
     }
@@ -180,6 +191,27 @@ public sealed class SectionPipeline<TModel>
         List<string> result = [];
         foreach (var entry in _entries)
         {
+            if (include is { Count: > 0 } && !include.Contains(entry.Name))
+                continue;
+            if (entry.IsApplicable(model))
+                result.Add(entry.Name);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns structurally applicable sections that were registered with an explicit
+    /// applicability gate. Effective discovery preserves these across render probes
+    /// because their renderability may depend on section selection, verbosity, or work
+    /// triggered only after the section is chosen.
+    /// </summary>
+    public HashSet<string> GetExplicitlyApplicableSections(TModel model, HashSet<string>? include = null)
+    {
+        HashSet<string> result = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in _entries)
+        {
+            if (!entry.HasExplicitApplicability)
+                continue;
             if (include is { Count: > 0 } && !include.Contains(entry.Name))
                 continue;
             if (entry.IsApplicable(model))


### PR DESCRIPTION
## Summary
- Preserve explicitly applicable member-row sections across the effective-discovery render probe.
- Register explicit applicability for Methods and related supplemental member-row alternates.
- Annotate non-default explicit alternates as section (verbose), so Methods is visible next to Method Groups in bare -D.

Closes #1223

## Validation
- npx markdownlint-cli docs/design/section-model.md
- dotnet build src/dotnet-inspect -c Release
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -noLogo -class DotnetInspector.Tests.SectionPipelineTests
- focused CommandExecutionTests for type/member effective discovery and Methods columns
- original repro now lists Method Groups plus Methods as section (verbose)

Full dotnet run --project src/dotnet-inspect.Tests -c Release was also run; it only hit the known preview-runtime environment failures:
- PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies
- CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute