### PR TITLE
Skip embedded attributes in fidelity skeleton

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EmbeddedAttributeSkeletonFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/EmbeddedAttributeSkeletonFixture.cs
@@ -1,0 +1,15 @@
+namespace ILInspector.Decompiler.Tests
+{
+    public static class EmbeddedAttributeSkeletonFixture
+    {
+        public static int Value() => 42;
+    }
+}
+
+namespace Microsoft.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.All, Inherited = false)]
+    internal sealed class EmbeddedAttribute : Attribute
+    {
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -47,4 +47,15 @@ public class SkeletonEmitTests
             $"Skeleton failed to compile CfgSampleClass.{method} (a missing using would surface here): "
             + $"{result.Status} / {result.Detail}");
     }
+
+    [Fact]
+    public void SkeletonSkipsCompilerEmbeddedAttributeDefinitions()
+    {
+        var result = FidelityCheck.Evaluate(typeof(EmbeddedAttributeSkeletonFixture).Assembly.Location)
+            .Single(r => r.Type == "ILInspector.Decompiler.Tests.EmbeddedAttributeSkeletonFixture" && r.Method == "Value");
+
+        Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton failed to compile with Microsoft.CodeAnalysis.EmbeddedAttribute present: {result.Status} / {result.Detail}");
+    }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -964,6 +964,8 @@ static class FidelityCheck
             string name = reader.GetString(typeDef.Name);
             if (name.Contains('<') || name == "<Module>")
                 continue; // compiler-generated / module pseudo-type
+            if (IsCompilerEmbeddedAttributeType(reader, typeDef))
+                continue;
             string ns = reader.GetString(typeDef.Namespace);
             if (ns.Length > 0)
             {
@@ -1068,7 +1070,9 @@ static class FidelityCheck
 
         foreach (var nested in typeDef.GetNestedTypes())
         {
-            if (reader.GetString(reader.GetTypeDefinition(nested).Name).Contains('<'))
+            var nestedDef = reader.GetTypeDefinition(nested);
+            if (reader.GetString(nestedDef.Name).Contains('<')
+                || IsCompilerEmbeddedAttributeType(reader, nestedDef))
                 continue; // compiler-generated (display class, iterator) — not valid C#
             EmitType(reader, nested, targets, fieldInits, fieldInitType, sb, indent + 1);
         }
@@ -1163,7 +1167,9 @@ static class FidelityCheck
 
         foreach (var nested in typeDef.GetNestedTypes())
         {
-            if (reader.GetString(reader.GetTypeDefinition(nested).Name).Contains('<'))
+            var nestedDef = reader.GetTypeDefinition(nested);
+            if (reader.GetString(nestedDef.Name).Contains('<')
+                || IsCompilerEmbeddedAttributeType(reader, nestedDef))
                 continue;
             EmitType(reader, nested, NoTargets, [], default, sb, indent + 1);
         }
@@ -1479,6 +1485,30 @@ static class FidelityCheck
             if (AttributeTypeFullName(reader, attribute) == "System.Runtime.CompilerServices.IsByRefLikeAttribute")
                 return true;
         }
+        return false;
+    }
+
+    /// <summary>
+    /// Compiler-embedded attribute definitions have compiler-mandated source
+    /// shapes. The skeleton's public/unsafe stubs violate those shapes (CS9271)
+    /// and the target body never needs these private implementation attributes to
+    /// bind, so omit them from compile-back units.
+    /// </summary>
+    static bool IsCompilerEmbeddedAttributeType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        string ns = reader.GetString(typeDef.Namespace);
+        string name = reader.GetString(typeDef.Name);
+        if ((ns, name) is ("Microsoft.CodeAnalysis", "EmbeddedAttribute")
+            or ("System.Runtime.CompilerServices", "NullableAttribute")
+            or ("System.Runtime.CompilerServices", "NullableContextAttribute")
+            or ("System.Runtime.CompilerServices", "RefSafetyRulesAttribute"))
+        {
+            return true;
+        }
+
+        foreach (var ah in typeDef.GetCustomAttributes())
+            if (AttributeTypeFullName(reader, reader.GetCustomAttribute(ah)) == "Microsoft.CodeAnalysis.EmbeddedAttribute")
+                return true;
         return false;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1313 by omitting compiler-embedded attribute definitions from the changed-method compile-back skeleton. These private compiler helper attributes have mandated source shapes; the skeleton's public stubs violate Roslyn's `EmbeddedAttribute` rule and poison the whole compilation with CS9271.

Skipped definitions:

- `Microsoft.CodeAnalysis.EmbeddedAttribute`
- `System.Runtime.CompilerServices.NullableAttribute`
- `System.Runtime.CompilerServices.NullableContextAttribute`
- `System.Runtime.CompilerServices.RefSafetyRulesAttribute`
- any type marked with `Microsoft.CodeAnalysis.EmbeddedAttribute`

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.
```

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.SkeletonEmitTests
Total: 4, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

## Changed-method fidelity delta (#1251/#1209)

Run with the #1251 gist delta plus materialized Roslyn NuGet assemblies.

Before (`origin/main`):

```text
CHANGED-METHOD COMPILE-BACK over 165 current changed methods (165 attempted)
  exact opcode match : 21
  opcode diff (Full) : 7
  not Full           : 0
  recompile fail     : 109
  context fail       : 28
  recompile-fail by code:
    CS9271: 21
```

After:

```text
CHANGED-METHOD COMPILE-BACK over 165 current changed methods (165 attempted)
  exact opcode match : 21
  opcode diff (Full) : 7
  not Full           : 0
  recompile fail     : 109
  context fail       : 28
  recompile-fail by code:
    CS9271: 0
    CS0122: 21
```

The CS9271 bucket is eliminated. Those Roslyn rows now advance to the next blocker (`CS0122` accessibility), so total recompile-fail count is unchanged but the compiler-embedded-attribute poison is removed from the queue.

Fixes #1313
