### PR TITLE
Qualify nested type references through their declaring type (#1324)

### DIFF
--- a/src/ILInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/ILInspector.Metadata/MetadataReaderExtensions.cs
@@ -21,10 +21,14 @@ public static class MetadataReaderExtensions
             => TypeResolver.GetFullName(reader, typeDef);
 
         /// <summary>
-        /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeReference"/>.
+        /// Gets the fully qualified name of a <see cref="TypeReference"/>,
+        /// qualifying a nested type through its declaring type (Outer.Inner) to
+        /// match <see cref="GetFullTypeName(TypeDefinition)"/>.
         /// </summary>
         public string GetFullTypeName(TypeReference typeRef)
-            => TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            => typeRef.ResolutionScope.Kind == HandleKind.TypeReference
+                ? $"{reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)typeRef.ResolutionScope))}.{reader.GetString(typeRef.Name)}"
+                : TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
 
         /// <summary>
         /// Gets the fully qualified name (Namespace.Name) of an <see cref="ExportedType"/>.

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -41,10 +41,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle));
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-    {
-        var typeRef = reader.GetTypeReference(handle);
-        return TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
-    }
+        => TypeResolver.GetTypeNameFromReference(reader, handle);
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -26,11 +26,18 @@ public static class TypeResolver
     }
 
     /// <summary>
-    /// Gets the type name from a TypeReference handle.
+    /// Gets the type name from a TypeReference handle, qualifying a nested type
+    /// through its declaring type (<c>Outer.Inner</c>) — a nested
+    /// <see cref="TypeReference"/> carries an empty namespace and a leaf name with
+    /// its enclosing type as the resolution scope, so a raw namespace+name would
+    /// drop the qualifier (rendering <c>ImmutableArray`1+Builder</c> as a bare
+    /// <c>Builder</c>). Mirrors <see cref="GetFullName(MetadataReader, TypeDefinition)"/>.
     /// </summary>
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
     {
         var typeRef = reader.GetTypeReference(handle);
+        if (typeRef.ResolutionScope.Kind == HandleKind.TypeReference)
+            return $"{GetTypeNameFromReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope)}.{reader.GetString(typeRef.Name)}";
         return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
     }
 

--- a/tests/ILInspector.Metadata.Tests/NestedTypeReferenceTests.cs
+++ b/tests/ILInspector.Metadata.Tests/NestedTypeReferenceTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Pins nested-type qualification in metadata signature rendering (#1324). A
+/// nested type reached through a <see cref="TypeReference"/> (a nested type from
+/// a referenced assembly) must be qualified through its declaring type, the same
+/// as a <see cref="TypeDefinition"/> — otherwise <c>ImmutableArray`1+Builder</c>
+/// rendered as a bare <c>Builder&lt;T&gt;</c> (the enclosing arguments attached to
+/// the leaf), which is CS0246 and poisons changed-method compile-back.
+/// </summary>
+public class NestedTypeReferenceTests
+{
+    static string ImmutableArrayPath => typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location;
+
+    [Fact]
+    public void SignatureDecoder_QualifiesNestedTypeReferenceThroughDeclaringType()
+    {
+        using var pe = new PEReader(File.OpenRead(ImmutableArrayPath));
+        var reader = pe.GetMetadataReader();
+
+        string? returnType = null;
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            // The non-generic static `ImmutableArray` factory class (the generic
+            // value type is `ImmutableArray`1`), which declares CreateBuilder<T>.
+            if (reader.GetString(typeDef.Name) != "ImmutableArray")
+                continue;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != "CreateBuilder")
+                    continue;
+                // ImmutableArray.CreateBuilder<T>() returns ImmutableArray<T>.Builder,
+                // a nested type of the referenced generic ImmutableArray<T>.
+                var signature = method.DecodeSignature(SignatureDecoder.Instance, new GenericContext(["T"], ["T"]));
+                returnType = signature.ReturnType;
+                break;
+            }
+            if (returnType is not null)
+                break;
+        }
+
+        Assert.NotNull(returnType);
+        Assert.Equal("System.Collections.Immutable.ImmutableArray<T>.Builder", returnType);
+    }
+}


### PR DESCRIPTION
Fixes #1324. Burns down a Priority-1 blocker on the #1318 changed-method fidelity queue (the metadata analog of #1321's IR-printer fix).

## Bug
The metadata signature renderer threaded nested declaring types for a `TypeDefinition` but **not** for a `TypeReference`. A nested `TypeReference` carries an empty namespace and a leaf name with its enclosing type as the *resolution scope*, so:
- `TypeResolver.GetTypeNameFromReference`, `SignatureDecoder.GetTypeFromReference`, and `MetadataReaderExtensions.GetFullTypeName(TypeReference)` returned a bare namespace+name;
- `ImmutableArray\`1+Builder` rendered as `Builder`, and `ApplyGenericArguments` then attached the **enclosing** type's argument to the leaf → `Builder<T>` → CS0246.

This is used by the product API-surface scanners (`dotnet-inspect library` signatures) **and** the changed-method fidelity skeleton.

## Fix
Thread the declaring `TypeReference` exactly as the `TypeDefinition` paths already do, so a referenced nested type qualifies through its declaring chain: `System.Collections.Immutable.ImmutableArray<T>.Builder`.

## Changed-method fidelity (#1251/#1209 delta)
| Metric | Before | After |
|---|--:|--:|
| exact opcode match | 21 | **22** |
| opcode diff (Full) | 7 | **19** |
| recompile fail | 109 | **96** |
| context fail | 28 | 28 |
| CS0246 | 39 | **12** |

The compile-checkable population grows **28 → 41**. The ~28 `Builder<>` CS0246 rows are gone; remaining CS0246 (12) is the NuGet/NuGetFetch reference closure (#1315). Other rows peel to their next blocker (CS1061/CS0103), now surfacing as **actionable opcode diffs** rather than masked compile failures — a materially larger opcode-checkable population for the #1175 evidence story.

## Tests
Adds `NestedTypeReferenceTests` (decodes `ImmutableArray.CreateBuilder<T>()`'s return type → `System.Collections.Immutable.ImmutableArray<T>.Builder`). Full suites pass with **zero blast radius**: Metadata 226, dotnet-inspect 1302, Decompiler 1113, Analysis 59, Services 159.