### PR TITLE
Keep precision-rounding float conv.r4/conv.r8 in IdentityConvertPass (#1403)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -139,6 +139,16 @@ public class CfgSampleClass
     // IdentityConvertPass must still drop it — `a.Length`, no `(int)` cast.
     public static int ArrayLen(int[] a) => a.Length;
 
+    // Float conv.r4/conv.r8 is precision-rounding, never an identity: ECMA-335
+    // keeps float stack values in the wider type F, so `(float)(a * b)` rounds the
+    // F-precision product to float32 before the add. csc emits a conv.r4 here that
+    // IdentityConvertPass must NOT drop (the operand `a * b` is already Single, so
+    // source and target IR types match) — dropping it changes the result and breaks
+    // compile-back.
+    public static float MidRoundFloat(float a, float b, float c) => (float)(a * b) + c;
+
+    public static double MidRoundDouble(double a, double b, double c) => (double)(a * b) + c;
+
     public static char LastChar(string s) => s[^1];
 
     // Negative fixture: hand-written string indexing re-loads the receiver

--- a/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
@@ -49,4 +49,43 @@ public class IdentityConvertPassTests
         Assert.Empty(function.Descendants.OfType<Pipeline.Convert>());
         Assert.Contains("return a.Length;", CSharpPrinter.Print(function).Output);
     }
