### PR TITLE
Document decompiler correctness gauntlet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Keep this file as a resolver plus essential repo workflow rules. Put detailed ar
 For decompiler raise, scorecard, ledger, adversarial fixture, or predicate work,
 read `docs/decompiler-quality.md` first, then
 `docs/design/decompiler-substrate.md`.
+Use `docs/decompiler-correctness-pipeline.md` to choose the right test/harness
+"boss" for a decompiler PR and to report the expected evidence.
 
 The current decompiler priority is high-value hardening:
 
@@ -102,6 +104,8 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 
 For decompiler-affecting PRs, follow this evidence and review contract:
 
+- Documentation-only PRs that do not claim new measured behavior may stop at
+  markdownlint; state that the change is docs-only.
 - Include the tool-generated quality-diff card. Paste harness output; do not
   hand-construct aggregate tables.
 - For risky behavior changes (raise/structuring/printer semantics), include a

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved. |
 | [Sample References](sample-references.md) | Extracting code samples from XML docs. |
 | [Reading IR Dumps](decompiler-ir-dumps.md) | How maintainers read DecompilerHarness per-pass IR dumps to diagnose decompiled output. |
+| [Decompiler Correctness Pipeline](decompiler-correctness-pipeline.md) | The staged gauntlet of decompiler checks, from entry gates to changed-method fidelity. |
 | [Decompiler Burndown Curator](decompiler-burndown-curator.md) | Operating protocol for decompiler burndown queue hygiene, stale PRs, CI breaks, and agent delegation. |
 
 ### Contributor docs

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -1,33 +1,55 @@
 # Decompiler Correctness Pipeline
 
-This document describes the decompiler test and harness stack as an intentionally
-designed gauntlet. [decompiler.md](decompiler.md) explains how the decompiler
-pipeline produces output. [decompiler-quality.md](decompiler-quality.md)
-explains the quality strategy and target selection. This page answers a more
-operational question: **which boss did this change beat, and which boss is still
-ahead?**
+This document designs the decompiler test and harness stack as an intentionally
+staged correctness gauntlet. It is **not** just a catalog of today's harness
+flags. The current tools are the raw material; this document names the
+first-class correctness system we want agents and maintainers to use.
 
-The core idea is to stop treating the harness modes as a bag of tools. They form
-a staged correctness pipeline. Early stages are cheap, local, and should be
-green all the time. Later stages are broader, slower, and answer harder
-questions. A PR should run the highest stage its change can affect, then report
-that result in reviewer-sized form.
+[decompiler.md](decompiler.md) explains how the decompiler pipeline produces
+output. [decompiler-quality.md](decompiler-quality.md) explains the quality
+strategy and target selection. This page answers a more operational design
+question: **which boss did this change beat, and which boss is still ahead?**
+
+The core idea is to stop treating the harness modes as a bag of independent
+tools. They should behave like a staged pipeline. Early stages are cheap, local,
+and should be green all the time. Later stages are broader, slower, and answer
+harder questions. A PR should run the highest stage its change can affect, then
+report that result in reviewer-sized form.
+
+## Design principles
+
+The correctness system should have these properties:
+
+1. **Named proof levels.** Every check has a role: entry, shape, validity,
+   annotation, artifact, structure, opcode, corpus, changed-method, final.
+2. **One claim per level.** A check should say exactly what it proves and what it
+   is blind to. No stage gets to imply more than it measured.
+3. **Machine-readable artifacts.** Corpus and changed-method stages produce JSON
+   artifacts that reviewers can drill into; PR bodies get compact generated
+   cards.
+4. **Population alignment.** Risky PRs must measure the methods they changed, not
+   only an unrelated global sample.
+5. **Honest exits.** If a method cannot be checked, the result is not success; it
+   is a named blocker bucket.
+6. **Work generation by failed boss.** New work comes from the lowest failing
+   stage, not from taste or a stale backlog.
 
 ## The gauntlet
 
