### PR TITLE
Fix non-incrementable ++ raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -179,7 +179,21 @@ public class IncrementDecrementPassTests
 
         Assert.Equal(3, statements.Count);
         Assert.IsType<StoreStackSlot>(statements[0]);
-        Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(statements[1]).Expression);
+        Assert.IsType<UnsupportedNode>(Assert.IsType<StoreLocal>(statements[1]).Value);
+        Assert.Empty(statements.OfType<Return>().SelectMany(r => r.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
+    public void BoolPrefixValueProducingDupShape_IsMarkedUnsupported()
+    {
+        var statements = Run(Function(
+            new StoreStackSlot(0,
+                new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(0, Boolean), new Constant(1, Int32))),
+            new StoreLocal(0, Boolean, new LoadStackSlot(0, Boolean)),
+            new Return(new LoadStackSlot(0, Boolean))));
+
+        Assert.Equal(3, statements.Count);
+        Assert.IsType<UnsupportedNode>(Assert.IsType<StoreStackSlot>(statements[0]).Value);
         Assert.Empty(statements.OfType<Return>().SelectMany(r => r.Descendants).OfType<IncrementDecrement>());
     }
 
@@ -196,6 +210,25 @@ public class IncrementDecrementPassTests
 
         Assert.Equal(DecompilationFidelity.Partial, result.Fidelity);
         Assert.DoesNotContain("V_0++", result.Output);
+        Assert.DoesNotContain("V_0 + 1", result.Output);
+        Assert.DoesNotContain("S_0 + 1", result.Output);
+        Assert.Contains("Unsupported", result.Output);
+    }
+
+    [Fact]
+    public void BoolPrefixValueProducingDupShape_RendersPartialUnsupported()
+    {
+        var function = FunctionWithSignature(Boolean, [Boolean],
+            new StoreStackSlot(0,
+                new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(0, Boolean), new Constant(1, Int32))),
+            new StoreLocal(0, Boolean, new LoadStackSlot(0, Boolean)),
+            new Return(new LoadStackSlot(0, Boolean)));
+
+        var result = CSharpPrinter.PrintRaised(function);
+
+        Assert.Equal(DecompilationFidelity.Partial, result.Fidelity);
+        Assert.DoesNotContain("V_0++", result.Output);
+        Assert.DoesNotContain("V_0 + 1", result.Output);
         Assert.DoesNotContain("S_0 + 1", result.Output);
         Assert.Contains("Unsupported", result.Output);
     }

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -8,18 +9,23 @@ public class IncrementDecrementPassTests
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef EnumType = TypeRef.Definition("Test", "Synthetic", "Mode", ValueTypeHint.ValueType);
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef UnknownValueType = TypeRef.Definition("External", "Synthetic", "Mode", ValueTypeHint.ValueType);
+    static readonly TypeRef ValueType = TypeRef.Definition("Test", "Synthetic", "StructLike", ValueTypeHint.ValueType);
 
     // Builds `tempStore; placeUpdate;` as the two statements of a single block,
     // declaring the place (slot 0) and the temporary (slot 1).
     static IrFunction Function(params IrNode[] statements)
+        => FunctionWithSignature(TypeRef.CoreLib("System", "Void"), [], statements);
+
+    static IrFunction FunctionWithSignature(TypeRef returnType, TypeRef[] locals, params IrNode[] statements)
     {
         var container = new BlockContainer();
         var block = new Block(0);
         container.Add(block);
         foreach (var statement in statements)
             block.Add(statement);
-        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
-        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+        var signature = new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [.. locals], container);
     }
 
     static IReadOnlyList<IrNode> Run(IrFunction function)
@@ -42,6 +48,16 @@ public class IncrementDecrementPassTests
 
     static StoreLocal EnumUpdateFromTemp() =>
         new(0, EnumType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, EnumType), new Constant(1, Int32)));
+
+    static StoreLocal UnknownValueTypeTempStore() => new(1, UnknownValueType, new LoadLocal(0, UnknownValueType));
+
+    static StoreLocal UnknownValueTypeUpdateFromTemp() =>
+        new(0, UnknownValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, UnknownValueType), new Constant(1, Int32)));
+
+    static StoreLocal ValueTypeTempStore() => new(1, ValueType, new LoadLocal(0, ValueType));
+
+    static StoreLocal ValueTypeUpdateFromTemp() =>
+        new(0, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, ValueType), new Constant(1, Int32)));
 
     [Fact]
     public void DeadTempPostIncrement_FoldsToOperator()
