### PR TITLE
Address GPT-5.5 review of optimization opportunities (#1260)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -301,11 +301,11 @@ public class LibraryBodyIndexTests
 
         var fieldAccessMethod = Assert.Single(index.OptimizationOpportunities.Where(opportunity =>
             opportunity.Method.Name == nameof(OptimizationOpportunityFixtures.MakesArrayAfterFieldAccess)));
-        Assert.Equal("small-nonescaping-array", fieldAccessMethod.Shape);
+        Assert.Equal("small-array", fieldAccessMethod.Shape);
 
         Assert.DoesNotContain(index.OptimizationOpportunities, opportunity =>
             opportunity.Method.Name == nameof(OptimizationOpportunityFixtures.MakesArrayAfterCallAndArgument)
-            && opportunity.Shape == "small-nonescaping-array");
+            && opportunity.Shape == "small-array");
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -589,13 +589,13 @@ public sealed class LibraryBodyIndex
                         {
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
-                                "small-nonescaping-array",
+                                "small-array",
                                 $"newarr with small constant length ({length})",
-                                "Prefer a span or local array literal when the temporary remains local.",
+                                "If the array does not escape, a span or stackalloc may avoid the allocation.",
                                 "medium",
                                 IsInLoopRegion(offset, loopRegions),
                                 offset,
-                                "Requires local-only escape evidence.",
+                                "Escape not analyzed; confirm the array stays local before replacing.",
                                 null));
                         }
                         pendingConstant = null;
@@ -609,13 +609,13 @@ public sealed class LibraryBodyIndex
                         {
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
-                                "capturing-delegate",
+                                "delegate-allocation",
                                 $"newobj {callee.DeclaringType.ToQualifiedDisplayString()}",
-                                "Prefer a static local function with explicit state parameters or a dedicated loop.",
+                                "If invoked repeatedly, a cached or static delegate avoids re-allocating it.",
                                 "medium",
                                 IsInLoopRegion(offset, loopRegions),
                                 offset,
-                                "Hoisting may need semantic review.",
+                                "Capture not analyzed; the target may be static, instance, or a closure.",
                                 null));
                         }
                         break;
@@ -647,13 +647,13 @@ public sealed class LibraryBodyIndex
                         ReadInt32(il, ref position, offset);
                         opportunities.Add(new OptimizationOpportunity(
                             caller,
-                            "capturing-delegate",
-                            opcode == ILOpCode.Ldftn ? "ldftn capture" : "ldvirtftn capture",
-                            "Prefer a static local function with explicit state parameters instead of capturing a delegate.",
+                            "delegate-allocation",
+                            opcode == ILOpCode.Ldftn ? "ldftn" : "ldvirtftn",
+                            "If invoked repeatedly, a cached or static delegate avoids re-allocating it.",
                             "medium",
                             IsInLoopRegion(offset, loopRegions),
                             offset,
-                            "Hoisting may need semantic review.",
+                            "Capture not analyzed; the target may be static, instance, or a closure.",
                             null));
                         break;
                     case ILOpCode.Ldarg_0:

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -34,7 +34,7 @@ public class OutputFormatterTests
 
         var rows = Assert.IsType<List<OptimizationOpportunityRow>>(view.OptimizationOpportunityRows);
         Assert.NotEmpty(rows);
-        Assert.Contains(rows, row => row.Shape == "small-nonescaping-array");
+        Assert.Contains(rows, row => row.Shape == "small-array");
     }
 
     [Fact]
@@ -63,7 +63,45 @@ public class OutputFormatterTests
         var markdown = ApiCommand.RenderTypeSectionsMarkdown(type, options);
 
         Assert.Contains("Optimization Opportunities", markdown);