-| Stage | Boss | Current tools | What it proves | Does not prove |
+| Stage | Boss | Current implementation | What it proves | Does not prove |
 | --- | --- | --- | --- | --- |
 | 0 | Entry gate | build, focused xUnit tests, IR invariant checks | The code compiles and the pass preserves tree shape. | That output is valid or faithful. |
 | 1 | Shape proof | pass fixtures, adversarial negatives, sidecar facts | The pass recognizes a specific lowering and declines near misses. | That the same logic is safe on the corpus. |
-| 2 | Syntax boss | `--validity-check`, `Full malformed`, Roslyn parse/statement legality | Claimed-Full C# parses and is statement-legal. | That valid C# means the same thing. |
-| 3 | Binding boss | semantic validity diagnostics | Claimed-Full C# binds outside known shell noise. | Opcode equivalence. |
-| 4 | Altitude boss | idiom scorecard, `LoweringCoverage`, sidecar rows | The output reached the intended C# idiom. | Soundness around near misses. |
-| 5 | Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` | Which control-flow or fidelity shapes remain unraised. | That raised shapes are semantically faithful. |
-| 6 | Opcode boss | `--fidelity-check`, fixture fidelity gates, lowered fidelity gates | Decompiled body recompiles to the same canonical opcode stream. | Methods the check cannot recompile. |
-| 7 | Artifact boss | `--type-check`, whole-type/source checks | Type/file-level artifacts are coherent: type kind, modifiers, members, usings. | Method-body semantic fidelity. |
-| 8 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card`, daily corpus, PR quick corpus | Aggregate movement across real assemblies, including regressions and coverage. | That the changed methods were opcode-checked. |
-| 9 | Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` | The methods a behavior PR changed are identified and attempted by compile-back fidelity. | That uncheckable changed methods are safe. |
-| 10 | Final boss | changed-method fidelity over the risky target population, improved examples, still-flat near misses, adversarial review | A risky raise/structuring PR has evidence over the methods it actually changed and its nearest false positives. | Whole-program semantic equivalence. |
+| 2 | Method validity boss | `--validity-check`, `Full malformed`, semantic validity diagnostics | Claimed-Full method C# parses, is statement-legal, and binds outside known shell noise. | That valid C# means the same thing. |
+| 3 | Annotation boss | `--annotation-check`, annotation gates | Allocation/unsafety/lifetime annotations agree with raw IL witnesses. | Whether the C# body itself is right. |
+| 4 | Type artifact boss | `--type-check`, whole-type/source checks | Type/file-level artifacts are coherent: type kind, modifiers, members, usings, surface. | Method-body semantic fidelity or binding. |
+| 5 | Type binding boss | `--bind-check`, type-bind gates | Whole-type/source artifacts bind without ambiguous/missing-reference errors outside known noise. | Method-body opcode equivalence. |
+| 6 | Altitude boss | idiom scorecard, `LoweringCoverage`, sidecar rows | The output reached the intended C# idiom. | Soundness around near misses. |
+| 7 | Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` | Which control-flow or fidelity shapes remain unraised. | That raised shapes are semantically faithful. |
+| 8 | Opcode boss | `--fidelity-check`, fixture fidelity gates, lowered fidelity gates | Decompiled body recompiles to the same canonical opcode stream. | Methods the check cannot recompile. |
+| 9 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card`, daily corpus, PR quick corpus | Aggregate movement across real assemblies, including regressions and coverage. | That the changed methods were opcode-checked. |
+| 10 | Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` | The methods a behavior PR changed are identified and attempted by compile-back fidelity. | That uncheckable changed methods are safe. |
+| 11 | Final boss | changed-method fidelity over the risky target population, improved examples, still-flat near misses, adversarial review | A risky raise/structuring PR has evidence over the methods it actually changed and its nearest false positives. | Whole-program semantic equivalence. |
 
 The goal is not to make every PR fight every boss. The goal is to make the
 highest relevant boss explicit. A docs-only PR may stop at markdown lint. A