+
+    [Fact]
+    public void FloatPrecisionConvert_IsKept()
+    {
+        // `(float)(a * b)` rounds the F-precision product to float32 before the add.
+        // The operand `a * b` is already Single, so source and target IR types match
+        // and the conv.r4 would look like an identity — but dropping it changes the
+        // result. IdentityConvertPass must keep the float convert.
+        var function = Raised(nameof(CfgSampleClass.MidRoundFloat));
+
+        var convert = Assert.Single(function.Descendants.OfType<Pipeline.Convert>());
+        Assert.Equal("Single", convert.Target.Name);
+    }
+
+    [Fact]
+    public void FloatPrecisionConvert_RendersCast()
+    {
+        var output = Print(nameof(CfgSampleClass.MidRoundFloat));
+
+        Assert.Contains("(float)(a * b)", output);
+    }
+
+    [Fact]
+    public void DoublePrecisionConvert_IsKept()
+    {
+        // conv.r8 over an already-Double operand rounds to float64; not an identity.
+        var function = Raised(nameof(CfgSampleClass.MidRoundDouble));
+
+        var convert = Assert.Single(function.Descendants.OfType<Pipeline.Convert>());
+        Assert.Equal("Double", convert.Target.Name);
+    }
+
+    [Fact]
+    public void DoublePrecisionConvert_RendersCast()
+    {
+        var output = Print(nameof(CfgSampleClass.MidRoundDouble));
+
+        Assert.Contains("(double)(a * b)", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IdentityConvertPass.cs
@@ -24,6 +24,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// numeric promotion and types that same expression as <c>int</c>, so the cast
 /// is a real narrowing the language requires (<c>b = b | x;</c> is CS0266 without
 /// it). Keeping it is fidelity-neutral — the <c>conv</c> was in the original IL.</para>
+///
+/// <para>Floating-point conversions are <em>never</em> identity even at equal
+/// types: ECMA-335 keeps float stack values in an implementation-defined wider
+/// type <c>F</c> (III.1.1.1), so <c>conv.r4</c> rounds the value down to
+/// <c>float32</c> precision and <c>conv.r8</c> to <c>float64</c>. A <c>conv.r4</c>
+/// over an already-<c>Single</c> operand (e.g. <c>Single*Single</c>, which
+/// <see cref="TypeFamilies.BinaryResult"/> types as <c>Single</c>) compares equal
+/// to its <c>Single</c> target yet rounds — dropping it changes
+/// <c>(float)(a * b) + c</c> into a higher-precision expression and breaks
+/// compile-back. The float family is excluded from the equal-type drop.</para>
 /// </summary>
 public sealed class IdentityConvertPass : IIrPass
 {
@@ -40,6 +50,8 @@ public sealed class IdentityConvertPass : IIrPass
             var operandType = convert.Operand.ResultType;
             if (operandType is not null && operandType.Equals(convert.Target))
             {
+                if (TypeFamilies.IsFloat(convert.Target))
+                    continue;  // conv.r4/conv.r8 rounds to float32/float64 precision; never an identity
                 if (IsSubInt32Integer(convert.Target) && PromotesToInt32(convert.Operand))
                     continue;  // C# promotes the operand to int; the narrowing cast is real
                 var operand = (IrExpression)convert.DetachChildren()[0];


### PR DESCRIPTION
Closes #1403 (row 24 of #1356).

## Over-raise claim being narrowed

`IdentityConvertPass` drops a plain `conv` whenever its target type already
equals the operand's IR result type. That holds for the integer idioms the
pass was built for (`ldlen; conv.i4` array length, sub-int narrowing), but is
**false for floating point**: ECMA-335 keeps float stack values in the wider
type `F` (III.1.1.1), so `conv.r4` rounds to float32 precision and `conv.r8`
to float64. A `conv.r4` over an already-`Single` operand (e.g. `Single*Single`,
which `TypeFamilies.BinaryResult` types as `Single`) compares equal to its
`Single` target yet is load-bearing — dropping it erased an explicit
`(float)`/`(double)` cast while reporting `Full`, changing the result and
breaking compile-back.

## Fix

Add the narrowest gate: decline the equal-type drop when the target is a
floating-point type (`TypeFamilies.IsFloat`). The kept `Convert` renders as
`(float)`/`(double)` (already proven by the differing-type cast cases).
Integer / sub-int behavior is untouched.

## End-to-end verification (real csc IL, product pipeline)

Imported optimized-Release csc IL through `IrImporter.Import` -> `IrPasses.Run`
-> `CSharpPrinter.Print`:

| method | raw conv (csc) | after passes | output |
| --- | ---: | --- | --- |
| `MidRoundFloat` `(float)(a*b)+c` | 1 | kept `[Single]` | `((float)(a * b)) + c` |
| `MidRoundDouble` `(double)(a*b)+c` | 1 | kept `[Double]` | `((double)(a * b)) + c` |
| `OrTwoBytes` `(byte)(a\|b)` (canary) | 1 | kept `[Byte]` | `(byte)(a \| b)` |
| `ArrayLen` `a.Length` (canary) | 1 | dropped | `a.Length` |

Before the fix `MidRoundFloat`/`MidRoundDouble` dropped the conv and printed
`(a * b) + c` (the bug); both canaries are unchanged.

## Tests

`src/ILInspector.Decompiler.Tests` — **1170 passing, 0 failed**. Adds
`CfgSampleClass.MidRoundFloat`/`MidRoundDouble` plus 4 tests (float and double
casts kept + rendered) alongside the existing sub-int / array-length canaries.

## Corpus card

Quality card attached below. Note: the pinned corpus baseline is **stale**
(+699 repo methods since 2026-06-23), so the aggregate count deltas are
corpus-composition drift, not this change — the card's own `Baseline staleness`
block (added in #1404) flags this, and the `Full malformed +14 / opcode-diff
+3` figures are byte-identical to an unrelated PR's run on the same drifted
baseline. A per-method delta against the drifted baseline is dominated by
signature-shift noise (3,332 rows) and is not a clean signal; a same-corpus
rebaseline A/B would be needed to isolate this change at the corpus level. The
change is a pure narrowing — equal-type float converts that were dropped are
now kept (strictly more correct / round-trippable), and per the #1356 guardrail
invalid->`Partial` is an honesty improvement, not a regression.

```text
### Decompiler quality diff

Corpus: 14 assemblies, 88,069 methods
Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23).
- total methods 87,370 -> 88,069 (+699)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,059 methods (+55)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,441 (87.93%) | +547 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 | 4/350 | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
Caveat: the corpus drifted from the baseline, so count-based regressions may be
corpus composition change rather than a real PR delta.
```

## Guardrails

- SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading.
- Pass not widened; one narrow float-family decline added.
- Adversarial fixtures (float/double casts kept) + positive canaries (sub-int,
  array-length) added.

Cross-model adversarial review to follow per AGENTS.md.
