### PR TITLE
Frame altitude vs soundness for scorecard climbs (#1396 Stage 6)

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -217,6 +217,25 @@ Guidance:
 - A purely synthetic decline fixture is fine when stock `csc` cannot emit the
   shape (hand-written/obfuscated IL); say so, matching the #1356 realism note.
 
+### Altitude and scorecard climbs
+
+A scorecard, ledger, or `LoweringCoverage` row moving is an **altitude** signal —
+the output reached the intended C# idiom — not a soundness proof. Report:
+
+1. the scorecard/ledger/sidecar row that moved (a positive climb or a shrunk
+   `Partial` row);
+2. shape proof for the raise: positive fixture plus near-miss decline (altitude
+   without a decline is just an unproven positive);
+3. for any behavior change, the opcode / changed-method fidelity evidence the
+   raise needs — altitude says nothing about near-miss soundness.
+
+Do not inflate the scorecard with positive-only rows just to move a number. Keep
+scorecard entries positive-by-construction, but back each one with adversarial
+negatives in pass tests (the #1356 shape-proof bar) rather than letting a rising
+count stand in for correctness. See
+[decompiler-quality.md](decompiler-quality.md) for the scorecard/ledger strategy
+and saturation guidance.
+
 ## Naming the harnesses by role
 
 The command names are historical and intentionally stable, but PRs and issues


### PR DESCRIPTION
Stage 6 (Altitude boss) improvement for the correctness-gauntlet tracker #1396.

## Gap

The pipeline doc's gauntlet table noted the Altitude boss "does not prove soundness around near misses," but there was no per-PR reporting band tying scorecard / ledger / `LoweringCoverage` movement to proof levels. This is a recurring failure mode the repo explicitly warns about ("do not add positive scorecard rows just to move a number").

## Change

Add an **"Altitude and scorecard climbs"** reporting band:

- a moved scorecard/ledger/sidecar row is a **completeness** (altitude) signal, not soundness;
- pair every climb with shape-proof declines, and for behavior changes the opcode / changed-method fidelity evidence;
- do not inflate the scorecard with positive-only rows; keep entries positive-by-construction but back each with adversarial negatives in pass tests (the #1356 bar).

Links to `decompiler-quality.md` for the scorecard/ledger strategy rather than duplicating it (per the #1396 "do not duplicate trackers" guardrail).

Docs-only, **no behavior change** — matches the Stage 6 done signal ("docs or tests clarify when altitude is not soundness").

## Entry gate (this PR)

Docs-only, so the entry gate stops at markdown lint:

```
npx markdownlint-cli docs/decompiler-correctness-pipeline.md   # clean
```

Per the tracker working model: claimed Stage 6 in a comment; will post evidence + unclaim without checking the stage box.
