### PR TITLE
Mark/suppress generated protobuf/gRPC types in perf triage (#1348)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -372,6 +372,9 @@ public class LibraryBodyIndexTests
         Assert.Contains(typeof(FakeGrpcServiceStub).FullName!, generated);
         // A normal protobuf-using type that doesn't bootstrap generated infrastructure stays out.
         Assert.DoesNotContain(typeof(NormalProtobufConsumer).FullName!, generated);
+        // Hand-written gRPC registration calling ServerServiceDefinition.CreateBuilder (without
+        // generated __* members) must not be flagged — gRPC calls alone are not a signal.
+        Assert.DoesNotContain(typeof(HandWrittenGrpcRegistration).FullName!, generated);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -361,6 +361,20 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void GeneratedFrameworkTypeNames_DetectsProtobufAndGrpcGeneratedTypes()
+    {
+        var index = LibraryBodyIndex.Open(typeof(FakeProtobufReflection).Assembly.Location);
+        var generated = index.GeneratedFrameworkTypeNames;
+
+        // protobuf reflection holder: its initializer calls FileDescriptor.FromGeneratedCode.
+        Assert.Contains(typeof(FakeProtobufReflection).FullName!, generated);
+        // gRPC service stub: binds via ServerServiceDefinition and declares __Helper_ members.
+        Assert.Contains(typeof(FakeGrpcServiceStub).FullName!, generated);
+        // A normal protobuf-using type that doesn't bootstrap generated infrastructure stays out.
+        Assert.DoesNotContain(typeof(NormalProtobufConsumer).FullName!, generated);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_SuppressesSourceGeneratedTypes()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -1,0 +1,58 @@
+// Minimal stand-ins for the protobuf/gRPC infrastructure that real generated code calls.
+// LibraryBodyIndex.GeneratedFrameworkTypeNames matches structurally by namespace/type/method
+// name, so these reproduce the bootstrap signals without a dependency on Google.Protobuf or
+// Grpc.Core. Block namespaces are required because the stubs live in foreign namespaces.
+
+namespace Google.Protobuf.Reflection
+{
+    public sealed class FileDescriptor
+    {
+        public static FileDescriptor FromGeneratedCode(byte[] descriptorData, FileDescriptor[] dependencies, GeneratedClrTypeInfo info) => new();
+    }
+
+    public sealed class GeneratedClrTypeInfo
+    {
+    }
+}
+
+namespace Grpc.Core
+{
+    public sealed class ServerServiceDefinition
+    {
+        public static Builder CreateBuilder() => new();
+
+        public sealed class Builder
+        {
+        }
+    }
+}
+
+namespace ILInspector.Analysis.Tests
+{
+    // A protobuf *Reflection holder: its static initializer bootstraps the descriptor.
+    public static class FakeProtobufReflection
+    {
+        static FakeProtobufReflection()
+        {
+            var info = new Google.Protobuf.Reflection.GeneratedClrTypeInfo();
+            Descriptor = Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode([], [], info);
+        }
+
+        public static Google.Protobuf.Reflection.FileDescriptor Descriptor { get; }
+    }
+
+    // A gRPC service stub: declares a __Helper_ member and binds via ServerServiceDefinition.
+    public static class FakeGrpcServiceStub
+    {
+        public static byte[] __Helper_SerializeMessage(object message) => [];
+
+        public static Grpc.Core.ServerServiceDefinition.Builder BindService()
+            => Grpc.Core.ServerServiceDefinition.CreateBuilder();
+    }
+
+    // Uses a protobuf type but does not bootstrap generated infrastructure — must NOT be flagged.
+    public static class NormalProtobufConsumer
+    {
+        public static Google.Protobuf.Reflection.FileDescriptor Passthrough(Google.Protobuf.Reflection.FileDescriptor descriptor) => descriptor;
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -55,4 +55,12 @@ namespace ILInspector.Analysis.Tests
     {
         public static Google.Protobuf.Reflection.FileDescriptor Passthrough(Google.Protobuf.Reflection.FileDescriptor descriptor) => descriptor;
     }
+
+    // Hand-written gRPC registration: legitimately calls ServerServiceDefinition.CreateBuilder
+    // but declares no generated __* members, so it must NOT be flagged as generated.
+    public static class HandWrittenGrpcRegistration
+    {
+        public static Grpc.Core.ServerServiceDefinition.Builder Register()
+            => Grpc.Core.ServerServiceDefinition.CreateBuilder();
+    }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -95,12 +95,13 @@ public sealed class LibraryBodyIndex
     /// detected structurally (no attributes are emitted on this code). A type qualifies when
     /// any of its methods bootstraps a protobuf descriptor — calling
     /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c> or constructing
-    /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c> — binds a gRPC service through
-    /// <c>Grpc.Core.ServerServiceDefinition</c>/<c>Marshallers</c>, or declares gRPC stub
-    /// infrastructure members (<c>__ServiceName</c>, <c>__Helper_*</c>, <c>__Marshaller_*</c>,
-    /// <c>__Method_*</c>). These signals appear only in generated code, so perf triage can mark
-    /// them in Top Leverage and suppress them from Optimization Opportunities like other
-    /// generated detail.
+    /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c> — or declares gRPC stub
+    /// infrastructure members whose names are codegen-only (<c>__ServiceName</c>,
+    /// <c>__Helper_*</c>, <c>__Marshaller_*</c>, <c>__Method_*</c>). gRPC binding calls
+    /// (<c>ServerServiceDefinition</c>/<c>Marshallers</c>) are intentionally not a signal,
+    /// since hand-written registration uses them too. These signals appear only in generated
+    /// code, so perf triage can mark them in Top Leverage and suppress them from Optimization
+    /// Opportunities like other generated detail.
     /// </summary>
     public IReadOnlySet<string> GeneratedFrameworkTypeNames => _generatedFrameworkTypes ??= ComputeGeneratedFrameworkTypes();
 
@@ -120,12 +121,12 @@ public sealed class LibraryBodyIndex
                 || (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
                     && callee.DeclaringType.Name == "GeneratedClrTypeInfo"
                     && callee.Name == ".ctor");
-            // gRPC service stubs bind their methods through ServerServiceDefinition / build
-            // marshallers via Grpc.Core.Marshallers — infrastructure only generated stubs call.
-            bool grpcBootstrap = callee.DeclaringType.Namespace == "Grpc.Core"
-                && ((callee.DeclaringType.Name == "ServerServiceDefinition" && callee.Name == "CreateBuilder")
-                    || (callee.DeclaringType.Name == "Marshallers" && callee.Name == "Create"));
-            if (protobufBootstrap || grpcBootstrap)
+            // Only the protobuf descriptor bootstrap is matched by call: FromGeneratedCode /
+            // GeneratedClrTypeInfo are codegen-only entry points. gRPC binding APIs
+            // (ServerServiceDefinition/Marshallers) are deliberately NOT matched by call, since
+            // hand-written low-level gRPC registration legitimately calls them; gRPC stubs are
+            // instead recognized by their generated __* infrastructure members below.
+            if (protobufBootstrap)
                 generated.Add(call.Caller.DeclaringType.ToQualifiedDisplayString());
         }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -88,6 +88,63 @@ public sealed class LibraryBodyIndex
     /// </summary>
     Dictionary<int, MethodSignals> Signals => _signals ??= MethodSignalAnalysis.Collect(DirectCalls, UnsafeEvidence, _bodySignals);
 
+    IReadOnlySet<string>? _generatedFrameworkTypes;
+
+    /// <summary>
+    /// Qualified names of types recognized as protobuf/gRPC generated implementation detail,
+    /// detected structurally (no attributes are emitted on this code). A type qualifies when
+    /// any of its methods bootstraps a protobuf descriptor — calling
+    /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c> or constructing
+    /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c> — binds a gRPC service through
+    /// <c>Grpc.Core.ServerServiceDefinition</c>/<c>Marshallers</c>, or declares gRPC stub
+    /// infrastructure members (<c>__ServiceName</c>, <c>__Helper_*</c>, <c>__Marshaller_*</c>,
+    /// <c>__Method_*</c>). These signals appear only in generated code, so perf triage can mark
+    /// them in Top Leverage and suppress them from Optimization Opportunities like other
+    /// generated detail.
+    /// </summary>
+    public IReadOnlySet<string> GeneratedFrameworkTypeNames => _generatedFrameworkTypes ??= ComputeGeneratedFrameworkTypes();
+
+    IReadOnlySet<string> ComputeGeneratedFrameworkTypes()
+    {
+        var generated = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var call in DirectCalls)
+        {
+            var callee = call.Callee;
+            if (callee.Kind == MemberKind.Unsupported)
+                continue;
+            bool protobufBootstrap =
+                (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
+                    && callee.DeclaringType.Name == "FileDescriptor"
+                    && callee.Name == "FromGeneratedCode")
+                || (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
+                    && callee.DeclaringType.Name == "GeneratedClrTypeInfo"
+                    && callee.Name == ".ctor");
+            // gRPC service stubs bind their methods through ServerServiceDefinition / build
+            // marshallers via Grpc.Core.Marshallers — infrastructure only generated stubs call.
+            bool grpcBootstrap = callee.DeclaringType.Namespace == "Grpc.Core"
+                && ((callee.DeclaringType.Name == "ServerServiceDefinition" && callee.Name == "CreateBuilder")
+                    || (callee.DeclaringType.Name == "Marshallers" && callee.Name == "Create"));
+            if (protobufBootstrap || grpcBootstrap)
+                generated.Add(call.Caller.DeclaringType.ToQualifiedDisplayString());
+        }
+
+        // gRPC service stubs declare marshaller/serialization-helper infrastructure members.
+        foreach (var method in Methods)
+        {
+            if (method.Name == "__ServiceName"
+                || method.Name.StartsWith("__Helper_", StringComparison.Ordinal)
+                || method.Name.StartsWith("__Marshaller_", StringComparison.Ordinal)
+                || method.Name.StartsWith("__Method_", StringComparison.Ordinal))
+            {
+                generated.Add(method.DeclaringType.ToQualifiedDisplayString());
+            }
+        }
+
+        return generated;
+    }
+
+
     public static LibraryBodyIndex Open(string path)
     {
         using var stream = File.OpenRead(path);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -598,6 +598,14 @@ internal static class LibraryMetadataService
            || ILInspector.Metadata.TypeFilters.IsCompilerGeneratedNested(method.DeclaringType.Name)
            || IsSystemTextJsonContextGeneratedMethod(method);
 
+    // Overload that also treats members of structurally-detected generated framework types
+    // (protobuf/gRPC, see LibraryBodyIndex.GeneratedFrameworkTypeNames) as generated, so their
+    // thick static initializers and stubs are marked in Top Leverage and suppressed from
+    // Optimization Opportunities even though no [GeneratedCode] attribute is emitted.
+    internal static bool IsGeneratedMethod(Analysis.MethodIdentity method, IReadOnlySet<string> generatedFrameworkTypes)
+        => IsGeneratedMethod(method)
+           || generatedFrameworkTypes.Contains(method.DeclaringType.ToQualifiedDisplayString());
+
     private static bool IsSystemTextJsonContextGeneratedMethod(Analysis.MethodIdentity method)
         => method.Name is "TryGetTypeInfoForRuntimeCustomConverter"
            && method.IsStatic
@@ -622,6 +630,7 @@ internal static class LibraryMetadataService
         try
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
+            var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             // Reuse the exact Member Index canonical-signature/digest path (via the
             // extracted API surface) so library-scope rows carry the same round-tripping
             // Stable selector, Visibility, and Name:N Selector as the type-scoped view.
@@ -638,7 +647,7 @@ internal static class LibraryMetadataService
                         Fanout = entry.Fanout,
                         Depth = entry.MaxDepth,
                         LoopCalls = entry.LoopCallCount,
-                        Generated = IsGeneratedMethod(entry.Method),
+                        Generated = IsGeneratedMethod(entry.Method, generatedFrameworkTypes),
                         Visibility = drill.Visibility,
                         Stable = drill.Stable,
                         Selector = drill.Selector,
@@ -706,8 +715,9 @@ internal static class LibraryMetadataService
         try
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
+            var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var rows = index.OptimizationOpportunities
-                .Where(opportunity => !IsGeneratedMethod(opportunity.Method))
+                .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes))
                 .OrderByDescending(opportunity => opportunity.RootReach)
                 .ThenBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
                 .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1519,7 +1519,7 @@ public static class ApiOutputFormatter
             : null;
         var rows = index.OptimizationOpportunities
             .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
-            .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method))
+            .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
             .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken))
             .OrderByDescending(opportunity => opportunity.RootReach)
             .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
