### PR TITLE
Add multi-cap fidelity coverage reporting

### DIFF
--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -20,7 +20,7 @@ internal static class CorpusSensor
     public static int Run(
         IReadOnlyList<string> assemblies,
         int validityCompileCap,
-        int fidelityCompileCap,
+        IReadOnlyList<int> fidelityCompileCaps,
         int maxExamples,
         string? emitBaseline,
         string? diffBaseline,
@@ -46,9 +46,9 @@ internal static class CorpusSensor
             return 1;
         }
 
-        var current = Capture(assemblies, validityCompileCap, fidelityCompileCap, maxExamples, methodCap);
+        var (current, fidelityReports) = Capture(assemblies, validityCompileCap, fidelityCompileCaps, maxExamples, methodCap);
         if (!qualityDiffCard)
-            PrintSummary(current);
+            PrintSummary(current, fidelityReports);
 
         if (emitBaseline is not null)
         {
@@ -66,7 +66,7 @@ internal static class CorpusSensor
 
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
             ?? throw new InvalidOperationException($"Could not read corpus baseline '{diffBaseline}'.");
-        var regressions = Compare(baseline, current);
+        var regressions = Compare(baseline, current, fidelityReports);
         if (qualityDiffCard)
         {
             PrintQualityDiffCard(baseline, current, regressions, qualityCardRisky);
@@ -87,21 +87,26 @@ internal static class CorpusSensor
         return 1;
     }
 
-    static CorpusSensorSnapshot Capture(
+    static (CorpusSensorSnapshot Snapshot, ImmutableArray<FidelityCapReport> Reports) Capture(
         IReadOnlyList<string> assemblies,
         int validityCompileCap,
-        int fidelityCompileCap,
+        IReadOnlyList<int> fidelityCompileCaps,
         int maxExamples,
         int methodCap)
     {
         var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap);
         var validity = AnalyzeValidity(assemblies, validityCompileCap);
         var structuring = AnalyzeStructuring(assemblies, methodCap);
-        var fidelity = AnalyzeFidelity(assemblies, fidelityCompileCap);
+        var fidelityReports = AnalyzeFidelity(assemblies, fidelityCompileCaps);
         var totalMethods = completeness.Assemblies.Sum(assembly => assembly.TotalMethods);
         var fullyRaisedMethods = completeness.FullyRaisedMethods;
         var conditionalBranchMethods = completeness.ResidualBuckets.GetValueOrDefault(ConditionalBranchBucket);
         var forwardMergeContainers = ForwardMergeStopReasons.Sum(reason => structuring.StopReasons.GetValueOrDefault(reason));
+        var requestedCaps = fidelityCompileCaps.Where(cap => cap > 0).Distinct().ToArray();
+        var primaryFidelityCap = requestedCaps.FirstOrDefault();
+        var selectedFidelity = fidelityReports.FirstOrDefault(report => report.Cap == primaryFidelityCap)?.Metrics
+            ?? fidelityReports.LastOrDefault()?.Metrics
+            ?? new FidelitySensorMetrics(0, 0, 0, 0, 0, 0);
 
         var metrics = new CorpusSensorMetrics(
             totalMethods,
@@ -117,18 +122,20 @@ internal static class CorpusSensor
             completeness.PassBugs + (int)structuring.PassBugs,
             completeness.ResidualBuckets,
             structuring,
-            fidelity);
+            selectedFidelity);
 
-        return new CorpusSensorSnapshot(
+        var snapshot = new CorpusSensorSnapshot(
             SchemaVersion: 1,
             Description: "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
             GeneratedUtc: DateTimeOffset.UtcNow,
             ValidityCompileCap: validityCompileCap,
-            FidelityCompileCap: fidelityCompileCap,
+            FidelityCompileCap: primaryFidelityCap,
             MethodCap: methodCap == int.MaxValue ? null : methodCap,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: completeness.Assemblies,
             Metrics: metrics);
+
+        return (snapshot, fidelityReports);
     }
 
     static CompletenessSensorMetrics AnalyzeCompleteness(IReadOnlyList<string> assemblies, int maxExamples, int methodCap)
@@ -226,16 +233,29 @@ internal static class CorpusSensor
         return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons);
     }
 
