### PR TITLE
Clarify output-shape flag semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ configuration switches such as `FeatureSwitchDefinitionAttribute` and
 
 ## Output and querying
 
-Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload, `--rows -n N` to cap rendered table rows, `--count` for a bare row count in one selected section, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
+Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--rows -n N` to cap rendered table rows, `--count` to reduce a selected section/vector to a single row count, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
 
 Sections and fields are queryable without a template language:
 

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -38,6 +38,18 @@ Most sections are Tables, but a section can also be a key-value field set, a
 list, a code/text blob, or a tree (for example a call graph). Those are still
 "one section" — the Table rung — and they collapse to Scalars the same way.
 
+## Three flag families
+
+A flag can contribute in one of three ways:
+
+- **Shape selectors** narrow the requested shape (`-S`, `--fields`/`--columns`,
+  `--count`, `-n 1`).
+- **Presentation modifiers** change how a selected payload is rendered without
+  changing the shape (`--bare`, `--markdown`, `--json`, `--table`, `--tsv`,
+  `--jsonl`, `--plaintext`, `--no-headers`).
+- **URL-shape modifiers** change only the form of GitHub URLs emitted as data
+  (`--raw`, `--blob`). They are orthogonal to the output-shape ladder.
+
 ## How Markout produces the shapes
 
 Markout serializes a view object into a **Document** of **Sections** and renders
@@ -71,24 +83,24 @@ Formatters decide presentation, not content:
 
 ## How dotnet-inspect flags select a shape
 
-Flags are how the user (or an agent) walks the ladder. They split into two
-groups: **selectors** that narrow the shape, and **format** flags that choose how
-the chosen shape is rendered.
+Flags are how the user (or an agent) walks the ladder. The important distinction
+is that a shape selector changes what data is requested, while a presentation
+modifier changes how a selected payload is rendered.
 
-### Selectors (narrow the shape)
+### Shape selectors (narrow the shape)
 
 | Target shape | Flags |
 | --- | --- |
 | Document | default view; `-v:q`/`-v:m`/`-v:n`/`-v:d` (breadth presets); `-S a,b` (multiple sections) |
 | Table | `-S OneSection` (a single section) |
 | Vector | `--fields X` / `--columns X` (project to one column) |
-| Scalar | `--count` (row count); `-n 1` (one row); `--bare` (a single content/`CodeSection` payload, e.g. redirect `Decompiled Source` to a `.cs` file) |
+| Scalar | `--count` (row count); `-n 1` (one row) |
 
 `-D`/`--discover` is orthogonal: it does not render the subject, it lists the
 *available* shapes — the sections of the Document and the columns of a Table (see
 [schema-query.md](schema-query.md)).
 
-### Format flags (render the chosen shape)
+### Presentation modifiers (render the chosen shape)
 
 | Flag | Effect |
 | --- | --- |
@@ -98,11 +110,26 @@ the chosen shape is rendered.
 | `--table` | render the single selected section as a space-padded pretty table |
 | `--no-header` (`--no-headers`) | drop the Table header row |
 | `-n N` / `--rows` | with `--rows`, `-n` trims to N **data rows per table**, across Markdown, TSV, and JSONL |
-| `--bare` | print only the selected payload, undecorated (the Scalar/blob rung) |
+| `--bare` | render the selected payload without document decoration; it changes presentation only, not the selected shape |
+| `--plaintext` | render a whole-document plain-text view; distinct from `--bare` |
 
 `--tsv`/`--jsonl`/`--table` render **one section at a time**, so they require a
 Table-or-narrower selection; multi-section (Document) output stays in Markdown or
 JSON.
+
+### URL-shape modifiers (orthogonal to the ladder)
+
+| Flag | Effect |
+| --- | --- |
+| `--raw` | emit GitHub URLs as raw/fetchable URLs (default) |
+| `--blob` | emit GitHub URLs as browser-friendly `/blob/` URLs |
+
+These flags are orthogonal to the output-shape ladder. They change the form of
+GitHub URLs that the tool emits as data (source links, sample links, link rows),
+but they do not change the selected shape or the framing around the payload.
+The safe default direction is `blob → raw`; the reverse is a browser-oriented
+mode and should not be applied to user-authored README/markdown content unless a
+separate opt-in path is introduced.
 
 ### Walking the ladder — one example
 
@@ -118,24 +145,21 @@ library MyLib.dll -S "Top Leverage" --fields Member --tsv
 
 # Scalar: collapse the table to a count …
 library MyLib.dll -S "Top Leverage" --count
-# … or print a blob payload undecorated
+# … or render a blob payload without decoration
 member MyType Method:1 --library MyLib.dll -S "Decompiled Source" --bare > Method.cs
 ```
 
