### PR TITLE
Guard ReturnDispatchPass against external arm entries

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
@@ -1,0 +1,81 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ReturnDispatchPassTests
+{
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void LeaveTargetedArm_DeclinesReturnDispatchFold()
+    {
+        var function = BuildReturnDispatchCandidate(includeLeaveTarget: true);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var tryFinally = Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.Equal(9, tryFinally.TryBody.Blocks.Count);
+        Assert.Contains(tryFinally.TryBody.Blocks, block => block.StartOffset == 0x0006);
+        Assert.Single(function.Descendants.OfType<Leave>());
+    }
+
+    [Fact]
+    public void UntargetedArms_StillFoldToOrderedGuardReturns()
+    {
+        var function = BuildReturnDispatchCandidate(includeLeaveTarget: false);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var tryFinally = Assert.Single(function.Descendants.OfType<TryFinally>());
+        var block = Assert.Single(tryFinally.TryBody.Blocks);
+        Assert.Equal(0x0000, block.StartOffset);
+        Assert.Equal(4, block.Children.OfType<IfStatement>().Count());
+        Assert.IsType<Return>(block.Children[^1]);
+    }
+
+    static IrFunction BuildReturnDispatchCandidate(bool includeLeaveTarget)
+    {
+        var tryBody = new BlockContainer();
+        for (int i = 0; i < 4; i++)
+        {
+            var guard = new Block(i);
+            guard.Add(new ConditionalBranch(new LoadArgument(0, "x", Int32), i + 5));
+            tryBody.Add(guard);
+        }
+
+        var fallback = new Block(0x0004);
+        fallback.Add(new Return(new Constant(0, Int32)));
+        tryBody.Add(fallback);
+
+        for (int i = 5; i < 9; i++)
+        {
+            var arm = new Block(i);
+            arm.Add(new Return(new Constant(i, Int32)));
+            tryBody.Add(arm);
+        }
+
+        var finallyBody = new BlockContainer();
+        var finallyBlock = new Block(0x0100);
+        if (includeLeaveTarget)
+            finallyBlock.Add(new Leave(0x0006));
+        else
+            finallyBlock.Add(new EndFinally());
+        finallyBody.Add(finallyBlock);
+
+        var body = new BlockContainer();
+        var outer = new Block(0x0200);
+        outer.Add(new TryFinally(tryBody, finallyBody));
+        outer.Add(new Return(new Constant(-1, Int32)));
+        body.Add(outer);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
@@ -24,14 +24,14 @@ public sealed class ReturnDispatchPass : IIrPass
     public void Run(IrFunction function, PassContext context)
     {
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
-            if (TryFold(container, context.Stepper))
+            if (TryFold(function, container, context.Stepper))
                 return;
     }
 
     sealed record Arm(IReadOnlyList<IrNode> Prefix, IrExpression Condition, IrExpression Value, int TargetIndex);
     sealed record Plan(List<Arm> Arms, IrExpression DefaultValue);
 
-    static bool TryFold(BlockContainer container, Stepper stepper)
+    static bool TryFold(IrFunction function, BlockContainer container, Stepper stepper)
     {
         var blocks = container.Blocks;
         if (blocks.Count < MinArms + 1)
@@ -42,6 +42,8 @@ public sealed class ReturnDispatchPass : IIrPass
             offsetToIndex[blocks[i].StartOffset] = i;
 
         if (BuildPlan(blocks, offsetToIndex) is not { } plan)
+            return false;
+        if (HasExternalEntry(function, container, blocks))
             return false;
 
         var block = new Block(blocks[0].StartOffset);
@@ -112,4 +114,35 @@ public sealed class ReturnDispatchPass : IIrPass
 
     static bool HasControlFlow(IrNode node)
         => node.Descendants.Prepend(node).Any(child => child is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter);
+
+    static bool HasExternalEntry(IrFunction function, BlockContainer container, IReadOnlyList<Block> blocks)
+    {
+        var hiddenOffsets = blocks.Skip(1).Select(block => block.StartOffset).ToHashSet();
+        foreach (var node in function.Descendants)
+        {
+            if (IsInside(node, container))
+                continue;
+            foreach (int target in Targets(node))
+                if (hiddenOffsets.Contains(target))
+                    return true;
+        }
+        return false;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        Leave leave => [leave.TargetOffset],
+        _ => [],
+    };
+
+    static bool IsInside(IrNode node, IrNode root)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (ReferenceEquals(current, root))
+                return true;
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1415.

`ReturnDispatchPass` now declines folding when a branch/conditional/switch/leave outside the matched `BlockContainer` targets a block that would be hidden inside the structured guard-return replacement. This prevents success-shaped output where a surviving `leave IL_x` renders without an emitted `IL_x:` label.

## Evidence

- Added a negative fixture with a `TryFinally` sibling `Leave` targeting a return-dispatch arm; the fold now declines and the target block remains in the container.
- Added a positive fixture with the same return-dispatch shape and no external target; it still folds to ordered guard returns.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnDispatchPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CompletenessTests
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
```

Adversarial review requested from Opus 4.8 and still running at PR creation time; I will post the review summary when it completes.