-    static FidelitySensorMetrics AnalyzeFidelity(IReadOnlyList<string> assemblies, int cap)
+    static ImmutableArray<FidelityCapReport> AnalyzeFidelity(IReadOnlyList<string> assemblies, IReadOnlyList<int> caps)
     {
-        var results = FidelityCheck.Evaluate(assemblies, cap, lowered: false);
-        return new FidelitySensorMetrics(
-            results.Count,
-            results.Count(result => result.Status == FidelityCheck.CompileBackStatus.Exact),
-            results.Count(result => result.Status == FidelityCheck.CompileBackStatus.OpcodeDiff),
-            results.Count(result => result.Status == FidelityCheck.CompileBackStatus.RecompileFail),
-            results.Count(result => result.Status == FidelityCheck.CompileBackStatus.ContextFail),
-            results.Count(result => result.Status == FidelityCheck.CompileBackStatus.NotFull));
+        var reports = ImmutableArray.CreateBuilder<FidelityCapReport>();
+        foreach (var cap in caps.Where(cap => cap > 0).Distinct().OrderBy(cap => cap))
+        {
+            var usefulResults = FidelityCheck.Evaluate(assemblies, cap, lowered: false, includeAllResults: false);
+            var allResults = FidelityCheck.Evaluate(assemblies, cap, lowered: false, includeAllResults: true);
+            var metrics = new FidelitySensorMetrics(
+                usefulResults.Count,
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.Exact),
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.OpcodeDiff),
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.RecompileFail),
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.ContextFail),
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.NotFull));
+            var contextBuckets = FidelityCheck.SummarizeFailures(allResults, FidelityCheck.CompileBackStatus.ContextFail);
+            var recompileBuckets = FidelityCheck.SummarizeFailures(allResults, FidelityCheck.CompileBackStatus.RecompileFail);
+            reports.Add(new FidelityCapReport(cap, metrics, contextBuckets, recompileBuckets));
+        }
+
+        if (reports.Count == 0)
+            reports.Add(new FidelityCapReport(0, new FidelitySensorMetrics(0, 0, 0, 0, 0, 0), ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty, ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty));
+
+        return reports.ToImmutable();
     }
 
     static string BucketFor(DecompilerDiagnostic diagnostic)
@@ -265,21 +285,26 @@ internal static class CorpusSensor
         return Path.GetFileName(path);
     }
 
