### PR TITLE
Map Top Leverage accessor rows to their owning property selector (#1287)

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -267,6 +267,13 @@ public class ApiMember
     /// </summary>
     public int? MetadataToken { get; set; }
 
+    /// <summary>
+    /// MethodDef tokens of a property's get/set accessors when known. Lets accessor-level
+    /// call-graph rows (e.g. <c>get_Foo</c>) map back to the owning property's selector.
+    /// </summary>
+    public int? GetterToken { get; set; }
+    public int? SetterToken { get; set; }
+
     public bool IsStatic { get; set; }
     public bool IsVirtual { get; set; }
     public bool IsAbstract { get; set; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -306,7 +306,9 @@ public static class ApiSurfaceExtractor
                     IsSealed = isSealedProperty,
                     Accessibility = GetAccessibility(bestAccess),
                     IsObsolete = isObsolete,
-                    ObsoleteMessage = obsoleteMessage
+                    ObsoleteMessage = obsoleteMessage,
+                    GetterToken = accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
+                    SetterToken = accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)
                 };
 
                 apiType.Members.Add(member);

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -16,6 +16,38 @@ namespace DotnetInspector.Tests;
 public class OutputFormatterTests
 {
     [Fact]
+    public void BuildMemberDrillMap_SuppressesAmbiguousStableForOverloadedIndexers()
+    {
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "T",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "property", Name = "Item", Signature = "int this[int index]", GetterToken = 1001 },
+                new ApiMember { Kind = "property", Name = "Item", Signature = "int this[string key]", GetterToken = 1002 },
+                new ApiMember { Kind = "property", Name = "Count", Signature = "int Count", GetterToken = 1003 },
+            ]
+        };
+
+        var map = ApiOutputFormatter.BuildMemberDrillMap(type);
+
+        // Overloaded indexers share the parameter-free property canonical signature, so the
+        // ambiguous Stable digest is suppressed while the Name:N selector disambiguates.
+        Assert.True(map.TryGetValue(1001, out var first));
+        Assert.Null(first.Stable);
+        Assert.Matches(@"^Item:[12]$", first.Selector);
+        Assert.True(map.TryGetValue(1002, out var second));
+        Assert.Null(second.Stable);
+
+        // A uniquely-named property keeps its round-tripping Stable selector.
+        Assert.True(map.TryGetValue(1003, out var count));
+        Assert.Matches(@"^Count~[0-9a-f]{10}$", count.Stable);
+        Assert.Equal("Count", count.Selector);
+    }
+
+    [Fact]
     public void PopulateOptimizationOpportunities_RendersRowsForMatchingType()
     {
         var type = new ApiType

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -213,6 +213,21 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    public void LibraryTopLeverage_AccessorRowUsesOwningPropertySelector()
+    {
+        var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
+            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+
+        Assert.NotNull(rows);
+        // The ranked accessor (get_Tag) maps to the owning property's selector, so an agent
+        // can drill `member Tag` / `member Tag~digest` instead of a blank cell (#1287).
+        var accessor = Assert.Single(rows!, r => r.Member.EndsWith("LeverageSampleType.get_Tag()"));
+        Assert.Equal("public", accessor.Visibility);
+        Assert.Equal("Tag", accessor.Selector);
+        Assert.Matches(@"^Tag~[0-9a-f]{10}$", accessor.Stable);
+    }
+
+    [Fact]
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
@@ -260,4 +275,10 @@ public static class LeverageSampleType
     public static int Shadowed(int x) => x;
 
     internal static int Shadowed(string s) => s.Length;
+
+    // A property whose getter is given call-graph leverage by UsesTag, so the accessor
+    // ranks in Top Leverage and must map back to the `Tag` property selector.
+    public static int Tag => 7;
+
+    public static int UsesTag() => Tag + Tag;
 }

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -648,9 +648,9 @@ internal static class LibraryMetadataService
     /// selector round-trippable in the same context a reader would use it. Failures degrade
     /// to an empty map (rows simply omit the selector columns).
     /// </summary>
