### PR TITLE
Fix generic event accessor over-raise

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
@@ -5,6 +5,7 @@ namespace ILInspector.Decompiler.Tests;
 public class PropertySugarPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
 
@@ -90,6 +91,30 @@ public class PropertySugarPassTests
         Assert.Single(property.IndexArguments);
     }
 
+    [Fact]
+    public void GenericEventAccessor_StaysCall()
+    {
+        var accessor = Accessor("add_Changed", Void, [Action], hasThis: true) with { TypeArguments = [Int32] };
+        var function = EventFunction(accessor);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<EventSubscription>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
+    public void EventAccessor_StillRaises()
+    {
+        var function = EventFunction(Accessor("add_Changed", Void, [Action], hasThis: true));
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
+        Assert.True(subscription.IsAdd);
+        Assert.Equal("Changed", subscription.EventName);
+    }
+
     static MethodRef Accessor(string name, TypeRef returnType, System.Collections.Immutable.ImmutableArray<TypeRef> parameters, bool hasThis)
         => new(Holder, name, returnType, parameters, hasThis) { IsSpecialName = true };
 
@@ -107,6 +132,19 @@ public class PropertySugarPassTests
         var body = new BlockContainer();
         var block = new Block();
         block.Add(new ExpressionStatement(new Call(accessor, isVirtual: false, arguments)));
+        block.Add(new Return(null));
+        body.Add(block);
+        return Function(Void, body);
+    }
+
+    static IrFunction EventFunction(MethodRef accessor)
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new ExpressionStatement(new Call(
+            accessor,
+            isVirtual: false,
+            [new LoadArgument(0, "self", Holder), new LoadArgument(1, "handler", Action)])));
         block.Add(new Return(null));
         body.Add(block);
         return Function(Void, body);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -80,6 +80,7 @@ public sealed class PropertySugarPass : IIrPass
             return false;
         int prefix = isAdd ? "add_".Length : "remove_".Length;
         return callee.Name.Length > prefix
+            && callee.TypeArguments.IsEmpty
             && callee.ParameterTypes.Length == 1
             && callee.ReturnType is { Namespace: "System", Name: "Void" };
     }


### PR DESCRIPTION
## Summary

Fixes #1422.

`PropertySugarPass` already declines generic `get_` and `set_` accessors because there is no C# property spelling for a generic accessor invocation. The event accessor path missed the same discriminator, so `add_Changed<T>(handler)` could become `Changed += handler`.

This PR requires `add_`/`remove_` accessor calls to have no method type arguments before raising them to `EventSubscription`.

## Evidence

- Added an adversarial negative fixture: generic `add_Changed<T>` stays as a call and produces no `EventSubscription`.
- Added a direct positive canary: ordinary `add_Changed` still raises to `EventSubscription`.
- Existing event rendering positives still run in the focused test slice.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PropertySugarPassTests -class ILInspector.Decompiler.Tests.EventSubscriptionRenderingTests
ILInspector.Decompiler.Tests  Total: 11, Errors: 0, Failed: 0, Skipped: 0
```

```text
dotnet build src/dotnet-inspect -c Release
Build succeeded.
0 Warning(s)
0 Error(s)
```

I also attempted the full `src/ILInspector.Decompiler.Tests` run before narrowing, but the local runner did not progress beyond startup in a crowded environment with several long-lived dotnet test/harness processes, so I cancelled it and ran the focused pass/rendering slice above.

## Review request

Please run an adversarial review from a different model family, focusing on whether any other event-accessor spelling edge remains over-raised by `PropertySugarPass`.
