### PR TITLE
Require compatible property accessors for ??= (#1400)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -183,6 +183,21 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void PropertyNullAssignmentWithIncompatibleAccessors_IsNotRaised()
+    {
+        var function = FunctionWithPropertyNullAssignment(
+            getterType: TypeRef.CoreLib("System", "Object"),
+            setterType: TypeRef.CoreLib("System", "String"));
+
+        new NullCoalescingAssignmentPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void IndexerNullAssignmentDiamond_RaisesToNullCoalescingPropertyAssignment()
     {
         var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignIndexer));
@@ -341,5 +356,42 @@ public class NullCoalescingAssignmentPassTests
             IsSpecialName = true,
         };
         return (owner, valueType, intType, getter, setter);
+    }
+
+    static IrFunction FunctionWithPropertyNullAssignment(TypeRef getterType, TypeRef setterType)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "PropertyOwner");
+        var getter = new MethodRef(owner, "get_P", getterType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var setter = new MethodRef(owner, "set_P", TypeRef.CoreLib("System", "Void"), [setterType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var condition = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadProperty(getter, new LoadArgument(0, "owner", owner), []),
+            new Constant(null, getterType));
+        var then = new Block();
+        then.Add(new StoreProperty(
+            setter,
+            new LoadArgument(0, "owner", owner),
+            [],
+            new LoadArgument(1, "fallback", setterType)));
+
+        var block = new Block();
+        block.Add(new IfStatement(condition, then, elseArm: null));
+        block.Add(new Return(new Constant(null, TypeRef.CoreLib("System", "Void"))));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("owner", owner), new Parameter("fallback", setterType)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -118,8 +118,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
         if (statement.HasElse
             || NullTested(statement.Condition) is not LoadProperty getter
             || statement.Then.Children is not [.., StoreProperty store]
-            || store.PropertyName != getter.PropertyName
-            || !Equals(store.Accessor.DeclaringType, getter.Accessor.DeclaringType)
+            || !CompatiblePropertyAccessors(getter, store)
             || !SameReceiver(getter.Instance, store.Instance)
             || !PlaceIdentity.SameOperands(getter.IndexArguments, store.IndexArguments))
         {
@@ -132,6 +131,30 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
         var value = RecoverSpilledValue(function, statement.Then, store);
         return value is null ? null : new PropertyMatch(store, value);
     }
+
+    static bool CompatiblePropertyAccessors(LoadProperty getter, StoreProperty store)
+    {
+        var getAccessor = getter.Accessor;
+        var setAccessor = store.Accessor;
+        if (store.PropertyName != getter.PropertyName
+            || !Equals(setAccessor.DeclaringType, getAccessor.DeclaringType)
+            || setAccessor.HasThis != getAccessor.HasThis
+            || store.HasInstance != getter.HasInstance
+            || store.IsVirtual != getter.IsVirtual
+            || !IsVoid(setAccessor.ReturnType)
+            || setAccessor.ParameterTypes.Length != getAccessor.ParameterTypes.Length + 1)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < getAccessor.ParameterTypes.Length; i++)
+            if (!Equals(setAccessor.ParameterTypes[i], getAccessor.ParameterTypes[i]))
+                return false;
+
+        return Equals(setAccessor.ParameterTypes[^1], getAccessor.ReturnType);
+    }
+
+    static bool IsVoid(TypeRef type) => type is { Namespace: "System", Name: "Void" };
 
     // The clean form is `Then = [store]` with the value inline (a static property,
     // or any setter csc fed directly). The spilled form is


### PR DESCRIPTION
## Summary

- tighten `NullCoalescingAssignmentPass` property `??=` raising to require a compatible getter/setter pair
- require same property name/declaring type, matching instance/static and virtual call shape, `void` setter return, matching index parameter types, and setter value type equal to getter return type
- add an adversarial synthetic IR fixture for `get_P(): object` plus `set_P(string)` that now declines instead of raising invalid `owner.P ??= fallback`

## Shape + proof + decline

Discriminator (shape): getter/setter name lookalike was paired as one C# property without proving signature compatibility.
Narrowest gate added: accessor-pair compatibility over existing `MethodRef`/IR facts; no metadata reload or inspected-assembly loading.

Positive fixture (still raises): existing instance/static property, indexer, constant-index, and dictionary indexer `??=` tests remain green.
Decline (adversarial near miss): `PropertyNullAssignmentWithIncompatibleAccessors_IsNotRaised` keeps `get_P(): object` / `set_P(string)` flat.

Proof level: shape proof (pass fixtures + adversarial negative).

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.NullCoalescingAssignmentPassTests"`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- PR quick corpus card:

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,461 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 1,212 (82.96%) | 1,217 (83.30%) | +5 |
| Conditional-branch residual | 36 (2.46%) | 35 (2.40%) | -1 |
| Forward-merge stops | 31 (2.12%) | 32 (2.19%) | +1 |
| Full malformed | not run | not run | - |
| Semantic defects | not run | not run | - |
| Fidelity diffs | not run | not run | - |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.
```

Local full `src/ILInspector.Decompiler.Tests` run was attempted but stopped after ~15 minutes without terminal output; focused pass tests and main build pass.

## Adversarial review

Opus 4.8 review found no blocking or non-blocking correctness issues. It verified the `void` TypeRef shape, static/instance/virtual checks, indexer parameter matching, and that the test captures the old over-raise.
