### PR TITLE
Match nested-type changed methods in fidelity delta (#1274)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -42,6 +42,8 @@
              Link="CorpusMetadata.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodIdentity.cs"
              Link="CorpusMethodIdentity.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodDelta.cs"
+             Link="CorpusMethodDelta.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"

--- a/src/ILInspector.Decompiler.Tests/NestedTargetFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedTargetFixture.cs
@@ -1,0 +1,17 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// A top-level type with a nested type, used by
+/// <see cref="NestedTargetLookupTests"/> to pin the changed-method fidelity
+/// path's nested-type identity matching (#1274). The bodies are trivial; only
+/// the type/member identity surface matters to the test.
+/// </summary>
+public class NestedTargetFixture
+{
+    public int OuterAdd(int a, int b) => a + b;
+
+    public class Inner
+    {
+        public int InnerAdd(int a, int b) => a + b;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
@@ -1,0 +1,51 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the changed-method fidelity path's identity matching for nested types
+/// (#1274). The corpus delta names nested types through their declaring type
+/// (<c>Outer.Inner</c>); before the fix the targeted path collected entries only
+/// for top-level types, so every changed method on a nested type landed in the
+/// <c>target-method-not-found</c> bucket and the check silently stopped measuring
+/// that part of the changed population.
+/// </summary>
+public class NestedTargetLookupTests
+{
+    const string Outer = "ILInspector.Decompiler.Tests.NestedTargetFixture";
+    const string Inner = "ILInspector.Decompiler.Tests.NestedTargetFixture.Inner";
+
+    static string FixtureAssembly => typeof(NestedTargetFixture).Assembly.Location;
+
+    [Fact]
+    public void TargetedPath_ReachesNestedTypeIdentity()
+    {
+        var collectible = FidelityCheck.CollectibleFullTypeNames(FixtureAssembly);
+
+        Assert.Contains(Outer, collectible);
+        // The fix: the nested type is now part of the identity surface a delta
+        // row is matched against, threaded through its declaring type.
+        Assert.Contains(Inner, collectible);
+    }
+
+    [Fact]
+    public void CorpusSweep_StillSkipsNestedTypes()
+    {
+        // Preserve existing --fidelity-check behavior: the non-targeted corpus
+        // sweep roots at top-level types only, so a nested type's methods never
+        // enter the broad sweep even though the targeted path can now reach them.
+        var swept = FidelityCheck.Evaluate(FixtureAssembly);
+
+        Assert.Contains(swept, r => r.Type == Outer && r.Method == "OuterAdd");
+        Assert.DoesNotContain(swept, r => r.Type == Inner);
+    }
+
+    [Theory]
+    [InlineData("ILInspector.Analysis.LibraryBodyIndex.IndexBuilder", "Build", false)]
+    [InlineData("System.Text.RegularExpressions.Generated.<RegexGenerator_g>X.RunnerFactory.Runner", "Scan", true)]
+    [InlineData("Some.Normal.Type", "<TryMatch>g__UncaptureUntil|2_0", true)]
+    [InlineData("<Module>", ".cctor", true)]
+    [InlineData("Some.Normal.Type", "Method", false)]
+    public void SynthesizedTargets_AreClassifiedSeparately(string type, string method, bool synthesized)
+        => Assert.Equal(synthesized, FidelityCheck.IsSynthesizedMember(type, method));
+}

--- a/tools/DecompilerHarness/CorpusMethodDelta.cs
+++ b/tools/DecompilerHarness/CorpusMethodDelta.cs
@@ -1,0 +1,44 @@
+namespace ILInspector.DecompilerHarness;
+
+// The corpus-method snapshot and changed-method delta artifact schema. Kept in
+// their own file (separate from CorpusSensor, which emits them) so the targeted
+// changed-method fidelity consumer in FidelityCheck can be linked into the
+// decompiler test project without dragging in the rest of the sensor pipeline.
+
+internal sealed record CorpusMethodSnapshot(
+    string Assembly,
+    string AssemblyPath,
+    string Type,
+    string Method,
+    int Overload,
+    string Signature,
+    string Fidelity,
+    bool FullyRaised,
+    string? Residual,
+    string? PassBug,
+    string Validity,
+    string FidelityCheck)
+{
+    public string DisplayMethod => $"{Assembly}!{Type}::{Method}#{Overload}";
+}
+
+internal sealed record CorpusMethodDeltaArtifact(
+    int SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    DateTimeOffset BaselineGeneratedUtc,
+    DateTimeOffset CurrentGeneratedUtc,
+    bool BaselineHasMethodDetails,
+    bool CurrentHasMethodDetails,
+    IReadOnlyList<CorpusMethodDeltaRow> ChangedMethods);
+
+internal sealed record CorpusMethodDeltaRow(
+    string Method,
+    string Assembly,
+    string AssemblyPath,
+    string Type,
+    string MethodName,
+    int Overload,
+    string Signature,
+    CorpusMethodSnapshot? Baseline,
+    CorpusMethodSnapshot? Current,
+    IReadOnlyList<string> Deltas);

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -744,44 +744,6 @@ internal sealed record CompletenessSensorMetrics(
     IReadOnlyDictionary<string, int> ResidualBuckets,
     IReadOnlyList<CorpusMethodSnapshot> Methods);
 
-internal sealed record CorpusMethodSnapshot(
-    string Assembly,
-    string AssemblyPath,
-    string Type,
-    string Method,
-    int Overload,
-    string Signature,
-    string Fidelity,
-    bool FullyRaised,
-    string? Residual,
-    string? PassBug,
-    string Validity,
-    string FidelityCheck)
-{
-    public string DisplayMethod => $"{Assembly}!{Type}::{Method}#{Overload}";
-}
-
-internal sealed record CorpusMethodDeltaArtifact(
-    int SchemaVersion,
-    DateTimeOffset GeneratedUtc,
-    DateTimeOffset BaselineGeneratedUtc,
-    DateTimeOffset CurrentGeneratedUtc,
-    bool BaselineHasMethodDetails,
-    bool CurrentHasMethodDetails,
-    IReadOnlyList<CorpusMethodDeltaRow> ChangedMethods);
-
-internal sealed record CorpusMethodDeltaRow(
-    string Method,
-    string Assembly,
-    string AssemblyPath,
-    string Type,
-    string MethodName,
-    int Overload,
-    string Signature,
-    CorpusMethodSnapshot? Baseline,
-    CorpusMethodSnapshot? Current,
-    IReadOnlyList<string> Deltas);
-
 internal sealed record ValiditySensorMetrics(
     int FullMalformedMethods,
     int SemanticCheckedMethods,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -101,16 +101,80 @@ static class FidelityCheck
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
             ?? throw new InvalidOperationException($"Could not read corpus delta '{deltaPath}'.");
 
-        var targets = artifact.ChangedMethods
+        var allTargets = artifact.ChangedMethods
             .Where(row => row.Current is not null)
             .Select(row => MethodTarget.From(row.Current!))
             .DistinctBy(TargetKey)
             .OrderBy(target => target.DisplayMethod, StringComparer.Ordinal)
             .ToArray();
 
-        var results = EvaluateTargets(assemblies, targets, lowered);
-        ReportTargeted(results, targets.Length, maxExamples);
+        // Compiler-generated / synthesized members — regex source-generator output
+        // (`<RegexGenerator_g>…`), lambda display classes, local-function frames,
+        // the `<Module>` pseudo-type — are never recompiled by the fidelity
+        // skeleton: their `<…>` names are not legal C# and CollectType/BuildUnit
+        // skip them by design. Classify them up front so they report as an explicit
+        // unsupported bucket instead of masquerading as a target-method-not-found
+        // lookup bug.
+        var supported = allTargets.Where(target => !IsSynthesizedTarget(target)).ToArray();
+
+        var results = EvaluateTargets(assemblies, supported, lowered).ToList();
+        foreach (var target in allTargets.Where(IsSynthesizedTarget))
+            results.Add(new TargetedCompileBackResult(
+                target,
+                new CompileBackResult(
+                    target.Type, target.Method, target.Overload, target.Signature,
+                    CompileBackStatus.ContextFail, "", "", "generated-member-unsupported")));
+
+        ReportTargeted(results, allTargets.Length, maxExamples);
         return 0;
+    }
+
+    /// <summary>
+    /// A changed method the fidelity skeleton cannot recompile because its type or
+    /// member is compiler-synthesized — an `<…>` name (source-generator output,
+    /// display class, iterator, async state machine, local-function frame) or the
+    /// `&lt;Module&gt;` pseudo-type. Reported as unsupported rather than a lookup miss.
+    /// </summary>
+    static bool IsSynthesizedTarget(MethodTarget target)
+        => IsSynthesizedMember(target.Type, target.Method);
+
+    /// <summary>
+    /// A delta row whose type or member is compiler-synthesized — an `&lt;…&gt;`
+    /// name (source-generator output, display class, iterator, async state
+    /// machine, local-function frame) or the `&lt;Module&gt;` pseudo-type. The
+    /// fidelity skeleton never recompiles these, so the targeted path reports them
+    /// as unsupported instead of a lookup miss.
+    /// </summary>
+    internal static bool IsSynthesizedMember(string type, string method)
+        => type.Contains('<') || method.Contains('<') || type == "<Module>";
+
+    /// <summary>
+    /// Every full type name the targeted delta path can collect compile-back
+    /// entries for, nested types included (each threaded through its declaring
+    /// types as <c>Outer.Inner</c>) — the identity surface a delta row's
+    /// <c>Type</c> is matched against. Exposed for the nested-type lookup
+    /// regression test; before the nested-aware fix this set held only top-level
+    /// types, so any changed method on a nested type fell into the
+    /// <c>target-method-not-found</c> bucket.
+    /// </summary>
+    internal static IReadOnlyList<string> CollectibleFullTypeNames(string assemblyPath)
+    {
+        var names = new List<string>();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            return names;
+        var reader = pe.GetMetadataReader();
+        using var source = MetadataSource.Open(assemblyPath);
+        var render = Renderer(source, lowered: false);
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!typeDef.GetDeclaringType().IsNil)
+                continue;
+            foreach (var (fullType, _, _) in EnumerateTypeTree(reader, pe, source, typeHandle, render))
+                names.Add(fullType);
+        }
+        return names;
     }
 
     /// <summary>The fidelity check outcome for one method.</summary>
@@ -297,29 +361,34 @@ static class FidelityCheck
                     {
                         if (pending.Count == 0)
                             break;
-                        if (CollectType(reader, pe, source, typeHandle, render) is not var (fullType, entries)
-                            || entries.Count == 0
-                            || !assemblyTargets.TryGetValue(fullType, out var typeTargets))
-                        {
-                            continue;
-                        }
+                        var rootDef = reader.GetTypeDefinition(typeHandle);
+                        if (!rootDef.GetDeclaringType().IsNil)
+                            continue; // each top-level root walks its own nested tree once
 
-                        var typeTargetMap = typeTargets.ToDictionary(
-                            target => $"{target.Method}{target.Signature}",
-                            StringComparer.Ordinal);
-                        var matched = entries
-                            .Where(entry => typeTargetMap.ContainsKey($"{entry.Name}{entry.Signature}"))
-                            .ToArray();
-                        if (matched.Length == 0)
-                            continue;
-
-                        var typeResults = EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, matched);
-                        for (int i = 0; i < matched.Length && i < typeResults.Count; i++)
+                        foreach (var (fullType, entries, treeHandle) in EnumerateTypeTree(reader, pe, source, typeHandle, render))
                         {
-                            var entry = matched[i];
-                            var target = typeTargetMap[$"{entry.Name}{entry.Signature}"];
-                            rows.Add(new TargetedCompileBackResult(target, typeResults[i]));
-                            pending.Remove(TargetKey(target));
+                            if (pending.Count == 0)
+                                break;
+                            if (entries.Count == 0 || !assemblyTargets.TryGetValue(fullType, out var typeTargets))
+                                continue;
+
+                            var typeTargetMap = typeTargets.ToDictionary(
+                                target => $"{target.Method}{target.Signature}",
+                                StringComparer.Ordinal);
+                            var matched = entries
+                                .Where(entry => typeTargetMap.ContainsKey($"{entry.Name}{entry.Signature}"))
+                                .ToArray();
+                            if (matched.Length == 0)
+                                continue;
+
+                            var typeResults = EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, treeHandle, matched);
+                            for (int i = 0; i < matched.Length && i < typeResults.Count; i++)
+                            {
+                                var entry = matched[i];
+                                var target = typeTargetMap[$"{entry.Name}{entry.Signature}"];
+                                rows.Add(new TargetedCompileBackResult(target, typeResults[i]));
+                                pending.Remove(TargetKey(target));
+                            }
                         }
                     }
                 }