@@ -77,6 +93,30 @@ public class IncrementDecrementPassTests
 
         var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.True(increment.IsIncrement);
+    }
+
+    [Fact]
+    public void UnknownValueTypeDeadTempPostIncrement_FoldsAsPotentialEnum()
+    {
+        var function = Function(UnknownValueTypeTempStore(), UnknownValueTypeUpdateFromTemp());
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [UnknownValueType] = TypeShape.Unknown };
+
+        var statements = Run(function);
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.True(increment.IsIncrement);
+    }
+
+    [Fact]
+    public void KnownValueTypeDeadTempPostIncrement_IsMarkedUnsupported()
+    {
+        var function = Function(ValueTypeTempStore(), ValueTypeUpdateFromTemp());
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [ValueType] = TypeShape.ValueType };
+
+        var statements = Run(function);
+
+        var unsupported = Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.Contains("++", unsupported.Reason);
     }
 
     [Fact]
@@ -129,7 +169,7 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
-    public void BoolValueProducingDupShape_IsNotFolded()
+    public void BoolValueProducingDupShape_IsMarkedUnsupported()
     {
         var statements = Run(Function(
             new StoreStackSlot(0, new LoadLocal(0, Boolean)),
@@ -139,16 +179,34 @@ public class IncrementDecrementPassTests
 
         Assert.Equal(3, statements.Count);
         Assert.IsType<StoreStackSlot>(statements[0]);
+        Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(statements[1]).Expression);
         Assert.Empty(statements.OfType<Return>().SelectMany(r => r.Descendants).OfType<IncrementDecrement>());
     }
 
     [Fact]
-    public void BoolDeadTempStatement_IsNotFolded()
+    public void BoolValueProducingDupShape_RendersPartialUnsupported()
+    {
+        var function = FunctionWithSignature(Boolean, [Boolean],
+            new StoreStackSlot(0, new LoadLocal(0, Boolean)),
+            new StoreLocal(0, Boolean,
+                new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadStackSlot(0, Boolean), new Constant(1, Int32))),
+            new Return(new LoadStackSlot(0, Boolean)));
+
+        var result = CSharpPrinter.PrintRaised(function);
+
+        Assert.Equal(DecompilationFidelity.Partial, result.Fidelity);
+        Assert.DoesNotContain("V_0++", result.Output);
+        Assert.DoesNotContain("S_0 + 1", result.Output);
+        Assert.Contains("Unsupported", result.Output);
+    }
+
+    [Fact]
+    public void BoolDeadTempStatement_IsMarkedUnsupported()
     {
         var statements = Run(Function(BoolTempStore(), BoolUpdateFromTemp()));
 
-        Assert.Equal(2, statements.Count);
-        Assert.IsType<StoreLocal>(statements[0]);
+        var unsupported = Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.Contains("++", unsupported.Reason);
         Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
     }
 
