### PR TITLE
Emit valid C# for explicit impls and const enums in fidelity skeleton (#1282)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitFixture.cs
@@ -1,0 +1,32 @@
+namespace ILInspector.Decompiler.Tests;
+
+public enum SkeletonFlags
+{
+    None = 0,
+    A = 1,
+    B = 2,
+}
+
+/// <summary>
+/// Exercises two whole-module skeleton-emit hazards the changed-method fidelity
+/// check must survive (#1282), used by <see cref="SkeletonEmitTests"/>:
+/// <list type="bullet">
+/// <item>a non-generic <b>explicit interface implementation</b> (IL name
+/// <c>System.IDisposable.Dispose</c>): a reconstructed `public Iface.Member`
+/// stub is invalid C# (CS0106) and poisons the whole-module compile;</item>
+/// <item>a <b>const enum field</b>: its metadata value is the integer underlying,
+/// so a `public const SkeletonFlags F = 1;` stub is CS0266 without a cast.</item>
+/// </list>
+/// Both live on a sibling type so the failure surfaces when any method in the
+/// module is fidelity-checked.
+/// </summary>
+public class SkeletonEmitFixture : IDisposable
+{
+    public const SkeletonFlags DefaultFlags = SkeletonFlags.A;
+
+    void IDisposable.Dispose()
+    {
+    }
+
+    public int Sum(int a, int b) => a + b;
+}

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -1,0 +1,32 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the changed-method fidelity skeleton against two whole-module emit
+/// hazards (#1282). Both a non-generic explicit interface implementation and a
+/// const enum field previously emitted invalid C# (CS0106 / CS0266) into the
+/// reconstructed module, poisoning the single compilation so every changed
+/// method in that assembly recompiled-failed. The fidelity check emits the whole
+/// module, so a method on the offending type only compiles back when both hazards
+/// are handled.
+/// </summary>
+public class SkeletonEmitTests
+{
+    const string FixtureType = "ILInspector.Decompiler.Tests.SkeletonEmitFixture";
+
+    [Fact]
+    public void SkeletonCompilesPastExplicitImplAndConstEnum()
+    {
+        var sum = FidelityCheck.Evaluate(typeof(SkeletonEmitFixture).Assembly.Location)
+            .Single(r => r.Type == FixtureType && r.Method == "Sum");
+
+        // The point is that the whole-module skeleton compiles: an unhandled
+        // explicit impl (CS0106) or const enum (CS0266) would surface here as a
+        // RecompileFail/ContextFail, not as the clean opcode comparison below.
+        Assert.False(sum.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton failed to compile for {FixtureType}.Sum: {sum.Status} / {sum.Detail}");
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, sum.Status);
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -429,11 +429,40 @@ static class FidelityCheck
         Console.WriteLine($"  recompile fail     : {recompileFail}");
         Console.WriteLine($"  context fail       : {contextFail}");
         PrintTargetFailureBuckets(rows, CompileBackStatus.RecompileFail, "  recompile-fail buckets:");
+        PrintTargetRecompileCodes(rows);
         PrintTargetFailureBuckets(rows, CompileBackStatus.ContextFail, "  context-fail buckets:");
         PrintTargetExamples(rows, CompileBackStatus.OpcodeDiff, "Opcode-diff examples", maxExamples, includeOpcodes: true);
         PrintTargetExamples(rows, CompileBackStatus.RecompileFail, "Recompile-fail examples", maxExamples, includeOpcodes: false);
         PrintTargetExamples(rows, CompileBackStatus.ContextFail, "Context-fail examples", maxExamples, includeOpcodes: false);
         PrintTargetExamples(rows, CompileBackStatus.NotFull, "Not-Full examples", maxExamples, includeOpcodes: false);
+    }
+
+    /// <summary>
+    /// The compiler-diagnostic code histogram for the recompile-fail rows — the
+    /// `compiler diagnostic` bucket is a catch-all, so this splits it by `CS####`
+    /// so the dominant skeleton-emit defect is visible without re-grepping the
+    /// examples. The first row of each code names a representative method.
+    /// </summary>
+    static void PrintTargetRecompileCodes(IReadOnlyList<TargetedCompileBackResult> rows)
+    {
+        var byCode = rows
+            .Where(row => row.Result.Status == CompileBackStatus.RecompileFail)
+            .GroupBy(row => DiagnosticCode(row.Result.Detail), StringComparer.Ordinal)
+            .Select(group => new
+            {
+                Code = group.Key,
+                Count = group.Count(),
+                Example = group.First().Target.DisplayMethod,
+            })
+            .OrderByDescending(entry => entry.Count)
+            .ThenBy(entry => entry.Code, StringComparer.Ordinal)
+            .ToArray();
+        if (byCode.Length == 0)
+            return;
+
+        Console.WriteLine("  recompile-fail by code:");
+        foreach (var entry in byCode)
+            Console.WriteLine($"    {entry.Code}: {entry.Count} (e.g. {entry.Example})");
     }
 
     static void PrintTargetFailureBuckets(IReadOnlyList<TargetedCompileBackResult> rows, CompileBackStatus status, string title)
@@ -1184,7 +1213,15 @@ static class FidelityCheck
             string? value = ConstantText(reader, field.GetDefaultValue());
             if (value is null)
                 return; // can't synthesize an initializer — drop it
-            sb.AppendLine($"{pad}public const {Clean(type)} {Identifier(name)} = {value};");
+            string constType = Clean(type);
+            // A const of enum type stores its integer underlying value in
+            // metadata, so `public const BindingFlags F = 20;` is CS0266. Cast
+            // the literal to the (often cross-assembly, Unknown-shape) enum type —
+            // a valid constant expression. C# const fields are only primitives,
+            // strings (dropped above as a null TypeCode), or enums, so any
+            // non-primitive const type is an enum that needs the cast.
+            string constValue = IsPrimitiveTypeName(constType) ? value : $"({constType}){value}";
+            sb.AppendLine($"{pad}public const {constType} {Identifier(name)} = {constValue};");
             return;
         }
         string? initializer = fieldInits.FirstOrDefault(fi => fi.Field == name).Value;
