### PR TITLE
Gate SlotStoreDiamond prefix inlining on effect order (#1369)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -59,4 +59,71 @@ public class SlotStoreDiamondPassTests
         Assert.Single(function.Descendants.OfType<Branch>());
         Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 2);
     }
+
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction TwoEffectfulPrefixDiamond(BinaryKind finalKind, bool loadTrueThenFalse)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var a = new MethodRef(owner, "A", Int32, [], HasThis: false);
+        var b = new MethodRef(owner, "B", Int32, [], HasThis: false);
+
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "cond", Bool), 8));
+
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, new Constant(0, Int32)));
+        falseArm.Add(new Branch(12));
+
+        // True arm: t1 = A(); t2 = B(); S = (t1 op t2) or (t2 op t1).
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(1, new Call(a, isVirtual: false, [])));
+        trueArm.Add(new StoreStackSlot(2, new Call(b, isVirtual: false, [])));
+        var (left, right) = loadTrueThenFalse
+            ? (1, 2)   // load t1 then t2 => load order == store order (safe)
+            : (2, 1);  // load t2 then t1 => reversed (effect reorder)
+        trueArm.Add(new StoreStackSlot(0, new Binary(
+            finalKind, isChecked: false, isUnsigned: false,
+            new LoadStackSlot(left, Int32), new LoadStackSlot(right, Int32))));
+        trueArm.Add(new Branch(12));
+
+        var merge = new Block(12);
+        merge.Add(new Return(new LoadStackSlot(0, Int32)));
+
+        var body = new BlockContainer();
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+
+        return new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(Int32, [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    [Fact]
+    public void DeclinesWhenTwoEffectfulPrefixesAreConsumedInReverseOrder()
+    {
+        var function = TwoEffectfulPrefixDiamond(BinaryKind.Subtract, loadTrueThenFalse: false);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        // Folding would emit S = cond ? (B() - A()) : 0, reordering A() before B().
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+        Assert.Equal(2, function.Descendants.OfType<Call>().Count());
+    }
+
+    [Fact]
+    public void FoldsWhenEffectfulPrefixesAreConsumedInStoreOrder()
+    {
+        var function = TwoEffectfulPrefixDiamond(BinaryKind.Subtract, loadTrueThenFalse: true);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        // S = cond ? (A() - B()) : 0 keeps A() before B(); ordered spill still folds.
+        Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot is 1 or 2);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -97,6 +97,8 @@ public sealed class SlotStoreDiamondPass : IIrPass
         }
 
         var whenTrue = (IrExpression)trueRegion.Store.Value.Clone();
+        if (!PrefixEffectsPreserved(whenTrue, prefixStores))
+            return null;
         if (!SubstitutePrefixStores(whenTrue, prefixStores, trueRegion.Store.Slot, out whenTrue))
             return null;
         var whenFalse = (IrExpression)falseStore.Value.Clone();
@@ -213,6 +215,70 @@ public sealed class SlotStoreDiamondPass : IIrPass
         }
         return null;
     }