@@ -214,7 +272,7 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
-    public void BoolForLoopTempIncrement_IsNotFolded()
+    public void BoolForLoopTempIncrement_IsMarkedUnsupported()
     {
         var init = new StoreLocal(0, Boolean, new Constant(false, Boolean));
         var condition = new LoadArgument(0, "keepGoing", Boolean);
@@ -226,7 +284,8 @@ public class IncrementDecrementPassTests
 
         new IncrementDecrementPass().Run(Function(loop), PassContext.None);
 
-        Assert.Equal(1, IncrementOperandIndex(loop));
-        Assert.Single(loop.Body.Children);
+        var unsupported = Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(loop.Increment).Expression);
+        Assert.Contains("++", unsupported.Reason);
+        Assert.Empty(loop.Body.Children);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -5,6 +5,8 @@ namespace ILInspector.Decompiler.Tests;
 
 public class IncrementDecrementPassTests
 {
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef EnumType = TypeRef.Definition("Test", "Synthetic", "Mode", ValueTypeHint.ValueType);
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
 
     // Builds `tempStore; placeUpdate;` as the two statements of a single block,
@@ -31,6 +33,16 @@ public class IncrementDecrementPassTests
     static StoreLocal Update(BinaryKind kind) =>
         new(0, Int32, new Binary(kind, isChecked: false, isUnsigned: false, new LoadLocal(1, Int32), new Constant(1, Int32)));
 
+    static StoreLocal BoolTempStore() => new(1, Boolean, new LoadLocal(0, Boolean));
+
+    static StoreLocal BoolUpdateFromTemp() =>
+        new(0, Boolean, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, Boolean), new Constant(1, Int32)));
+
+    static StoreLocal EnumTempStore() => new(1, EnumType, new LoadLocal(0, EnumType));
+
+    static StoreLocal EnumUpdateFromTemp() =>
+        new(0, EnumType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, EnumType), new Constant(1, Int32)));
+
     [Fact]
     public void DeadTempPostIncrement_FoldsToOperator()
     {
@@ -53,6 +65,18 @@ public class IncrementDecrementPassTests
 
         var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.False(increment.IsIncrement);
+    }
+
+    [Fact]
+    public void KnownEnumDeadTempPostIncrement_FoldsToOperator()
+    {
+        var function = Function(EnumTempStore(), EnumUpdateFromTemp());
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [EnumType] = TypeShape.Enum };
+
+        var statements = Run(function);
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.True(increment.IsIncrement);
     }
 
     [Fact]
@@ -102,6 +126,30 @@ public class IncrementDecrementPassTests
         var statements = Run(Function(TempStore(), update));
 
         Assert.Equal(2, statements.Count);
+    }
+
+    [Fact]
+    public void BoolValueProducingDupShape_IsNotFolded()
+    {
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadLocal(0, Boolean)),
+            new StoreLocal(0, Boolean,
+                new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadStackSlot(0, Boolean), new Constant(1, Int32))),
+            new Return(new LoadStackSlot(0, Boolean))));
+
+        Assert.Equal(3, statements.Count);
+        Assert.IsType<StoreStackSlot>(statements[0]);
+        Assert.Empty(statements.OfType<Return>().SelectMany(r => r.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
+    public void BoolDeadTempStatement_IsNotFolded()
+    {
+        var statements = Run(Function(BoolTempStore(), BoolUpdateFromTemp()));
+
+        Assert.Equal(2, statements.Count);
+        Assert.IsType<StoreLocal>(statements[0]);
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
     }
 
     // Builds a `for (place = 0; place < 2; place = temp + 1) { ...head; temp = place; }`
@@ -163,5 +211,22 @@ public class IncrementDecrementPassTests
 
         Assert.Equal(1, IncrementOperandIndex(loop));
         Assert.Equal(2, loop.Body.Children.Count);
+    }
+
+    [Fact]
+    public void BoolForLoopTempIncrement_IsNotFolded()
+    {
+        var init = new StoreLocal(0, Boolean, new Constant(false, Boolean));
+        var condition = new LoadArgument(0, "keepGoing", Boolean);
+        var increment = new StoreLocal(0, Boolean,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, Boolean), new Constant(1, Int32)));
+        var body = new Block(0);
+        body.Add(new StoreLocal(1, Boolean, new LoadLocal(0, Boolean)));
+        var loop = new ForLoop(init, condition, increment, body);
+
+        new IncrementDecrementPass().Run(Function(loop), PassContext.None);
+
+        Assert.Equal(1, IncrementOperandIndex(loop));
+        Assert.Single(loop.Body.Children);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -89,6 +89,8 @@ public sealed class IncrementDecrementPass : IIrPass
         {
             return false;
         }
+        if (!IsIncrementable(place.Type, function))
+            return false;
 
         // The dup slot must be written once and read exactly twice: the local
         // update above, plus one downstream consumer.
@@ -229,6 +231,8 @@ public sealed class IncrementDecrementPass : IIrPass
             return false;
         if (writePlace.IsLocal && writePlace.Index == tempStore.Index)
             return false;
+        if (!IsIncrementable(writePlace.Type, function))
+            return false;
 
         if (updateValue is not Binary { IsChecked: false, Kind: var kind } binary
             || binary.Left is not LoadLocal load || load.Index != tempStore.Index
@@ -296,6 +300,8 @@ public sealed class IncrementDecrementPass : IIrPass
                 continue;
             if (captured.IsLocal != place.IsLocal || captured.Index != place.Index)
                 continue;
+            if (!IsIncrementable(place.Type, function))
+                continue;
 
             candidates.Add(new ForLoopIncrement(loop, tempRead.Index, place, capture, tempRead, binary.Kind));
         }
