### PR TITLE
Fix await using rethrow helper identity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -23,6 +23,8 @@ public class MemberIdentityTests
     static readonly TypeRef s_handler = TypeRef.CoreLib("System.Runtime.CompilerServices", "DefaultInterpolatedStringHandler");
     static readonly TypeRef s_intArray = TypeRef.SzArray(s_int);
     static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
+    static readonly TypeRef s_exception = TypeRef.CoreLib("System", "Exception");
+    static readonly TypeRef s_exceptionDispatchInfo = TypeRef.CoreLib("System.Runtime.ExceptionServices", "ExceptionDispatchInfo");
 
     [Fact]
     public void IsCoreLibraryType_RequiresCoreLibraryIdentity()
@@ -203,6 +205,48 @@ public class MemberIdentityTests
             },
             isVirtual: false,
             [new LoadArgument(0, "x", s_int)])));
+    }
+
+    [Fact]
+    public void ExceptionDispatchInfoMembers_RequireExactBclSignatures()
+    {
+        Assert.True(MemberIdentity.IsExceptionDispatchInfoCapture(ExceptionDispatchInfoCapture(s_exceptionDispatchInfo)));
+        Assert.True(MemberIdentity.IsExceptionDispatchInfoThrow(ExceptionDispatchInfoThrow(s_exceptionDispatchInfo)));
+        Assert.True(MemberIdentity.IsExceptionDispatchInfoCapture(ExceptionDispatchInfoCapture(TypeRef.Definition(
+            "System.Runtime",
+            "System.Runtime.ExceptionServices",
+            "ExceptionDispatchInfo"))));
+        Assert.True(MemberIdentity.IsExceptionDispatchInfoThrow(ExceptionDispatchInfoThrow(TypeRef.Definition(
+            "System.Runtime",
+            "System.Runtime.ExceptionServices",
+            "ExceptionDispatchInfo"))));
+
+        var userDispatchInfo = TypeRef.Definition(
+            "UserAssembly",
+            "System.Runtime.ExceptionServices",
+            "ExceptionDispatchInfo");
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoCapture(ExceptionDispatchInfoCapture(userDispatchInfo)));
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoThrow(ExceptionDispatchInfoThrow(userDispatchInfo)));
+
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoCapture(new Call(
+            ExceptionDispatchInfoCaptureMethod(s_exceptionDispatchInfo) with { ParameterTypes = [s_object] },
+            isVirtual: false,
+            [new LoadArgument(0, "exception", s_exception)])));
+
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoCapture(new Call(
+            ExceptionDispatchInfoCaptureMethod(s_exceptionDispatchInfo) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadArgument(0, "exception", s_exception)])));
+
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoThrow(new Call(
+            ExceptionDispatchInfoThrowMethod(s_exceptionDispatchInfo) with { ReturnType = s_object },
+            isVirtual: true,
+            [ExceptionDispatchInfoCapture(s_exceptionDispatchInfo)])));
+
+        Assert.False(MemberIdentity.IsExceptionDispatchInfoThrow(new Call(
+            ExceptionDispatchInfoThrowMethod(s_exceptionDispatchInfo) with { ParameterTypes = [s_object] },
+            isVirtual: true,
+            [ExceptionDispatchInfoCapture(s_exceptionDispatchInfo), new LoadArgument(1, "state", s_object)])));
     }
 
     [Fact]
@@ -519,6 +563,24 @@ public class MemberIdentityTests
             CreateSpanMethod(declaringType),
             isVirtual: false,
             [new LoadArgument(0, "field", s_runtimeFieldHandle)]);
+
+    static MethodRef ExceptionDispatchInfoCaptureMethod(TypeRef declaringType)
+        => new(declaringType, "Capture", declaringType, [s_exception], HasThis: false);
+
+    static Call ExceptionDispatchInfoCapture(TypeRef declaringType)
+        => new(
+            ExceptionDispatchInfoCaptureMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "exception", s_exception)]);
+
+    static MethodRef ExceptionDispatchInfoThrowMethod(TypeRef declaringType)
+        => new(declaringType, "Throw", s_void, [], HasThis: true);
+
+    static Call ExceptionDispatchInfoThrow(TypeRef declaringType)
+        => new(
+            ExceptionDispatchInfoThrowMethod(declaringType),
+            isVirtual: true,
+            [ExceptionDispatchInfoCapture(declaringType)]);
 
     static MethodRef MonitorEnterMethod(TypeRef declaringType)
         => new(declaringType, "Enter", s_void, [s_object, s_refBool], HasThis: false);

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -167,6 +167,21 @@ public class UsingStatementPassTests
     }
 
     [Fact]