@@ -435,12 +504,25 @@ static class FidelityCheck
         var typeDef = reader.GetTypeDefinition(typeHandle);
         if (!typeDef.GetDeclaringType().IsNil)
             return null; // nested types are emitted by their enclosing type
+        return CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render);
+    }
+
+    /// <summary>
+    /// Builds the entry list for one type, keyed by its full name (nested types
+    /// thread their declaring types: <c>Outer.Inner</c>, matching how the corpus
+    /// snapshot names them). Unlike <see cref="CollectType"/> this does not reject
+    /// a nested type, so the targeted delta path can reach a changed method that
+    /// lives on a nested type; the corpus sweep keeps rooting at top-level types
+    /// through <see cref="CollectType"/>, so non-targeted behavior is unchanged.
+    /// </summary>
+    static (string FullType, List<Entry> Entries)? CollectTypeEntries(
+        MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
+        TypeDefinition typeDef, Func<IrFunction, DecompilerResult> render)
+    {
         if (ShapeOf(reader, typeDef) is not (TypeKind.Class or TypeKind.Struct))
             return null;
 
-        string ns = reader.GetString(typeDef.Namespace);
-        string tn = reader.GetString(typeDef.Name);
-        string fullType = ns.Length == 0 ? tn : $"{ns}.{tn}";
+        string fullType = reader.GetFullTypeName(typeDef);
         if (fullType.Contains('<'))
             return null;
 
@@ -474,6 +556,25 @@ static class FidelityCheck
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
         }
         return (fullType, entries);
