### PR TITLE
Allow graph field projection alongside the implied Callers table (#1322)

### DIFF
--- a/docs/design/schema-query.md
+++ b/docs/design/schema-query.md
@@ -205,6 +205,7 @@ The section-level callback maps directly to `SectionEntry.CanRender`. The field-
 
 **Projection diagnostics (type path).** When `--columns`/`--fields` are combined with a section selection on the type/member path, the requested names are validated and diagnosed, mirroring the package path:
 - Pre-render (`ProjectionDiagnostics.ValidateProjection`): an unknown name (typo) warns `column '<name>' not found in section '<Section>'` with prefix suggestions.
+- Across multiple selected sections, a name is accepted when it resolves in **at least one** of them (the others simply don't project it); it is only an error — warned per section, then `No <kind>s matched projection` — when it resolves in **none**. This keeps graph-field projection over `-S "Caller Graph"`/`"Call Graph"` working even when a scope flag (`--bin`/`--project`/`--caller-package`) implies the companion `-S Callers` table that lacks those fields.
 - Post-render (`ProjectionDiagnostics.DiagnoseRendered`): a name valid in the schema but absent from the rendered output (e.g. `Signature` below Detailed verbosity) emits `note: N field(s) have no data: <names>`.
 All columns are still shown (warn, don't suppress) and the exit code stays `0`. To capture the rendered output for the post-render check, `ApiCommand.WriteTypeOutput` accepts an optional `TextWriter`.
 

--- a/src/dotnet-inspect.Tests/ProjectionDiagnosticsTests.cs
+++ b/src/dotnet-inspect.Tests/ProjectionDiagnosticsTests.cs
@@ -1,0 +1,74 @@
+using DotnetInspector.Output;
+using Markout;
+
+namespace DotnetInspector.Tests;
+
+public class ProjectionDiagnosticsTests
+{
+    // Mirrors the member detail schema: a graph section that carries the projected fields
+    // alongside a companion table section that does not (e.g. Caller Graph + Callers, where
+    // a scope flag such as --bin implies -S Callers).
+    private static DocumentSchema GraphAndTableSchema() =>
+        new DocumentSchema()
+            .Add("Caller Graph", "field", "Fanin", "Depth", "Loop", "Root", "EvidenceIL")
+            .Add("Callers", "column", "Caller", "Kind", "IL", "Token");
+
+    [Fact]
+    public async Task ValidateProjection_FieldResolvingInOneSection_SucceedsWithoutWarning()
+    {
+        var schema = GraphAndTableSchema();
+        bool result = false;
+
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            result = ProjectionDiagnostics.ValidateProjection(
+                schema, ["Caller Graph", "Callers"], fields: ["Fanin", "Depth"], columns: null);
+            return Task.FromResult(0);
+        });
+
+        // Graph fields resolve in Caller Graph, so the projection is valid even though the
+        // companion Callers table lacks them — no error, no spurious warning.
+        Assert.True(result);
+        Assert.DoesNotContain("not found", error);
+        Assert.DoesNotContain("No fields matched", error);
+    }
+
+    [Fact]
+    public async Task ValidateProjection_FieldResolvingInNoSection_FailsWithError()
+    {
+        var schema = GraphAndTableSchema();
+        bool result = true;
+
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            result = ProjectionDiagnostics.ValidateProjection(
+                schema, ["Caller Graph", "Callers"], fields: ["Bogus"], columns: null);
+            return Task.FromResult(0);
+        });
+
+        Assert.False(result);
+        Assert.Contains("warning: field 'Bogus' not found in section 'Caller Graph'", error);
+        Assert.Contains("Run -D \"Caller Graph\" to list available fields.", error);
+        Assert.Contains("No fields matched projection", error);
+    }
+
+    [Fact]
+    public async Task ValidateProjection_MixedValidAndUnknown_WarnsOnUnknownButSucceeds()
+    {
+        var schema = GraphAndTableSchema();
+        bool result = false;
+
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            result = ProjectionDiagnostics.ValidateProjection(
+                schema, ["Caller Graph", "Callers"], fields: ["Fanin", "Bogus"], columns: null);
+            return Task.FromResult(0);
+        });
+
+        // One valid graph field is enough to proceed; only the genuine typo is reported.
+        Assert.True(result);
+        Assert.Contains("warning: field 'Bogus' not found in section", error);
+        Assert.DoesNotContain("'Fanin'", error);
+        Assert.DoesNotContain("No fields matched projection", error);
+    }
+}

--- a/src/dotnet-inspect/Output/ProjectionDiagnostics.cs
+++ b/src/dotnet-inspect/Output/ProjectionDiagnostics.cs
@@ -33,7 +33,13 @@ public static class ProjectionDiagnostics
 
     /// <summary>
     /// Validates --fields/--columns names against multiple selected sections.
