### PR TITLE
Gate local display-class elision on capture-store order (#1358)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -282,6 +282,72 @@ public class LambdaRaisingPassTests
         return (function, lambdaMethod, lambdaBody);
     }
 
+    // #1358 (adversarial review): two lambdas capture disjoint fields, interleaved
+    // with their creations (store a; create g1; store b; create g2). Each lambda
+    // reads only its own field, stored before its own creation, so both must still
+    // raise — a global "all stores precede all creations" gate would wrongly decline
+    // because store b follows g1's creation.
+    [Fact]
+    public void SyntheticDisjointInterleavedCaptures_RaiseEveryLambda()
+    {
+        var (function, importBody) = BuildDisjointInterleavedSetup();
+        var context = new PassContext(new Stepper(enabled: false), importMethodBody: importBody);
+
+        new LambdaRaisingPass().Run(function, context);
+
+        Assert.Equal(2, function.Descendants.OfType<Lambda>().Count());
+        Assert.Empty(function.Descendants.OfType<DelegateCreation>());
+        Assert.Empty(function.Descendants.OfType<StoreField>());
+        function.CheckInvariant();
+    }
+
+    static (IrFunction Function, Func<MethodRef, IrFunction?> ImportBody) BuildDisjointInterleavedSetup()
+    {
+        var outer = TypeRef.Definition("Synthetic", "Samples", "Outer");
+        var dcType = TypeRef.Definition("Synthetic", "Samples", "Outer+<>c__DisplayClass0_0");
+        var aField = new FieldRef(dcType, "a", s_int);
+        var bField = new FieldRef(dcType, "b", s_int);
+        var dcCtor = new MethodRef(dcType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true);
+        var lambdaA = new MethodRef(dcType, "<M>b__0", s_int, [], HasThis: true) { DeclaringTypeCompilerGenerated = MetadataFactState.Yes };
+        var lambdaB = new MethodRef(dcType, "<M>b__1", s_int, [], HasThis: true) { DeclaringTypeCompilerGenerated = MetadataFactState.Yes };
+
+        var block = new Block();
+        block.Add(new StoreLocal(1, s_int, new Constant(10, s_int)));                                   // value for a
+        block.Add(new StoreLocal(0, dcType, new NewObject(dcCtor, [])));                                // alloc
+        block.Add(new StoreField(aField, new LoadLocal(0, dcType), new LoadLocal(1, s_int)));           // store a
+        block.Add(new StoreLocal(3, s_func1, new DelegateCreation(s_func1, lambdaA, isVirtual: false, new LoadLocal(0, dcType)))); // create g1
+        block.Add(new StoreLocal(2, s_int, new Constant(20, s_int)));                                   // value for b
+        block.Add(new StoreField(bField, new LoadLocal(0, dcType), new LoadLocal(2, s_int)));           // store b (after g1)
+        block.Add(new StoreLocal(4, s_func1, new DelegateCreation(s_func1, lambdaB, isVirtual: false, new LoadLocal(0, dcType)))); // create g2
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            outer,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [dcType, s_int, s_int, s_func1, s_func1],
+            body);
+
+        IrFunction LambdaBodyReading(MethodRef method, FieldRef field)
+        {
+            var lambdaBlock = new Block();
+            lambdaBlock.Add(new Return(new LoadField(field, new LoadArgument(0, "this", dcType))));
+            var container = new BlockContainer();
+            container.Add(lambdaBlock);
+            return new IrFunction(
+                method.Name, dcType,
+                new MethodSignature(s_int, [], HasThis: true, GenericParameterCount: 0),
+                [], container);
+        }
+
+        Func<MethodRef, IrFunction?> importBody = method =>
+            method == lambdaA ? LambdaBodyReading(lambdaA, aField)
+            : method == lambdaB ? LambdaBodyReading(lambdaB, bField)
+            : null;
+        return (function, importBody);
+    }
+
     static IrFunction FunctionReturningDelegate(MethodRef method)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -183,6 +183,105 @@ public class LambdaRaisingPassTests
         function.CheckInvariant();
     }
 