-    static ImmutableArray<string> Compare(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    static ImmutableArray<string> Compare(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current, ImmutableArray<FidelityCapReport> fidelityReports)
     {
         var failures = ImmutableArray.CreateBuilder<string>();
         var tolerance = baseline.Tolerances ?? CorpusSensorTolerances.Default;
+        var matchedFidelityReport = fidelityReports.FirstOrDefault(report => report.Cap == baseline.FidelityCompileCap)
+            ?? fidelityReports.FirstOrDefault(report => report.Cap == current.FidelityCompileCap)
+            ?? fidelityReports.LastOrDefault();
+        var currentFidelityMetrics = matchedFidelityReport?.Metrics ?? current.Metrics.Fidelity;
+        var currentFidelityCap = matchedFidelityReport?.Cap ?? current.FidelityCompileCap;
 
         if (current.ValidityCompileCap < baseline.ValidityCompileCap)
             failures.Add($"validity cap lower than baseline (baseline {baseline.ValidityCompileCap}, current {current.ValidityCompileCap})");
-        if (current.FidelityCompileCap < baseline.FidelityCompileCap)
-            failures.Add($"fidelity cap lower than baseline (baseline {baseline.FidelityCompileCap}, current {current.FidelityCompileCap})");
+        if (currentFidelityCap < baseline.FidelityCompileCap)
+            failures.Add($"fidelity cap lower than baseline (baseline {baseline.FidelityCompileCap}, current {currentFidelityCap})");
         if (current.MethodCap != baseline.MethodCap)
             failures.Add($"method cap differs from baseline (baseline {CapText(baseline.MethodCap)}, current {CapText(current.MethodCap)})");
         if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
             failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
-        if (current.Metrics.Fidelity.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
-            failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {current.Metrics.Fidelity.CheckedMethods})");
+        if (currentFidelityMetrics.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
+            failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {currentFidelityMetrics.CheckedMethods})");
 
         int fullyRaisedDrop = baseline.Metrics.FullyRaisedBasisPoints - current.Metrics.FullyRaisedBasisPoints;
         if (fullyRaisedDrop > tolerance.FullyRaisedDropBasisPoints)
@@ -299,9 +324,9 @@ internal static class CorpusSensor
 
         if (baseline.Metrics.Fidelity.CheckedMethods > 0)
         {
-            AddCountRegression(failures, "fidelity opcode diffs", baseline.Metrics.Fidelity.OpcodeDiffMethods, current.Metrics.Fidelity.OpcodeDiffMethods, tolerance.FidelityOpcodeDiffIncrease);
-            AddCountRegression(failures, "fidelity recompile failures", baseline.Metrics.Fidelity.RecompileFailMethods, current.Metrics.Fidelity.RecompileFailMethods, tolerance.FidelityRecompileFailIncrease);
-            AddCountRegression(failures, "fidelity context failures", baseline.Metrics.Fidelity.ContextFailMethods, current.Metrics.Fidelity.ContextFailMethods, tolerance.FidelityContextFailIncrease);
+            AddCountRegression(failures, "fidelity opcode diffs", baseline.Metrics.Fidelity.OpcodeDiffMethods, currentFidelityMetrics.OpcodeDiffMethods, tolerance.FidelityOpcodeDiffIncrease);
+            AddCountRegression(failures, "fidelity recompile failures", baseline.Metrics.Fidelity.RecompileFailMethods, currentFidelityMetrics.RecompileFailMethods, tolerance.FidelityRecompileFailIncrease);
+            AddCountRegression(failures, "fidelity context failures", baseline.Metrics.Fidelity.ContextFailMethods, currentFidelityMetrics.ContextFailMethods, tolerance.FidelityContextFailIncrease);
         }
 
         return failures.ToImmutable();
@@ -314,7 +339,7 @@ internal static class CorpusSensor
             failures.Add($"{name} increased by {increase} (baseline {baseline}, current {current}, tolerance {tolerance})");
     }
 
-    static void PrintSummary(CorpusSensorSnapshot snapshot)
+    static void PrintSummary(CorpusSensorSnapshot snapshot, ImmutableArray<FidelityCapReport> fidelityReports)
     {
         var metrics = snapshot.Metrics;
         Console.WriteLine("# Decompiler corpus sensor");
@@ -339,8 +364,41 @@ internal static class CorpusSensor
         Console.WriteLine($"Pass bugs: {metrics.PassBugs}");
         if (snapshot.FidelityCompileCap <= 0)
             Console.WriteLine("Fidelity: not run");
+        else if (fidelityReports.Length == 1)
+        {
+            var report = fidelityReports[0];
+            Console.WriteLine($"Fidelity (cap {report.Cap}): {report.Metrics.ExactMethods} exact, {report.Metrics.OpcodeDiffMethods} opcode diffs, {report.Metrics.RecompileFailMethods} recompile failures, {report.Metrics.ContextFailMethods} context failures over {report.Metrics.CheckedMethods} checked");
+            PrintFailureBuckets(report.ContextFailureBuckets, report.RecompileFailureBuckets, "  ");
+        }
         else
-            Console.WriteLine($"Fidelity: {metrics.Fidelity.ExactMethods} exact, {metrics.Fidelity.OpcodeDiffMethods} opcode diffs, {metrics.Fidelity.RecompileFailMethods} recompile failures over {metrics.Fidelity.CheckedMethods} checked");
+        {
+            Console.WriteLine("Fidelity coverage by cap:");
+            foreach (var report in fidelityReports)
+            {
+                Console.WriteLine($"  cap {report.Cap}: {report.Metrics.ExactMethods} exact, {report.Metrics.OpcodeDiffMethods} opcode diffs, {report.Metrics.RecompileFailMethods} recompile failures, {report.Metrics.ContextFailMethods} context failures over {report.Metrics.CheckedMethods} checked");
+                PrintFailureBuckets(report.ContextFailureBuckets, report.RecompileFailureBuckets, "    ");
+            }
+        }
+    }
+
+    static void PrintFailureBuckets(
+        IReadOnlyDictionary<string, FidelityCheck.FailureBucketSummary> contextBuckets,
+        IReadOnlyDictionary<string, FidelityCheck.FailureBucketSummary> recompileBuckets,
+        string indent)
+    {
+        if (contextBuckets.Count > 0)
+        {
+            Console.WriteLine($"{indent}context-failure buckets:");
+            foreach (var bucket in contextBuckets.OrderByDescending(pair => pair.Value.Count))
+                Console.WriteLine($"{indent}  {bucket.Key}: {bucket.Value.Count} (e.g. {string.Join(", ", bucket.Value.Examples)})");
+        }
+
+        if (recompileBuckets.Count > 0)
+        {
+            Console.WriteLine($"{indent}recompile-failure buckets:");
+            foreach (var bucket in recompileBuckets.OrderByDescending(pair => pair.Value.Count))
+                Console.WriteLine($"{indent}  {bucket.Key}: {bucket.Value.Count} (e.g. {string.Join(", ", bucket.Value.Examples)})");
+        }
     }
 
     static void PrintQualityDiffCard(
@@ -551,6 +609,12 @@ internal sealed record FidelitySensorMetrics(
     int RecompileFailMethods,
     int ContextFailMethods,
     int NotFullMethods);
+
+internal sealed record FidelityCapReport(
+    int Cap,
+    FidelitySensorMetrics Metrics,
+    IReadOnlyDictionary<string, FidelityCheck.FailureBucketSummary> ContextFailureBuckets,
+    IReadOnlyDictionary<string, FidelityCheck.FailureBucketSummary> RecompileFailureBuckets);
 
 internal sealed record CorpusSensorTolerances(
     int FullyRaisedDropBasisPoints,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -154,6 +154,9 @@ static class FidelityCheck
     }
 
     public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered)
+        => Evaluate(assemblies, perAssemblyCap, lowered, includeAllResults: false);
+
+    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered, bool includeAllResults)
     {
         if (perAssemblyCap <= 0)
             return [];
@@ -192,7 +195,8 @@ static class FidelityCheck
                         var typeResults = new List<CompileBackResult>();
                         EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, Math.Min(8, attemptCap - attempts));
                         attempts += typeResults.Count;