@@ -356,6 +362,13 @@ public sealed class IncrementDecrementPass : IIrPass
     static IrExpression ClonePlace(PlaceRef place) => place.IsLocal
         ? new LoadLocal(place.Index, place.Type)
         : new LoadArgument(place.Index, place.Name, place.Type);
+
+    static bool IsIncrementable(TypeRef type, IrFunction function)
+        => TypeFamilies.IsNumericPrimitive(type)
+            || MemberIdentity.IsCoreLibraryType(type, "System", "Decimal")
+            || type.Kind == TypeRefKind.Pointer
+            // Enum ++/-- is legal C#, but only same-assembly enum shapes are proven here.
+            || function.TypeShapes.TryGetValue(type, out var shape) && shape == TypeShape.Enum;
 
     static bool ReferencesPlace(IrNode node, PlaceRef place)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -116,7 +116,7 @@ public sealed class IncrementDecrementPass : IIrPass
         }
         if (!IsIncrementable(place.Type, function))
         {
-            MarkUnsupportedIncrement(update, place, isIncrement ? BinaryKind.Add : BinaryKind.Subtract, stepper);
+            MarkUnsupportedIncrementExpression(isPrefix ? slotStore.Value : updateValue, place, isIncrement ? BinaryKind.Add : BinaryKind.Subtract, stepper);
             return true;
         }
 
@@ -251,7 +251,7 @@ public sealed class IncrementDecrementPass : IIrPass
 
         if (!IsIncrementable(writePlace.Type, function))
         {
-            MarkUnsupportedIncrement(tempStore, writePlace, kind, stepper);
+            MarkUnsupportedIncrementStatement(tempStore, writePlace, kind, stepper);
             block.Children[i + 1].Detach();
             return true;
         }
@@ -333,7 +333,7 @@ public sealed class IncrementDecrementPass : IIrPass
             {
                 if (!fold.IsIncrementable)
                 {
-                    MarkUnsupportedIncrement(fold.Loop.Increment, fold.Place, fold.Kind, stepper);
+                    MarkUnsupportedIncrementStatement(fold.Loop.Increment, fold.Place, fold.Kind, stepper);
                     fold.Capture.Detach();
                     continue;
                 }
@@ -392,7 +392,23 @@ public sealed class IncrementDecrementPass : IIrPass
         return type.Kind == TypeRefKind.Definition && type.DeclaredValueTypeHint == ValueTypeHint.ValueType;
     }
 
-    static void MarkUnsupportedIncrement(IrNode node, PlaceRef place, BinaryKind kind, Stepper stepper)
+    static void MarkUnsupportedIncrementExpression(IrExpression expression, PlaceRef place, BinaryKind kind, Stepper stepper)
+    {
+        var marker = UnsupportedIncrementNode(expression, place, kind);
+        stepper.StepOver($"mark non-incrementable {place.Type.ToDisplayString()} {marker.Opcode} expression unsupported", expression);
+        expression.ReplaceWith(marker);
+    }
+
+    static void MarkUnsupportedIncrementStatement(IrNode node, PlaceRef place, BinaryKind kind, Stepper stepper)
+    {
+        var marker = UnsupportedIncrementNode(node, place, kind);
+        var statement = new ExpressionStatement(marker);
+        statement.InheritSourceOffset(node);
+        stepper.StepOver($"mark non-incrementable {place.Type.ToDisplayString()} {marker.Opcode} shape unsupported", node);
+        node.ReplaceWith(statement);
+    }
+
+    static UnsupportedNode UnsupportedIncrementNode(IrNode node, PlaceRef place, BinaryKind kind)
     {
         string op = kind is BinaryKind.Add ? "++" : "--";
         var marker = new UnsupportedNode(
@@ -400,10 +416,7 @@ public sealed class IncrementDecrementPass : IIrPass
             op,
             $"{op} is not defined for {place.Type.ToDisplayString()}");
         marker.InheritSourceOffset(node);
-        var statement = new ExpressionStatement(marker);
-        statement.InheritSourceOffset(node);
-        stepper.StepOver($"mark non-incrementable {place.Type.ToDisplayString()} {op} shape unsupported", node);
-        node.ReplaceWith(statement);
+        return marker;
     }
 
     static bool ReferencesPlace(IrNode node, PlaceRef place)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -89,9 +89,6 @@ public sealed class IncrementDecrementPass : IIrPass
         {
             return false;
         }
