### PR TITLE
Fix prioritized decompiler pass over-raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -8,6 +8,8 @@ public class ExpressionInliningPassTests
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef ExceptionType = TypeRef.CoreLib("System", "Exception");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
 
     static string PrintRaised(string methodName)
     {
@@ -118,5 +120,36 @@ public class ExpressionInliningPassTests
         Assert.Contains(block.Children.OfType<StoreLocal>(), store => store.Index == 0);
         Assert.Contains(block.Children.OfType<ExpressionStatement>(), statement =>
             statement.Expression is LoadLocal { Index: 0 });
+    }
+
+    [Fact]
+    public void DelegateCreationTargetFieldWrite_BlocksLiveRangeInlining()
+    {
+        var receiverField = new FieldRef(Holder, "Receiver", Object);
+        var target = new MethodRef(Holder, "M", Void, [], HasThis: true);
+        var use = new MethodRef(Holder, "Use", Void, [Action], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new DelegateCreation(
+            Action,
+            target,
+            isVirtual: false,
+            new LoadField(receiverField, instance: null))));
+        block.Add(new StoreField(receiverField, instance: null, new LoadArgument(0, "newReceiver", Object)));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Action)])));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("newReceiver", Object)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
     }
 }

--- a/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
@@ -92,4 +92,76 @@ public class LambdaCachePassTests
         Assert.Single(function.Descendants.OfType<DelegateCreation>());
         Assert.Equal(2, function.Body.Blocks.Count);
     }
