### PR TITLE
Decline foreach-iterator reconstruction when a user try/finally is present (#1429)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2361,6 +2361,33 @@ public class CfgSampleClass
         }
     }
 
+    // A non-IDisposable pattern enumerator whose Dispose() has an observable side
+    // effect. A compiler foreach over it would NOT call Dispose; a user who manually
+    // writes the enumerator loop and calls e.Dispose() in a finally must keep it
+    // (#1429 review follow-up: the user enumerator is a hoisted <e>5__N local, not a
+    // compiler <>7__wrap field, so reconstruction must not strip its disposal).
+    public sealed class SideEffectDisposeEnumerable
+    {
+        public SideEffectDisposeEnumerator GetEnumerator() => new();
+    }
+
+    public sealed class SideEffectDisposeEnumerator
+    {
+        int _current;
+
+        public int Current => _current;
+
+        public bool MoveNext()
+        {
+            if (_current == 3)
+                return false;
+            _current++;
+            return true;
+        }
+
+        public void Dispose() => System.Console.Write("x");
+    }
+
     public static int ForeachPatternEnumerable(PatternEnumerable source)
     {
         int sum = 0;
@@ -3558,6 +3585,22 @@ public class CfgSampleClass
             try { yield return x; }
             finally { System.Console.Write("p"); }
         }
+    }
+
+    // Adversarial (#1429 review follow-up): a MANUAL enumerator loop whose enumerator's
+    // Dispose() has a side effect, wrapped in a user try/finally. The enumerator is a
+    // hoisted user local (<e>5__N), not a compiler <>7__wrap field, and a real foreach
+    // over this non-IDisposable type would not call Dispose — so reconstruction must
+    // not raise this to foreach (which would drop the observable e.Dispose()).
+    public static System.Collections.Generic.IEnumerable<int> ManualEnumeratorSideEffectDispose(SideEffectDisposeEnumerable source)
+    {
+        var e = source.GetEnumerator();
+        try
+        {
+            while (e.MoveNext())
+                yield return e.Current;
+        }
+        finally { e.Dispose(); }
     }
 
     // Conditional yield: a guarded yield with a trailing unconditional one. Two

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3472,6 +3472,46 @@ public class CfgSampleClass
             yield return x;
     }
 
+    // Adversarial (#1429): a USER try/finally INSIDE a foreach-delegation iterator.
+    // csc lowers the user finally to the same `<>m__FinallyN()` + EndFinally handler
+    // + region shape as the enumerator's disposal scaffolding, so the reconstruction
+    // must NOT strip it — dropping the finally erases the Console.Write("f") cleanup
+    // that runs on every iteration completion and on early Dispose().
+    public static System.Collections.Generic.IEnumerable<int> ForeachUserFinally(System.Collections.Generic.IEnumerable<int> source)
+    {
+        foreach (var x in source)
+        {
+            try { yield return x; }
+            finally { System.Console.Write("f"); }
+        }
+    }
+
+    // Adversarial (#1429): a user try/finally WRAPPING a foreach-delegation iterator,
+    // disposing a resource. The user finally (`d.Dispose()`) wears the enumerator
+    // split-disposal shape; reconstruction must not drop it or the StringWriter leaks.
+    public static System.Collections.Generic.IEnumerable<int> DisposeResource(System.Collections.Generic.IEnumerable<int> source)
+    {
+        var d = new System.IO.StringWriter();
+        try
+        {
+            foreach (var x in source)
+                yield return x;
+        }
+        finally { d.Dispose(); }
+    }
+
+    // Nested foreach-delegation: two enumerators, hence two compiler `<>m__Finally`
+    // disposal helpers but NO user finally. Used to confirm the #1429 gate keys on
+    // user-finally evidence, not merely a `<>m__Finally` count.
+    public static System.Collections.Generic.IEnumerable<int> NestedForeachYield(
+        System.Collections.Generic.IEnumerable<int> outer,
+        System.Collections.Generic.IEnumerable<int> inner)
+    {
+        foreach (var a in outer)
+            foreach (var b in inner)
+                yield return a + b;
+    }
+
     // Conditional yield: a guarded yield with a trailing unconditional one. Two
     // yields but no loop; the guard references a parameter. Reconstructed by
     // MultiYieldReconstruction (jump-table dispatch the structurer raises to an `if`).

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2338,6 +2338,29 @@ public class CfgSampleClass
         }
     }
 
