### PR TITLE
Surface top-level non-public types under --all (#1300)

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -25,8 +25,15 @@ public static class ApiSurfaceExtractor
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
             var attributes = typeDef.Attributes;
 
-            // Only include public types
-            if (!typeDef.IsPublic)
+            // Only include public types by default. --all (includeAll) also surfaces
+            // non-public TOP-LEVEL types (internal classes/structs/records) so an author can
+            // inspect and drill into their own library's internals. Nested types keep their
+            // existing public-only rule: a non-public nested type's selector cannot round-trip
+            // through the member command's name resolution yet, so surfacing it would emit a
+            // dead selector. Compiler-generated types are still skipped below regardless.
+            bool isTopLevel = (typeDef.Attributes & TypeAttributes.VisibilityMask)
+                is TypeAttributes.Public or TypeAttributes.NotPublic;
+            if (!typeDef.IsPublic && !(includeAll && isTopLevel))
                 continue;
 
             string metadataName = reader.GetString(typeDef.Name);

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -31,6 +31,28 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_SurfacesTopLevelInternalTypesOnlyUnderIncludeAll()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+
+        using (var stream = File.OpenRead(assemblyPath))
+        using (var peReader = new PEReader(stream))
+        {
+            var all = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            // --all surfaces the top-level internal type so its members are inspectable (#1300).
+            Assert.Contains(all.Types, t => t.Name == nameof(InternalTopLevelSurfaceFixture));
+        }
+
+        using (var stream = File.OpenRead(assemblyPath))
+        using (var peReader = new PEReader(stream))
+        {
+            var publicOnly = ApiSurfaceExtractor.Extract(peReader, includeAll: false);
+            // The default (public) surface is unchanged: internal types stay hidden.
+            Assert.DoesNotContain(publicOnly.Types, t => t.Name == nameof(InternalTopLevelSurfaceFixture));
+        }
+    }
+
+    [Fact]
     public void Extract_RecoversRefAndReadonlyStructModifiers()
     {
         // #1066: [IsByRefLike]/[IsReadOnly] are suppressed from the attribute list as
@@ -864,4 +886,13 @@ public interface ISampleInterface
 public class SampleImplementation : ISampleInterface
 {
     public void Execute() { }
+}
+
+/// <summary>
+/// A top-level internal type used to verify that --all (includeAll) surfaces non-public
+/// top-level types so their members are inspectable and gain Top Leverage selectors (#1300).
+/// </summary>
+internal class InternalTopLevelSurfaceFixture
+{
+    public int Value() => 1;
 }

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -228,6 +228,20 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    public void LibraryTopLeverage_TopLevelInternalTypeRowGainsSelector()
+    {
+        var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
+            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+
+        Assert.NotNull(rows);
+        // --all now surfaces top-level internal types, so a method on one gets a round-tripping
+        // selector instead of a blank cell (#1300).
+        var internalRow = Assert.Single(rows!, r => r.Member.EndsWith("InternalLeverageSample.InternalHelper()"));
+        Assert.Matches(@"^InternalHelper~[0-9a-f]{10}$", internalRow.Stable);
+        Assert.Equal("InternalHelper", internalRow.Selector);
+    }
+
+    [Fact]
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
@@ -281,4 +295,13 @@ public static class LeverageSampleType
     public static int Tag => 7;
 
     public static int UsesTag() => Tag + Tag;
+
+    // Gives a method on a top-level internal type call-graph leverage, so its row must
+    // gain a round-tripping selector now that --all surfaces internal types (#1300).
+    public static void UsesInternalHelper() => InternalLeverageSample.InternalHelper();
+}
+
+internal static class InternalLeverageSample
+{
+    public static void InternalHelper() => System.Console.WriteLine("internal");
 }


### PR DESCRIPTION
Tracker #1309 priority 2. The API surface extractor unconditionally skipped non-public types, so internal/private types were not inspectable even with `--all`, and their high-leverage `Top Leverage` rows (e.g. `MarkoutInline.Code`, `AuditSignalBuilder.*`, `LibraryIntegrationDescriptor.*`) had blank `Visibility`/`Stable`/`Selector` cells — forcing agents to reverse-engineer the next command.

## Change

Relax the one type-visibility gate in `ApiSurfaceExtractor.Extract` so `--all` (`includeAll`) also surfaces non-public **top-level** types. Their members then flow through the existing `BuildMemberDrillMap` path (#1279/#1287) and gain round-tripping selectors automatically. The **default (public) surface is unchanged** — the gate only relaxes under `includeAll`.

## Scope: top-level only

Non-public **nested** types stay excluded: their selector cannot round-trip through the `member` command's name resolution yet (the leverage display also flattens the nested name to `Namespace.Nested`), so surfacing them would emit a *dead* selector. Keeping nested behavior exactly as before avoids that regression. The nested case (e.g. `AuditSignalBuilder.SignalValue`) remains a follow-up that needs nested-type addressing work — it stays blank, as today.

## Verification

- `type`/`member ... --all` now resolve top-level internal types (`MarkoutInline.Code~digest` round-trips); their Top Leverage rows carry `Visibility`/`Stable`/`Selector`.
- Nested private `SignalValue` row stays blank (no dead selector) — no regression.
- Suites green: `ILInspector.Metadata.Tests` 225, `dotnet-inspect.Tests` 1301 (9 env-skips). Added surface include/exclude + library-leverage internal-selector tests.

Closes #1300.