### PR TITLE
Strip AOT symbols from tool publish output

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -67,4 +67,12 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
+  <Target Name="StripSymbolsFromPublishOutput" AfterTargets="Publish" Condition="'$(PublishAot)' == 'true' and '$(PackAsTool)' == 'true'">
+    <ItemGroup>
+      <PublishSymbolFiles Include="$(PublishDir)**/*.pdb" />
+      <PublishSymbolFiles Include="$(PublishDir)**/*.dbg" />
+    </ItemGroup>
+    <Delete Files="@(PublishSymbolFiles)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary

This PR removes Native AOT symbol payload from the RID-specific tool packages. The packaged tool was carrying `.pdb` and `.dbg` files from the publish output, which dramatically inflated the `.nupkg` size for shipped tool packages.

## Why

The tool package size was dominated by NativeAOT symbol artifacts rather than the executable itself. Removing those files from the publish output before packing cuts the RID package size from about 22 MB to about 10 MB on Linux x64 while leaving the published binary intact.

## What changed

- Added a publish-time target in `src/dotnet-inspect/dotnet-inspect.csproj` that deletes `*.pdb` and `*.dbg` files from the publish directory when packing the AOT tool.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false`
- `dotnet pack src/dotnet-inspect -c Release -r linux-x64 -p:OfficialAotBuild=true`
- Smoke-tested the published `dotnet-inspect` binary with `--help`

## Notes

I also checked whether restricting satellite resource languages would meaningfully reduce the package size. On this packaging path it did not produce a meaningful win, so I left it unchanged.
