### PR TITLE
Document opcode boss evidence

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -183,6 +183,33 @@ For #1175-class retained-label work, the changed-method population must include
 the forward-merge / structuring-residual methods the PR changes. A green global
 fidelity sample that does not intersect those methods is not enough.
 
+### Opcode fidelity changes
+
+Behavior changes that can alter emitted method-body semantics fight the
+**opcode boss**. Use this band when a PR changes the importer, a raising pass, a
+structuring pass, or printer semantics such as branch sense, checked/unchecked
+context, conversions, field/local ordering, or shift masking.
+
+Report opcode evidence in two layers:
+
+1. **Fixture gate** — the focused `src/ILInspector.Decompiler.Tests` fixture that
+   covers the changed shape. Name whether the sugared gate (`FidelityGateTests`),
+   lowered gate (`LoweredFidelityGateTests`), or a pass-specific test is the
+   relevant guard. If an opcode-diff docket row is fixed, shrink `KnownDiffs` and
+   add the method to `PinnedExact` in the same PR.
+2. **Changed-method / corpus layer** — for risky or broad changes, identify the
+   methods the PR actually changed and run `--fidelity-method-delta` over that
+   population when available. Treat `Exact` as checked green and `OpcodeDiff` as
+   the semantic docket. Report `RecompileFail`, `ContextFail`, `NotFull`, and
+   uncheckable buckets separately; they are not passing evidence.
+
+Keep the axes separate:
+
+- A green validity check proves the C# parses and binds, not that it is faithful.
+- A green corpus card is aggregate health, not proof over the changed methods.
+- A lowered-view result belongs to the lowered gate; it does not automatically
+  prove the shipped sugared view, or vice versa.
+
 ### Annotation classifier changes
 
 Hidden-fact annotation changes fight the **annotation boss**, not the method-body


### PR DESCRIPTION
## Summary

Part of #1396 Stage 8.

Adds an "Opcode fidelity changes" reporting band to `docs/decompiler-correctness-pipeline.md` so method-body semantic PRs know how to report the opcode boss:

- fixture gate evidence (`FidelityGateTests`, `LoweredFidelityGateTests`, or pass-specific fixtures);
- shrinking `KnownDiffs` / adding `PinnedExact` when a docket row is fixed;
- changed-method fidelity evidence with `Exact`, `OpcodeDiff`, `RecompileFail`, `ContextFail`, `NotFull`, and uncheckable buckets kept separate;
- explicit separation from validity checks, corpus aggregate cards, and lowered-vs-sugared views.

Docs-only; no product behavior change.

## Evidence

- `npx markdownlint-cli --fix docs/decompiler-correctness-pipeline.md`
- `npx markdownlint-cli docs/decompiler-correctness-pipeline.md`