-## Flag bindings still in flux
+## Design discipline for future flags
 
-The **shape ladder above is stable**; some flag *bindings* to it are still being
-designed and may change:
+The stable vocabulary is:
 
-- **#1241** — `--bare`/`--count` should key off **shape, not row count**: a
-  one-column Vector and a Scalar are different rungs, and `--bare` should apply to
-  a one-column Vector, not only a single row.
-- **#1219** — generalize `--bare` to text/doc sections and single-value
-  selections (the full Scalar/blob rung), not just `CodeSection`s.
-- **#1211** — `--raw`/`--blob` are a *URL-shape* pair (raw vs GitHub `/blob/`
-  URLs), distinct from the output-shape ladder; a proposed rename would move the
-  undecorated-output meaning onto `--bare` and keep `--raw`/`--blob` for URL
-  shape only.
+- `--count` is a shape-reduction selector: it collapses a selected table/vector to a
+  single scalar count.
+- `--bare` is a presentation modifier: it strips the surrounding framing from an
+  already-selected payload.
+- `--raw` / `--blob` are URL-shape modifiers: they control the form of emitted
+  GitHub links, not the shape of the payload itself.
+- `--plaintext` remains distinct from `--bare`; if it stays in the product, it is
+  a whole-document plain-text rendering mode rather than a bare-payload mode.
 
-When those settle, update the flag tables here to match; keep the ladder and the
-Markout mapping as the stable spine.
+New flags should fit one of those buckets rather than blending concepts.

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -113,13 +113,14 @@ also have sections for documentation and safety evidence:
 and a safety row such as `safe`, `unsafe boundary`, or `unsafe`. Safety comments
 should come from the documentation block, not SourceLink URL inference.
 
-`--bare` is the right output shape when a caller wants section content without a
-heading, table, or Markdown decoration. It supports type/member code sections
-such as `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`,
-one-column SourceLink URL output such as `Source Locations`, and package README/content
-payloads. If `Documentation` returns the complete `///` block, it should follow
-the same single-section bare-output contract so users can redirect the exact
-comment block or feed it to downstream tools without Markout framing.
+`--bare` is the right presentation modifier when a caller wants section content
+without a heading, table, or Markdown decoration. It supports type/member code
+sections such as `Decompiled Source`, `Annotated Source`, `Original Source`, and
+`IL`, one-column SourceLink URL output such as `Source Locations`, and package
+README/content payloads. It does not change the selected shape; it simply strips
+framing from an already-selected payload. `--count` remains the reduction that
+collapses a selected section to a single row count, and `--raw`/`--blob` remain
+the URL-shape pair for emitted GitHub links.
 
 ## PDB dependency
 

--- a/docs/workflows/core/line-and-result-limiting.md
+++ b/docs/workflows/core/line-and-result-limiting.md
@@ -7,7 +7,7 @@ areas: [output, limiting, count, agents]
 
 # Line, Result, and Row Counting
 
-> Control how much output is returned. `-n` limits output lines (like `head`). `--rows -n N` interprets the same count as table data rows per rendered table. `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` returns one integer for the rendered row count of a single selected section. These are essential for agents that need compact, predictable output.
+> Control how much output is returned. `-n` limits output lines (like `head`). `--rows -n N` interprets the same count as table data rows per rendered table. `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` reduces a selected section/vector to one integer row count, while `--bare` stays a presentation-only modifier for already-selected payloads. These are essential for agents that need compact, predictable output.
 
 ## Preconditions
 