-    static Dictionary<int, (string Stable, string Visibility, string Selector)> BuildLibraryDrillMap(string path, VerboseLogger logger)
+    static Dictionary<int, (string? Stable, string Visibility, string Selector)> BuildLibraryDrillMap(string path, VerboseLogger logger)
     {
-        var map = new Dictionary<int, (string Stable, string Visibility, string Selector)>();
+        var map = new Dictionary<int, (string? Stable, string Visibility, string Selector)>();
         try
         {
             using var stream = File.OpenRead(path);
@@ -670,7 +670,7 @@ internal static class LibraryMetadataService
         }
         return map;
 
-        static void AddSurface(ILInspector.Metadata.ApiSurface surface, Dictionary<int, (string Stable, string Visibility, string Selector)> target)
+        static void AddSurface(ILInspector.Metadata.ApiSurface surface, Dictionary<int, (string? Stable, string Visibility, string Selector)> target)
         {
             foreach (var type in surface.Types)
             {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1507,7 +1507,7 @@ public static class ApiOutputFormatter
     /// path so both type- and library-scope Top Leverage emit selectors that resolve via
     /// <c>member Name~digest</c> / <c>member Name:N</c>.
     /// </summary>
-    internal static Dictionary<int, (string Stable, string Visibility, string Selector)> BuildMemberDrillMap(ApiType type)
+    internal static Dictionary<int, (string? Stable, string Visibility, string Selector)> BuildMemberDrillMap(ApiType type)
     {
         // Number overloads in the same order the Member Index uses, so the emitted
         // Name:N selector matches `member Name:N` resolution (the digest is order-free).
@@ -1519,8 +1519,15 @@ public static class ApiOutputFormatter
         var overloadCounts = ordered
             .GroupBy(GetMemberSelectorName, StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        // Property/field/event canonical signatures omit parameters, so overloaded indexers
+        // (all named Item) collapse to one digest. Count canonical signatures to detect such
+        // collisions and suppress the ambiguous Stable selector (the Name:N selector still
+        // disambiguates), so an emitted Name~digest always round-trips.
+        var canonicalCounts = ordered
+            .GroupBy(m => GetCanonicalSignature(type, m), StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
         var overloadIndices = new Dictionary<string, int>(StringComparer.Ordinal);
-        var map = new Dictionary<int, (string Stable, string Visibility, string Selector)>();
+        var map = new Dictionary<int, (string? Stable, string Visibility, string Selector)>();
 
         foreach (var member in ordered)
         {
@@ -1531,9 +1538,10 @@ public static class ApiOutputFormatter
             index++;
             overloadIndices[selectorName] = index;
 
-            var digest = GetMemberDigest(GetCanonicalSignature(type, member));
+            var canonical = GetCanonicalSignature(type, member);
             var selector = overloadCounts[selectorName] > 1 ? $"{selectorName}:{index}" : selectorName;
-            var drill = ($"{selectorName}~{digest}", member.Accessibility ?? "public", selector);
+            string? stable = canonicalCounts[canonical] > 1 ? null : $"{selectorName}~{GetMemberDigest(canonical)}";
+            var drill = (stable, member.Accessibility ?? "public", selector);
 
             // Register under the member's own token and, for properties, both accessor
             // MethodDef tokens, so accessor-level leverage rows (get_X/set_X) resolve to
@@ -1545,7 +1553,7 @@ public static class ApiOutputFormatter
 
         return map;
 
-        void Register(int? token, (string Stable, string Visibility, string Selector) drill)
+        void Register(int? token, (string? Stable, string Visibility, string Selector) drill)
         {
             if (token is { } resolved && !map.ContainsKey(resolved))
                 map[resolved] = drill;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1531,15 +1531,25 @@ public static class ApiOutputFormatter
             index++;
             overloadIndices[selectorName] = index;
 
-            if (member.MetadataToken is not { } token || map.ContainsKey(token))
-                continue;
-
             var digest = GetMemberDigest(GetCanonicalSignature(type, member));
             var selector = overloadCounts[selectorName] > 1 ? $"{selectorName}:{index}" : selectorName;
-            map[token] = ($"{selectorName}~{digest}", member.Accessibility ?? "public", selector);
+            var drill = ($"{selectorName}~{digest}", member.Accessibility ?? "public", selector);
+
+            // Register under the member's own token and, for properties, both accessor
+            // MethodDef tokens, so accessor-level leverage rows (get_X/set_X) resolve to
+            // the owning property's selector.
+            Register(member.MetadataToken, drill);
+            Register(member.GetterToken, drill);
+            Register(member.SetterToken, drill);
         }
 
         return map;
+
+        void Register(int? token, (string Stable, string Visibility, string Selector) drill)
+        {
+            if (token is { } resolved && !map.ContainsKey(resolved))
+                map[resolved] = drill;
+        }
     }
 
     internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath, bool restrictToModelMembers = false)


### PR DESCRIPTION
High-leverage accessor rows (`get_X`/`set_X`) in `Top Leverage` had blank `Visibility`/`Stable`/`Selector` because property accessors are folded into a single property member in the API surface, so their MethodDef tokens weren't in `BuildMemberDrillMap`.

## Fix

- Capture the get/set accessor MethodDef tokens (`GetterToken`/`SetterToken`) on `ApiMember`, populated by `ApiSurfaceExtractor` from `PropertyAccessors`.
- Register the property's drill tuple (`Stable`, `Visibility`, `Selector`) under both accessor tokens, so a ranked `get_Foo`/`set_Foo` resolves to the owning property's selector (`Foo` / `Foo~digest`) with the property's visibility. Applies to both library and type scope (shared `BuildMemberDrillMap`).

## Verification

- `get_IncludeSections` rows now render `public | IncludeSections~5cedcedbbe | IncludeSections`, and both the digest and the name selector round-trip to the property via `member ApiOptions IncludeSections~digest` / `member ApiOptions IncludeSections`.
- Suites green: `dotnet-inspect.Tests` 1293 (9 env-skips), `ILInspector.Metadata.Tests` 225. Added `LibraryTopLeverage_AccessorRowUsesOwningPropertySelector`.

## Scope note

Constructors of addressable types already round-trip via `.ctor` selectors. The remaining blank rows belong to **internal/private types** (e.g. `internal record`, `private record struct`, `<PrivateImplementationDetails>`) which the `member`/`type` command cannot address even with `--all` (the surface extractor skips non-public *types*). A blank selector is the honest result there; broadening `--all` to surface internal types is a separate, larger change worth its own issue.

Closes #1287.