### PR TITLE
Member-scope Top Leverage + suppress generated Optimization Opportunities (#1264, #1267)

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -125,7 +125,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
-    public void RenderOptimizationOpportunities_SuppressesGeneratedMethodsUnlessAll()
+    public void RenderOptimizationOpportunities_SuppressesGeneratedMethods()
     {
         var type = new ApiType
         {
@@ -143,12 +143,14 @@ public class OutputFormatterTests
             IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.OptimizationOpportunities }
         };
 
+        // Generated implementation details are not actionable source fixes and are not
+        // selectable at member scope (the API surface omits them), so they are suppressed
+        // unconditionally — including under --all — to keep the contract consistent (#1267).
         var defaultMarkdown = ApiCommand.RenderTypeSectionsMarkdown(type, options);
         var allMarkdown = ApiCommand.RenderTypeSectionsMarkdown(type, options with { IncludeAll = true });
 
-        // The generated local function is suppressed by default and exposed with --all (#1267).
         Assert.DoesNotContain("g__Make", defaultMarkdown);
-        Assert.Contains("g__Make", allMarkdown);
+        Assert.DoesNotContain("g__Make", allMarkdown);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -116,6 +116,58 @@ public class OutputFormatterTests
         _ = bytes.Length;
     }
 
+    // The local function compiles to a compiler-generated method (<...>g__Make|...)
+    // declared on this type, carrying the small-array opportunity from `new int[3]`.
+    private static int[] HasGeneratedLocalFunctionOpportunity()
+    {
+        return Make();
+        static int[] Make() => new int[3];
+    }
+
+    [Fact]
+    public void RenderOptimizationOpportunities_SuppressesGeneratedMethodsUnlessAll()
+    {
+        var type = new ApiType
+        {
+            Namespace = typeof(OutputFormatterTests).Namespace,
+            Name = nameof(OutputFormatterTests),
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "method", Name = nameof(HasGeneratedLocalFunctionOpportunity) }
+            ]
+        };
+        var options = new MemberOptions
+        {
+            DllPath = typeof(OutputFormatterTests).Assembly.Location,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.OptimizationOpportunities }
+        };
+
+        var defaultMarkdown = ApiCommand.RenderTypeSectionsMarkdown(type, options);
+        var allMarkdown = ApiCommand.RenderTypeSectionsMarkdown(type, options with { IncludeAll = true });
+
+        // The generated local function is suppressed by default and exposed with --all (#1267).
+        Assert.DoesNotContain("g__Make", defaultMarkdown);
+        Assert.Contains("g__Make", allMarkdown);
+    }
+
+    [Fact]
+    public void ScanOptimizationOpportunities_SuppressesGeneratedMethods()
+    {
+        var rows = LibraryMetadataService.ScanOptimizationOpportunities(
+            typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
+
+        Assert.NotNull(rows);
+        Assert.NotEmpty(rows);
+        Assert.DoesNotContain(rows, r =>
+            r.Member.Contains("<>c")
+            || r.Member.Contains(">g__")
+            || r.Member.Contains(">b__")
+            || r.Member.Contains(">d__")
+            || r.Member.Contains("c__Display")
+            || r.Member.Contains("<PrivateImplementationDetails>"));
+    }
+
     [Fact]
     public void BuildShapeView_GroupsMethodOverloadsByLogicalName()
     {

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -279,6 +279,28 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void MemberDetailPipeline_TopLeverage_IsStructurallyDiscoverable()
+    {
+        // Top Leverage mirrors Optimization Opportunities: index-backed and unprobed
+        // (ProbeEffectiveness=false), so -D must list it structurally in the single-member
+        // detail pipeline for any type with method-like members (#1264).
+        var pipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "T",
+            Kind = "class",
+            Members = [new ApiMember { Kind = "method", Name = "M" }]
+        };
+
+        var applicable = pipeline.GetApplicableSections(type);
+        var unprobed = pipeline.GetUnprobedSections();
+
+        Assert.Contains(SectionNames.TopLeverage, applicable);
+        Assert.Contains(SectionNames.TopLeverage, unprobed);
+    }
+
+    [Fact]
     public void CanRender_IntegrationOpportunities_UsesScannedRows()
     {
         var pipeline = LibrarySections.CreatePipeline();

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -151,6 +151,29 @@ public class TopLeverageSectionTests
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("Top Leverage\tsection", result.Output);
     }
+    [Fact]
+    public async Task MemberTopLeverage_ScopesRowsToSelectedMember()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(LeverageSampleType).FullName,
+            AssemblyPath = typeof(LeverageSampleType).Assembly.Location,
+            MemberFilter = [nameof(LeverageSampleType.SharedHelper)],
+            OverloadIndex = 1,
+            IncludeAll = true,
+            IncludeSections = [SectionNames.TopLeverage],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Detailed,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        // Member scope is now selectable (#1264) and rows are restricted to the selected
+        // member, not the whole declaring type.
+        Assert.Contains("## Top Leverage", result.Output);
+        Assert.Contains("SharedHelper", result.Output);
+        Assert.DoesNotContain(nameof(LeverageSampleType.EntryA), result.Output);
+    }
 }
 
 public static class LeverageSampleType

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -660,8 +660,7 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
-                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options),
-                    includeGenerated: options.IncludeAll);
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }
 
             if (options.DllPath is { } leverageDllPath
@@ -1038,8 +1037,7 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, renderOptions.IncludeSections,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
-                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions),
-                    includeGenerated: renderOptions.IncludeAll);
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
             }
 
             if (renderOptions.DllPath is { } leverageDllPath

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -660,13 +660,16 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
-                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options),
+                    includeGenerated: options.IncludeAll);
             }
 
             if (options.DllPath is { } leverageDllPath
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.TopLeverage))
             {
-                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath);
+                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath,
+                    restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }
 
             // Source code (already resolved in command layer)