--- a/docs/workflows/getting-started/verbosity-and-tips.md
+++ b/docs/workflows/getting-started/verbosity-and-tips.md
@@ -19,7 +19,7 @@ Verbosity levels:
 
 The `member` command follows the same scale for member lists. A selected overload defaults to `Signature`; normal verbosity adds bounded local implementation sections: `Decompiled Source` (raised C# without IL comments) and `IL` (raw IL). `Source Locations` is an explicit SourceLink file/line URL table that does not fetch source bodies. `Annotated Source` is the mixed C#+IL view with hidden-fact comments; `Original Source` is SourceLink-backed source when available. `-S @Source` selects Decompiled, Annotated, Original, and IL evidence. The `Facts` section — the structured table of the same hidden facts — is opt-in via `-S "Facts"` / `--tsv`.
 
-Section selection (`-S`, with lowercase `-s` as an alias) lists available sections or filters to specific ones. Tips are suppressed when sections are selected. `--count` with exactly one selected section returns a single integer.
+Section selection (`-S`, with lowercase `-s` as an alias) lists available sections or filters to specific ones. Tips are suppressed when sections are selected. `--count` with exactly one selected section returns a single integer count, while `--bare` is a presentation-only modifier that strips framing from an already-selected payload.
 
 ## Preconditions
 

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -17,9 +17,9 @@ public class SharedOptions
     public Option<bool> Json { get; } = new("--json") { Description = "Output as JSON" };
     public Option<bool> Markdown { get; } = new("--markdown") { Description = "Output as markdown" };
     public Option<bool> PlainText { get; } = new("--plaintext") { Description = "Output as plain text" };
-    public Option<bool> Bare { get; } = new("--bare") { Description = "Print only the selected payload, undecorated (single -S content section; e.g. redirect Decompiled Source to a .cs file)" };
-    public Option<bool> RawUrls { get; } = new("--raw") { Description = "Emit raw/fetchable GitHub URLs (default; pairs with --blob)" };
-    public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Use GitHub /blob/ URLs for browser viewing (default: raw URLs for agents)" };
+    public Option<bool> Bare { get; } = new("--bare") { Description = "Render the selected payload without document decoration; does not change the selected shape" };
+    public Option<bool> RawUrls { get; } = new("--raw") { Description = "Emit GitHub URLs as raw/fetchable URLs (default; URL-shape modifier, not an output-shape modifier)" };
+    public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Emit GitHub URLs as browser-friendly /blob/ URLs (URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };
@@ -35,7 +35,7 @@ public class SharedOptions
     public Option<int?> Limit { get; }
     public Option<bool> Rows { get; } = new("--rows") { Description = "Interpret -n/-N as data rows per rendered table instead of output lines" };
     public Option<int?> Tail { get; }
-    public Option<bool> Count { get; } = new("--count") { Description = "With a single selected section, output the number of table rows" };
+    public Option<bool> Count { get; } = new("--count") { Description = "Reduce a selected table/vector to a single row count" };
     public Option<bool> Info { get; } = new("--info") { Description = "Show operational metrics (output, time, HTTP, cache) on stderr" };
     public Option<string?> Tips { get; }
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -7,6 +7,9 @@
 - Renames the undecorated single-section output mode from `--raw` to `--bare`;
   `--raw` now names the default raw/fetchable GitHub URL shape and pairs with
   `--blob`.
+- Clarifies that `--bare` is a presentation-only modifier for already-selected
+  payloads, while `--count` remains the reduction that collapses a selected
+  section/vector to a single row count.
 - Generalizes `--bare` beyond code sections to package README/content payloads
   and one-column SourceLink URL output.
 - Normalizes GitHub file links in package README/content output from `blob` to


### PR DESCRIPTION
## Summary
- clarify the distinction between shape selectors, presentation modifiers, and URL-shape modifiers in the output-shape design doc
- update shared CLI help text for --bare, --count, --raw, and --blob so they describe the intended semantics precisely
- align README and workflow docs with the new terminology

## Testing
- npx --yes markdownlint-cli README.md docs/design/output-shapes.md docs/sourcelink-exposure.md docs/workflows/getting-started/verbosity-and-tips.md docs/workflows/core/line-and-result-limiting.md
- dotnet build src/dotnet-inspect -c Release