### PR TITLE
Honor -n/--rows in TSV/JSONL table output (#1231)

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -315,6 +315,57 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void LimitRenderedTableRows_TsvKeepsHeaderAndLimitsDataRows()
+    {
+        var tsv = "name\tcount\nA\t1\nB\t2\nC\t3\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, 2, hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Equal("name\tcount\nA\t1\nB\t2\n", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_TsvWithoutHeaderLimitsFromFirstLine()
+    {
+        var tsv = "A\t1\nB\t2\nC\t3\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, 2, hasHeader: false).ReplaceLineEndings("\n");
+
+        Assert.Equal("A\t1\nB\t2\n", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_JsonlHasNoHeaderLineEvenWhenHeaderRequested()
+    {
+        var jsonl = "{\"name\":\"A\"}\n{\"name\":\"B\"}\n{\"name\":\"C\"}\n";
+
+        // hasHeader is true (callers pass !--no-header) but jsonl rows are self-describing.
+        var output = OutputFormatter.LimitRenderedTableRows(jsonl, 2, hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Equal("{\"name\":\"A\"}\n{\"name\":\"B\"}\n", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_MarkdownDelegatesToMarkdownLimiter()
+    {
+        var markdown = "| Name |\n| ---- |\n| A |\n| B |\n| C |\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(markdown, 2, hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Contains("| A |", output);
+        Assert.Contains("| B |", output);
+        Assert.DoesNotContain("| C |", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_NullLimitIsUnchanged()
+    {
+        var tsv = "name\tcount\nA\t1\nB\t2\n";
+
+        Assert.Equal(tsv, OutputFormatter.LimitRenderedTableRows(tsv, null, hasHeader: true));
+    }
+
+    [Fact]
     public void LimitMarkdownTableRows_LimitsEachTable()
     {
         const string markdown = """

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -8,6 +8,31 @@ namespace DotnetInspector.Tests;
 public class TopLeverageSectionTests
 {
     [Fact]
+    public async Task TypeTopLeverage_TsvHonorsRowLimit()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(LeverageSampleType).FullName,
+            AssemblyPath = typeof(LeverageSampleType).Assembly.Location,
+            IncludeSections = [SectionNames.TopLeverage],
+            Tsv = true,
+            Rows = 2,
+            OneLine = true,
+            OneLineExplicitlySet = true,
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        var lines = result.Output.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        // Header row plus exactly two data rows.
+        Assert.Equal(3, lines.Length);
+        Assert.StartsWith("member", lines[0]);
+        Assert.Contains("SharedHelper()", result.Output);
+    }
+
+    [Fact]
     public async Task TypeTopLeverage_RanksMostCalledMemberFirst()
     {
         var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -377,7 +377,7 @@ public class ApiCommand
                 (writer, formatter, writerOptions) =>
                     MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOptions));
             ProjectionDiagnostics.DiagnoseRendered(options.Fields ?? options.Columns, rendered);
-            Console.Out.Write(rendered);
+            Console.Out.Write(OutputFormatter.LimitRenderedTableRows(rendered, options.Rows, !options.NoHeader));
         }
         else
         {
@@ -733,7 +733,7 @@ public class ApiCommand
                             view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
                             explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, markoutWriter);
                         markoutWriter.Flush();
-                    });
+                    }, options.Rows);
             }
             else
             {
@@ -741,7 +741,8 @@ public class ApiCommand
                 OutputFormatter.WriteProjectedTable(sink, !options.NoHeader, options.Tsv, options.Jsonl,
                     options.Columns, options.Fields,
                     (writer, formatter, writerOptions) =>
-                        MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOptions));
+                        MarkoutSerializer.Serialize(oneLineView, writer, formatter, ApiViewContext.Default, writerOptions),
+                    options.Rows);
             }
         }
         else

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -94,7 +94,8 @@ public class DiffCommand
                 OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
                     options.Columns, options.Fields,
                     (writer, formatter, writerOptions) =>
-                        MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions));
+                        MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                    options.Rows);
             }
             else
             {

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -88,7 +88,8 @@ public class FindCommand
             OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
                 options.Columns, options.Fields,
                 (writer, formatter, writerOptions) =>
-                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions));
+                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
+                options.Rows);
         }
         else
         {

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -139,7 +139,8 @@ public class ImplementsCommand
         {
             OutputFormatter.WriteProjectedTable(Console.Out, !noHeader, tsv, jsonl, columns, fields,
                 (writer, formatter, writerOptions) =>
-                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions));
+                    MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
+                rows);
         }
         else
         {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1253,7 +1253,7 @@ public class PackageCommand
                 ["package", "version", "path", "size"],
                 rows);
             markoutWriter.Flush();
-        });
+        }, options.Rows);
     }
 
     private static void WritePackageFilesJsonl(InspectionResult result, string section)
@@ -1341,7 +1341,7 @@ public class PackageCommand
                 ["package", "field", "value"],
                 rows);
             markoutWriter.Flush();
-        });
+        }, options.Rows);
     }
 
     private static void ApplyNuspec(NuspecData nuspec, InspectionResult result)
@@ -1758,7 +1758,7 @@ public class PackageCommand
             var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
             markoutWriter.WriteTable(table.Headers, table.StableHeaders, table.Rows);
             markoutWriter.Flush();
-        });
+        }, options.Rows);
         return true;
     }
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -26,8 +26,42 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
-    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize) =>
-        output.Write(RenderTable(showHeader, serialize));
+    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, int? maxRows = null) =>
+        output.Write(LimitRenderedTableRows(RenderTable(showHeader, serialize), maxRows, showHeader));
+
+    /// <summary>
+    /// Trims a rendered single-section table to <paramref name="maxRows"/> data rows,
+    /// for any table output format. <c>--tsv</c>/<c>--jsonl</c> render one section at a
+    /// time, so the rendered text is a single table: jsonl is one self-describing row
+    /// object per line (no header line), tsv has an optional header line, and the default
+    /// table mode is a Markdown table delimited by a separator line. A null/negative limit
+    /// (no <c>--rows</c>) leaves the output untouched.
+    /// </summary>
+    public static string LimitRenderedTableRows(string rendered, int? maxRows, bool hasHeader)
+    {
+        if (maxRows is null or < 0 || string.IsNullOrEmpty(rendered))
+            return rendered;
+
+        var trailingNewline = rendered.EndsWith('\n');
+        var body = rendered.ReplaceLineEndings("\n");
+        if (trailingNewline)
+            body = body.TrimEnd('\n');
+        var lines = body.Split('\n');
+
+        // Markdown table (header row followed by a separator line): delegate to the
+        // Markdown-aware limiter, which also tolerates surrounding prose/code fences.
+        if (lines.Length >= 2 && MarkdownScan.IsTableLine(lines[0]) && MarkdownScan.IsSeparatorLine(lines[1]))
+            return MarkdownTableRowLimiter.Apply(rendered, maxRows);
+
+        // jsonl rows are self-describing objects with no header line; tsv keeps its header.
+        bool jsonl = lines[0].StartsWith('{');
+        int headerLines = !jsonl && hasHeader ? 1 : 0;
+        if (lines.Length <= headerLines)
+            return rendered;
+
+        var kept = string.Join('\n', lines.Take(headerLines + maxRows.Value));
+        return trailingNewline ? kept + "\n" : kept;
+    }
 
     public static MarkoutWriterOptions ConfigureTableWriterOptions(MarkoutWriterOptions options, bool tsv, bool jsonl)
     {
@@ -68,8 +102,9 @@ public static class OutputFormatter
         bool jsonl,
         string[]? columns,
         string[]? fields,
-        Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize) =>
-        output.Write(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize));
+        Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize,
+        int? maxRows = null) =>
+        output.Write(LimitRenderedTableRows(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize), maxRows, showHeader));
 
     public static string ApplyRowLimit(string markdown, int? rows) =>
         MarkdownTableRowLimiter.Apply(markdown.TrimEnd(), rows);
@@ -224,7 +259,8 @@ public static class OutputFormatter
         {
             ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
             WriteTable(Console.Out, !options.NoHeader,
-                (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts));
+                (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
+                options.Rows);
         }
     }
 
@@ -287,7 +323,8 @@ public static class OutputFormatter
                 };
                 ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
                 WriteTable(Console.Out, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts));
+                    (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
+                    options.Rows);
             }
         }
     }


### PR DESCRIPTION
## Summary

`-n`/`--rows` row limiting was applied only in Markdown output; `--tsv`/`--jsonl` emitted the full table regardless. This breaks the agent "top N" workflow for ranked sections like `Top Leverage`, `Callers`, and `Calls`.

Since `--tsv`/`--jsonl` render **one section at a time**, the rendered text is always a single table. This PR adds a format-aware `OutputFormatter.LimitRenderedTableRows` helper:

- **jsonl** — keep the first N self-describing row objects (no header line)
- **tsv** — keep the header (when present) plus N data rows
- **Markdown** — delegate to the existing `MarkdownTableRowLimiter`

and threads an optional `maxRows` through `WriteTable`/`WriteProjectedTable`. The result-table call sites in the type/member, find, implements, diff, package, and library output paths now pass `options.Rows`, matching what Markdown already did. Discovery (`-D`) and single-value list outputs are intentionally left unlimited.

## Before / after

```bash
# before: emits all rows
type LibraryBodyIndex --library X.dll -S "Top Leverage" --tsv --rows -n 3 | wc -l   # 19

# after: header + 3 rows
type LibraryBodyIndex --library X.dll -S "Top Leverage" --tsv --rows -n 3 | wc -l   # 4
type LibraryBodyIndex --library X.dll -S "Top Leverage" --jsonl --rows -n 2 | wc -l # 2
```

## Tests

- Unit coverage for `LimitRenderedTableRows`: tsv (with/without header), jsonl (no header even when requested), Markdown delegation, and null-limit passthrough.
- Command-level regression: `--tsv` with a row limit trims to N rows.
- Full suite green apart from the two pre-existing platform-resolution env failures.

Fixes #1231