### PR TITLE
Document real-world fidelity coverage targeting

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -67,6 +67,38 @@ compiler. The supporting evidence:
 - **Corpus sweeps.** Emit-all stress over each platform's CoreLib (three OSes in
   CI = three corpora), measured by the floors below.
 
+### Expanding real-world fidelity coverage
+
+The real-world corpus card exposes compile-back fidelity coverage honestly, but
+coverage can be thin because many methods are not yet standalone-recompilable.
+Increasing the cap is only a measurement step: it characterizes how much useful
+opcode evidence exists today and buckets why the rest fails. The first expansion
+target is therefore the **checked population inside the fixed corpus**, not a
+larger random assembly set.
+
+Use this order for risky decompiler work:
+
+1. Run the fixed corpus with multiple `--corpus-fidelity-cap` values and record
+   exact, opcode-diff, recompile-failed, and context-failed counts plus failure
+   buckets.
+2. For a risky raise/structuring PR, emit a per-method corpus delta and treat the
+   changed methods as the fidelity population to cover. A bigger general sample
+   is not enough if the changed methods remain unchecked.
+3. Improve harness context only where failure buckets show many methods can be
+   converted into useful opcode comparisons without changing the product path.
+   The product decompiler stays SRM-only, NativeAOT-friendly, Roslyn-free, and
+   free of inspected-assembly loading.
+4. Add new corpus assemblies only when the current fixed corpus lacks enough
+   examples of the target lowering family. Add pinned deterministic assemblies
+   with a documented shape reason, refresh the baseline, and prove a no-op
+   `--emit-corpus-delta` stays empty.
+
+For #1175-class retained-label / forward-merge work, the interim bar is fidelity
+coverage over the methods the PR changes, especially methods in the
+forward-merge/structuring-residual population. If that population recompiles at a
+lower rate than the corpus average, treat that as the next context-injection
+target rather than declaring victory from an easier global sample.
+
 ### Fixture idiom-shape scorecard
 
 `IdiomShapeScorecardTests` is the fixture-backed C# altitude check. It renders

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -61,10 +61,26 @@ card shape but warns when semantic validity coverage is below 1.00% or
 compile-back fidelity coverage is below 0.10%, and reminds authors to add
 targeted improved examples plus still-flat near misses.
 
+For risky PRs whose changed-method population is known, use that population as
+the fidelity target. The general corpus card is still the aggregate health view,
+but it can be green while the methods a broad structuring change actually
+rewrote remain unchecked. Generate a per-method delta, inspect the changed rows,
+and run targeted dump/fidelity checks over that set before relying on the global
+sample. If the changed population is mostly not recompilable, classify those
+failures first; simply raising `--corpus-fidelity-cap` grows an easier general
+sample, not necessarily the risky shape.
+
 To deliberately rebaseline after reviewed corpus movement, run the same command
 with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json`.
 For a quick before/after coverage sweep, repeat `--corpus-fidelity-cap` (for
 example `--corpus-fidelity-cap 3 --corpus-fidelity-cap 10`).
+
+Expand the fixed corpus only after that targeting step shows a shape gap. Prefer
+deterministic, pinned assemblies that add many examples of the missing lowering
+family (for example forward-merge or retained-label control flow), then refresh
+the baseline and prove a no-op `--emit-corpus-delta` stays empty. Keep the PR
+quick corpus small; broad shape additions belong in the daily/manual corpus
+unless they are cheap and stable enough for every PR.
 
 **PR quick corpus** (`tools/DecompilerHarness/corpus/pr-quick-baseline.json`):
 CI also runs a small artifact-producing corpus sensor after the managed tool


### PR DESCRIPTION
## Summary

- Document the #1214 policy conclusion: fidelity coverage should expand inside the fixed corpus first, then target changed methods from per-method deltas for risky PRs.
- Clarify that adding assemblies is shape-driven and second-order: only add pinned deterministic assemblies after changed-method targeting shows the fixed corpus lacks the target lowering family.
- Add reviewer guidance for #1175-class retained-label / forward-merge work: a larger global sample is not enough if the changed methods remain unchecked.

Fixes #1214.

## Measured characterization

Tool-produced corpus run after rebuilding `src/dotnet-inspect`:

```text
Fidelity coverage by cap:
  cap 3: 5 exact, 1 opcode diffs, 0 recompile failures, 0 context failures over 6 checked
    recompile-failure buckets:
      compiler diagnostic: 21 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor)
      missing symbol: 15 (e.g. DotnetInspector.Core.CoreCache::Initialize, DotnetInspector.Packages.DependencyGroup::get_TargetFramework, DotnetInspector.Packages.DependencyGroup::set_TargetFramework)
      syntax: 3 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.ExtensionMarkerAttribute::.ctor, FixedSizeArrayBuilder`1::.ctor)
      accessibility: 1 (e.g. ILInspector.Metadata.GenericContext::get_TypeParameters)
  cap 10: 15 exact, 1 opcode diffs, 0 recompile failures, 0 context failures over 16 checked
    recompile-failure buckets:
      compiler diagnostic: 72 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor)
      missing symbol: 48 (e.g. DotnetInspector.Core.CoreCache::Initialize, DotnetInspector.Core.CoreCache::GetDefaultBasePath, DotnetInspector.Core.CoreCache::GetLegacyBasePath)
      syntax: 10 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.ExtensionMarkerAttribute::.ctor, FixedSizeArrayBuilder`1::.ctor)
      accessibility: 5 (e.g. DotnetInspector.Core.CacheMaintenanceResult::.ctor, DotnetInspector.Core.CacheMaintenanceResult::get_BytesFreed, ILInspector.Metadata.GenericContext::get_TypeParameters)
      conversion: 1 (e.g. ILInspector.Metadata.SignatureDecoder::GetPrimitiveType)
  cap 25: 29 exact, 2 opcode diffs, 0 recompile failures, 0 context failures over 31 checked
    recompile-failure buckets:
      compiler diagnostic: 178 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor, System.Runtime.CompilerServices.NullableAttribute::.ctor)
      missing symbol: 119 (e.g. DotnetInspector.Core.CoreCache::Initialize, DotnetInspector.Core.CoreCache::GetDefaultBasePath, DotnetInspector.Core.CoreCache::GetLegacyBasePath)
      syntax: 25 (e.g. Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor, System.Runtime.CompilerServices.ExtensionMarkerAttribute::.ctor, FixedSizeArrayBuilder`1::.ctor)
      accessibility: 14 (e.g. DotnetInspector.Core.CacheMaintenanceResult::.ctor, DotnetInspector.Core.CacheMaintenanceResult::get_BytesFreed, DotnetInspector.Core.CacheMaintenanceResult::set_BytesFreed)
      conversion: 1 (e.g. ILInspector.Metadata.SignatureDecoder::GetPrimitiveType)

Corpus sensor matched baseline: tools/DecompilerHarness/corpus/real-world-baseline.json
```

Conclusion: raising the cap grows useful checks, but the absolute population is still too small for risky structuring changes. The next useful slice is changed-method targeting plus context/shell work for the top failure buckets, not adding random corpus assemblies.

## Validation

- `npx markdownlint-cli --fix docs/decompiler-quality.md tools/DecompilerHarness/README.md`
- `npx markdownlint-cli docs/decompiler-quality.md tools/DecompilerHarness/README.md`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo`
- `dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --compile-cap 25 --corpus-fidelity-cap 3,10,25 --max-examples 3`
