### PR TITLE
Document when to run the type bosses (#1396 Stage 5)

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -236,6 +236,30 @@ count stand in for correctness. See
 [decompiler-quality.md](decompiler-quality.md) for the scorecard/ledger strategy
 and saturation guidance.
 
+### Type and composer changes
+
+Changes to `TypeSourceComposer`, type-declaration rendering, member-surface
+projection, `using` emission, or name qualification affect whole-type
+**artifacts**, not method bodies. Method-body fidelity checks are blind to them,
+so run the two type bosses — both stub method bodies before checking, so a body
+codegen defect can neither mask nor manufacture a type/binding artifact defect:
+
+- **Type artifact boss** (`--type-check`) — syntactic: the namespace, type kind
+  and modifiers, and the full member surface match the metadata inventory. Run it
+  after any composer, type-declaration, or signature/`ApiSurfaceExtractor`
+  change. Deltas bucket by kind (`namespace`, `type-kind`, `modifier-dropped`,
+  `member-missing`, …); report the count outside the visibility-code noise.
+- **Type binding boss** (`--bind-check`) — binds each composed type and reports
+  the `CS0104` ambiguous-reference collisions a binder sees but the SRM-only
+  product path cannot (the competing type lives outside the composed assembly, so
+  the composer cannot detect it). Run it when a change can alter which namespaces
+  are imported or whether a name is emitted qualified: `using` hoisting,
+  namespace qualification, or new references. Report new collisions outside the
+  known-ambiguous buckets.
+
+See [tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md) for
+the flags, buckets, and current baselines.
+
 ## Naming the harnesses by role
 
 The command names are historical and intentionally stable, but PRs and issues


### PR DESCRIPTION
Stage 5 (Type binding boss) improvement for the correctness-gauntlet tracker #1396.

## Gap

The pipeline doc named the type-binding boss in the gauntlet table but gave no per-PR guidance for **when** a PR must run `--bind-check` (or its syntactic companion `--type-check`). Agents changing `TypeSourceComposer`, `using` emission, or name qualification had no cue that method-body fidelity checks are blind to those whole-type artifacts.

## Change

Add a **"Type and composer changes"** reporting band:

- `--type-check` (type artifact boss) — syntactic match of namespace, type kind/modifiers, and member surface against the metadata inventory; run after composer/type-declaration/`ApiSurfaceExtractor` changes.
- `--bind-check` (type binding boss) — binds each composed type and reports `CS0104` ambiguous-reference collisions a binder sees but the SRM-only product path cannot (the competing type lives outside the composed assembly); run when a change can alter imported namespaces or name qualification (`using` hoist, qualification, new references).
- both stub method bodies, so they are orthogonal to body codegen.

Links to the harness README for flags/buckets/baselines rather than duplicating it.

Docs-only, **no behavior change** — matches the Stage 5 done signal ("docs/harness guidance mentions type-binding use cases").

## Entry gate (this PR)

Docs-only, so the entry gate stops at markdown lint:

```
npx markdownlint-cli docs/decompiler-correctness-pipeline.md   # clean
```

Per the tracker working model: claimed Stage 5 in a comment; will post evidence + unclaim without checking the stage box.
