### PR TITLE
Decline duplicate-label switch raises (#1430)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchDuplicateLabelTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchDuplicateLabelTests.cs
@@ -1,0 +1,97 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Adversarial guards for the positive-polarity equality-chain switch raisers
+// (issue #1430). C# forbids duplicate case labels (CS0152), so a chain with a
+// repeated literal/constant is not a source switch; the raiser must decline
+// rather than emit an uncompilable duplicate-label `switch`. csc can never emit
+// such a chain (the source would not compile), so these are synthetic-IR
+// near-misses pinning the guard, paired with a distinct-label positive canary.
+public class SwitchDuplicateLabelTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "T");
+
+    static IrFunction Run(TypeRef governingType, Func<IrExpression> value, int firstLabel, int secondLabel, bool asString)
+    {
+        IrExpression Test(int label) => asString
+            ? new Call(
+                new MethodRef(String, "op_Equality", Boolean, [String, String], HasThis: false),
+                isVirtual: false,
+                [value(), new Constant(label.ToString(), String)])
+            : new Comparison(ComparisonKind.Equal, isUnsigned: false, value(), new Constant(label, Int32));
+
+        var container = new BlockContainer();
+
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(Test(firstLabel), 100));
+
+        var b1 = new Block(8);
+        b1.Add(new ConditionalBranch(Test(secondLabel), 200));
+
+        var b2 = new Block(16);
+        b2.Add(new Branch(300));
+
+        var case1 = new Block(100);
+        case1.Add(new Return(new Constant(1, Int32)));
+
+        var case2 = new Block(200);
+        case2.Add(new Return(new Constant(2, Int32)));
+
+        var def = new Block(300);
+        def.Add(new Return(new Constant(0, Int32)));
+
+        foreach (var block in (Block[])[b0, b1, b2, case1, case2, def])
+            container.Add(block);
+
+        var signature = new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Owner, signature, [governingType], container);
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void SparseIntChain_DistinctLabels_RaisesToSwitch()
+    {
+        var function = Run(Int32, () => new LoadLocal(0, Int32), 5, 7, asString: false);
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        var labels = node.Sections.Where(s => !s.IsDefault)
+            .SelectMany(s => s.Labels).Select(l => l.Value).ToArray();
+        Assert.Equal(new object[] { 5, 7 }, labels);
+    }
+
+    [Fact]
+    public void SparseIntChain_DuplicateLabel_StaysFlat()
+    {
+        var function = Run(Int32, () => new LoadLocal(0, Int32), 5, 5, asString: false);
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        // The flat equality chain is preserved (valid C#), not rewritten.
+        Assert.Equal(2, function.Descendants.OfType<ConditionalBranch>().Count());
+    }
+
+    [Fact]
+    public void StringEqualityChain_DistinctLiterals_RaisesToSwitch()
+    {
+        var function = Run(String, () => new LoadLocal(0, String), 5, 7, asString: true);
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        var labels = node.Sections.Where(s => !s.IsDefault)
+            .SelectMany(s => s.Labels).Select(l => l.Value).ToArray();
+        Assert.Equal(new object[] { "5", "7" }, labels);
+    }
+
+    [Fact]
+    public void StringEqualityChain_DuplicateLiteral_StaysFlat()
+    {
+        var function = Run(String, () => new LoadLocal(0, String), 5, 5, asString: true);
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Equal(2, function.Descendants.OfType<ConditionalBranch>().Count());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -768,6 +768,11 @@ public sealed class SwitchRaisingPass : IIrPass
             && TryStringEqualityTest(cb.Condition, out var testValue, out var literal)
             && PlaceIdentity.SameVariable(value, testValue))
         {
+            // C# forbids duplicate case labels (CS0152); a repeated literal is not a
+            // source switch. Decline rather than emit an uncompilable duplicate-label
+            // switch — matching the hash / length-bucket raisers' guards.
+            if (caseLabels.Any(label => Equals(label.Value, literal)))
+                return false;
             caseLabels.Add(StringConst(literal));
             caseTargetOffsets.Add(cb.TargetOffset);
             idx++;
@@ -1051,6 +1056,11 @@ public sealed class SwitchRaisingPass : IIrPass
             {
                 if (isEqual)
                 {
+                    // C# forbids duplicate case labels (CS0152); a repeated constant is
+                    // not a source switch. Decline rather than emit an uncompilable
+                    // duplicate-label switch (mirrors the string raisers' guards).
+                    if (caseLabels.Any(label => Equals(label.Value, constant)))
+                        return false;
                     caseLabels.Add(IntConst(constant));
                     caseTargetOffsets.Add(cb.TargetOffset);
                 }


### PR DESCRIPTION
Fixes #1430.

## Over-raise claim narrowed

`SwitchRaisingPass.RaiseStringEqualityChain` and `RaiseSparseIntSwitch` collected case labels with no duplicate guard, so a positive-polarity equality chain with a repeated literal/constant raised to a `switch` with duplicate `case` labels — invalid C# (CS0152) emitted while reporting success. The sibling `RaiseStringHashSwitch` (`:843`) and `RaiseStringLengthBucketSwitch` (`:953`) raisers already guard exactly this.

## Fix

Add the same one-line guard to both raisers: decline (leave the flat equality chain, which is valid C#) when a literal/constant is already collected.

## Soundness / blast radius

csc can never emit such a chain (C# forbids duplicate case labels), so this only adds a decline path for hand-written/obfuscated IL. `CorpusSweepGateTests` is unchanged (still green).

## Evidence

`SwitchDuplicateLabelTests`: synthetic-IR negatives (duplicate int constant / string literal stay flat) that **fail without this change**, plus distinct-label positive canaries that still raise. Existing switch suites (`SparseIntSwitchRaisingTests`, `StringSwitchRaisingTests`, `SwitchExpressionRaisingTests`, `SwitchBranchRenderingTests`) green.
