### PR TITLE
Skip fixed-buffer backing fields in fidelity skeleton

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
@@ -1,0 +1,8 @@
+namespace ILInspector.Decompiler.Tests;
+
+public unsafe struct FixedBufferSkeletonFixture
+{
+    public fixed byte Buffer[16];
+
+    public int Value() => 42;
+}

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -58,4 +58,15 @@ public class SkeletonEmitTests
             or FidelityCheck.CompileBackStatus.ContextFail,
             $"Skeleton failed to compile with Microsoft.CodeAnalysis.EmbeddedAttribute present: {result.Status} / {result.Detail}");
     }
+
+    [Fact]
+    public void SkeletonSkipsFixedBufferBackingFieldTypes()
+    {
+        var result = FidelityCheck.Evaluate(typeof(FixedBufferSkeletonFixture).Assembly.Location)
+            .Single(r => r.Type == "ILInspector.Decompiler.Tests.FixedBufferSkeletonFixture" && r.Method == "Value");
+
+        Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton failed to compile with a fixed-buffer backing type present: {result.Status} / {result.Detail}");
+    }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -699,6 +699,13 @@ static class FidelityCheck
         if (!emit.Success)
         {
             var err = emit.Diagnostics.FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
+            if (Environment.GetEnvironmentVariable("CB_DUMP") is not null && err is not null)
+            {
+                var safe = string.Concat($"{fullType}.{e.Name}".Select(ch => char.IsLetterOrDigit(ch) ? ch : '_'));
+                var path = Path.Combine(Path.GetTempPath(), $"cb-{safe}.cs");
+                File.WriteAllText(path, unit);
+                Console.Error.WriteLine($"{path}: {err}");
+            }
             return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.RecompileFail, e.OrigText, "", FormatDiagnostic(err));
         }
         ms.Position = 0;
@@ -1246,6 +1253,8 @@ static class FidelityCheck
         string type;
         try { type = field.DecodeSignature(SignatureDecoder.Instance, context); }
         catch { return; }
+        if (type.Contains(">e__FixedBuffer", StringComparison.Ordinal))
+            return; // compiler-generated fixed-buffer backing type: <Name>e__FixedBuffer is not valid C#
 
         bool isConst = field.Attributes.HasFlag(FieldAttributes.Literal);
         bool isStatic = field.Attributes.HasFlag(FieldAttributes.Static);


### PR DESCRIPTION
## Summary

Fixes #1314 by skipping compiler-generated fixed-buffer backing fields in the changed-method fidelity skeleton. Roslyn/System.IO.Hashing structs contain fields whose metadata type is a generated nested type such as `<Buffer>e__FixedBuffer`; emitting that type name in C# produced `CS1001: Identifier expected` and poisoned the whole compile-back unit.

Also adds `CB_DUMP=1` support to write failing compile-back units to `/tmp/cb-*.cs`, which is the diagnostic path the issue already points at.

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.
```

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.SkeletonEmitTests
Total: 5, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

## Changed-method fidelity delta (#1251/#1209)

Run with the #1251 gist delta plus materialized Roslyn NuGet assemblies, after #1321 was merged into `origin/main`.

Before (`origin/main` / #1321):

```text
CHANGED-METHOD COMPILE-BACK over 165 current changed methods (165 attempted)
  exact opcode match : 21
  opcode diff (Full) : 7
  not Full           : 0
  recompile fail     : 109
  context fail       : 28
  recompile-fail by code:
    CS1001: 24
```

After:

```text
CHANGED-METHOD COMPILE-BACK over 165 current changed methods (165 attempted)
  exact opcode match : 21
  opcode diff (Full) : 7
  not Full           : 0
  recompile fail     : 109
  context fail       : 28
  recompile-fail by code:
    CS1001: 0
    CS0305: 23
```

The CS1001 skeleton syntax bucket is eliminated. The affected Roslyn rows now advance to the next blocker (`CS0305` generic arity), so total recompile-fail count is unchanged but #1314 is cleared from the queue.

Fixes #1314
