### PR TITLE
Require out Deconstruct targets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -161,6 +161,34 @@ public class DeconstructionAssignmentPassTests
     }
 
     [Fact]
+    public void DeconstructMethodWithRefParameters_IsNotRaised()
+    {
+        var function = BuildDeconstructCall(ArgumentRefKind.Ref);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        var call = Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "Deconstruct");
+        Assert.Equal(ParameterRefKindFacts.Known, call.Callee.ParameterRefKindsFacts);
+        Assert.All(call.Callee.ParameterRefKinds, kind => Assert.Equal(ArgumentRefKind.Ref, kind));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DeconstructMethodWithOutParameters_Raises()
+    {
+        var function = BuildDeconstructCall(ArgumentRefKind.Out);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Equal(2, deconstruction.LocalIndices.Length);
+        Assert.True(deconstruction.IsDeclaration);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), call => call.Callee.Name == "Deconstruct");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void DeconstructMethodWithNonLocalTarget_IsNotRaised()
     {
         // `r.Deconstruct(out localA, out byRefParam)` — a target that is a
@@ -388,7 +416,11 @@ public class DeconstructionAssignmentPassTests
             "Deconstruct",
             TypeRef.CoreLib("System", "Void"),
             [TypeRef.ByRef(intType), TypeRef.ByRef(intType)],
-            HasThis: true);
+            HasThis: true)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Out, ArgumentRefKind.Out],
+            ParameterRefKindsFacts = ParameterRefKindFacts.Known,
+        };
 
         var block = new Block();
         block.Add(new ExpressionStatement(new Call(
@@ -420,7 +452,11 @@ public class DeconstructionAssignmentPassTests
             "Deconstruct",
             TypeRef.CoreLib("System", "Void"),
             [TypeRef.ByRef(intType), TypeRef.ByRef(intType)],
-            HasThis: true);
+            HasThis: true)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Out, ArgumentRefKind.Out],
+            ParameterRefKindsFacts = ParameterRefKindFacts.Known,
+        };
 
         IrExpression receiver = new LoadField(
             new FieldRef(holderType, "Pair", receiverType),
@@ -568,6 +604,9 @@ public class DeconstructionAssignmentPassTests
     }
 
     static IrFunction BuildDeconstructCall(bool receiverIsSideEffecting)
+        => BuildDeconstructCall(ArgumentRefKind.Out, receiverIsSideEffecting);
+
+    static IrFunction BuildDeconstructCall(ArgumentRefKind refKind, bool receiverIsSideEffecting = false)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         var receiverType = TypeRef.Definition("UserAssembly", "Samples", "Pairing");
@@ -576,7 +615,11 @@ public class DeconstructionAssignmentPassTests
             "Deconstruct",
             TypeRef.CoreLib("System", "Void"),
             [TypeRef.ByRef(intType), TypeRef.ByRef(intType)],
-            HasThis: true);
+            HasThis: true)
+        {
+            ParameterRefKinds = [refKind, refKind],
+            ParameterRefKindsFacts = ParameterRefKindFacts.Known,
+        };
         var makePair = new MethodRef(
             TypeRef.Definition("UserAssembly", "Samples", "Factory"),
             "MakePair",

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -89,7 +89,9 @@ public sealed class DeconstructionAssignmentPass : IIrPass
     /// <c>r</c>'s type supplies a <c>Deconstruct</c> method. Scoped to a
     /// side-effect-free local/parameter receiver (the only shape in the corpus —
     /// foreach <c>Current</c> and locals); the out-temp + copy form and other
-    /// receivers are later slices.
+    /// receivers are later slices. Requires known ref-kind metadata proving every
+    /// non-receiver parameter is <c>out</c>; <c>ref</c>/<c>in</c>/unknown calls keep
+    /// their explicit call spelling.
     /// </summary>
     static bool TryRaiseDeconstructMethod(IrFunction function, IrNode statement, PassContext context)
     {
@@ -102,6 +104,9 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         }
 
         int arity = call.Arguments.Count - 1;
+        if (!HasKnownOutTargets(call.Callee, arity))
+            return false;
+
         var receiver = call.Arguments[0];
         if (ReceiverValue(receiver) is not { } source)
             return false;
@@ -126,6 +131,27 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared);
         context.Stepper.StepOver("raise Deconstruct-method call to deconstruction", statement);
         statement.ReplaceWith(deconstruction);
+        return true;
+    }
+
+    static bool HasKnownOutTargets(MethodRef deconstruct, int arity)
+    {
+        if (deconstruct.ParameterRefKindsFacts != ParameterRefKindFacts.Known
+            || deconstruct.ParameterRefKinds.Length != arity
+            || deconstruct.ParameterTypes.Length != arity)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < arity; i++)
+        {
+            if (deconstruct.ParameterTypes[i].Kind != TypeRefKind.ByRef
+                || deconstruct.ParameterRefKinds[i] != ArgumentRefKind.Out)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1357. Narrows method-form `DeconstructionAssignmentPass` so `r.Deconstruct(...)` raises only when metadata proves every non-receiver target parameter is a known `out` by-ref parameter.

This prevents `Deconstruct(ref int, ref int)` calls from being rewritten as C# deconstruction assignments, which only model `out`-style `Deconstruct` pattern semantics.

## Tests

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/DeconstructionAssignmentPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IdiomShapeScorecardTests/*"`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll --pass-impact deconstruction-assignment --cap 100000`

`src/ILInspector.Decompiler.Tests` full-project runner was also attempted, but it produced no terminal result after a long wait and was stopped; the focused pass tests and scorecard slice completed successfully.

## Quality card

Checked-in baseline card (current `origin/main` shows the same baseline drift class, so this PR also includes the branch-vs-current-origin card below):

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,897 methods
Correctness coverage: validity sampled 350 / 87,897 (0.40%); fidelity sampled 22 / 87,897 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,298 (87.94%) | +404 |
| Conditional-branch residual | 2,290 (2.62%) | 2,305 (2.62%) | +15 |
| Forward-merge stops | 2,284 (2.61%) | 2,296 (2.61%) | +12 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,897 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,897 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

Branch-vs-current-origin snapshot card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,897 methods
Correctness coverage: validity sampled 350 / 87,897 (0.40%); fidelity sampled 22 / 87,897 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,298 (87.94%) | 77,298 (87.94%) | 0 |
| Conditional-branch residual | 2,304 (2.62%) | 2,305 (2.62%) | +1 |
| Forward-merge stops | 2,295 (2.61%) | 2,296 (2.61%) | +1 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 87,896 (0.40%) | 4/350 — sampled 350 / 87,897 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,896 (0.03%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,897 (0.03%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/corpus-delta-1357.json`
```

Delta summary: `changedMethods=83`, `sourceChanged=0`, `passBugChanged=0`.

Pass impact:

```text
deconstruction-assignment changed 26/5041 methods (0.52%); 0 pass bugs
```

## Adversarial review

Requested cross-model review from Opus 4.8. Result: no blocking correctness, fidelity, test, or design findings. Follow-up applied: documented the new method-form precondition in `DeconstructionAssignmentPass` comments.
