### PR TITLE
Fix property sugar over-raise guards

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
@@ -1,0 +1,122 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class PropertySugarPassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void StaticIndexedGetter_StaysCall()
+    {
+        var function = GetterFunction(Accessor("get_Item", Int32, [Int32], hasThis: false), [new LoadArgument(0, "i", Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
+    public void StaticIndexedSetter_StaysCall()
+    {
+        var function = SetterFunction(Accessor("set_Item", Void, [Int32, Int32], hasThis: false), [new LoadArgument(0, "i", Int32), new Constant(42, Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
+    public void GenericGetter_StaysCall()
+    {
+        var function = GetterFunction(Accessor("get_Value", Int32, [], hasThis: false) with { TypeArguments = [Int32] }, []);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
+    public void GenericSetter_StaysCall()
+    {
+        var function = SetterFunction(Accessor("set_Value", Void, [Int32], hasThis: false) with { TypeArguments = [Int32] }, [new Constant(42, Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
+    public void StaticNonIndexedGetter_StillRaises()
+    {
+        var function = GetterFunction(Accessor("get_Count", Int32, [], hasThis: false), []);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        var property = Assert.Single(function.Descendants.OfType<LoadProperty>());
+        Assert.False(property.HasInstance);
+        Assert.Empty(property.IndexArguments);
+    }
+
+    [Fact]
+    public void StaticNonIndexedSetter_StillRaises()
+    {
+        var function = SetterFunction(Accessor("set_Count", Void, [Int32], hasThis: false), [new Constant(42, Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        var property = Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.False(property.HasInstance);
+        Assert.Empty(property.IndexArguments);
+    }
+
+    [Fact]
+    public void InstanceIndexedSetter_StillRaises()
+    {
+        var function = SetterFunction(
+            Accessor("set_Item", Void, [Int32, Int32], hasThis: true),
+            [new LoadArgument(0, "self", Holder), new LoadArgument(1, "i", Int32), new Constant(42, Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        var property = Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.True(property.HasInstance);
+        Assert.Single(property.IndexArguments);
+    }
+
+    static MethodRef Accessor(string name, TypeRef returnType, System.Collections.Immutable.ImmutableArray<TypeRef> parameters, bool hasThis)
+        => new(Holder, name, returnType, parameters, hasThis) { IsSpecialName = true };
+
+    static IrFunction GetterFunction(MethodRef accessor, IReadOnlyList<IrExpression> arguments)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new Return(new Call(accessor, isVirtual: false, arguments)));
+        body.Add(block);
+        return Function(accessor.ReturnType, body);
+    }
+
+    static IrFunction SetterFunction(MethodRef accessor, IReadOnlyList<IrExpression> arguments)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new ExpressionStatement(new Call(accessor, isVirtual: false, arguments)));
+        block.Add(new Return(null));
+        body.Add(block);
+        return Function(Void, body);
+    }
+
+    static IrFunction Function(TypeRef returnType, BlockContainer body)
+        => new(
+            "M",
+            Holder,
+            new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -56,14 +56,18 @@ public sealed class PropertySugarPass : IIrPass
         => callee.IsSpecialName
             && callee.Name.StartsWith("get_", StringComparison.Ordinal)
             && callee.Name.Length > "get_".Length
-            && callee.ReturnType is not { Namespace: "System", Name: "Void" };
+            && callee.ReturnType is not { Namespace: "System", Name: "Void" }
+            && callee.TypeArguments.IsEmpty
+            && (callee.HasThis || callee.ParameterTypes.Length == 0);
 
     static bool IsSetter(MethodRef callee)
         => callee.IsSpecialName
             && callee.Name.StartsWith("set_", StringComparison.Ordinal)
             && callee.Name.Length > "set_".Length
             && callee.ParameterTypes.Length >= 1
-            && callee.ReturnType is { Namespace: "System", Name: "Void" };
+            && callee.ReturnType is { Namespace: "System", Name: "Void" }
+            && callee.TypeArguments.IsEmpty
+            && (callee.HasThis || callee.ParameterTypes.Length == 1);
 
     // An event accessor is a void add_X/remove_X special-name method taking the
     // handler delegate — exactly one explicit parameter (the receiver, if any,


### PR DESCRIPTION
Fixes #1350.

## Summary

Narrows `PropertySugarPass` so it no longer raises accessor shapes that have no C# property/indexer spelling in this model:

- generic `get_`/`set_` accessors decline because `LoadProperty`/`StoreProperty` cannot carry method type arguments;
- static accessor calls with index arguments decline because static indexers are not spellable here;
- spellable static non-indexed properties and instance indexers still raise.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PropertySugarPassTests/*"`
  - `Total: 7, Errors: 0, Failed: 0, Skipped: 0`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
  - `Total: 1126, Errors: 0, Failed: 0, Skipped: 0`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false`
  - succeeded

Generated quality-diff card for this branch:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,883 methods
Correctness coverage: validity sampled 350 / 87,883 (0.40%); fidelity sampled 22 / 87,883 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,318 (87.98%) | +424 |
| Conditional-branch residual | 2,290 (2.62%) | 2,304 (2.62%) | +14 |
| Forward-merge stops | 2,284 (2.61%) | 2,295 (2.61%) | +11 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,883 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

The same generated card and exit 1 reproduced on clean `origin/main` at `4ece0ed6`, so this is current baseline drift/corpus-size change rather than a regression from this patch.

## Adversarial review

Requested Opus 4.8 review. It found no material pass-logic defects; it identified one low coverage gap for static non-indexed setters, which this PR addressed with `StaticNonIndexedSetter_StillRaises`.
