### PR TITLE
Declare nested skeleton types with only their own generic parameters (#1344)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GenericNestedFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericNestedFixture.cs
@@ -1,0 +1,25 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// A generic type with a non-generic nested type, used by
+/// <see cref="SkeletonEmitTests"/> to pin the fidelity skeleton's nested-type
+/// generic-parameter emission (#1344). A nested type's metadata generic
+/// parameter list is cumulative (it inherits the enclosing <c>T</c>), so the
+/// skeleton must declare <c>struct Nested</c>, not <c>struct Nested&lt;T&gt;</c> —
+/// the latter shadows <c>T</c> and rejects a <c>GenericNestedHolder&lt;int&gt;.Nested</c>
+/// reference as CS0305.
+/// </summary>
+public class GenericNestedHolder<T>
+{
+    public struct Nested
+    {
+        public T Value;
+    }
+
+    public Nested MakeNested() => default;
+}
+
+public static class GenericNestedUser
+{
+    public static GenericNestedHolder<int>.Nested UseNested() => default;
+}

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -69,4 +69,19 @@ public class SkeletonEmitTests
             or FidelityCheck.CompileBackStatus.ContextFail,
             $"Skeleton failed to compile with a fixed-buffer backing type present: {result.Status} / {result.Detail}");
     }
+
+    [Fact]
+    public void SkeletonDeclaresNestedTypeWithoutInheritedGenericParameters()
+    {
+        // GenericNestedUser.UseNested returns GenericNestedHolder<int>.Nested. The
+        // skeleton reconstructs the nested Nested struct; emitting its inherited T
+        // (struct Nested<T>) makes the GenericNestedHolder<int>.Nested reference
+        // CS0305. Only the own (zero) parameters may be restated.
+        var result = FidelityCheck.Evaluate(typeof(GenericNestedHolder<>).Assembly.Location)
+            .Single(r => r.Type == "ILInspector.Decompiler.Tests.GenericNestedUser" && r.Method == "UseNested");
+
+        Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton mis-declared a nested generic type (CS0305): {result.Status} / {result.Detail}");
+    }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1174,7 +1174,7 @@ static class FidelityCheck
             return;
         }
 
-        string genParams = GenericParamList(reader, typeDef.GetGenericParameters());
+        string genParams = GenericParamList(reader, typeDef.GetGenericParameters(), InheritedGenericArity(reader, typeDef));
 
         if (kind == TypeKind.Delegate)
         {
@@ -1607,12 +1607,27 @@ static class FidelityCheck
         return ns.Length == 0 ? n : $"{ns}.{n}";
     }
 
-    static string GenericParamList(MetadataReader reader, GenericParameterHandleCollection handles)
+    static string GenericParamList(MetadataReader reader, GenericParameterHandleCollection handles, int skip = 0)
     {
-        if (handles.Count == 0)
+        if (handles.Count <= skip)
             return "";
-        var names = handles.Select(h => Identifier(reader.GetString(reader.GetGenericParameter(h).Name)));
+        var names = handles.Skip(skip).Select(h => Identifier(reader.GetString(reader.GetGenericParameter(h).Name)));
         return "<" + string.Join(", ", names) + ">";
+    }
+
+    /// <summary>
+    /// The number of generic parameters a nested type inherits from its enclosing
+    /// type — its declaring type's full arity. A nested type's metadata generic
+    /// parameter list is cumulative (enclosing + own), but a C# nested-type
+    /// declaration may only restate its own parameters, so the inherited leading
+    /// ones must be dropped (<c>ConsList&lt;T&gt;</c>'s nested <c>Enumerator</c> is
+    /// <c>struct Enumerator</c>, never <c>struct Enumerator&lt;T&gt;</c>, which would
+    /// shadow <c>T</c> and reject the in-scope <c>Enumerator</c> reference as CS0305).
+    /// </summary>
+    static int InheritedGenericArity(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var declaring = typeDef.GetDeclaringType();
+        return declaring.IsNil ? 0 : reader.GetTypeDefinition(declaring).GetGenericParameters().Count;
     }
 
     /// <summary>C# keywords that can appear as IL identifiers get an @ escape.</summary>


### PR DESCRIPTION
Burns down the CS0305 (generic arity) half of #1344 on the #1318 changed-method fidelity queue, and classifies/splits the constraint half.

## Bug (CS0305, 24 rows)
The fidelity skeleton declared a nested type with the **cumulative** generic parameter list from `typeDef.GetGenericParameters()` (which includes the enclosing type's parameters). So `ConsList<T>`'s non-generic nested `Enumerator` was emitted as `struct Enumerator<T>`, shadowing the enclosing `T`. The correctly-spelled (#1328) reference `ConsList<T>.Enumerator` then failed:

```text
CS0305: Using the generic type 'ConsList<T>.Enumerator<T>' requires 1 type arguments
CS0305: Using the generic type 'ImmutableSegmentedList<T>.Builder<T>' requires 1 type arguments
```

A C# nested-type declaration may only restate its **own** parameters.

## Fix
`EmitType` drops the inherited leading parameters (the declaring type's arity) when emitting a nested type's parameter list. Method parameter lists are unaffected.

## Changed-method fidelity (#1251/#1209 delta)
| Metric | Before | After |
|---|--:|--:|
| exact opcode match | 22 | 22 |
| opcode diff (Full) | 21 | 21 |
| recompile fail | 94 | 94 |
| context fail | 28 | 28 |
| **CS0305 (arity)** | **24** | **0** |

CS0305 is eliminated. Totals are flat because the same rows immediately expose the **next** blocker — the missing-constraint bucket the skeleton drops:
- **CS0453** `struct` constraint: 24 (unmasked by this fix)
- **CS0314** type constraint (`SyntaxList<TNode>` needs `where TNode : SyntaxNode`): 20

That constraint reconstruction (whole-module `where` clauses, with regression risk) is the top remaining concrete root cause and is split to a focused follow-up rather than bundled here, per the queue's one-fix-at-a-time guidance.

## Tests
Adds `GenericNestedFixture` + a `SkeletonEmitTests` case (a `GenericNestedHolder<int>.Nested` reference must compile back — would be CS0305 without the fix). Full decompiler suite: **1118 passed**.

Adversarial review (GPT-5.5) requested; will summarize in a comment.