### PR TITLE
Add changed-method fidelity check

### DIFF
--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
+using System.Text.Json;
 
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -90,6 +91,25 @@ static class FidelityCheck
 
         Report(total, full, exact, contextFail, recompileFail, diffCount,
             recompileFailCodes, diffExamples);
+        return 0;
+    }
+
+    public static int RunMethodDelta(IReadOnlyList<string> assemblies, string deltaPath, int maxExamples, bool lowered = false)
+    {
+        var artifact = JsonSerializer.Deserialize<CorpusMethodDeltaArtifact>(
+            File.ReadAllText(deltaPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? throw new InvalidOperationException($"Could not read corpus delta '{deltaPath}'.");
+
+        var targets = artifact.ChangedMethods
+            .Where(row => row.Current is not null)
+            .Select(row => MethodTarget.From(row.Current!))
+            .DistinctBy(TargetKey)
+            .OrderBy(target => target.DisplayMethod, StringComparer.Ordinal)
+            .ToArray();
+
+        var results = EvaluateTargets(assemblies, targets, lowered);
+        ReportTargeted(results, targets.Length, maxExamples);
         return 0;
     }
 
@@ -207,6 +227,195 @@ static class FidelityCheck
 
     internal static bool IsUsefulCorpusSample(CompileBackResult result)
         => result.Status is CompileBackStatus.Exact or CompileBackStatus.OpcodeDiff;
+
+    sealed record MethodTarget(
+        string Assembly,
+        string AssemblyPath,
+        string Type,
+        string Method,
+        int Overload,
+        string Signature,
+        string DisplayMethod)
+    {
+        public static MethodTarget From(CorpusMethodSnapshot method)
+            => new(
+                method.Assembly,
+                method.AssemblyPath,
+                method.Type,
+                method.Method,
+                method.Overload,
+                method.Signature,
+                method.DisplayMethod);
+    }
+
+    sealed record TargetedCompileBackResult(MethodTarget Target, CompileBackResult Result);
+
+    static string TargetKey(MethodTarget target)
+        => $"{target.AssemblyPath}!{target.Type}::{target.Method}{target.Signature}";
+
+    static IReadOnlyList<TargetedCompileBackResult> EvaluateTargets(IReadOnlyList<string> assemblies, IReadOnlyList<MethodTarget> targets, bool lowered)
+    {
+        if (targets.Count == 0)
+            return [];
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compileOptions = new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
+            optimizationLevel: OptimizationLevel.Release,
+            nullableContextOptions: NullableContextOptions.Disable);
+
+        var pending = targets.ToDictionary(TargetKey, StringComparer.Ordinal);
+        var rows = new List<TargetedCompileBackResult>();
+        foreach (var assemblyPath in assemblies)
+        {
+            if (pending.Count == 0)
+                break;
+            PEReader pe;
+            try { pe = new PEReader(File.OpenRead(assemblyPath)); }
+            catch { continue; }
+            using (pe)
+            {
+                if (!pe.HasMetadata)
+                    continue;
+                var portablePath = PortablePath(assemblyPath);
+                var reader = pe.GetMetadataReader();
+                MetadataSource source;
+                try { source = MetadataSource.Open(assemblyPath); }
+                catch { continue; }
+                using (source)
+                {
+                    var assemblyTargets = pending.Values
+                        .Where(target => string.Equals(target.AssemblyPath, portablePath, StringComparison.Ordinal))
+                        .GroupBy(target => target.Type, StringComparer.Ordinal)
+                        .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+                    if (assemblyTargets.Count == 0)
+                        continue;
+
+                    var render = Renderer(source, lowered);
+                    var references = RuntimeReferences(assemblyPath);
+                    foreach (var typeHandle in reader.TypeDefinitions)
+                    {
+                        if (pending.Count == 0)
+                            break;
+                        if (CollectType(reader, pe, source, typeHandle, render) is not var (fullType, entries)
+                            || entries.Count == 0
+                            || !assemblyTargets.TryGetValue(fullType, out var typeTargets))
+                        {
+                            continue;
+                        }
+
+                        var typeTargetMap = typeTargets.ToDictionary(
+                            target => $"{target.Method}{target.Signature}",
+                            StringComparer.Ordinal);
+                        var matched = entries
+                            .Where(entry => typeTargetMap.ContainsKey($"{entry.Name}{entry.Signature}"))
+                            .ToArray();
+                        if (matched.Length == 0)
+                            continue;
+
+                        var typeResults = EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, matched);
+                        for (int i = 0; i < matched.Length && i < typeResults.Count; i++)
+                        {
+                            var entry = matched[i];
+                            var target = typeTargetMap[$"{entry.Name}{entry.Signature}"];
+                            rows.Add(new TargetedCompileBackResult(target, typeResults[i]));
+                            pending.Remove(TargetKey(target));
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach (var target in pending.Values.OrderBy(target => target.DisplayMethod, StringComparer.Ordinal))
+        {
+            rows.Add(new TargetedCompileBackResult(
+                target,
+                new CompileBackResult(
+                    target.Type,
+                    target.Method,
+                    target.Overload,
+                    target.Signature,
+                    CompileBackStatus.ContextFail,
+                    "",
+                    "",
+                    "target-method-not-found")));
+        }
+
+        return rows;
+    }
+
+    static void ReportTargeted(IReadOnlyList<TargetedCompileBackResult> rows, int targetCount, int maxExamples)
+    {
+        int exact = rows.Count(row => row.Result.Status == CompileBackStatus.Exact);
+        int opcodeDiff = rows.Count(row => row.Result.Status == CompileBackStatus.OpcodeDiff);
+        int notFull = rows.Count(row => row.Result.Status == CompileBackStatus.NotFull);
+        int recompileFail = rows.Count(row => row.Result.Status == CompileBackStatus.RecompileFail);
+        int contextFail = rows.Count(row => row.Result.Status == CompileBackStatus.ContextFail);
+
+        Console.WriteLine($"CHANGED-METHOD COMPILE-BACK over {targetCount} current changed methods ({rows.Count} attempted)");
+        Console.WriteLine();
+        Console.WriteLine($"  exact opcode match : {exact}");
+        Console.WriteLine($"  opcode diff (Full) : {opcodeDiff}");
+        Console.WriteLine($"  not Full           : {notFull}");
+        Console.WriteLine($"  recompile fail     : {recompileFail}");
+        Console.WriteLine($"  context fail       : {contextFail}");
+        PrintTargetFailureBuckets(rows, CompileBackStatus.RecompileFail, "  recompile-fail buckets:");
+        PrintTargetFailureBuckets(rows, CompileBackStatus.ContextFail, "  context-fail buckets:");
+        PrintTargetExamples(rows, CompileBackStatus.OpcodeDiff, "Opcode-diff examples", maxExamples, includeOpcodes: true);
+        PrintTargetExamples(rows, CompileBackStatus.RecompileFail, "Recompile-fail examples", maxExamples, includeOpcodes: false);
+        PrintTargetExamples(rows, CompileBackStatus.ContextFail, "Context-fail examples", maxExamples, includeOpcodes: false);
+        PrintTargetExamples(rows, CompileBackStatus.NotFull, "Not-Full examples", maxExamples, includeOpcodes: false);
+    }
+
+    static void PrintTargetFailureBuckets(IReadOnlyList<TargetedCompileBackResult> rows, CompileBackStatus status, string title)
+    {
+        var buckets = rows
+            .Where(row => row.Result.Status == status)
+            .GroupBy(row => status == CompileBackStatus.ContextFail
+                ? ClassifyContextFailure(row.Result.Detail)
+                : ClassifyRecompileFailure(row.Result.Detail), StringComparer.OrdinalIgnoreCase)
+            .Select(group => new
+            {
+                Name = group.Key,
+                Count = group.Count(),
+                Examples = group.Select(row => row.Target.DisplayMethod).Take(3).ToArray(),
+            })
+            .OrderByDescending(bucket => bucket.Count)
+            .ThenBy(bucket => bucket.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (buckets.Length == 0)
+            return;
+
+        Console.WriteLine(title);
+        foreach (var bucket in buckets)
+            Console.WriteLine($"    {bucket.Name}: {bucket.Count} (e.g. {string.Join(", ", bucket.Examples)})");
+    }
+
+    static void PrintTargetExamples(
+        IReadOnlyList<TargetedCompileBackResult> rows,
+        CompileBackStatus status,
+        string title,
+        int maxExamples,
+        bool includeOpcodes)
+    {
+        var examples = rows.Where(row => row.Result.Status == status).Take(maxExamples).ToArray();
+        if (examples.Length == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine($"{title}:");
+        foreach (var row in examples)
+        {
+            Console.WriteLine($"  {row.Target.DisplayMethod}");
+            if (!string.IsNullOrWhiteSpace(row.Result.Detail))
+                Console.WriteLine($"    {row.Result.Detail}");
+            if (includeOpcodes)
+            {
+                Console.WriteLine($"    orig : {row.Result.OriginalOpcodes}");
+                Console.WriteLine($"    recmp: {row.Result.RecompiledOpcodes}");
+            }
+        }
+    }
 
     /// <summary>One method ready to compile back: its decompiled body and the original opcode stream to match.</summary>
     sealed record Entry(
@@ -402,6 +611,20 @@ static class FidelityCheck
         return prefix.Length == 0 ? "<unknown>" : prefix;
     }
 
+    static string PortablePath(string path)
+    {
+        var full = Path.GetFullPath(path).Replace('\\', '/');
+        const string nugetMarker = "/.nuget/packages/";
+        int nuget = full.IndexOf(nugetMarker, StringComparison.OrdinalIgnoreCase);
+        if (nuget >= 0)
+            return $"nuget:{full[(nuget + nugetMarker.Length)..]}";
+
+        var cwd = Path.GetFullPath(Environment.CurrentDirectory).Replace('\\', '/').TrimEnd('/');
+        if (full.StartsWith(cwd + "/", StringComparison.Ordinal))
+            return full[(cwd.Length + 1)..];
+        return Path.GetFileName(path);
+    }
+
     static void RunType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
         ImmutableArray<MetadataReference> references, CSharpParseOptions parseOptions,
@@ -513,6 +736,8 @@ static class FidelityCheck
     {
         if (string.IsNullOrWhiteSpace(detail))
             return "skeleton emission";
+        if (detail.Contains("target-method-not-found", StringComparison.OrdinalIgnoreCase))
+            return "target method not found";
         if (detail.Contains("method", StringComparison.OrdinalIgnoreCase)
             && detail.Contains("not found", StringComparison.OrdinalIgnoreCase))
             return "target method not found";

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -58,6 +58,7 @@ static class Program
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
         string? emitCorpusDelta = null;
+        string? fidelityMethodDelta = null;
         bool qualityDiffCard = false;
         bool qualityCardRisky = false;
         var corpusFidelityCaps = new List<int>();
@@ -115,6 +116,7 @@ static class Program
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
                 case "--emit-corpus-delta": emitCorpusDelta = args[++i]; break;
+                case "--fidelity-method-delta": fidelityMethodDelta = args[++i]; break;
                 case "--quality-diff-card": qualityDiffCard = true; break;
                 case "--quality-card-risky": qualityDiffCard = true; qualityCardRisky = true; break;
                 case "--corpus-fidelity-cap":
@@ -141,6 +143,13 @@ static class Program
 
         if (validityCheck || emitValidityDefects is not null || diffValidityDefects is not null)
             return ValidityCheck.Run(assemblies, compileCap, maxExamples, emitValidityDefects, diffValidityDefects, lowered);
+
+        if (fidelityMethodDelta is not null)
+        {
+            if (!fidelityCheck)
+                return Fail("--fidelity-method-delta requires --fidelity-check.");
+            return FidelityCheck.RunMethodDelta(assemblies, fidelityMethodDelta, maxExamples, lowered);
+        }
 
         if (fidelityCheck)
             return FidelityCheck.Run(assemblies, compileCap, maxExamples, lowered);
@@ -1129,6 +1138,8 @@ static class Program
           --emit-corpus-delta <f>        with --diff-corpus-baseline: write
                                 changed per-method corpus rows as JSON for
                                 reviewer drill-down and targeted fidelity runs.
+          --fidelity-method-delta <f>    with --fidelity-check: compile back the
+                                current changed methods from a corpus delta JSON.
           --quality-diff-card  with --diff-corpus-baseline: emit a Markdown
                                 Decompiler quality diff card generated from the
                                 baseline/current corpus snapshots.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -255,6 +255,18 @@ lowerings at once).
 
 **Fidelity check** (`--fidelity-check`): the *semantic-fidelity* check — `--gaps` is *completeness*, the validity check is *validity*, and this is *does it still mean the same thing*. It closes the round trip named in [docs/decompiler.md](../../docs/decompiler.md): decompile → recompile → compare IL. A body that parses, binds, and reads plausibly but recompiles to a **different opcode stream changed the program** — the worst failure class ([docs/decompiler-taste.md](../../docs/decompiler-taste.md)), invisible to every other check because they never run the output back through a compiler. Each member is recompiled inside a reconstructed **whole-module skeleton** — every top-level type stubbed (fields present, sibling and nested members as throwing stubs) with the one target carrying its real decompiled body, the C# analog of the IL round-trip suite's `IlasmScaffold`. With fields and sibling types in scope, a dropped or mis-bound field access surfaces as a true opcode diff rather than a bind error. The recompiled method is disassembled and its canonical opcode stream (short forms folded, `ldarg`/`ldloc`/`ldc.i4` families normalized) compared against the original; `Full`-fidelity diffs are the docket. References are the running runtime plus the target's sibling DLLs, minus the target itself (it is reconstructed, not referenced). Recompile failures here overlap `--validity-check` (an un-bindable body cannot be opcode-compared) and are reported separately, not as diffs. `CB_TYPE=<substr>` filters to a type; `CB_DUMP=1` prints the first failing compilation units. `--compile-cap N` bounds the (slow) recompile pass.
 
+Add `--fidelity-method-delta <delta.json>` when the question is "did the
+methods this PR changed still compile back faithfully?" The input is the
+per-method artifact from `--emit-corpus-delta`; removed methods are skipped and
+current changed methods are attempted exactly, with `Exact`, `OpcodeDiff`,
+`RecompileFail`, `ContextFail`, and `NotFull` buckets:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --fidelity-check \
+  --fidelity-method-delta /tmp/pr-corpus-delta.json
+```
+
 *When to use it.* Reach for fidelity check when the question is **"is this decompilation faithful,"** not "does it compile." Run it after any change to the importer, a raising pass, or the printer that could alter emitted semantics — branch sense, checked/unchecked, conversions, field/local ordering, shift masking — and read the `Full` opcode-diff bucket as a regression docket. It is the tool that catches a fix in one method silently degrading another. Prefer the small, fast, purpose-built fixture corpus (`CfgSampleClass` in `ILInspector.Decompiler.Tests`) for a tight loop; sweep a real assembly (BCL) for breadth once the fixtures are clean. Use `--validity-check` first when you only need to know the output is valid C#, and `--gaps` to track the structuring completeness.
 
 *The CI gate.* The console mode above is for exploration; the durable regression guard is `FidelityGateTests` in `ILInspector.Decompiler.Tests`, which calls the same machinery through `FidelityCheck.Evaluate` (the non-printing, structured-result entry point) over `CfgSampleClass`. It fails CI when a method newly recompiles to a different opcode stream (a regression beyond the documented `KnownDiffs` docket) and when a previously-fixed method (`PinnedExact`) regresses. Shrink `KnownDiffs` as you fix docket entries; add the fixed method to `PinnedExact` to pin the fix. `LoweredFidelityGateTests` is the twin gate for the lowered view (`--lowered`), with its own docket — the lowered C# is recompiled and opcode-compared the same way, so both official C# views earn a per-view E2E roundtrip.


### PR DESCRIPTION
## Summary
- add `--fidelity-method-delta <delta.json>` for `--fidelity-check`
- consume corpus per-method delta artifacts and compile back the current changed methods exactly
- report exact/opcode-diff/not-full/recompile-fail/context-fail counts, buckets, and examples

## Validation
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- #1251/#1209 delta artifact: attempted 165 current changed methods and reported 132 recompile failures / 33 context failures with explicit buckets

Fixes #1263.