+
+    [Fact]
+    public void StructuredCache_WithLaterCacheFieldRead_StaysUnfolded()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var actionType = TypeRef.CoreLib("System", "Action");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var cacheHolder = TypeRef.Definition("Synthetic", "Samples", "Owner+<>c");
+        var cacheField = new FieldRef(cacheHolder, "<>9__0_0", actionType);
+        var target = new MethodRef(owner, "Target", TypeRef.CoreLib("System", "Void"), [], HasThis: false);
+        var use = new MethodRef(owner, "Use", TypeRef.CoreLib("System", "Void"), [actionType], HasThis: false);
+
+        var then = new Block(0);
+        then.Add(new StoreStackSlot(2, new DelegateCreation(actionType, target, isVirtual: false, new Constant(null, objectType))));
+        then.Add(new StoreField(cacheField, null, new LoadStackSlot(2, actionType)));
+        then.Add(new StoreStackSlot(1, new LoadStackSlot(2, actionType)));
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadField(cacheField, null)));
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, actionType)));
+        block.Add(new IfStatement(new LogicalNot(new LoadStackSlot(0, actionType)), then, elseArm: null));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(1, actionType)])));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadField(cacheField, null)])));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction("M", owner, new MethodSignature(stringType, [], HasThis: false, GenericParameterCount: 0), [], container);
+
+        new LambdaCachePass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Contains(function.Descendants.OfType<StoreField>(), store => store.Field.Equals(cacheField));
+        Assert.Equal(2, function.Descendants.OfType<LoadField>().Count(load => load.Field.Equals(cacheField)));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void FlatCache_WithLaterCacheFieldRead_StaysUnfolded()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var funcType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`2"), [stringType, stringType]);
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var cacheHolder = TypeRef.Definition("Synthetic", "Samples", "Owner+<>O");
+        var cacheField = new FieldRef(cacheHolder, "<0>__Identity", funcType);
+        var identity = new MethodRef(owner, "Identity", stringType, [stringType], HasThis: false);
+        var use = new MethodRef(owner, "Use", TypeRef.CoreLib("System", "Void"), [funcType], HasThis: false);
+
+        var container = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new StoreStackSlot(0, new LoadField(cacheField, null)));
+        head.Add(new StoreStackSlot(2, new LoadStackSlot(0, funcType)));
+        head.Add(new ConditionalBranch(new LoadStackSlot(0, funcType), 8));
+        var create = new Block(4);
+        create.Add(new StoreStackSlot(3, new DelegateCreation(funcType, identity, isVirtual: false, new Constant(null, objectType))));
+        create.Add(new StoreField(cacheField, null, new LoadStackSlot(3, funcType)));
+        create.Add(new StoreStackSlot(2, new LoadStackSlot(3, funcType)));
+        var join = new Block(8);
+        join.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(2, funcType)])));
+        join.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadField(cacheField, null)])));
+        foreach (var block in (Block[])[head, create, join])
+            container.Add(block);
+        var function = new IrFunction("M", owner, new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0), [], container);
+
+        new LambdaCachePass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Contains(function.Descendants.OfType<StoreField>(), store => store.Field.Equals(cacheField));
+        Assert.Equal(2, function.Descendants.OfType<LoadField>().Count(load => load.Field.Equals(cacheField)));
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
@@ -8,9 +8,7 @@ public class NullConditionalCoalescePassTests
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
-    // A stand-in for the unconstrained generic receiver type; the pass matches the
-    // structural shape, not the type's genericity.
-    static readonly TypeRef s_tk = TypeRef.Definition("Synthetic", "", "T");
+    static readonly TypeRef s_tk = TypeRef.GenericParameter(0, "T");
 
     /// <summary>
     /// Builds csc's generic null-conditional invocation lowering with the given

--- a/src/ILInspector.Decompiler.Tests/NullValueTypeGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullValueTypeGuardTests.cs
@@ -1,0 +1,245 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class NullValueTypeGuardTests
+{
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_dateTime = TypeRef.CoreLib("System", "DateTime");
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+
+    [Fact]
+    public void NullConditional_ReevaluableValueTypeReceiver_StaysConditional()
+    {
+        var toString = new MethodRef(s_bool, "ToString", s_string, [], HasThis: true);
+        var function = FunctionReturning(
+            new Conditional(
+                new LoadLocal(0, s_bool),
+                new Call(toString, isVirtual: true, [new LoadLocal(0, s_bool)]),
+                new Constant(null, s_string)),
+            s_string,
+            [s_bool]);
+
+        new NullConditionalPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        Assert.Single(function.Descendants.OfType<Conditional>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NullConditional_SpilledValueTypeReceiver_StaysConditional()
+    {
+        var toString = new MethodRef(s_bool, "ToString", s_string, [], HasThis: true);
+        var block = new Block();
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, s_bool)));
+        block.Add(new StoreStackSlot(2, new Conditional(
+            new LoadStackSlot(0, s_bool),
+            new Call(toString, isVirtual: true, [new LoadStackSlot(1, s_bool)]),
+            new Constant(null, s_string))));
+        block.Add(new Return(new LoadStackSlot(2, s_string)));
+        var function = FunctionWithBlock(block, s_string, []);
+
+        new NullConditionalPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        Assert.Single(function.Descendants.OfType<Conditional>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NullCoalescingAssignment_ValueTypeLocal_StaysIf()
+    {
+        var thenBlock = new Block();
+        thenBlock.Add(new StoreLocal(0, s_dateTime, new LoadArgument(0, "fallback", s_dateTime)));
+        var block = new Block();
+        block.Add(new IfStatement(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadLocal(0, s_dateTime), new Constant(null, s_object)),
+            thenBlock,
+            elseArm: null));
+        var function = FunctionWithBlock(block, s_void, [s_dateTime], [new Parameter("fallback", s_dateTime)]);
+
+        new NullCoalescingAssignmentPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void BooleanFolding_CoalesceValueType_StaysIf()
+    {
+        var block = new Block();
+        block.Add(new StoreLocal(1, s_dateTime, new LoadLocal(0, s_dateTime)));
+        var thenBlock = new Block();
+        thenBlock.Add(new StoreLocal(1, s_dateTime, new LoadArgument(0, "fallback", s_dateTime)));
+        block.Add(new IfStatement(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadLocal(0, s_dateTime), new Constant(null, s_object)),
+            thenBlock,
+            elseArm: null));
+        block.Add(new Return(new LoadLocal(1, s_dateTime)));
+        var function = FunctionWithBlock(block, s_dateTime, [s_dateTime, s_dateTime], [new Parameter("fallback", s_dateTime)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Coalesce>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NullConditionalCoalesce_ConcreteValueTypeReceiver_StaysFlat()
+    {
+        var function = ConcreteValueTypeNullConditionalCoalesceShape();
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        Assert.NotEmpty(function.Descendants.OfType<Box>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotDiamond_NullArmWithValueTypeSlot_StaysFlat()
+    {
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "c", s_bool), 20));
+        var falseArm = new Block(10);
+        falseArm.Add(new StoreStackSlot(0, new Constant(null, s_object)));
+        falseArm.Add(new Branch(30));
+        var trueArm = new Block(20);
+        trueArm.Add(new StoreStackSlot(0, new LoadArgument(1, "value", s_dateTime)));
+        var merge = new Block(30);
+        merge.Add(new Return(new LoadStackSlot(0, s_dateTime)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(s_dateTime, [new Parameter("c", s_bool), new Parameter("value", s_dateTime)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new SlotDiamondPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void BooleanFolding_SlotDiamondNullArmWithValueTypeSlot_StaysIf()
+    {
+        var thenBlock = new Block();
+        thenBlock.Add(new StoreStackSlot(0, new LoadArgument(1, "value", s_dateTime)));
+        var elseBlock = new Block();
+        elseBlock.Add(new StoreStackSlot(0, new Constant(null, s_object)));
+        var block = new Block();
+        block.Add(new IfStatement(new LoadArgument(0, "c", s_bool), thenBlock, elseBlock));
+        block.Add(new Return(new LoadStackSlot(0, s_dateTime)));
+        var function = FunctionWithBlock(
+            block,
+            s_dateTime,
+            [],
+            [new Parameter("c", s_bool), new Parameter("value", s_dateTime)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotStoreDiamond_NullArmWithValueTypeSlot_StaysFlat()
+    {
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "c", s_bool), 20));
+        var falseArm = new Block(10);
+        falseArm.Add(new StoreStackSlot(0, new Constant(null, s_object)));
+        falseArm.Add(new Branch(30));
+        var trueArm = new Block(20);
+        trueArm.Add(new StoreStackSlot(0, new LoadArgument(1, "value", s_dateTime)));
+        var merge = new Block(30);
+        merge.Add(new StoreLocal(0, s_dateTime, new LoadStackSlot(0, s_dateTime)));
+        merge.Add(new Return(new LoadLocal(0, s_dateTime)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(s_dateTime, [new Parameter("c", s_bool), new Parameter("value", s_dateTime)], HasThis: false, GenericParameterCount: 0),
+            [s_dateTime],
+            body);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+        function.CheckInvariant();
+    }
+
+    static IrFunction ConcreteValueTypeNullConditionalCoalesceShape()
+    {
+        const int temp = 0, receiverSlot = 1, resultSlot = 2;
+        var getHashCode = new MethodRef(s_object, "GetHashCode", s_int, [], HasThis: true);
+        var a = new Block(0);
+        a.Add(new InitObject(s_dateTime, new LoadLocalAddress(temp, s_dateTime)));
+        a.Add(new StoreStackSlot(receiverSlot, new LoadArgumentAddress(0, "value", s_dateTime)));
+        a.Add(new ConditionalBranch(new Box(s_dateTime, new LoadLocal(temp, s_dateTime)), 30));
+
+        var b = new Block(10);
+        b.Add(new StoreLocal(temp, s_dateTime, new LoadIndirect(s_dateTime, new LoadStackSlot(receiverSlot, TypeRef.ByRef(s_dateTime)))));
+        b.Add(new StoreStackSlot(receiverSlot, new LoadLocalAddress(temp, s_dateTime)));
+        b.Add(new ConditionalBranch(new Box(s_dateTime, new LoadLocal(temp, s_dateTime)), 30));
+
+        var falseArm = new Block(20);
+        falseArm.Add(new StoreStackSlot(resultSlot, new Constant(0, s_int)));
+        falseArm.Add(new Branch(40));
+
+        var trueArm = new Block(30);
+        trueArm.Add(new StoreStackSlot(resultSlot, new Call(getHashCode, isVirtual: true, [new LoadStackSlot(receiverSlot, TypeRef.ByRef(s_dateTime))]) { ConstrainedTo = s_dateTime }));
+
+        var merge = new Block(40);
+        merge.Add(new Return(new LoadStackSlot(resultSlot, s_int)));
+
+        var body = new BlockContainer();
+        foreach (var block in (Block[])[a, b, falseArm, trueArm, merge])
+            body.Add(block);
+        return new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(s_int, [new Parameter("value", s_dateTime)], HasThis: false, GenericParameterCount: 0),
+            [s_dateTime],
+            body);
+    }
+
+    static IrFunction FunctionReturning(IrExpression expression, TypeRef returnType, IReadOnlyList<TypeRef> locals)
+    {
+        var block = new Block();
+        block.Add(new Return(expression));
+        return FunctionWithBlock(block, returnType, locals);
+    }
+
+    static IrFunction FunctionWithBlock(
+        Block block,
+        TypeRef returnType,
+        IReadOnlyList<TypeRef> locals,
+        IReadOnlyList<Parameter>? parameters = null)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(returnType, parameters is null ? [] : [.. parameters], HasThis: false, GenericParameterCount: 0),
+            [.. locals],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/NullValueTypeGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullValueTypeGuardTests.cs
@@ -11,6 +11,7 @@ public class NullValueTypeGuardTests
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef s_owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+    static readonly TypeRef s_shapeOnlyStruct = TypeRef.Definition("Synthetic", "Samples", "ShapeOnlyStruct");
 
     [Fact]
     public void NullConditional_ReevaluableValueTypeReceiver_StaysConditional()
@@ -133,6 +134,38 @@ public class NullValueTypeGuardTests
     }
 
     [Fact]
+    public void SlotDiamond_NullArmWithShapeOnlyValueTypeSlot_StaysFlat()
+    {
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "c", s_bool), 20));
+        var falseArm = new Block(10);
+        falseArm.Add(new StoreStackSlot(0, new Constant(null, s_object)));
+        falseArm.Add(new Branch(30));
+        var trueArm = new Block(20);
+        trueArm.Add(new StoreStackSlot(0, new LoadArgument(1, "value", s_shapeOnlyStruct)));
+        var merge = new Block(30);
+        merge.Add(new Return(new LoadStackSlot(0, s_shapeOnlyStruct)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(s_shapeOnlyStruct, [new Parameter("c", s_bool), new Parameter("value", s_shapeOnlyStruct)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [s_shapeOnlyStruct] = TypeShape.ValueType },
+        };
+
+        new SlotDiamondPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void BooleanFolding_SlotDiamondNullArmWithValueTypeSlot_StaysIf()
     {
         var thenBlock = new Block();
@@ -177,6 +210,39 @@ public class NullValueTypeGuardTests
             new MethodSignature(s_dateTime, [new Parameter("c", s_bool), new Parameter("value", s_dateTime)], HasThis: false, GenericParameterCount: 0),
             [s_dateTime],
             body);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotStoreDiamond_NullArmWithShapeOnlyValueTypeSlot_StaysFlat()
+    {
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "c", s_bool), 20));
+        var falseArm = new Block(10);
+        falseArm.Add(new StoreStackSlot(0, new Constant(null, s_object)));
+        falseArm.Add(new Branch(30));
+        var trueArm = new Block(20);
+        trueArm.Add(new StoreStackSlot(0, new LoadArgument(1, "value", s_shapeOnlyStruct)));
+        var merge = new Block(30);
+        merge.Add(new StoreLocal(0, s_shapeOnlyStruct, new LoadStackSlot(0, s_shapeOnlyStruct)));
+        merge.Add(new Return(new LoadLocal(0, s_shapeOnlyStruct)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            s_owner,
+            new MethodSignature(s_shapeOnlyStruct, [new Parameter("c", s_bool), new Parameter("value", s_shapeOnlyStruct)], HasThis: false, GenericParameterCount: 0),
+            [s_shapeOnlyStruct],
+            body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [s_shapeOnlyStruct] = TypeShape.ValueType },
+        };
 
         new SlotStoreDiamondPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -127,6 +127,32 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void InitializeArray_LocalClobberedBeforeCall_StaysUnraised()
+    {
+        var function = BuildInitializeArrayWithClobberedLocal();
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void InitializeArray_StackSlotClobberedBeforeCall_StaysUnraised()
+    {
+        var function = BuildInitializeArrayWithClobberedStackSlot();
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
     static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
         => BuildReadOnlySpanCtor(s_byte, s_readOnlySpanByte, blob, spanLength);
 
@@ -161,5 +187,58 @@ public class RvaSpanPassTests
         body.Add(block);
         var signature = new MethodSignature(s_readOnlySpanByte, [], HasThis: false, GenericParameterCount: 0);
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
+
+    static IrFunction BuildInitializeArrayWithClobberedLocal()
+    {
+        var intArray = TypeRef.SzArray(s_int);
+        var block = new Block();
+        block.Add(new StoreLocal(0, intArray, new NewArray(s_int, new Constant(1, s_int))));
+        block.Add(new StoreLocal(0, intArray, new LoadArgument(0, "other", intArray)));
+        block.Add(new ExpressionStatement(InitializeArrayCall(new LoadLocal(0, intArray))));
+        block.Add(new Return(new LoadLocal(0, intArray)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(intArray, [new Parameter("other", intArray)], HasThis: false, GenericParameterCount: 0),
+            [intArray],
+            body);
+    }
+
+    static IrFunction BuildInitializeArrayWithClobberedStackSlot()
+    {
+        var intArray = TypeRef.SzArray(s_int);
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new NewArray(s_int, new Constant(1, s_int))));
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "other", intArray)));
+        block.Add(new ExpressionStatement(InitializeArrayCall(new LoadStackSlot(0, intArray))));
+        block.Add(new Return(new LoadStackSlot(0, intArray)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(intArray, [new Parameter("other", intArray)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static Call InitializeArrayCall(IrExpression array)
+    {
+        var initializeArray = new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "InitializeArray",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Array"), s_runtimeFieldHandle],
+            HasThis: false);
+        var token = new LoadToken(RuntimeTokenKind.Field, null, "<PrivateImplementationDetails>.Blob")
+        {
+            FieldRvaData = [1, 0, 0, 0],
+        };
+        return new Call(initializeArray, isVirtual: false, [array, token]);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/TypeOfRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeOfRenderingTests.cs
@@ -5,6 +5,32 @@ namespace ILInspector.Decompiler.Tests;
 public class TypeOfRenderingTests
 {
     [Fact]
+    public void TypeGetTypeFromHandle_UserLookalike_IsNotFolded()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Tests", "Owner");
+        var target = TypeRef.Definition("Synthetic", "Tests", "Target");
+        var getTypeFromHandle = new MethodRef(
+            TypeRef.Definition("UserAssembly", "System", "Type"),
+            "GetTypeFromHandle",
+            TypeRef.CoreLib("System", "Object"),
+            [TypeRef.CoreLib("System", "RuntimeTypeHandle")],
+            HasThis: false);
+        var function = Returning(
+            new Call(
+                getTypeFromHandle,
+                isVirtual: false,
+                [new LoadToken(RuntimeTokenKind.Type, target, "Synthetic.Tests.Target")]),
+            returnType: TypeRef.CoreLib("System", "Object"),
+            owner);
+
+        new TypeOfFoldingPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<TypeOf>());
+        Assert.Single(function.Descendants.OfType<Call>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void TypeOf_OpenGenericDefinition_RendersUnboundGenericType()
     {
         var output = CSharpPrinter.Print(Returning(new TypeOf(TypeRef.CoreLib("System.Collections.Generic", "List`1")))).Output;
