### PR TITLE
Accept member detail sections before overload selection

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1917,6 +1917,91 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_BareNameCallerGraph_AutoSelectsSingleOverload()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.Inner), "-S", "Caller Graph", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Caller Graph", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), output);
+        Assert.DoesNotContain("Select value 'Caller Graph' not found", error);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallGraph_AmbiguousOverloadReportsSelectorHint()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.Overloaded), "-S", "Call Graph", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("section 'Call Graph' requires a single selected overload", error);
+        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
+        Assert.Contains("-S \"Member Index\"", error);
+        Assert.DoesNotContain("Select value 'Call Graph' not found", error);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallersWithCallerScope_AutoSelectsSingleOverload()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.Inner), "-S", "Callers", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Callers", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), output);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallersWithCallerScope_AmbiguousOverloadReportsSelectorHint()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.Overloaded), "-S", "Callers", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("section 'Callers' requires a single selected overload", error);
+        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallerScope_AutoSelectsSingleOverloadWithoutExplicitSection()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.Inner), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Callers", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), output);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallerScope_AmbiguousOverloadReportsSelectorHint()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.Overloaded), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("section 'Callers' requires a single selected overload", error);
+        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectDecompiledSource_RendersPlainCSharp()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1395,6 +1395,9 @@ public class SectionPipelineTests
 
         Assert.Contains("Methods", pipeline.InfoSectionNames);
         Assert.DoesNotContain("Method Groups", pipeline.InfoSectionNames);
+        Assert.Contains("Call Graph", pipeline.AllSectionNames);
+        Assert.Contains("Caller Graph", pipeline.AllSectionNames);
+        Assert.Contains("Unsafe Operations", pipeline.AllSectionNames);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -113,6 +113,8 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
+            if (effectiveOptions.HasCallerScope)
+                effectiveOptions = IncludeCallersSection(effectiveOptions);
 
             // Keep member-name lookups as overload inventories. Only auto-select the lone
             // overload when the user explicitly asks for a selected-overload detail section.
@@ -212,6 +214,22 @@ public static class MemberCommand
             }
 
             if (effectiveOptions.OverloadIndex is null
+                && TryGetSelectedSingleOverloadSections(effectiveOptions, out var singleOverloadSections))
+            {
+                var memberName = effectiveOptions.MemberFilter.First();
+                var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
+                if (overloads.Count > 1)
+                {
+                    var sectionLabel = singleOverloadSections.Count == 1
+                        ? $"section '{singleOverloadSections[0]}' requires"
+                        : $"sections {string.Join(", ", singleOverloadSections.Select(section => $"'{section}'"))} require";
+                    Console.Error.WriteLine($"Error: {sectionLabel} a single selected overload for member '{memberName}'.");
+                    Console.Error.WriteLine($"Use {memberName}:1 through {memberName}:{overloads.Count}, or run -S \"Member Index\" to list stable ~digest selectors.");
+                    return 1;
+                }
+            }
+
+            if (effectiveOptions.OverloadIndex is null
                 && effectiveOptions.IncludeSections?.Contains(SectionNames.UnsafeMembers) == true
                 && (runtimeAssemblyPath ?? apiDllPath) is { } unsafeDllPath)
             {
@@ -292,15 +310,10 @@ public static class MemberCommand
 
                     // Supplying a caller scope is an explicit request for the Callers section, so it
                     // renders (with an empty-state note when nothing matches) even at low verbosity.
-                    var includeSections = effectiveOptions.IncludeSections is { Count: > 0 } existing
-                        ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-                        : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    includeSections.Add(SectionNames.Callers);
-
                     effectiveOptions = effectiveOptions with
                     {
                         CallerScopeAssemblies = scopeAssemblies,
-                        IncludeSections = includeSections
+                        IncludeSections = IncludeCallersSection(effectiveOptions).IncludeSections
                     };
                 }
                 finally