@@ -1205,6 +1242,15 @@ static class FidelityCheck
         string name = reader.GetString(method.Name);
         if (name.Contains('<') && name is not ".ctor" and not ".cctor")
             return; // compiler-generated
+        // An explicit interface implementation carries the dotted interface-
+        // qualified IL name (e.g. `System.IDisposable.Dispose`); a reconstructed
+        // stub spelled `public Iface.Member(...)` is invalid C# (CS0106) and
+        // poisons the whole-module compile. It is never invoked by name (only
+        // through the interface), so the target never needs the stub to bind —
+        // drop sibling explicit impls. The target itself (realBody set) is still
+        // emitted so a changed explicit impl is not silently lost.
+        if (realBody is null && name.Contains('.') && name is not ".ctor" and not ".cctor")
+            return;
         if (method.RelativeVirtualAddress == 0 && realBody is null)
             return; // abstract/extern sibling — no body, and we strip abstractness
 
@@ -1285,6 +1331,16 @@ static class FidelityCheck
 
     static bool RequiresUnsafeSignature(string typeText)
         => typeText.Contains('*', StringComparison.Ordinal);
+
+    /// <summary>
+    /// The C# spellings <see cref="Clean"/> produces for primitive types — the
+    /// types a `const` field can hold directly without a cast. Any other const
+    /// field type is an enum, whose integer literal must be cast to the enum type.
+    /// </summary>
+    static bool IsPrimitiveTypeName(string type) => type is
+        "bool" or "char" or "sbyte" or "byte" or "short" or "ushort"
+        or "int" or "uint" or "long" or "ulong" or "float" or "double"
+        or "decimal" or "string" or "object" or "nint" or "nuint";
 
     static string Parameters(MetadataReader reader, MethodDefinition method, MethodSignature<string> sig)
     {


### PR DESCRIPTION
Addresses #1282 (classify + reduce the `recompile-fail: compiler diagnostic` bucket in changed-method fidelity).

## Classification (post-#1280 delta)
The `compiler diagnostic` bucket (76) is two root causes — both **whole-module skeleton-emit defects**: one invalid member poisons the single compilation, so every changed method in that assembly recompile-fails.

| Code | Count | Root cause | Assembly |
|------|-------|-----------|----------|
| CS0106 | 56 | `public Iface.Member` emitted for a non-generic explicit interface implementation (`SourceLinkJsonContext.IJsonTypeInfoResolver.GetTypeInfo`) | ILInspector.Metadata (55), dotnet-inspect (1) |
| CS9271 | 20 | Roslyn `EmbeddedAttribute` reconstruction | Microsoft.CodeAnalysis.CSharp |

Representative skeleton emission (before):
```csharp
public global::System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver.GetTypeInfo(...) // CS0106
public const System.Reflection.BindingFlags F = 20;                                            // CS0266 (unmasked by the CS0106 fix)
```

## Fixes (harness-only, `FidelityCheck` skeleton)
1. **`EmitMethod`** skips non-generic explicit-interface-implementation *sibling* stubs (dotted IL name, no real body). They are never invoked by name, so the target never needs them to bind. The target itself is still emitted.
2. **`EmitField`** casts a const enum's integer literal to its enum type (`(BindingFlags)20`) — fixes the CS0266 the CS0106 was masking on the same 56 methods.
3. **`ReportTargeted`** gains a `recompile-fail by code` histogram so the catch-all bucket self-classifies by `CS####`.

## Before → after (on the #1251/#1209 delta)
```
compiler-diagnostic bucket: 76 → 21   (CS0106 + CS0266 eliminated; remaining = CS9271)
recompile-fail by code (after): CS0246: 92, CS1001: 24, CS9271: 21
```
The headline `recompile fail: 137` is unchanged because the 56 ILInspector.Metadata methods now floor on a **shared CS0246 (missing-symbol)** cause — a separate bucket per #1272's classification. These two emit fixes are correct and on the critical path for that batch, but greening it needs the missing-symbol work.

## Split to follow-ups (per the issue's "stop and split" guardrail)
- **CS0246 missing-symbol (92)** — the dominant floor; cross-assembly type resolution in the skeleton.
- **CS9271 EmbeddedAttribute (21)** — Roslyn embedded-attribute reconstruction.
- **CS1001 syntax (24)** — `Identifier expected`, a distinct skeleton-emit defect.

## Tests
Adds `SkeletonEmitFixture` + `SkeletonEmitTests` (a non-generic explicit interface impl + a const enum field). **Verified the test fails without the fixes** and passes with them. Full decompiler suite: **1093 passed**.

Harness/test-only; product decompiler path stays SRM-only, NativeAOT-friendly, Roslyn-free.