@@ -22,7 +48,7 @@ public class TypeOfRenderingTests
         Assert.DoesNotContain("typeof(Dictionary)", output);
     }
 
-    static IrFunction Returning(IrExpression expression)
+    static IrFunction Returning(IrExpression expression, TypeRef? returnType = null, TypeRef? owner = null)
     {
         var body = new BlockContainer();
         var block = new Block();
@@ -30,8 +56,8 @@ public class TypeOfRenderingTests
         body.Add(block);
         return new IrFunction(
             "M",
-            TypeRef.Definition("Synthetic", "Tests", "Owner"),
-            new MethodSignature(TypeRef.CoreLib("System", "Type"), [], HasThis: false, GenericParameterCount: 0),
+            owner ?? TypeRef.Definition("Synthetic", "Tests", "Owner"),
+            new MethodSignature(returnType ?? TypeRef.CoreLib("System", "Type"), [], HasThis: false, GenericParameterCount: 0),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -82,6 +82,34 @@ public static class TypeFamilies
     /// <summary>True when the family is a known integer (I4/I8/I).</summary>
     public static bool IsInteger(TypeRef? type) => Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I;
 
+    /// <summary>
+    /// True when C# null syntax (<c>??</c>, <c>??=</c>, <c>?.</c>, or a null arm)
+    /// is known to be illegal for this type because it is a non-nullable value
+    /// type. Nullable&lt;T&gt; is deliberately excluded.
+    /// </summary>
+    public static bool IsKnownNonNullableValueType(TypeRef? type, IReadOnlyDictionary<TypeRef, TypeShape>? shapes = null)
+    {
+        if (type is null || IsNullableType(type))
+            return false;
+        if (Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+            return true;
+        if (type.DeclaredValueTypeHint == ValueTypeHint.ValueType)
+            return true;
+        if (shapes is not null && shapes.TryGetValue(type, out var shape))
+            return shape is TypeShape.ValueType or TypeShape.Enum;
+        return type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && type.Name is "DateTime" or "DateOnly" or "TimeOnly" or "TimeSpan" or "Guid" or "Decimal"
+                or "RuntimeTypeHandle" or "RuntimeFieldHandle" or "ModuleHandle"
+                or "TypedReference";
+    }
+
+    public static bool IsNullableType(TypeRef type)
+        => type is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType: { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" },
+        };
+
     /// <summary>The canonical TypeRef for a family — what the evaluation stack physically carries at a join.</summary>
     public static TypeRef Canonical(StackFamily family) => family switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -14,7 +14,9 @@ public static class MemberIdentity
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
+    static readonly TypeRef s_runtimeTypeHandle = TypeRef.CoreLib("System", "RuntimeTypeHandle");
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_type = TypeRef.CoreLib("System", "Type");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef s_refBool = TypeRef.ByRef(TypeRef.CoreLib("System", "Boolean"));
 
@@ -65,6 +67,14 @@ public static class MemberIdentity
             && arrayParameter.Equals(arrayReturn)
             && rangeParameter.Equals(s_range);
     }
+
+    public static bool IsTypeGetTypeFromHandle(Call call)
+        => !call.IsVirtual
+            && IsStaticCoreLibraryMethod(call.Callee, "System", "Type", "GetTypeFromHandle")
+            && call.Arguments.Count == 1
+            && call.Callee.ParameterTypes is [var handle]
+            && handle.Equals(s_runtimeTypeHandle)
+            && call.Callee.ReturnType.Equals(s_type);
 
     public static bool IsStringSubstring(Call call)
         => call.IsVirtual

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -240,7 +240,7 @@ public sealed class BooleanFoldingPass : IIrPass
                 IfStatement statement => FoldNestedGuard(statement, stepper) || FoldGuardReturn(statement, stepper)
                     || FoldElseReturn(function, statement, stepper)
                     || FoldTernaryReturn(statement, stepper)
-                    || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(statement, stepper),
+                    || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(function, statement, stepper),
                 Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
                 Conditional conditional => MaterializeBoolConditional(function, conditional, stepper),
                 _ => false,
@@ -585,7 +585,7 @@ public sealed class BooleanFoldingPass : IIrPass
     /// null-coalescing lowering. X must be a plain load matching the tested
     /// operand exactly; both stores must target the same place.
     /// </summary>
-    static bool FoldCoalesce(IfStatement guard, Stepper stepper)
+    static bool FoldCoalesce(IrFunction function, IfStatement guard, Stepper stepper)
     {
         if (guard.HasElse || guard.Parent is not Block container || guard.ChildIndex == 0)
             return false;
@@ -600,7 +600,7 @@ public sealed class BooleanFoldingPass : IIrPass
         if (tested is null || guard.Then.Children.Count != 1)
             return false;
         // ?? is reference-only; brfalse over a known integer/bool means == 0.
-        if (TypeFamilies.Of(tested.ResultType) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F)
+        if (TypeFamilies.IsKnownNonNullableValueType(tested.ResultType, function.TypeShapes))
             return false;
         var previous = container.Children[guard.ChildIndex - 1];
         var inner = guard.Then.Children[0];
@@ -652,6 +652,15 @@ public sealed class BooleanFoldingPass : IIrPass
         {
             return false;
         }
+        // The importer merged this slot to the genuine common supertype at the
+        // join this diamond feeds. Slot numbers are stack-depth positions and can
+        // be reused by earlier live ranges, so look after the whole diamond, not
+        // at the first same-number load in the method.
+        var mergedType = FirstLoadAfter(function, diamond, thenStore.Slot)?.Type
+            ?? EqualArmType(thenStore.Value, elseStore.Value);
+        if (HasNullArmForNonNullableValue(thenStore.Value, elseStore.Value, mergedType, function))
+            return false;
+
         var condition = diamond.Condition;
         condition.Detach();
         var whenTrue = (IrExpression)thenStore.DetachChildren()[0];
@@ -662,16 +671,14 @@ public sealed class BooleanFoldingPass : IIrPass
             condition = (IrExpression)doubleNegative.DetachChildren()[0];
             (whenTrue, whenFalse) = (whenFalse, whenTrue);
         }
-        // The importer merged this slot to the genuine common supertype at the
-        // join this diamond feeds. Slot numbers are stack-depth positions and can
-        // be reused by earlier live ranges, so look after the whole diamond, not
-        // at the first same-number load in the method.
-        var mergedType = FirstLoadAfter(function, diamond, thenStore.Slot)?.Type
-            ?? EqualArmType(whenTrue, whenFalse);
         stepper.StepOver("fold store diamond into ternary", diamond);
         diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
         return true;
     }
+
+    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? mergedType, IrFunction function)
+        => (whenTrue is Constant { Value: null } || whenFalse is Constant { Value: null })
+            && TypeFamilies.IsKnownNonNullableValueType(mergedType, function.TypeShapes);
 
     static LoadStackSlot? FirstLoadAfter(IrFunction function, IrNode node, int slot)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -193,7 +193,9 @@ public sealed class ExpressionInliningPass : IIrPass
                         blocked = use is null;    // dead before use ⇒ leave it alone
                         break;
                     }