-    /// Returns false when any section has a projection with no matches.
+    /// A name is valid when it resolves in <em>at least one</em> selected section; sections
+    /// that lack it simply don't project it. This matters when a section is implicitly added
+    /// alongside an explicit one — for example a scope flag (<c>--bin</c>/<c>--project</c>/
+    /// <c>--caller-package</c>) implies <c>-S Callers</c>, so projecting graph-only fields
+    /// such as <c>Fanin</c>/<c>Depth</c> over <c>-S "Caller Graph"</c> must not fail just
+    /// because those fields don't exist on the companion <c>Callers</c> table. Returns false
+    /// only when a projection matches no selected section at all.
     /// </summary>
     public static bool ValidateProjection(DocumentSchema schema, IReadOnlyCollection<string>? sectionNames,
         string[]? fields, string[]? columns)
@@ -44,11 +50,54 @@ public static class ProjectionDiagnostics
             return true;
         }
 
-        var allValid = true;
-        foreach (var section in sectionNames)
-            allValid &= ValidateProjection(schema, section, fields, columns);
+        var ok = true;
+        if (fields is { Length: > 0 })
+            ok &= ValidateNamesAcrossSections(schema, sectionNames, fields, "field");
+        if (columns is { Length: > 0 })
+            ok &= ValidateNamesAcrossSections(schema, sectionNames, columns, "column");
 
-        return allValid;
+        return ok;
+    }
+
+    private static bool ValidateNamesAcrossSections(DocumentSchema schema,
+        IReadOnlyCollection<string> sectionNames, string[] names, string kind)
+    {
+        // A name is an error only when it resolves in NO selected section. Names that
+        // resolve in any section drop out, so a valid graph field is not reported against a
+        // companion table that happens to lack it (e.g. the Callers table implied by --bin).
+        var resolvedSomewhere = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var section in sectionNames)
+        {
+            var unresolved = new HashSet<string>(
+                schema.ValidateProjection(section, names).Unresolved, StringComparer.OrdinalIgnoreCase);
+            foreach (var name in names)
+                if (!unresolved.Contains(name))
+                    resolvedSomewhere.Add(name);
+        }
+
+        // Warn (with the per-section discovery hint) only for names missing everywhere.
+        foreach (var section in sectionNames)
+        {
+            var validation = schema.ValidateProjection(section, names);
+            foreach (var name in validation.Unresolved)
+            {
+                if (resolvedSomewhere.Contains(name))
+                    continue;
+                var msg = $"warning: {kind} '{name}' not found in section '{section}'";
+                if (validation.Suggestions.TryGetValue(name, out var suggestions))
+                    msg += $" (did you mean: {string.Join(", ", suggestions)}?)";
+                msg += $" Run -D \"{section}\" to list available {kind}s.";
+                Console.Error.WriteLine(msg);
+            }
+        }
+
+        // Proceed when at least one requested name matched some section (mirrors the
+        // single-section contract of rendering partial matches); abort only when none did.
+        if (resolvedSomewhere.Count > 0)
+            return true;
+
+        Console.Error.WriteLine($"Error: No {kind}s matched projection: {string.Join(", ", names)}");
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #1322: `--fields` projection on `-S "Caller Graph"` (and `"Call Graph"`) aborted the whole command when a scope flag was also present.

## Root cause

Scope flags (`--bin`/`--project`/`--caller-package`) imply `-S Callers`. So with the issue's repro, the selected sections were `["Caller Graph", "Callers"]`. `ProjectionDiagnostics.ValidateProjection` required **every** selected section to resolve the requested fields (`allValid &= ValidateProjection(section, …)`), so the graph-only fields (`Fanin`/`Depth`/`Loop`/`Root`/`EvidenceIL`) validated fine against `Caller Graph` but failed against the companion `Callers` table — producing five spurious warnings and `Error: No fields matched projection`, aborting before render.

Verified: the same command **without** `--bin` already worked, confirming the implied `Callers` table was the trigger.

## Fix

Relax the multi-section contract: a field/column is valid when it resolves in **at least one** selected section; sections that lack it simply don't project it. A name is an error — warned per section (keeping the `Run -D "<section>"` discovery hint), then `No <kind>s matched projection` — only when it resolves in **no** selected section. Single-section behavior (typo detection + partial-match rendering) is unchanged.

## Before / after (repro)

```bash
member …ArgumentPreprocessor --all -m PreprocessArgs --index 1 \
  -S "Caller Graph" --fields "Fanin;Depth;Loop;Root;EvidenceIL" \
  --bin artifacts/bin/dotnet-inspect/release
```

- Before: `Error: No fields matched projection: Fanin, Depth, Loop, Root, EvidenceIL` (exit 1).
- After: renders the `Callers` table (default columns) and the `Caller Graph` with the projected `fanin/depth/loop/root/il` annotations (exit 0, no warnings).

Genuine typos still warn per section with the discovery hint and abort; a valid+typo mix warns on the typo and proceeds.

## Tests

- New `ProjectionDiagnosticsTests`: resolve-in-one-section success (no warning/error), resolve-in-none failure (warns + `No fields matched projection`), mixed valid/typo (warns on typo, proceeds).
- Full suite green: `dotnet-inspect.Tests` 1305 (9 env-skipped). Three pre-existing single-section projection tests still pass (message format preserved).

## Docs

- `docs/design/schema-query.md`: documents the at-least-one-section projection semantics and the implied-`Callers` interaction.

Closes #1322.