+    // #1358: a local <>c__DisplayClass whose capture store runs AFTER the delegate
+    // is created. Eliding the store and substituting its value would make the raised
+    // lambda read the later value, but the lowered delegate observes the field's
+    // prior value (the environment is shared by reference). The setup is not a
+    // straight-line prefix, so the environment must stay lowered.
+    [Fact]
+    public void DelegateCreatedBeforeCaptureStore_StaysLowered()
+    {
+        var (function, lambdaMethod, lambdaBody) = BuildLocalCaptureSetup(storeBeforeCreate: false);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method == lambdaMethod ? lambdaBody : null);
+
+        new LambdaRaisingPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<Lambda>());          // not raised...
+        Assert.Single(function.Descendants.OfType<DelegateCreation>()); // ...creation survives
+        Assert.Single(function.Descendants.OfType<StoreField>());      // ...capture store preserved
+        function.CheckInvariant();
+    }
+
+    // Positive twin: the same nodes in the normal compiler order (alloc; capture
+    // store; create delegate) are a straight-line prefix and still raise + elide.
+    [Fact]
+    public void CaptureStoreBeforeDelegateCreation_RaisesLambda()
+    {
+        var (function, lambdaMethod, lambdaBody) = BuildLocalCaptureSetup(storeBeforeCreate: true);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method == lambdaMethod ? lambdaBody : null);
+
+        new LambdaRaisingPass().Run(function, context);
+
+        Assert.Single(function.Descendants.OfType<Lambda>());        // raised...
+        Assert.Empty(function.Descendants.OfType<DelegateCreation>()); // ...creation replaced
+        Assert.Empty(function.Descendants.OfType<StoreField>());     // ...capture store elided
+        function.CheckInvariant();
+    }
+
+    static readonly TypeRef s_func1 = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`1"), [s_int]);
+
+    static (IrFunction Function, MethodRef Lambda, IrFunction LambdaBody) BuildLocalCaptureSetup(bool storeBeforeCreate)
+    {
+        var outer = TypeRef.Definition("Synthetic", "Samples", "Outer");
+        var dcType = TypeRef.Definition("Synthetic", "Samples", "Outer+<>c__DisplayClass0_0");
+        var lambdaMethod = new MethodRef(dcType, "<M>b__0", s_int, [], HasThis: true)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var dcCtor = new MethodRef(dcType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true);
+        var xField = new FieldRef(dcType, "x", s_int);
+        var invokeMethod = new MethodRef(s_func1, "Invoke", s_int, [], HasThis: true);
+
+        var storeValue = new StoreLocal(1, s_int, new Constant(42, s_int));
+        var alloc = new StoreLocal(0, dcType, new NewObject(dcCtor, []));
+        var captureStore = new StoreField(xField, new LoadLocal(0, dcType), new LoadLocal(1, s_int));
+        var creation = new StoreLocal(2, s_func1,
+            new DelegateCreation(s_func1, lambdaMethod, isVirtual: false, new LoadLocal(0, dcType)));
+        var invoke = new ExpressionStatement(new Call(invokeMethod, isVirtual: true, [new LoadLocal(2, s_func1)]));
+
+        var block = new Block();
+        block.Add(storeValue);
+        block.Add(alloc);
+        if (storeBeforeCreate)
+        {
+            block.Add(captureStore);
+            block.Add(creation);
+            block.Add(invoke);
+        }
+        else
+        {
+            block.Add(creation);
+            block.Add(invoke);
+            block.Add(captureStore);
+        }
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            outer,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [dcType, s_int, s_func1],
+            body);
+
+        var lambdaBlock = new Block();
+        lambdaBlock.Add(new Return(new LoadField(xField, new LoadArgument(0, "this", dcType))));
+        var lambdaContainer = new BlockContainer();
+        lambdaContainer.Add(lambdaBlock);
+        var lambdaBody = new IrFunction(
+            lambdaMethod.Name,
+            dcType,
+            new MethodSignature(s_int, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            lambdaContainer);
+
+        return (function, lambdaMethod, lambdaBody);
+    }
+
     static IrFunction FunctionReturningDelegate(MethodRef method)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -101,7 +101,7 @@ public sealed class LambdaRaisingPass : IIrPass
         // rather than the delegate creation: it is the earliest outer offset the
         // lambda subsumes, so the closure allocation fact and its setup IL anchor
         // to this statement in the mixed view (see Finish).
-        return RaiseWithCaptures(creation, captures, env.Creation, context);
+        return RaiseWithCaptures(creation, captures, env.Creation, context, out _);
     }
 
     // Recover lambdas whose captured environment is a local <>c__DisplayClass set
@@ -165,22 +165,43 @@ public sealed class LambdaRaisingPass : IIrPass
             if (!elidable || creations.Count == 0)
                 continue;
 
-            // The environment is shared by reference: a delegate created (and
-            // possibly invoked) before a capture store observes the field's prior
-            // value, but eliding the store and substituting its value makes the
-            // raised lambda read the later value. Only elide when the setup is a
-            // straight-line prefix — every capture store executes before every
-            // delegate creation, in the same block — so no created delegate can run
-            // ahead of a substituted store (#1358).
-            if (!CaptureStoresPrecedeCreations(alloc, captureStores, creations))
+            // Sound elision requires each lambda's consumed capture fields to be
+            // stored before that lambda's delegate is created. The environment is
+            // shared by reference, so a delegate created (and later invoked) before a
+            // field it reads is stored observes the field's prior value, while the
+            // raised lambda reads the substituted later value (#1358). Disjoint
+            // captures may still interleave (`store a; create g1; store b; create g2`)
+            // because each creation follows the stores it actually depends on. The
+            // setup must be straight-line: the allocation, capture stores, and
+            // creations are direct statements of one block (a store nested in control
+            // flow is conditional and cannot be elided).
+            if (alloc.Parent is not Block setupBlock)
+                continue;
+            var storeIndexByField = new Dictionary<string, int>(StringComparer.Ordinal);
+            bool layoutOk = true;
+            foreach (var store in captureStores)
+            {
+                int index = StatementIndex(store, setupBlock);
+                if (index < 0)
+                {
+                    layoutOk = false;
+                    break;
+                }
+                storeIndexByField[store.Field.Name] = index;
+            }
+            if (!layoutOk)
                 continue;
 
-            // Raise every lambda first; commit nothing unless all succeed. The
-            // environment allocation is each lambda's outer provenance anchor.
+            // Raise every lambda first; commit nothing unless all succeed and each
+            // lambda's read fields are stored before its creation. The environment
+            // allocation is each lambda's outer provenance anchor.
             var raised = new List<(DelegateCreation Creation, Lambda Lambda)>(creations.Count);
             foreach (var creation in creations)
             {
-                if (RaiseWithCaptures(creation, captures, alloc.Value, context) is not { } lambda)
+                int creationIndex = StatementIndex(creation, setupBlock);
+                if (creationIndex < 0
+                    || RaiseWithCaptures(creation, captures, alloc.Value, context, out var readFields) is not { } lambda
+                    || readFields.Any(field => storeIndexByField[field] >= creationIndex))
                 {
                     raised = null!;
                     break;
@@ -201,62 +222,39 @@ public sealed class LambdaRaisingPass : IIrPass
         }
     }
 
-    // Sound elision requires the captured environment to be fully populated
-    // before any delegate over it is created: a straight-line setup prefix. We
-    // require the allocation, every capture store, and every delegate creation to
-    // be direct statements of one block, with each capture store positioned before
-    // every creation. A store nested in control flow (a conditional/looped store)
-    // is not a straight-line prefix and declines, leaving the environment lowered.
-    static bool CaptureStoresPrecedeCreations(
-        StoreLocal alloc, IReadOnlyList<StoreField> captureStores, IReadOnlyList<DelegateCreation> creations)
-    {
-        if (alloc.Parent is not Block setupBlock)
-            return false;
-
-        int lastStoreIndex = -1;
-        foreach (var store in captureStores)
-        {
-            int index = StatementIndex(store, setupBlock);
-            if (index < 0)
-                return false;
-            if (index > lastStoreIndex)
-                lastStoreIndex = index;
-        }
-
-        foreach (var creation in creations)
-        {
-            int index = StatementIndex(creation, setupBlock);
-            if (index < 0 || index <= lastStoreIndex)
-                return false;
-        }
-
-        return true;
-    }
-
-    // The index within <paramref name="block"/> of the statement containing
-    // <paramref name="node"/>, or -1 when the node is not inside that block (it
-    // lives in a nested block — i.e. under control flow — or another block
-    // entirely).
+    // The index within <paramref name="block"/> of the direct statement containing
+    // <paramref name="node"/>, or -1 when the node is not a direct statement of that
+    // block — it lives in a nested block (under control flow) or another block
+    // entirely. The walk fails on the first intervening block boundary, so a node
+    // inside a conditional/loop body does not resolve to the enclosing statement.
     static int StatementIndex(IrNode node, Block block)
     {
-        var current = node;
-        while (current.Parent is not null && !ReferenceEquals(current.Parent, block))
-            current = current.Parent;
-        if (!ReferenceEquals(current.Parent, block))
-            return -1;
-        var statements = block.Children;
-        for (int i = 0; i < statements.Count; i++)
-            if (ReferenceEquals(statements[i], current))
-                return i;
+        for (var current = node; current.Parent is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current.Parent, block))
+            {
+                var statements = block.Children;
+                for (int i = 0; i < statements.Count; i++)
+                    if (ReferenceEquals(statements[i], current))
+                        return i;
+                return -1;
+            }
+            if (current.Parent is Block)
+                return -1;  // nested under a different block — i.e. control flow
+        }
         return -1;
     }
 
     // Import and raise the lambda body, then substitute each read of a captured
     // field (through the display-class `this`, arg 0) with the captured value.
     // Bails if `this` is used any way other than reading a known captured field.
+    // <paramref name="readFields"/> reports the capture fields the body reads, so
+    // the local-display-class caller can verify each is stored before this creation.
     static Lambda? RaiseWithCaptures(
-        DelegateCreation creation, Dictionary<string, IrExpression> captures, IrNode provenance, PassContext context)
+        DelegateCreation creation, Dictionary<string, IrExpression> captures, IrNode provenance, PassContext context,
+        out IReadOnlyCollection<string> readFields)
     {
+        readFields = [];
         var body = RaisedBody(creation, context);
         if (body is null)
             return null;
@@ -266,6 +264,10 @@ public sealed class LambdaRaisingPass : IIrPass
                 && Equals(field.Field.DeclaringType, creation.Method.DeclaringType)
                 && captures.ContainsKey(field.Field.Name)))
             return null;
+
+        readFields = thisReads
+            .Select(a => ((LoadField)a.Parent!).Field.Name)
+            .ToHashSet(StringComparer.Ordinal);
 
         foreach (var load in body.Descendants.OfType<LoadField>().ToList())
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -165,6 +165,16 @@ public sealed class LambdaRaisingPass : IIrPass
             if (!elidable || creations.Count == 0)
                 continue;
 
+            // The environment is shared by reference: a delegate created (and
+            // possibly invoked) before a capture store observes the field's prior
+            // value, but eliding the store and substituting its value makes the
+            // raised lambda read the later value. Only elide when the setup is a
+            // straight-line prefix — every capture store executes before every
+            // delegate creation, in the same block — so no created delegate can run
+            // ahead of a substituted store (#1358).
+            if (!CaptureStoresPrecedeCreations(alloc, captureStores, creations))
+                continue;
+
             // Raise every lambda first; commit nothing unless all succeed. The
             // environment allocation is each lambda's outer provenance anchor.
             var raised = new List<(DelegateCreation Creation, Lambda Lambda)>(creations.Count);
@@ -189,6 +199,56 @@ public sealed class LambdaRaisingPass : IIrPass
                 store.Detach();
             alloc.Detach();
         }
+    }
+
+    // Sound elision requires the captured environment to be fully populated
+    // before any delegate over it is created: a straight-line setup prefix. We
+    // require the allocation, every capture store, and every delegate creation to
+    // be direct statements of one block, with each capture store positioned before
+    // every creation. A store nested in control flow (a conditional/looped store)
+    // is not a straight-line prefix and declines, leaving the environment lowered.
+    static bool CaptureStoresPrecedeCreations(
+        StoreLocal alloc, IReadOnlyList<StoreField> captureStores, IReadOnlyList<DelegateCreation> creations)
+    {
+        if (alloc.Parent is not Block setupBlock)
+            return false;
+
+        int lastStoreIndex = -1;
+        foreach (var store in captureStores)
+        {
+            int index = StatementIndex(store, setupBlock);
+            if (index < 0)
+                return false;
+            if (index > lastStoreIndex)
+                lastStoreIndex = index;
+        }
+
+        foreach (var creation in creations)
+        {
+            int index = StatementIndex(creation, setupBlock);
+            if (index < 0 || index <= lastStoreIndex)
+                return false;
+        }
+
+        return true;
+    }
+
+    // The index within <paramref name="block"/> of the statement containing
+    // <paramref name="node"/>, or -1 when the node is not inside that block (it
+    // lives in a nested block — i.e. under control flow — or another block
+    // entirely).
+    static int StatementIndex(IrNode node, Block block)
+    {
+        var current = node;
+        while (current.Parent is not null && !ReferenceEquals(current.Parent, block))
+            current = current.Parent;
+        if (!ReferenceEquals(current.Parent, block))
+            return -1;
+        var statements = block.Children;
+        for (int i = 0; i < statements.Count; i++)
+            if (ReferenceEquals(statements[i], current))
+                return i;
+        return -1;
     }
 
     // Import and raise the lambda body, then substitute each read of a captured


### PR DESCRIPTION
Fixes #1358. Burndown row 9 of #1356.

## Over-raise claim being narrowed

`LambdaRaisingPass.RaiseLocalDisplayClasses` recovered lambdas whose captured environment is a local `<>c__DisplayClass` (`dc = new DC(); dc.f = v; … use(new Func(dc.b__N))`) by collecting the capture stores and delegate creations **by use kind only, ignoring statement order**, then substituting the captured values and eliding the stores. When a delegate is created (and can be invoked) **before** a capture store runs, the lowered, by-reference environment observes the field's prior/default value, but the raised lambda reads the substituted later value — a silent behavior change at `Full` fidelity.

## Fix

Require the setup to be a **straight-line prefix** (`CaptureStoresPrecedeCreations`): the allocation, every capture store, and every delegate creation must be direct statements of one block, with each capture store positioned before every creation. A store nested in control flow, or any creation at/before a store, declines and leaves the environment lowered. This is an honesty improvement (the prior `Partial`/lowered form), not a regression.

The existing duplicate-store guard already handled the *mutated-after-create* case (two stores to one field); this adds the missing *single-store-after-create* ordering case from the issue.

## Evidence

`LambdaRaisingPassTests` (15/15):

- **Adversarial** `DelegateCreatedBeforeCaptureStore_StaysLowered`: synthetic IR matching the issue counterexample (genuine compiler-generated `<>c__DisplayClass` + `b__` lambda) — not raised; `DelegateCreation` and the capture `StoreField` both survive.
- **Positive twin** `CaptureStoreBeforeDelegateCreation_RaisesLambda`: the *same nodes* in normal `alloc; store; create` order still raise and elide — proving the gate is order-sensitive, not shape-rejecting.
- Existing real-fixture positives still raise (`LocalDisplayClassEnvironment_…`, `SharedDisplayClassEnvironment_…`) and the existing mutation negatives stay lowered.

```
LambdaRaisingPassTests   Total: 15, Failed: 0
```

Full `src/ILInspector.Decompiler.Tests` running; summary to follow as a comment.

This pass only declines more (never emits new output), so it cannot move corpus compile-check/fidelity in a way that needs a card. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summary per AGENTS.md.
