### PR TITLE
Report true outbound fan-out for non-expanded Call Graph nodes (#1232)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -583,6 +583,8 @@ public class CallTreeTests
         var two = Find(tree, nameof(CallTreeFixtures.LevelTwo));
         Assert.NotNull(two);
         Assert.Equal(CallTreeStatus.DepthLimited, two!.Status);
+        // Depth-limited, but LevelTwo still calls LevelThree: true fan-out is reported.
+        Assert.Equal(1, two.Perf?.Fanout);
         Assert.Empty(two.Children);
         Assert.Null(Find(tree, nameof(CallTreeFixtures.LevelThree)));
     }
@@ -608,6 +610,8 @@ public class CallTreeTests
         var pingAgain = Assert.Single(pong.Children);
         Assert.Equal(nameof(CallTreeFixtures.Ping), pingAgain.Member.Name);
         Assert.Equal(CallTreeStatus.AlreadyShown, pingAgain.Status);
+        // Shown above, but Ping still calls Pong: true fan-out is reported.
+        Assert.Equal(1, pingAgain.Perf?.Fanout);
         Assert.Empty(pingAgain.Children);
     }
 
@@ -618,6 +622,8 @@ public class CallTreeTests
 
         Assert.Equal(CallTreeStatus.Truncated, tree.Status);
         Assert.Single(tree.Children);
+        // Only one child fit the node budget, but Root's true fan-out (LevelOne + External) is 2.
+        Assert.Equal(2, tree.Perf?.Fanout);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -158,11 +158,16 @@ public sealed class LibraryBodyIndex
                 return new CallTreeNode(member, kind, leafStatus, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incoming) ? incoming : 0, 1, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));
             }
 
+            // True outbound degree (call sites), independent of how far the bounded
+            // tree expanded. CallTreeStatus separately conveys why expansion stopped,
+            // so depth-limited/already-shown/truncated nodes still report their real
+            // fan-out instead of reading like leaves.
+            var fanout = edges.Count;
             if (depth >= maxDepth)
-                return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incomingDepth) ? incomingDepth : 0, 1, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));
+                return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(fanout, incomingCounts.TryGetValue(token, out var incomingDepth) ? incomingDepth : 0, 1, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));
 
             if (!expanded.Add(token))
-                return new CallTreeNode(member, kind, CallTreeStatus.AlreadyShown, [], new CallTreePerf(0, incomingCounts.TryGetValue(token, out var incomingShown) ? incomingShown : 0, 1, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));
+                return new CallTreeNode(member, kind, CallTreeStatus.AlreadyShown, [], new CallTreePerf(fanout, incomingCounts.TryGetValue(token, out var incomingShown) ? incomingShown : 0, 1, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));
 
             var children = ImmutableArray.CreateBuilder<CallTreeNode>();
             bool truncated = false;
@@ -180,7 +185,6 @@ public sealed class LibraryBodyIndex
             var status = truncated
                 ? CallTreeStatus.Truncated
                 : children.Count == 0 ? CallTreeStatus.Leaf : CallTreeStatus.Expanded;
-            var fanout = children.Count;
             var maxTreeDepth = children.Count == 0 ? 1 : 1 + children.Max(child => child.Perf?.MaxDepth ?? 1);
             var fanin = incomingCounts.TryGetValue(token, out var count) ? count : 0;
             return new CallTreeNode(member, kind, status, children.ToImmutable(), new CallTreePerf(fanout, fanin, maxTreeDepth, inLoop, inLoop ? "loop" : null, null, sig.Allocations, sig.Copies, sig.Unsafe));


### PR DESCRIPTION
## Summary

The bounded `Call Graph` derived a node's `fanout` from how far the tree expanded (`children.Count`), and hardcoded `0` for `DepthLimited` and `AlreadyShown` nodes (and a partial count for `Truncated`). So a node with many outbound calls rendered as if it were a leaf — exactly at the boundary where a reader decides whether to drill deeper with a higher `--depth`.

Now `fanout` reports the node's **true outbound degree** (outbound call-site count) for every status. `CallTreeStatus` already conveys *why* expansion stopped, so the two signals are no longer conflated. The unit matches `fanin`'s call-site counting.

## Before / after

```bash
member LibraryBodyIndex BuildCallTree:1 --library X.dll --all -S "Call Graph"
```

```text
# before: depth-limited / shown-above nodes report no fan-out
TypeRef..ctor(TypeRefKind) (…, fanin 11)
TypeRef.Unsupported(string) (shown above, fanin 5)

# after: real fan-out is shown
TypeRef..ctor(TypeRefKind) (…, fanout 6, fanin 11)
TypeRef.Unsupported(string) (shown above, fanout 2, fanin 5)
```

## Scope

- Fixes the **Call Graph** (outbound) as filed. `Top Leverage` was already correct (it computes fan-out independently).
- The **Caller Graph** (reverse view) keeps `fanout = 0` by design — it emphasizes inbound reach (`fanin`); a caller's own outbound degree there is a separate enhancement, out of scope here.

## Tests

Restores the depth-limited / already-shown / truncated `fanout` assertions that were dropped when reconciling with #1213's `children.Count` semantics — they now assert the true outbound degree. Full suite green apart from the two pre-existing platform-resolution env failures.

Fixes #1232