### PR TITLE
Emit bare URL vectors

### DIFF
--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -116,7 +116,7 @@ should come from the documentation block, not SourceLink URL inference.
 `--bare` is the right output shape when a caller wants section content without a
 heading, table, or Markdown decoration. It supports type/member code sections
 such as `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`,
-single SourceLink URL rows such as `Source Locations`, and package README/content
+one-column SourceLink URL output such as `Source Locations`, and package README/content
 payloads. If `Documentation` returns the complete `///` block, it should follow
 the same single-section bare-output contract so users can redirect the exact
 comment block or feed it to downstream tools without Markout framing.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -51,7 +51,7 @@ For perf or correctness triage, rank by call-graph leverage (direct callers, fan
 
 ## Query and output
 
-Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON object per row, `--json` for structured documents, `--bare` for one undecorated payload, `--count` for a bare row count, and `--mermaid` for graph-shaped output.
+Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON object per row, `--json` for structured documents, `--bare` for one undecorated payload or URL list, `--count` for a bare row count, and `--mermaid` for graph-shaped output.
 
 Use `-D` to discover sections/columns, `-S Section` to select sections by name or wildcard, and `--columns`/`--fields` to project values. Discover first instead of guessing names.
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1601,15 +1601,40 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_SourceLocations_BareGroup_ErrorsWhenMultipleUrls()
+    public async Task Member_SourceLocations_BareGroup_EmitsUrlColumn()
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "JsonConvert", "--package", "Newtonsoft.Json@13.0.4",
             "-m", "SerializeObject", "-S", "Source Locations", "--bare", "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("--bare requires section 'Source Locations' to resolve exactly one URL", error);
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(lines.Length > 1);
+        Assert.All(lines, line =>
+        {
+            Assert.StartsWith("https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/", line);
+            Assert.Contains("JsonConvert.cs", line);
+        });
+        Assert.DoesNotContain("## Source Locations", output);
+        Assert.DoesNotContain("| Url |", output);
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_Bare_EmitsUrlColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--bare", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", StringComparison.Ordinal));
+        Assert.All(lines, line => Assert.StartsWith("https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/", line));
+        Assert.DoesNotContain("url", lines);
     }
 
     [Fact]
@@ -4857,6 +4882,22 @@ public class CommandExecutionTests
         Assert.Contains("lib/net6.0/Newtonsoft.Json.dll\tNewtonsoft.Json.JsonConvert\t", output);
         Assert.Contains("github.com/JamesNK/Newtonsoft.Json/blob/", output);
         Assert.DoesNotContain("Newtonsoft.Json.JsonSerializer\t", output);
+    }
+
+    [Fact]
+    public async Task Package_SourceFilesSection_Bare_EmitsUrlColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "-t", "JsonReader", "--bare", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", StringComparison.Ordinal));
+        Assert.All(lines, line => Assert.StartsWith("https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/", line));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -787,8 +787,8 @@ public class ApiCommand
             SectionNames.AnnotatedSource => view.MemberCode?.AnnotatedSourceCode.Content ?? "",
             SectionNames.OriginalSource => view.MemberCode?.OriginalSourceCode.Content ?? "",
             SectionNames.IL => view.MemberCode?.ILCode.Content ?? "",
-            SectionNames.SourceFiles => BareSingleUrl(view.SourceFileRows?.Select(row => row.Url), SectionNames.SourceFiles, out error),
-            SectionNames.SourceLocations => BareSingleUrl(view.SourceLocationRows?.Select(row => row.Url), SectionNames.SourceLocations, out error),
+            SectionNames.SourceFiles => BareUrlColumn(view.SourceFileRows?.Select(row => row.Url), SectionNames.SourceFiles, out error),
+            SectionNames.SourceLocations => BareUrlColumn(view.SourceLocationRows?.Select(row => row.Url), SectionNames.SourceLocations, out error),
             _ => ""
         };
 
@@ -800,7 +800,7 @@ public class ApiCommand
         return false;
     }
 
-    private static string BareSingleUrl(IEnumerable<string?>? urls, string section, out string error)
+    private static string BareUrlColumn(IEnumerable<string?>? urls, string section, out string error)
     {
         error = "";
         var values = urls?
@@ -808,12 +808,10 @@ public class ApiCommand
             .Select(url => url!)
             .ToList() ?? [];
 
-        if (values.Count == 1)
-            return values[0];
+        if (values.Count > 0)
+            return string.Join('\n', values);
 
-        error = values.Count == 0
-            ? $"Error: --bare found no URL in section '{section}'."
-            : $"Error: --bare requires section '{section}' to resolve exactly one URL; found {values.Count}.";
+        error = $"Error: --bare found no URL in section '{section}'.";
         return "";
     }
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1336,7 +1336,7 @@ public class PackageCommand
         if (section.Equals(PackageSections.SourceFiles, StringComparison.OrdinalIgnoreCase))
         {
             var urls = result.SourceFiles?.Select(row => row.Url);
-            return PrintBarePackageUrl(urls, section, options.OutputPath);
+            return PrintBarePackageUrlColumn(urls, section, options.OutputPath);
         }
 
         Console.Error.WriteLine($"Error: --bare does not support section '{section}'. Select a text section or a single URL section.");
@@ -1369,19 +1369,17 @@ public class PackageCommand
         return WriteBarePackageText(content.Content, options.OutputPath);
     }
 
-    private static int PrintBarePackageUrl(IEnumerable<string?>? urls, string section, string? outputPath)
+    private static int PrintBarePackageUrlColumn(IEnumerable<string?>? urls, string section, string? outputPath)
     {
         var values = urls?
             .Where(url => !string.IsNullOrWhiteSpace(url))
             .Select(url => url!)
             .ToList() ?? [];
 
-        if (values.Count == 1)
-            return WriteBarePackageText(values[0], outputPath);
+        if (values.Count > 0)
+            return WriteBarePackageText(string.Join('\n', values), outputPath);
 
-        Console.Error.WriteLine(values.Count == 0
-            ? $"Error: --bare found no URL in section '{section}'."
-            : $"Error: --bare requires section '{section}' to resolve exactly one URL; found {values.Count}.");
+        Console.Error.WriteLine($"Error: --bare found no URL in section '{section}'.");
         return 1;
     }
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -8,7 +8,7 @@
   `--raw` now names the default raw/fetchable GitHub URL shape and pairs with
   `--blob`.
 - Generalizes `--bare` beyond code sections to package README/content payloads
-  and unambiguous single SourceLink URL rows.
+  and one-column SourceLink URL output.
 - Normalizes GitHub file links in package README/content output from `blob` to
   raw URLs in the default agent-friendly URL mode.
 - Removes the standalone `source` command. Use `package`, `library`, and `type`


### PR DESCRIPTION
## Summary
- Treat --bare Source Files and Source Locations URL payloads as one-column vectors instead of single-row scalars.
- Emit each URL on its own line for type/member/package URL sections.
- Keep empty URL selections as errors and preserve README/content/code-section scalar bare behavior.
- Update release notes, SourceLink docs, and SKILL wording.

Closes #1241

## Validation
- npx markdownlint-cli docs/sourcelink-exposure.md src/dotnet-inspect/release-notes.md skills/dotnet-inspect/SKILL.md
- dotnet build src/dotnet-inspect -c Release
- focused dotnet-inspect.Tests methods for member Source Locations scalar/vector, type Source Files vector, package Source Files vector, package README bare, and code-section bare
- manual repros for type/package Source Files vectors and member Source Locations vector
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -parallel none

The full serial test run only hit the known local preview-runtime failures:
- PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies
- CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute