### PR TITLE
Require narrow iterator kickoff reconstruction

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -193,6 +193,23 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void SideEffectBeforeIteratorHandoff_IsNotReconstructed()
+    {
+        var (function, moveNext, sideEffect) = BuildKickoffWithSideEffectBeforeHandoff();
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method.Name == "MoveNext" ? moveNext : null);
+
+        new IteratorReconstructionPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<YieldBreak>());
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee == sideEffect);
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<Return>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void NonEmptyIterator_HasNoSpuriousYieldBreak()
     {
         // A normal linear iterator falls off the end implicitly; reconstruction
@@ -356,5 +373,56 @@ public class IteratorReconstructionPassTests
         // The split disposal scaffolding is fully gone.
         Assert.DoesNotContain("Finally", output);
         Assert.DoesNotContain("GetEnumerator", output);
+    }
+
+    static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectBeforeHandoff()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [intType]);
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var constructor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            voidType,
+            [intType],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Effects"),
+            "SideEffect",
+            voidType,
+            [],
+            HasThis: false);
+
+        var kickoffBlock = new Block();
+        kickoffBlock.Add(new ExpressionStatement(new Call(sideEffect, isVirtual: false, [])));
+        kickoffBlock.Add(new Return(new NewObject(constructor, [new Constant(-2, intType)])));
+        var kickoffBody = new BlockContainer();
+        kickoffBody.Add(kickoffBlock);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            kickoffBody);
+
+        var moveNextBlock = new Block();
+        moveNextBlock.Add(new Return(new Constant(false, boolType)));
+        var moveNextBody = new BlockContainer();
+        moveNextBody.Add(moveNextBlock);
+        var moveNext = new IrFunction(
+            "MoveNext",
+            stateMachine,
+            new MethodSignature(boolType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            moveNextBody);
+
+        return (function, moveNext, sideEffect);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -60,6 +60,8 @@ public sealed class IteratorReconstructionPass : IIrPass
             return;
         if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return;
+        if (!IsNarrowKickoffHandoff(function, handoff))
+            return;
 
         var moveNextMethod = handoff.Constructor with { Name = "MoveNext" };
         if (!context.TryImportAndRunMethodBody(moveNextMethod, IrPasses.Default, out var moveNext)
@@ -105,6 +107,16 @@ public sealed class IteratorReconstructionPass : IIrPass
         foreach (var statement in statements)
             block.Add(statement);
         function.Body.Add(block);
+    }
+
+    static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
+    {
+        if (function.Body.Blocks is not [{ Children: [Return { Value: { } returned }] }])
+            return false;
+
+        return ReferenceEquals(returned, handoff)
+            || returned is ObjectInitializerExpression { Creation: var creation }
+                && ReferenceEquals(creation, handoff);
     }
 
     // Adopts a transform-then-restructure reconstruction: the kickoff's body is replaced


### PR DESCRIPTION
## Summary

Fixes #1363. Narrows `IteratorReconstructionPass` so it reconstructs only when the kickoff body is exactly the compiler handoff shape: one return of the generated iterator state-machine construction, either directly or through the parameter object-initializer form.

If user-visible work appears before the handoff, reconstruction now declines instead of replacing the whole body and dropping that work. Row #1362 owns the acknowledgment fallback; this PR intentionally only guards reconstruction.

## Tests

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IteratorReconstructionPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IdiomShapeScorecardTests/*"`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll --pass-impact iterator-reconstruction --cap 100000`

`src/ILInspector.Decompiler.Tests` full-project runner was also attempted, but it produced no terminal result after a long wait and was stopped; the focused iterator tests and scorecard slice completed successfully.

## Quality card

Checked-in baseline card (current `origin/main` shows the same baseline drift class, so this PR also includes the branch-vs-current-origin card below):

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,901 methods
Correctness coverage: validity sampled 350 / 87,901 (0.40%); fidelity sampled 22 / 87,901 (0.03%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,301 (87.94%) | +407 |
| Conditional-branch residual | 2,290 (2.62%) | 2,306 (2.62%) | +16 |
| Forward-merge stops | 2,284 (2.61%) | 2,297 (2.61%) | +13 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 87,901 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 87,901 (0.03%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

Branch-vs-current-origin snapshot card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,055 methods
Correctness coverage: validity sampled 350 / 88,055 (0.40%); fidelity sampled 22 / 88,055 (0.02%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,428 (87.93%) | 77,428 (87.93%) | 0 |
| Conditional-branch residual | 2,305 (2.62%) | 2,306 (2.62%) | +1 |
| Forward-merge stops | 2,296 (2.61%) | 2,297 (2.61%) | +1 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,054 (0.40%) | 4/350 — sampled 350 / 88,055 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,054 (0.02%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,055 (0.02%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/corpus-delta-1363.json`
```

Delta summary: `changedMethods=61`, `sourceChanged=0`, `passBugChanged=0`.

Pass impact:

```text
iterator-reconstruction changed 0/5045 methods (0.00%); 0 pass bugs
```

## Adversarial review

Requested cross-model review from Opus 4.8. Result: no blocking correctness, fidelity, test, or design findings.

Reviewer confirmed the new test is non-vacuous: reverting the production guard makes the side-effect-before-handoff test fail by reconstructing to bare `yield break;`, while the guard preserves the side-effecting call.
