### PR TITLE
Import the printer's assumed usings in the fidelity skeleton

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -33,6 +33,17 @@ public class FidelityGateTests
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
+        // AllOuterMatchInner, CachedStaticMethodGroup, and
+        // CompoundAssignDictionaryIndexer were previously recompile failures: the
+        // skeleton lacked the System.Linq / System.Collections.Generic usings the
+        // product printer's short names assume, so they never compiled to be
+        // compared. The widened skeleton using set (changed-method missing-symbol
+        // work) now compiles them, surfacing pre-existing over-renders (LINQ All,
+        // static method-group caching, compound dictionary-indexer double access)
+        // that were masked, not introduced. Triage tracked separately.
+        "AllOuterMatchInner",
+        "CachedStaticMethodGroup",
+        "CompoundAssignDictionaryIndexer",
         "BothPositive",
         // ByteRangeSearchTree is the #1084 comparison-tree bool-arm fixture:
         // now fully raised by ComparisonTreeBoolArmPass, but still recompiles to

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -27,6 +27,17 @@ public class LoweredFidelityGateTests
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
+        // AllOuterMatchInner, CachedStaticMethodGroup, and
+        // CompoundAssignDictionaryIndexer were previously recompile failures: the
+        // skeleton lacked the System.Linq / System.Collections.Generic usings the
+        // product printer's short names assume, so they never compiled to be
+        // compared. The widened skeleton using set (changed-method missing-symbol
+        // work) now compiles them, surfacing pre-existing over-renders (LINQ All,
+        // static method-group caching, compound dictionary-indexer double access)
+        // that were masked, not introduced. Triage tracked separately.
+        "AllOuterMatchInner",
+        "CachedStaticMethodGroup",
+        "CompoundAssignDictionaryIndexer",
         "BothPositive",
         // ByteRangeSearchTree is the #1084 comparison-tree bool-arm fixture:
         // now fully raised by ComparisonTreeBoolArmPass, but still recompiles to

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -3,13 +3,13 @@ using ILInspector.DecompilerHarness;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Pins the changed-method fidelity skeleton against two whole-module emit
-/// hazards (#1282). Both a non-generic explicit interface implementation and a
-/// const enum field previously emitted invalid C# (CS0106 / CS0266) into the
-/// reconstructed module, poisoning the single compilation so every changed
-/// method in that assembly recompiled-failed. The fidelity check emits the whole
-/// module, so a method on the offending type only compiles back when both hazards
-/// are handled.
+/// Pins the changed-method fidelity skeleton against whole-module emit hazards.
+/// A non-generic explicit interface implementation and a const enum field
+/// previously emitted invalid C# (CS0106 / CS0266) into the reconstructed module
+/// (#1282); and the bare `using System;` skeleton recompile-failed any body whose
+/// short type names needed a wider using set (CS0246, the changed-method
+/// missing-symbol bucket). The fidelity check emits the whole module, so a method
+/// on the offending type only compiles back when every hazard is handled.
 /// </summary>
 public class SkeletonEmitTests
 {
@@ -28,5 +28,23 @@ public class SkeletonEmitTests
             or FidelityCheck.CompileBackStatus.ContextFail,
             $"Skeleton failed to compile for {FixtureType}.Sum: {sum.Status} / {sum.Detail}");
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, sum.Status);
+    }
+
+    [Theory]
+    // Bodies the product printer spells with short names that need a using the
+    // bare `using System;` skeleton lacked: System.Collections.Generic
+    // (Dictionary) and System.Linq (Enumerable). Before the skeleton's widened
+    // using set these recompile-failed with CS0246; now they bind and compare.
+    [InlineData("CompoundAssignDictionaryIndexer")]
+    [InlineData("CachedStaticMethodGroup")]
+    public void SkeletonImportsUsingsForShortNamedFrameworkTypes(string method)
+    {
+        var result = FidelityCheck.Evaluate(typeof(CfgSampleClass).Assembly.Location)
+            .Single(r => r.Type == "ILInspector.Decompiler.Tests.CfgSampleClass" && r.Method == method);
+
+        Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton failed to compile CfgSampleClass.{method} (a missing using would surface here): "
+            + $"{result.Status} / {result.Detail}");
     }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -947,11 +947,15 @@ static class FidelityCheck
     {
         var sb = new StringBuilder();
         sb.AppendLine("#pragma warning disable");
-        // The decompiled bodies spell common framework types by their short name
-        // (e.g. `Span<int>`), matching the product view's assumed `using System;`;
-        // the skeleton imports the same namespace so those names bind.
-        sb.AppendLine("using System;");
-        sb.AppendLine("using System.Threading.Tasks;");
+        // The product printer spells framework types by their short name
+        // (`List<T>`, `PEReader`, `AssemblyReferenceHandle`), assuming the standard
+        // decompiler-output using set. The skeleton imports the same namespaces so
+        // those short names bind instead of failing CS0246 and poisoning the
+        // whole-module compile. Kept conservative — only widely-assumed, low-
+        // collision namespaces — so a body's short name resolves without
+        // introducing CS0104 ambiguity.
+        foreach (var ns in SkeletonUsings)
+            sb.AppendLine($"using {ns};");
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -1169,6 +1173,37 @@ static class FidelityCheck
 
     static readonly IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> NoTargets =
         new Dictionary<MethodDefinitionHandle, TargetBody>();
+
+    /// <summary>
+    /// The namespaces the whole-module skeleton imports so the product printer's
+    /// short type names bind. This mirrors the using set the decompiler output
+    /// assumes (the same family <see cref="ValidityCheck"/> uses) plus the
+    /// metadata namespaces that dominate the changed-method corpus
+    /// (<c>System.Reflection.Metadata</c> handle/struct types, <c>PEReader</c>,
+    /// immutable collections). Conservative on purpose: every entry is a
+    /// widely-assumed, low-collision namespace, so adding it resolves short names
+    /// without risking CS0104 ambiguity.
+    /// </summary>
+    static readonly string[] SkeletonUsings =
+    [
+        "System",
+        "System.Buffers",
+        "System.Collections",
+        "System.Collections.Generic",
+        "System.Collections.Immutable",
+        "System.Globalization",
+        "System.IO",
+        "System.Linq",
+        "System.Numerics",
+        "System.Reflection",
+        "System.Reflection.Metadata",
+        "System.Reflection.PortableExecutable",
+        "System.Runtime.CompilerServices",
+        "System.Runtime.InteropServices",
+        "System.Text",
+        "System.Threading",
+        "System.Threading.Tasks",
+    ];
 
     static void EmitEnum(MetadataReader reader, TypeDefinition typeDef, string name, StringBuilder sb, string pad)
     {


### PR DESCRIPTION
Reduces the `recompile-fail: missing symbol` bucket in changed-method fidelity (follow-up to #1293, toward useful evidence for #1175).

## Root cause
The fidelity skeleton (`BuildUnit`) is one whole-module compilation but declared only `using System;` and `using System.Threading.Tasks;`. The product printer (`PrintRaised`) spells framework types by their **short** name — `List<T>`, `PEReader`, `AssemblyReferenceHandle`, and the `System.Reflection.Metadata` handle/struct types. Those short names failed **CS0246** and poisoned every changed method in the assembly. Example product body:
```csharp
List<AssemblyReference> references = new List<AssemblyReference>();
AssemblyReferenceHandleCollection V_2 = metadataReader.AssemblyReferences;   // needs System.Reflection.Metadata
foreach (AssemblyReferenceHandle refHandle in V_2) { ... }
```

## Fix (harness-only)
Widen the skeleton's using set (`SkeletonUsings`) to the namespaces the printer assumes — the family `ValidityCheck` already uses plus the metadata namespaces that dominate the corpus (`System.Reflection.Metadata`, `System.Reflection.PortableExecutable`, `System.Collections.Generic`/`Immutable`, `System.Linq`). Conservative, low-collision entries only, to avoid CS0104.

## Before → after (#1251/#1209 delta)
| metric | before | after |
|--------|-------:|------:|
| exact opcode match | 0 | **21** |
| opcode diff (Full) | 0 | **7** |
| recompile fail | 137 | **109** |
| CS0246 | 92 | **39** |

The check now actually **measures** the changed population (21 exact + 7 actionable diffs) instead of failing to compile — the signal #1175 needs.

## Split to follow-ups (remaining CS0246 = 39)
- **`Builder<>` (~28)** — the product printer mis-spells a nested type of a generic (e.g. `ImmutableArray<T>.Builder`) as `Builder<…>`. A **product-path** printer bug, not harness.
- **NuGet / NuGetFetch (~8)** — missing assembly references in the corpus set.

## Side effect (good): three unmasked fixture diffs
Widening the usings let three CfgSampleClass methods that were **recompile-failing for lack of a using** finally compile, surfacing pre-existing over-renders (`AllOuterMatchInner`, `CachedStaticMethodGroup`, `CompoundAssignDictionaryIndexer`). Usings don't change a compiling method's IL, so these are **masked, not introduced** — added to the `FidelityGateTests` and `LoweredFidelityGateTests` dockets with an explanation.

## Tests
`SkeletonEmitTests` gains a theory pinning the fix (Dictionary / LINQ short names must bind). Full decompiler suite: **1093 passed**. Harness/test-only; product decompiler path unchanged.