@@ -43,6 +65,9 @@ Use these names in issues and PRs when selecting evidence:
 | **Entry gate** | Build and focused tests. This should be 100% green before any broader claim. |
 | **Shape proof** | The pass-specific `shape + proof + decline` story: positive fixture plus near-miss negative. |
 | **Validity** | Parse/statement/binding proof. This catches invalid C# and many skeleton defects. |
+| **Annotation fidelity** | Allocation/unsafety/lifetime facts agree with independent IL witnesses. |
+| **Type artifact correctness** | Whole-type/source output has the right type/file/member shape. |
+| **Type binding** | Whole-type/source output binds in a Roslyn harness. |
 | **Fidelity** | Compile-back opcode proof. This is the semantic body oracle. |
 | **Completeness** | Raised-vs-residual coverage: `--gaps`, `--structuring-stops`, scorecard/ledger movement. |
 | **Corpus health** | Aggregate real-world signal from the fixed corpus. |
@@ -116,9 +141,11 @@ should refer to the role they serve:
 
 | Role | Command / artifact |
 | --- | --- |
-| Syntax boss | `--validity-check`, `Full malformed` |
+| Method validity boss | `--validity-check`, `Full malformed`, semantic defects |
+| Annotation boss | `--annotation-check` |
 | Opcode boss | `--fidelity-check` |
