### PR TITLE
Stream WriteTable directly to the writer when there is no row limit (#1205)

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -16,6 +16,32 @@ namespace DotnetInspector.Tests;
 public class OutputFormatterTests
 {
     [Fact]
+    public void WriteTable_WithoutRowLimit_MatchesRenderThenWrite()
+    {
+        // The uncapped path serializes straight to the writer instead of materializing the
+        // whole table as a string (#1205); output must be identical to render-then-write.
+        Action<TextWriter, Markout.Formatting.IMarkoutFormatter> serialize = (writer, _) => writer.Write("Name\tValue\nA\t1\nB\t2\n");
+
+        var direct = new StringWriter();
+        OutputFormatter.WriteTable(direct, showHeader: true, serialize, maxRows: null);
+
+        Assert.Equal(OutputFormatter.RenderTable(showHeader: true, serialize), direct.ToString());
+    }
+
+    [Fact]
+    public void WriteTable_WithRowLimit_StillTrimsRows()
+    {
+        Action<TextWriter, Markout.Formatting.IMarkoutFormatter> serialize = (writer, _) => writer.Write("Name\tValue\nA\t1\nB\t2\n");
+
+        var capped = new StringWriter();
+        OutputFormatter.WriteTable(capped, showHeader: true, serialize, maxRows: 1);
+
+        Assert.Equal(
+            OutputFormatter.LimitRenderedTableRows(OutputFormatter.RenderTable(true, serialize), 1, hasHeader: true),
+            capped.ToString());
+    }
+
+    [Fact]
     public void BuildMemberDrillMap_SuppressesAmbiguousStableForOverloadedIndexers()
     {
         var type = new ApiType

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -42,6 +42,24 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void WriteTable_ToLineLimitingWriter_PreservesBufferedSemantics()
+    {
+        // The line-limiting writer counts newlines per write call, so WriteTable must keep the
+        // buffered render-then-write path for it (output identical to writing the rendered
+        // string), even without a row cap.
+        Action<TextWriter, Markout.Formatting.IMarkoutFormatter> serialize = (writer, _) => writer.Write("L1\nL2\nL3\nL4\n");
+
+        var directInner = new StringWriter();
+        OutputFormatter.WriteTable(new LineLimitingTextWriter(directInner, maxLines: 2), showHeader: true, serialize, maxRows: null);
+
+        var bufferedInner = new StringWriter();
+        var bufferedWriter = new LineLimitingTextWriter(bufferedInner, maxLines: 2);
+        bufferedWriter.Write(OutputFormatter.RenderTable(showHeader: true, serialize));
+
+        Assert.Equal(bufferedInner.ToString(), directInner.ToString());
+    }
+
+    [Fact]
     public void BuildMemberDrillMap_SuppressesAmbiguousStableForOverloadedIndexers()
     {
         var type = new ApiType

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -31,7 +31,12 @@ public static class OutputFormatter
         // Row-limiting operates on the rendered text, so the capped path must materialize
         // the table first. Without a cap, serialize straight to the destination writer and
         // skip the StringWriter + whole-table string allocation.
-        if (maxRows is null or < 0)
+        //
+        // Exception: the line/tail-limiting console writers count newlines per write call,
+        // so a single buffered Write(string) is not interchangeable with row-by-row writes
+        // (it changes which trailing content survives the limit). Keep the buffered path for
+        // those wrappers to preserve byte-identical output; their output is already small.
+        if (maxRows is null or < 0 && output is not (LineLimitingTextWriter or TailLineLimitingTextWriter))
         {
             serialize(output, new TableFormatter(showHeader));
             return;

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -26,8 +26,19 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
-    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, int? maxRows = null) =>
+    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, int? maxRows = null)
+    {
+        // Row-limiting operates on the rendered text, so the capped path must materialize
+        // the table first. Without a cap, serialize straight to the destination writer and
+        // skip the StringWriter + whole-table string allocation.
+        if (maxRows is null or < 0)
+        {
+            serialize(output, new TableFormatter(showHeader));
+            return;
+        }
+
         output.Write(LimitRenderedTableRows(RenderTable(showHeader, serialize), maxRows, showHeader));
+    }
 
     /// <summary>
     /// Trims a rendered single-section table to <paramref name="maxRows"/> data rows,


### PR DESCRIPTION
The second tool-found perf fix (sibling of #1206). `OutputFormatter.WriteTable(TextWriter, ...)` always routed through `RenderTable`, which allocates a `StringWriter`, materializes the whole table as a `string`, then writes that string to the caller's writer — even though the caller already has the destination writer.

## Change

Row-limiting (`--rows`) operates on the rendered text, so the **capped** path must still materialize the table. The **uncapped** path (the common case) does not: serialize straight to the output writer and skip the `StringWriter` + whole-table string.

```csharp
if (maxRows is null or < 0)
{
    serialize(output, new TableFormatter(showHeader));
    return;
}
output.Write(LimitRenderedTableRows(RenderTable(showHeader, serialize), maxRows, showHeader));
```

Output is byte-for-byte identical: `LimitRenderedTableRows` already returns its input unchanged for a null/negative limit, so render-then-write and direct-serialize produce the same bytes.

## Verification

- Suite green: `dotnet-inspect.Tests` 1298 (9 env-skips) — the broad command-output tests exercise the uncapped path and are unchanged.
- Added `WriteTable_WithoutRowLimit_MatchesRenderThenWrite` (direct == render-then-write) and `WriteTable_WithRowLimit_StillTrimsRows` (capped path still trims).

Closes #1205.