### PR TITLE
Document range-endpoint precedence in the printer (superseded fix #1424 landed via #1495)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1429,6 +1429,11 @@ public sealed partial class CSharpPrinter
         InitializerBlock ib => InitializerBodyText(ib.IsCollection, ib.Entries),
         ArrayLength l => $"{Operand(l.Array)}.Length",
         SliceExpression sl => $"{ReceiverText(sl.Receiver)}[{Expression(sl.Range)}]",
+        // Endpoints go through Operand(), not Expression(): the range operator `..`
+        // binds tighter than `+`/`-`/`*`/… on its operand, so a compound bound must
+        // keep its parentheses (`arr[(a + b)..]`, not `arr[a + b..]`, which reparses
+        // as `arr[a + (b..)]` — CS0019). Operand() wraps non-atoms and leaves atoms
+        // (including nested ranges and `^x`) bare, matching IndexFromEnd below.
         RangeExpression r => $"{(r.HasStart ? Operand(r.Start!) : "")}..{(r.HasEnd ? Operand(r.End!) : "")}",
         IndexFromEnd i => $"^{Operand(i.Offset)}",
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",


### PR DESCRIPTION
## What changed (after rebase)

The actual fix for #1424 — routing `RangeExpression` endpoints through `Operand()` instead of `Expression()` so compound bounds keep their parentheses (`arr[(a + b)..]`, not the CS0019-producing `arr[a + b..]`) — **already landed on `main` via #1495**, along with the `ArrayRangeCompound{Start,End,Both}` fixtures and `GetSubArray_Compound*` round-trip tests.

This PR is therefore rebased down to its **one piece of unique, non-redundant value**: a 5-line precedence-rationale comment above the `RangeExpression` printer arm in `CSharpPrinter.cs`. It documents *why* endpoints must use `Operand()` and guards against a future `Operand()`→`Expression()` regression.

## Net diff vs `main`

```
 src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs | 5 +++++
 1 file changed, 5 insertions(+)
```

Comment-only; builds clean. No behavior change.

## Alternative

If a comment-only PR isn't worth keeping, this can simply be **closed as superseded by #1495** with no loss — the fix and its tests are already in `main`.
