### PR TITLE
Reconstruct generic constraints (where clauses) in the fidelity skeleton (#1347)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstraintFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstraintFixture.cs
@@ -1,0 +1,16 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Generic methods whose bodies rely on their generic constraints, used by
+/// <see cref="SkeletonEmitTests"/> to pin the fidelity skeleton's <c>where</c>
+/// clause reconstruction (#1347). Each body uses a referenced constrained
+/// generic — <see cref="System.Nullable{T}"/> requires <c>struct</c>, and
+/// <see cref="System.Exception"/>'s members require the type constraint — so the
+/// skeleton must restate the constraint or the recompile fails (CS0453 / CS1061).
+/// </summary>
+public static class ConstraintFixture
+{
+    public static T? WrapNullable<T>(T value) where T : struct => value;
+
+    public static string DescribeException<T>(T error) where T : System.Exception => error.Message;
+}

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -84,4 +84,20 @@ public class SkeletonEmitTests
             or FidelityCheck.CompileBackStatus.ContextFail,
             $"Skeleton mis-declared a nested generic type (CS0305): {result.Status} / {result.Detail}");
     }
+
+    [Theory]
+    // Bodies whose referenced constrained generic (Nullable<T> needs struct;
+    // Exception members need the type constraint) only binds when the skeleton
+    // restates the method's where clause — otherwise CS0453 / CS1061.
+    [InlineData("WrapNullable")]
+    [InlineData("DescribeException")]
+    public void SkeletonRestatesGenericConstraints(string method)
+    {
+        var result = FidelityCheck.Evaluate(typeof(ConstraintFixture).Assembly.Location)
+            .Single(r => r.Type == "ILInspector.Decompiler.Tests.ConstraintFixture" && r.Method == method);
+
+        Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail,
+            $"Skeleton dropped the generic constraint on {method}: {result.Status} / {result.Detail}");
+    }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1663,24 +1663,29 @@ static class FidelityCheck
             bool defaultCtor = (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
 
             var parts = new List<string>();
-            if (valueType)
-                parts.Add("struct");
-            else if (referenceType)
-                parts.Add("class");
-
+            var baseClasses = new List<string>();
+            var interfaces = new List<string>();
             foreach (var constraintHandle in parameter.GetConstraints())
             {
                 var constraint = reader.GetGenericParameterConstraint(constraintHandle);
-                string typeName = ConstraintTypeName(reader, constraint.Type);
-                // System.ValueType/Object/Enum/Delegate are implied by struct or
-                // are the universal base; an explicit clause is invalid or noise.
-                if (typeName.Length == 0
-                    || typeName is "System.Object" or "System.ValueType")
-                {
+                if (ConstraintTypeName(reader, constraint.Type) is not { Name.Length: > 0 } spelled)
                     continue;
-                }
-                parts.Add(typeName);
+                // System.ValueType/Object are implied by struct or are the
+                // universal base; an explicit clause is invalid or noise.
+                if (spelled.Name is "System.Object" or "System.ValueType")
+                    continue;
+                (spelled.IsInterface ? interfaces : baseClasses).Add(spelled.Name);
             }
+
+            // C# ordering: a single primary constraint first (struct, class, or a
+            // base class — class is invalid alongside a base class, so suppress it
+            // when one is present), then interface constraints, then new() last.
+            if (valueType)
+                parts.Add("struct");
+            else if (referenceType && baseClasses.Count == 0)
+                parts.Add("class");
+            parts.AddRange(baseClasses);
+            parts.AddRange(interfaces);
 
             // `struct` already implies a public parameterless constructor.
             if (defaultCtor && !valueType)
@@ -1694,27 +1699,34 @@ static class FidelityCheck
     }
 
     /// <summary>
