### PR TITLE
Add library-scope Top Leverage ranking (#1225)

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -47,7 +47,7 @@ A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`.
 
 Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (widen with `--bin`, `--project`, or `--caller-package`), `-S "Call Graph"` for a bounded outbound tree, `-S "Caller Graph"` for a bounded reverse tree that shows which entry points or callers reach the selected method, `-S "Unsafe Operations"` for unsafe evidence, and `-S Facts --tsv` for structured hidden facts.
 
-For perf or correctness triage, start with `type T --library MyLib.dll -S "Top Leverage"` to rank a type's members by call-graph leverage (direct callers, fanout, depth, loop calls), then drill the top candidates with `-S "Call Graph,Facts"` (outbound cost) and `-S "Caller Graph"` (inbound reach). Add `--tsv`, or `-n` in Markdown, to trim rows.
+For perf or correctness triage, rank by call-graph leverage (direct callers, fanout, depth, loop calls): `library MyLib.dll -S "Top Leverage"` ranks across the whole assembly, or `type T --library MyLib.dll -S "Top Leverage"` ranks one type's members. Then drill the top candidates with `-S "Call Graph,Facts"` (outbound cost) and `-S "Caller Graph"` (inbound reach). Add `--tsv` or `-n` to trim to the top rows.
 
 ## Query and output
 

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -413,7 +413,7 @@ public static class AssemblyDetailScanner
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             if (flags.HasExtensionTypes && flags.HasPInvokeImports && flags.HasUnsafeCode
-                && flags.HasRuntimeAsync && flags.HasStateMachineAsync)
+                && flags.HasRuntimeAsync && flags.HasStateMachineAsync && flags.HasMethodBodies)
                 break;
 
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
@@ -433,16 +433,21 @@ public static class AssemblyDetailScanner
             bool considerAsync = (!flags.HasRuntimeAsync || !flags.HasStateMachineAsync)
                                  && !reader.GetString(typeDef.Name).StartsWith('<');
 
-            // P/Invoke, unsafe, async: check methods
-            if (!flags.HasPInvokeImports || !flags.HasUnsafeCode || considerAsync)
+            // P/Invoke, unsafe, async, method bodies: check methods
+            if (!flags.HasPInvokeImports || !flags.HasUnsafeCode || considerAsync || !flags.HasMethodBodies)
             {
                 foreach (var methodHandle in typeDef.GetMethods())
                 {
                     if (flags.HasPInvokeImports && flags.HasUnsafeCode
-                        && flags.HasRuntimeAsync && flags.HasStateMachineAsync)
+                        && flags.HasRuntimeAsync && flags.HasStateMachineAsync && flags.HasMethodBodies)
                         break;
 
                     var method = reader.GetMethodDefinition(methodHandle);
+
+                    // A non-zero RVA means the method carries an IL body (not abstract/extern),
+                    // so the assembly has code to rank for Top Leverage.
+                    if (!flags.HasMethodBodies && method.RelativeVirtualAddress != 0)
+                        flags.HasMethodBodies = true;
 
                     if (!flags.HasPInvokeImports
                         && (method.Attributes & MethodAttributes.PinvokeImpl) != 0)
@@ -499,6 +504,7 @@ public class PresenceFlags
     public bool HasExtensionTypes { get; set; }
     public bool HasPInvokeImports { get; set; }
     public bool HasUnsafeCode { get; set; }
+    public bool HasMethodBodies { get; set; }
     public bool HasManifestResources { get; set; }
     public bool HasAssemblyAttributes { get; set; }
     public bool HasTypeForwarders { get; set; }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3332,6 +3332,7 @@ public class CommandExecutionTests
                 "SourceLink Integrity",
                 "SourceLink Missing Files",
                 "Switches",
+                "Top Leverage",
                 "Type Forwarders",
                 "Unsafe Members"
             ],

--- a/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
@@ -1,0 +1,50 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class LibraryTopLeverageTests
+{
+    [Fact]
+    public async Task LibraryTopLeverage_RendersRankedTable()
+    {
+        var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions
+        {
+            AssemblyName = typeof(LibraryLeverageFixture).Assembly.Location,
+            IncludeSections = ["Top Leverage"],
+            Markdown = true,
+            Rows = 25,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Top Leverage", result.Output);
+        Assert.Contains("| Member | Callers | Fanout | Depth | Loop Calls |", result.Output);
+        // Assembly-wide rows are fully-qualified.
+        Assert.Contains("| `DotnetInspector.Tests.", result.Output);
+    }
+
+    [Fact]
+    public async Task LibraryTopLeverage_StaysSilentWhenNotSelected()
+    {
+        var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions
+        {
+            AssemblyName = typeof(LibraryLeverageFixture).Assembly.Location,
+            IncludeSections = ["Library Info"],
+            Markdown = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("## Top Leverage", result.Output);
+    }
+}
+
+public static class LibraryLeverageFixture
+{
+    public static void EntryA() => SharedHelper();
+
+    public static void EntryB() => SharedHelper();
+
+    public static void SharedHelper() => System.Console.WriteLine("x");
+}

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -231,7 +231,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(33, pipeline.AllSectionNames.Length);
+        Assert.Equal(34, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -75,6 +75,7 @@ internal static class LibraryMetadataService
             inspection.HasExtensionTypes = presenceFlags.HasExtensionTypes;
             inspection.HasPInvokeImports = presenceFlags.HasPInvokeImports;
             inspection.HasUnsafeCode = presenceFlags.HasUnsafeCode;
+            inspection.HasMethodBodies = presenceFlags.HasMethodBodies;
             inspection.HasRuntimeAsync = presenceFlags.HasRuntimeAsync;
             inspection.HasStateMachineAsync = presenceFlags.HasStateMachineAsync;
             inspection.HasManifestResources = presenceFlags.HasManifestResources;
@@ -587,6 +588,34 @@ internal static class LibraryMetadataService
 
     private static string FormatMethod(Analysis.MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+
+    /// <summary>
+    /// Ranks the assembly's methods by call-graph leverage (distinct direct callers,
+    /// then outbound shape). Capped at the most-leveraged <paramref name="count"/>.
+    /// </summary>
+    internal static List<MethodLeverageSummary>? ScanTopLeverage(string path, VerboseLogger logger, int count = 50)
+    {
+        try
+        {
+            var index = Analysis.LibraryBodyIndex.Open(path);
+            var rows = index.TopLeverage(count)
+                .Select(entry => new MethodLeverageSummary
+                {
+                    Member = FormatMethod(entry.Method),
+                    Callers = entry.DirectCallerCount,
+                    Fanout = entry.Fanout,
+                    Depth = entry.MaxDepth,
+                    LoopCalls = entry.LoopCallCount,
+                })
+                .ToList();
+            return rows.Count > 0 ? rows : null;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning leverage in {path}: {ex.Message}");
+            return null;
+        }
+    }
 
     internal static List<IntegrationSignal>? ScanOpenTelemetry(string path, VerboseLogger logger)
     {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -591,14 +591,15 @@ internal static class LibraryMetadataService
 
     /// <summary>
     /// Ranks the assembly's methods by call-graph leverage (distinct direct callers,
-    /// then outbound shape). Capped at the most-leveraged <paramref name="count"/>.
+    /// then outbound shape). Emits the full ranked set so the row limiter (<c>-n</c>/
+    /// <c>--rows</c>) controls how many rows are shown, matching the type-scoped view.
     /// </summary>
-    internal static List<MethodLeverageSummary>? ScanTopLeverage(string path, VerboseLogger logger, int count = 50)
+    internal static List<MethodLeverageSummary>? ScanTopLeverage(string path, VerboseLogger logger)
     {
         try
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
-            var rows = index.TopLeverage(count)
+            var rows = index.TopLeverage(int.MaxValue)
                 .Select(entry => new MethodLeverageSummary
                 {
                     Member = FormatMethod(entry.Method),

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -371,6 +371,7 @@ public class LibraryInspection
     public bool HasUnsafeCode { get; set; }
 
     /// <summary>True when the assembly has at least one method with an IL body (not a pure ref/abstract assembly).</summary>
+    [JsonIgnore]
     public bool HasMethodBodies { get; set; }
 
     /// <summary>Whether the assembly contains any public runtime-async methods (impl flag 0x2000).</summary>

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -204,6 +204,13 @@ public class LibraryInspection
     public List<UnsafeMemberSummary>? UnsafeMembers { get; set; }
 
     /// <summary>
+    /// Methods ranked by call-graph leverage (distinct direct callers, then outbound
+    /// shape). Assembly-wide; populated only when the Top Leverage section is selected.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<MethodLeverageSummary>? TopLeverage { get; set; }
+
+    /// <summary>
     /// Public P/Invoke (DllImport/LibraryImport) methods.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -363,6 +370,9 @@ public class LibraryInspection
     [JsonIgnore]
     public bool HasUnsafeCode { get; set; }
 
+    /// <summary>True when the assembly has at least one method with an IL body (not a pure ref/abstract assembly).</summary>
+    public bool HasMethodBodies { get; set; }
+
     /// <summary>Whether the assembly contains any public runtime-async methods (impl flag 0x2000).</summary>
     [JsonIgnore]
     public bool HasRuntimeAsync { get; set; }
@@ -493,6 +503,19 @@ public record class UnsafeMemberSummary
     public string? IL { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Token { get; init; }
+}
+
+/// <summary>
+/// A method ranked by call-graph leverage: distinct direct callers (fanin), outbound
+/// call sites (fanout), longest intra-assembly call chain (depth), and in-loop call sites.
+/// </summary>
+public record class MethodLeverageSummary
+{
+    public string Member { get; init; } = "";
+    public int Callers { get; init; }
+    public int Fanout { get; init; }
+    public int Depth { get; init; }
+    public int LoopCalls { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -24,6 +24,7 @@ public static class LibrarySections
     public const string ScannerIntegrationOpportunities = "IntegrationOpportunities";
     public const string ScannerSwitches = "Switches";
     public const string ScannerUnsafeMembers = "UnsafeMembers";
+    public const string ScannerTopLeverage = "TopLeverage";
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
@@ -56,6 +57,7 @@ public static class LibrarySections
             .Add<Dependencies>()
             .Add<ExtensionMethods>()
             .Add<UnsafeMembers>()
+            .Add<TopLeverage>()
             .Add<PInvokeMethods>()
             .Add<AsyncMethods>()
             .Add<Resources>()
@@ -92,6 +94,8 @@ public static class LibrarySections
                 ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerUnsafeMembers, ctx =>
                 ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.AssemblyPath, ctx.Logger))
+            .Add(ScannerTopLeverage, ctx =>
+                ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>
@@ -375,6 +379,16 @@ public static class LibrarySections
         public static string? ScannerKey => ScannerUnsafeMembers;
         public static bool CanRender(LibraryInspection model)
             => model.UnsafeMembers is { Count: > 0 } || model.HasUnsafeCode;
+    }
+
+    public sealed class TopLeverage : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.TopLeverage;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerTopLeverage;
+        public static bool CanRender(LibraryInspection model)
+            => model.TopLeverage is { Count: > 0 } || model.HasMethodBodies;
     }
 
     public sealed class PInvokeMethods : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -550,6 +550,20 @@ public class LibraryInspectionView
                 m.IL is null ? null : MarkoutInline.Code(m.IL), m.Token is null ? null : MarkoutInline.Code(m.Token)))
             .ToList();
 
+    public bool HasTopLeverage => _data.TopLeverage is { Count: > 0 };
+
+    // Rows arrive pre-ranked from the scanner; preserve that order (most leveraged first).
+    [MarkoutSection(Name = "Top Leverage", ShowWhenProperty = nameof(HasTopLeverage))]
+    public List<TopLeverageRow>? TopLeverageSection =>
+        _data.TopLeverage?
+            .Select(m => new TopLeverageRow(
+                MarkoutInline.Code(m.Member),
+                m.Callers.ToString(),
+                m.Fanout.ToString(),
+                m.Depth.ToString(),
+                m.LoopCalls.ToString()))
+            .ToList();
+
     /// <summary>
     /// Resolves the display version using priority: PlatformVersion, InformationalVersion (prefix), AssemblyVersion, FileVersion.
     /// </summary>


### PR DESCRIPTION
## Summary

Extends **Top Leverage** to the `library` command, so it ranks an entire assembly's methods by call-graph leverage — complementing the type-scoped view shipped earlier.

```bash
# Rank the whole assembly's methods by leverage, top 25
library MyLib.dll -S "Top Leverage" --rows -n 25

# Drill the top candidate
member Type Method~digest --library MyLib.dll -S "Call Graph,Facts"   # outbound cost
member Type Method~digest --library MyLib.dll -S "Caller Graph"        # inbound reach
```

Columns: **Member** (fully-qualified), **Callers** (distinct direct callers / fanin), **Fanout**, **Depth** (longest intra-assembly call chain), **Loop Calls**.

## Implementation

Reuses the existing ranking substrate (`LibraryBodyIndex.TopLeverage` / `MethodLeverageRanking.Top`) — no changes there — and wires it through the library section pipeline:

- New `ScanTopLeverage` scanner → `LibraryInspection.TopLeverage` (`MethodLeverageSummary`).
- New explicit-only `TopLeverage` section descriptor + scanner registration + pipeline entry.
- `TopLeverageSection` view reuses `TopLeverageRow`, preserving the scanner's ranked order (no re-sort).
- New `HasMethodBodies` structural presence flag (cheap pre-scan) so the opt-in section appears in `-D` discovery without running the scan — keeping discovery a superset of what can render.
- Emits the full ranked set so `-n`/`--rows` controls how many rows show (consistent with the type-scoped view; `--count` reflects the real total).

## Review

Reviewed by GPT-5.5. Findings addressed in-branch:
- Replaced a hard top-50 cap with the full ranked set so `-n` isn't misleading and `--count` isn't clamped.
- Marked `HasMethodBodies` `[JsonIgnore]` (like its sibling presence flags) so it doesn't leak into `library --json`.

GPT-5.5 also verified the subtle `HasMethodBodies` weaving into the existing single-pass presence scan (no false-negative even when a later type holds the only method body).

## Tests

- Library Top Leverage render + opt-in behavior.
- Section-count and `-D --schema` opt-in lists updated for the new section.
- Metadata presence-flag suite (215) green.
- Full CLI suite green apart from the two pre-existing platform-resolution env failures.

Part of #1225 (library scope; namespace scope and richer columns remain follow-ups).