### PR TITLE
Treat static field branch conditions as effectful (#1353)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -65,6 +65,22 @@ public class RedundantBranchEliminationPassTests
     }
 
     [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionReadsStaticFieldAddress()
+    {
+        // ldsflda Holder::Gate; ldind.u1; brtrue.s next — taking a static field's address
+        // also triggers the declaring type's .cctor, so this redundant branch must stay too.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var holder = TypeRef.Definition("SyntheticAssembly", "Samples", "Holder");
+        var field = new FieldRef(holder, "Gate", boolType);
+        var condition = new LoadIndirect(boolType, new LoadFieldAddress(field, instance: null));
+        var function = TwoBlocks(new ConditionalBranch(condition, targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
+
+        Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
+    }
+
+    [Fact]
     public void RemovesUnconditionalBranchToFallthrough()
     {
         // The pre-existing behavior still holds.

--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -50,6 +50,21 @@ public class RedundantBranchEliminationPassTests
     }
 
     [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionReadsStaticField()
+    {
+        // Even a redundant conditional branch must preserve an ldsfld condition:
+        // reading a static field can trigger the declaring type's .cctor.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var holder = TypeRef.Definition("SyntheticAssembly", "Samples", "Holder");
+        var field = new FieldRef(holder, "Gate", boolType);
+        var function = TwoBlocks(new ConditionalBranch(new LoadField(field, instance: null), targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
+
+        Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
+    }
+
+    [Fact]
     public void RemovesUnconditionalBranchToFallthrough()
     {
         // The pre-existing behavior still holds.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
@@ -44,11 +44,12 @@ public sealed class RedundantBranchEliminationPass : IIrPass
     /// Whether evaluating the expression has no observable effect, so dropping it
     /// is sound. Conservative: any call-like node (or an unsupported one) is
     /// assumed to have side effects, leaving its branch in place rather than risk
-    /// eliding an effect. Static field reads are also treated as effectful because
-    /// <c>ldsfld</c> can trigger a type initializer.
+    /// eliding an effect. A static field access is also treated as effectful because
+    /// <c>ldsfld</c>/<c>ldsflda</c> can trigger the declaring type's static constructor.
     /// </summary>
     static bool IsSideEffectFree(IrExpression condition)
         => condition.Descendants.Prepend(condition).All(node => node is not
             (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode)
-            and not LoadField { Instance: null });
+            and not LoadField { Instance: null }
+            and not LoadFieldAddress { Instance: null });
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
@@ -44,9 +44,11 @@ public sealed class RedundantBranchEliminationPass : IIrPass
     /// Whether evaluating the expression has no observable effect, so dropping it
     /// is sound. Conservative: any call-like node (or an unsupported one) is
     /// assumed to have side effects, leaving its branch in place rather than risk
-    /// eliding an effect.
+    /// eliding an effect. Static field reads are also treated as effectful because
+    /// <c>ldsfld</c> can trigger a type initializer.
     /// </summary>
     static bool IsSideEffectFree(IrExpression condition)
         => condition.Descendants.Prepend(condition).All(node => node is not
-            (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode));
+            (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode)
+            and not LoadField { Instance: null });
 }


### PR DESCRIPTION
Burndown row 1 of #1356. Preserves the complete fix from the stale `fix/issue-1353-static-field-branch` branch (676e271f, cherry-picked) and drives it through the decompiler-PR contract — coordinated on the issue.

## Over-raise claim being narrowed

`RedundantBranchEliminationPass` drops a `ConditionalBranch` to the immediately following block when its condition `IsSideEffectFree`. That set rejected only call-like nodes, so a **static field read** condition (`ldsfld`) was treated as pure and dropped:

```text
Block IL_0000
  ConditionalBranch IL_0001
    LoadField WithCctor.Flag (bool)   // static read — can trigger WithCctor::.cctor
Block IL_0001
  Return
```

folded to just the return, **dropping the `ldsfld` evaluation** (and any type-initializer it triggers) while reporting Full.

## Fix (narrowest proof gate)

Add `LoadField { Instance: null }` (a static field read) to the effectful set, so a redundant branch with a static-field condition is left in place and the read is preserved. Instance reads are unchanged (out of this issue's scope). Pure narrowing — the pass only declines more.

## Adversarial fixture

- `KeepsConditionalBranchToFallthrough_WhenConditionReadsStaticField`: a redundant `ConditionalBranch` whose condition is a static `LoadField` stays a `ConditionalBranch` (not detached).
- Existing positives (pure conditions still folded) intact: `RedundantBranchEliminationPassTests` 4/4.

## Validation

Full `ILInspector.Decompiler.Tests` suite and a corpus quality-diff card (vs a freshly captured base snapshot) are in progress and will be posted as comments. Cross-model adversarial review (GPT-5.5) requested.

Closes #1353.