### PR TITLE
Pin: non-foreach iterators don't drop user try/finally (#1429 class)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3493,6 +3493,53 @@ public class CfgSampleClass
         }
     }
 
+    // Negative coverage for the #1429 class: a user try/finally inside a non-foreach
+    // iterator. csc lowers a user finally to a <>m__Finally call + EndFinally handler +
+    // EH region — the same scaffolding shape ForeachIteratorReconstruction strips for
+    // foreach-delegation iterators (#1429). The linear / multi-yield / counting
+    // reconstruction paths must NOT silently drop the user finally: they either preserve
+    // it or decline to honest acknowledgment (lower fidelity). Asserted by
+    // IteratorUserFinallyTests.
+    public static System.Collections.Generic.IEnumerable<int> LinearYieldUserFinally()
+    {
+        try
+        {
+            yield return 1;
+            yield return 2;
+        }
+        finally
+        {
+            System.Console.Write("f");
+        }
+    }
+
+    public static System.Collections.Generic.IEnumerable<int> MultiYieldUserFinally(bool flag)
+    {
+        try
+        {
+            if (flag)
+                yield return 1;
+            yield return 2;
+        }
+        finally
+        {
+            System.Console.Write("f");
+        }
+    }
+
+    public static System.Collections.Generic.IEnumerable<int> CountingLoopUserFinally(int n)
+    {
+        try
+        {
+            for (int i = 0; i < n; i++)
+                yield return i;
+        }
+        finally
+        {
+            System.Console.Write("f");
+        }
+    }
+
     // An early `break` out of the INNER foreach over a disposable enumerator:
     // the inner loop body lives in a try (the enumerator's dispose finally), and
     // the break lowers to a non-tail `leave` to the continuation after the inner

--- a/src/ILInspector.Decompiler.Tests/IteratorUserFinallyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorUserFinallyTests.cs
@@ -1,0 +1,43 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Regression coverage for the #1429 class of over-raise: a user try/finally inside an
+// iterator lowers to the same <>m__Finally + EndFinally + EH-region scaffolding that the
+// iterator reconstruction passes strip. ForeachIteratorReconstruction was found to drop
+// it (#1429); these prove the non-foreach reconstruction paths (linear, multi-yield,
+// counting) do NOT silently drop the user finally — they either preserve the cleanup or
+// decline to honest acknowledgment (a non-Full fidelity), never reporting Full while the
+// observable finally is gone.
+public class IteratorUserFinallyTests
+{
+    static (string Output, DecompilationFidelity Fidelity) Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        var context = new PassContext(new Stepper(enabled: false),
+            importMethodBody: method => IrImporter.Import(source, method));
+        IrPasses.Run(function!, IrPasses.Default, context);
+        function!.CheckInvariant();
+        return (CSharpPrinter.Print(function).Output!, function.Fidelity);
+    }
+
+    [Theory]
+    [InlineData(nameof(CfgSampleClass.LinearYieldUserFinally))]
+    [InlineData(nameof(CfgSampleClass.MultiYieldUserFinally))]
+    [InlineData(nameof(CfgSampleClass.CountingLoopUserFinally))]
+    public void UserFinallyNeverSilentlyDropped(string method)
+    {
+        var (output, fidelity) = Raised(method);
+
+        // The user finally either survives in the rendered C#, or the method honestly
+        // degrades below Full. What must never happen: Full fidelity with the finally
+        // (the Console.Write("f") cleanup) erased.
+        bool finallyPreserved = output.Contains("finally") || output.Contains("\"f\"");
+        Assert.True(
+            finallyPreserved || fidelity != DecompilationFidelity.Full,
+            $"User finally silently dropped at Full fidelity:\n==== {method} ====\n{output}\n====");
+    }
+}


### PR DESCRIPTION
Test-only regression coverage from a #1356 over-raise discovery audit.

## What this adds

#1429 found that `ForeachIteratorReconstruction` strips the foreach-delegation disposal scaffolding (`<>m__Finally` call + `EndFinally` handler + EH region) **by shape**, silently deleting a user `try/finally` that wears the same shape while reporting `Full`.

This audit asked: do the **sibling non-foreach iterator reconstruction paths** share the disease? A user `try/finally` inside a **linear**, **multi-yield**, or **counting** iterator lowers to the same scaffolding shape.

## Finding (verified empirically through the cross-method import seam)

All three paths **decline to honest acknowledgment** (non-`Full` fidelity) rather than dropping the finally:

```
LinearYieldUserFinally   -> fidelity=Partial (iterator state machine '...' not reconstructed)
MultiYieldUserFinally    -> fidelity=Partial
CountingLoopUserFinally  -> fidelity=Partial
```

So the over-raise is **unique to `ForeachIteratorReconstruction`** (the #1429 target); the linear/multi-yield/counting rewriters bail on the EH region / `<>m__Finally` call rather than stripping it. No new bug — a confirmed-clean result, pinned with a guard.

## The guard

`IteratorUserFinallyTests` asserts the invariant for all three shapes: a user finally must either survive in the rendered C# **or** the method must degrade below `Full` — it must never report `Full` with the cleanup erased. Three new fixtures added to `CfgSampleClass`.

## Evidence

- New tests pass (3/3): `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -filter "/*/*/IteratorUserFinallyTests/*"`.
- **Test-only**: no product/decompiler code changed, so no corpus quality card applies (changed methods are the new tests/fixtures only).

Complementary to (not overlapping) the active #1429 fix for `ForeachIteratorReconstruction`.
