### PR TITLE
Require corelib identity for ReadOnlySpan RVA raise (#1399)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -153,6 +153,22 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void ReadOnlySpanByte_FromUserLookalikeConstructor_IsNotRaised()
+    {
+        // #1399: a user assembly's `System.ReadOnlySpan<byte>` lookalike has the same
+        // name/shape but is not corelib, so the RVA optimization raise must decline.
+        var userSpan = TypeRef.GenericInstance(
+            TypeRef.Definition("UserAssembly", "System", "ReadOnlySpan`1"), [s_byte]);
+        var function = BuildReadOnlySpanCtor(s_byte, userSpan, [10, 20, 30, 0], spanLength: 3);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SpanLiteral>());
+        Assert.Contains(function.Descendants.OfType<NewObject>(), n => n.Constructor.Name == ".ctor");
+        function.CheckInvariant();
+    }
+
     static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
         => BuildReadOnlySpanCtor(s_byte, s_readOnlySpanByte, blob, spanLength);
 

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -243,6 +243,37 @@ public static class MemberIdentity
         return true;
     }
 
+    /// <summary>
+    /// Exact identity for csc's constant-<c>ReadOnlySpan&lt;T&gt;</c> RVA optimization
+    /// constructor — corelib <c>System.ReadOnlySpan`1</c>'s <c>(ref T, int)</c> ctor.
+    /// A user assembly can define a <c>System.ReadOnlySpan&lt;T&gt;</c> lookalike with
+    /// the same name/shape, so the raise must check exact corelib identity rather than
+    /// the type name (#1399).
+    /// </summary>
+    public static bool IsReadOnlySpanRvaConstructor(NewObject newObject, out TypeRef element)
+    {
+        element = TypeRef.Unsupported("unmatched ReadOnlySpan RVA constructor");
+        if (newObject.Constructor is not
+            {
+                Name: ".ctor",
+                HasThis: true,
+                TypeArguments.IsEmpty: true,
+                DeclaringType: var declaringType,
+                ParameterTypes: [var reference, var length],
+            }
+            || newObject.Arguments.Count != 2
+            || !IsCoreLibraryType(declaringType, "System", "ReadOnlySpan`1")
+            || declaringType.TypeArguments is not [var spanElement]
+            || !reference.Equals(TypeRef.ByRef(spanElement))
+            || !length.Equals(s_int))
+        {
+            return false;
+        }
+
+        element = spanElement;
+        return true;
+    }
+
     public static bool IsReadOnlySpanCopyTo(Call call, TypeRef element)
         => !call.IsVirtual
             && call.Callee is

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -61,11 +61,11 @@ public sealed class RvaSpanPass : IIrPass
             // length (a trailing pad), so the captured blob runs longer than the
             // data the span reads — decode exactly `rvaLength` elements from the
             // start, the span's own authoritative length.
-            if (construction.Constructor.DeclaringType is not
-                { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: "ReadOnlySpan`1" }, TypeArguments: [var spanElement] } spanInstance)
+            if (!MemberIdentity.IsReadOnlySpanRvaConstructor(construction, out var spanElement))
                 continue;
             if (construction.Arguments is not [LoadFieldAddress { FieldRvaData: { } rvaData }, Constant { Value: int rvaLength }])
                 continue;
+            var spanInstance = construction.Constructor.DeclaringType;
 
             var spanElements = DecodeElements(function, spanElement, rvaData, rvaLength);
             if (spanElements is null)


### PR DESCRIPTION
Fixes #1399. Burndown row 27 of #1356.

## Over-raise claim being narrowed

`RvaSpanPass`'s direct-constructor path raised csc's constant-`ReadOnlySpan<T>` RVA optimization (`new ReadOnlySpan<T>(ref <PrivateImplementationDetails>.HASH, length)`) whenever the constructor's declaring type matched `System.ReadOnlySpan\`1` **by namespace/name only**. A user assembly can define a `System.ReadOnlySpan<T>` lookalike; the pass replaced its constructor with a `SpanLiteral`/array literal, producing misleading source at raised altitude.

## Fix

Gate the raise on **exact corelib identity** via a new `MemberIdentity.IsReadOnlySpanRvaConstructor` (modeled on `IsStackAllocSpanConstructor`):

- declaring type is **corelib** `System.ReadOnlySpan\`1` (`IsCoreLibraryType`, not a name match);
- constructor signature is `(ref T, int)` returning the ctor's `this`;
- decoded span element matches the generic argument.

User lookalikes now stay lowered/honest; the real corelib padded-RVA positive still raises to the exact-length literal.

## Evidence

`RvaSpanPassTests` (9/9) + `MemberIdentityTests` (16/16):

- **Adversarial** `ReadOnlySpanByte_FromUserLookalikeConstructor_IsNotRaised`: a user-assembly `System.ReadOnlySpan<byte>` lookalike with RVA data → no `SpanLiteral`, constructor survives.
- Existing positives still raise: `ReadOnlySpanByte_FromPaddedRvaField_RaisesToExactLengthLiteral`, enum/int RVA spans; negative guards (negative/overflow length) unchanged.

```
RvaSpanPassTests     Total: 9, Failed: 0
MemberIdentityTests  Total: 16, Failed: 0
```

Full `src/ILInspector.Decompiler.Tests` running; summary to follow.

This pass only declines more, so it cannot move corpus compile-check/fidelity in a way that needs a card. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summary per AGENTS.md.
