### PR TITLE
Decline cross-block stack-slot live-range splits (#1432)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackSlotLiveRangeCrossBlockTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotLiveRangeCrossBlockTests.cs
@@ -1,0 +1,69 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Adversarial guard for StackSlotLiveRangePass cross-block live ranges (issue #1432).
+// The split only renumbers loads inside the store's own block, so a slot read from a
+// successor block (live-out) would be left on the stale slot — now holding a different
+// range's value. The pass claims block-local ranges only, so it must decline when the
+// slot escapes the block. Synthetic-IR near-miss (csc keeps these ranges block-local)
+// paired with a block-local positive canary that still splits.
+public class StackSlotLiveRangeCrossBlockTests
+{
+    static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "T");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+
+    const int Slot = 5;
+
+    // block0: S5 = int (range A, used); S5 = string (range B, used). When
+    // crossBlock, a successor block also reads S5 (range B live-out).
+    static IrFunction Build(bool crossBlock)
+    {
+        var container = new BlockContainer();
+
+        var b0 = new Block(0);
+        b0.Add(new StoreStackSlot(Slot, new Constant(1, Int32)));                 // range A
+        b0.Add(new ExpressionStatement(new LoadStackSlot(Slot, Int32)));
+        b0.Add(new StoreStackSlot(Slot, new Constant("x", String)));             // range B (split candidate)
+        b0.Add(new ExpressionStatement(new LoadStackSlot(Slot, String)));        // in-block range-B read
+        container.Add(b0);
+
+        if (crossBlock)
+        {
+            var b1 = new Block(100);
+            b1.Add(new ExpressionStatement(new LoadStackSlot(Slot, String)));    // live-out range-B read
+            b1.Add(new Return(null));
+            container.Add(b1);
+        }
+        else
+        {
+            b0.Add(new Return(null));
+        }
+
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Owner, signature, [], container);
+        new StackSlotLiveRangePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
+    }
+
+    static bool Split(IrFunction function)
+        => function.Descendants.OfType<StoreStackSlot>().Any(s => s.Slot >= StoreStackSlot.DupSlotBase)
+            || function.Descendants.OfType<LoadStackSlot>().Any(l => l.Slot >= StoreStackSlot.DupSlotBase);
+
+    [Fact]
+    public void BlockLocalRange_Splits()
+    {
+        Assert.True(Split(Build(crossBlock: false)));
+    }
+
+    [Fact]
+    public void CrossBlockRange_StaysUnsplit()
+    {
+        var function = Build(crossBlock: true);
+        Assert.False(Split(function));
+        // The successor read is left intact on the original slot.
+        Assert.Equal(3, function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == Slot));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotLiveRangePass.cs
@@ -37,6 +37,15 @@ public sealed class StackSlotLiveRangePass : IIrPass
                 if (liveLoads.Count == 0)
                     continue;
 
+                // The split only renumbers loads inside this block (LiveLoads scans
+                // block.Children). If the slot is read from any other block, that value
+                // may be live-out and the out-of-block read would be left on the old
+                // slot — now holding a different range. The pass only handles block-local
+                // ranges, so decline when the slot escapes the block.
+                if (function.Descendants.OfType<LoadStackSlot>()
+                    .Any(load => load.Slot == store.Slot && !IsDescendantOf(load, block)))
+                    continue;
+
                 int newSlot = FreshStackSlot(function);
                 stepper.StepOver($"split stack slot {store.Slot} live range to S_{newSlot}", store);
                 foreach (var load in liveLoads)


### PR DESCRIPTION
Fixes #1432.

## Over-raise claim narrowed

`StackSlotLiveRangePass` renumbers only the loads inside the store's own block (`LiveLoads` scans `block.Children`) but did not verify the slot was block-local. A slot also read from a successor block (live-out) had that read left on the old slot — now holding a different range's value — a silent wrong value / type mismatch, though the pass claims block-local ranges only.

## Fix

Decline the split when the slot is read from any other block.

## Soundness / blast radius

csc keeps these synthetic carrier ranges block-local (the importer keys carry slots by type), so this only adds a decline path for cross-block hand-IL. A full CoreLib sweep finds 0 cross-block cases; `CorpusSweepGateTests` is unchanged (still green).

## Evidence

`StackSlotLiveRangeCrossBlockTests`: a synthetic-IR negative (live-out read stays unsplit) that **fails without this change**, plus a block-local positive canary that still splits.
