### PR TITLE
Flag baseline staleness in the corpus quality card (#1396)

### DIFF
--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -584,6 +584,7 @@ internal static class CorpusSensor
         Console.WriteLine($"Correctness coverage: {CoverageSummary(current)}");
         if (risky)
             PrintRiskyCoverageGuidance(current);
+        PrintBaselineStaleness(baseline, current);
         Console.WriteLine();
         Console.WriteLine("| Metric | Baseline | PR | Delta |");
         Console.WriteLine("| --- | ---: | ---: | ---: |");
@@ -647,7 +648,77 @@ internal static class CorpusSensor
             Console.WriteLine("Regressions:");
             foreach (var regression in regressions)
                 Console.WriteLine($"- {regression}");
+            if (IsBaselineStale(baseline, current))
+            {
+                Console.WriteLine();
+                Console.WriteLine(
+                    "Caveat: the corpus drifted from the baseline (see baseline staleness above), "
+                    + "so count-based regressions may be corpus composition change rather than a "
+                    + "real PR delta. Rebaseline against current main and re-run before treating "
+                    + "these as blocking.");
+            }
         }
+    }
+
+    /// <summary>
+    /// The real-world corpus includes the repo's own assemblies, which grow as
+    /// unrelated code lands, so a baseline captured earlier can disagree with the
+    /// current run on method population even when the PR changed nothing. When that
+    /// happens the aggregate count deltas (fully raised, Full malformed, fidelity
+    /// diffs) mix the PR's effect with corpus drift and stop being a clean signal.
+    /// Surface the drift explicitly so reviewers rebaseline instead of chasing a
+    /// phantom regression.
+    /// </summary>
+    static void PrintBaselineStaleness(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    {
+        var drift = DescribeBaselineDrift(baseline, current);
+        if (drift.Count == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine(
+            $"Baseline staleness: corpus drifted from the pinned baseline "
+            + $"(generated {baseline.GeneratedUtc:yyyy-MM-dd}). Aggregate count deltas below include "
+            + "this corpus change and are not a clean PR signal; rebaseline against current main "
+            + "(--emit-corpus-baseline) before trusting count-based regressions.");
+        foreach (var line in drift)
+            Console.WriteLine($"- {line}");
+    }
+
+    static bool IsBaselineStale(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+        => DescribeBaselineDrift(baseline, current).Count > 0;
+
+    static List<string> DescribeBaselineDrift(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    {
+        var lines = new List<string>();
+        if (baseline.Metrics.TotalMethods != current.Metrics.TotalMethods)
+        {
+            lines.Add(
+                $"total methods {Number(baseline.Metrics.TotalMethods)} -> {Number(current.Metrics.TotalMethods)} "
+                + $"({Delta(current.Metrics.TotalMethods - baseline.Metrics.TotalMethods)})");
+        }
+
+        var baselineByName = baseline.Assemblies
+            .GroupBy(assembly => assembly.Assembly)
+            .ToDictionary(group => group.Key, group => group.First().TotalMethods);
+        var currentByName = current.Assemblies
+            .GroupBy(assembly => assembly.Assembly)
+            .ToDictionary(group => group.Key, group => group.First().TotalMethods);
+
+        foreach (var name in baselineByName.Keys.Concat(currentByName.Keys).Distinct().OrderBy(name => name))
+        {
+            bool inBaseline = baselineByName.TryGetValue(name, out int baselineMethods);
+            bool inCurrent = currentByName.TryGetValue(name, out int currentMethods);
+            if (!inCurrent)
+                lines.Add($"{name}: removed from corpus (was {Number(baselineMethods)} methods)");
+            else if (!inBaseline)
+                lines.Add($"{name}: added to corpus ({Number(currentMethods)} methods)");
+            else if (baselineMethods != currentMethods)
+                lines.Add(
+                    $"{name}: {Number(baselineMethods)} -> {Number(currentMethods)} methods "
+                    + $"({Delta(currentMethods - baselineMethods)})");
+        }
+        return lines;
     }
 
     static void PrintMetric(string metric, string baseline, string current, string delta)

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -75,6 +75,15 @@ with `--emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.
 For a quick before/after coverage sweep, repeat `--corpus-fidelity-cap` (for
 example `--corpus-fidelity-cap 3 --corpus-fidelity-cap 10`).
 
+The corpus includes the repo's own assemblies, which grow as unrelated code
+lands, so a baseline captured earlier can disagree with the current run on
+method population even when a PR changed no decompiler behavior. When that
+happens the card prints a **`Baseline staleness:`** block (which assemblies
+drifted and the net method-count delta) and appends a caveat to any
+`Regressions:` list, because the aggregate count deltas then mix corpus drift
+with the PR's real effect. Treat that as a signal to rebaseline against current
+main and re-run, not as a blocking regression.
+
 Expand the fixed corpus only after that targeting step shows a shape gap. Prefer
 deterministic, pinned assemblies that add many examples of the missing lowering
 family (for example forward-merge or retained-label control flow), then refresh


### PR DESCRIPTION
Stage 9 (Corpus boss) of the #1396 gauntlet tracker — closes the
"detect stale baseline / delta usability issues" gap.

## Problem

The real-world corpus sensor compares a run against
`tools/DecompilerHarness/corpus/real-world-baseline.json`, but the corpus
includes the repo's **own** assemblies, which grow as unrelated code lands.
So the pinned baseline silently drifts: current main is **+540 methods** vs the
2026-06-23 baseline (87,370 -> 87,910), entirely in repo assemblies (the
pinned NuGet sum, 67,322, is fixed).

Because the card compares the full aggregate, that drift shows up as phantom
count "regressions" (fully raised, Full malformed, fidelity diffs) on PRs that
changed no decompiler behavior. This already misled a pure-decline PR card:
#1395 reported "fully raised +408 / Full malformed +14" purely from corpus
growth.

## Change

Add baseline-staleness detection to `--quality-diff-card` (`CorpusSensor`):
when the baseline and current run disagree on assembly set or per-assembly
method totals, the card prints a `Baseline staleness:` block listing which
assemblies drifted and the net method-count delta, and appends a caveat to any
`Regressions:` list directing reviewers to rebaseline against current main
rather than treat count drift as blocking. README documents it.

## Verification

Ran the card on a single small assembly against the full 14-assembly baseline
to force drift; the staleness block and regression caveat printed correctly:

```
Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). ...
- total methods 87,370 -> 61 (-87,309)
- dotnet-inspect: removed from corpus (was 11,710 methods)
...
Caveat: the corpus drifted from the baseline (see baseline staleness above), so
count-based regressions may be corpus composition change rather than a real PR delta. ...
```

In a normal full-corpus run only the few drifted repo assemblies are listed.

## Scope

Harness-only (card formatting + a pure comparison helper). No decompiler or
product-path behavior change; SRM-only / NativeAOT / Roslyn-free constraints
untouched. No harness test project exists, so verification is the manual run
above.

Follow-ups (noted on #1396, not in this PR): a deliberate rebaseline against
current main to clear the existing +540 drift, and/or restricting the count
comparison to the pinned subset so repo growth stops drifting it.