-| Artifact boss | `--type-check` |
+| Type artifact boss | `--type-check` |
+| Type binding boss | `--bind-check` |
 | Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` |
 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card` |
 | Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` |
@@ -134,6 +161,9 @@ When the burndown queue is empty, do not invent rows. Ask which boss is failing:
 - Entry gate failures become build/test fixes.
 - Shape proof failures become adversarial fixtures or predicate hardening.
 - Validity failures become `Full malformed` or semantic-defect root-cause issues.
+- Annotation failures become classifier/importer precision or recall issues.
+- Type artifact failures become composer/signature/display issues.
+- Type binding failures become qualification, using-hoist, or reference issues.
 - Structure failures become `--gaps` / `--structuring-stops` pattern issues.
 - Opcode failures become fidelity docket issues.
 - Corpus aggregate movement becomes quality-card regression work.

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -1,0 +1,156 @@
+# Decompiler Correctness Pipeline
+
+This document describes the decompiler test and harness stack as an intentionally
+designed gauntlet. [decompiler.md](decompiler.md) explains how the decompiler
+pipeline produces output. [decompiler-quality.md](decompiler-quality.md)
+explains the quality strategy and target selection. This page answers a more
+operational question: **which boss did this change beat, and which boss is still
+ahead?**
+
+The core idea is to stop treating the harness modes as a bag of tools. They form
+a staged correctness pipeline. Early stages are cheap, local, and should be
+green all the time. Later stages are broader, slower, and answer harder
+questions. A PR should run the highest stage its change can affect, then report
+that result in reviewer-sized form.
+
+## The gauntlet
+
+| Stage | Boss | Current tools | What it proves | Does not prove |
+| --- | --- | --- | --- | --- |
+| 0 | Entry gate | build, focused xUnit tests, IR invariant checks | The code compiles and the pass preserves tree shape. | That output is valid or faithful. |
+| 1 | Shape proof | pass fixtures, adversarial negatives, sidecar facts | The pass recognizes a specific lowering and declines near misses. | That the same logic is safe on the corpus. |
+| 2 | Syntax boss | `--validity-check`, `Full malformed`, Roslyn parse/statement legality | Claimed-Full C# parses and is statement-legal. | That valid C# means the same thing. |
+| 3 | Binding boss | semantic validity diagnostics | Claimed-Full C# binds outside known shell noise. | Opcode equivalence. |
+| 4 | Altitude boss | idiom scorecard, `LoweringCoverage`, sidecar rows | The output reached the intended C# idiom. | Soundness around near misses. |
+| 5 | Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` | Which control-flow or fidelity shapes remain unraised. | That raised shapes are semantically faithful. |
+| 6 | Opcode boss | `--fidelity-check`, fixture fidelity gates, lowered fidelity gates | Decompiled body recompiles to the same canonical opcode stream. | Methods the check cannot recompile. |
+| 7 | Artifact boss | `--type-check`, whole-type/source checks | Type/file-level artifacts are coherent: type kind, modifiers, members, usings. | Method-body semantic fidelity. |
+| 8 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card`, daily corpus, PR quick corpus | Aggregate movement across real assemblies, including regressions and coverage. | That the changed methods were opcode-checked. |
+| 9 | Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` | The methods a behavior PR changed are identified and attempted by compile-back fidelity. | That uncheckable changed methods are safe. |
+| 10 | Final boss | changed-method fidelity over the risky target population, improved examples, still-flat near misses, adversarial review | A risky raise/structuring PR has evidence over the methods it actually changed and its nearest false positives. | Whole-program semantic equivalence. |
+
+The goal is not to make every PR fight every boss. The goal is to make the
+highest relevant boss explicit. A docs-only PR may stop at markdown lint. A
+small pass refactor may need the entry gate plus a no-movement quality card. A
+new raise or structuring change must go much higher.
+
+## Vocabulary
+
+Use these names in issues and PRs when selecting evidence:
+
+| Name | Meaning |
+| --- | --- |
+| **Entry gate** | Build and focused tests. This should be 100% green before any broader claim. |
+| **Shape proof** | The pass-specific `shape + proof + decline` story: positive fixture plus near-miss negative. |
+| **Validity** | Parse/statement/binding proof. This catches invalid C# and many skeleton defects. |
+| **Fidelity** | Compile-back opcode proof. This is the semantic body oracle. |
+| **Completeness** | Raised-vs-residual coverage: `--gaps`, `--structuring-stops`, scorecard/ledger movement. |
+| **Corpus health** | Aggregate real-world signal from the fixed corpus. |
+| **Changed-method evidence** | Per-method delta plus compile-back over methods the PR actually changed. |
+
+Avoid saying "fidelity" when you mean two different things. The pipeline has
+both:
+
+- **Decompiler fidelity grade**: `Full`, `Partial`, `StructuredOnly`, `IlOnly`,
+  `Failed`.
+- **Compile-back fidelity result**: `Exact`, `OpcodeDiff`, `RecompileFail`,
+  `ContextFail`, `NotFull`, `not-sampled`.
+
+When reporting deltas, spell out `currentValidity`, `currentDecompilerFidelity`,
+and `currentFidelityCheck` rather than mixing axes.
+
+## What each PR should report
+
+### Documentation-only
+
+Run the relevant markdown lint. No corpus card is needed unless the doc claims a
+new measured number.
+
+### Harness-only measurement changes
+
+Report the entry gate plus a small smoke run that proves the new mode works. If
+the mode changes corpus cards, include a same-revision card or a before/after
+example.
+
+### Behavior-preserving decompiler refactors
+
+Report:
+
+1. focused tests;
+2. `src/ILInspector.Decompiler.Tests`;
+3. generated quality card showing no unexpected corpus movement;
+4. adversarial review summary.
+
+### Bug fixes
+
+Report:
+
+1. the failing fixture or corpus example before the fix;
+2. the same example after the fix;
+3. generated quality card if corpus behavior can move;
+4. any changed-method fidelity result if the fix came from a corpus-delta issue.
+
+Invalid `Full` becoming `Partial` is an honesty improvement, not a regression,
+but say that explicitly.
+
+### New raises, printer semantics, and structuring changes
+
+Report:
+
+1. shape proof: positive fixture plus near-miss negative;
+2. improved examples and still-flat near misses;
+3. generated quality card, preferably with `--quality-card-risky`;
+4. per-method delta artifact;
+5. changed-method fidelity result, or a clear statement that changed methods are
+   not currently checkable;
+6. cross-model adversarial review summary.
+
+For #1175-class retained-label work, the changed-method population must include
+the forward-merge / structuring-residual methods the PR changes. A green global
+fidelity sample that does not intersect those methods is not enough.
+
+## Naming the harnesses by role
+
+The command names are historical and intentionally stable, but PRs and issues
+should refer to the role they serve:
+
+| Role | Command / artifact |
+| --- | --- |
+| Syntax boss | `--validity-check`, `Full malformed` |
+| Opcode boss | `--fidelity-check` |
+| Artifact boss | `--type-check` |
+| Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` |
+| Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card` |
+| Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` |
+| Drill-down view | `--dump --steps --diff --cfg --facts --remarks` |
+
+Do not paste drill-down walls into PR bodies. Link artifacts or gists when a
+reviewer needs to inspect the fight.
+
+## Using the gauntlet to generate work
+
+When the burndown queue is empty, do not invent rows. Ask which boss is failing:
+
+- Entry gate failures become build/test fixes.
+- Shape proof failures become adversarial fixtures or predicate hardening.
+- Validity failures become `Full malformed` or semantic-defect root-cause issues.
+- Structure failures become `--gaps` / `--structuring-stops` pattern issues.
+- Opcode failures become fidelity docket issues.
+- Corpus aggregate movement becomes quality-card regression work.
+- Changed-method uncheckability becomes harness context/skeleton work.
+
+This keeps work generation tied to evidence rather than taste.
+
+## Current boss for risky work
+
+As of the changed-method fidelity work, the current blocker for risky
+structuring PRs is not target selection. We can identify changed methods. The
+blocker is making enough of those changed methods compile-back checkable to be a
+useful semantic safety net.
+
+Until that improves, a risky PR must either:
+
+- provide changed-method fidelity over its actual changed population;
+- explain why the changed methods are not checkable and bound the safety case to
+  fixtures, validity, readability, and near-miss negatives; or
+- first fix the harness context/skeleton bucket that blocks those methods.

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -6,6 +6,9 @@ is the architecture (*how* output is produced), [decompiler-taste.md](decompiler
 is *what* to render. This doc is the goal — *how we know the output is right*.
 Tool invocation lives in the harness reference ([tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md));
 here we describe the strategy those tools serve.
+The staged test/harness ladder — which check is the entry gate, which is the
+final boss, and what evidence each PR should report — is in
+[decompiler-correctness-pipeline.md](decompiler-correctness-pipeline.md).
 
 ## Correct by construction
 

--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -1,6 +1,13 @@
 # Decompiler Design
 
-This document describes the architecture of `ILInspector.Decompiler` — *how the pipeline decides* its output. Three companion docs cover the rest: [decompiler-ir.md](decompiler-ir.md) is the focused reference for the IR and importer contracts this doc builds on, [decompiler-taste.md](decompiler-taste.md) governs *what* the decompiler renders, and [decompiler-quality.md](decompiler-quality.md) is *how we know the output is right*.
+This document describes the architecture of `ILInspector.Decompiler` — *how the
+pipeline decides* its output. Companion docs cover the rest:
+[decompiler-ir.md](decompiler-ir.md) is the focused reference for the IR and
+importer contracts this doc builds on, [decompiler-taste.md](decompiler-taste.md)
+governs *what* the decompiler renders, [decompiler-quality.md](decompiler-quality.md)
+is *how we know the output is right*, and
+[decompiler-correctness-pipeline.md](decompiler-correctness-pipeline.md) maps the
+test/harness stack into a staged correctness gauntlet.
 
 ## Design goal: recognizability
 


### PR DESCRIPTION
## Summary

- add `docs/decompiler-correctness-pipeline.md`, a staged gauntlet for decompiler correctness checks from entry gates through changed-method fidelity
- link the new doc from the docs index, decompiler architecture doc, decompiler quality doc, and AGENTS.md
- clarify that docs-only decompiler PRs can stop at markdownlint when they do not claim measured behavior

## Notes

This is docs-only. It does not change decompiler behavior or measured corpus state.

## Validation

- `npx markdownlint-cli --fix AGENTS.md docs/README.md docs/decompiler.md docs/decompiler-quality.md docs/decompiler-correctness-pipeline.md`
- `npx markdownlint-cli AGENTS.md docs/README.md docs/decompiler.md docs/decompiler-quality.md docs/decompiler-correctness-pipeline.md`
