### PR TITLE
Add analysis annotation diff

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1598,6 +1598,8 @@ public sealed class LibraryBodyIndex
                     or ILOpCode.Ble_un or ILOpCode.Blt_un or ILOpCode.Leave
                     or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4
                     or ILOpCode.Jmp or ILOpCode.Ldstr
+                    or ILOpCode.Call or ILOpCode.Calli or ILOpCode.Callvirt or ILOpCode.Newobj
+                    or ILOpCode.Ldftn or ILOpCode.Ldvirtftn
                     or ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld
                     or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
                     or ILOpCode.Cpobj or ILOpCode.Ldobj or ILOpCode.Castclass

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -88,6 +88,11 @@ public sealed class LibraryBodyIndex
     /// </summary>
     Dictionary<int, MethodSignals> Signals => _signals ??= MethodSignalAnalysis.Collect(DirectCalls, UnsafeEvidence, _bodySignals);
 
+    /// <summary>
+    /// Returns per-method body/call signals keyed by metadata token.
+    /// </summary>
+    public IReadOnlyDictionary<int, MethodSignals> GetMethodSignals() => Signals;
+
     IReadOnlySet<string>? _generatedFrameworkTypes;
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -744,6 +744,15 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void DiffCommand_WithLibraryRange_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Analysis Diff"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("diff", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
     public void DiffCommand_WithTypeArgument_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "JsonSerializer", "--package", "System.Text.Json@8.0.0..9.0.0"]);

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,4 +1,6 @@
 using ILInspector.Metadata;
+using DotnetInspector.Output;
+using DotnetInspector.Views;
 
 namespace DotnetInspector.Tests;
 