-    /// A reliably spellable name for a generic-constraint type, or empty to skip
-    /// it. Only a top-level <see cref="TypeDefinition"/> or an assembly-scoped
-    /// <see cref="TypeReference"/> is spelled; nested, generic-instance (TypeSpec),
-    /// and generic-parameter constraints are skipped so the clause never names
-    /// something the unit cannot bind.
+    /// A reliably spellable name for a generic-constraint type and whether it is
+    /// an interface, or null to skip it. Only a top-level
+    /// <see cref="TypeDefinition"/> or an assembly-scoped <see cref="TypeReference"/>
+    /// is spelled; nested, generic-instance (TypeSpec), and generic-parameter
+    /// constraints are skipped so the clause never names something the unit cannot
+    /// bind. A cross-assembly reference's interface-ness is not visible from the
+    /// target reader, so it is treated as an interface — almost all cross-assembly
+    /// constraint types are interfaces, and a base-class constraint there does not
+    /// carry the reference-type flag that would make `class, Base` invalid.
     /// </summary>
-    static string ConstraintTypeName(MetadataReader reader, EntityHandle handle)
+    static (string Name, bool IsInterface)? ConstraintTypeName(MetadataReader reader, EntityHandle handle)
     {
         switch (handle.Kind)
         {
             case HandleKind.TypeDefinition:
                 var definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
-                return definition.GetDeclaringType().IsNil ? FullName(reader, definition) : "";
+                if (!definition.GetDeclaringType().IsNil)
+                    return null;
+                bool isInterface = (definition.Attributes & TypeAttributes.Interface) != 0;
+                return (FullName(reader, definition), isInterface);
             case HandleKind.TypeReference:
                 var reference = reader.GetTypeReference((TypeReferenceHandle)handle);
                 return reference.ResolutionScope.Kind is HandleKind.AssemblyReference
                     or HandleKind.ModuleDefinition or HandleKind.ModuleReference
-                    ? FullName(reader, reference)
-                    : "";
+                    ? (FullName(reader, reference), true)
+                    : null;
             default:
-                return "";
+                return null;
         }
     }
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1175,16 +1175,17 @@ static class FidelityCheck
         }
 
         string genParams = GenericParamList(reader, typeDef.GetGenericParameters(), InheritedGenericArity(reader, typeDef));
+        string whereClauses = WhereClauses(reader, typeDef.GetGenericParameters(), InheritedGenericArity(reader, typeDef));
 
         if (kind == TypeKind.Delegate)
         {
-            EmitDelegate(reader, typeDef, name, genParams, typeContext, sb, pad);
+            EmitDelegate(reader, typeDef, name, genParams, whereClauses, typeContext, sb, pad);
             return;
         }
 
         if (kind == TypeKind.Interface)
         {
-            EmitInterface(reader, typeHandle, name, genParams, accessibility, sb, pad, indent);
+            EmitInterface(reader, typeHandle, name, genParams, whereClauses, accessibility, sb, pad, indent);
             return;
         }
 
@@ -1200,7 +1201,7 @@ static class FidelityCheck
         if (kind == TypeKind.Struct && InlineArrayAttributeText(reader, typeDef) is { } inlineArrayAttr)
             sb.AppendLine($"{pad}{inlineArrayAttr}");
         string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
-        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{baseClause}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{baseClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
 
         // Field initializers lifted from a target ctor apply to this type's
@@ -1252,7 +1253,7 @@ static class FidelityCheck
     /// references to it (and <c>new D(...)</c> / invocation) bind in a target body.
     /// </summary>
     static void EmitDelegate(MetadataReader reader, TypeDefinition typeDef, string name,
-        string genParams, GenericContext typeContext, StringBuilder sb, string pad)
+        string genParams, string whereClauses, GenericContext typeContext, StringBuilder sb, string pad)
     {
         string ret = "void", parameters = "";
         foreach (var mh in typeDef.GetMethods())
@@ -1269,7 +1270,7 @@ static class FidelityCheck
             catch { }
             break;
         }
-        sb.AppendLine($"{pad}public unsafe delegate {ret} {Identifier(name)}{genParams}({parameters});");
+        sb.AppendLine($"{pad}public unsafe delegate {ret} {Identifier(name)}{genParams}({parameters}){whereClauses};");
     }
 
     /// <summary>
