### PR TITLE
Resolve non-public member bodies under --all (#1323)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2068,6 +2068,24 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_NonPublicMethod_UnderIncludeAll_RendersBodyAndIL()
+    {
+        // #1323: a non-public method selected under --all must render its body and IL, not
+        // report "has no IL body". The body-load path counts overloads on the same
+        // visibility basis the member index numbered them on (all overloads under --all).
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "--all", "InternalHelper:1", "-S", "Decompiled Source,IL", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Decompiled Source", output);
+        Assert.Contains("## IL", output);
+        Assert.DoesNotContain("has no IL body", output);
+        Assert.Contains("InternalHelper", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SourceCategory_IncludesIlAndNoLoweredSource()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -107,4 +107,13 @@ public static class MemberCallsFixture
     {
         Console.WriteLine(value);
     }
+
+    // Non-public member: only selectable under --all. Regression coverage for #1323,
+    // where the body-load path counted overloads public-only and so reported "no IL body"
+    // for a method that the Calls/IL index reads fine.
+    internal static int InternalHelper(int value)
+    {
+        Console.WriteLine(value);
+        return value + 1;
+    }
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1031,7 +1031,7 @@ public class ApiCommand
                         memberOptions.DllPath!,
                         memberOptions.OverloadIndex.HasValue ? memberOptions.OverloadIndex.Value - 1 : null,
                         requestedSections, memberOptions.PdbPath, memberOptions.IncludeSections,
-                        memberOptions.CallerScopeAssemblies);
+                        memberOptions.CallerScopeAssemblies, memberOptions);
 
                 if (memberOptions.MethodSource != null && requestedSections.Contains(SectionNames.OriginalSource))
                 {

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -38,7 +38,7 @@ internal static class MemberCodeProvider
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
-        Request request, string? pdbPath = null)
+        Request request, string? pdbPath = null, bool includeAll = false)
     {
         var results = new List<(ApiMember, Item)>();
         
@@ -73,7 +73,15 @@ internal static class MemberCodeProvider
             var lookupOverloadIndex = method.DeclaringOverloadIndex is { } declaringIndex
                 ? declaringIndex - 1
                 : overloadIndex!.Value;
-            var publicOnly = method.Kind != "explicit-interface-implementation";
+            // Overload selection counts same-named methods at the visibility basis the
+            // member index numbered them on: only public members are numbered by default,
+            // but `--all` numbers every overload regardless of visibility. Counting public-
+            // only here while the index numbered all overloads (the `--all` case) skips the
+            // selected non-public method, so the body falsely reports "no IL body" even
+            // though sections like Calls — which index every method — read it fine.
+            // Explicit interface implementations are metadata-private but always selectable,
+            // so they too must count across all visibilities.
+            var publicOnly = !includeAll && method.Kind != "explicit-interface-implementation";
 
             if (!typeIndex.TryGetValue(lookupType, out var typeHandle))
                 continue;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1227,7 +1227,7 @@ public static class ApiOutputFormatter
         if (request.DecompiledSource || request.AnnotatedSource || request.IL || request.Attributes || request.Facts)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
-        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath))
+        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false))
         {
             if (code.Attributes is { Count: > 0 } attributes)
             {


### PR DESCRIPTION
## Summary

Fixes #1323: a non-public method selected under `--all` reported `DEC0001: … has no IL body` in Decompiled Source and rendered empty IL, while the `Calls` section read the same body and reported valid IL offsets — contradictory evidence.

## Root cause

`MemberCodeProvider.Collect` hardcoded:

```csharp
var publicOnly = method.Kind != "explicit-interface-implementation";
```

The body-load overload selectors (`IrImporter.Import`, `ILDisassembler.DisassembleMethod`, `AttributeReader`) count same-named methods **at that visibility basis**, body-or-not. For a `private`/`internal` method, `publicOnly: true` counts zero matches, so the requested overload index resolves to nothing and the lookup returns `null` → the false "no IL body". The `Calls`/`IL` index (`LibraryBodyIndex`) indexes every method regardless of visibility, so it read the body fine.

The member index numbers overloads on a visibility basis that depends on `--all`: public-only by default, **all** overloads under `--all`. So the counting basis must match.

## Fix

```csharp
var publicOnly = !includeAll && method.Kind != "explicit-interface-implementation";
```

`includeAll` is threaded from the member options through `PopulateIndexSections` into `Collect`. This keeps the counting basis aligned with how the index numbered the overload the user selected, so a non-public selection resolves correctly. Fixes Decompiled Source, Annotated Source, IL, Facts, and method attributes together (all share this path).

### Before / after (repro)

```bash
member SharedOptions --library …/dotnet-inspect.dll --all \
  -m ValidateRendererFlags --index 1 -S "Decompiled Source,Calls,IL"
```

- Before: `// DEC0001: … ValidateRendererFlags has no IL body`, empty IL.
- After: full decompiled body + IL render, consistent with `Calls`.

Public-method behavior is unchanged with and without `--all` (the basis still matches): verified no regression.

## Tests

- New `InternalHelper` fixture method + `Member_NonPublicMethod_UnderIncludeAll_RendersBodyAndIL` asserting a non-public method renders body + IL under `--all` and never says "has no IL body".
- Full suite green: `dotnet-inspect.Tests` 1303 (9 env-skipped).

Closes #1323.