### PR TITLE
Guard stackalloc span raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -1,0 +1,95 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StackAllocSpanPassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+
+    [Fact]
+    public void CorelibSpanDirectStackalloc_Raises()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(new Constant(4, Int32))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CorelibReadOnlySpanDirectStackalloc_Raises()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "ReadOnlySpan`1"),
+            new StackAllocate(new Constant(4, Int32))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void UserSystemSpanLookalike_DoesNotRaise()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.Definition("UserAssembly", "System", "Span`1"),
+            new StackAllocate(new Constant(4, Int32))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Equal("UserAssembly", construction.Constructor.DeclaringType.ElementType?.Assembly);
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void WrappedStackallocPointer_DoesNotRaise()
+    {
+        var wrapper = new Call(
+            new MethodRef(Holder, "Wrap", TypeRef.Pointer(Void), [TypeRef.Pointer(Byte)], HasThis: false),
+            isVirtual: false,
+            [new StackAllocate(new Constant(4, Int32))]);
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), wrapper));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<Call>());
+        Assert.Single(function.Descendants.OfType<StackAllocate>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer)
+    {
+        var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
+        var ctor = new MethodRef(span, ".ctor", Void, [TypeRef.Pointer(Void), Int32], HasThis: true);
+        return new NewObject(ctor, [pointer, new Constant(1, Int32)]);
+    }
+
+    static IrFunction Build(IrExpression value)
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(value));
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(value.ResultType ?? Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -192,6 +192,30 @@ public static class MemberIdentity
         && parameter is { Kind: TypeRefKind.SzArray, ElementType: { } arrayElement }
         && arrayElement.Equals(element);
 
+    public static bool IsStackAllocSpanConstructor(NewObject newObject, out TypeRef element)
+    {
+        element = TypeRef.Unsupported("unmatched stackalloc span constructor");
+        if (newObject.Constructor is not
+            {
+                Name: ".ctor",
+                HasThis: true,
+                TypeArguments.IsEmpty: true,
+                DeclaringType: var declaringType,
+                ParameterTypes: [var pointer, var length],
+            }
+            || newObject.Arguments.Count != 2
+            || !IsSpanLikeType(declaringType)
+            || declaringType.TypeArguments is not [var spanElement]
+            || !pointer.Equals(TypeRef.Pointer(s_void))
+            || !length.Equals(s_int))
+        {
+            return false;
+        }
+
+        element = spanElement;
+        return true;
+    }
+
     public static bool IsReadOnlySpanCopyTo(Call call, TypeRef element)
         => !call.IsVirtual
             && call.Callee is

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -29,17 +27,13 @@ public sealed class StackAllocSpanPass : IIrPass
     {
         foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
         {
-            var declaring = newObject.Constructor.DeclaringType;
-            if (declaring.Kind != TypeRefKind.GenericInstance
-                || declaring.ElementType is not { Namespace: "System" } definition
-                || StripArity(definition.Name) is not ("Span" or "ReadOnlySpan")
-                || declaring.TypeArguments is not [var element])
+            if (!MemberIdentity.IsStackAllocSpanConstructor(newObject, out var element))
                 continue;
 
             // Span<T>(void* pointer, int length): the pointer is the stackalloc,
             // the length is the logical element count.
             if (newObject.Arguments is not [{ } pointer, var count]
-                || !(pointer is StackAllocate || pointer.Descendants.OfType<StackAllocate>().Any()))
+                || pointer is not StackAllocate)
                 continue;
 
             count.Detach();
@@ -48,11 +42,5 @@ public sealed class StackAllocSpanPass : IIrPass
             context.Stepper.StepOver("raise Span-over-stackalloc to stackalloc T[n]", newObject);
             newObject.ReplaceWith(raised);
         }
-    }
-
-    static string StripArity(string name)
-    {
-        int tick = name.IndexOf('`');
-        return tick < 0 ? name : name[..tick];
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1351. Narrows `StackAllocSpanPass` so it only raises the real compiler shape for corelib `System.Span<T>` / `System.ReadOnlySpan<T>` `.ctor(void*, int)` with a direct `StackAllocate` pointer operand.

This prevents two over-raises:

- user `System.Span<T>` lookalikes no longer raise to source `stackalloc T[n]`;
- wrapper calls such as `Wrap(stackalloc byte[n])` are no longer dropped just because a `StackAllocate` appears below the pointer argument.

## Tests

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/StackAllocSpanPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/UnsafeEmitterTests/*"`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll --pass-impact stackalloc-span --cap 100000`

`src/ILInspector.Decompiler.Tests` full-project runner was also attempted, but it produced no terminal result after a long wait and was stopped; the focused pass tests and adjacent real-IL unsafe emitter tests completed successfully.

## Quality card

Checked-in baseline card (same result on clean `origin/main`, so the reported regressions are baseline drift, not this branch):

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,883 methods
Correctness coverage: validity sampled 350 / 87,883 (0.40%); fidelity sampled 22 / 87,883 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,318 (87.98%) | +424 |
| Conditional-branch residual | 2,290 (2.62%) | 2,304 (2.62%) | +14 |
| Forward-merge stops | 2,284 (2.61%) | 2,295 (2.61%) | +11 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,883 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

Branch-vs-current-origin snapshot card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,883 methods
Correctness coverage: validity sampled 350 / 87,883 (0.40%); fidelity sampled 22 / 87,883 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,318 (87.98%) | 77,318 (87.98%) | 0 |
| Conditional-branch residual | 2,304 (2.62%) | 2,304 (2.62%) | 0 |
| Forward-merge stops | 2,295 (2.61%) | 2,295 (2.61%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 87,883 (0.40%) | 4/350 — sampled 350 / 87,883 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/corpus-delta-1351.json`
```

Pass impact:

```text
stackalloc-span changed 0/5029 methods (0.00%); 0 pass bugs
```

## Adversarial review

Requested cross-model review from Opus 4.8. Result: no blocking findings. Follow-up applied: added a `ReadOnlySpan<T>` direct-stackalloc positive canary in addition to the `Span<T>` positive and the two adversarial negatives.