-        Assert.Contains("small-nonescaping-array", markdown);
+        Assert.Contains("small-array", markdown);
+    }
+
+    [Fact]
+    public void RenderTypeSectionsMarkdown_ScopesOptimizationOpportunitiesToSelectedMember()
+    {
+        var method = typeof(OutputFormatterTests).GetMethod(
+            nameof(CreateSmallArrayOpportunity),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var type = new ApiType
+        {
+            Namespace = typeof(OutputFormatterTests).Namespace,
+            Name = nameof(OutputFormatterTests),
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Kind = "method",
+                    Name = nameof(CreateSmallArrayOpportunity),
+                    MetadataToken = method.MetadataToken
+                }
+            ]
+        };
+        // OverloadIndex selects the single-member detail pipeline, which restricts rows
+        // to the selected member instead of the whole declaring type.
+        var options = new MemberOptions
+        {
+            DllPath = typeof(OutputFormatterTests).Assembly.Location,
+            OverloadIndex = 1,
+            MemberFilter = [nameof(CreateSmallArrayOpportunity)],
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.OptimizationOpportunities }
+        };
+
+        var markdown = ApiCommand.RenderTypeSectionsMarkdown(type, options);
+
+        Assert.Contains("Optimization Opportunities", markdown);
+        Assert.Contains(nameof(CreateSmallArrayOpportunity), markdown);
+        Assert.DoesNotContain(nameof(CreateTemporaryArray), markdown);
     }
 
     private static int[] CreateSmallArrayOpportunity()

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -257,6 +257,28 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void MemberDetailPipeline_OptimizationOpportunities_IsStructurallyDiscoverable()
+    {
+        // -D must over-report: Optimization Opportunities is index-backed and unprobed
+        // (ProbeEffectiveness=false), so it must be listed structurally in the single-member
+        // detail pipeline for any type with method-like members, even without selection.
+        var pipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "T",
+            Kind = "class",
+            Members = [new ApiMember { Kind = "method", Name = "M" }]
+        };
+
+        var applicable = pipeline.GetApplicableSections(type);
+        var unprobed = pipeline.GetUnprobedSections();
+
+        Assert.Contains(SectionNames.OptimizationOpportunities, applicable);
+        Assert.Contains(SectionNames.OptimizationOpportunities, unprobed);
+    }
+
+    [Fact]
     public void CanRender_IntegrationOpportunities_UsesScannedRows()
     {
         var pipeline = LibrarySections.CreatePipeline();

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -658,7 +658,9 @@ public class ApiCommand
             if (options.DllPath is { } optimizationDllPath
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.OptimizationOpportunities))
             {
-                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections);
+                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections,
+                    restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }
 
             if (options.DllPath is { } leverageDllPath
@@ -1031,7 +1033,9 @@ public class ApiCommand
             if (renderOptions.DllPath is { } optimizationDllPath
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.OptimizationOpportunities))
             {
-                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, renderOptions.IncludeSections);
+                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, renderOptions.IncludeSections,
+                    restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
             }
 
             if (renderOptions.DllPath is { } leverageDllPath

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -496,6 +496,7 @@ public static class MemberCommand
         SectionNames.CallGraph,
         SectionNames.CallerGraph,
         SectionNames.UnsafeOperations,
+        SectionNames.OptimizationOpportunities,
         SectionNames.Facts,
         SectionNames.IL
     ];

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1456,11 +1456,15 @@ public static class ApiOutputFormatter
             view.UnsafeMemberRows = rows;
     }
 
-    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null)
+    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        HashSet<int>? memberTokens = restrictToModelMembers
+            ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
+            : null;
         var rows = index.OptimizationOpportunities
             .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
+            .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken))
             .OrderBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
             .ThenBy(opportunity => opportunity.ILOffset ?? -1)
             .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -427,6 +427,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
             .Add<ApiMemberDetailSectionDescriptors.CallerGraph>()
             .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
+            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
             .Add<ApiMemberSectionDescriptors.Facts>();
     }
@@ -462,6 +463,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<CallGraph>()
             .Add<CallerGraph>()
             .Add<UnsafeOperations>()
+            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
             .Add<Facts>()
             .Add<ILBody>()
             .AddCategory(SectionCategoryNames.Source,

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -280,6 +280,9 @@ public static class ApiMemberSectionDescriptors
         public static string Name => SectionNames.OptimizationOpportunities;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        // Backed by the whole-assembly body index; list structurally during -D rather
+        // than opening the index to probe, mirroring SourceLocations/UnsafeOperations.
+        public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(IsMethodLike);


### PR DESCRIPTION
Follow-up to #1260 (merged) addressing the GPT-5.5 review.

## Findings addressed

**① `small-nonescaping-array` claimed non-escape it never proved** → renamed **`small-array`**. The detector flags any `newarr` with a small constant length but performs no escape analysis; the old name implied stackalloc/span safety. Evidence/fix text now state escape is unanalyzed.

**② `capturing-delegate` fired on non-capturing lambdas** → renamed **`delegate-allocation`**. Every `ldftn`/`ldvirtftn` and delegate `newobj` was labeled capturing, but method groups and non-capturing lambdas (cached on `<>c`) also use these opcodes.

**③ Section missing from member-detail discovery/selection** → registered `Optimization Opportunities` in the overload-inventory and single-member detail pipelines and added it to the single-overload auto-select set. `member Type Method:1 -S "Optimization Opportunities"` is now accepted, `-D --schema` over-reports it, and rows are scoped to the selected member instead of the whole declaring type.

## Deferred

Filed **#1268** for the deeper analysis the renames make honest: local escape analysis for `small-array`, capture detection for `delegate-allocation`, and de-duplicating the two rows emitted per delegate construction.

## Verification

- Renames render correctly (type + member scope).
- `member Type Method:1` and single-overload `member Type Method` both auto-resolve to detail and scope rows to the member; `-D --schema` lists the section in member contexts; type-scope view unchanged.
- Full suites green: `ILInspector.Analysis.Tests` (41), `dotnet-inspect.Tests` (1278, 9 env-skips). Added `RenderTypeSectionsMarkdown_ScopesOptimizationOpportunitiesToSelectedMember`.