### PR TITLE
Treat DecompilerHarness docs as docs-only in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           while IFS= read -r file; do
             case "$file" in
               src/*) CODE=true ;;
+              tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
               tools/DecompilerHarness/*) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;


### PR DESCRIPTION
## Summary

- fix the CI change classifier so `tools/DecompilerHarness/*.md` / `*.txt` are docs-only, not code
- keep `tools/DecompilerHarness/*` code changes on the full test/pack path
- addresses the #1414 observation: docs-only changes to `tools/DecompilerHarness/README.md` were running full CI because the broad harness path matched before docs classification

## Validation

- `npx -y yaml-lint .github/workflows/ci.yml`
- local filter smoke:
  - `tools/DecompilerHarness/README.md` -> `code=false docs=true`
  - `tools/DecompilerHarness/CorpusSensor.cs` -> `code=true docs=false`
  - `docs/decompiler-correctness-pipeline.md` -> `code=false docs=true`
  - `.github/workflows/ci.yml` -> `code=true docs=false`