@@ -1035,13 +1038,16 @@ public class ApiCommand
             {
                 ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, renderOptions.IncludeSections,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
-                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions),
+                    includeGenerated: renderOptions.IncludeAll);
             }
 
             if (renderOptions.DllPath is { } leverageDllPath
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.TopLeverage))
             {
-                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath);
+                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath,
+                    restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
+                        || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
             }
         }
 

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -496,6 +496,7 @@ public static class MemberCommand
         SectionNames.CallGraph,
         SectionNames.CallerGraph,
         SectionNames.UnsafeOperations,
+        SectionNames.TopLeverage,
         SectionNames.OptimizationOpportunities,
         SectionNames.Facts,
         SectionNames.IL

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -589,6 +589,13 @@ internal static class LibraryMetadataService
     private static string FormatMethod(Analysis.MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
+    // Compiler-generated implementation details (display classes, state machines, the
+    // <>c lambda cache, <PrivateImplementationDetails>) are not actionable source-shape
+    // fixes, so they are suppressed from Optimization Opportunities by default.
+    internal static bool IsGeneratedMethod(Analysis.MethodIdentity method)
+        => ILInspector.Metadata.MemberFilters.IsCompilerGenerated(method.Name)
+           || ILInspector.Metadata.TypeFilters.IsCompilerGeneratedNested(method.DeclaringType.Name);
+
     /// <summary>
     /// Ranks the assembly's methods by call-graph leverage (distinct direct callers,
     /// then outbound shape). Emits the full ranked set so the row limiter (<c>-n</c>/
@@ -631,6 +638,7 @@ internal static class LibraryMetadataService
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
             var rows = index.OptimizationOpportunities
+                .Where(opportunity => !IsGeneratedMethod(opportunity.Method))
                 .OrderBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
                 .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
                 .ThenBy(opportunity => opportunity.ILOffset ?? -1)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1456,7 +1456,7 @@ public static class ApiOutputFormatter
             view.UnsafeMemberRows = rows;
     }
 
-    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false)
+    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false, bool includeGenerated = false)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
         HashSet<int>? memberTokens = restrictToModelMembers
@@ -1464,6 +1464,7 @@ public static class ApiOutputFormatter
             : null;
         var rows = index.OptimizationOpportunities
             .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
+            .Where(opportunity => includeGenerated || !LibraryMetadataService.IsGeneratedMethod(opportunity.Method))
             .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken))
             .OrderBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
             .ThenBy(opportunity => opportunity.ILOffset ?? -1)
@@ -1482,7 +1483,7 @@ public static class ApiOutputFormatter
             view.OptimizationOpportunityRows = rows;
     }
 