-        if (!IsIncrementable(place.Type, function))
-            return false;
-
         // The dup slot must be written once and read exactly twice: the local
         // update above, plus one downstream consumer.
         var loads = function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == slot).ToList();
@@ -116,6 +113,11 @@ public sealed class IncrementDecrementPass : IIrPass
         {
             if (ReferencesPlace(block.Children[k], place))
                 return false;
+        }
+        if (!IsIncrementable(place.Type, function))
+        {
+            MarkUnsupportedIncrement(update, place, isIncrement ? BinaryKind.Add : BinaryKind.Subtract, stepper);
+            return true;
         }
 
         stepper.StepOver($"fold dup {(isIncrement ? "++" : "--")} idiom into operator", useLoad);
@@ -231,8 +233,6 @@ public sealed class IncrementDecrementPass : IIrPass
             return false;
         if (writePlace.IsLocal && writePlace.Index == tempStore.Index)
             return false;
-        if (!IsIncrementable(writePlace.Type, function))
-            return false;
 
         if (updateValue is not Binary { IsChecked: false, Kind: var kind } binary
             || binary.Left is not LoadLocal load || load.Index != tempStore.Index
@@ -249,6 +249,13 @@ public sealed class IncrementDecrementPass : IIrPass
         if (function.Descendants.OfType<LoadLocal>().Count(l => l.Index == tempStore.Index) != 1)
             return false;
 
+        if (!IsIncrementable(writePlace.Type, function))
+        {
+            MarkUnsupportedIncrement(tempStore, writePlace, kind, stepper);
+            block.Children[i + 1].Detach();
+            return true;
+        }
+
         var increment = new IncrementDecrement(ClonePlace(writePlace), kind is BinaryKind.Add, isPrefix: false);
         stepper.StepOver($"fold dead-temp {(kind is BinaryKind.Add ? "++" : "--")} statement into operator", tempStore);
         tempStore.ReplaceWith(new ExpressionStatement(increment));
@@ -256,7 +263,7 @@ public sealed class IncrementDecrementPass : IIrPass
         return true;
     }
 
-    readonly record struct ForLoopIncrement(ForLoop Loop, int TempIndex, PlaceRef Place, StoreLocal Capture, LoadLocal IncrementRead, BinaryKind Kind);
+    readonly record struct ForLoopIncrement(ForLoop Loop, int TempIndex, PlaceRef Place, StoreLocal Capture, LoadLocal IncrementRead, BinaryKind Kind, bool IsIncrementable);
 
     /// <summary>
     /// Folds the for-loop post-increment temp form that iterator reconstruction
@@ -300,10 +307,7 @@ public sealed class IncrementDecrementPass : IIrPass
                 continue;
             if (captured.IsLocal != place.IsLocal || captured.Index != place.Index)
                 continue;
-            if (!IsIncrementable(place.Type, function))
-                continue;
-
-            candidates.Add(new ForLoopIncrement(loop, tempRead.Index, place, capture, tempRead, binary.Kind));
+            candidates.Add(new ForLoopIncrement(loop, tempRead.Index, place, capture, tempRead, binary.Kind, IsIncrementable(place.Type, function)));
         }
 
         foreach (var group in candidates.GroupBy(c => c.TempIndex))
