### PR TITLE
Hint at --all when drilling a non-public Top Leverage candidate (#1234)

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -47,7 +47,7 @@ A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`.
 
 Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (widen with `--bin`, `--project`, or `--caller-package`), `-S "Call Graph"` for a bounded outbound tree, `-S "Caller Graph"` for a bounded reverse tree that shows which entry points or callers reach the selected method, `-S "Unsafe Operations"` for unsafe evidence, and `-S Facts --tsv` for structured hidden facts.
 
-For perf or correctness triage, rank by call-graph leverage (direct callers, fanout, depth, loop calls): `library MyLib.dll -S "Top Leverage"` ranks across the whole assembly, or `type T --library MyLib.dll -S "Top Leverage"` ranks one type's members. Then drill the top candidates with `-S "Call Graph,Facts"` (outbound cost) and `-S "Caller Graph"` (inbound reach). Add `--tsv` or `-n` to trim to the top rows.
+For perf or correctness triage, rank by call-graph leverage (direct callers, fanout, depth, loop calls): `library MyLib.dll -S "Top Leverage"` ranks across the whole assembly, or `type T --library MyLib.dll -S "Top Leverage"` ranks one type's members. Then drill the top candidates with `-S "Call Graph,Facts"` (outbound cost) and `-S "Caller Graph"` (inbound reach). Add `--tsv` or `-n` to trim to the top rows. The ranking surfaces non-public helpers, so add `--all` when drilling a private/internal candidate (otherwise member selection can't resolve it).
 
 ## Query and output
 

--- a/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
@@ -48,6 +48,53 @@ public class ApiTypeLookupServiceTests
         Assert.True(result.IsValid);
     }
 
+    [Fact]
+    public void FindNonPublicMatches_IdentifiesMembersThatExistOnlyInFullSet()
+    {
+        var matches = ApiTypeLookupService.FindNonPublicMatches(
+            ["SerializeObjectInternal", "TotallyBogus"],
+            ["Serialize", "Deserialize", "SerializeObjectInternal"]);
+
+        Assert.Equal(["SerializeObjectInternal"], matches);
+    }
+
+    [Fact]
+    public void FindNonPublicMatches_HonorsGlobFilters()
+    {
+        var matches = ApiTypeLookupService.FindNonPublicMatches(
+            ["*Internal"],
+            ["Serialize", "SerializeObjectInternal"]);
+
+        Assert.Equal(["*Internal"], matches);
+    }
+
+    [Fact]
+    public void WriteError_NonPublicMatch_HintsAtAllFlag()
+    {
+        var result = new MemberFilterValidationResult(
+            ["SerializeObjectInternal"], [], ["SerializeObjectInternal"]);
+
+        var writer = new StringWriter();
+        result.WriteError(writer);
+        var output = writer.ToString();
+
+        Assert.Contains("No members matched filter 'SerializeObjectInternal'", output);
+        Assert.Contains("Member 'SerializeObjectInternal' is non-public; pass --all to include it.", output);
+    }
+
+    [Fact]
+    public void WriteError_NoNonPublicMatch_OmitsHint()
+    {
+        var result = new MemberFilterValidationResult(["Bogus"], ["Serialize"]);
+
+        var writer = new StringWriter();
+        result.WriteError(writer);
+        var output = writer.ToString();
+
+        Assert.DoesNotContain("pass --all", output);
+        Assert.Contains("Did you mean:", output);
+    }
+
     private static ApiSurface CreateSurface()
     {
         return new ApiSurface

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -85,6 +85,23 @@ public static class MemberCommand
                 var memberValidation = ApiTypeLookupService.ValidateMemberFilters(apiType, options.MemberFilter);
                 if (!memberValidation.IsValid)
                 {
+                    // The ranking/graph surfaces walk the full IL index and surface non-public
+                    // members; member selection hides them without --all. If a missed filter
+                    // would match a non-public member, hint at --all instead of dead-ending.
+                    if (!options.IncludeAll && apiDllPath is { } dllForHint)
+                    {
+                        var allMemberNames = AssemblyReader.ExtractApiSurface(dllForHint, includeAll: true)?
+                            .Types.FirstOrDefault(t => t.FullName == apiType.FullName)?
+                            .Members.Select(m => m.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                        if (allMemberNames is { Count: > 0 })
+                        {
+                            var nonPublic = ApiTypeLookupService.FindNonPublicMatches(
+                                memberValidation.MissedFilters, allMemberNames);
+                            if (nonPublic.Count > 0)
+                                memberValidation = memberValidation with { NonPublicMatches = nonPublic };
+                        }
+                    }
+
                     memberValidation.WriteError(Console.Error);
                     return 1;
                 }

--- a/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
@@ -21,8 +21,16 @@ internal sealed record ApiTypeLookupResult(string Query, LookupResult Lookup, Ap
     }
 }
 
-internal sealed record MemberFilterValidationResult(IReadOnlyList<string> MissedFilters, IReadOnlyList<string> Suggestions)
+internal sealed record MemberFilterValidationResult(
+    IReadOnlyList<string> MissedFilters,
+    IReadOnlyList<string> Suggestions,
+    IReadOnlyList<string> NonPublicMatches)
 {
+    public MemberFilterValidationResult(IReadOnlyList<string> missedFilters, IReadOnlyList<string> suggestions)
+        : this(missedFilters, suggestions, [])
+    {
+    }
+
     public bool IsValid => MissedFilters.Count == 0;
 
     public void WriteError(TextWriter error)
@@ -31,6 +39,17 @@ internal sealed record MemberFilterValidationResult(IReadOnlyList<string> Missed
             return;
 
         error.WriteLine($"Error: No members matched filter '{string.Join(", ", MissedFilters)}'");
+
+        // The ranking/graph surfaces (Top Leverage, Call Graph, Caller Graph) walk the full
+        // IL index, so they surface non-public members that member selection hides without
+        // --all. Point the user at the flag instead of a dead end.
+        if (NonPublicMatches.Count > 0)
+        {
+            error.WriteLine();
+            foreach (var name in NonPublicMatches)
+                error.WriteLine($"Member '{name}' is non-public; pass --all to include it.");
+        }
+
         if (Suggestions.Count == 0)
             return;
 
@@ -81,5 +100,28 @@ internal static class ApiTypeLookupService
 
         var memberLookup = TypeMatcher.LookupMembers(memberNames, missedFilters);
         return new MemberFilterValidationResult(missedFilters, memberLookup.Suggestions);
+    }
+
+    /// <summary>
+    /// Of the <paramref name="missedFilters"/> (which matched no visible member), returns
+    /// those that would match against <paramref name="allMemberNames"/> — i.e. members that
+    /// exist but are non-public, so the user needs <c>--all</c> to select them.
+    /// </summary>
+    public static IReadOnlyList<string> FindNonPublicMatches(
+        IReadOnlyCollection<string> missedFilters,
+        IReadOnlyCollection<string> allMemberNames)
+    {
+        List<string> matches = [];
+        foreach (var filter in missedFilters)
+        {
+            bool isGlob = filter.Contains('*') || filter.Contains('?');
+            bool anyMatch = isGlob
+                ? allMemberNames.Any(n => TypeMatcher.MatchesGlob(n, filter))
+                : allMemberNames.Any(n => TypeMatcher.MatchesMemberName(n, filter));
+
+            if (anyMatch)
+                matches.Add(filter);
+        }
+        return matches;
     }
 }


### PR DESCRIPTION
## Summary

`Top Leverage` / `Call Graph` / `Caller Graph` rank and walk the **full IL index**, so they surface non-public helpers as top candidates without `--all`. But `member` selection is visibility-filtered to the public surface, so drilling one of those candidates dead-ends on:

```
Error: No members matched filter 'SerializeObjectInternal'

Did you mean:
  SerializeObject
```

— public-only suggestions that are actively misleading, since the member exists and is exactly what the ranking just recommended.

## Fix

When a member filter matches no visible member and `--all` was not passed, re-check it against the full (non-public-inclusive) member set — extracted only on the failure path, so the happy path is unchanged — and if it would match there, append:

```
Member 'SerializeObjectInternal' is non-public; pass --all to include it.
```

Also note in `skills/dotnet-inspect/SKILL.md` that non-public Top Leverage candidates need `--all` to drill.

## Before / after

```bash
member JsonConvert SerializeObjectInternal:1 --library Newtonsoft.Json.dll -S "Caller Graph"
# before: "No members matched filter" + public-only "Did you mean"
# after:  + "Member 'SerializeObjectInternal' is non-public; pass --all to include it."
```

Typos still get only the plain error (no spurious `--all` hint), and `--all` resolves the member as before.

## Scope note

This addresses the visibility gap (#1234). A separate, pre-existing quirk affects bare-name selection of context-gated sections (`member T Name -S "Caller Graph"` without an overload/`~digest` selector errors with `Select value 'Caller Graph' not found` in the preamble) — that affects **public** members equally and is not a visibility issue, so it's out of scope here. The hint fires once the section is selectable (via `:1`, `~digest`, auto-selected overload, or a non-context-gated section like `Callers`).

## Tests

- Unit: `FindNonPublicMatches` (exact + glob); `WriteError` emits the hint only for non-public matches.
- Full CLI suite green apart from the two pre-existing platform-resolution env failures.

Fixes #1234