### PR TITLE
Fix ReturnMergePass leave-target preservation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ReturnMergePassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void LeaveTargetedReturnTail_RemainsAfterMergeFold()
+    {
+        var function = BuildReturnTailCandidate(includeLeaveTarget: true);
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Body.Blocks, block => block.StartOffset == 0x0003);
+        Assert.Single(function.Descendants.OfType<Leave>());
+    }
+
+    [Fact]
+    public void UntargetedReturnTail_IsRemovedAfterMergeFold()
+    {
+        var function = BuildReturnTailCandidate(includeLeaveTarget: false);
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.DoesNotContain(function.Body.Blocks, block => block.StartOffset == 0x0003);
+        Assert.All(function.Body.Blocks, block => Assert.IsType<Return>(Assert.Single(block.Children)));
+    }
+
+    static IrFunction BuildReturnTailCandidate(bool includeLeaveTarget)
+    {
+        var body = new BlockContainer();
+
+        var first = new Block(0x0000);
+        first.Add(new Branch(0x0003));
+        body.Add(first);
+
+        var second = new Block(0x0001);
+        second.Add(new Branch(0x0003));
+        body.Add(second);
+
+        var merge = new Block(0x0003);
+        merge.Add(new Return(new Constant(1, Int32)));
+        body.Add(merge);
+
+        if (includeLeaveTarget)
+        {
+            var residue = new Block(0x0004);
+            residue.Add(new Leave(0x0003));
+            body.Add(residue);
+        }
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
@@ -37,11 +37,14 @@ public sealed class ReturnMergePass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
-            Fold(container, context);
+            Fold(container, context, leaveTargets);
     }
 
-    static void Fold(BlockContainer container, PassContext context)
+    static void Fold(BlockContainer container, PassContext context, HashSet<int> leaveTargets)
     {
         // Folding one merge can turn its own predecessor (a default arm that
         // fell into it) into a fresh return tail, so iterate to a fixpoint.
@@ -103,9 +106,10 @@ public sealed class ReturnMergePass : IIrPass
                     $"inline return-merge IL_{merge.StartOffset:X4} into {branchPreds.Count} arm(s)", merge);
 
                 // Every unconditional and the fallthrough edge now carries the
-                // tail; if no conditional guard still targets the merge, nothing
-                // reaches it (and the block before it now terminates), so drop it.
-                if (!hasConditionalOrSwitchPred)
+                // tail; if no conditional guard or surviving leave still targets
+                // the merge, nothing reaches it (and the block before it now
+                // terminates), so drop it.
+                if (!hasConditionalOrSwitchPred && !leaveTargets.Contains(merge.StartOffset))
                     merge.Detach();
 
                 changed = true;


### PR DESCRIPTION
## Summary

Fixes #1398.

`ReturnMergePass` now keeps a shared return-tail block when a surviving `leave` still targets that block offset. The pass still inlines the tail into unconditional predecessors, but it no longer detaches the merge block when the label remains externally reachable.

## Evidence

- Added a negative fixture where `leave IL_0003` targets the return tail; the tail remains present after the fold.
- Added a positive fixture where the same return tail has no `leave` target; the existing merge-removal behavior is preserved.
- Existing return-merge stepper canary still passes.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnMergePassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method ILInspector.Decompiler.Tests.StepperTests.DeclarationPlacementAudit_ReturnAccumulatorIsSunkAfterStructuring
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
```

Adversarial review: Opus 4.8 reviewed the patch and found no high-confidence issues. Key checks: preserved merge cannot re-fold, stale `leaveTargets` is safe as an over-preserving superset, and `Leave` is not accidentally treated as a `Branch` predecessor.
