### PR TITLE
Gate struct-ctor raise on receiver storage type identity (#1352)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1740,6 +1740,56 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void StructConstructor_MismatchedReceiverStorageType_StaysLowered()
+    {
+        // ldloca A; call B::.ctor()  — the receiver's storage type (A) differs from the
+        // constructor's declaring type (B), so raising would emit the invalid whole-value
+        // assignment `A V_0 = new B();`. The pass must decline and leave the call lowered.
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var typeA = TypeRef.Definition("Synthetic", "Samples", "A", ValueTypeHint.ValueType);
+        var typeB = TypeRef.Definition("Synthetic", "Samples", "B", ValueTypeHint.ValueType);
+        var ctorB = new MethodRef(typeB, ".ctor", voidType, [], HasThis: true);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ExpressionStatement(new Call(ctorB, isVirtual: false, [new LoadLocalAddress(0, typeA)])));
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("Synthetic", "Samples", "Owner"), signature, [typeA], container);
+
+        new StructConstructorPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), s => s.Index == 0);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var call = Assert.IsType<Call>(Assert.IsType<ExpressionStatement>(Assert.Single(block.Children)).Expression);
+        Assert.Equal(".ctor", call.Callee.Name);
+        Assert.Equal(typeB, call.Callee.DeclaringType);
+    }
+
+    [Fact]
+    public void StructConstructor_GenericValueTypeReceiverMatch_RaisesToNewObject()
+    {
+        // A matching generic value-type receiver (MyStruct<int> storage and declaring type)
+        // is a real `s = new MyStruct<int>(7)` shape and must still raise.
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var definition = TypeRef.Definition("Synthetic", "Samples", "MyStruct`1", ValueTypeHint.ValueType);
+        var genericStruct = TypeRef.GenericInstance(definition, [intType]);
+        var ctor = new MethodRef(genericStruct, ".ctor", voidType, [intType], HasThis: true);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ExpressionStatement(new Call(ctor, isVirtual: false, [new LoadLocalAddress(0, genericStruct), new Constant(7, intType)])));
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("Synthetic", "Samples", "Owner"), signature, [genericStruct], container);
+
+        new StructConstructorPass().Run(function, PassContext.None);
+
+        var store = Assert.IsType<StoreLocal>(Assert.Single(block.Children));
+        var value = Assert.IsType<NewObject>(store.Value);
+        Assert.Equal(ctor, value.Constructor);
+    }
+
+    [Fact]
     public void CallSite_RefKinds_PrintRefOutAndBareIn()
     {
         // A managed pointer forwarded to a by-ref parameter needs the parameter's

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructConstructorPass.cs
@@ -33,6 +33,14 @@ public sealed class StructConstructorPass : IIrPass
             if (call.Arguments.Count == 0)
                 continue;
 
+            // The receiver's storage type must be the same value type as the constructor's
+            // declaring type. Without this, `ldloca a; call B::.ctor()` would raise to the
+            // invalid whole-value assignment `A a = new B();`. Check before the (destructive)
+            // ResolveTarget so a decline leaves the IR untouched.
+            var receiverType = ReceiverStorageType(call.Arguments[0], byRefSlots);
+            if (receiverType is null || !receiverType.Equals(call.Callee.DeclaringType))
+                continue;
+
             var receiver = ResolveTarget(call.Arguments[0], byRefSlots);
             if (receiver is null)
                 continue;
@@ -49,6 +57,29 @@ public sealed class StructConstructorPass : IIrPass
     // receiver travels with it, so the rewrite stays a local tree edit.
     static bool IsRaisableTarget(IrExpression receiver)
         => receiver is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress;
+
+    // The value type of the receiver's storage, read non-destructively (unlike
+    // ResolveTarget, which detaches the by-ref slot's address/store). Used to verify
+    // the storage type matches the constructor's declaring type before raising.
+    static TypeRef? ReceiverStorageType(IrExpression receiver, Dictionary<int, SlotTarget> byRefSlots)
+    {
+        var address = receiver;
+        if (!IsRaisableTarget(address)
+            && receiver is LoadStackSlot slot
+            && byRefSlots.TryGetValue(slot.Slot, out var target)
+            && ReferenceEquals(target.Load, receiver))
+        {
+            address = target.Address;
+        }
+
+        return address switch
+        {
+            LoadLocalAddress local => local.Type,
+            LoadArgumentAddress argument => argument.Type,
+            LoadFieldAddress field => field.Field.Type,
+            _ => null,
+        };
+    }
 
     static IrExpression? ResolveTarget(IrExpression receiver, Dictionary<int, SlotTarget> byRefSlots)
     {


### PR DESCRIPTION
Burndown row 3 of #1356.

## Over-raise claim being narrowed

`StructConstructorPass` raised any instance `.ctor` call whose receiver was the address of a nameable storage location, **without** checking the receiver's storage type against the constructor's declaring type. The mismatched shape

```text
ldloca A; call B::.ctor()
```

became the invalid whole-value assignment `A V_0 = new B();` while still reporting **Full** fidelity.

## Fix (narrowest proof gate)

Before raising, require the receiver's storage value type to equal the callee's declaring type. `TypeRef.Equals` already compares generic-instance definition plus type arguments, so a matching `MyStruct<int>` receiver still raises while a mismatched `A`/`B` declines. The storage type is read **non-destructively** before `ResolveTarget` mutates the by-ref-slot tree, so a decline leaves the IR untouched and the call stays lowered/diagnostic (an honesty improvement, not a regression).

No pass widening; the gate only makes the over-raise impossible.

## Adversarial fixture + positive canary

- `StructConstructor_MismatchedReceiverStorageType_StaysLowered`: `ldloca A; call B::.ctor()` stays a lowered `Call` — no `StoreLocal`/`NewObject` emitted.
- `StructConstructor_GenericValueTypeReceiverMatch_RaisesToNewObject`: matching `MyStruct<int>` receiver/declaring type still raises to `new MyStruct<int>(7)`.
- The 3 existing struct-ctor positives (interpolated-handler in-place ctor, by-ref stack-slot receiver) still raise.

## Corpus quality diff

Compared against a **freshly captured origin/main snapshot** over the same 14-assembly corpus (the committed baseline.json is stale — different method count/sample — so it conflated drift with this change):

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,319 (87.98%) | 77,319 (87.98%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18 | opcode-diff 4/22, exact 18 | 0 |
| Pass bugs | 0 | 0 | 0 |

**Verdict: corpus sensor matched baseline tolerances.** The over-raise is an adversarial shape not present in the corpus, so there is no fidelity movement; changed-method fidelity is therefore not separately checkable here.

`src/ILInspector.Decompiler.Tests` struct-ctor tests pass (5/5); full suite run in progress.

Cross-model adversarial review (GPT-5.5) requested per AGENTS.md; result will be posted as a follow-up comment.

Closes #1352.