-                    if (use is null && reads.Any(r => Writes(stmt, r.Kind, r.Index)))
+                    if (use is null
+                        && (reads.Any(r => Writes(stmt, r.Kind, r.Index))
+                            || WritesStaticDelegateTarget(stmt, value)))
                     {
                         blocked = true;
                         break;
@@ -306,6 +308,12 @@ public sealed class ExpressionInliningPass : IIrPass
             PlaceKind.Argument => n is StoreArgument a && a.Index == index,
             _ => false,
         });
+
+    static bool WritesStaticDelegateTarget(IrNode statement, IrExpression value)
+        => value is DelegateCreation { Target: LoadField { Instance: null, Field: var field } }
+            && statement.Descendants.Prepend(statement)
+                .OfType<StoreField>()
+                .Any(store => !store.HasInstance && store.Field.Equals(field));
 
     /// <summary>
     /// The first statement of the block after <paramref name="block"/>, when

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -88,6 +88,8 @@ public sealed class LambdaCachePass : IIrPass
             }
             if (cacheLoad is null)
                 continue;
+            if (!FieldReferencesOnlyWithin(function, cacheField, [cacheLoad, ifStmt]))
+                continue;
 
             context.Stepper.StepOver($"collapse lazy delegate cache {cacheField.Name}", ifStmt);
             delegateCreation.Detach();