+    public void AwaitUsingRethrowHelperLookalike_IsLeftLowered()
+    {
+        var helperType = TypeRef.Definition("UserAssembly", "Synthetic.Samples", "FakeDispatchInfo");
+        var function = BuildAwaitUsingWithRethrowHelper(helperType);
+
+        new UsingStatementPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<UsingStatement>(), statement => statement.IsAwait);
+        Assert.Single(function.Descendants.OfType<TryCatch>());
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.DeclaringType.Equals(helperType) && call.Callee.Name == "Capture");
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.DeclaringType.Equals(helperType) && call.Callee.Name == "Throw");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void ManualDisposeAsyncInFinally_IsLeftAsTryFinally()
     {
         var function = Raised(nameof(CfgSampleClass.ManualDisposeAsyncInFinally));
@@ -329,5 +344,77 @@ public class UsingStatementPassTests
             };
         }
         return function;
+    }
+
+    static IrFunction BuildAwaitUsingWithRethrowHelper(TypeRef helperType)
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var exceptionType = TypeRef.CoreLib("System", "Exception");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var valueTaskType = TypeRef.CoreLib("System.Threading.Tasks", "ValueTask");
+        var resourceType = TypeRef.Definition("UserAssembly", "Synthetic.Samples", "AsyncResource");
+
+        const int resourceLocal = 0;
+        const int exceptionLocal = 1;
+        const int stateLocal = 2;
+        const int isInstanceSlot = 256;
+        const int exceptionSlot = 257;
+
+        var disposeAsync = new MethodRef(resourceType, "DisposeAsync", valueTaskType, [], HasThis: true);
+        var capture = new MethodRef(helperType, "Capture", helperType, [objectType], HasThis: false);
+        var throwMethod = new MethodRef(helperType, "Throw", voidType, [], HasThis: true);
+
+        var tryBody = new BlockContainer();
+        tryBody.Add(new Block(0));
+
+        var catchBody = new BlockContainer();
+        catchBody.Add(new Block(0));
+        var catchClause = new CatchClause(objectType, catchBody) { VariableIndex = exceptionLocal };
+
+        var disposeThen = new Block(0);
+        disposeThen.Add(new ExpressionStatement(new AwaitExpression(
+            new Call(disposeAsync, isVirtual: true, [new LoadLocal(resourceLocal, resourceType)]),
+            voidType)));
+
+        var fallbackThen = new Block(0);
+        fallbackThen.Add(new ExpressionStatement(new LoadStackSlot(exceptionSlot, exceptionType)));
+        fallbackThen.Add(new Throw(new LoadLocal(exceptionLocal, objectType)));
+
+        var rethrowThen = new Block(0);
+        rethrowThen.Add(new StoreStackSlot(
+            isInstanceSlot,
+            new IsInstance(exceptionType, new LoadLocal(exceptionLocal, objectType))));
+        rethrowThen.Add(new StoreStackSlot(exceptionSlot, new LoadStackSlot(isInstanceSlot, exceptionType)));
+        rethrowThen.Add(new IfStatement(
+            new LogicalNot(new LoadStackSlot(isInstanceSlot, exceptionType)),
+            fallbackThen,
+            elseArm: null));
+        rethrowThen.Add(new ExpressionStatement(new Call(
+            throwMethod,
+            isVirtual: true,
+            [new Call(capture, isVirtual: false, [new LoadStackSlot(exceptionSlot, exceptionType)])])));
+
+        var returnThen = new Block(0);
+        returnThen.Add(new Return(null));
+
+        var entry = new Block(0);
+        entry.Add(new StoreLocal(resourceLocal, resourceType, new Constant(null, resourceType)));
+        entry.Add(new StoreLocal(exceptionLocal, objectType, new Constant(null, objectType)));
+        entry.Add(new StoreLocal(stateLocal, intType, new Constant(0, intType)));
+        entry.Add(new TryCatch(tryBody, [catchClause]));
+        entry.Add(new IfStatement(new LoadLocal(resourceLocal, resourceType), disposeThen, elseArm: null));
+        entry.Add(new IfStatement(new LoadLocal(exceptionLocal, objectType), rethrowThen, elseArm: null));
+        entry.Add(new IfStatement(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadLocal(stateLocal, intType), new Constant(1, intType)),
+            returnThen,
+            elseArm: null));
+        entry.Add(new Throw(new Constant(null, objectType)));
+
+        var body = new BlockContainer();
+        body.Add(entry);
+
+        var signature = new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [resourceType, objectType, intType], body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -317,6 +317,34 @@ public static class MemberIdentity
             && exception.Equals(s_exception)
             && call.Arguments.Count == 1;
 