-    internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath)
+    internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath, bool restrictToModelMembers = false)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
 
@@ -1501,8 +1502,11 @@ public static class ApiOutputFormatter
 
         // Rank every method declared on this type; fanin is still measured across all
         // callers in the assembly. The full ranked set is emitted and the generic row
-        // limiter (`-n`/`--rows`) trims the rendered table.
+        // limiter (`-n`/`--rows`) trims the rendered table. In member-detail/overload
+        // contexts `type.Members` is narrowed to the selected member(s), so restrict the
+        // ranked rows to those tokens (mirrors PopulateOptimizationOpportunities).
         var rows = index.TopLeverage(count: int.MaxValue, scope: method => SameType(method.DeclaringType, type))
+            .Where(entry => !restrictToModelMembers || drillByToken.ContainsKey(entry.Method.MetadataToken))
             .Select(entry =>
             {
                 drillByToken.TryGetValue(entry.Method.MetadataToken, out var drill);

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1456,7 +1456,7 @@ public static class ApiOutputFormatter
             view.UnsafeMemberRows = rows;
     }
 
-    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false, bool includeGenerated = false)
+    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
         HashSet<int>? memberTokens = restrictToModelMembers
@@ -1464,7 +1464,7 @@ public static class ApiOutputFormatter
             : null;
         var rows = index.OptimizationOpportunities
             .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
-            .Where(opportunity => includeGenerated || !LibraryMetadataService.IsGeneratedMethod(opportunity.Method))
+            .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method))
             .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken))
             .OrderBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
             .ThenBy(opportunity => opportunity.ILOffset ?? -1)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -270,6 +270,9 @@ public static class ApiMemberSectionDescriptors
         public static string Name => SectionNames.TopLeverage;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        // Backed by the whole-assembly body index; list structurally during -D rather
+        // than opening the index to probe, mirroring OptimizationOpportunities.
+        public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(IsMethodLike);
@@ -430,6 +433,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
             .Add<ApiMemberDetailSectionDescriptors.CallerGraph>()
             .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
+            .Add<ApiMemberSectionDescriptors.TopLeverage>()
             .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
             .Add<ApiMemberSectionDescriptors.ILBody>()
             .Add<ApiMemberSectionDescriptors.Facts>();
@@ -466,6 +470,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<CallGraph>()
             .Add<CallerGraph>()
             .Add<UnsafeOperations>()
+            .Add<ApiMemberSectionDescriptors.TopLeverage>()
             .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
             .Add<Facts>()
             .Add<ILBody>()


### PR DESCRIPTION
Two connected leverage/opportunity refinements that touch the cluster's central section-rendering files.

## #1264 — Top Leverage selectable at member scope
`Top Leverage` rendered only at type scope; `member Type Method -S "Top Leverage"` errored and `-D` omitted it (#1264 also flagged Optimization Opportunities, fixed by #1269). Mirrors the #1269 pattern:
- Register `TopLeverage` in the overload-inventory and single-member detail pipelines.
- Mark the descriptor `ProbeEffectiveness=false` → `-D` over-reports it structurally.
- Add `SectionNames.TopLeverage` to `SingleOverloadSectionNames` → single-overload member auto-resolves to detail.
- `PopulateTopLeverage` gains `restrictToModelMembers` (reuses the member-token map) so member-detail/overload views scope rows to the selected member(s). Type scope unchanged.

## #1267 — Suppress generated methods from Optimization Opportunities
The section reported compiler-generated `<>c` lambdas, display classes, state machines, and `<PrivateImplementationDetails>` as `instance-method-no-state` etc., dominating the first screen with non-actionable guidance. Now filtered (shared `IsGeneratedMethod`) from the library scan and type/member populate. Type/member scope re-includes them under `--all`; library scope suppresses by default (no `--all` there yet).

## Verification
- Member `-S "Top Leverage"` selectable + scoped to the member; `-D` lists it; single-overload auto-resolves; type scope unchanged.
- Optimization Opportunities: library + type default show 0 generated rows; type `--all` re-exposes them.
- Suites green: `dotnet-inspect.Tests` (1286, 9 env-skips), `ILInspector.Analysis.Tests` (41). Added member-scope, `-D` discovery, and generated-suppression tests.