@@ -104,13 +106,13 @@ public sealed class LambdaCachePass : IIrPass
             .ToHashSet();
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
-            if (TryFoldFlatCache(container, leaveTargets, stepper))
+            if (TryFoldFlatCache(function, container, leaveTargets, stepper))
                 return true;
         }
         return false;
     }
 
-    static bool TryFoldFlatCache(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
+    static bool TryFoldFlatCache(IrFunction function, BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
         var offsetToIndex = new Dictionary<int, int>();
@@ -151,6 +153,8 @@ public sealed class LambdaCachePass : IIrPass
             if (FindSeedAndLoad(block, cacheRead.Slot, resultStore.Slot, cacheField) is not { } prior)
                 continue;
             if (HasExternalEntry(blocks, i + 1))
+                continue;
+            if (!FieldReferencesOnlyWithin(function, cacheField, [prior.CacheLoad, createBlock]))
                 continue;
 
             delegateCreation.Detach();
@@ -230,6 +234,27 @@ public sealed class LambdaCachePass : IIrPass
             || (field.DeclaringType.Name.EndsWith("+<>O", StringComparison.Ordinal)
                 && field.Name.StartsWith("<", StringComparison.Ordinal)
                 && field.Name.Contains(">__", StringComparison.Ordinal));
+
+    static bool FieldReferencesOnlyWithin(IrFunction function, FieldRef field, IReadOnlyCollection<IrNode> allowed)
+        => function.Descendants
+            .Where(node => ReferencesField(node, field))
+            .All(node => allowed.Any(root => IsInside(node, root)));
+
+    static bool ReferencesField(IrNode node, FieldRef field) => node switch
+    {
+        LoadField load => load.Field.Equals(field),
+        StoreField store => store.Field.Equals(field),
+        LoadFieldAddress address => address.Field.Equals(field),
+        _ => false,
+    };
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, root))
+                return true;
+        return false;
+    }
 
     // Whether the statement reads or writes the given stack slot anywhere in its
     // subtree — the guard for what may be interleaved ahead of the cache load.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -24,7 +24,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
     {
         foreach (var statement in function.Descendants.OfType<IfStatement>().ToList())
         {
-            if (TryMatchLocal(statement) is { } local)
+            if (TryMatchLocal(function, statement) is { } local)
             {
                 var value = (IrExpression)local.Store.DetachChildren()[0];
                 var replacement = new NullCoalescingAssignment(local.Local.Index, local.Local.Type, value);
@@ -33,7 +33,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 continue;
             }
 
-            if (TryMatchField(statement) is { } field)
+            if (TryMatchField(function, statement) is { } field)
             {
                 var children = field.Store.DetachChildren();
                 var instance = field.Store.HasInstance ? (IrExpression)children[0] : null;
@@ -63,7 +63,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     sealed record LocalMatch(LoadLocal Local, StoreLocal Store);
 
-    static LocalMatch? TryMatchLocal(IfStatement statement)
+    static LocalMatch? TryMatchLocal(IrFunction function, IfStatement statement)
     {
         if (statement.HasElse
             || statement.Then.Children is not [StoreLocal store]
@@ -73,7 +73,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             return null;
         }
 
-        if (IsNonNullableNumeric(local.Type))
+        if (IsNonNullableValue(function, local.Type))
             return null;
 
         return new LocalMatch(local, store);
@@ -81,7 +81,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     sealed record FieldMatch(StoreField Store);
 
-    static FieldMatch? TryMatchField(IfStatement statement)
+    static FieldMatch? TryMatchField(IrFunction function, IfStatement statement)
     {
         if (statement.HasElse
             || statement.Then.Children is not [StoreField store]
@@ -92,14 +92,14 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             return null;
         }
 
-        if (IsNonNullableNumeric(store.Field.Type))
+        if (IsNonNullableValue(function, store.Field.Type))
             return null;
 
         return new FieldMatch(store);
     }
 
-    static bool IsNonNullableNumeric(TypeRef type)
-        => TypeFamilies.Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F;
+    static bool IsNonNullableValue(IrFunction function, TypeRef type)
+        => TypeFamilies.IsKnownNonNullableValueType(type, function.TypeShapes);
 
     static bool SameField(FieldRef a, FieldRef b)
         => a.Name == b.Name && Equals(a.DeclaringType, b.DeclaringType);
@@ -126,7 +126,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             return null;
         }
 
-        if (IsNonNullableNumeric(store.Accessor.ParameterTypes[^1]))
+        if (IsNonNullableValue(function, store.Accessor.ParameterTypes[^1]))
             return null;
 
         var value = RecoverSpilledValue(function, statement.Then, store);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
@@ -103,7 +103,8 @@ public sealed class NullConditionalCoalescePass : IIrPass
                 ConditionalBranch { TargetOffset: var trueOffA } condA,
             ]
             || !IsDefaultBoxTest(condA, vkInit, tkInit)
-            || !IsPureAddress(receiver))
+            || !IsPureAddress(receiver)
+            || !CanBeGenericNullConditionalReceiver(tkInit))
         {
             return null;
         }
