### PR TITLE
Gate iterator acknowledgment on the narrow kickoff shape (#1362)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -162,6 +162,55 @@ public class IteratorAcknowledgmentPassTests
             body);
     }
 
+    [Fact]
+    public void IteratorKickoff_WithSideEffectingHandoffArgument_DeclinesAndPreservesSideEffect()
+    {
+        // The body is a single `return new <M>d__0(SideEffect())` — narrow by shape, but the
+        // construction consumes a side-effecting call. Acknowledging would drop that call, so
+        // the pass must decline (#1362, GPT-5.5 adversarial finding).
+        var function = BuildKickoffWithSideEffectingArgument();
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SideEffectInt");
+    }
+
+    static IrFunction BuildKickoffWithSideEffectingArgument()
+    {
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [TypeRef.CoreLib("System", "Int32")]);
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var ctor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Int32")],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            "SideEffectInt",
+            TypeRef.CoreLib("System", "Int32"),
+            [],
+            HasThis: false);
+
+        var block = new Block();
+        block.Add(new Return(new NewObject(ctor, [new Call(sideEffect, isVirtual: false, [])])));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
     static IrFunction BuildStateMachineNameLookalike()
     {
         var enumerable = TypeRef.GenericInstance(

--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -110,6 +110,58 @@ public class IteratorAcknowledgmentPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void IteratorKickoff_WithPrecedingSideEffect_DeclinesAndPreservesSideEffect()
+    {
+        // A user side effect before the iterator handoff is observable work. The pass must
+        // not collapse the whole body to a marker (which would drop it); it declines and
+        // leaves the lowered body visible (#1362).
+        var function = BuildKickoffWithSideEffect();
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SideEffect");
+        // The handoff construction is still present (lowered), not replaced by a marker.
+        Assert.Single(function.Descendants.OfType<NewObject>());
+    }
+
+    static IrFunction BuildKickoffWithSideEffect()
+    {
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [TypeRef.CoreLib("System", "Int32")]);
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var ctor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Int32")],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            "SideEffect",
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            HasThis: false);
+
+        var block = new Block();
+        block.Add(new ExpressionStatement(new Call(sideEffect, isVirtual: false, [])));
+        block.Add(new Return(new NewObject(ctor, [new Constant(-2, TypeRef.CoreLib("System", "Int32"))])));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
     static IrFunction BuildStateMachineNameLookalike()
     {
         var enumerable = TypeRef.GenericInstance(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -68,14 +68,36 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
 
     // The narrow kickoff shape: the whole body is `return new <M>d__N(state);`, where the
     // construction may be decorated by the capture object initializer (`<>3__param`,
-    // `<>4__this`). Anything else means user-visible work precedes the iterator handoff.
+    // `<>4__this`). Anything else means user-visible work precedes/feeds the iterator handoff.
+    // The construction arguments and capture entries must themselves be inert (the state
+    // Constant and parameter/this loads), so a side-effecting expression consumed by the
+    // handoff (e.g. `new <M>d__0(SideEffect())`) is not silently dropped by the marker.
     static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
     {
         if (function.Body.Children is not [Block block])
             return false;
         if (block.Children is not [Return { Value: { } returned }])
             return false;
-        var construction = returned is ObjectInitializerExpression initializer ? initializer.Creation : returned;
-        return ReferenceEquals(construction, handoff);
+
+        if (returned is ObjectInitializerExpression initializer)
+        {
+            if (!ReferenceEquals(initializer.Creation, handoff))
+                return false;
+            // Children[0] is the Creation; the rest are the capture entries' argument values.
+            foreach (var entry in initializer.Children.Skip(1).Cast<IrExpression>())
+                if (!IsInertCapture(entry))
+                    return false;
+        }
+        else if (!ReferenceEquals(returned, handoff))
+        {
+            return false;
+        }
+
+        return handoff.Arguments.All(IsInertCapture);
     }
+
+    // The only expressions a real compiler iterator kickoff feeds to the state-machine
+    // construction: the state Constant and direct loads of the captured parameters/this.
+    static bool IsInertCapture(IrExpression expression)
+        => expression is Constant or LoadArgument;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -53,8 +53,29 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
         if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return false;
 
+        // Only replace the whole body when it is exactly the compiler kickoff handoff: a
+        // single block that returns the state-machine construction (optionally wrapped in the
+        // captured-parameter/this object initializer). If the body carries any other
+        // statement — a user call, an extra store — that is observable work the marker would
+        // silently drop, so decline and leave the lowered body visible at Partial (#1362).
+        if (!IsNarrowKickoffHandoff(function, handoff))
+            return false;
+
         stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
         sourceOffset = handoff.SourceOffset;
         return true;
+    }
+
+    // The narrow kickoff shape: the whole body is `return new <M>d__N(state);`, where the
+    // construction may be decorated by the capture object initializer (`<>3__param`,
+    // `<>4__this`). Anything else means user-visible work precedes the iterator handoff.
+    static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
+    {
+        if (function.Body.Children is not [Block block])
+            return false;
+        if (block.Children is not [Return { Value: { } returned }])
+            return false;
+        var construction = returned is ObjectInitializerExpression initializer ? initializer.Creation : returned;
+        return ReferenceEquals(construction, handoff);
     }
 }


### PR DESCRIPTION
Burndown row 12 of #1356.

## Over-raise claim being narrowed

`IteratorAcknowledgmentPass` replaced the entire body of any enumerable-returning method that merely *contained* a compiler-generated iterator state-machine construction with a single unsupported marker — it never verified the body was only the kickoff handoff. So

```text
SideEffect(); return new <M>d__0(-2);
```

lost the `SideEffect()` call (the marker dropped the whole body) while still reporting Partial.

## Fix (narrowest proof gate)

Before replacing the body, require it to be exactly the kickoff handoff: a single block returning the state-machine construction, optionally decorated by the captured-parameter/`this` object initializer. These are the real shapes Roslyn emits, confirmed by dumping the corpus fixtures:

- `YieldTwo` → `return new <YieldTwo>d__N(-2);`
- `YieldRange(int n)` → `return new <YieldRange>d__N(-2) { <>3__n = n };` (an `ObjectInitializerExpression` over the construction)

If any other statement precedes the handoff, the pass declines and leaves the lowered body visible at Partial (the side effect survives). No pass widening — the gate only makes the over-raise impossible.

## Adversarial fixture + positive canaries

- `IteratorKickoff_WithPrecedingSideEffect_DeclinesAndPreservesSideEffect`: synthetic `SideEffect(); return new <M>d__0(-2)` (state machine carries positive `DeclaringTypeCompilerGenerated` evidence) — no iterator marker emitted, the `SideEffect` call and the handoff `NewObject` both survive.
- Existing positives intact: `YieldTwo`/`YieldRange` still acknowledged; the no-generated-evidence name lookalike still not acknowledged.

`src/ILInspector.Decompiler.Tests` `IteratorAcknowledgmentPassTests` 8/8 pass.

## Corpus quality diff

This change can alter iterator-acknowledgment output, so a quality-diff card against a freshly captured origin/main snapshot (same 14-assembly corpus) is in progress and will be posted as a follow-up comment. Declining acknowledgment leaves the kickoff lowered (still Partial), so no Full-fidelity metric should move.

Cross-model adversarial review (GPT-5.5) requested per AGENTS.md; result to follow.

Closes #1362.