### PR TITLE
Qualify a nested type of a generic through its declaring type (#1312)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -208,9 +208,18 @@ public class TypeRefTests
         Assert.Equal("List<int>.Enumerator", enumerator.ToDisplayString(foreignScope));
         Assert.Equal("ImmutableArray<string>.Builder", builder.ToDisplayString(foreignScope));
 
-        // In scope (inside the enclosing type itself): innermost simple name.
-        Assert.Equal("Enumerator",
+        // A different instantiation referenced from inside the enclosing type is
+        // still foreign: bare `Enumerator` inside List<T> would rebind to
+        // List<T>.Enumerator, so List<int>.Enumerator must qualify.
+        Assert.Equal("List<int>.Enumerator",
             enumerator.ToDisplayString(TypeRef.CoreLib("System.Collections.Generic", "List`1")));
+
+        // The enclosing type's own instantiation, in scope: innermost simple name.
+        var identityEnumerator = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "List`1+Enumerator"),
+            [TypeRef.GenericParameter(0, "T")]);
+        Assert.Equal("Enumerator",
+            identityEnumerator.ToDisplayString(TypeRef.CoreLib("System.Collections.Generic", "List`1")));
 
         // No scope (diagnostics/tests): innermost, unchanged.
         Assert.Equal("Enumerator", enumerator.ToDisplayString());

--- a/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineImporterTests.cs
@@ -191,6 +191,33 @@ public class TypeRefTests
     }
 
     [Fact]
+    public void NestedGenericInstance_QualifiesThroughDeclaringTypeWhenReferencedFromOutside()
+    {
+        // A nested type of a generic is innermost-only in scope, but a reference
+        // from outside the enclosing type must qualify through the declaring
+        // chain — a bare `Enumerator` / `Builder` is CS0246 elsewhere.
+        var enumerator = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "List`1+Enumerator"),
+            [TypeRef.CoreLib("System", "Int32")]);
+        var builder = TypeRef.GenericInstance(
+            TypeRef.Definition("System.Collections.Immutable", "System.Collections.Immutable", "ImmutableArray`1+Builder"),
+            [TypeRef.CoreLib("System", "String")]);
+
+        // Foreign scope (a method of some unrelated type): qualified.
+        var foreignScope = TypeRef.Definition("MyAsm", "MyNs", "MyType");
+        Assert.Equal("List<int>.Enumerator", enumerator.ToDisplayString(foreignScope));
+        Assert.Equal("ImmutableArray<string>.Builder", builder.ToDisplayString(foreignScope));
+
+        // In scope (inside the enclosing type itself): innermost simple name.
+        Assert.Equal("Enumerator",
+            enumerator.ToDisplayString(TypeRef.CoreLib("System.Collections.Generic", "List`1")));
+
+        // No scope (diagnostics/tests): innermost, unchanged.
+        Assert.Equal("Enumerator", enumerator.ToDisplayString());
+        Assert.Equal("Builder", builder.ToDisplayString());
+    }
+
+    [Fact]
     public void UnsupportedShapes_PropagateToContainingTypes()
     {
         var unsupported = TypeRef.Unsupported("function pointer");

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -92,7 +92,10 @@ public class UsingStatementPassTests
         var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.StructUsing))).Output;
 
         Assert.NotNull(output);
-        Assert.Contains("using (Enumerator e = items.GetEnumerator())", output);
+        // List<int>.Enumerator is a foreign nested type here (StructUsing is a
+        // method of CfgSampleClass, not List<T>), so it qualifies through its
+        // declaring type — a bare `Enumerator` would be CS0246 in this scope.
+        Assert.Contains("using (List<int>.Enumerator e = items.GetEnumerator())", output);
         Assert.DoesNotContain("finally", output);
         Assert.DoesNotContain("Dispose", output);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2284,14 +2284,18 @@ public sealed partial class CSharpPrinter
         _ => c.ToString(),
     };
 