+    // A non-IDisposable CLASS pattern enumerable. foreach over this in an iterator
+    // emits NO enumerator-disposal <>m__Finally helper, so a user finally is the only
+    // helper (#1429 reviewer case).
+    public sealed class ClassPatternEnumerable
+    {
+        public ClassPatternEnumerator GetEnumerator() => new();
+    }
+
+    public sealed class ClassPatternEnumerator
+    {
+        int _current;
+
+        public int Current => _current;
+
+        public bool MoveNext()
+        {
+            if (_current == 3)
+                return false;
+            _current++;
+            return true;
+        }
+    }
+
     public static int ForeachPatternEnumerable(PatternEnumerable source)
     {
         int sum = 0;
@@ -3510,6 +3533,31 @@ public class CfgSampleClass
         foreach (var a in outer)
             foreach (var b in inner)
                 yield return a + b;
+    }
+
+    // Adversarial (#1429): user try/finally over a foreach whose enumerator is a
+    // NON-IDisposable pattern struct. csc emits NO enumerator-disposal helper, so the
+    // user finally is the ONLY `<>m__Finally` — a count-based gate would miss it. The
+    // fix must prove the helper is the enumerator disposal, not merely count helpers.
+    public static System.Collections.Generic.IEnumerable<int> ForeachPatternUserFinally(PatternEnumerable source)
+    {
+        foreach (var x in source)
+        {
+            try { yield return x; }
+            finally { System.Console.Write("p"); }
+        }
+    }
+
+    // Adversarial (#1429): the reviewer's exact shape — user try/finally over a foreach
+    // whose enumerator is a NON-IDisposable CLASS. csc emits no enumerator-disposal
+    // helper, so the user finally is the ONLY `<>m__Finally`; a count-only gate misses it.
+    public static System.Collections.Generic.IEnumerable<int> ForeachClassPatternUserFinally(ClassPatternEnumerable source)
+    {
+        foreach (var x in source)
+        {
+            try { yield return x; }
+            finally { System.Console.Write("p"); }
+        }
     }
 
     // Conditional yield: a guarded yield with a trailing unconditional one. Two

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -415,6 +415,20 @@ public class IteratorReconstructionPassTests
         Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
     }
 
+    [Fact]
+    public void ManualEnumeratorLoopWithSideEffectingDispose_DeclinesRatherThanRaisingForeach()
+    {
+        // A user-managed enumerator loop whose enumerator is a hoisted user local
+        // (<e>5__N), not a compiler <>7__wrap field. Its e.Dispose() has a side effect a
+        // real foreach over this non-IDisposable type would not run, so raising to foreach
+        // would drop it. The pass must decline when the enumerator is a hoisted user local.
+        var function = Raised(nameof(CfgSampleClass.ManualEnumeratorSideEffectDispose));
+
+        Assert.NotEqual(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+    }
+
     static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectBeforeHandoff()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -401,6 +401,20 @@ public class IteratorReconstructionPassTests
         Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
     }
 
+    [Fact]
+    public void ForeachOverNonDisposableEnumeratorWithUserFinally_DeclinesRatherThanDroppingFinally()
+    {
+        // The enumerator is a non-IDisposable class, so csc emits NO disposal helper —
+        // the user finally is the ONLY <>m__Finally. A helper count would miss it; the
+        // body check sees the lone helper calls Console.Write (not enumerator.Dispose)
+        // and declines, instead of silently deleting the finally (#1429 review finding).
+        var function = Raised(nameof(CfgSampleClass.ForeachClassPatternUserFinally));
+
+        Assert.NotEqual(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+    }
+
     static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectBeforeHandoff()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -375,6 +375,32 @@ public class IteratorReconstructionPassTests
         Assert.DoesNotContain("GetEnumerator", output);
     }
 
