### PR TITLE
Keep fixed-array pointer uses in fixed scope

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FixedArrayStatementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedArrayStatementTests.cs
@@ -37,4 +37,65 @@ public class FixedArrayStatementTests
         Assert.Contains("fixed (byte* p = ", output);
         Assert.DoesNotContain("pinned", output);
     }
+
+    [Fact]
+    public void ArrayPin_PointerUseAfterUnpin_StaysLowered()
+    {
+        var function = PostUnpinPointerUseFunction();
+
+        new FixedStatementPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Fixed>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Single(function.Descendants.OfType<Return>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction PostUnpinPointerUseFunction()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var arrayType = TypeRef.SzArray(byteType);
+        var pinnedArrayType = TypeRef.Pinned(arrayType);
+        var pointerType = TypeRef.Pointer(byteType);
+
+        var thenBlock = new Block();
+        thenBlock.Add(new StoreLocal(1, pointerType, new Constant(0, intType)));
+        var elseBlock = new Block();
+        elseBlock.Add(new StoreLocal(
+            1,
+            pointerType,
+            new LoadElementAddress(
+                byteType,
+                new LoadLocal(0, pinnedArrayType),
+                new Constant(0, intType),
+                isReadOnly: false)));
+        var guard = new IfStatement(
+            new LogicalBinary(
+                LogicalKind.Or,
+                new LogicalNot(new LoadArgument(0, "array", arrayType)),
+                new Comparison(
+                    ComparisonKind.Equal,
+                    isUnsigned: false,
+                    new ArrayLength(new LoadArgument(0, "array", arrayType)),
+                    new Constant(0, intType))),
+            thenBlock,
+            elseBlock);
+
+        var block = new Block();
+        block.Add(new StoreLocal(0, pinnedArrayType, new LoadArgument(0, "array", arrayType)));
+        block.Add(guard);
+        block.Add(new StoreLocal(0, pinnedArrayType, new Constant(null, pinnedArrayType)));
+        block.Add(new Return(new LoadLocal(1, pointerType)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(pointerType, [new Parameter("array", arrayType)], HasThis: false, GenericParameterCount: 0),
+            [pinnedArrayType, pointerType],
+            body);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -107,6 +107,13 @@ internal static class FixedArrayRaising
             if (node is StoreLocal s && s.Index == pointerSlot && s != zeroStore && s != addressStore)
                 return;
         }
+        foreach (var reference in function.Descendants.Where(node => ReferencesPointerSlot(node, pointerSlot)))
+        {
+            if (reference is StoreLocal store && (store == zeroStore || store == addressStore))
+                continue;
+            if (!bodyStmts.Any(stmt => IsInside(reference, stmt)))
+                return;
+        }
 
         // Shape proven. Lift the array source out of the pin store, detach the body,
         // and replace the diamond with `fixed (T* ptr = array) { body }`. The pin
@@ -148,6 +155,14 @@ internal static class FixedArrayRaising
 
     static bool IsNullStore(StoreLocal store)
         => StripConverts(store.Value) is Constant { Value: null or 0 or 0L };
+
+    static bool ReferencesPointerSlot(IrNode node, int pointerSlot) => node switch
+    {
+        LoadLocal load => load.Index == pointerSlot,
+        LoadLocalAddress address => address.Index == pointerSlot,
+        StoreLocal store => store.Index == pointerSlot,
+        _ => false,
+    };
 
     static IrExpression StripConverts(IrExpression value)
     {


### PR DESCRIPTION
## Summary

Fixes #1372 by making `FixedArrayRaising` prove the derived fixed pointer local is scoped entirely inside the recovered `fixed` body before raising the pinned-array guard diamond.

A post-unpin pointer use now keeps the lowered shape instead of emitting a fixed pointer outside its `fixed` scope.

## Evidence

- Added adversarial negative: post-unpin derived pointer load leaves the guard diamond lowered and emits no `Fixed` node.
- Positive canary: existing `FixedWholeArray` array-pin tests still raise and render `fixed (byte* p = ...)`.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.FixedArrayStatementTests` — 3/3 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 1163/1163 passed.
- `dotnet build src/dotnet-inspect -c Release -v:q` — passed.

Generated quality card against the checked-in baseline reports stale-baseline regressions also present on pristine `origin/main`. The branch shows a small expected honesty movement compared with the control (3 fewer fully raised methods) from declining unsafe fixed-array raises.

Branch card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,069 methods
Correctness coverage: validity sampled 350 / 88,069 (0.40%); fidelity sampled 22 / 88,069 (0.02%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,438 (87.93%) | +544 |
| Conditional-branch residual | 2,290 (2.62%) | 2,307 (2.62%) | +17 |
| Forward-merge stops | 2,284 (2.61%) | 2,299 (2.61%) | +15 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,069 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,069 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```

`origin/main` control card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,069 methods
Correctness coverage: validity sampled 350 / 88,069 (0.40%); fidelity sampled 22 / 88,069 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,069 (+699)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,059 methods (+55)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,441 (87.93%) | +547 |
| Conditional-branch residual | 2,290 (2.62%) | 2,307 (2.62%) | +17 |
| Forward-merge stops | 2,284 (2.61%) | 2,298 (2.61%) | +14 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,069 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,069 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```
