### PR TITLE
Match nested types in type-scoped IL sections (#1228)

### DIFF
--- a/src/dotnet-inspect.Tests/NestedTypeLeverageTests.cs
+++ b/src/dotnet-inspect.Tests/NestedTypeLeverageTests.cs
@@ -1,0 +1,42 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class NestedTypeLeverageTests
+{
+    [Fact]
+    public async Task TypeTopLeverage_ReturnsRowsForNestedType()
+    {
+        var nested = typeof(NestedLeverageHost.Inner);
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = nested.FullName!.Replace('+', '.'),
+            AssemblyPath = nested.Assembly.Location,
+            IncludeSections = [SectionNames.TopLeverage],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            MarkdownExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Top Leverage", result.Output);
+        // Shared is called by EntryA and EntryB on the nested type.
+        Assert.Contains("`Shared()` | 2 |", result.Output);
+    }
+}
+
+public class NestedLeverageHost
+{
+    public class Inner
+    {
+        public void EntryA() => Shared();
+
+        public void EntryB() => Shared();
+
+        public void Shared() => System.Console.WriteLine("x");
+    }
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1508,7 +1508,9 @@ public static class ApiOutputFormatter
     static bool SameType(Analysis.TypeRef typeRef, ApiType type)
         => typeRef.Kind == Analysis.TypeRefKind.Definition
            && string.Equals(typeRef.Namespace, type.Namespace ?? "", StringComparison.Ordinal)
-           && string.Equals(typeRef.Name, type.Name, StringComparison.Ordinal);
+           // Nested types use the metadata '+' separator in the analysis TypeRef
+           // (Outer+Inner) but the '.' separator in the API surface (Outer.Inner).
+           && string.Equals(typeRef.Name.Replace('+', '.'), type.Name, StringComparison.Ordinal);
 
     /// <summary>
     /// Converts the decompiler's telemetry-free <see cref="Decompiler.DecompilerTrace"/>


### PR DESCRIPTION
## Summary

`ApiOutputFormatter.SameType` scopes type-level IL sections (`Top Leverage`, `Unsafe Members`) by comparing the analysis `TypeRef.Name` against `ApiType.Name`. For **nested types** the two models use different separators:

- analysis `TypeRef.Name`: metadata `+` form — `Outer+Inner`
- API surface `ApiType.Name`: dotted form — `Outer.Inner`

(The namespace already matches: the analysis side inherits the outer type's root namespace.) The names never matched, so selecting a nested type yielded an empty section even when it had clear leverage or unsafe evidence.

## Fix

Normalize the nested separator (`+` → `.`) before comparison in `SameType`. Non-nested types are unaffected (their name contains no `+`). The fix is shared, so both `Top Leverage` and `Unsafe Members` now return rows for nested types.

## Repro / test

```bash
type Outer.Inner --library X.dll -S "Top Leverage"   # before: no rows; after: ranked members
```

Added `NestedTypeLeverageTests.TypeTopLeverage_ReturnsRowsForNestedType` (a nested type whose `Shared()` method is called by two siblings now reports 2 callers).

## Tests

- New nested-type test passes; existing Unsafe Members / Top Leverage tests still green.
- Full CLI suite green apart from the two pre-existing platform-resolution env failures.

Fixes #1228