+    [Fact]
+    public void ForeachWithUserFinally_DeclinesRatherThanDroppingFinally()
+    {
+        // A user try/finally inside the foreach-delegation iterator lowers to the same
+        // <>m__FinallyN + fault-handler shape as the enumerator disposal, so reconstruction
+        // used to strip it and report Full — silently deleting the finally (#1429). The
+        // second <>m__Finally helper now declines the match to honest acknowledgment.
+        var function = Raised(nameof(CfgSampleClass.ForeachUserFinally));
+
+        Assert.NotEqual(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+    }
+
+    [Fact]
+    public void ForeachWrappedInUserFinally_DeclinesRatherThanDroppingDispose()
+    {
+        // try { foreach … yield } finally { resource.Dispose() } — the user finally would
+        // be erased (the resource silently leaks). Reconstruction must decline.
+        var function = Raised(nameof(CfgSampleClass.DisposeResource));
+
+        Assert.NotEqual(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Contains(function.Descendants.OfType<UnsupportedNode>(), u => u.Opcode == "iterator");
+    }
+
     static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectBeforeHandoff()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -78,6 +78,16 @@ internal static class ForeachIteratorReconstruction
         if (enumeratorField is null)
             return false;
 
+        // The compiler hoists a foreach-delegation enumerator into a synthesized wrapper
+        // field (`<>7__wrap*`), whose disposal `foreach` re-implies. A *user*-managed
+        // enumerator loop instead hoists the enumerator as an ordinary user local
+        // (`<e>5__N`), and any `e.Dispose()` the user wrote is observable — a real
+        // `foreach` over a non-IDisposable enumerator would not call it. Reconstructing
+        // such a loop to `foreach` would silently drop that Dispose, so proceed only when
+        // the enumerator is the compiler wrapper, not a hoisted user local (#1429).
+        if (GeneratedCodeIdentity.IsHoistedLocalFieldName(enumeratorField.Name))
+            return false;
+
         // The foreach-delegation disposal lowers each enumerator's split-disposal to a
         // `<>m__FinallyN` helper that does nothing but dispose the enumerator field. A
         // user `try { … } finally { … }` inside or around the iterator lowers to the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -37,8 +37,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// restructured body still carries raw control flow, an unresolved state-machine field, no
 /// yield, or no recovered <c>foreach</c>, the match is rejected and the iterator falls
 /// through to honest acknowledgment. A user <c>try/finally</c> inside or around the
-/// iterator lowers to a second <c>&lt;&gt;m__FinallyN</c> helper sharing the disposal
-/// shape, so the match also declines when more than one such helper is present, rather
+/// iterator lowers to a <c>&lt;&gt;m__FinallyN</c> helper sharing the disposal shape, so
+/// the match verifies that every such helper is exactly the enumerator's disposal
+/// (<c>enumeratorField.Dispose()</c> and nothing else) and otherwise declines, rather
 /// than stripping the user finally (#1429).</para>
 /// </summary>
 internal static class ForeachIteratorReconstruction
@@ -77,22 +78,27 @@ internal static class ForeachIteratorReconstruction
         if (enumeratorField is null)
             return false;
 
-        // The foreach-delegation disposal lowers to exactly ONE `<>m__FinallyN` helper
-        // (the enumerator's split-disposal). A user `try/finally` inside or around the
-        // iterator wears the identical fault-region + EndFinally + `<>m__Finally` shape
-        // but produces an ADDITIONAL helper, and reconstruction below strips every
-        // `<>m__Finally*` call and the whole handler by shape — which would silently
-        // delete the user finally while reporting Full (#1429). Reconstruction only
-        // models the single-enumerator disposal, so if more than one distinct
-        // `<>m__Finally` helper is present, decline to honest acknowledgment rather than
-        // risk dropping observable cleanup. (Nested/sequential foreach-delegation also
-        // yields multiple helpers and already falls through here today.)
-        var finallyHelpers = new HashSet<string>(StringComparer.Ordinal);
+        // The foreach-delegation disposal lowers each enumerator's split-disposal to a
+        // `<>m__FinallyN` helper that does nothing but dispose the enumerator field. A
+        // user `try { … } finally { … }` inside or around the iterator lowers to the
+        // identical fault-region + EndFinally + `<>m__Finally` shape, so the strip loop
+        // below would silently delete the user finally while reporting Full (#1429).
+        // Before stripping, require every `<>m__Finally` helper the body invokes to be
+        // exactly the discovered enumerator's disposal; if any helper is a user finally
+        // (or disposes a different resource), decline to honest acknowledgment. The
+        // cross-method import seam is always present on this path (the caller imported
+        // MoveNext through it), but guard defensively and decline if it is unavailable.
         foreach (var node in work.Descendants)
-            if (node is Call { Callee.Name: var callee } && callee.StartsWith("<>m__Finally", StringComparison.Ordinal))
-                finallyHelpers.Add(callee);
-        if (finallyHelpers.Count > 1)
-            return false;
+        {
+            if (node is not Call { Callee.Name: var callee } helperCall
+                || !callee.StartsWith("<>m__Finally", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var helper = context.ImportMethodBody?.Invoke(helperCall.Callee);
+            if (helper is null || !IsEnumeratorDisposalHelper(helper, enumeratorField))
+                return false;
+        }
 
         // field name -> (local index, type): the enumerator, plus any hoisted loop fields.
         var locals = new Dictionary<string, (int Index, TypeRef Type)>(StringComparer.Ordinal)
@@ -382,4 +388,42 @@ internal static class ForeachIteratorReconstruction
         var close = fieldName.IndexOf('>');
         return close > 1 ? fieldName[1..close] : "i";
     }
+
+    // A `<>m__FinallyN` is the enumerator's split-disposal (safe to strip with the
+    // foreach) iff its only call disposes the discovered enumerator field — i.e.
+    // `enumeratorField.Dispose()`, optionally null-guarded — and it stores nothing but
+    // the state-machine state field. Any other call (a user finally body, or a Dispose
+    // on a different hoisted resource) or any other field store means it carries
+    // user-observable behavior and must not be deleted (#1429).
+    static bool IsEnumeratorDisposalHelper(IrFunction helper, FieldRef enumeratorField)
+    {
+        var disposeCount = 0;
+        foreach (var node in helper.Descendants)
+        {
+            switch (node)
+            {
+                case Call call:
+                    if (call.Callee.Name != "Dispose" || !DisposesEnumeratorField(call, enumeratorField))
+                        return false;
+                    disposeCount++;
+                    break;
+                case CallIndirect:
+                case NewObject:
+                    return false;
+                case StoreField { Field.Name: "<>1__state" }:
+                    break;  // resume-state bookkeeping
+                case StoreField:
+                    return false;  // any other field write is not pure disposal
+            }
+        }
+        return disposeCount > 0;
+    }
+
+    static bool DisposesEnumeratorField(Call call, FieldRef enumeratorField)
+        => call.Arguments.Count >= 1
+            && StripConversions(call.Arguments[0]) is LoadField { Instance: LoadArgument { Index: 0 }, Field: var field }
+            && field.Name == enumeratorField.Name;
+
+    static IrExpression StripConversions(IrExpression expression)
+        => expression is Convert convert ? StripConversions(convert.Operand) : expression;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -36,7 +36,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// hidden-enumerator loop into a <see cref="ForeachStatement"/>. Sound by validation: if the
 /// restructured body still carries raw control flow, an unresolved state-machine field, no
 /// yield, or no recovered <c>foreach</c>, the match is rejected and the iterator falls
-/// through to honest acknowledgment.</para>
+/// through to honest acknowledgment. A user <c>try/finally</c> inside or around the
+/// iterator lowers to a second <c>&lt;&gt;m__FinallyN</c> helper sharing the disposal
+/// shape, so the match also declines when more than one such helper is present, rather
+/// than stripping the user finally (#1429).</para>
 /// </summary>
 internal static class ForeachIteratorReconstruction
 {
@@ -72,6 +75,23 @@ internal static class ForeachIteratorReconstruction
             if (node is StoreField { Instance: LoadArgument { Index: 0 }, Field: var f, Value: Call { Callee.Name: "GetEnumerator" } })
                 enumeratorField = f;
         if (enumeratorField is null)
+            return false;
+
+        // The foreach-delegation disposal lowers to exactly ONE `<>m__FinallyN` helper
+        // (the enumerator's split-disposal). A user `try/finally` inside or around the
+        // iterator wears the identical fault-region + EndFinally + `<>m__Finally` shape
+        // but produces an ADDITIONAL helper, and reconstruction below strips every
+        // `<>m__Finally*` call and the whole handler by shape — which would silently
+        // delete the user finally while reporting Full (#1429). Reconstruction only
+        // models the single-enumerator disposal, so if more than one distinct
+        // `<>m__Finally` helper is present, decline to honest acknowledgment rather than
+        // risk dropping observable cleanup. (Nested/sequential foreach-delegation also
+        // yields multiple helpers and already falls through here today.)
+        var finallyHelpers = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var node in work.Descendants)
+            if (node is Call { Callee.Name: var callee } && callee.StartsWith("<>m__Finally", StringComparison.Ordinal))
+                finallyHelpers.Add(callee);
+        if (finallyHelpers.Count > 1)
             return false;
 
         // field name -> (local index, type): the enumerator, plus any hoisted loop fields.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -430,9 +430,22 @@ internal static class ForeachIteratorReconstruction
     }
 
     static bool DisposesEnumeratorField(Call call, FieldRef enumeratorField)
-        => call.Arguments.Count >= 1
-            && StripConversions(call.Arguments[0]) is LoadField { Instance: LoadArgument { Index: 0 }, Field: var field }
-            && field.Name == enumeratorField.Name;
+    {
+        if (call.Arguments.Count < 1)
+            return false;
+        // A class enumerator disposes through a loaded field reference (`ldfld`); a
+        // struct enumerator (e.g. List<T>.Enumerator) disposes through the field address
+        // (`ldflda`). Accept either, on the discovered enumerator field via `this`.
+        var (instance, field) = StripConversions(call.Arguments[0]) switch
+        {
+            LoadField load => (load.Instance, load.Field),
+            LoadFieldAddress load => (load.Instance, load.Field),
+            _ => ((IrExpression?)null, (FieldRef?)null),
+        };
+        return field is not null
+            && field.Name == enumeratorField.Name
+            && instance is LoadArgument { Index: 0 };
+    }
 
     static IrExpression StripConversions(IrExpression expression)
         => expression is Convert convert ? StripConversions(convert.Operand) : expression;


### PR DESCRIPTION
Closes #1429 (row 25 of #1356).

## Over-raise claim being narrowed

`ForeachIteratorReconstruction` strips the iterator's compiler-synthesized
enumerator-disposal scaffolding (`<>m__FinallyN()` calls, the `EndFinally`
handler, all EH regions) **by shape alone**. csc lowers a user
`try { … } finally { … }` inside or around an iterator into the same shape, so
the user's finally was silently deleted during reconstruction while reporting
`Full` — cleanup that runs on every completion (and on early `Dispose()`)
disappeared. Likewise a user-managed enumerator loop whose `Dispose()` has a
side effect was raised to a `foreach` that drops it.

Before this PR (all `fidelity=Full`): `ForeachUserFinally` dropped the
`finally`; `DisposeResource` dropped `d.Dispose()` (writer leaks);
`ForeachClassPatternUserFinally` (non-`IDisposable` enumerator) dropped the
`finally`; `ManualEnumeratorSideEffectDispose` dropped a side-effecting
`e.Dispose()`.

## Fix — two proof gates before stripping

The discriminator went through a multi-round GPT-5.5 adversarial review (see the
review comment); the final form is two narrow gates:

1. **Wrapper gate:** the discovered enumerator field must be a compiler wrapper
   (`<>7__wrap*`), not a hoisted user local
   (`GeneratedCodeIdentity.IsHoistedLocalFieldName`). This rejects user-managed
   enumerator loops whose explicit `Dispose()` is observable.
2. **Body gate:** every `<>m__Finally` helper the `MoveNext` body invokes is
   imported and must be *exactly* that wrapper's disposal — its only call is
   `enumeratorField.Dispose()` (receiver via `ldfld` or `ldflda` for struct
   enumerators), it stores nothing but `<>1__state`, and it has no other
   call/construction. Any user finally (other code, or a `Dispose` on a
   different hoisted resource) declines to honest acknowledgment (`Partial`).

The strip logic itself is unchanged; the cross-method import seam is always
present on this path (the caller imported `MoveNext` through it).

## End-to-end verification (both gates disabled = base behavior in parens)

| method | result | base |
| --- | --- | --- |
| `YieldEach` (positive) | Full, foreach | Full |
| `ForeachUserFinally` | Partial (finally kept) | Full (bug) |
| `DisposeResource` | Partial | Full (bug) |
| `ForeachClassPatternUserFinally` (non-IDisposable) | Partial | Full (bug) |
| `ManualEnumeratorSideEffectDispose` (user-managed) | Partial | Full (bug) |
| `ForeachPatternUserFinally` / `NestedForeachYield` | Partial | Partial |

No working positive regresses: the only foreach-delegation shape the base pass
reconstructs (`YieldEach`) still raises `foreach` at `Full`. `List<T>`/generic
struct-enumerator iterators are pre-existing `Partial` acknowledgments (base
limitation), unchanged by this PR.

## Tests

`src/ILInspector.Decompiler.Tests` green. Adds `CfgSampleClass` samples
(`ForeachUserFinally`, `DisposeResource`, `ForeachClassPatternUserFinally`,
`ManualEnumeratorSideEffectDispose`, `NestedForeachYield`,
`ForeachPatternUserFinally`) plus iterator tests asserting each user-finally /
user-managed shape declines to acknowledgment, alongside the `YieldEach`
positive canary.

## Corpus card

The pinned baseline is stale (+700 repo methods since 2026-06-23); the card's own
`Baseline staleness` block (from #1404) flags the count deltas as corpus drift.
This change only declines a few iterator-with-user-finally shapes (none present
in the sampled corpus), so its real footprint is ~zero. Per the #1356 guardrail,
dropped-effect output becoming `Partial` is an honesty improvement, not a
regression.

## Guardrails

- SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading.
- Pass not widened; two narrow decline gates added.
- Adversarial fixtures (4 user-finally / user-managed shapes) + positive canary
  + multi-helper-no-finally control.

Cross-model adversarial review (GPT-5.5): three rounds, two real High-severity
defects found and fixed plus one struct-enumerator robustness fix — see the
review comment.
