### PR TITLE
Fix switch expression leave-target overraise

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchExpressionRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchExpressionRaisingTests.cs
@@ -1,0 +1,72 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class SwitchExpressionRaisingTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void ValueBlocksWithLeaveTargetedArm_DeclinesSwitchExpressionRaise()
+    {
+        var function = BuildLeaveTargetedCandidate();
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<SwitchExpression>());
+        Assert.Contains(function.Body.Blocks, block => block.StartOffset == 0x0002);
+        Assert.Single(function.Descendants.OfType<Leave>());
+    }
+
+    [Fact]
+    public void ValueBlocksWithoutLeaveTarget_RaisesToSwitchExpression()
+    {
+        var function = BuildLeaveTargetedCandidate(includeLeaveTarget: false);
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var expression = Assert.Single(function.Descendants.OfType<SwitchExpression>());
+        Assert.Equal(2, expression.Arms.Count);
+        Assert.DoesNotContain(function.Body.Blocks, block => block.StartOffset == 0x0002);
+    }
+
+    static IrFunction BuildLeaveTargetedCandidate(bool includeLeaveTarget = true)
+    {
+        var body = new BlockContainer();
+
+        var entry = new Block(0x0000);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [0x0002]));
+        body.Add(entry);
+
+        var defaultBlock = new Block(0x0001);
+        defaultBlock.Add(new StoreLocal(0, Int32, new Constant(99, Int32)));
+        defaultBlock.Add(new Branch(0x0003));
+        body.Add(defaultBlock);
+
+        var caseBlock = new Block(0x0002);
+        caseBlock.Add(new StoreLocal(0, Int32, new Constant(42, Int32)));
+        caseBlock.Add(new Branch(0x0003));
+        body.Add(caseBlock);
+
+        var join = new Block(0x0003);
+        join.Add(new Return(new LoadLocal(0, Int32)));
+        body.Add(join);
+
+        if (includeLeaveTarget)
+        {
+            var residue = new Block(0x0004);
+            residue.Add(new Leave(0x0002));
+            body.Add(residue);
+        }
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -65,7 +65,7 @@ public sealed class SwitchRaisingPass : IIrPass
             for (int s = 0; s < blocks.Count; s++)
             {
                 if (blocks[s].Children is [.., SwitchBranch sw]
-                    && (RaiseSwitchExpressionReturn(container, s, sw, stepper)
+                    && (RaiseSwitchExpressionReturn(container, s, sw, leaveTargets, stepper)
                         || Raise(container, s, sw, leaveTargets, stepper)
                         || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
                     return true;
@@ -355,7 +355,7 @@ public sealed class SwitchRaisingPass : IIrPass
     /// between two value blocks (lowered to a <c>?:</c> arm). This is the
     /// AssemblyNameParser::IsWhiteSpace shape.
     /// </summary>
-    static bool RaiseSwitchExpressionReturn(BlockContainer container, int s, SwitchBranch sw, Stepper stepper)
+    static bool RaiseSwitchExpressionReturn(BlockContainer container, int s, SwitchBranch sw, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks;
         var offsetToIndex = new Dictionary<int, int>();
@@ -469,7 +469,7 @@ public sealed class SwitchRaisingPass : IIrPass
         foreach (int idx in owned)
             if (idx < defaultIndex || idx >= join)
                 return false;
-        if (!OnlyReachedByTable(blocks, owned, s, []))
+        if (!OnlyReachedByTable(blocks, owned, s, leaveTargets))
             return false;
 
         BuildSwitchExpression(container, s, sw, caseTargets, defaultArm, join, stepper);


### PR DESCRIPTION
## Summary

Fixes #1354 and claims #1356 priority 2.

`SwitchRaisingPass` already computes function-wide `leaveTargets`, but the switch-expression return path passed an empty set into `OnlyReachedByTable`. This threads the real `leaveTargets` into that path so a residual `Leave` targeting an owned value arm prevents the switch-expression raise instead of removing a still-targeted block.

## Tests

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/SwitchExpressionRaisingTests/*"`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`

## Quality card against checked-in baseline

The checked-in baseline predates current `origin/main` after #1355, so this generated card reports existing baseline drift.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,883 methods
Correctness coverage: validity sampled 350 / 87,883 (0.40%); fidelity sampled 22 / 87,883 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,318 (87.98%) | +424 |
| Conditional-branch residual | 2,290 (2.62%) | 2,304 (2.62%) | +14 |
| Forward-merge stops | 2,284 (2.61%) | 2,295 (2.61%) | +11 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,883 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)

## Patch-local quality card

Generated by first emitting a same-worktree parent snapshot at `HEAD^`, then diffing this branch against it.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,883 methods
Correctness coverage: validity sampled 350 / 87,883 (0.40%); fidelity sampled 22 / 87,883 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,318 (87.98%) | 77,318 (87.98%) | 0 |
| Conditional-branch residual | 2,304 (2.62%) | 2,304 (2.62%) | 0 |
| Forward-merge stops | 2,295 (2.61%) | 2,295 (2.61%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 87,883 (0.40%) | 4/350 — sampled 350 / 87,883 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,883 (0.03%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/1354-samepath-corpus-delta.json`

## Changed-method fidelity

`--emit-corpus-delta` against the same-worktree parent snapshot produced 2 method-key changes: the removed/added `SwitchRaisingPass::RaiseSwitchExpressionReturn` helper signature after adding the `HashSet<int> leaveTargets` parameter. Both entries are `Partial` and `fidelityCheck: not-sampled`; no product corpus method changed fidelity or aggregate corpus metrics.

## Adversarial review

Cross-model adversarial review (Opus 4.8) found no blocking correctness issues. It verified that `Targets()` does not enumerate `Leave`, so `OnlyReachedByTable`'s `ownedOffsets.Overlaps(leaveTargets)` guard is the only protection for this edge class; the patch makes the expression path consistent with the statement switch paths. Non-blocking suggestions were limited to optional extra default-arm coverage and noting that the discriminating assertions are the absence of `SwitchExpression` and preservation of the targeted arm block.
