### PR TITLE
Fix local function capture store ordering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -180,6 +180,33 @@ public class LocalFunctionRaisingPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void CapturingLocalFunctionCallBeforeCaptureStore_StaysLowered()
+    {
+        var (function, context) = CapturingLocalFunctionOrderFixture(storeBeforeCall: false);
+
+        new LocalFunctionRaisingPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<LocalFunctionStatement>());
+        Assert.Empty(function.Descendants.OfType<LocalFunctionInvocation>());
+        Assert.Single(function.Descendants.OfType<StoreField>());
+        Assert.Single(function.Descendants.OfType<Call>(), call => GeneratedCodeIdentity.IsLocalFunctionMethod(call.Callee));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CapturingLocalFunctionCaptureStoreBeforeCall_StillRaises()
+    {
+        var (function, context) = CapturingLocalFunctionOrderFixture(storeBeforeCall: true);
+
+        new LocalFunctionRaisingPass().Run(function, context);
+
+        Assert.Single(function.Descendants.OfType<LocalFunctionStatement>());
+        Assert.Single(function.Descendants.OfType<LocalFunctionInvocation>());
+        Assert.Empty(function.Descendants.OfType<StoreField>());
+        function.CheckInvariant();
+    }
+
     static int CountOccurrences(string haystack, string needle)
     {
         int count = 0, index = 0;
@@ -189,6 +216,66 @@ public class LocalFunctionRaisingPassTests
             index += needle.Length;
         }
         return count;
+    }
+
+    static (IrFunction Function, PassContext Context) CapturingLocalFunctionOrderFixture(bool storeBeforeCall)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var envType = TypeRef.Definition("Synthetic", "Samples", "<>c__DisplayClass0_0", ValueTypeHint.ValueType);
+        var byRefEnv = TypeRef.ByRef(envType);
+        var field = new FieldRef(envType, "x", s_int);
+        var method = new MethodRef(
+            owner,
+            "<M>g__Local|0_0",
+            s_int,
+            [byRefEnv],
+            HasThis: false)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+        };
+
+        var captureStore = new StoreField(field, new LoadLocalAddress(0, envType), new LoadLocal(1, s_int));
+        var call = new ExpressionStatement(new Call(method, isVirtual: false, [new LoadLocalAddress(0, envType)]));
+        var block = new Block();
+        block.Add(new StoreLocal(1, s_int, new Constant(42, s_int)));
+        if (storeBeforeCall)
+        {
+            block.Add(captureStore);
+            block.Add(call);
+        }
+        else
+        {
+            block.Add(call);
+            block.Add(captureStore);
+        }
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [envType, s_int],
+            body);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: imported => imported == method ? CapturingLocalFunctionBody(method, field, byRefEnv) : null);
+        return (function, context);
+    }
+
+    static IrFunction CapturingLocalFunctionBody(MethodRef method, FieldRef field, TypeRef byRefEnv)
+    {
+        var block = new Block();
+        block.Add(new Return(new LoadField(field, new LoadArgument(0, "env", byRefEnv))));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            method.Name,
+            method.DeclaringType,
+            new MethodSignature(method.ReturnType, [new Parameter("env", byRefEnv)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -182,8 +182,37 @@ public sealed class LocalFunctionRaisingPass : IIrPass
         if (function.Descendants.OfType<LoadLocal>().Any(l => l.Index == slot)
             || addressUses != stores.Count + calls.Count)
             return null;
+        if (!CaptureStoresPrecedeCalls(stores, calls))
+            return null;
 
         return new Environment(envType, method.ParameterTypes.Length - 1, captures, stores);
+    }
+
+    static bool CaptureStoresPrecedeCalls(IReadOnlyList<StoreField> stores, IReadOnlyList<Call> calls)
+    {
+        foreach (var call in calls)
+        {
+            if (StatementInBlock(call) is not { } callStatement)
+                return false;
+            foreach (var store in stores)
+            {
+                if (StatementInBlock(store) is not { } storeStatement
+                    || !ReferenceEquals(storeStatement.Parent, callStatement.Parent)
+                    || storeStatement.ChildIndex >= callStatement.ChildIndex)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static IrNode? StatementInBlock(IrNode node)
+    {
+        for (var current = node; current.Parent is not null; current = current.Parent)
+            if (current.Parent is Block)
+                return current;
+        return null;
     }
 
     static bool SubstituteEnvironment(IrFunction body, Environment environment)


### PR DESCRIPTION
## Summary

Fixes #1359 by making `LocalFunctionRaisingPass` decline capturing local-function recovery unless every consumed display-class capture store is in the same straight-line block and precedes every rewritten local-function call.

This prevents substituting a later environment field value into a local-function body that was called before that field store executed.

## Evidence

- Added adversarial negative: call before capture store stays lowered, keeps the `StoreField`, and emits no local-function declaration/invocation.
- Added positive canary: capture store before call still raises, elides the store, and emits the local-function declaration/invocation.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -v:q`

Generated quality card against the checked-in baseline reports the same regressions on pristine `origin/main`; this branch only changes corpus method counts by the two added test methods.

Branch card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,898 methods
Correctness coverage: validity sampled 350 / 87,898 (0.40%); fidelity sampled 22 / 87,898 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,300 (87.94%) | +406 |
| Conditional-branch residual | 2,290 (2.62%) | 2,304 (2.62%) | +14 |
| Forward-merge stops | 2,284 (2.61%) | 2,295 (2.61%) | +11 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,898 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,898 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```

`origin/main` control card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,896 methods
Correctness coverage: validity sampled 350 / 87,896 (0.40%); fidelity sampled 22 / 87,896 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,298 (87.94%) | +404 |
| Conditional-branch residual | 2,290 (2.62%) | 2,304 (2.62%) | +14 |
| Forward-merge stops | 2,284 (2.61%) | 2,295 (2.61%) | +11 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,896 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,896 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```
