### PR TITLE
Guard address compound folds for effectful indexes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -484,6 +484,14 @@ public class CfgSampleClass
     // (no slot) must NOT fold, so both spellings are kept for contrast.
     public static void ArrayElementAdd(int[] a, int i, int v) => a[i] += v;
 
+    public static void ArrayElementAddEffectfulIndex(int[] a, int v) => a[RecordIndex()] += v;
+
+    static int RecordIndex()
+    {
+        LastValue++;
+        return 0;
+    }
+
     public static void ArrayElementShift(int[] a, int i, int n) => a[i] <<= n;
 
     public static void ArrayElementInc(int[] a, int i) => a[i]++;

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -121,6 +121,9 @@ public class FidelityGateTests
     /// a `ref` local keeps a single get_Item evaluation and recompiles opcode-exact,
     /// where the fold would leak `s[i] = (s[i]) + v` and call the getter twice
     /// (#1011 byref-provenance audit).
+    /// ArrayElementAddEffectfulIndex must similarly keep a call-indexed array
+    /// address as a captured `ref` local; cloning `a[RecordIndex()]` into read and
+    /// write would double-evaluate the index (#1382).
     /// GenericNullConditionalToString must keep folding csc's generic
     /// null-conditional invocation (the default(T)-box two-stage null test with a
     /// reload) back into `value?.ToString() ?? "none"`, which recompiles to the
@@ -190,6 +193,7 @@ public class FidelityGateTests
         "NestedMixedSignArithmetic",
         "RefEnumMask",
         "RvaIntArray",
+        "ArrayElementAddEffectfulIndex",
         "SpanElementCompoundAdd",
         "BoolBitwiseOrWidened",
         "CrossAssemblyEnumSwitch",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1999,6 +1999,21 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void CompoundAssignment_ArrayElementEffectfulIndex_KeepsSingleIndexEvaluation()
+    {
+        // `a[RecordIndex()] += v` lowers to one captured &a[RecordIndex()]. The
+        // pass must not clone that address unless the printer can fold it back to
+        // a compound lvalue; otherwise the call index would be evaluated twice.
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ArrayElementAddEffectfulIndex), source);
+
+        Assert.Equal(1, output.Split("RecordIndex()", StringSplitOptions.None).Length - 1);
+        Assert.Contains("ref int", output);
+        Assert.Contains("= ref a[CfgSampleClass.RecordIndex()];", output);
+        Assert.Contains(") + v;", output);
+    }
+
+    [Fact]
     public void CompoundAssignment_ArrayElementShift_FoldsToCompoundOperator()
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -160,13 +160,12 @@ public sealed class IncrementDecrementPass : IIrPass
         // back as `target op= v`. That collapse only happens when the printer's
         // CSharpPrinter.SameLValue recognizes the address as a side-effect-free
         // place (LoadArgument/LoadLocal/LoadField{,Address}/LoadElementAddress).
-        // A ref-returning property/indexer getter (LoadProperty, e.g.
-        // Span<T>.this[int]) is NOT in that set, so the printer cannot fold and
-        // would emit `target = (target) + v`, re-evaluating the getter. That both
-        // breaks opcode-exactness and double-evaluates a side-effecting getter.
-        // Decline the fold here and let the slot render as a `ref` local, which
-        // keeps a single getter evaluation (opcode-exact).
-        if (slotStore.Value is LoadProperty)
+        // Anything outside that set (a ref-returning property/indexer getter, or
+        // an array element whose index is a call) would leak as `target = target +
+        // v`, re-evaluating the unrecognized receiver/index. Decline the fold
+        // here and let the slot render as a `ref` local, which keeps a single
+        // evaluation (opcode-exact).
+        if (!IsPrinterFoldableClonedAddress(slotStore.Value))
             return false;
         if (block.Children[i + 1] is not StoreIndirect store)
             return false;
@@ -196,6 +195,17 @@ public sealed class IncrementDecrementPass : IIrPass
         slotStore.Detach();
         return true;
     }
+
+    static bool IsPrinterFoldableClonedAddress(IrExpression? expression) => expression switch
+    {
+        null => true,
+        LoadArgument or LoadLocal or Constant => true,
+        LoadField field => IsPrinterFoldableClonedAddress(field.Instance),
+        LoadFieldAddress field => IsPrinterFoldableClonedAddress(field.Instance),
+        LoadElementAddress element => IsPrinterFoldableClonedAddress(element.Array)
+            && IsPrinterFoldableClonedAddress(element.Index),
+        _ => false,
+    };
 
     /// <summary>
     /// Folds the dead-temp post-increment statement form — a value-less


### PR DESCRIPTION
Fixes #1382.

## Summary

- Tighten `IncrementDecrementPass.TryFoldAddressCompound` so it only clones captured byref addresses that the printer can collapse back to a compound lvalue.
- Keep `a[RecordIndex()] += v` as a captured `ref` local instead of cloning the call-indexed address into read and write.
- Add an adversarial fixture and pin its compile-back fidelity; existing local-index array compound positives still fold.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IncrementDecrementPassTests -class ILInspector.Decompiler.Tests.RaisingPassTests -class ILInspector.Decompiler.Tests.FidelityGateTests`
  - 109 passed, 0 failed.
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
  - Succeeded.

### Decompiler quality diff

Generated on the final branch after merging current `origin/main`:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,055 methods
Correctness coverage: validity sampled 350 / 88,055 (0.40%); fidelity sampled 22 / 88,055 (0.02%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,429 (87.93%) | +535 |
| Conditional-branch residual | 2,290 (2.62%) | 2,305 (2.62%) | +15 |
| Forward-merge stops | 2,284 (2.61%) | 2,296 (2.61%) | +12 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,055 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,055 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

The malformed/fidelity regression counts match the same card run on clean main before this branch's fix; this PR's diff is limited to the targeted pass/test files.

## Adversarial review

Opus 4.8 reviewed the guard and tests. Result: no blocking findings. The review confirmed the new predicate mirrors `CSharpPrinter.SameLValue` for the cloned-address self-compare, preserves existing positives, and closes the call-index double-evaluation bug.
