### PR TITLE
Guard constructor-call diagnostics by chain target

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
@@ -7,6 +7,7 @@ public class ConstructorCallDiagnosticsPassTests
 {
     static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");
     static readonly TypeRef Base = TypeRef.CoreLib("Synthetic", "Base");
+    static readonly TypeRef Unrelated = TypeRef.CoreLib("Synthetic", "Unrelated");
     static readonly TypeRef StructType = TypeRef.CoreLib("Synthetic", "StructType");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
@@ -31,7 +32,7 @@ public class ConstructorCallDiagnosticsPassTests
     {
         var ctor = new MethodRef(Base, ".ctor", Void, [Int32], HasThis: true);
         var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner), new Constant(5, Int32)]);
-        var function = Function(".ctor", [new ExpressionStatement(call)]);
+        var function = Function(".ctor", [new ExpressionStatement(call)], baseType: Base);
 
         new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
 
@@ -47,7 +48,7 @@ public class ConstructorCallDiagnosticsPassTests
         var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
         var ctor = new MethodRef(Base, ".ctor", Void, [], HasThis: true);
         var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner)]);
-        var function = Function(".ctor", [store, new ExpressionStatement(call)]);
+        var function = Function(".ctor", [store, new ExpressionStatement(call)], baseType: Base);
 
         new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
 
@@ -56,7 +57,37 @@ public class ConstructorCallDiagnosticsPassTests
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
 
