### PR TITLE
Decline anonymous objects with unspellable member names

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
@@ -125,6 +125,30 @@ public class AnonymousObjectPassTests
     }
 
     [Fact]
+    public void UnspellablePropertyName_IsNotRaisedToInvalidAnonymousObject()
+    {
+        var function = FunctionWithAnonymousMetadata(["bad-name"], [new Constant(1, TypeRef.CoreLib("System", "Int32"))]);
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void KeywordPropertyName_IsNotRaisedUntilPrinterEscapesAnonymousMembers()
+    {
+        var function = FunctionWithAnonymousMetadata(["int"], [new Constant(1, TypeRef.CoreLib("System", "Int32"))]);
+
+        new AnonymousObjectPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<AnonymousObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void GeneratedLookingTypeWithoutCapturedPropertyNames_IsNotRaised()
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "<>f__AnonymousType0`1");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/AnonymousObjectPass.cs
@@ -24,7 +24,7 @@ public sealed class AnonymousObjectPass : IIrPass
             var names = newObject.AnonymousPropertyNames;
             if (names.IsDefaultOrEmpty || names.Length != newObject.Arguments.Count)
                 continue;
-            if (HasDuplicateNames(names))
+            if (HasDuplicateOrUnspellableNames(names))
                 continue;
 
             var values = newObject.DetachChildren().Cast<IrExpression>().ToList();
@@ -34,12 +34,16 @@ public sealed class AnonymousObjectPass : IIrPass
         }
     }
 
-    static bool HasDuplicateNames(IEnumerable<string> names)
+    static bool HasDuplicateOrUnspellableNames(IEnumerable<string> names)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var name in names)
+        {
+            if (!CSharpNaming.IsUsableIdentifier(name))
+                return true;
             if (!seen.Add(name))
                 return true;
+        }
         return false;
     }
 }


### PR DESCRIPTION
Fixes #1371.

## Summary

- Decline anonymous-object raising when captured member names cannot be emitted by the current printer.
- Preserve the existing duplicate-name guard while adding illegal-name and keyword-name negative fixtures.
- Keep normal compiler anonymous-object positives covered by existing pass and fidelity tests.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.AnonymousObjectPassTests -class ILInspector.Decompiler.Tests.FidelityGateTests`
  - 15 passed, 0 failed.
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
  - Succeeded.
- An unfiltered `src/ILInspector.Decompiler.Tests` run was attempted before publishing but did not produce terminal output after 20 minutes; the focused pass and fidelity coverage above completed.

### Decompiler quality diff

Generated after merging current `origin/main` into the branch:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,069 methods
Correctness coverage: validity sampled 350 / 88,069 (0.40%); fidelity sampled 22 / 88,069 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,069 (+699)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,059 methods (+55)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,441 (87.93%) | +547 |
| Conditional-branch residual | 2,290 (2.62%) | 2,307 (2.62%) | +17 |
| Forward-merge stops | 2,284 (2.61%) | 2,298 (2.61%) | +14 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,069 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,069 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)

Caveat: the corpus drifted from the baseline (see baseline staleness above), so count-based regressions may be corpus composition change rather than a real PR delta. Rebaseline against current main and re-run before treating these as blocking.
```

## Adversarial review

Opus 4.8 reviewed the guard and tests. Result: no blocking findings. It confirmed `CSharpNaming.IsUsableIdentifier` matches the current anonymous-object printer behavior because member names are emitted bare, and that `AnonymousObject` is constructed only by `AnonymousObjectPass`.
