### PR TITLE
Require contiguous escape for stack-slot object-initializer raise (#1408)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
@@ -1,0 +1,59 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Adversarial guard for ObjectInitializerPass stack-slot contiguity (issue #1408).
+// The stack-slot form folds member-store values into `new T { ... }` at the single
+// downstream escape. If a non-consumed (side-effecting) statement sits between the
+// member stores and the escape, folding moves the member-value computations after
+// it — reordering observable side effects. csc emits the dup-chain use contiguously,
+// so this is a synthetic-IR near-miss; paired with a contiguous positive canary.
+public class ObjectInitializerContiguityTests
+{
+    static readonly TypeRef Type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    const int Slot = 3;
+
+    static IrFunction Build(bool interveningStatement)
+    {
+        var ctor = new MethodRef(Type, ".ctor", Void, [], HasThis: true);
+        var setX = new MethodRef(Type, "set_X", Void, [Int32], HasThis: true) { IsSpecialName = true };
+        var log = new MethodRef(Owner, "Log", Int32, [], HasThis: false);
+        var other = new MethodRef(Owner, "Other", Void, [], HasThis: false);
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(Slot, new NewObject(ctor, [])));                                  // seed
+        block.Add(new StoreProperty(setX, new LoadStackSlot(Slot, Type), [],
+            new Call(log, isVirtual: false, [])));                                                     // member store (value has a side effect)
+        if (interveningStatement)
+            block.Add(new ExpressionStatement(new Call(other, isVirtual: false, [])));                 // non-consumed side-effecting statement
+        block.Add(new Return(new LoadStackSlot(Slot, Type)));                                          // escape
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction("M", Owner, new MethodSignature(Type, [], HasThis: false, GenericParameterCount: 0), [], body);
+        new ObjectInitializerPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void ContiguousRun_RaisesToInitializer()
+    {
+        var function = Build(interveningStatement: false);
+        Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+    }
+
+    [Fact]
+    public void StatementBetweenStoresAndEscape_IsNotFolded()
+    {
+        var function = Build(interveningStatement: true);
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        // The member store and the intervening call keep their original order.
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.Equal(2, function.Descendants.OfType<Call>().Count());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -212,6 +212,21 @@ public sealed class ObjectInitializerPass : IIrPass
         if (outsideUses.Count != 1)
             return null;
 
+        // The escape must immediately follow the consumed run: every statement between
+        // the seed and the statement that consumes the reference must itself be consumed.
+        // Otherwise a non-consumed (side-effecting) statement sits between the member
+        // stores and the escape, and folding the member values into the initializer at
+        // the escape would move them after that statement — reordering observable side
+        // effects. csc emits the dup-chain use contiguously, so a gap is hand-written IL.
+        IrNode escapeStatement = outsideUses[0];
+        while (escapeStatement.Parent is { } parent && !ReferenceEquals(parent, seed.Parent))
+            escapeStatement = parent;
+        if (!ReferenceEquals(escapeStatement.Parent, seed.Parent))
+            return null;   // the reference escapes in another block — not a contiguous run
+        for (int i = seed.ChildIndex + 1; i < escapeStatement.ChildIndex; i++)
+            if (!consumedSet.Contains(statements[i]))
+                return null;
+
         return new Plan(consumed, creation, isCollection ?? false, entries, new StackSlotTarget(outsideUses[0]));
     }
 


### PR DESCRIPTION
Fixes #1408.

## Over-raise claim narrowed

`ObjectInitializerPass`'s stack-slot form collected a contiguous run of member stores from the seed, but found the escape (the single downstream load) via a whole-function scan. A non-consumed side-effecting statement between the member stores and the escape was therefore allowed: folding the member-store values into `new T { ... }` at the escape moved those value computations after the intervening statement, reordering observable side effects while reporting success.

## Fix

Require every statement between the seed and the statement that consumes the reference to be part of the consumed run (and the escape to be in the seed's block).

## Soundness / blast radius

csc emits the dup-chain use contiguously, so this only declines hand-written/obfuscated IL. `CorpusSweepGateTests` and the existing `ObjectInitializerPassTests` (22) stay green.

## Evidence

`ObjectInitializerContiguityTests`: a synthetic-IR negative (a side-effecting call between the store and the escape stays unfolded) that **fails without this change**, plus a contiguous positive canary.
