### PR TITLE
Decline instance ldftn method addresses

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
@@ -83,6 +83,25 @@ public class FunctionPointerDiagnosticsPassTests
         Assert.Contains("RuntimeAsyncTarget", diagnostic.Message);
     }
 
+    [Fact]
+    public void MethodAddress_InstanceTarget_StaysDiagnosticResidual()
+    {
+        var method = new MethodRef(Owner, "InstanceTarget", Void, [], HasThis: true);
+        var function = FunctionWith(new LoadFunctionPointer(method, isVirtual: false, instance: null));
+
+        new MethodAddressPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<LoadFunctionPointer>());
+        Assert.Empty(function.Descendants.OfType<AddressOfMethod>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+
+        new FunctionPointerDiagnosticsPass().Run(function, PassContext.None);
+        var diagnostic = Assert.Single(function.Diagnostics);
+        Assert.Equal(DiagnosticIds.UnsupportedFunctionPointer, diagnostic.Id);
+        Assert.Contains("instance method", diagnostic.Message);
+        Assert.Contains("InstanceTarget", diagnostic.Message);
+    }
+
     private static IrFunction FunctionWith(IrExpression expression)
     {
         var body = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FunctionPointerDiagnosticsPass.cs
@@ -24,6 +24,8 @@ public sealed class FunctionPointerDiagnosticsPass : IIrPass
                 DiagnosticIds.UnsupportedFunctionPointer,
                 pointer.IsVirtual
                     ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} requires a receiver; C# cannot spell a virtual method address as a delegate* target"
+                    : pointer.Method.HasThis
+                        ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is an instance method; C# &Method can only spell static method addresses"
                     : pointer.Method.IsPInvoke == MetadataFactState.Yes
                         ? $"function-pointer {opcode}: {FormatMethod(pointer.Method)} is a P/Invoke target; C# &Method would claim an unsupported native callback target is faithful"
                     : pointer.Method.IsRuntimeAsync == MetadataFactState.Yes

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MethodAddressPass.cs
@@ -28,7 +28,8 @@ public sealed class MethodAddressPass : IIrPass
     }
 
     static bool IsInvalidNativeCallbackTarget(MethodRef method)
-        => method.IsPInvoke == MetadataFactState.Yes
+        => method.HasThis
+            || method.IsPInvoke == MetadataFactState.Yes
             || method.IsRuntimeAsync == MetadataFactState.Yes;
 
     static TypeRef? ContextualFunctionPointerType(IrFunction function, LoadFunctionPointer pointer)


### PR DESCRIPTION
## Summary

Fixes #1331 by keeping instance-method `ldftn` as an honest function-pointer residual instead of raising it to C# `&Method`.

- `MethodAddressPass` now declines targets where `MethodRef.HasThis` is true.
- `FunctionPointerDiagnosticsPass` reports the residual as an instance-method address that C# `&Method` cannot spell.
- Static method-address positives still raise to `AddressOfMethod`.

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.
```

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release
Total: 1118, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

Focused:

```text
FunctionPointerDiagnosticsPassTests
Total: 5, Errors: 0, Failed: 0
```

### Corpus control

The checked-in real-world corpus baseline is stale relative to current main. To isolate this PR from local artifact drift, I emitted a current-main NuGet-only baseline and compared this branch against the same six NuGet corpus assemblies:

```text
Assemblies: 6
Methods: 67,322
Fully raised: 60,368 -> 60,368 (delta 0)
Conditional-branch residual: 1,839 -> 1,839 (delta 0)
Forward-merge stops: 1,854 -> 1,854 (delta 0)
Full malformed: 46 -> 46 (delta 0)
Semantic defects: 1/150 -> 1/150 (delta 0)
Pass bugs: 0 -> 0
Verdict: corpus sensor matched baseline tolerances.
```

Fixes #1331