@@ -70,5 +72,20 @@ public class DiffCommandTests
     {
         var type = new ApiType { Name = "MyType", Namespace = "" };
         Assert.Equal("MyType", type.FullName);
+    }
+
+    [Fact]
+    public void RenderAnalysisDiffMarkdown_RendersRows()
+    {
+        var markdown = DiffOutputFormatter.RenderAnalysisDiffMarkdown(
+            "Sample",
+            [new AnalysisDiffRow("`Sample.Type.M()`", "allocations", "0", "1", "+1", null, "old -; new IL_0001")],
+            "old.dll",
+            "new.dll");
+
+        Assert.Contains("## Analysis Diff", markdown);
+        Assert.Contains("allocations", markdown);
+        Assert.Contains("+1", markdown);
+        Assert.Contains("IL_0001", markdown);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -13,11 +13,11 @@ public static class InspectionCommandDefinitions
 {
     public static Command CreateDiffCommand(SharedOptions opts)
     {
-        var diffCommand = new Command(DiffCommand.Name, "Compare API surfaces between package or platform versions");
+        var diffCommand = new Command(DiffCommand.Name, "Compare API surfaces between package, platform, or local library versions");
 
         var argsArg = new Argument<string[]>("args")
         {
-            Description = "Version range and type filter. When no --package/--platform is given, first arg is the package version range.",
+            Description = "Version range and type filter. When no --package/--platform/--library is given, first arg is the package version range.",
             Arity = ArgumentArity.ZeroOrMore
         };
 
@@ -28,6 +28,10 @@ public static class InspectionCommandDefinitions
         var platformOption = new Option<string?>("--platform")
         {
             Description = "Platform library with version range (e.g., System.Text.Json@8.0.23..10.0.2)"
+        };
+        var libraryOption = new Option<string?>("--library")
+        {
+            Description = "Local library path range (e.g., old/Foo.dll..new/Foo.dll)"
         };
         var frameworkOption = new Option<string?>("--framework")
         {
@@ -49,6 +53,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Arguments.Add(argsArg);
         diffCommand.Options.Add(packageOption);
         diffCommand.Options.Add(platformOption);
+        diffCommand.Options.Add(libraryOption);
         diffCommand.Options.Add(frameworkOption);
         diffCommand.Options.Add(tfmOption);
         diffCommand.Options.Add(allOption);
@@ -63,7 +68,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(opts.Select);
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(
-            argsArg, packageOption, platformOption, frameworkOption, tfmOption, allOption,
+            argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
             typeFilterOption, opts.OneLine, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, legendOption);
 
         diffCommand.SetAction(async (parseResult, ct) =>

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -20,6 +20,7 @@ public static class DiffOptionsParser
         Argument<string[]> ArgsArg,
         Option<string?> PackageOption,
         Option<string?> PlatformOption,
+        Option<string?> LibraryOption,
         Option<string?> FrameworkOption,
         Option<string?> TfmOption,
         Option<bool> AllOption,
@@ -57,10 +58,12 @@ public static class DiffOptionsParser
         var argsValue = parseResult.GetValue(args.ArgsArg) ?? [];
         var explicitPackage = parseResult.GetValue(args.PackageOption);
         var explicitPlatform = parseResult.GetValue(args.PlatformOption);
-        bool hasExplicitSource = explicitPackage != null || explicitPlatform != null;
+        var explicitLibrary = parseResult.GetValue(args.LibraryOption);
+        bool hasExplicitSource = explicitPackage != null || explicitPlatform != null || explicitLibrary != null;
 
         string? packageVersionRange = explicitPackage;
         string? platformVersionRange = explicitPlatform;
+        string? libraryVersionRange = explicitLibrary;
         string? typeName = null;
 
         if (hasExplicitSource)
@@ -97,6 +100,7 @@ public static class DiffOptionsParser
         {
             PackageVersionRange = packageVersionRange,
             PlatformVersionRange = platformVersionRange,
+            LibraryVersionRange = libraryVersionRange,
             Framework = parseResult.GetValue(args.FrameworkOption),
             Tfm = parseResult.GetValue(args.TfmOption),
             IncludeAll = parseResult.GetValue(args.AllOption),

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using DotnetInspector.Inspectors;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
@@ -6,6 +7,7 @@ using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
+using ILInspector.Analysis;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -20,28 +22,31 @@ public class DiffCommand
     {
         var hasPlatform = !string.IsNullOrEmpty(options.PlatformVersionRange);
         var hasPackage = !string.IsNullOrEmpty(options.PackageVersionRange);
+        var hasLibrary = !string.IsNullOrEmpty(options.LibraryVersionRange);
 
         // Discovery mode: -D/--discover lists schema
         if (options.Discover != null)
         {
             var schemaMap = new DocumentSchema()
-                .Add("Changes", "column", "Change", "Type", "Detail");
+                .Add("Changes", "column", "Change", "Type", "Detail")
+                .Add("Analysis Diff", "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence");
             return DiscoverOutput.Execute(options.Discover, schemaMap,
                 tree: options.Tree, json: false, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine);
         }
 
-        if (!hasPlatform && !hasPackage)
+        if (!hasPlatform && !hasPackage && !hasLibrary)
         {
-            Console.Error.WriteLine("Error: --package or --platform with version range required.");
+            Console.Error.WriteLine("Error: --package, --platform, or --library with version range required.");
             Console.Error.WriteLine("Examples:");
             Console.Error.WriteLine("  --package System.Text.Json@9.0.0..10.0.2");
             Console.Error.WriteLine("  --platform System.Text.Json@8.0.23..10.0.2");
+            Console.Error.WriteLine("  --library old/Foo.dll..new/Foo.dll");
             return 1;
         }
 
-        if (hasPlatform && hasPackage)
+        if ((hasPlatform ? 1 : 0) + (hasPackage ? 1 : 0) + (hasLibrary ? 1 : 0) > 1)
         {
-            Console.Error.WriteLine("Error: Cannot specify both --package and --platform.");
+            Console.Error.WriteLine("Error: Cannot specify more than one of --package, --platform, and --library.");
             return 1;
         }
 
@@ -50,11 +55,7 @@ public class DiffCommand
 
         try
         {
-            ApiSurface fromSurface;
-            ApiSurface toSurface;
-            string fromVersion;
-            string toVersion;
-            string name;
+            DiffInputs inputs;
 
             if (hasPackage)
             {
@@ -64,13 +65,9 @@ public class DiffCommand
                     Console.Error.WriteLine(result.error);
                     return 1;
                 }
-                fromSurface = result.fromSurface!;
-                toSurface = result.toSurface!;
-                fromVersion = result.fromVersion!;
-                toVersion = result.toVersion!;
-                name = result.name!;
+                inputs = result.inputs!;
             }
-            else
+            else if (hasPlatform)
             {
                 var result = await ExecutePlatformDiffAsync(options, logger, context.HttpClient);
                 if (result.error != null)
@@ -78,32 +75,53 @@ public class DiffCommand
                     Console.Error.WriteLine(result.error);
                     return 1;
                 }
-                fromSurface = result.fromSurface!;
-                toSurface = result.toSurface!;
-                fromVersion = result.fromVersion!;
-                toVersion = result.toVersion!;
-                name = result.name!;
-            }
-
-            var diff = ApiDiffAnalyzer.Compare(fromSurface, toSurface);
-
-            if (options.OneLine)
-            {
-                var typeDiffs = ApplyFilters(diff, options);
-                var view = DiffOutputFormatter.BuildOneLineView(name, typeDiffs, fromVersion, toVersion);
-                OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
-                    options.Columns, options.Fields,
-                    (writer, formatter, writerOptions) =>
-                        MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                    options.Rows);
+                inputs = result.inputs!;
             }
             else
             {
-                var output = RenderDiff(name, diff, fromVersion, toVersion, options);
-                Console.WriteLine(output);
+                var result = ExecuteLibraryDiff(options);
+                if (result.error != null)
+                {
+                    Console.Error.WriteLine(result.error);
+                    return 1;
+                }
+                inputs = result.inputs!;
             }
 
-            return 0;
+            try
+            {
+                if (SelectsAnalysisDiff(options))
+                {
+                    var rows = BuildAnalysisDiffRows(inputs.FromPaths, inputs.ToPaths, options);
+                    var output = DiffOutputFormatter.RenderAnalysisDiffMarkdown(inputs.Name, rows, inputs.FromVersion, inputs.ToVersion);
+                    Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                    return 0;
+                }
+
+                var diff = ApiDiffAnalyzer.Compare(inputs.FromSurface, inputs.ToSurface);
+
+                if (options.OneLine)
+                {
+                    var typeDiffs = ApplyFilters(diff, options);
+                    var view = DiffOutputFormatter.BuildOneLineView(inputs.Name, typeDiffs, inputs.FromVersion, inputs.ToVersion);
+                    OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                        options.Columns, options.Fields,
+                        (writer, formatter, writerOptions) =>
+                            MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                        options.Rows);
+                }
+                else
+                {
+                    var output = RenderDiff(inputs.Name, diff, inputs.FromVersion, inputs.ToVersion, options);
+                    Console.WriteLine(output);
+                }
+
+                return 0;
+            }
+            finally
+            {
+                inputs.Dispose();
+            }
         }
         catch (Exception ex)
         {
@@ -112,51 +130,65 @@ public class DiffCommand
         }
     }
 
-    private static async Task<(ApiSurface? fromSurface, ApiSurface? toSurface, string? fromVersion, string? toVersion, string? name, string? error)>
+    sealed record DiffInputs(
+        ApiSurface FromSurface,
+        ApiSurface ToSurface,
+        string FromVersion,
+        string ToVersion,
+        string Name,
+        IReadOnlyList<string> FromPaths,
+        IReadOnlyList<string> ToPaths,
+        string? FromTempDir = null,
+        string? ToTempDir = null) : IDisposable
+    {
+        public void Dispose()
+        {
+            DeleteTemp(FromTempDir);
+            DeleteTemp(ToTempDir);
+        }
+
+        static void DeleteTemp(string? tempDir)
+        {
+            if (!string.IsNullOrEmpty(tempDir) && Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+    }
+
+    private static async Task<(DiffInputs? inputs, string? error)>
         ExecutePackageDiffAsync(DiffOptions options, VerboseLogger logger, HttpClient httpClient)
     {
         var (packageName, fromVersion, toVersion) = ParseVersionRange(options.PackageVersionRange!);
         if (packageName == null || fromVersion == null || toVersion == null)
         {
-            return (null, null, null, null, null, "Error: Invalid version range. Use format: Package@v1..v2");
+            return (null, "Error: Invalid version range. Use format: Package@v1..v2");
         }
 
         logger.Log($"Comparing {packageName} v{fromVersion} -> v{toVersion}");
 
-        var fromOptions = new ApiOptions
+        var from = await ExtractPackageInputAsync($"{packageName}@{fromVersion}", options, logger, httpClient);
+        if (from.error is not null)
+            return (null, $"Error resolving v{fromVersion}: {from.error}");
+        var to = await ExtractPackageInputAsync($"{packageName}@{toVersion}", options, logger, httpClient);
+        if (to.error is not null)
         {
-            PackagePath = $"{packageName}@{fromVersion}",
-            Tfm = options.Tfm,
-            IncludeAll = options.IncludeAll,
-            Verbose = options.Verbose
-        };
-
-        var toOptions = new ApiOptions
-        {
-            PackagePath = $"{packageName}@{toVersion}",
-            Tfm = options.Tfm,
-            IncludeAll = options.IncludeAll,
-            Verbose = options.Verbose
-        };
-
-        var (fromSurface, _) = await ApiServices.ExtractMergedApiSurfaceAsync(fromOptions, logger, httpClient);
-        var (toSurface, _) = await ApiServices.ExtractMergedApiSurfaceAsync(toOptions, logger, httpClient);
-
-        if (fromSurface == null || toSurface == null)
-        {
-            return (null, null, null, null, null, "Error: Failed to extract API surface from one or both versions.");
+            DeleteTempDir(from.tempDir);
+            return (null, $"Error resolving v{toVersion}: {to.error}");
         }
 
-        return (fromSurface, toSurface, fromVersion, toVersion, packageName, null);
+        return (new DiffInputs(
+            from.surface!, to.surface!, fromVersion, toVersion, packageName,
+            from.paths!, to.paths!, from.tempDir, to.tempDir), null);
     }
 
-    private static async Task<(ApiSurface? fromSurface, ApiSurface? toSurface, string? fromVersion, string? toVersion, string? name, string? error)>
+    private static async Task<(DiffInputs? inputs, string? error)>
         ExecutePlatformDiffAsync(DiffOptions options, VerboseLogger logger, HttpClient httpClient)
     {
         var (assemblyName, fromVersion, toVersion) = ParseVersionRange(options.PlatformVersionRange!);
         if (assemblyName == null || fromVersion == null || toVersion == null)
         {
-            return (null, null, null, null, null, "Error: Invalid version range. Use format: Library@v1..v2");
+            return (null, "Error: Invalid version range. Use format: Library@v1..v2");
         }
 
         var framework = options.Framework ?? "runtime";
@@ -171,7 +203,7 @@ public class DiffCommand
 
         if (fromError != null)
         {
-            return (null, null, null, null, null, $"Error resolving v{fromVersion}: {fromError}");
+            return (null, $"Error resolving v{fromVersion}: {fromError}");
         }
 
         var (toPath, _, _, toError) = await PlatformResolver.ResolveAssemblyAsync(
@@ -182,7 +214,7 @@ public class DiffCommand
 
         if (toError != null)
         {
-            return (null, null, null, null, null, $"Error resolving v{toVersion}: {toError}");
+            return (null, $"Error resolving v{toVersion}: {toError}");
         }
 
         // Extract API surfaces from both assemblies
@@ -191,10 +223,298 @@ public class DiffCommand
 
         if (fromSurface == null || toSurface == null)
         {
-            return (null, null, null, null, null, "Error: Failed to extract API surface from one or both versions.");
+            return (null, "Error: Failed to extract API surface from one or both versions.");
         }
 
-        return (fromSurface, toSurface, fromVersion, toVersion, assemblyName, null);
+        return (new DiffInputs(
+            fromSurface, toSurface, fromVersion, toVersion, assemblyName,
+            [fromPath!], [toPath!]), null);
+    }
+
+    private static (DiffInputs? inputs, string? error) ExecuteLibraryDiff(DiffOptions options)
+    {
+        var (fromPath, toPath) = ParsePathRange(options.LibraryVersionRange!);
+        if (fromPath is null || toPath is null)
+            return (null, "Error: Invalid library range. Use format: old/Foo.dll..new/Foo.dll");
+        if (!File.Exists(fromPath))
+            return (null, $"Error: File not found: {fromPath}");
+        if (!File.Exists(toPath))
+            return (null, $"Error: File not found: {toPath}");
+        var fromSurface = ExtractApiSurface(fromPath, options.IncludeAll);
+        var toSurface = ExtractApiSurface(toPath, options.IncludeAll);
+        if (fromSurface is null || toSurface is null)
+            return (null, "Error: Failed to extract API surface from one or both libraries.");
+
+        var name = Path.GetFileNameWithoutExtension(toPath);
+        return (new DiffInputs(
+            fromSurface, toSurface,
+            Path.GetFileName(fromPath), Path.GetFileName(toPath), name,
+            [fromPath], [toPath]), null);
+    }
+
+    private static async Task<(ApiSurface? surface, List<string>? paths, string? tempDir, string? error)> ExtractPackageInputAsync(
+        string packageReference, DiffOptions options, VerboseLogger logger, HttpClient httpClient)
+    {
+        var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, packageReference, logger.Log, "inspect-diff", options.SourceOptions).ConfigureAwait(false);
+        if (!outcome.IsSuccess)
+            return (null, null, null, outcome.ErrorMessage);
+
+        var extracted = outcome.Result!;
+        var dlls = TfmSelector.GetPackageDlls(extracted.ExtractPath);
+        if (dlls.Count == 0)
+            return (null, null, extracted.TempDir, "No DLLs found in package.");
+
+        List<string> paths;
+        string? selectedTfm;
+        if (!string.IsNullOrEmpty(options.Tfm))
+        {
+            paths = dlls
+                .Where(path =>
+                {
+                    var relativePath = Path.GetRelativePath(extracted.ExtractPath, path).Replace('\\', '/');
+                    return relativePath.Split('/').Any(part => string.Equals(part, options.Tfm, StringComparison.OrdinalIgnoreCase));
+                })
+                .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+            selectedTfm = options.Tfm;
+        }
+        else
+        {
+            (paths, selectedTfm) = TfmSelector.SelectHighestTfmAssemblies(dlls, extracted.ExtractPath);
+        }
+
+        if (paths.Count == 0)
+            return (null, null, extracted.TempDir, "No DLLs found for selected TFM.");
+
+        var surface = MergeSurfaces(paths, extracted.PackageName, selectedTfm, options.IncludeAll, logger);
+        return surface is null
+            ? (null, null, extracted.TempDir, "Failed to extract API surface.")
+            : (surface, paths, extracted.TempDir, null);
+    }
+
+    private static ApiSurface? MergeSurfaces(IReadOnlyList<string> paths, string? name, string? tfm, bool includeAll, VerboseLogger logger)
+    {
+        if (paths.Count == 1)
+        {
+            var single = AssemblyReader.ExtractApiSurface(paths[0], includeAll);
+            if (single is not null)
+            {
+                single.Name = name ?? Path.GetFileNameWithoutExtension(paths[0]);
+                single.Tfm = tfm;
+            }
+            return single;
+        }
+
+        var merged = new ApiSurface { Name = name, Tfm = tfm };
+        foreach (var path in paths)
+        {
+            var surface = AssemblyReader.ExtractApiSurface(path, includeAll);
+            if (surface is null)
+                continue;
+            logger.Log($"  + {Path.GetFileNameWithoutExtension(path)}: {surface.PublicTypeCount} types");
+            merged.Types.AddRange(surface.Types);
+            merged.PublicTypeCount += surface.PublicTypeCount;
+            merged.PublicMethodCount += surface.PublicMethodCount;
+            merged.PublicPropertyCount += surface.PublicPropertyCount;
+            merged.PublicEventCount += surface.PublicEventCount;
+            merged.PublicFieldCount += surface.PublicFieldCount;
+        }
+        merged.Types = merged.Types.OrderBy(type => type.FullName).ToList();
+        return merged.Types.Count == 0 ? null : merged;
+    }
+
+    private static (string? fromPath, string? toPath) ParsePathRange(string input)
+    {
+        int dotDotIndex = input.IndexOf("..", StringComparison.Ordinal);
+        if (dotDotIndex <= 0 || dotDotIndex + 2 >= input.Length)
+            return (null, null);
+        return (input[..dotDotIndex], input[(dotDotIndex + 2)..]);
+    }
+
+    private static bool SelectsAnalysisDiff(DiffOptions options)
+        => options.Select?.Any(value => string.Equals(value, "Analysis Diff", StringComparison.OrdinalIgnoreCase)) == true;
+
+    private static List<AnalysisDiffRow> BuildAnalysisDiffRows(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
+    {
+        var oldSnapshot = BuildAnalysisSnapshot(fromPaths, options);
+        var newSnapshot = BuildAnalysisSnapshot(toPaths, options);
+        var rows = new List<AnalysisDiffRow>();
+        foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys).OrderBy(key => key, StringComparer.Ordinal))
+        {
+            oldSnapshot.TryGetValue(key, out var oldMethod);
+            newSnapshot.TryGetValue(key, out var newMethod);
+            var display = newMethod?.Display ?? oldMethod?.Display ?? key;
+            AddCountRows(rows, display, oldMethod?.Signals, newMethod?.Signals);
+            AddExceptionRow(rows, display, oldMethod?.Signals, newMethod?.Signals);
+            AddOptimizationRows(rows, display, oldMethod?.Opportunities, newMethod?.Opportunities);
+        }
+        return rows
+            .OrderBy(row => row.Member, StringComparer.Ordinal)
+            .ThenBy(row => row.Signal, StringComparer.Ordinal)
+            .ThenBy(row => row.Shape ?? "", StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private sealed record AnalysisMethod(string Display, MethodSignals Signals, List<OptimizationOpportunity> Opportunities);
+
+    private static Dictionary<string, AnalysisMethod> BuildAnalysisSnapshot(IReadOnlyList<string> paths, DiffOptions options)
+    {
+        var methods = new Dictionary<string, AnalysisMethod>(StringComparer.Ordinal);
+        foreach (var path in paths)
+        {
+            var index = LibraryBodyIndex.Open(path);
+            var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
+            var signalsByToken = index.GetMethodSignals();
+            foreach (var method in index.Methods)
+            {
+                if (LibraryMetadataService.IsGeneratedMethod(method, generatedFrameworkTypes))
+                    continue;
+                if (!MatchesTypeFilters(method.DeclaringType.ToQualifiedDisplayString(), options.TypeFilter))
+                    continue;
+                signalsByToken.TryGetValue(method.MetadataToken, out var signals);
+                var key = MethodKey(method);
+                if (!methods.TryGetValue(key, out var entry))
+                {
+                    entry = new AnalysisMethod(FormatMethod(method), signals ?? MethodSignals.None, []);
+                    methods[key] = entry;
+                }
+                else
+                {
+                    methods[key] = entry with { Signals = signals ?? MethodSignals.None };
+                }
+            }
+
+            foreach (var opportunity in index.OptimizationOpportunities)
+            {
+                if (LibraryMetadataService.IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes))
+                    continue;
+                if (!MatchesTypeFilters(opportunity.Method.DeclaringType.ToQualifiedDisplayString(), options.TypeFilter))
+                    continue;
+                var key = MethodKey(opportunity.Method);
+                if (!methods.TryGetValue(key, out var entry))
+                {
+                    entry = new AnalysisMethod(FormatMethod(opportunity.Method), MethodSignals.None, []);
+                    methods[key] = entry;
+                }
+                entry.Opportunities.Add(opportunity);
+            }
+        }
+        return methods;
+    }
+
+    private static bool MatchesTypeFilters(string typeFullName, HashSet<string> filters)
+        => filters.Count == 0 || filters.Any(filter => MatchesDiffTypeFilter(typeFullName, filter));
+
+    private static string MethodKey(MethodIdentity method)
+        => $"{method.AssemblyName}|{method.DeclaringType.ToQualifiedDisplayString()}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))}|{method.ReturnType.ToQualifiedDisplayString()}";
+
+    private static string FormatMethod(MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
+
+    private static void AddCountRows(List<AnalysisDiffRow> rows, string display, MethodSignals? oldSignals, MethodSignals? newSignals)
+    {
+        AddCountRow(rows, display, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "catches", oldSignals?.Catches ?? 0, newSignals?.Catches ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "finallys", oldSignals?.Finallys ?? 0, newSignals?.Finallys ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
+    }
+
+    private static void AddCountRow(List<AnalysisDiffRow> rows, string display, string signal, int oldValue, int newValue, string? evidence)
+    {
+        if (oldValue == newValue)
+            return;
+        rows.Add(new AnalysisDiffRow(
+            MarkoutInline.Code(display),
+            signal,
+            oldValue.ToString(),
+            newValue.ToString(),
+            FormatDelta(newValue - oldValue),
+            null,
+            evidence));
+    }
+
+    private static void AddExceptionRow(List<AnalysisDiffRow> rows, string display, MethodSignals? oldSignals, MethodSignals? newSignals)
+    {
+        var oldTypes = oldSignals?.ExceptionTypes ?? [];
+        var newTypes = newSignals?.ExceptionTypes ?? [];
+        if (oldTypes.SequenceEqual(newTypes))
+            return;
+        rows.Add(new AnalysisDiffRow(
+            MarkoutInline.Code(display),
+            "constructed-exceptions",
+            FormatList(oldTypes),
+            FormatList(newTypes),
+            "changed",
+            null,
+            Evidence(oldSignals, newSignals)));
+    }
+
+    private static void AddOptimizationRows(List<AnalysisDiffRow> rows, string display, List<OptimizationOpportunity>? oldOps, List<OptimizationOpportunity>? newOps)
+    {
+        var oldCounts = CountShapes(oldOps);
+        var newCounts = CountShapes(newOps);
+        foreach (var shape in oldCounts.Keys.Union(newCounts.Keys).OrderBy(shape => shape, StringComparer.Ordinal))
+        {
+            var oldValue = oldCounts.GetValueOrDefault(shape);
+            var newValue = newCounts.GetValueOrDefault(shape);
+            if (oldValue == newValue)
+                continue;
+            rows.Add(new AnalysisDiffRow(
+                MarkoutInline.Code(display),
+                "optimization",
+                oldValue.ToString(),
+                newValue.ToString(),
+                FormatDelta(newValue - oldValue),
+                shape,
+                FormatOptimizationEvidence(oldOps, newOps, shape)));
+        }
+    }
+
+    private static Dictionary<string, int> CountShapes(List<OptimizationOpportunity>? opportunities)
+        => opportunities is null
+            ? []
+            : opportunities.GroupBy(opportunity => opportunity.Shape, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+
+    private static string FormatDelta(int delta) => delta > 0 ? $"+{delta}" : delta.ToString();
+
+    private static string FormatList(ImmutableArray<string> values)
+        => values.IsDefaultOrEmpty ? "-" : string.Join(", ", values);
+
+    private static string? Evidence(MethodSignals? oldSignals, MethodSignals? newSignals)
+    {
+        var oldEvidence = FormatOffsets(oldSignals?.Evidence ?? []);
+        var newEvidence = FormatOffsets(newSignals?.Evidence ?? []);
+        if (oldEvidence is null && newEvidence is null)
+            return null;
+        return $"old {oldEvidence ?? "-"}; new {newEvidence ?? "-"}";
+    }
+
+    private static string? FormatOptimizationEvidence(List<OptimizationOpportunity>? oldOps, List<OptimizationOpportunity>? newOps, string shape)
+    {
+        var oldOffsets = FormatOffsets(Offsets(oldOps, shape));
+        var newOffsets = FormatOffsets(Offsets(newOps, shape));
+        if (oldOffsets is null && newOffsets is null)
+            return null;
+        return $"old {oldOffsets ?? "-"}; new {newOffsets ?? "-"}";
+    }
+
+    private static ImmutableArray<int> Offsets(List<OptimizationOpportunity>? ops, string shape)
+        => ops is null ? [] : [.. ops.Where(op => op.Shape == shape && op.ILOffset is not null).Select(op => op.ILOffset!.Value).Distinct().Order()];
+
+    private static string? FormatOffsets(ImmutableArray<int> offsets)
+        => offsets.IsDefaultOrEmpty ? null : string.Join(",", offsets.Select(offset => $"IL_{offset:X4}"));
+
+    private static void DeleteTempDir(string? tempDir)
+    {
+        if (!string.IsNullOrEmpty(tempDir) && Directory.Exists(tempDir))
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
     }
 
     private static ApiSurface? ExtractApiSurface(string assemblyPath, bool includeAll)
@@ -313,6 +633,7 @@ public record DiffOptions
 {
     public string? PackageVersionRange { get; init; }
     public string? PlatformVersionRange { get; init; }
+    public string? LibraryVersionRange { get; init; }
     public string? Framework { get; init; }
     public string? Tfm { get; init; }
     public bool IncludeAll { get; init; }

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -104,6 +104,23 @@ public static class DiffOutputFormatter
         return writer.ToString().TrimEnd();
     }
 
+    public static string RenderAnalysisDiffMarkdown(string name, IReadOnlyList<AnalysisDiffRow> rows, string fromVersion, string toVersion)
+    {
+        var view = new AnalysisDiffView
+        {
+            Title = $"Analysis Diff: {name}",
+            Versions = $"**{fromVersion}** -> **{toVersion}**",
+            Summary = rows.Count == 0 ? "No analysis signal changes detected." : $"{rows.Count} changed analysis signals",
+            Status = rows.Count == 0
+                ? new Callout(CalloutSeverity.Note, "No analysis signal changes detected.")
+                : new Callout(CalloutSeverity.Note, "Analysis signal changes are body-level evidence, not public API compatibility changes."),
+            Rows = rows.Count > 0 ? rows.ToList() : null
+        };
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        DiffViewContext.Default.Serialize(view, writer);
+        return writer.ToString().TrimEnd();
+    }
+
     internal static string FormatSummaryCounts(int breaking, int additive, int potentiallyBreaking)
     {
         var parts = new List<string>(3);

--- a/src/dotnet-inspect/Views/DiffViews.cs
+++ b/src/dotnet-inspect/Views/DiffViews.cs
@@ -40,6 +40,30 @@ public class DiffFullView
     public List<DiffChangeRow>? AdditiveChanges { get; set; }
 }
 
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    FieldLayout = FieldLayout.Table)]
+public class AnalysisDiffView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Versions { get; set; } = "";
+    public string Summary { get; set; } = "";
+    public Callout Status { get; set; }
+
+    [MarkoutSection(Name = "Analysis Diff")]
+    public List<AnalysisDiffRow>? Rows { get; set; }
+}
+
+[MarkoutSerializable]
+public record AnalysisDiffRow(
+    string Member,
+    string Signal,
+    string Old,
+    string New,
+    string Delta,
+    string? Shape,
+    string? Evidence);
+
 [MarkoutSerializable]
 public record DiffChangeRow(
     [property: MarkoutIgnore] string TypeName,
@@ -50,6 +74,8 @@ public record DiffChangeRow(
 [MarkoutContext(typeof(DiffOneLineRow))]
 [MarkoutContext(typeof(DiffFullView))]
 [MarkoutContext(typeof(DiffChangeRow))]
+[MarkoutContext(typeof(AnalysisDiffView))]
+[MarkoutContext(typeof(AnalysisDiffRow))]
 public partial class DiffViewContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- Add an opt-in `Analysis Diff` section to `diff`.
- Compare body-analysis signal counts and optimization-shape rows by stable method identity.
- Support package, platform, and local library path ranges via `--package`, `--platform`, and new `--library old.dll..new.dll`.

Closes #1381.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -v:q
dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.DiffCommandTests"
dotnet run --project src/dotnet-inspect.Tests -c Release -class "DotnetInspector.Tests.CommandLineTests"
dotnet run --project src/ILInspector.Analysis.Tests -c Release

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  diff --library "/tmp/analysis-diff-smoke/old/bin/Release/net11.0/old.dll../tmp/analysis-diff-smoke/new/bin/Release/net11.0/new.dll" \
  -S "Analysis Diff" \
  --rows -n 40

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  diff --platform System.Runtime@10.0.0..10.0.0 \
  -S "Analysis Diff" \
  --rows -n 20

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  diff --package Markout@0.13.7..0.13.7 \
  -S "Analysis Diff" \
  --rows -n 20

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  diff --package Markout@0.13.7..0.13.7 \
  --rows -n 20
```
