### PR TITLE
Gate SlotStoreDiamond fold on prefix effect order (#1369)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -117,6 +117,28 @@ public class SlotStoreDiamondPassTests
         Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
     }
 
+    // The final value places effectful prefixes inside a conditionally-evaluated
+    // construct (`t0 ?? t1`). Inlining would make B() conditional (only when A() is
+    // null), changing whether it runs at all, so the pass must decline.
+    [Fact]
+    public void DeclinesWhenEffectfulPrefixFeedsConditionalEvaluation()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var a = new MethodRef(owner, "A", Int32, [], HasThis: false);
+        var b = new MethodRef(owner, "B", Int32, [], HasThis: false);
+        var coalesce = new Coalesce(new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32));
+        var function = BuildPrefixDiamond(owner,
+            new StoreStackSlot(0, new Call(a, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(b, isVirtual: false, [])),
+            coalesce);
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+    }
+
     static IrFunction BuildEffectfulPrefixDiamond(bool reverseLoadOrder)
     {
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -59,4 +59,105 @@ public class SlotStoreDiamondPassTests
         Assert.Single(function.Descendants.OfType<Branch>());
         Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 2);
     }
+
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    // Two effectful prefix stores whose loads in the final value are in store order:
+    // the fold preserves evaluation order, so it must still raise.
+    [Fact]
+    public void FoldsTwoEffectfulPrefixesConsumedInStoreOrder()
+    {
+        var function = BuildEffectfulPrefixDiamond(reverseLoadOrder: false);
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot is 0 or 1);
+    }
+
+    // Same diamond, but the final value loads the two effectful prefixes in reverse
+    // store order. Inlining would swap the side effects (A() then B() -> B() then A()),
+    // so the pass must decline and leave the flat diamond intact.
+    [Fact]
+    public void DeclinesWhenEffectfulPrefixesReorder()
+    {
+        var function = BuildEffectfulPrefixDiamond(reverseLoadOrder: true);
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    // A prefix value itself loads an earlier effectful prefix in reversed order:
+    // t0 = A(); t1 = B() - t0; S = t1. Inlining yields S = B() - A(), swapping the
+    // effects. The recursive order check must expand the nested prefix load and decline.
+    [Fact]
+    public void DeclinesWhenNestedPrefixReordersEffects()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var a = new MethodRef(owner, "A", Int32, [], HasThis: false);
+        var b = new MethodRef(owner, "B", Int32, [], HasThis: false);
+        var nestedValue = new Binary(
+            BinaryKind.Subtract, isChecked: false, isUnsigned: false,
+            new Call(b, isVirtual: false, []),
+            new LoadStackSlot(0, Int32));
+        var function = BuildPrefixDiamond(owner,
+            new StoreStackSlot(0, new Call(a, isVirtual: false, [])),
+            new StoreStackSlot(1, nestedValue),
+            new LoadStackSlot(1, Int32));
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    static IrFunction BuildEffectfulPrefixDiamond(bool reverseLoadOrder)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var a = new MethodRef(owner, "A", Int32, [], HasThis: false);
+        var b = new MethodRef(owner, "B", Int32, [], HasThis: false);
+
+        IrExpression left = new LoadStackSlot(reverseLoadOrder ? 1 : 0, Int32);
+        IrExpression right = new LoadStackSlot(reverseLoadOrder ? 0 : 1, Int32);
+        var finalValue = new Binary(BinaryKind.Subtract, isChecked: false, isUnsigned: false, left, right);
+
+        return BuildPrefixDiamond(owner,
+            new StoreStackSlot(0, new Call(a, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(b, isVirtual: false, [])),
+            finalValue);
+    }
+
+    // Builds a non-returning slot-store diamond whose true arm is the given prefix
+    // stores followed by `S = finalValue`, and whose false arm is `S = 0`.
+    static IrFunction BuildPrefixDiamond(TypeRef owner, StoreStackSlot prefix0, StoreStackSlot prefix1, IrExpression finalValue)
+    {
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "cond", Bool), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(2, new Constant(0, Int32)));
+        falseArm.Add(new Branch(20));
+        var trueArm = new Block(8);
+        trueArm.Add(prefix0);
+        trueArm.Add(prefix1);
+        trueArm.Add(new StoreStackSlot(2, finalValue));
+        trueArm.Add(new Branch(20));
+        var merge = new Block(20);
+        merge.Add(new Return(new LoadStackSlot(2, Int32)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+
+        return new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(Int32, [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -285,7 +285,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
     /// <summary>
     /// Appends effect ranks for <paramref name="node"/> in evaluation order (children
     /// first, then the node's own effect), expanding prefix loads into the value that
-    /// will be inlined there. Returns false on a slot cycle, declining conservatively.
+    /// will be inlined there. Returns false on a slot cycle, or when an effect would be
+    /// linearized across a node that only conditionally evaluates its children (where a
+    /// flat evaluation order cannot represent the real one) — declining conservatively.
     /// </summary>
     static bool CollectEffectTimeline(
         IrNode node,
@@ -294,9 +296,17 @@ public sealed class SlotStoreDiamondPass : IIrPass
         HashSet<int> active,
         List<int> timeline)
     {
+        int before = timeline.Count;
         foreach (var child in node.Children)
             if (!CollectEffectTimeline(child, currentTag, bySlot, active, timeline))
                 return false;
+
+        // A node that evaluates some children only conditionally (?:, ??, ?., &&/||,
+        // switch) breaks the flat children-then-self order this walk assumes, so any
+        // effect under it cannot be safely linearized — decline rather than risk
+        // accepting a reorder or an effect that becomes conditional.
+        if (timeline.Count != before && ConditionallyEvaluatesChildren(node))
+            return false;
 
         if (node is LoadStackSlot load && bySlot.TryGetValue(load.Slot, out var prefix))
         {
@@ -311,8 +321,23 @@ public sealed class SlotStoreDiamondPass : IIrPass
         return true;
     }
 
+    /// <summary>
+    /// Nodes that perform an observable action beyond evaluating their children: a
+    /// method/property/local-function invocation, object or delegate construction, an
+    /// await, an in-place increment/decrement, or an unsupported node (assumed
+    /// effectful). Reordering these relative to one another is observable.
+    /// </summary>
     static bool HasOwnEffect(IrNode node)
-        => node is Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode;
+        => node is Call or CallIndirect or NewObject or DelegateCreation
+            or LoadProperty or IncrementDecrement or AwaitExpression or LocalFunctionInvocation
+            or UnsupportedNode;
+
+    /// <summary>
+    /// Nodes that evaluate at least one child only conditionally, so a flat
+    /// children-first effect order does not describe their real evaluation.
+    /// </summary>
+    static bool ConditionallyEvaluatesChildren(IrNode node)
+        => node is Conditional or Coalesce or NullConditional or LogicalBinary or SwitchExpression;
 
     static bool PrefixSlotsDeadOutside(
         IrFunction function,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -221,6 +221,8 @@ public sealed class SlotStoreDiamondPass : IIrPass
         out IrExpression substituted)
     {
         substituted = initial;
+        if (!PreservesPrefixEffectOrder(initial, prefixStores))
+            return false;
         for (int i = prefixStores.Count - 1; i >= 0; i--)
         {
             var store = prefixStores[i];
@@ -246,6 +248,71 @@ public sealed class SlotStoreDiamondPass : IIrPass
         }
         return true;
     }
+
+    /// <summary>
+    /// Guards against the substitution reordering observable side effects. Inlining a
+    /// prefix store's value into the final expression moves its effects to the value's
+    /// load position; that is sound only when the resulting evaluation order still runs
+    /// the effects in their original program order. The original order is: every prefix
+    /// value's effects in store order, then the final value's own effects. We rebuild
+    /// the substituted evaluation order by walking the final value and expanding each
+    /// prefix load in place (recursively, since a prefix value may load an earlier
+    /// prefix), tagging every effect with the rank of the store it came from. The
+    /// substitution is safe only when those ranks are non-decreasing. Anything else
+    /// declines (stays a flat diamond / lower fidelity), an honesty improvement.
+    /// </summary>
+    static bool PreservesPrefixEffectOrder(IrExpression finalValue, IReadOnlyList<StoreStackSlot> prefixStores)
+    {
+        var bySlot = new Dictionary<int, (int Index, IrExpression Value)>();
+        for (int i = 0; i < prefixStores.Count; i++)
+            bySlot[prefixStores[i].Slot] = (i, prefixStores[i].Value);
+
+        var timeline = new List<int>();
+        // Final-value-own effects rank after every prefix; int.MaxValue sorts last.
+        if (!CollectEffectTimeline(finalValue, int.MaxValue, bySlot, new HashSet<int>(), timeline))
+            return false;
+
+        int last = -1;
+        foreach (int rank in timeline)
+        {
+            if (rank < last)
+                return false;
+            last = rank;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Appends effect ranks for <paramref name="node"/> in evaluation order (children
+    /// first, then the node's own effect), expanding prefix loads into the value that
+    /// will be inlined there. Returns false on a slot cycle, declining conservatively.
+    /// </summary>
+    static bool CollectEffectTimeline(
+        IrNode node,
+        int currentTag,
+        Dictionary<int, (int Index, IrExpression Value)> bySlot,
+        HashSet<int> active,
+        List<int> timeline)
+    {
+        foreach (var child in node.Children)
+            if (!CollectEffectTimeline(child, currentTag, bySlot, active, timeline))
+                return false;
+
+        if (node is LoadStackSlot load && bySlot.TryGetValue(load.Slot, out var prefix))
+        {
+            if (!active.Add(load.Slot))
+                return false;
+            bool ok = CollectEffectTimeline(prefix.Value, prefix.Index, bySlot, active, timeline);
+            active.Remove(load.Slot);
+            return ok;
+        }
+        if (HasOwnEffect(node))
+            timeline.Add(currentTag);
+        return true;
+    }
+
+    static bool HasOwnEffect(IrNode node)
+        => node is Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode;
 
     static bool PrefixSlotsDeadOutside(
         IrFunction function,


### PR DESCRIPTION
Closes #1369. Burndown row 20 of #1356.

## Over-raise claim being narrowed

`SlotStoreDiamondPass` folds a slot-store diamond into `S = cond ? whenTrue : whenFalse` and builds `whenTrue` by inlining the true-arm prefix `StoreStackSlot` values into the final store value (`SubstitutePrefixStores`). The existing gates require each prefix slot be dead outside the region (`PrefixSlotsDeadOutside`) and loaded exactly once (`loads.Count == 1`) — that prevents *dropping* an effect, but nothing checked the inlined values are evaluated in their original order. With ≥2 effectful prefix stores whose loads appear in the final value in a different order than they were stored, the fold silently **reorders** the side effects while still reporting `Full`.

Minimal counterexample (true arm): `t0 = A(); t1 = B(); S = t1 - t0;` folds to `S = cond ? (B() - A()) : 0`, evaluating `B()` before `A()` — valid C# that runs the two effects in swapped order. This is the #1353 effect class (not unspellable), so `CSharpSpellability` does not catch it.

## Fix

Add the narrowest order gate (`PreservesPrefixEffectOrder`): rebuild the post-substitution evaluation order by walking the final value and expanding each prefix load in place — **recursively**, since a prefix value may itself load an earlier prefix — tagging every effect with the rank of the store it came from, and require those ranks to be non-decreasing. When the order would change, decline and leave the flat diamond (lower fidelity / honesty improvement, not a regression). The pass is not widened.

Pure-valued and single-effect prefix folds are unaffected, so the common raise path still folds; only the reordering shape declines.

## Evidence

Adversarial fixtures + positive canary (`SlotStoreDiamondPassTests`):

- `DeclinesWhenEffectfulPrefixesReorder` — flat `t1 - t0` reverse-order declines (stays a flat diamond, no `Conditional`).
- `DeclinesWhenNestedPrefixReordersEffects` — nested `t1 = B() - t0; S = t1` declines (exercises the recursive expansion).
- `FoldsTwoEffectfulPrefixesConsumedInStoreOrder` — in-store-order effectful prefixes still fold.
- Existing `FoldsNestedNullableBoolDiamondAheadOfSharedTrueArm` still folds (pure prefixes unaffected).

`src/ILInspector.Decompiler.Tests`: full suite green (1142 tests) on the flat version; re-running against the final recursive version + regenerating the corpus quality card (will post as a comment).

Corpus quality diff (against a freshly-emitted `origin/main` baseline on the same 14-assembly / 87,901-method corpus) was **all-deltas-zero / matched baseline tolerances** — the reordering shape does not occur in stock-csc output, as expected (csc spills in evaluation order). Card to be re-posted against final code.

## Guardrails

SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading. Adversarial negatives + positive canary added per #1356.

Adversarial cross-model review (GPT-5.5) to be requested per `AGENTS.md`; summary to follow.