-                        assemblyResults.AddRange(typeResults.Where(IsUsefulCorpusSample).Take(perAssemblyCap - assemblyResults.Count));
+                        var selectableResults = includeAllResults ? typeResults : typeResults.Where(IsUsefulCorpusSample);
+                        assemblyResults.AddRange(selectableResults.Take(perAssemblyCap - assemblyResults.Count));
                     }
                 }
             }
@@ -201,7 +205,7 @@ static class FidelityCheck
         return results;
     }
 
-    static bool IsUsefulCorpusSample(CompileBackResult result)
+    internal static bool IsUsefulCorpusSample(CompileBackResult result)
         => result.Status is CompileBackStatus.Exact or CompileBackStatus.OpcodeDiff;
 
     /// <summary>One method ready to compile back: its decompiled body and the original opcode stream to match.</summary>
@@ -356,7 +360,7 @@ static class FidelityCheck
         if (!emit.Success)
         {
             var err = emit.Diagnostics.FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
-            return new(fullType, e.Name, e.Overload, CompileBackStatus.RecompileFail, e.OrigText, "", err?.Id);
+            return new(fullType, e.Name, e.Overload, CompileBackStatus.RecompileFail, e.OrigText, "", FormatDiagnostic(err));
         }
         ms.Position = 0;
         using var rpe = new PEReader(ms);
@@ -371,6 +375,32 @@ static class FidelityCheck
             e.OrigOps.SequenceEqual(rOps) ? CompileBackStatus.Exact
                 : e.IsFull ? CompileBackStatus.OpcodeDiff : CompileBackStatus.NotFull,
             e.OrigText, string.Join(" ", rOps), null);