@@ -436,25 +449,52 @@ public static class MemberCommand
     {
         if (options.MemberFilter.Count != 1)
             return false;
-        if (options.IncludeSections is not { Count: > 0 } sections)
+        if (!TryGetSelectedSingleOverloadSections(options, out _))
+            return false;
+        return true;
+    }
+
+    private static bool TryGetSelectedSingleOverloadSections(MemberOptions options, out List<string> sections)
+    {
+        sections = [];
+        if (options.MemberFilter.Count != 1)
+            return false;
+        if (options.IncludeSections is not { Count: > 0 } includeSections)
             return false;
         if (IsPureSelector(options.Select, SelectResolver.InfoSelector)
             || IsPureSelector(options.Select, SelectResolver.AllSelector))
             return false;
 
-        return sections.Contains(SectionNames.Signature)
-               || sections.Contains(SectionNames.CustomAttributes)
-               || sections.Contains(SectionNames.DecompiledSource)
-               || sections.Contains(SectionNames.AnnotatedSource)
-               || sections.Contains(SectionNames.OriginalSource)
-               || sections.Contains(SectionNames.Calls)
-               || sections.Contains(SectionNames.Callers)
-               || sections.Contains(SectionNames.CallGraph)
-               || sections.Contains(SectionNames.CallerGraph)
-               || sections.Contains(SectionNames.UnsafeOperations)
-               || sections.Contains(SectionNames.Facts)
-               || sections.Contains(SectionNames.IL);
+        sections = SingleOverloadSectionNames
+            .Where(includeSections.Contains)
+            .ToList();
+        return sections.Count > 0;
     }
+
+    private static MemberOptions IncludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { Count: > 0 } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        includeSections.Add(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
+    }
+
+    private static readonly string[] SingleOverloadSectionNames =
+    [
+        SectionNames.Signature,
+        SectionNames.CustomAttributes,
+        SectionNames.DecompiledSource,
+        SectionNames.AnnotatedSource,
+        SectionNames.OriginalSource,
+        SectionNames.Calls,
+        SectionNames.Callers,
+        SectionNames.CallGraph,
+        SectionNames.CallerGraph,
+        SectionNames.UnsafeOperations,
+        SectionNames.Facts,
+        SectionNames.IL
+    ];
 
     private static bool IsPureSelector(string[]? select, string name) =>
         select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -409,9 +409,13 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Events>()
             .Add<ApiMemberSectionDescriptors.MethodAttributes>()
             .Add<ApiMemberSectionDescriptors.DecompiledSource>()
+            .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>()
             .Add<ApiMemberSectionDescriptors.OriginalSource>()
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.Callers>()
+            .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
+            .Add<ApiMemberDetailSectionDescriptors.CallerGraph>()
+            .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
             .Add<ApiMemberSectionDescriptors.Facts>();
     }


### PR DESCRIPTION
## Summary
- Register selected-overload detail sections in the member-name scoped pipeline so -S validation accepts Call Graph, Caller Graph, Annotated Source, and Unsafe Operations before overload selection.
- Auto-select lone overloads for selected detail sections, including implied Callers from caller-scope flags.
- Report a clear overload-selector hint when a requested detail section is ambiguous instead of saying the section was not found.

Closes #1244

## Validation
- dotnet build src/dotnet-inspect -c Release
- focused dotnet-inspect.Tests methods for Caller Graph auto-selection, ambiguous Call Graph hints, Callers with --bin auto-selection, and ambiguous Callers with --bin hints
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -noLogo -class DotnetInspector.Tests.MemberCallGraphSectionTests -class DotnetInspector.Tests.SectionPipelineTests
- manual repro with Newtonsoft.Json DeserializeXmlNode now reports overload selector guidance instead of Select value not found; pinned overload still renders Caller Graph
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -parallel none

The full serial test run only hit the known local preview-runtime failures:
- PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies
- CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute