### PR TITLE
Suppress source-generated [GeneratedCode] types from Optimization Opportunities (#1273)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -295,6 +295,18 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_SuppressesSourceGeneratedTypes()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A [GeneratedCode] type (source generators: JSON/regex/etc.) is not an actionable
+        // source-shape target, so none of its methods produce optimization opportunities,
+        // even though MakesSmallArray would otherwise be a small-array row (#1273).
+        Assert.DoesNotContain(index.OptimizationOpportunities, opportunity =>
+            opportunity.Method.DeclaringType.Name == nameof(SourceGeneratedOptimizationFixtures));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_TracksFieldAccessAndClearsStaleConstants()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -449,6 +461,15 @@ public class OptimizationOpportunityFixtures
     }
 
     private static int ParseLength(string value) => value.Length;
+}
+
+// A source-generated type (mirrors the [GeneratedCode] System.Text.Json source generator
+// emits): its MakesSmallArray would be a small-array opportunity, but #1273 suppresses
+// optimization opportunities for [GeneratedCode] types.
+[System.CodeDom.Compiler.GeneratedCode("TestSourceGenerator", "1.0")]
+public class SourceGeneratedOptimizationFixtures
+{
+    public static int[] MakesSmallArray() => new int[4];
 }
 
 public static class CallerTreeFixtures

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -369,6 +369,10 @@ public sealed class LibraryBodyIndex
             foreach (var typeHandle in _reader.TypeDefinitions)
             {
                 var typeDef = _reader.GetTypeDefinition(typeHandle);
+                // Source-generated types (JSON/regex/etc. carry [GeneratedCode]) are not
+                // actionable source-shape opportunities, so skip optimization-opportunity
+                // collection for them (they are still indexed for calls/leverage/signals).
+                bool typeSourceGenerated = HasGeneratedCodeAttribute(typeDef.GetCustomAttributes());
                 foreach (var methodHandle in typeDef.GetMethods())
                 {
                     try
@@ -394,7 +398,8 @@ public sealed class LibraryBodyIndex
                         var il = body.GetILBytes() ?? [];
                         bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
                         var loopRegions = CollectLoopRegions(il);
-                        optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, caller, scope, loopRegions));
+                        if (!typeSourceGenerated && !HasGeneratedCodeAttribute(methodDef.GetCustomAttributes()))
+                            optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, caller, scope, loopRegions));
                         var signals = CollectBodySignals(il, body);
                         if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0)
                             bodySignals[caller.MetadataToken] = signals;
@@ -470,6 +475,13 @@ public sealed class LibraryBodyIndex
             }
             return false;
         }
+
+        // True when the member/type is marked [System.CodeDom.Compiler.GeneratedCode] —
+        // the universal source-generator signal (System.Text.Json, regex, etc.). Such code
+        // has ordinary names (so the compiler-generated name heuristics miss it) but is not
+        // an actionable source-shape optimization target.
+        bool HasGeneratedCodeAttribute(CustomAttributeHandleCollection attributes)
+            => HasAttributeNamed(attributes, "GeneratedCodeAttribute", "System.CodeDom.Compiler");
 
         (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
         {


### PR DESCRIPTION
Tracker #1309 priority 1. #1267 suppressed compiler-generated (`<>c`/display-class) noise by name, but library-wide `Optimization Opportunities` is still dominated by `System.Text.Json` source-generated context rows:

```jsonl
{"member":"DotnetInspector.ApiJsonContext.ApiMemberPropInit(...)","shape":"delegate-allocation",...}
```

These have **ordinary names**, so name heuristics miss them. The universal signal is the **`[System.CodeDom.Compiler.GeneratedCode]`** attribute every source generator (JSON, regex, …) emits — here on the generated context **type** (verified via SRM: `ApiJsonContext` carries `GeneratedCodeAttribute`; the methods themselves carry none).

## Change

In the index builder, skip optimization-opportunity collection for any method whose **declaring type or self** carries `[GeneratedCode]` (reusing the existing `HasAttributeNamed` helper). Such types are still indexed for calls, leverage, and signals — only the non-actionable source-fix suggestions are dropped (matching the unconditional compiler-generated suppression from #1267/#1271).

## Verification

- `ApiJsonContext` rows drop to **zero** in `library ... -S "Optimization Opportunities"`; product-authored opportunities (`ArgumentPreprocessor`, `ApiCommandDefinitions`, …) remain.
- Suites green: `ILInspector.Analysis.Tests` 32, `dotnet-inspect.Tests` 1296 (9 env-skips). Added a `[GeneratedCode]` fixture whose small-array opportunity is suppressed.

Closes #1273.