@@ -327,6 +331,13 @@ public sealed class IncrementDecrementPass : IIrPass
 
             foreach (var fold in folds)
             {
+                if (!fold.IsIncrementable)
+                {
+                    MarkUnsupportedIncrement(fold.Loop.Increment, fold.Place, fold.Kind, stepper);
+                    fold.Capture.Detach();
+                    continue;
+                }
+
                 stepper.StepOver($"inline for-loop post-increment temp into {(fold.Kind is BinaryKind.Add ? "++" : "--")} update", fold.Loop.Increment);
                 fold.IncrementRead.ReplaceWith(ClonePlace(fold.Place));
                 fold.Capture.Detach();
@@ -367,8 +378,33 @@ public sealed class IncrementDecrementPass : IIrPass
         => TypeFamilies.IsNumericPrimitive(type)
             || MemberIdentity.IsCoreLibraryType(type, "System", "Decimal")
             || type.Kind == TypeRefKind.Pointer
-            // Enum ++/-- is legal C#, but only same-assembly enum shapes are proven here.
-            || function.TypeShapes.TryGetValue(type, out var shape) && shape == TypeShape.Enum;
+            || IsEnumOrPotentialEnum(type, function);
+
+    static bool IsEnumOrPotentialEnum(TypeRef type, IrFunction function)
+    {
+        if (function.TypeShapes.TryGetValue(type, out var shape))
+            return shape == TypeShape.Enum
+                || shape == TypeShape.Unknown && type.DeclaredValueTypeHint == ValueTypeHint.ValueType;
+
+        // Cross-assembly enum definitions are commonly unresolved here: signature
+        // metadata proves value-type-ness, while the Binary ± 1 shape cannot be a
+        // user-defined struct operator (those import as calls).
+        return type.Kind == TypeRefKind.Definition && type.DeclaredValueTypeHint == ValueTypeHint.ValueType;
+    }
+
+    static void MarkUnsupportedIncrement(IrNode node, PlaceRef place, BinaryKind kind, Stepper stepper)
+    {
+        string op = kind is BinaryKind.Add ? "++" : "--";
+        var marker = new UnsupportedNode(
+            node.SourceOffset >= 0 ? node.SourceOffset : 0,
+            op,
+            $"{op} is not defined for {place.Type.ToDisplayString()}");
+        marker.InheritSourceOffset(node);
+        var statement = new ExpressionStatement(marker);
+        statement.InheritSourceOffset(node);
+        stepper.StepOver($"mark non-incrementable {place.Type.ToDisplayString()} {op} shape unsupported", node);
+        node.ReplaceWith(statement);
+    }
 
     static bool ReferencesPlace(IrNode node, PlaceRef place)
     {


### PR DESCRIPTION
## Summary

Fixes #1366 and #1356 row 16.

- Gates `IncrementDecrementPass` on C#-incrementable place types.
- Marks recognized non-incrementable dup/temp increment shapes as explicit unsupported residuals instead of leaking invalid C# such as `bool++` or `bool + 1`.
- Preserves numeric, decimal, pointer, known enum, and unresolved value-type enum-compatible raises while declining known non-enum value types.
- Adds positive and adversarial coverage for postfix/prefix value-producing bool shapes, dead-temp statements, for-loop temps, known structs, known enums, unresolved value-type cases, and rendered Partial output.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IncrementDecrementPassTests/*"` — 18 passed.
- `dotnet build src/dotnet-inspect -c Release` — passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 1156 passed.

## Quality card

Generated against a same-worktree merge-base snapshot to isolate this PR from checked-in baseline drift.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,061 methods
Correctness coverage: validity sampled 350 / 88,061 (0.40%); fidelity sampled 22 / 88,061 (0.02%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,428 (87.93%) | 77,435 (87.93%) | +7 |
| Conditional-branch residual | 2,305 (2.62%) | 2,305 (2.62%) | 0 |
| Forward-merge stops | 2,296 (2.61%) | 2,296 (2.61%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,054 (0.40%) | 4/350 — sampled 350 / 88,061 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,054 (0.02%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,061 (0.02%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/1366-postfix-corpus-delta.json`

## Changed-method fidelity

`--emit-corpus-delta` against the same-worktree merge-base snapshot produced 11 method-key changes, all in `ILInspector.Decompiler.Pipeline.IncrementDecrementPass`: added helper methods plus the `ForLoopIncrement` record-shape add/remove after carrying the `IsIncrementable` flag. The aggregate quality card has zero semantic/fidelity/pass-bug regressions; helper method fidelity was not sampled.

## Adversarial review

Opus 4.8 review initially found a blocking prefix value-producing dup gap: `S = x + 1; x = S; ... use S` marked the copy unsupported but left invalid `bool + 1` arithmetic. Fixed by marking the arithmetic expression itself unsupported (`slotStore.Value` for prefix, `updateValue` for postfix) and adding prefix render tests that assert Partial output and no residual `V_0 + 1`/`S_0 + 1`/`V_0++`.

Follow-up review verified the prefix gap is fixed and found no remaining high-confidence correctness issues.
