### PR TITLE
Suppress protobuf message generated rows

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -368,6 +368,8 @@ public class LibraryBodyIndexTests
 
         // protobuf reflection holder: its initializer calls FileDescriptor.FromGeneratedCode.
         Assert.Contains(typeof(FakeProtobufReflection).FullName!, generated);
+        // protobuf message: its initializer constructs MessageParser<T>.
+        Assert.Contains(typeof(FakeProtobufMessage).FullName!, generated);
         // gRPC service stub: binds via ServerServiceDefinition and declares __Helper_ members.
         Assert.Contains(typeof(FakeGrpcServiceStub).FullName!, generated);
         // A normal protobuf-using type that doesn't bootstrap generated infrastructure stays out.

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -15,6 +15,16 @@ namespace Google.Protobuf.Reflection
     }
 }
 
+namespace Google.Protobuf
+{
+    public sealed class MessageParser<T>
+    {
+        public MessageParser(Func<T> factory)
+        {
+        }
+    }
+}
+
 namespace Grpc.Core
 {
     public sealed class ServerServiceDefinition
@@ -39,6 +49,17 @@ namespace ILInspector.Analysis.Tests
         }
 
         public static Google.Protobuf.Reflection.FileDescriptor Descriptor { get; }
+    }
+
+    // A generated protobuf message: its static initializer bootstraps the per-message parser.
+    public sealed class FakeProtobufMessage
+    {
+        static FakeProtobufMessage()
+        {
+            Parser = new Google.Protobuf.MessageParser<FakeProtobufMessage>(() => new FakeProtobufMessage());
+        }
+
+        public static Google.Protobuf.MessageParser<FakeProtobufMessage> Parser { get; }
     }
 
     // A gRPC service stub: declares a __Helper_ member and binds via ServerServiceDefinition.

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -93,15 +93,16 @@ public sealed class LibraryBodyIndex
     /// <summary>
     /// Qualified names of types recognized as protobuf/gRPC generated implementation detail,
     /// detected structurally (no attributes are emitted on this code). A type qualifies when
-    /// any of its methods bootstraps a protobuf descriptor — calling
-    /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c> or constructing
-    /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c> — or declares gRPC stub
+    /// any of its methods bootstraps protobuf generated infrastructure — calling
+    /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c>, constructing
+    /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c>, or constructing the
+    /// per-message <c>Google.Protobuf.MessageParser&lt;T&gt;</c> — or declares gRPC stub
     /// infrastructure members whose names are codegen-only (<c>__ServiceName</c>,
     /// <c>__Helper_*</c>, <c>__Marshaller_*</c>, <c>__Method_*</c>). gRPC binding calls
     /// (<c>ServerServiceDefinition</c>/<c>Marshallers</c>) are intentionally not a signal,
-    /// since hand-written registration uses them too. These signals appear only in generated
-    /// code, so perf triage can mark them in Top Leverage and suppress them from Optimization
-    /// Opportunities like other generated detail.
+    /// since hand-written registration uses them too. These signals appear in generated
+    /// protobuf/gRPC code, so perf triage can mark them in Top Leverage and suppress them
+    /// from Optimization Opportunities like other generated detail.
     /// </summary>
     public IReadOnlySet<string> GeneratedFrameworkTypeNames => _generatedFrameworkTypes ??= ComputeGeneratedFrameworkTypes();
 
@@ -120,12 +121,15 @@ public sealed class LibraryBodyIndex
                     && callee.Name == "FromGeneratedCode")
                 || (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
                     && callee.DeclaringType.Name == "GeneratedClrTypeInfo"
+                    && callee.Name == ".ctor")
+                || (IsType(callee.DeclaringType, "Google.Protobuf", "MessageParser")
                     && callee.Name == ".ctor");
-            // Only the protobuf descriptor bootstrap is matched by call: FromGeneratedCode /
-            // GeneratedClrTypeInfo are codegen-only entry points. gRPC binding APIs
-            // (ServerServiceDefinition/Marshallers) are deliberately NOT matched by call, since
-            // hand-written low-level gRPC registration legitimately calls them; gRPC stubs are
-            // instead recognized by their generated __* infrastructure members below.
+            // Only protobuf generated bootstraps are matched by call: FromGeneratedCode,
+            // GeneratedClrTypeInfo, and MessageParser<T> construction are codegen signals.
+            // gRPC binding APIs (ServerServiceDefinition/Marshallers) are deliberately NOT
+            // matched by call, since hand-written low-level gRPC registration legitimately
+            // calls them; gRPC stubs are instead recognized by their generated __*
+            // infrastructure members below.
             if (protobufBootstrap)
                 generated.Add(call.Caller.DeclaringType.ToQualifiedDisplayString());
         }
@@ -145,6 +149,19 @@ public sealed class LibraryBodyIndex
         return generated;
     }
 
+    static bool IsType(TypeRef type, string ns, string name)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null
+            && definition.Namespace == ns
+            && StripGenericArity(definition.Name) == name;
+    }
+
+    static string StripGenericArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
+    }
 
     public static LibraryBodyIndex Open(string path)
     {


### PR DESCRIPTION
## Summary

- Treat protobuf `MessageParser<T>` construction as generated framework infrastructure.
- Mark generated protobuf message types as generated via `GeneratedFrameworkTypeNames`.
- Suppress their rows from `Optimization Opportunities`, while keeping product-authored wrapper rows visible.

Closes #1361.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -v:q
dotnet run --project src/ILInspector.Analysis.Tests -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.TopLeverageSectionTests"
dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.OutputFormatterTests"

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  package Microsoft.Azure.Functions.Worker.Grpc \
  --library \
  -S "Optimization Opportunities" \
  --rows -n 120

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  package Microsoft.Azure.WebJobs.Extensions.ServiceBus \
  --library \
  -S "Optimization Opportunities" \
  --rows -n 120
```

The Functions smokes no longer show generated protobuf message `.cctor()` /
`pb::Google.Protobuf.IMessage.get_Descriptor()` rows for the issue examples.