+    public static bool IsExceptionDispatchInfoCapture(Call call)
+        => !call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: false,
+                Name: "Capture",
+                TypeArguments.IsEmpty: true,
+                ReturnType: var returnType,
+            }
+            && IsExceptionDispatchInfoType(call.Callee.DeclaringType)
+            && IsExceptionDispatchInfoType(returnType)
+            && call.Callee.ParameterTypes is [var exception]
+            && exception.Equals(s_exception)
+            && call.Arguments.Count == 1;
+
+    public static bool IsExceptionDispatchInfoThrow(Call call)
+        => call.Callee is
+        {
+            HasThis: true,
+            Name: "Throw",
+            TypeArguments.IsEmpty: true,
+            ParameterTypes.IsEmpty: true,
+            ReturnType: var returnType,
+        }
+        && returnType.Equals(s_void)
+        && IsExceptionDispatchInfoType(call.Callee.DeclaringType)
+        && call.Arguments.Count == 1;
+
     public static bool IsDefaultInterpolatedStringHandlerConstructor(NewObject newObject)
         => newObject.Constructor is
         {
@@ -667,5 +695,12 @@ public static class MemberIdentity
             type,
             "System.Runtime.CompilerServices",
             "DefaultInterpolatedStringHandler",
+            "System.Runtime");
+
+    static bool IsExceptionDispatchInfoType(TypeRef type)
+        => IsCoreLibraryOrFacadeType(
+            type,
+            "System.Runtime.ExceptionServices",
+            "ExceptionDispatchInfo",
             "System.Runtime");
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -242,7 +242,7 @@ public sealed class UsingStatementPass : IIrPass
                     Condition: LogicalNot,
                     Then.Children: [ExpressionStatement { Expression: LoadStackSlot discardedException }, Throw { Value: LoadLocal throwOriginal }],
                 },
-                ExpressionStatement { Expression: Call { Callee: var throwMethod, Arguments: [Call { Callee: var captureMethod, Arguments: [LoadStackSlot capturedException] }] } },
+                ExpressionStatement { Expression: Call { Arguments: [Call { Arguments: [LoadStackSlot capturedException] } captureCall] } throwCall },
             ],
         }
         && condition.Index == exceptionLocal
@@ -251,8 +251,8 @@ public sealed class UsingStatementPass : IIrPass
         && copiedException.Slot == isInstanceSlot
         && discardedException.Slot == exceptionSlot
         && capturedException.Slot == exceptionSlot
-        && throwMethod is { HasThis: true, Name: "Throw", ParameterTypes.IsEmpty: true, ReturnType: { Namespace: "System", Name: "Void" } }
-        && captureMethod is { HasThis: false, Name: "Capture", ParameterTypes.Length: 1 };
+        && MemberIdentity.IsExceptionDispatchInfoThrow(throwCall)
+        && MemberIdentity.IsExceptionDispatchInfoCapture(captureCall);
 
     static bool IsReturnState(IfStatement returnIf, int stateLocal)
         => returnIf is


### PR DESCRIPTION
## Summary

Fixes #1418.

`UsingStatementPass` now recognizes the runtime-async await-using exception rethrow helper only when the nested calls are the exact BCL `System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(Exception)` and instance `ExceptionDispatchInfo.Throw()` shape. This prevents user lookalikes named `Capture`/`Throw` from being deleted while raising to `await using`.

## Changes

- Added `MemberIdentity` predicates for `ExceptionDispatchInfo.Capture` and `Throw`, accepting corelib/System.Runtime facade identity and rejecting user assemblies or incompatible signatures.
- Replaced the await-using rethrow scaffold name-only check with those identity predicates.
- Added identity tests plus an adversarial direct-IR fixture where `FakeDispatchInfo.Capture(object).Throw()` stays lowered.
- Existing runtime async await-using tests remain the positive canary and still raise/render without `ExceptionDispatchInfo`.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.MemberIdentityTests -class ILInspector.Decompiler.Tests.UsingStatementPassTests`
  - Passed: 36 total, 0 failed.
- `dotnet build src/dotnet-inspect -c Release -m:1`
  - Passed.
- `dotnet build src/dotnet-inspect -c Release` initially hit `MSB4166` from crashed parallel MSBuild child nodes, then passed with `-m:1`.
- Attempted full `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`; cancelled after it remained silent for several minutes on a machine with other long-running dotnet harness/test jobs.

## Review

Please request adversarial review from Opus 4.8 for the identity boundary and the direct negative fixture.
