### PR TITLE
Gate iterator acknowledgment on the narrow handoff shape (#1362)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -110,6 +110,90 @@ public class IteratorAcknowledgmentPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void SideEffectBeforeHandoff_IsNotAcknowledged_AndPreservesSideEffect()
+    {
+        // #1362: the kickoff body is not the narrow handoff scaffold — a side
+        // effect runs before `return new <M>d__0(-2)`. Acknowledging would replace
+        // the whole body with a marker and silently drop the call. The pass must
+        // decline; the side effect and the (residual) handoff stay visible.
+        var function = BuildKickoffWithLeadingSideEffect();
+
+        IrPasses.Run(function);
+
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SideEffect");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NarrowHandoffWithGeneratedEvidence_IsAcknowledged()
+    {
+        // Positive canary: the same generated state-machine evidence in a *pure*
+        // handoff body (just `return new <M>d__0(-2)`) still acknowledges.
+        var function = BuildNarrowKickoff();
+
+        IrPasses.Run(function);
+
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    static MethodRef GeneratedKickoffConstructor()
+    {
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "C+<M>d__0");
+        return new MethodRef(
+            stateMachine,
+            ".ctor",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Int32")],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+    }
+
+    static IrFunction BuildKickoff(params IrNode[] statements)
+    {
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [TypeRef.CoreLib("System", "Int32")]);
+        var block = new Block();
+        foreach (var statement in statements)
+            block.Add(statement);
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "C"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction BuildNarrowKickoff()
+        => BuildKickoff(new Return(new NewObject(
+            GeneratedKickoffConstructor(),
+            [new Constant(-2, TypeRef.CoreLib("System", "Int32"))])));
+
+    static IrFunction BuildKickoffWithLeadingSideEffect()
+    {
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "C"),
+            "SideEffect",
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            HasThis: false);
+        return BuildKickoff(
+            new ExpressionStatement(new Call(sideEffect, isVirtual: false, [])),
+            new Return(new NewObject(
+                GeneratedKickoffConstructor(),
+                [new Constant(-2, TypeRef.CoreLib("System", "Int32"))])));
+    }
+
     static IrFunction BuildStateMachineNameLookalike()
     {
         var enumerable = TypeRef.GenericInstance(

--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -142,6 +142,36 @@ public class IteratorAcknowledgmentPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void SideEffectInHandoffConstructorArgument_IsNotAcknowledged()
+    {
+        // #1362 (adversarial review): the side effect hides inside the handoff
+        // construction's own argument — `return new <M>d__0(Side());` — instead of
+        // a preceding statement. Acknowledging would still drop the call; the gate
+        // must reject a non-constant/effectful constructor argument.
+        var function = BuildKickoffWithSideEffectingConstructorArgument();
+
+        IrPasses.Run(function);
+
+        Assert.DoesNotContain(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SideEffect");
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildKickoffWithSideEffectingConstructorArgument()
+    {
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "C"),
+            "SideEffect",
+            TypeRef.CoreLib("System", "Int32"),
+            [],
+            HasThis: false);
+        return BuildKickoff(new Return(new NewObject(
+            GeneratedKickoffConstructor(),
+            [new Call(sideEffect, isVirtual: false, [])])));
+    }
+
     static MethodRef GeneratedKickoffConstructor()
     {
         var stateMachine = TypeRef.Definition("Synthetic", "Samples", "C+<M>d__0");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -76,6 +76,13 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
     // makes whole-body replacement lossy, so the acknowledgment declines.
     static bool IsNarrowHandoffShape(IrFunction function, NewObject handoff)
     {
+        // The handoff itself must be the bare `new <M>d__N(state)` construction:
+        // its constructor arguments are compiler-supplied (the initial state, -2),
+        // never user side effects. A side-effecting argument would be dropped by
+        // whole-body replacement just like a leading statement (#1362).
+        if (!handoff.Arguments.All(IsPureLoad))
+            return false;
+
         var returns = 0;
         foreach (var statement in EnumerateKickoffStatements(function.Body))
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using ILInspector.Decompiler;
 
 namespace ILInspector.Decompiler.Pipeline;
@@ -53,8 +54,91 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
         if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return false;
 
+        // Replacing the whole body with a marker is only honest when the body *is*
+        // the narrow compiler handoff scaffold. A real kickoff carries no user
+        // logic — it just constructs the state machine, copies `this`/parameters
+        // into its hoisted capture fields, and returns it. If any other statement
+        // is present (e.g. a side-effecting call before the handoff), acknowledging
+        // would silently drop it (#1362); decline and leave the lowered residual.
+        if (!IsNarrowHandoffShape(function, handoff))
+            return false;
+
         stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
         sourceOffset = handoff.SourceOffset;
         return true;
     }
+
+    // The kickoff body must consist solely of the handoff scaffold:
+    //   * the state-machine construction (returned directly or stored to a slot/local),
+    //   * pure capture stores into the state-machine instance, and
+    //   * a single return of the constructed instance.
+    // Any foreign statement — or a side effect hidden in a capture-store subtree —
+    // makes whole-body replacement lossy, so the acknowledgment declines.
+    static bool IsNarrowHandoffShape(IrFunction function, NewObject handoff)
+    {
+        var returns = 0;
+        foreach (var statement in EnumerateKickoffStatements(function.Body))
+        {
+            switch (statement)
+            {
+                case Return ret:
+                    returns++;
+                    if (!IsReturnedHandoff(ret.Value, handoff))
+                        return false;
+                    break;
+                case StoreStackSlot store when ReferenceEquals(store.Value, handoff):
+                    break;
+                case StoreLocal store when ReferenceEquals(store.Value, handoff):
+                    break;
+                case StoreField capture when IsPureLoad(capture.Instance) && IsPureLoad(capture.Value):
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return returns == 1;
+    }
+
+    static bool IsReturnedHandoff(IrExpression? value, NewObject handoff)
+    {
+        // `return new <M>d__0(-2);` directly, or `return slotOrLocal;` after the
+        // construction was stored above, or the object-initializer fold of the
+        // construction plus its hoisted-parameter capture stores
+        // (`return new <M>d__0(-2) { <>3__n = n };`). Capture member values must be
+        // pure copies; a side effect there is not a real compiler handoff.
+        if (ReferenceEquals(value, handoff) || IsPureLoad(value))
+            return true;
+        if (value is ObjectInitializerExpression initializer)
+            return ReferenceEquals(initializer.Creation, handoff)
+                && initializer.Children.Skip(1).Cast<IrExpression>().All(IsPureLoad);
+        return false;
+    }
+
+    static IEnumerable<IrNode> EnumerateKickoffStatements(BlockContainer body)
+    {
+        foreach (var child in body.Children)
+        {
+            if (child is Block block)
+            {
+                foreach (var statement in block.Children)
+                    yield return statement;
+            }
+            else
+            {
+                yield return child;
+            }
+        }
+    }
+
+    static bool IsPureLoad(IrExpression? expression) => expression switch
+    {
+        null => true,
+        Constant => true,
+        LoadArgument => true,
+        LoadLocal => true,
+        LoadStackSlot => true,
+        LoadField field => IsPureLoad(field.Instance),
+        _ => false,
+    };
 }


### PR DESCRIPTION
Fixes #1362. Burndown row 12 of #1356.

## Over-raise claim being narrowed

`IteratorAcknowledgmentPass` acknowledged **any** enumerable-returning method whose body anywhere constructed a compiler-generated iterator state machine, then replaced the **entire body** with a single unsupported-iterator marker — without proving the body was only the kickoff handoff. A side effect before the handoff (`SideEffect(); return new <M>d__0(-2);`) was silently dropped while the method kept reporting its prior `Partial` fidelity.

## Fix

Before acknowledging, require the kickoff body to be the narrow compiler scaffold (`IsNarrowHandoffShape`):

- the state-machine construction — returned directly, stored to a stack-slot/local, or folded into a `return new <M>d__0(-2) { <>3__n = n }` object initializer;
- pure capture stores of `this`/parameters into the state-machine instance;
- a single return of that instance.

Any other statement — or a side effect hidden in a capture-store / initializer subtree — declines acknowledgment and leaves the lowered residual visible. This is an **honesty improvement**, not a regression: fidelity was already `Partial` and stays `Partial`.

Scope is confined to `IteratorAcknowledgmentPass` (no change to the shared `IteratorShapes` or `IteratorReconstructionPass`), keeping it independent of the sibling row #1363.

## Evidence

New tests in `IteratorAcknowledgmentPassTests`:

- **Adversarial** `SideEffectBeforeHandoff_IsNotAcknowledged_AndPreservesSideEffect`: side-effect-before-handoff (with genuine generated-ctor evidence) stays lowered — no iterator marker, `NewObject` and the `SideEffect` `Call` both survive.
- **Positive canary** `NarrowHandoffWithGeneratedEvidence_IsAcknowledged`: a pure generated-evidence handoff still acknowledges.

Existing real-fixture positives still acknowledge: `YieldTwo` (bare handoff) and `YieldRange` (parameterized — `return new <YieldRange>d__491(-2) { <>3__n = n }`).

```
IteratorAcknowledgmentPassTests   Total: 9, Failed: 0
IteratorReconstructionPassTests   Total: 27, Failed: 0
```

Full `src/ILInspector.Decompiler.Tests` run in progress; will post the summary as a comment.

This pass is a Diagnostic/acknowledgment fallback (caps fidelity at `Partial`, emits no raised C#), so it does not change corpus compile-check or changed-method fidelity cards. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summarized result per `AGENTS.md`.