### PR TITLE
Require generated evidence for inline-array element-ref raise (#1365)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -79,6 +79,27 @@ public class InlineArrayElementRefPassTests
     }
 
     [Fact]
+    public void ElementRef_OverMismatchedPlaceType_StaysLowered()
+    {
+        // A genuine generated helper (TBuffer = Buffer) invoked over a place whose storage
+        // type is a different, non-inline-array struct must not raise to `plain[i]` — that
+        // would be invalid C# at Full fidelity. Place type must equal the helper's TBuffer (#1365).
+        var plain = TypeRef.Definition("UserAssembly", "Samples", "Plain", ValueTypeHint.ValueType);
+        var function = StoreThroughHelper(
+            Helper("InlineArrayElementRef", [TypeRef.ByRef(Buffer), Int32]),
+            [
+                new LoadArgumentAddress(0, "plain", plain),
+                new LoadArgument(2, "index", Int32),
+            ]);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadElementAddress>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayElementRef");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void InitOnlyLocalBufferAsSpan_RaisesToCast()
     {
         var function = LocalBufferAsSpan(includeElementStore: false);

--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -48,6 +48,37 @@ public class InlineArrayElementRefPassTests
     }
 
     [Fact]
+    public void ElementRef_WithoutGeneratedEvidence_StaysLowered()
+    {
+        // A <PrivateImplementationDetails>.InlineArrayElementRef lookalike that lacks the
+        // [CompilerGenerated] attribute is not the runtime intrinsic. Raising it to buffer[i]
+        // would drop the real call and emit invalid/inequivalent C# at Full fidelity, so it
+        // must stay lowered (#1365).
+        var lookalike = new MethodRef(
+            TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+            "InlineArrayElementRef",
+            TypeRef.ByRef(Int32),
+            [TypeRef.ByRef(Buffer), Int32],
+            HasThis: false)
+        {
+            TypeArguments = [Buffer, Int32],
+            DeclaringTypeCompilerGenerated = MetadataFactState.No,
+        };
+        var function = StoreThroughHelper(
+            lookalike,
+            [
+                new LoadArgumentAddress(0, "buffer", Buffer),
+                new LoadArgument(2, "index", Int32),
+            ]);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadElementAddress>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayElementRef");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void InitOnlyLocalBufferAsSpan_RaisesToCast()
     {
         var function = LocalBufferAsSpan(includeElementStore: false);
@@ -242,6 +273,9 @@ public class InlineArrayElementRefPassTests
             HasThis: false)
         {
             TypeArguments = [Buffer, Int32],
+            // The real runtime intrinsic holder is [CompilerGenerated]; the raise now
+            // requires that evidence (#1365), so the positive fixtures carry it.
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
         };
 
     static MethodRef RuntimeHelper(string name, IReadOnlyList<TypeRef> parameterTypes)
@@ -256,5 +290,6 @@ public class InlineArrayElementRefPassTests
             HasThis: false)
         {
             TypeArguments = [RuntimeBuffer, Int32],
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
         };
 }

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -56,6 +56,46 @@ public static class GeneratedCodeIdentity
             && method.ParameterTypes is [var parameter]
             && parameter.Equals(TypeRef.CoreLib("System", "String"));
 
+    /// <summary>
+    /// A compiler-generated inline-array element-ref helper:
+    /// <c>&lt;PrivateImplementationDetails&gt;.InlineArray{First}ElementRef[ReadOnly]&lt;TBuffer, TElement&gt;</c>,
+    /// the runtime intrinsic the C# compiler emits for <c>buffer[i]</c> indexing of an
+    /// <c>[InlineArray]</c> buffer. Like every other helper here, the
+    /// <c>[CompilerGenerated]</c> attribute on the static <c>&lt;PrivateImplementationDetails&gt;</c>
+    /// holder is required before the name is trusted, so a user type or method that merely
+    /// reuses the unspeakable holder name and a helper name is not mistaken for the intrinsic
+    /// and over-raised into <c>buffer[i]</c> (#1365). <paramref name="first"/> marks the
+    /// zero-index form, <paramref name="readOnly"/> the read-only form.
+    /// </summary>
+    public static bool IsInlineArrayElementRefHelper(MethodRef method, out bool first, out bool readOnly)
+    {
+        first = false;
+        readOnly = false;
+        if (method.DeclaringTypeCompilerGenerated != MetadataFactState.Yes
+            || method.HasThis
+            || LeafTypeName(MetadataTypeName(method.DeclaringType)) != "<PrivateImplementationDetails>")
+        {
+            return false;
+        }
+        switch (method.Name)
+        {
+            case "InlineArrayElementRef":
+                return true;
+            case "InlineArrayElementRefReadOnly":
+                readOnly = true;
+                return true;
+            case "InlineArrayFirstElementRef":
+                first = true;
+                return true;
+            case "InlineArrayFirstElementRefReadOnly":
+                first = true;
+                readOnly = true;
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static bool IsIteratorStateMachineTypeName(TypeRef type)
         => LeafTypeName(MetadataTypeName(type)).Contains(">d__", StringComparison.Ordinal);
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -533,9 +533,20 @@ public sealed class InlineArrayCollectionPass : IIrPass
         }
     }
 