-    static string TypeText(TypeRef type)
+    string TypeText(TypeRef type)
     {
-        string text = type.ToDisplayString();
+        // Scope is the method's declaring type: a nested type of a generic is
+        // qualified through its declaring chain (ImmutableArray<string>.Builder)
+        // unless the reference is made from inside that enclosing type, where the
+        // innermost name is in scope (Enumerator inside List<T>.GetEnumerator).
+        string text = type.ToDisplayString(_function.DeclaringType);
         int tick = text.IndexOf('`');
         return tick < 0 ? text : text[..tick];
     }
 
-    static string TypeOfTypeText(TypeRef type)
+    string TypeOfTypeText(TypeRef type)
         => type.Kind == TypeRefKind.Definition && OpenGenericArity(type) is { } arity
             ? $"{TypeText(type)}<{new string(',', arity - 1)}>"
             : TypeText(type);

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -365,19 +365,36 @@ public sealed class TypeRef : IEquatable<TypeRef>
     }
 
     /// <summary>
-    /// True when this nested type's enclosing type is <paramref name="scope"/> (or
-    /// an enclosing type of it) — the printing context is inside the declaring
-    /// type, so the innermost simple name is in scope.
+    /// True when the innermost simple name is in scope: the printing context is
+    /// inside the enclosing type (<paramref name="scope"/> is that type or a type
+    /// nested in it) AND this is the enclosing type's own instantiation. The
+    /// second condition matters because a bare <c>Inner</c> inside <c>Outer&lt;T&gt;</c>
+    /// binds to <c>Outer&lt;T&gt;.Inner</c>, so a reference to a different
+    /// instantiation (<c>Outer&lt;int&gt;.Inner</c>) is foreign and must qualify —
+    /// the enclosing-segment arguments must be the enclosing type's own generic
+    /// parameters in order (<c>T0, T1, …</c>) to stay innermost.
     /// </summary>
     bool EnclosingInScope(TypeRef scope)
     {
         var scopeDefinition = scope.Kind == TypeRefKind.GenericInstance ? scope.ElementType! : scope;
         string name = ElementType!.Name;
         string enclosing = name[..name.LastIndexOf('+')];
-        return ElementType.Assembly == scopeDefinition.Assembly
-            && ElementType.Namespace == scopeDefinition.Namespace
-            && (enclosing == scopeDefinition.Name
-                || scopeDefinition.Name.StartsWith(enclosing + "+", StringComparison.Ordinal));
+        if (ElementType.Assembly != scopeDefinition.Assembly
+            || ElementType.Namespace != scopeDefinition.Namespace
+            || (enclosing != scopeDefinition.Name
+                && !scopeDefinition.Name.StartsWith(enclosing + "+", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+        int innermostArity = ArityOf(name[(name.LastIndexOf('+') + 1)..]);
+        int enclosingArguments = TypeArguments.Length - innermostArity;
+        for (int i = 0; i < enclosingArguments; i++)
+        {
+            var argument = TypeArguments[i];
+            if (argument.Kind != TypeRefKind.GenericParameter || argument.GenericParameterIndex != i)
+                return false;
+        }
+        return true;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -286,18 +286,29 @@ public sealed class TypeRef : IEquatable<TypeRef>
     }
 
     /// <summary>Diagnostic/test rendering in C# style. Product output paths render at the printer, not here.</summary>
-    public string ToDisplayString() => Kind switch
+    public string ToDisplayString() => ToDisplayString(null);
+
+    /// <summary>
+    /// Scope-aware C# rendering for the product printer. A nested type of a
+    /// generic enclosing type is qualified through its declaring type
+    /// (<c>ImmutableArray&lt;string&gt;.Builder</c>) UNLESS the reference is made
+    /// from within that enclosing type (<paramref name="scope"/> — the declaring
+    /// type of the method being printed), where the innermost simple name is in
+    /// scope and idiomatic (<c>Enumerator</c> inside <c>List&lt;T&gt;.GetEnumerator</c>).
+    /// A null scope keeps the bare innermost spelling used by diagnostics and tests.
+    /// </summary>
+    public string ToDisplayString(TypeRef? scope) => Kind switch
     {
         TypeRefKind.Definition => DisplayName(),
-        TypeRefKind.GenericInstance => RenderGenericInstance(),
-        TypeRefKind.SzArray => $"{ElementType!.ToDisplayString()}[]",
-        TypeRefKind.Array => $"{ElementType!.ToDisplayString()}[{new string(',', Rank - 1)}]",
-        TypeRefKind.ByRef => $"ref {ElementType!.ToDisplayString()}",
-        TypeRefKind.Pointer => $"{ElementType!.ToDisplayString()}*",
-        TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString()}",
+        TypeRefKind.GenericInstance => RenderGenericInstance(scope),
+        TypeRefKind.SzArray => $"{ElementType!.ToDisplayString(scope)}[]",
+        TypeRefKind.Array => $"{ElementType!.ToDisplayString(scope)}[{new string(',', Rank - 1)}]",
+        TypeRefKind.ByRef => $"ref {ElementType!.ToDisplayString(scope)}",
+        TypeRefKind.Pointer => $"{ElementType!.ToDisplayString(scope)}*",
+        TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString(scope)}",
         TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter =>
             GenericParameterName.Length > 0 ? GenericParameterName : $"!{GenericParameterIndex}",
-        TypeRefKind.FunctionPointer => RenderFunctionPointer(),
+        TypeRefKind.FunctionPointer => RenderFunctionPointer(scope),
         _ => $"<unsupported: {UnsupportedReason}>",
     };
 
@@ -327,9 +338,22 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// to the (elided) outer name, so attaching them is invalid C#:
     /// <c>List`1+Enumerator</c> is <c>Enumerator</c>, never <c>Enumerator&lt;T&gt;</c>
     /// (CS0308); <c>Outer`1+Inner`1</c> is <c>Inner&lt;TInner&gt;</c>.
+    ///
+    /// That innermost spelling is only valid from inside the enclosing type. When
+    /// a <paramref name="scope"/> is given and this nested type's enclosing type
+    /// is not that scope, the reference is foreign and must be qualified through
+    /// the declaring chain (<c>ImmutableArray&lt;string&gt;.Builder</c>, not a
+    /// bare <c>Builder</c> that fails CS0246).
     /// </summary>
-    string RenderGenericInstance()
+    string RenderGenericInstance(TypeRef? scope = null)
     {
+        if (scope is not null
+            && ElementType!.Name.Contains('+')
+            && !EnclosingInScope(scope)
+            && RenderNestedGenericInstance(scope) is { } qualified)
+        {
+            return qualified;
+        }
         int nested = ElementType!.Name.LastIndexOf('+');
         string innermost = nested < 0 ? ElementType.Name : ElementType.Name[(nested + 1)..];
         int ownArity = ArityOf(innermost);
@@ -337,7 +361,58 @@ public sealed class TypeRef : IEquatable<TypeRef>
         if (ownArity == 0)
             return simpleName;
         var ownArguments = TypeArguments.Skip(Math.Max(0, TypeArguments.Length - ownArity));
-        return $"{simpleName}<{string.Join(", ", ownArguments.Select(a => a.ToDisplayString()))}>";
+        return $"{simpleName}<{string.Join(", ", ownArguments.Select(a => a.ToDisplayString(scope)))}>";
+    }
+
+    /// <summary>
+    /// True when this nested type's enclosing type is <paramref name="scope"/> (or
+    /// an enclosing type of it) — the printing context is inside the declaring
+    /// type, so the innermost simple name is in scope.
+    /// </summary>
+    bool EnclosingInScope(TypeRef scope)
+    {
+        var scopeDefinition = scope.Kind == TypeRefKind.GenericInstance ? scope.ElementType! : scope;
+        string name = ElementType!.Name;
+        string enclosing = name[..name.LastIndexOf('+')];
+        return ElementType.Assembly == scopeDefinition.Assembly
+            && ElementType.Namespace == scopeDefinition.Namespace
+            && (enclosing == scopeDefinition.Name
+                || scopeDefinition.Name.StartsWith(enclosing + "+", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Renders a nested generic instance through its declaring chain
+    /// (<c>Outer&lt;A&gt;.Inner&lt;B&gt;</c>), distributing the flat type-argument
+    /// list across each <c>+</c>-separated segment by that segment's own arity.
+    /// Returns null when the per-segment arities do not sum to the argument count
+    /// (an unexpected metadata encoding) so the caller falls back to the safe
+    /// innermost spelling rather than emitting wrong C#.
+    /// </summary>
+    string? RenderNestedGenericInstance(TypeRef? scope)
+    {
+        var segments = ElementType!.Name.Split('+');
+        var arities = Array.ConvertAll(segments, ArityOf);
+        int total = 0;
+        foreach (int arity in arities)
+            total += arity;
+        if (total != TypeArguments.Length)
+            return null;
+
+        var parts = new List<string>(segments.Length);
+        int argIndex = 0;
+        for (int i = 0; i < segments.Length; i++)
+        {
+            string name = StripArity(segments[i]);
+            int arity = arities[i];
+            if (arity > 0)
+            {
+                var segmentArguments = TypeArguments.Skip(argIndex).Take(arity);
+                name = $"{name}<{string.Join(", ", segmentArguments.Select(a => a.ToDisplayString(scope)))}>";
+                argIndex += arity;
+            }
+            parts.Add(name);
+        }
+        return string.Join(".", parts);
     }
 
     /// <summary>
@@ -345,9 +420,9 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// the return type last, with the calling-convention keyword (when the
     /// pointer is unmanaged) between <c>delegate*</c> and the type list.
     /// </summary>
-    string RenderFunctionPointer()
+    string RenderFunctionPointer(TypeRef? scope = null)
     {
-        var parts = TypeArguments.Select(p => p.ToDisplayString()).Append(ElementType!.ToDisplayString());
+        var parts = TypeArguments.Select(p => p.ToDisplayString(scope)).Append(ElementType!.ToDisplayString(scope));
         string convention = CallingConvention.Length > 0 ? $" {CallingConvention}" : "";
         return $"delegate*{convention}<{string.Join(", ", parts)}>";
     }


### PR DESCRIPTION
Fixes #1312.

## Bug
The C# printer rendered a nested type of a generic by its **innermost simple name only**, dropping the enclosing qualifier:

```csharp
Builder names = ImmutableArray.CreateBuilder<string>(handles.Count);   // CS0246: 'Builder<>' not found
```

The correct C# is `ImmutableArray<string>.Builder names = ...`. But the innermost spelling is *right* when the reference is made **inside** the enclosing type — `List<T>.GetEnumerator()` idiomatically returns `new Enumerator(this)`. So the fix is **context-aware**, not unconditional.

## Fix
- `TypeRef` gains a scope-aware `ToDisplayString(TypeRef? scope)`. A nested generic instance qualifies through its declaring chain (`Outer<A>.Inner<B>`, distributing the flat type-argument list across each `+` segment by its own arity) **unless** its enclosing type is the scope (or an enclosing type of it). The scopeless overload keeps the bare innermost spelling diagnostics/tests rely on.
- `CSharpPrinter.TypeText` passes the method's declaring type as scope, so the body qualifies **foreign** nested types and keeps **in-scope** ones bare.

After:
```csharp
ImmutableArray<string>.Builder names = ImmutableArray.CreateBuilder<string>(handles.Count);   // ✓
```
…while `List<T>.GetEnumerator()` still prints `return new Enumerator(this);`.

## Tests
- `NestedGenericInstance_QualifiesThroughDeclaringTypeWhenReferencedFromOutside` pins both directions (foreign → qualified, in-scope → innermost, no-scope → innermost).
- `ValueTypeUsing_RendersUsingHeaderWithoutFinally` updated to the now-correct `using (List<int>.Enumerator e = ...)` (previously the **invalid** bare `Enumerator` in `CfgSampleClass` scope — the test codified the bug).
- Full decompiler suite: **1112 passed**, incl. the fidelity/lowered-fidelity gates and the CoreLib corpus-sweep gate. Corpus validity stays healthy (0.11% Full malformed).

## Follow-up (not this PR)
The changed-method fidelity skeleton still shows `Builder<>` on the #1251/#1209 delta. That is a **separate** bug in the shared metadata `SignatureDecoder` (used by the API-surface scanners): its `GetTypeFromReference` does not thread nested declaring types, so a sibling signature renders `Builder<string>` instead of `ImmutableArray<string>.Builder`. Distinct renderer, distinct (wider) blast radius — I'll file it separately.