@@ -1278,10 +1279,10 @@ static class FidelityCheck
     /// without bodies or accessibility, as the interface form requires.
     /// </summary>
     static void EmitInterface(MetadataReader reader, TypeDefinitionHandle typeHandle,
-        string name, string genParams, SignatureAccessibility accessibility, StringBuilder sb, string pad, int indent)
+        string name, string genParams, string whereClauses, SignatureAccessibility accessibility, StringBuilder sb, string pad, int indent)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
-        sb.AppendLine($"{pad}public unsafe interface {Identifier(name)}{genParams}");
+        sb.AppendLine($"{pad}public unsafe interface {Identifier(name)}{genParams}{whereClauses}");
         sb.AppendLine($"{pad}{{");
         string inner = pad + "    ";
 
@@ -1319,7 +1320,8 @@ static class FidelityCheck
             try { sig = method.DecodeSignature(SignatureDecoder.Instance, context); }
             catch { continue; }
             string mGen = GenericParamList(reader, method.GetGenericParameters());
-            sb.AppendLine($"{inner}{Clean(sig.ReturnType)} {Identifier(mn)}{mGen}({Parameters(reader, method, sig)});");
+            string mWhere = WhereClauses(reader, method.GetGenericParameters());
+            sb.AppendLine($"{inner}{Clean(sig.ReturnType)} {Identifier(mn)}{mGen}({Parameters(reader, method, sig)}){mWhere};");
         }
 
         foreach (var nested in typeDef.GetNestedTypes())
@@ -1494,6 +1496,7 @@ static class FidelityCheck
         }
 
         string genParams = GenericParamList(reader, method.GetGenericParameters());
+        string whereClauses = WhereClauses(reader, method.GetGenericParameters());
         string returnType = Clean(sig.ReturnType);
         string asyncModifier = realBody is not null && realRequiresAsync && CanBeAsync(returnType)
             ? "async "
@@ -1505,7 +1508,7 @@ static class FidelityCheck
             sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
             return;
         }
-        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}) {{{body}}}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
     }
 
     static string? OperatorDeclaration(string name, string returnType, string parameters)
@@ -1628,6 +1631,91 @@ static class FidelityCheck
     {
         var declaring = typeDef.GetDeclaringType();
         return declaring.IsNil ? 0 : reader.GetTypeDefinition(declaring).GetGenericParameters().Count;
+    }
+
+    /// <summary>
+    /// The C# <c>where</c> clauses for a generic parameter list, so a reconstructed
+    /// type or method restates the constraints its real type arguments satisfy —
+    /// without them a value-type argument is CS0453 and a constrained type
+    /// argument is CS0314. Special constraints (<c>struct</c>/<c>class</c>/
+    /// <c>new()</c>) are always emitted; a type constraint is emitted only when it
+    /// is reliably spellable (a top-level definition or assembly-scoped reference),
+    /// skipping nested, generic (TypeSpec), and parameter constraints so a dropped
+    /// clause never miscompiles worse than today's no-constraint baseline.
+    /// <paramref name="skip"/> drops a nested type's inherited leading parameters,
+    /// matching <see cref="GenericParamList"/>.
+    /// </summary>
+    static string WhereClauses(MetadataReader reader, GenericParameterHandleCollection handles, int skip = 0)
+    {
+        if (handles.Count <= skip)
+            return "";
+
+        var clauses = new List<string>();
+        int index = 0;
+        foreach (var handle in handles)
+        {
+            if (index++ < skip)
+                continue;
+            var parameter = reader.GetGenericParameter(handle);
+            var attributes = parameter.Attributes;
+            bool valueType = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+            bool referenceType = (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+            bool defaultCtor = (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+
+            var parts = new List<string>();
+            if (valueType)
+                parts.Add("struct");
+            else if (referenceType)
+                parts.Add("class");
+
+            foreach (var constraintHandle in parameter.GetConstraints())
+            {
+                var constraint = reader.GetGenericParameterConstraint(constraintHandle);
+                string typeName = ConstraintTypeName(reader, constraint.Type);
+                // System.ValueType/Object/Enum/Delegate are implied by struct or
+                // are the universal base; an explicit clause is invalid or noise.
+                if (typeName.Length == 0
+                    || typeName is "System.Object" or "System.ValueType")
+                {
+                    continue;
+                }
+                parts.Add(typeName);
+            }
+
+            // `struct` already implies a public parameterless constructor.
+            if (defaultCtor && !valueType)
+                parts.Add("new()");
+
+            if (parts.Count > 0)
+                clauses.Add($"where {Identifier(reader.GetString(parameter.Name))} : {string.Join(", ", parts)}");
+        }
+
+        return clauses.Count == 0 ? "" : " " + string.Join(" ", clauses);
+    }
+
+    /// <summary>
+    /// A reliably spellable name for a generic-constraint type, or empty to skip
+    /// it. Only a top-level <see cref="TypeDefinition"/> or an assembly-scoped
+    /// <see cref="TypeReference"/> is spelled; nested, generic-instance (TypeSpec),
+    /// and generic-parameter constraints are skipped so the clause never names
+    /// something the unit cannot bind.
+    /// </summary>
+    static string ConstraintTypeName(MetadataReader reader, EntityHandle handle)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.TypeDefinition:
+                var definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+                return definition.GetDeclaringType().IsNil ? FullName(reader, definition) : "";
+            case HandleKind.TypeReference:
+                var reference = reader.GetTypeReference((TypeReferenceHandle)handle);
+                return reference.ResolutionScope.Kind is HandleKind.AssemblyReference
+                    or HandleKind.ModuleDefinition or HandleKind.ModuleReference
+                    ? FullName(reader, reference)
+                    : "";
+            default:
+                return "";
+        }
     }
 
     /// <summary>C# keywords that can appear as IL identifiers get an @ escape.</summary>