+
+    static string? FormatDiagnostic(Diagnostic? diagnostic)
+    {
+        if (diagnostic is null)
+            return null;
+
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(diagnostic.Id))
+            parts.Add(diagnostic.Id);
+        var message = diagnostic.GetMessage();
+        if (!string.IsNullOrWhiteSpace(message))
+            parts.Add(message);
+        return parts.Count == 0 ? null : string.Join(": ", parts);
+    }
+
+    static string DiagnosticCode(string? detail)
+    {
+        if (string.IsNullOrWhiteSpace(detail))
+            return "<unknown>";
+
+        var prefix = detail.Trim();
+        int separator = prefix.IndexOf(':');
+        if (separator >= 0)
+            prefix = prefix[..separator].Trim();
+        return prefix.Length == 0 ? "<unknown>" : prefix;
+    }
 
     static void RunType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
@@ -408,7 +438,7 @@ static class FidelityCheck
                     break;
                 case CompileBackStatus.RecompileFail:
                     recompileFail++;
-                    recompileFailCodes[r.Detail ?? "<unknown>"] = recompileFailCodes.GetValueOrDefault(r.Detail ?? "<unknown>") + 1;
+                    recompileFailCodes[DiagnosticCode(r.Detail)] = recompileFailCodes.GetValueOrDefault(DiagnosticCode(r.Detail)) + 1;
                     break;
                 case CompileBackStatus.ContextFail:
                     contextFail++;
@@ -441,6 +471,82 @@ static class FidelityCheck
             foreach (var e in diffExamples)
                 Console.WriteLine($"  {e}");
         }