@@ -1616,7 +1616,7 @@ public static class ApiOutputFormatter
             .Select(entry =>
             {
                 drillByToken.TryGetValue(entry.Method.MetadataToken, out var drill);
-                bool generated = LibraryMetadataService.IsGeneratedMethod(entry.Method);
+                bool generated = LibraryMetadataService.IsGeneratedMethod(entry.Method, index.GeneratedFrameworkTypeNames);
                 return new TopLeverageRow(
                     MarkoutInline.Code(FormatMember(null, entry.Method.Name, entry.Method.ParameterTypes, [])),
                     entry.DirectCallerCount.ToString(),


### PR DESCRIPTION
## Summary

Fixes #1348: protobuf/gRPC generated implementation detail no longer crowds `Top Leverage` and `Optimization Opportunities`.

These generated types (protobuf `*Reflection` descriptor holders, gRPC service stubs) emit **no** `[GeneratedCode]`/`[CompilerGenerated]` attribute and have ordinary type names, so the existing generated-detection (attributes + angle-bracket names) missed them. Their thick, allocation-heavy static initializers produced many non-actionable rows.

## Detector

New `LibraryBodyIndex.GeneratedFrameworkTypeNames` — a structural detector keyed on signals that appear **only** in generated code:

- **protobuf descriptor bootstrap**: a method calls `Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode` or constructs `Google.Protobuf.Reflection.GeneratedClrTypeInfo` (the `*Reflection` holders);
- **gRPC service stub**: a method binds via `Grpc.Core.ServerServiceDefinition`/`Marshallers`, or the type declares `__ServiceName`/`__Helper_*`/`__Marshaller_*`/`__Method_*` infrastructure members.

The set is threaded through `LibraryMetadataService.IsGeneratedMethod` so both library- and type-scope `Top Leverage` mark these rows `generated`, and `Optimization Opportunities` suppresses them — consistent with how other generated detail is handled.

## Verification (real packages)

`Microsoft.Azure.Functions.Worker.Grpc`:
- `Optimization Opportunities`: 0 `*Reflection..cctor` rows remain (were small-array/delegate noise).
- `Top Leverage`: `FunctionRpcReflection.get_Descriptor` etc. now `Generated = generated`.

`Microsoft.Azure.WebJobs.Extensions.ServiceBus` (the issue's `Settlement` gRPC service):

| Member | Generated (before → after) |
| --- | --- |
| `Settlement..cctor()` | blank → **generated** |
| `Settlement.BindService(...)` (both overloads) | blank → **generated** |
| `Settlement.get_Descriptor()` | blank → **generated** |
| `SettlementReflection.*` | blank → **generated** |

All four representative rows from the issue are now marked/suppressed.

## Tests

- `GeneratedFrameworkTypeNames_DetectsProtobufAndGrpcGeneratedTypes`: new `Google.Protobuf.Reflection`/`Grpc.Core` stand-in stubs + fixtures (detector is structural by namespace/name, so no real dependency needed). Asserts the protobuf reflection holder and gRPC stub are detected and a normal protobuf-*using* type is not.
- Full suites green: `ILInspector.Analysis.Tests` 64, `dotnet-inspect.Tests` 1310 (9 env-skipped).

Closes #1348.