### PR TITLE
Decouple platform-resolution tests from host runtime version (#1256)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4485,10 +4485,18 @@ public class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute()
     {
-        var currentRuntimeVersion = Path.GetFileName(Path.GetDirectoryName(typeof(object).Assembly.Location))!;
+        // Decouple from the host's running runtime version (#1256). Probe an installed
+        // shared runtime version the resolver can find rather than binding to wherever
+        // the test host's System.Private.CoreLib happens to live, which fails on
+        // preview/self-contained hosts whose running version isn't a discoverable
+        // shared framework.
+        var (_, installedVersion, frameworkError) = PlatformResolver.ResolveRuntimeFramework("runtime");
+        Assert.SkipWhen(
+            installedVersion is null,
+            $"No installed Microsoft.NETCore.App shared runtime found: {frameworkError}");
 
         var (exit, output, error) = await RunAppAsync(
-            "library", "System.Text.Json", "--version", currentRuntimeVersion, "-v:q");
+            "library", "System.Text.Json", "--version", installedVersion!, "-v:q");
 
         Assert.Equal(0, exit);
         Assert.Contains("Source: Platform", output);

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -249,16 +249,24 @@ public class PlatformResolverTests
     [Fact]
     public void ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies()
     {
-        var currentRuntimeVersion = Path.GetFileName(Path.GetDirectoryName(typeof(object).Assembly.Location))!;
+        // Decouple from the host's running runtime version (#1256). Binding to
+        // typeof(object).Assembly.Location asserts "the host's running runtime is a
+        // discoverable shared framework" — an environment precondition, not resolver
+        // behavior — and fails on preview/self-contained hosts. Probe an installed
+        // shared runtime version the resolver itself can find, then assert against that.
+        var (_, installedVersion, frameworkError) = PlatformResolver.ResolveRuntimeFramework("runtime");
+        Assert.SkipWhen(
+            installedVersion is null,
+            $"No installed Microsoft.NETCore.App shared runtime found: {frameworkError}");
 
         var (path, framework, version, error) = PlatformResolver.ResolveAssembly(
             "System.Text.Json",
             useRuntimeAssemblies: true,
-            platformVersion: currentRuntimeVersion);
+            platformVersion: installedVersion);
 
         Assert.Null(error);
         Assert.NotNull(path);
-        Assert.Equal(currentRuntimeVersion, version);
+        Assert.Equal(installedVersion, version);
         Assert.Equal("runtime", framework);
         Assert.Contains($"{Path.DirectorySeparatorChar}shared{Path.DirectorySeparatorChar}", path);
     }


### PR DESCRIPTION
Fixes #1256.

## Problem

Two platform-resolution tests derived their expected version from where the **test host's** `System.Private.CoreLib` lives:

```csharp
var currentRuntimeVersion = Path.GetFileName(Path.GetDirectoryName(typeof(object).Assembly.Location))!;
```

then asserted the resolver/CLI resolves `System.Text.Json` from the shared runtime at **exactly** that version. On a preview/self-contained host whose running version isn't a discoverable shared framework, both fail — even though the resolver is correct. The tests were implicitly asserting an environment precondition ("the host's running runtime is an installed shared framework"), not tool behavior.

- `PlatformResolverTests.ResolveAssembly_RuntimeVersionWithoutFramework_SearchesRuntimeFamilies`
- `CommandExecutionTests.LibraryCommand_PlatformVersion_UsesPlatformRuntimeRoute`

## Fix

Implements the issue's preferred direction (1) + (2): probe an installed shared runtime version the resolver itself can find via `PlatformResolver.ResolveRuntimeFramework("runtime")`, assert against that, and `Assert.SkipWhen` no shared runtime is installed.

This keeps the platform/runtime route covered end-to-end while making a failure mean "the resolver is broken," not "this host's runtime isn't installed where we looked." No product behavior changes — test robustness only.

## Verification

Both tests pass on this host (xUnit v3 runner, .NET 11 preview):

```
=== TEST EXECUTION SUMMARY ===
   dotnet-inspect.Tests  Total: 2, Errors: 0, Failed: 0, Skipped: 0
```