### PR TITLE
Fix destructor recovery trailing statements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
@@ -7,6 +7,10 @@ namespace ILInspector.Decompiler.Tests;
 // scaffold back to BODY and marks the function a destructor.
 public class DestructorRecoveryPassTests
 {
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "HasFinalizer");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
     static IrFunction Raised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -35,4 +39,84 @@ public class DestructorRecoveryPassTests
         Assert.DoesNotContain("base.Finalize", output);
         Assert.DoesNotContain("finally", output);
     }
+
+    [Fact]
+    public void FinalizeOverride_WithOnlyTrailingReturn_RecoversAsDestructorBody()
+    {
+        var function = BuildManualFinalize(includeExecutableTrailingStatement: false);
+
+        new DestructorRecoveryPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.True(function.IsDestructor);
+        Assert.Empty(function.Descendants.OfType<TryFinally>());
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            call => call.Callee.Name == "Finalize");
+    }
+
+    [Fact]
+    public void FinalizeOverride_WithExecutableTrailingStatement_StandsDown()
+    {
+        var function = BuildManualFinalize(includeExecutableTrailingStatement: true);
+
+        new DestructorRecoveryPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.False(function.IsDestructor);
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Contains(
+            function.Descendants.OfType<Call>(),
+            call => call.Callee.Name == "AfterBase");
+        Assert.Contains(
+            function.Descendants.OfType<Call>(),
+            call => call.Callee.Name == "Finalize");
+    }
+
+    static IrFunction BuildManualFinalize(bool includeExecutableTrailingStatement)
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new TryFinally(
+            BlockWithCall("Body"),
+            BlockWithBaseFinalize()));
+        if (includeExecutableTrailingStatement)
+            block.Add(new ExpressionStatement(Call("AfterBase")));
+        block.Add(new Return(null));
+        body.Add(block);
+
+        return new IrFunction(
+            "Finalize",
+            Holder,
+            new MethodSignature(Void, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static BlockContainer BlockWithCall(string methodName)
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(Call(methodName)));
+        body.Add(block);
+        return body;
+    }
+
+    static BlockContainer BlockWithBaseFinalize()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(Object, "Finalize", Void, [], HasThis: true),
+            isVirtual: false,
+            [new LoadArgument(0, "this", Holder)])));
+        body.Add(block);
+        return body;
+    }
+
+    static Call Call(string methodName)
+        => new(
+            new MethodRef(Holder, methodName, Void, [], HasThis: false),
+            isVirtual: false,
+            []);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
@@ -16,9 +16,10 @@ namespace ILInspector.Decompiler.Pipeline;
 ///
 /// <para>Runs after structuring so the EH region is a <see cref="TryFinally"/>.
 /// Conservative: the method must be a parameterless instance <c>void Finalize</c>
-/// whose body is exactly that try/finally with a finally of nothing but the base
-/// call; anything else (a prologue before the try, extra finally work) keeps the
-/// literal form.</para>
+/// whose body is that try/finally, followed at most by the implicit void
+/// return, with a finally of nothing but the base call; anything else (a
+/// prologue before the try, executable trailing work, extra finally work) keeps
+/// the literal form.</para>
 /// </summary>
 public sealed class DestructorRecoveryPass : IIrPass
 {
@@ -43,16 +44,11 @@ public sealed class DestructorRecoveryPass : IIrPass
 
         var tryBody = tryFinally.TryBody;
         var trailing = block.Children.Skip(tryFinally.ChildIndex + 1).ToList();
-
-        tryBody.Detach();
-        var lastBlock = (Block)tryBody.Children[^1];
-        foreach (var statement in trailing)
-        {
-            statement.Detach();
-            lastBlock.Add(statement);
-        }
+        if (trailing is not [] && trailing is not [Return { Value: null }])
+            return;
 
         context.Stepper.StepOver("recover finalizer try/finally as a destructor body", tryFinally);
+        tryBody.Detach();
         function.SetChild(0, tryBody);
         function.IsDestructor = true;
     }


### PR DESCRIPTION
## Summary

Fixes #1368 by making `DestructorRecoveryPass` decline destructor recovery when executable statements trail the finalizer `try/finally`. The pass now only accepts the compiler-shaped trailing surface: no trailing statement, or exactly one inert `return;`.

## Shape proof

- Added a positive synthetic IR fixture for `try { Body(); } finally { base.Finalize(); } return;` that still recovers as a destructor.
- Added an adversarial synthetic IR fixture for `try { Body(); } finally { base.Finalize(); } AfterBase(); return;` that now stays lowered instead of moving `AfterBase()` before the implicit `base.Finalize()`.

Before/after evidence for the negative fixture:

```text
origin/main + test: FinalizeOverride_WithExecutableTrailingStatement_StandsDown failed
Assert.False() Failure
Expected: False
Actual:   True

this branch: DestructorRecoveryPassTests Total: 3, Errors: 0, Failed: 0
```

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/DestructorRecoveryPassTests/*"
ILInspector.Decompiler.Tests  Total: 3, Errors: 0, Failed: 0, Skipped: 0

 dotnet run --project src/ILInspector.Decompiler.Tests -c Release
ILInspector.Decompiler.Tests  Total: 1149, Errors: 0, Failed: 0, Skipped: 0

 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```

Generated quality card on the final branch:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,054 methods
Correctness coverage: validity sampled 350 / 88,054 (0.40%); fidelity sampled 22 / 88,054 (0.02%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,428 (87.93%) | +534 |
| Conditional-branch residual | 2,290 (2.62%) | 2,305 (2.62%) | +15 |
| Forward-merge stops | 2,284 (2.61%) | 2,296 (2.61%) | +12 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,054 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,054 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)
```

The same card on freshly built `origin/main` is identical, so the reported quality-card regressions are current baseline drift, not movement from this row. Changed-method fidelity is not applicable: the regression is pinned by a hand-built IR near-miss rather than a corpus-derived changed-method population.