@@ -154,6 +155,9 @@ public sealed class NullConditionalCoalescePass : IIrPass
         => branch.Condition is Box { Type: var boxType, Operand: LoadLocal { Index: var index } }
             && index == tempLocal
             && boxType.Equals(tempType);
+
+    static bool CanBeGenericNullConditionalReceiver(TypeRef type)
+        => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter;
 
     /// <summary>
     /// The receiver address is evaluated once in <c>recv?.M()</c>, so it must

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -70,6 +70,8 @@ public sealed class NullConditionalPass : IIrPass
                     continue;
                 if (MemberReceiver(member) is not LoadStackSlot memberReceiver || memberReceiver.Slot != spill.Slot)
                     continue;
+                if (TypeFamilies.IsKnownNonNullableValueType(memberReceiver.Type, function.TypeShapes))
+                    continue;
 
                 member.Detach();
                 var receiver = (IrExpression)spill.DetachChildren()[0];
@@ -91,6 +93,8 @@ public sealed class NullConditionalPass : IIrPass
             if (!IsNullConditionalShape(conditional, out var member))
                 continue;
             if (MemberReceiver(member) is not { } receiver || !PlaceIdentity.SameVariable(conditional.Condition, receiver))
+                continue;
+            if (TypeFamilies.IsKnownNonNullableValueType(receiver.ResultType, function.TypeShapes))
                 continue;
 
             member.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -90,7 +90,7 @@ public sealed class RvaSpanPass : IIrPass
             {
                 continue;
             }