+
+    /// <summary>
+    /// Whether inlining each true-arm prefix store value into the final value
+    /// preserves the observable effect order. Inlining moves a prefix store's
+    /// value from its (sequential) store position into its single load position
+    /// inside the final expression. That is sound only if the prefix values are
+    /// side-effect-free, or every effectful prefix value's load is reached in
+    /// store order and before any side effect of the final value itself —
+    /// otherwise the fold would silently reorder side effects (see #1369).
+    /// </summary>
+    static bool PrefixEffectsPreserved(IrExpression finalValue, IReadOnlyList<StoreStackSlot> prefixStores)
+    {
+        var effectfulSlots = new List<int>();
+        foreach (var store in prefixStores)
+            if (!IsSideEffectFree(store.Value))
+                effectfulSlots.Add(store.Slot);
+        if (effectfulSlots.Count == 0)
+            return true;
+
+        var effectfulSet = effectfulSlots.ToHashSet();
+        var loadOrder = new List<int>();
+        bool sawFinalValueEffect = false;
+        foreach (var node in EvaluationOrder(finalValue))
+        {
+            if (node is LoadStackSlot load && effectfulSet.Contains(load.Slot))
+            {
+                if (sawFinalValueEffect)
+                    return false;
+                loadOrder.Add(load.Slot);
+            }
+            else if (!IsSideEffectFree(node))
+            {
+                sawFinalValueEffect = true;
+            }
+        }
+        return loadOrder.Count == effectfulSlots.Count
+            && loadOrder.SequenceEqual(effectfulSlots);
+    }
+
+    /// <summary>
+    /// Yields nodes in C# evaluation order: operands (children, left to right)
+    /// before the operation itself. Conservative for short-circuit and
+    /// conditional operators (it visits all children), which can only cause an
+    /// over-strict decline, never an unsound accept.
+    /// </summary>
+    static IEnumerable<IrNode> EvaluationOrder(IrNode node)
+    {
+        foreach (var child in node.Children)
+            foreach (var descendant in EvaluationOrder(child))
+                yield return descendant;
+        yield return node;
+    }
+
+    /// <summary>
+    /// Whether evaluating the node (not its descendants) introduces no
+    /// observable side effect. Mirrors the conservative call-like set used by
+    /// <see cref="RedundantBranchEliminationPass"/>: any call/construction or
+    /// unsupported node is assumed effectful.
+    /// </summary>
+    static bool IsSideEffectFree(IrNode node)
+        => node is not (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode);
+
+    static bool IsSideEffectFree(IrExpression value)
+        => value.Descendants.Prepend(value).All(IsSideEffectFree);
 
     static bool SubstitutePrefixStores(
         IrExpression initial,


### PR DESCRIPTION
Closes #1369 (row 20 of #1356).

## Over-raise claim being narrowed

`SlotStoreDiamondPass` folds a slot-store diamond into
`S = cond ? whenTrue : whenFalse` and builds `whenTrue` by inlining the
true-arm prefix `StoreStackSlot` values into a single expression
(`SubstitutePrefixStores`). The existing `loads.Count == 1` gate already
prevents effect *drop*, but there was **no purity or evaluation-order gate**
on the substituted values. With two or more prefix stores whose effectful
values are loaded in an order different from their store order, the fold
**reordered the side effects** while reporting `Full`:

```
t1 = A();      // effectful
t2 = B();      // effectful
S  = t2 - t1;  // load order (t2,t1) != store order (t1,t2)
```

folded to `S = cond ? (B() - A()) : 0` — valid C# that runs `B()` before
`A()`. This is the #1353 effect class, not an unspellable case, so
`CSharpSpellability` does not catch it.

## Fix shape

Add the narrowest proof gate (`PrefixEffectsPreserved`) before substitution.
Decline unless:

- all prefix values are side-effect-free, **or**
- every effectful prefix value's single load is reached in **store order**
  and **before any side effect of the final value itself**.

When the gate fails the diamond is left flat (lower fidelity / `Partial`),
which is an honesty improvement, not a regression.

The evaluation-order walk is operand-before-operation (post-order) and
conservative for short-circuit/conditional operators, so it can only
over-decline, never accept an unsound reorder. The pass is not widened.

## Tests

`src/ILInspector.Decompiler.Tests` — **1142 passing, 0 failed** (includes
the existing pure-prefix positive plus two new cases):

- `DeclinesWhenTwoEffectfulPrefixesAreConsumedInReverseOrder` — adversarial
  reverse-order fixture stays a diamond (no `Conditional`, both calls kept).
- `FoldsWhenEffectfulPrefixesAreConsumedInStoreOrder` — positive canary:
  ordered effectful spill `A() - B()` still folds to the ternary.

## Corpus impact

Pure narrowing (adds a decline gate only). Per the issue realism note, stock
csc spills/consumes the stack in order, so the triggering load-order != 
store-order shape is unlikely from current csc output; expected corpus delta
is ~zero. Quality-diff card to follow in a comment.

## Guardrails

- SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading.
- Adversarial negative + positive canary added; pass not widened.

Note: claimed first on this row (04:15Z) ahead of a parallel `-order` branch;
coordinating to avoid a duplicate PR.