+    }
+
+    internal static IReadOnlyDictionary<string, FailureBucketSummary> SummarizeFailures(
+        IReadOnlyList<CompileBackResult> results, CompileBackStatus status)
+    {
+        var bucketCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var bucketExamples = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var result in results.Where(result => result.Status == status))
+        {
+            var bucket = ClassifyFailure(result);
+            bucketCounts[bucket] = bucketCounts.GetValueOrDefault(bucket) + 1;
+            if (!bucketExamples.TryGetValue(bucket, out var examples))
+            {
+                examples = [];
+                bucketExamples[bucket] = examples;
+            }
+            if (examples.Count < 3)
+                examples.Add($"{result.Type}::{result.Method}");
+        }
+
+        return bucketCounts.ToDictionary(
+            kv => kv.Key,
+            kv => new FailureBucketSummary(
+                kv.Value,
+                bucketExamples.GetValueOrDefault(kv.Key, []).ToImmutableArray()),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed record FailureBucketSummary(int Count, ImmutableArray<string> Examples);
+
+    static string ClassifyFailure(CompileBackResult result)
+    {
+        if (result.Status == CompileBackStatus.ContextFail)
+            return ClassifyContextFailure(result.Detail);
+        return ClassifyRecompileFailure(result.Detail);
+    }
+
+    static string ClassifyContextFailure(string? detail)
+    {
+        if (string.IsNullOrWhiteSpace(detail))
+            return "skeleton emission";
+        if (detail.Contains("method", StringComparison.OrdinalIgnoreCase)
+            && detail.Contains("not found", StringComparison.OrdinalIgnoreCase))
+            return "target method not found";
+        if (detail.Contains("skeleton", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("emit", StringComparison.OrdinalIgnoreCase))
+            return "skeleton emission";
+        return "other context failure";
+    }
+
+    static string ClassifyRecompileFailure(string? detail)
+    {
+        if (string.IsNullOrWhiteSpace(detail))
+            return "compiler diagnostic";
+        if (detail.Contains("does not exist", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("could not be found", StringComparison.OrdinalIgnoreCase))
+            return "missing symbol";
+        if (detail.Contains("inaccessible", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("protected", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("access", StringComparison.OrdinalIgnoreCase))
+            return "accessibility";
+        if (detail.Contains("constraint", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("where", StringComparison.OrdinalIgnoreCase))
+            return "generic constraint";
+        if (detail.Contains("syntax", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("expected", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("identifier", StringComparison.OrdinalIgnoreCase))
+            return "syntax";
+        if (detail.Contains("convert", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("implicit", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("explicit", StringComparison.OrdinalIgnoreCase)
+            || detail.Contains("cast", StringComparison.OrdinalIgnoreCase))
+            return "conversion";
+        return "compiler diagnostic";
     }
 
     // ---- Type-skeleton emission (the C# analog of IlasmScaffold) ----

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -59,7 +59,7 @@ static class Program
         string? diffCorpusBaseline = null;
         bool qualityDiffCard = false;
         bool qualityCardRisky = false;
-        int corpusFidelityCap = 0;
+        var corpusFidelityCaps = new List<int>();
         int corpusMethodCap = int.MaxValue;
         bool json = false;
         int topPatterns = 10;
@@ -115,7 +115,14 @@ static class Program
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
                 case "--quality-diff-card": qualityDiffCard = true; break;
                 case "--quality-card-risky": qualityDiffCard = true; qualityCardRisky = true; break;
-                case "--corpus-fidelity-cap": corpusFidelityCap = int.Parse(args[++i]); break;
+                case "--corpus-fidelity-cap":
+                    foreach (var token in args[++i].Split(','))
+                    {
+                        if (token.Length == 0)
+                            continue;
+                        corpusFidelityCaps.Add(int.Parse(token));
+                    }
+                    break;
                 case "--corpus-method-cap": corpusMethodCap = int.Parse(args[++i]); break;
                 case "--json": json = true; break;
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
@@ -152,7 +159,7 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCap, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, qualityCardRisky, corpusMethodCap);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, qualityDiffCard, qualityCardRisky, corpusMethodCap);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1124,6 +1131,7 @@ static class Program
                                 warnings and targeted-example guidance for risky
                                 raise/structuring PRs.
           --corpus-fidelity-cap <n>      with corpus baseline modes: cap methods
+                                        (repeat or use comma-separated values to compare multiple caps)
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).
           --corpus-method-cap <n>        with corpus baseline modes: cap the

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -25,9 +25,10 @@ Decompiler Daily workflow tracks fully-raised rate,
 (`cond-target-past-region` + `forward-branch-not-region-exit`), Full malformed
 output, semantic validity defects, compile-back fidelity defects, and pass bugs.
 The validity and fidelity caps are per assembly so the sensor samples every
-corpus member at bounded cost without adding that cost to every PR. The fidelity
-sample records useful compile-back outcomes (`Exact`/`OpcodeDiff`) rather than
-mostly recording methods whose generated shell does not recompile. Each daily run
+corpus member at bounded cost without adding that cost to every PR. When you
+want to compare a baseline cap with a larger exploratory cap, repeat
+`--corpus-fidelity-cap` (or use a comma-separated list) and the harness prints a
+fidelity coverage series with the same per-bucket failure breakdown for each cap. The fidelity sample records useful compile-back outcomes (`Exact`/`OpcodeDiff`) while surfacing recompile- and context-failure buckets for triage. Each daily run
 uploads the current JSON snapshot as the `decompiler-corpus-snapshot` artifact so
 trends can be compared without scraping logs.
 
@@ -57,6 +58,8 @@ targeted improved examples plus still-flat near misses.
 
 To deliberately rebaseline after reviewed corpus movement, run the same command
 with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.
+For a quick before/after coverage sweep, repeat `--corpus-fidelity-cap` (for
+example `--corpus-fidelity-cap 3 --corpus-fidelity-cap 10`).
 
 **PR quick corpus** (`tools/DecompilerHarness/corpus/pr-quick-baseline.json`):
 CI also runs a small artifact-producing corpus sensor after the managed tool

--- a/tools/DecompilerHarness/corpus/real-world-baseline.json
+++ b/tools/DecompilerHarness/corpus/real-world-baseline.json
@@ -1,9 +1,10 @@
 {
   "schemaVersion": 1,
   "description": "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
-  "generatedUtc": "2026-06-23T15:06:00.5422037+00:00",
+  "generatedUtc": "2026-06-23T21:03:36.860687+00:00",
   "validityCompileCap": 25,
   "fidelityCompileCap": 3,
+  "methodCap": null,
   "tolerances": {
     "fullyRaisedDropBasisPoints": 10,
     "conditionalBranchIncreaseBasisPoints": 10,
@@ -64,7 +65,7 @@
     {
       "assembly": "ILInspector.Metadata",
       "path": "artifacts/bin/DotnetInspector.Services/release/ILInspector.Metadata.dll",
-      "totalMethods": 1818
+      "totalMethods": 1824
     },
     {
       "assembly": "ILInspector.MetadataPrimitives",
@@ -74,52 +75,52 @@
     {
       "assembly": "dotnet-inspect",
       "path": "artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll",
-      "totalMethods": 12392
+      "totalMethods": 11652
     },
     {
       "assembly": "ILInspector.Analysis",
       "path": "artifacts/bin/dotnet-inspect/release/ILInspector.Analysis.dll",
-      "totalMethods": 410
+      "totalMethods": 446
     },
     {
       "assembly": "ILInspector.Decompiler",
       "path": "artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll",
-      "totalMethods": 4961
+      "totalMethods": 5004
     }
   ],
   "metrics": {
-    "totalMethods": 87907,
-    "fullyRaisedMethods": 77376,
+    "totalMethods": 87252,
+    "fullyRaisedMethods": 76799,
     "fullyRaisedBasisPoints": 8802,
-    "conditionalBranchMethods": 2298,
-    "conditionalBranchBasisPoints": 261,
-    "forwardMergeStoppedContainers": 2290,
-    "forwardMergeBasisPoints": 261,
-    "fullMalformedMethods": 165,
+    "conditionalBranchMethods": 2287,
+    "conditionalBranchBasisPoints": 262,
+    "forwardMergeStoppedContainers": 2282,
+    "forwardMergeBasisPoints": 262,
+    "fullMalformedMethods": 33,
     "semanticCheckedMethods": 350,
     "semanticDefectMethods": 4,
     "passBugs": 0,
     "residualBuckets": {
-      "structuring: conditional-branch": 2298,
-      "fidelity: (typed)": 7374,
-      "structuring: switch-branch": 136,
+      "structuring: conditional-branch": 2287,
+      "fidelity: (typed)": 7313,
+      "structuring: switch-branch": 137,
       "fidelity: (join-type):": 53,
-      "structuring: unconditional-branch": 21,
+      "structuring: unconditional-branch": 22,
       "eh: leave/endfinally": 41,
-      "fidelity: unsupported-node": 558,
-      "fidelity: type unspellable C# type name \u0027\u003CPrivateImplementationDetails\u003E\u0027": 50
+      "fidelity: unsupported-node": 553,
+      "fidelity: type unspellable C# type name \u0027\u003CPrivateImplementationDetails\u003E\u0027": 47
     },
     "structuring": {
-      "totalMethods": 87907,
-      "structuredContainers": 29156,
-      "stoppedContainers": 2507,
-      "methodsWithStops": 2464,
+      "totalMethods": 87252,
+      "structuredContainers": 29009,
+      "stoppedContainers": 2498,
+      "methodsWithStops": 2454,
       "passBugs": 0,
       "stopReasons": {
-        "cond-target-past-region": 1444,
-        "forward-branch-not-region-exit": 846,
+        "cond-target-past-region": 1434,
+        "forward-branch-not-region-exit": 848,
         "cond-backward-branch": 82,
-        "unconsumed-regions": 134,
+        "unconsumed-regions": 133,
         "cond-target-external": 1
       }
     },


### PR DESCRIPTION
## Summary
- extend the decompiler harness corpus sensor to accept repeated/comma-separated `--corpus-fidelity-cap` values and report per-cap fidelity coverage
- add failure-bucket summaries for context-build and recompile failures to make the corpus report more actionable
- update the real-world corpus baseline and docs for the new workflow

## Testing
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet run --project tools/DecompilerHarness -c Release -- <prepared corpus assemblies> --emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3`
- `dotnet run --project tools/DecompilerHarness -c Release -- <prepared corpus assemblies> --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3`