-            if (ResolveArrayCreation(arrayArg, function) is not { } creation)
+            if (ResolveArrayCreation(arrayArg, statement) is not { } creation)
                 continue;
 
             var arrayElements = DecodeElements(function, creation.ElementType, data);
@@ -110,30 +110,44 @@ public sealed class RvaSpanPass : IIrPass
 
     /// <summary>
     /// Resolves the <see cref="NewArray"/> that initialized an InitializeArray target:
-    /// the argument inline, or the unique array-creating store of the slot/local it
-    /// loads. Null when the creation can't be pinned to a single array allocation.
+    /// the argument inline, or the reaching array-creating store of the slot/local it
+    /// loads in the same straight-line block. Null when the creation can't be pinned
+    /// to the value that reaches this call.
     /// </summary>
-    static NewArray? ResolveArrayCreation(IrExpression arrayArg, IrFunction function)
+    static NewArray? ResolveArrayCreation(IrExpression arrayArg, ExpressionStatement statement)
     {
         if (arrayArg is NewArray inline)
             return inline;
 
-        IEnumerable<NewArray> defs = arrayArg switch
-        {
-            LoadStackSlot { Slot: var slot } => function.Descendants
-                .OfType<StoreStackSlot>()
-                .Where(store => store.Slot == slot)
-                .Select(store => store.Value)
-                .OfType<NewArray>(),
-            LoadLocal { Index: var index } => function.Descendants
-                .OfType<StoreLocal>()
-                .Where(store => store.Index == index)
-                .Select(store => store.Value)
-                .OfType<NewArray>(),
-            _ => [],
-        };
+        if (statement.Parent is not Block block)
+            return null;
 
-        return defs.ToList() is [var single] ? single : null;
+        return arrayArg switch
+        {
+            LoadStackSlot { Slot: var slot } => ReachingStackSlotArray(block, statement.ChildIndex, slot),
+            LoadLocal { Index: var index } => ReachingLocalArray(block, statement.ChildIndex, index),
+            _ => null,
+        };
+    }
+
+    static NewArray? ReachingStackSlotArray(Block block, int beforeIndex, int slot)
+    {
+        for (int i = beforeIndex - 1; i >= 0; i--)
+        {
+            if (block.Children[i] is StoreStackSlot store && store.Slot == slot)
+                return store.Value as NewArray;
+        }
+        return null;
+    }
+
+    static NewArray? ReachingLocalArray(Block block, int beforeIndex, int index)
+    {
+        for (int i = beforeIndex - 1; i >= 0; i--)
+        {
+            if (block.Children[i] is StoreLocal store && store.Index == index)
+                return store.Value as NewArray;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
@@ -179,8 +179,15 @@ public sealed class SlotDiamondPass : IIrPass
             condition = negated.Operand;
             (whenTrue, whenFalse) = (whenFalse, whenTrue);
         }
+        if (HasNullArmForNonNullableValue(whenTrue, whenFalse, load.Type))
+            return null;
+
         return new Diamond(condition, whenTrue, whenFalse, load.Type);
     }
+
+    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? slotType)
+        => (whenTrue is Constant { Value: null } || whenFalse is Constant { Value: null })
+            && TypeFamilies.IsKnownNonNullableValueType(slotType);
 
     /// <summary>
     /// A split store diamond:

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
@@ -60,13 +60,13 @@ public sealed class SlotDiamondPass : IIrPass
             .ToHashSet();
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
-            if (TryFold(container, leaveTargets, stepper))
+            if (TryFold(function, container, leaveTargets, stepper))
                 return true;
         }
         return false;
     }
 