+    }
+
+    /// <summary>
+    /// Yields the entry list for a top-level type and every nested type beneath
+    /// it, each under its own full name (and the handle to root its skeleton
+    /// field-initializers). Used only by the targeted delta path so a changed
+    /// method on a nested type can be found and attempted instead of falling into
+    /// the <c>target-method-not-found</c> bucket.
+    /// </summary>
+    static IEnumerable<(string FullType, List<Entry> Entries, TypeDefinitionHandle Handle)> EnumerateTypeTree(
+        MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
+        Func<IrFunction, DecompilerResult> render)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        if (CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render) is { } collected)
+            yield return (collected.FullType, collected.Entries, typeHandle);
+        foreach (var nested in typeDef.GetNestedTypes())
+            foreach (var result in EnumerateTypeTree(reader, pe, source, nested, render))
+                yield return result;
     }
 
     static void EvaluateType(
@@ -736,6 +837,8 @@ static class FidelityCheck
     {
         if (string.IsNullOrWhiteSpace(detail))
             return "skeleton emission";
+        if (detail.Contains("generated-member-unsupported", StringComparison.OrdinalIgnoreCase))
+            return "generated/synthesized member (unsupported)";
         if (detail.Contains("target-method-not-found", StringComparison.OrdinalIgnoreCase))
             return "target method not found";
         if (detail.Contains("method", StringComparison.OrdinalIgnoreCase)
@@ -1390,9 +1493,9 @@ static class FidelityCheck
         foreach (var tdh in reader.TypeDefinitions)
         {
             var td = reader.GetTypeDefinition(tdh);
-            string ns = reader.GetString(td.Namespace);
-            string tn = reader.GetString(td.Name);
-            string ft = ns.Length == 0 ? tn : $"{ns}.{tn}";
+            // Nested-aware full name (Outer.Inner) so a recompiled nested-type
+            // target re-resolves; top-level names are unchanged (ns.tn).
+            string ft = reader.GetFullTypeName(td);
             if (ft != fullType)
                 continue;
             // The IL names .ctor/.cctor become the type name / static-ctor in C#;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -259,7 +259,17 @@ Add `--fidelity-method-delta <delta.json>` when the question is "did the
 methods this PR changed still compile back faithfully?" The input is the
 per-method artifact from `--emit-corpus-delta`; removed methods are skipped and
 current changed methods are attempted exactly, with `Exact`, `OpcodeDiff`,
-`RecompileFail`, `ContextFail`, and `NotFull` buckets:
+`RecompileFail`, `ContextFail`, and `NotFull` buckets. Changed methods on
+**nested types** are matched through their declaring type (`Outer.Inner`), so a
+risky PR's nested-type changes are measured rather than silently dropped.
+Compiler-synthesized rows the skeleton can never recompile — regex
+source-generator output, lambda display classes, iterator/async frames, the
+`<Module>` pseudo-type, any `<…>` name — are classified up front into a
+`generated/synthesized member (unsupported)` bucket instead of masquerading as a
+lookup miss. A `target method not found` row therefore means a genuine identity
+miss: most often a **stale delta** whose method signature has drifted from the
+current corpus build (e.g. a return type changed since the snapshot), so the
+exact method no longer exists to attempt.
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \


### PR DESCRIPTION
Closes #1274.

## Root cause
The `--fidelity-method-delta` path collected compile-back entries only for
**top-level** types — `CollectType` rejects nested types and `FindAndDisassemble`
built `ns.tn` names — while the corpus snapshot names nested types
`Outer.Inner` (via `GetFullTypeName`). So every changed method on a nested type
never matched and fell through to `target-method-not-found`.

On the #1251/#1209 delta all 33 context failures were nested types:
- ~27 regex source-generator frames (`<RegexGenerator_g>…`), intentionally unmatchable;
- 6 genuine nested classes (`IndexBuilder`, `AnonymousType*`, `WithQueryLambdaParametersBinder`).

## Fix (harness-only)
- **Nested-type lookup:** factor the entry builder into `CollectTypeEntries`
  (full name via `GetFullTypeName`, no nested guard) and add `EnumerateTypeTree`;
  `EvaluateTargets` walks each top-level root's tree. The corpus sweep keeps
  rooting at top-level types through `CollectType`, so `--fidelity-check`
  behavior is unchanged.
- `FindAndDisassemble` is now nested-aware so recompiled nested-type targets re-resolve.
- **Clearer status:** compiler-synthesized rows (`<…>` names, `<Module>`) are
  pre-classified into a `generated/synthesized member (unsupported)` bucket
  instead of masquerading as a lookup miss.

## Result
`target-method-not-found` drops **33 → 1**. The remaining row is genuine
**stale-delta drift**: `IndexBuilder.Build`'s return type changed from
`ValueTuple` 5 to `ValueTuple` 6 since the snapshot, so the exact method no
longer exists — the honest meaning of the bucket.

```
context-fail buckets (before): target method not found: 33
context-fail buckets (after):  generated/synthesized member (unsupported): 27
                               target method not found: 1
```

## Also
Extract the delta DTO records into `CorpusMethodDelta.cs` and link it into the
decompiler test project, fixing a **pre-existing build break**: #1270 referenced
`CorpusMethodSnapshot` from the linked `FidelityCheck.cs` without linking its
defining file, so `ILInspector.Decompiler.Tests` did not compile on `main`.

## Tests
Adds `NestedTargetLookupTests` (nested reachability, corpus-sweep guard,
synthesized classification). Full suite: **1092 passed**.