-    static bool CanPlaceFromAddress(IrExpression address, TypeRef arrayType)
-        => address is LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress
-            || address is LoadLocal { ResultType: { Kind: TypeRefKind.ByRef, ElementType: { } element } } && element.Equals(arrayType);
+    // The receiver address must be a nameable place whose storage type is the helper's
+    // inline-array type argument (TBuffer). Requiring that equality — together with the
+    // generated helper identity — proves the place is a real inline-array buffer, so a
+    // genuine helper MethodSpec'd over a non-inline-array place is not raised to `plain[i]`
+    // (#1365).
+    static bool CanPlaceFromAddress(IrExpression address, TypeRef arrayType) => address switch
+    {
+        LoadLocalAddress local => local.Type.Equals(arrayType),
+        LoadArgumentAddress argument => argument.Type.Equals(arrayType),
+        LoadFieldAddress field => field.Field.Type.Equals(arrayType),
+        LoadElementAddress element => element.ElementType.Equals(arrayType),
+        LoadLocal { ResultType: { Kind: TypeRefKind.ByRef, ElementType: { } element } } => element.Equals(arrayType),
+        _ => false,
+    };
 
     static IrExpression? PlaceFromAddress(IrExpression address, TypeRef arrayType) => address switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -554,29 +554,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         => callee.Name == name && callee.DeclaringType.Name == PrivateImpl;
 
     static bool IsInlineArrayElementRef(MethodRef callee, out bool first, out bool readOnly)
-    {
-        first = false;
-        readOnly = false;
-        if (callee.DeclaringType.Name != PrivateImpl)
-            return false;
-        switch (callee.Name)
-        {
-            case "InlineArrayElementRef":
-                return true;
-            case "InlineArrayElementRefReadOnly":
-                readOnly = true;
-                return true;
-            case "InlineArrayFirstElementRef":
-                first = true;
-                return true;
-            case "InlineArrayFirstElementRefReadOnly":
-                first = true;
-                readOnly = true;
-                return true;
-            default:
-                return false;
-        }
-    }
+        => GeneratedCodeIdentity.IsInlineArrayElementRefHelper(callee, out first, out readOnly);
 
     /// <summary>
     /// True for a compiler-synthesized inline-array buffer — the span source csc


### PR DESCRIPTION
Burndown row 15 of #1356.

## Over-raise claim being narrowed

`InlineArrayCollectionPass.RaiseElementRefs` replaced any `<PrivateImplementationDetails>.InlineArray{First}ElementRef[ReadOnly]` call with an indexed address (`buffer[i]` / `ref buffer[i]`) using **only** the unspeakable holder name and the helper method name — no generated/helper-identity evidence. A lookalike with no generated evidence was raised to `return ref _buffer[2];` at **Full** fidelity, dropping the real call and emitting inequivalent C#.

## Fix (narrowest proof gate)

Add `GeneratedCodeIdentity.IsInlineArrayElementRefHelper`, which — like every other helper in that file (e.g. `IsStringHashHelper`, the iterator state-machine ctor) — requires the `[CompilerGenerated]` attribute (`DeclaringTypeCompilerGenerated == Yes`) on the static `<PrivateImplementationDetails>` holder before trusting the name pattern. The pass's `IsInlineArrayElementRef` now routes through it. Lookalikes without the evidence stay lowered/Partial; the real runtime intrinsic (which the importer marks generated) still raises. No pass widening.

## Adversarial fixture + positive canaries

- `ElementRef_WithoutGeneratedEvidence_StaysLowered`: a `<PrivateImplementationDetails>.InlineArrayElementRef` lookalike with `DeclaringTypeCompilerGenerated = No` stays a lowered `Call` (no `LoadElementAddress`).
- Existing positives intact: the synthetic helper factories are stamped with the generated evidence the real intrinsic carries; **real-importer** inline-array tests (incl. `RuntimeInlineArrayForeach_RaisesRefLocalElementRef`, the element-ref raise) still raise. `*InlineArray*` tests: 15/15.

## Corpus quality diff

This change gates element-ref raising, so a quality-diff card vs a freshly captured origin/main snapshot is in progress and will be posted as a comment. The real-importer element-ref test passing indicates the importer sets the generated evidence, so real corpus raises are preserved (expected ~zero delta).

Cross-model adversarial review (GPT-5.5) requested per AGENTS.md; result to follow.

Closes #1365.