### PR TITLE
Make --count win over --bare

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1638,6 +1638,30 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_CountAndBare_ComposesForTableSection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonConvert", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Member Index", "--count", "--bare", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("67", output.Trim());
+    }
+
+    [Fact]
+    public async Task Type_CountAndBare_ComposesForVectorSection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--count", "--bare", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("2", output.Trim());
+    }
+
+    [Fact]
     public async Task Member_SourceLocations_UnpinnedSnupkgPackage_ResolvesSourceRows()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -690,6 +690,19 @@ public class ApiCommand
             }
         }
 
+        if (options.Count)
+        {
+            var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
+            var sw = new StringWriter();
+            var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
+            ApiOutputFormatter.SerializeTypeDocument(
+                view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
+                explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
+            writer.Flush();
+            CountOutput.WriteCountFromMarkdown(OutputFormatter.ApplyRowLimit(sw.ToString(), options.Rows));
+            return 0;
+        }
+
         // --bare: only the selected payload — no heading, fence, separator, or tips.
         if (options.Bare)
         {
@@ -702,18 +715,7 @@ public class ApiCommand
             return 0;
         }
 
-        if (options.Count)
-        {
-            var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
-            var sw = new StringWriter();
-            var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
-            ApiOutputFormatter.SerializeTypeDocument(
-                view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
-                explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
-            writer.Flush();
-            CountOutput.WriteCountFromMarkdown(OutputFormatter.ApplyRowLimit(sw.ToString(), options.Rows));
-        }
-        else if (options.OneLine)
+        if (options.OneLine)
         {
             if (ApiOutputFormatter.ShouldRenderSectionedTabularView(type, options))
             {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -396,6 +396,12 @@ public class PackageCommand
             // Filter output based on options
             FilterResultForOutput(result, options);
 
+            if (options.Count)
+            {
+                Console.WriteLine(OutputFormatter.FormatResult(result, options, pipeline));
+                return 0;
+            }
+
             if (options.Bare)
                 return PrintPackageBareSelection(result, extractPath, packageName, version, options);
 
@@ -443,11 +449,7 @@ public class PackageCommand
             }
             WarnEmptySections(result, options, pipeline);
             bool hasProjection = options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 };
-            if (options.Count)
-            {
-                Console.WriteLine(OutputFormatter.FormatResult(result, options, pipeline));
-            }
-            else if (options.OneLine)
+            if (options.OneLine)
             {
                 if (options.Jsonl && TryGetSingleFileSection(options, out var fileSection) && !hasProjection)
                 {


### PR DESCRIPTION
## Summary
- make `--count` take precedence over `--bare` so the requested shape reduction is preserved for both table and vector sections
- apply the same precedence rule to package output paths for consistency
- add regression tests covering both table-shaped and vector-shaped selections

## Testing
- dotnet run --project src/dotnet-inspect.Tests -c Release