-    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
+    static bool TryFold(IrFunction function, BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
         var offsetToIndex = new Dictionary<int, int>();
@@ -75,7 +75,7 @@ public sealed class SlotDiamondPass : IIrPass
 
         for (int p = 0; p + 3 < blocks.Count; p++)
         {
-            if (Match(blocks, offsetToIndex, p) is { } match
+            if (Match(function, blocks, offsetToIndex, p) is { } match
                 && NoExternalEntry(blocks, p, leaveTargets))
             {
                 Fold(container, p, match, stepper);
@@ -112,7 +112,7 @@ public sealed class SlotDiamondPass : IIrPass
     /// and <c>J</c> immediately returns the slot. Null when block <paramref name="p"/>
     /// is not such a root.
     /// </summary>
-    static Diamond? Match(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
+    static Diamond? Match(IrFunction function, IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
     {
         var head = blocks[p];
         if (head.Children.Count == 0 || head.Children[^1] is not ConditionalBranch branch)
@@ -179,15 +179,15 @@ public sealed class SlotDiamondPass : IIrPass
             condition = negated.Operand;
             (whenTrue, whenFalse) = (whenFalse, whenTrue);
         }
-        if (HasNullArmForNonNullableValue(whenTrue, whenFalse, load.Type))
+        if (HasNullArmForNonNullableValue(whenTrue, whenFalse, load.Type, function))
             return null;
 
         return new Diamond(condition, whenTrue, whenFalse, load.Type);
     }
 
-    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? slotType)
+    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? slotType, IrFunction function)
         => (whenTrue is Constant { Value: null } || whenFalse is Constant { Value: null })
-            && TypeFamilies.IsKnownNonNullableValueType(slotType);
+            && TypeFamilies.IsKnownNonNullableValueType(slotType, function.TypeShapes);
 
     /// <summary>
     /// A split store diamond:

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -109,7 +109,7 @@ public sealed class SlotStoreDiamondPass : IIrPass
         if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
             return null;
         var resultType = whenTrue.ResultType ?? whenFalse.ResultType;
-        if (HasNullArmForNonNullableValue(whenTrue, whenFalse, resultType))
+        if (HasNullArmForNonNullableValue(function, whenTrue, whenFalse, resultType))
             return null;
 
         if (!NoExternalEntry(blocks, p, falseIndex, trueStart, trueRegion.EndIndex, leaveTargets))
@@ -127,9 +127,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
             whenFalse);
     }
 
-    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? resultType)
+    static bool HasNullArmForNonNullableValue(IrFunction function, IrExpression whenTrue, IrExpression whenFalse, TypeRef? resultType)
         => (whenTrue is Constant { Value: null } || whenFalse is Constant { Value: null })
-            && TypeFamilies.IsKnownNonNullableValueType(resultType);
+            && TypeFamilies.IsKnownNonNullableValueType(resultType, function.TypeShapes);
 
     static bool NormalizeArmTypes(ref IrExpression whenTrue, ref IrExpression whenFalse)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -108,6 +108,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
         }
         if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
             return null;
+        var resultType = whenTrue.ResultType ?? whenFalse.ResultType;
+        if (HasNullArmForNonNullableValue(whenTrue, whenFalse, resultType))
+            return null;
 
         if (!NoExternalEntry(blocks, p, falseIndex, trueStart, trueRegion.EndIndex, leaveTargets))
             return null;
@@ -118,11 +121,15 @@ public sealed class SlotStoreDiamondPass : IIrPass
             trueRegion.EndIndex,
             mergeIndex,
             falseStore.Slot,
-            whenTrue.ResultType ?? whenFalse.ResultType,
+            resultType,
             condition,
             whenTrue,
             whenFalse);
     }
+
+    static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? resultType)
+        => (whenTrue is Constant { Value: null } || whenFalse is Constant { Value: null })
+            && TypeFamilies.IsKnownNonNullableValueType(resultType);
 
     static bool NormalizeArmTypes(ref IrExpression whenTrue, ref IrExpression whenFalse)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypeOfFoldingPass.cs
@@ -14,8 +14,7 @@ public sealed class TypeOfFoldingPass : IIrPass
         {
             if (call.Parent is null)
                 continue;
-            if (call.Callee is { Name: "GetTypeFromHandle", HasThis: false, ParameterTypes.Length: 1 }
-                && call.Callee.DeclaringType is { Namespace: "System", Name: "Type" }
+            if (MemberIdentity.IsTypeGetTypeFromHandle(call)
                 && call.Children.Count == 1
                 && call.Children[0] is LoadToken { Kind: RuntimeTokenKind.Type, Type: { } type })
             {


### PR DESCRIPTION
## Summary

Fixes the prioritized concrete decompiler pass bugs from the quality arc:

- #1303: make `RvaSpanPass` resolve `InitializeArray` targets by reaching definition, not unique historical `NewArray` store.
- #1296/#1291: keep delegate cache/inlining rewrites from dropping or moving observable static-field reads/writes.
- #1302: require exact corelib `System.Type.GetTypeFromHandle(RuntimeTypeHandle)` identity for `typeof` folding.
- #1295/#1297/#1298/#1299/#1301: add shared known-non-nullable value-type guards for null-syntax folds (`?.`, `??`, `??=`, null-arm conditionals).

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.
```

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release
Total: 1107, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

```text
Focused regression set: 75 passed, 0 failed
```

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,801 methods
Correctness coverage: validity sampled 350 / 87,801 (0.40%); fidelity sampled 9 / 87,801 (0.01%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,262 (88.00%) | +368 |
| Conditional-branch residual | 2,290 (2.62%) | 2,301 (2.62%) | +11 |
| Forward-merge stops | 2,284 (2.61%) | 2,292 (2.61%) | +8 |
| Full malformed | 33 | 33 | 0 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,801 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 1/9, exact 8, recompile-failed 0, context-failed 0; sampled 9 / 87,801 (0.01%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Fixes #1303
Fixes #1296
Fixes #1291
Fixes #1302
Fixes #1295
Fixes #1297
Fixes #1298
Fixes #1299
Fixes #1301