-    static IrFunction Function(string name, IEnumerable<IrNode> statements)
+    [Fact]
+    public void Run_MarksUnrelatedConstructorCallOnThisUnsupported()
+    {
+        var ctor = new MethodRef(Unrelated, ".ctor", Void, [], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner)]);
+        var function = Function(".ctor", [new ExpressionStatement(call)], baseType: Base);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(Assert.Single(function.Body.Blocks[0].Children));
+        Assert.IsType<UnsupportedNode>(statement.Expression);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void Run_LeavesGenericThisConstructorChain()
+    {
+        var genericOwner = TypeRef.Definition("Synthetic", "Samples", "Owner`1");
+        var genericInstance = TypeRef.GenericInstance(genericOwner, [TypeRef.GenericParameter(0, "T")]);
+        var ctor = new MethodRef(genericInstance, ".ctor", Void, [], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", genericOwner)]);
+        var function = Function(".ctor", [new ExpressionStatement(call)], owner: genericOwner);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(Assert.Single(function.Body.Blocks[0].Children));
+        Assert.Same(call, statement.Expression);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    static IrFunction Function(string name, IEnumerable<IrNode> statements, TypeRef? baseType = null, TypeRef? owner = null)
     {
         var body = new BlockContainer();
         var block = new Block();
@@ -70,6 +101,9 @@ public class ConstructorCallDiagnosticsPassTests
             HasThis: true,
             GenericParameterCount: 0);
 
-        return new IrFunction(name, Owner, signature, [], body);
+        return new IrFunction(name, owner ?? Owner, signature, [], body)
+        {
+            BaseType = baseType,
+        };
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ConstructorChainRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorChainRenderingTests.cs
@@ -11,10 +11,11 @@ public class ConstructorChainRenderingTests
 {
     static readonly TypeRef Derived = TypeRef.CoreLib("System", "MyDerived");
     static readonly TypeRef Base = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Unrelated = TypeRef.CoreLib("System", "Unrelated");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
 
-    static DecompilerResult RenderConstructor(TypeRef chainDeclaringType, IrExpression receiver)
+    static DecompilerResult RenderConstructor(TypeRef chainDeclaringType, IrExpression receiver, bool diagnose = false)
     {
         var ctor = new MethodRef(chainDeclaringType, ".ctor", Void, [Int32], HasThis: true);
         var call = new Call(ctor, isVirtual: false, [receiver, new Constant(5, Int32)]);
@@ -24,7 +25,12 @@ public class ConstructorChainRenderingTests
         var container = new BlockContainer();
         container.Add(entry);
         var signature = new MethodSignature(Void, [new Parameter("value", Int32)], HasThis: true, GenericParameterCount: 0);
-        var function = new IrFunction(".ctor", Derived, signature, [Derived], container);
+        var function = new IrFunction(".ctor", Derived, signature, [Derived], container)
+        {
+            BaseType = Base,
+        };
+        if (diagnose)
+            new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
         return CSharpPrinter.Print(function);
     }
 
@@ -54,4 +60,14 @@ public class ConstructorChainRenderingTests
         Assert.Equal("base(5)", result.ConstructorChain);
         Assert.DoesNotContain(".ctor", result.Output);
     }
+
+    [Fact]
+    public void UnrelatedConstructorCallOnThis_DoesNotRenderAsChain()
+    {
+        var result = RenderConstructor(Unrelated, new LoadArgument(0, "this", Derived), diagnose: true);
+
+        Assert.Null(result.ConstructorChain);
+        Assert.Contains("direct constructor call", result.Output);
+    }
+
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -309,6 +309,7 @@ public static class IrImporter
         var container = new BlockContainer();
         var function = new IrFunction(method.Name, method.DeclaringType, method.Signature, method.Body.Locals, container)
         {
+            BaseType = source.ResolveBaseType(method.DeclaringType),
             Regions = method.Body.Handlers,
             LocalNames = method.Body.LocalNames,
             UsesUpdatedMemorySafetyRules = source.SimulateNewRules || ModuleUsesUpdatedMemorySafetyRules(source.Reader),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -138,6 +138,7 @@ public sealed class IrFunction : IrNode
 
     public string Name { get; }
     public TypeRef DeclaringType { get; }
+    public TypeRef? BaseType { get; set; }
     public MethodSignature Signature { get; }
     public ImmutableArray<TypeRef> Locals { get; private set; }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
@@ -36,6 +36,7 @@ public sealed class ConstructorCallDiagnosticsPass : IIrPass
     {
         if (function.Name != ".ctor"
             || call.Arguments is not [LoadArgument { Index: 0 }, ..]
+            || !IsConstructorChainTarget(function, call.Callee.DeclaringType)
             || function.Body.Blocks is not [{ } entry, ..])
         {
             return false;
@@ -45,6 +46,16 @@ public sealed class ConstructorCallDiagnosticsPass : IIrPass
         return chainIndex >= 0
             && entry.Children.Take(chainIndex).All(IsFieldInitializerStore);
     }
+
+    static bool IsConstructorChainTarget(IrFunction function, TypeRef declaringType)
+        => SameDefinition(declaringType, function.DeclaringType)
+            || function.BaseType is { } baseType && SameDefinition(declaringType, baseType);
+
+    static bool SameDefinition(TypeRef left, TypeRef right)
+        => Definition(left).Equals(Definition(right));
+
+    static TypeRef Definition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance && type.ElementType is { } definition ? definition : type;
 
     static int ChildIndexOf(Block block, IrNode node)
     {


### PR DESCRIPTION
## Summary

Fixes #1332 by letting `ConstructorCallDiagnosticsPass` distinguish real constructor chains from unrelated direct `.ctor(this)` calls.

- `IrFunction` now carries the declaring type's base type, stamped at import.
- `ConstructorCallDiagnosticsPass` only exempts `.ctor(this, ...)` calls whose declaring type is the current type (including generic instantiations of it) or the known base type.
- Unrelated direct constructor calls now become `UnsupportedNode` / `Partial` instead of reaching the printer as `Full` and disappearing.

The printer's existing constructor-chain spelling is intentionally unchanged to avoid broad rendering churn; this PR narrows the diagnostics bypass that let invalid residuals through.

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.
```

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release
Total: 1117, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

Focused constructor tests:

```text
ConstructorCallDiagnosticsPassTests + ConstructorChainRenderingTests + ConstructorChainTests
Total: 16, Errors: 0, Failed: 0
```

### Corpus control

The full real-world corpus card against the checked-in baseline is noisy because local artifact composition has moved since the baseline. To isolate product behavior from local-artifact churn, I emitted a current-main NuGet-only baseline and compared this branch against the same six NuGet corpus assemblies:

```text
Assemblies: 6
Methods: 67,322
Fully raised: 60,368 -> 60,368 (delta 0)
Conditional-branch residual: 1,839 -> 1,839 (delta 0)
Forward-merge stops: 1,854 -> 1,854 (delta 0)
Full malformed: 46 -> 46 (delta 0)
Semantic defects: 1/150 -> 1/150 (delta 0)
Pass bugs: 0 -> 0
Verdict: corpus sensor matched baseline tolerances.
```

Fixes #1332