### PR DESCRIPTION
Fixes #1347 (the constraint half of #1344). Burns down CS0453 + CS0314 on the #1318 changed-method fidelity queue.

## Bug
The fidelity skeleton reconstructed generic types/methods **without their `where` clauses**. So once a referenced constrained generic enforced its real constraint:
- a value-type argument was **CS0453** (`must be a non-nullable value type`),
- a constrained type argument was **CS0314** (`SyntaxList<TNode>` needs `where TNode : SyntaxNode`).

## Fix
`EmitType` (class/struct/interface/delegate) and `EmitMethod` restate constraints from metadata:
- special constraints (`struct`/`class`/`new()`) — always;
- a type constraint — only when **reliably spellable** (top-level definition or assembly-scoped reference); nested, generic-instance, and parameter constraints are skipped so a dropped clause never miscompiles worse than today.

Nested types restate only their own parameters' constraints (reusing the inherited-arity skip from #1346).

## Changed-method fidelity (#1251/#1209 delta)
| Metric | Before | After |
|---|--:|--:|
| exact opcode match | 22 | 22 |
| opcode diff (Full) | 21 | 21 |
| recompile fail | 94 | 94 |
| **CS0453 (struct)** | **24** | **0** |
| **CS0314 (type)** | **20** | **0** |

CS0453 and CS0314 are eliminated and the emitted clauses are correct (110 well-formed `where` clauses in one Roslyn unit). Totals are flat because the same rows unmask two **deeper, pre-existing** skeleton gaps:
- **CS0311** — the skeleton reconstructs types without their base type/interfaces (`UsingDirectiveSyntax` without `SyntaxNode`, `ITypeDefinition` without `IReference`), so a now-present constraint can't be satisfied;
- **CS0234** — internal types of a *referenced* assembly used in sibling signatures (`OneOrMany<T>`) aren't bindable.

Both are the type-hierarchy / cross-assembly-internal reconstruction blocker, split to a follow-up (filing next). This PR is the constraint layer — correct and necessary, parallel to the #1346 arity layer.

## Tests
Adds `ConstraintFixture` + `SkeletonEmitTests` cases (`Nullable<T>` struct constraint, `Exception` type constraint — each only compiles back when the skeleton restates the clause). Full decompiler suite: **1119 passed** (no gate regression from the broad where-clause emission).

Adversarial review (GPT-5.5) requested; will summarize in a comment.