### PR TITLE
Mark JsonContext Top Leverage helpers generated

### DIFF
--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -1,6 +1,8 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Sections;
+using ILInspector.Analysis;
 
 namespace DotnetInspector.Tests;
 
@@ -242,6 +244,22 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    public void LibraryTopLeverage_MarksSystemTextJsonContextRuntimeConverterHelperAsGenerated()
+    {
+        var method = CreateRuntimeConverterHelper("TryGetTypeInfoForRuntimeCustomConverter");
+
+        Assert.True(LibraryMetadataService.IsGeneratedMethod(method));
+    }
+
+    [Fact]
+    public void LibraryTopLeverage_DoesNotMarkUnrelatedMethodsWithSimilarShapeAsGenerated()
+    {
+        var method = CreateRuntimeConverterHelper("TryResolveConverter");
+
+        Assert.False(LibraryMetadataService.IsGeneratedMethod(method));
+    }
+
+    [Fact]
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
@@ -266,6 +284,23 @@ public class TopLeverageSectionTests
 
         Assert.Equal(0, drilled.ExitCode);
     }
+
+    private static MethodIdentity CreateRuntimeConverterHelper(string name)
+        => new(
+            AssemblyName: "TestAssembly",
+            ModuleVersionId: Guid.Empty,
+            DeclaringType: TypeRef.Definition("TestAssembly", "Samples", "JsonContext"),
+            Name: name,
+            ParameterTypes:
+            [
+                TypeRef.Definition("System.Text.Json", "System.Text.Json", "JsonSerializerOptions"),
+                TypeRef.ByRef(TypeRef.GenericInstance(
+                    TypeRef.Definition("System.Text.Json", "System.Text.Json.Serialization.Metadata", "JsonTypeInfo`1"),
+                    [TypeRef.MethodGenericParameter(0, "TJsonMetadataType")]))
+            ],
+            ReturnType: TypeRef.CoreLib("System", "Boolean"),
+            MetadataToken: 0x06000001,
+            IsStatic: true);
 }
 
 public static class LeverageSampleType

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -589,12 +589,28 @@ internal static class LibraryMetadataService
     private static string FormatMethod(Analysis.MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
-    // Compiler-generated implementation details (display classes, state machines, the
-    // <>c lambda cache, <PrivateImplementationDetails>) are not actionable source-shape
-    // fixes, so they are suppressed from Optimization Opportunities by default.
+    // Compiler/source-generated implementation details (display classes, state machines,
+    // the <>c lambda cache, <PrivateImplementationDetails>, System.Text.Json context
+    // helpers) are not actionable source-shape fixes, so optimization scans suppress them
+    // and leverage scans label them as generated.
     internal static bool IsGeneratedMethod(Analysis.MethodIdentity method)
         => ILInspector.Metadata.MemberFilters.IsCompilerGenerated(method.Name)
-           || ILInspector.Metadata.TypeFilters.IsCompilerGeneratedNested(method.DeclaringType.Name);
+           || ILInspector.Metadata.TypeFilters.IsCompilerGeneratedNested(method.DeclaringType.Name)
+           || IsSystemTextJsonContextGeneratedMethod(method);
+
+    private static bool IsSystemTextJsonContextGeneratedMethod(Analysis.MethodIdentity method)
+        => method.Name is "TryGetTypeInfoForRuntimeCustomConverter"
+           && method.IsStatic
+           && method.ReturnType.Equals(Analysis.TypeRef.CoreLib("System", "Boolean"))
+           && method.ParameterTypes.Length == 2
+           && method.ParameterTypes[0].Equals(Analysis.TypeRef.Definition("System.Text.Json", "System.Text.Json", "JsonSerializerOptions"))
+           && method.ParameterTypes[1] is { Kind: Analysis.TypeRefKind.ByRef, ElementType: { } jsonTypeInfo }
+           && IsJsonTypeInfo(jsonTypeInfo);
+
+    private static bool IsJsonTypeInfo(Analysis.TypeRef type)
+        => type.Kind == Analysis.TypeRefKind.GenericInstance
+           && type.ElementType is { } definition
+           && definition.Equals(Analysis.TypeRef.Definition("System.Text.Json", "System.Text.Json.Serialization.Metadata", "JsonTypeInfo`1"));
 
     /// <summary>
     /// Ranks the assembly's methods by call-graph leverage (distinct direct callers,
@@ -622,8 +638,7 @@ internal static class LibraryMetadataService
                         Fanout = entry.Fanout,
                         Depth = entry.MaxDepth,
                         LoopCalls = entry.LoopCallCount,
-                        Generated = ILInspector.Metadata.MemberFilters.IsCompilerGenerated(entry.Method.Name)
-                            || ILInspector.Metadata.TypeFilters.IsCompilerGeneratedNested(entry.Method.DeclaringType.Name),
+                        Generated = IsGeneratedMethod(entry.Method),
                         Visibility = drill.Visibility,
                         Stable = drill.Stable,
                         Selector = drill.Selector,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1580,8 +1580,7 @@ public static class ApiOutputFormatter
             .Select(entry =>
             {
                 drillByToken.TryGetValue(entry.Method.MetadataToken, out var drill);
-                bool generated = MemberFilters.IsCompilerGenerated(entry.Method.Name)
-                    || TypeFilters.IsCompilerGeneratedNested(entry.Method.DeclaringType.Name);
+                bool generated = LibraryMetadataService.IsGeneratedMethod(entry.Method);
                 return new TopLeverageRow(
                     MarkoutInline.Code(FormatMember(null, entry.Method.Name, entry.Method.ParameterTypes, [])),
                     entry.DirectCallerCount.ToString(),


### PR DESCRIPTION
## Summary

- mark the System.Text.Json source-generated runtime-converter helper as generated in the shared method classifier
- reuse that classifier for type-scoped Top Leverage so library/type views agree
- add regression coverage for the generated helper shape and a nearby negative case

Closes #1329.

## Validation

```bash
dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.TopLeverageSectionTests"
dotnet build src/dotnet-inspect -c Release -v:q
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll -S "Top Leverage" --rows -n 25
dotnet run --project src/dotnet-inspect.Tests -c Release
```
