### PR TITLE
Decline foreach iterator reconstruction with user finally

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3472,6 +3472,52 @@ public class CfgSampleClass
             yield return x;
     }
 
+    public static System.Collections.Generic.IEnumerable<int> ForeachUserFinally(System.Collections.Generic.IEnumerable<int> source)
+    {
+        foreach (var x in source)
+        {
+            try
+            {
+                yield return x;
+            }
+            finally
+            {
+                System.Console.Write("f");
+            }
+        }
+    }
+
+    public static System.Collections.Generic.IEnumerable<int> ForeachWithOuterFinally(System.Collections.Generic.IEnumerable<int> source)
+    {
+        var writer = new System.IO.StringWriter();
+        try
+        {
+            foreach (var x in source)
+                yield return x;
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+    }
+
+    public static System.Collections.Generic.IEnumerable<int> ForeachUserFinallyBeforeYield(System.Collections.Generic.IEnumerable<int> source)
+    {
+        foreach (var x in source)
+        {
+            try
+            {
+                System.Console.Write(x);
+            }
+            finally
+            {
+                System.Console.Write("f");
+            }
+
+            yield return x;
+        }
+    }
+
     // Conditional yield: a guarded yield with a trailing unconditional one. Two
     // yields but no loop; the guard references a parameter. Reconstructed by
     // MultiYieldReconstruction (jump-table dispatch the structurer raises to an `if`).

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -375,6 +375,42 @@ public class IteratorReconstructionPassTests
         Assert.DoesNotContain("GetEnumerator", output);
     }
 
+    [Fact]
+    public void ForeachDelegationIterator_WithUserFinally_DeclinesToAcknowledgment()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachUserFinally));
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void ForeachDelegationIterator_WithOuterFinally_DeclinesToAcknowledgment()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachWithOuterFinally));
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void ForeachDelegationIterator_WithUserFinallyBeforeYield_DeclinesToAcknowledgment()
+    {
+        var function = Raised(nameof(CfgSampleClass.ForeachUserFinallyBeforeYield));
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Empty(function.Descendants.OfType<YieldReturn>());
+        var marker = Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal("iterator", marker.Opcode);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
     static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectBeforeHandoff()
     {
         var intType = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachIteratorReconstruction.cs
@@ -73,6 +73,8 @@ internal static class ForeachIteratorReconstruction
                 enumeratorField = f;
         if (enumeratorField is null)
             return false;
+        if (!HasSingleEnumeratorDisposalFinally(work, enumeratorField))
+            return false;
 
         // field name -> (local index, type): the enumerator, plus any hoisted loop fields.
         var locals = new Dictionary<string, (int Index, TypeRef Type)>(StringComparer.Ordinal)
@@ -254,6 +256,29 @@ internal static class ForeachIteratorReconstruction
     static bool IsCurrentOf(IrExpression expression, int enumeratorIndex)
         => expression is LoadProperty { PropertyName: "Current", Instance: LoadLocal receiver }
             && receiver.Index == enumeratorIndex;
+
+    static bool HasSingleEnumeratorDisposalFinally(IrFunction work, FieldRef enumeratorField)
+    {
+        if (work.Regions is not [{ Kind: HandlerKind.Fault }])
+            return false;
+
+        var finallyCalls = work.Descendants.OfType<ExpressionStatement>()
+            .Select(statement => statement.Expression)
+            .OfType<Call>()
+            .Where(call => call.Callee.Name.StartsWith("<>m__Finally", StringComparison.Ordinal))
+            .ToList();
+        if (finallyCalls.Count != 1)
+            return false;
+
+        var statement = (ExpressionStatement)finallyCalls[0].Parent!;
+        return statement.Parent is Block block
+            && block.Children.Any(child => child is StoreField
+            {
+                Instance: LoadArgument { Index: 0 },
+                Field: var field,
+                Value: Constant { Value: null },
+            } && Equals(field, enumeratorField));
+    }
 
     static bool IsDefaultExit(Block block, int returnLocal)
         => block.Children is [Return { Value: Constant }]


### PR DESCRIPTION
Fixes #1429.

## Summary

- Gate `ForeachIteratorReconstruction` so it strips disposal scaffolding only when the raw MoveNext has exactly the single enumerator-disposal finally shape.
- Decline foreach-delegation reconstruction when extra user `try/finally` cleanup appears, falling back to the honest iterator acknowledgment instead of dropping cleanup at `Full`.
- Add foreach iterator adversarial fixtures for a finally crossing the yield, wrapping the foreach, and preceding the yield; keep the plain foreach-delegation positive intact.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IteratorReconstructionPassTests -class ILInspector.Decompiler.Tests.IteratorUserFinallyTests -class ILInspector.Decompiler.Tests.FidelityGateTests`
  - 36 passed, 0 failed.
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
  - Succeeded.

### Decompiler quality diff

Generated after merging current `origin/main`:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,096 methods
Correctness coverage: validity sampled 350 / 88,096 (0.40%); fidelity sampled 22 / 88,096 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,096 (+726)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,086 methods (+82)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,455 (87.92%) | +561 |
| Conditional-branch residual | 2,290 (2.62%) | 2,310 (2.62%) | +20 |
| Forward-merge stops | 2,284 (2.61%) | 2,301 (2.61%) | +17 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,096 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,096 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)

Caveat: the corpus drifted from the baseline (see baseline staleness above), so count-based regressions may be corpus composition change rather than a real PR delta. Rebaseline against current main and re-run before treating these as blocking.
```

## Adversarial review

Opus 4.8 reviewed the discriminator and tests. Result: no blocking findings. It confirmed the guard runs before mutation, the single-fault/single-`<>m__Finally`/enumerator-null-reset shape conservatively declines user cleanup, and the added before-yield finally fixture pins the broader region-count invariant.
