### PR TITLE
Fix DOTNET_ROOT parallel-race flake in platform-resolution tests

### DIFF
--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -10,6 +10,9 @@ namespace DotnetInspector.Tests;
 /// native ILAsm/ILDasm reference tools: disassemble, reassemble, and compare.
 /// Tests skip when the tools are not installed.
 /// </summary>
+// Resolves real platform assemblies via PlatformResolver; share "Console" so it never runs in
+// parallel with the DOTNET_ROOT-mutating PlatformResolverTests (#1256).
+[Collection("Console")]
 public class ILDisassemblerComparisonTests
 {
     static readonly string CoreDll = FindAssembly("DotnetInspector.Core.dll");

--- a/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
@@ -8,6 +8,9 @@ using DotnetInspector.Services;
 
 namespace DotnetInspector.Tests;
 
+// Resolves real platform assemblies via PlatformResolver; share "Console" so it never runs in
+// parallel with the DOTNET_ROOT-mutating PlatformResolverTests (#1256).
+[Collection("Console")]
 public class MethodClassificationScannerTests
 {
     [Fact]

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -7,6 +7,10 @@ namespace DotnetInspector.Tests;
 /// <summary>
 /// Tests for PlatformResolver, particularly around DOTNET_ROOT priority and Linux path detection.
 /// </summary>
+// Some tests here mutate the process-global DOTNET_ROOT env var, which GetSharedDirectory /
+// GetInstalledFrameworks read live. Share the "Console" collection so these run serially with
+// other PlatformResolver-reading tests and never race a parallel reader (#1256).
+[Collection("Console")]
 public class PlatformResolverTests
 {
     [Fact]

--- a/src/dotnet-inspect.Tests/VersionDisplayTests.cs
+++ b/src/dotnet-inspect.Tests/VersionDisplayTests.cs
@@ -11,6 +11,9 @@ namespace DotnetInspector.Tests;
 /// (e.g., "10.0.1") rather than 4-part PE assembly versions (e.g., "10.0.0.0").
 /// Version priority: PlatformVersion → InformationalVersion prefix → AssemblyVersion → FileVersion.
 /// </summary>
+// Resolves real platform assemblies via PlatformResolver; share "Console" so it never runs in
+// parallel with the DOTNET_ROOT-mutating PlatformResolverTests (#1256).
+[Collection("Console")]
 public class VersionDisplayTests
 {
     private static string SerializeCompact(LibraryInspection inspection)


### PR DESCRIPTION
Follow-up to #1261 (issue #1256). While verifying that fix I hit a separate, genuinely flaky failure.

## Symptom

`VersionDisplayTests.PlatformVersion_MatchesRuntimeDirectory` fails intermittently in full runs (~1 in 5) but always passes in isolation and within its own class.

## Root cause — parallel race, not coupling

`PlatformResolverTests` temporarily mutates the **process-global** `DOTNET_ROOT` env var (`GetSharedDirectory_WhenDotnetRootSet_ChecksItFirst`, `GetSharedDirectory_WhenDotnetRootNotSet_UsesCurrentRuntime`, `GetPacksDirectory_WhenDotnetRootNotSet_UsesStandardPaths`). `PlatformResolver.GetSharedDirectory` / `GetInstalledFrameworks` read `DOTNET_ROOT` **live**. xUnit runs different test classes in parallel, so a class resolving a platform assembly can observe the temporary `DOTNET_ROOT` (a bogus temp dir) during the mutation window — and can even cache temp-derived frameworks for the rest of the process.

## Fix

xUnit only serializes classes that share a collection. Move every `PlatformResolver`-reading class into the existing `"Console"` collection alongside the env-mutating `PlatformResolverTests`:

- `PlatformResolverTests` (the mutator)
- `VersionDisplayTests`
- `ILDisassemblerComparisonTests`
- `MethodClassificationScannerTests`

(`CommandExecutionTests`, `CommandLineTests`, `FindCommandTests`, `SourceResolverTests`, `MemberOptionsParserTests` already use `"Console"`.)

Test-only change; no product behavior.

## Verification

19 consecutive clean full-suite runs after the change (was ~1 in 5 failing). Suite time unchanged (~22–24s), so cross-collection parallelism elsewhere is preserved.

```
dotnet-inspect.Tests  Total: 1272, Errors: 0, Failed: 0, Skipped: 9
```