### PR TITLE
Add compiled object-initializer contiguity fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2040,6 +2040,17 @@ public class CfgSampleClass
 
     public static int MakeAndRead(int a) => InitTargetX(new InitTarget { X = a });
 
+    public static int ObjectInitializerArgumentBeforeShortCircuit(int a)
+        => UseInitTarget(new InitTarget { X = a }, InitializerProbe(a) && InitializerProbe(a + 1));
+
+    static int UseInitTarget(InitTarget target, bool flag) => flag ? target.X : -target.X;
+
+    static bool InitializerProbe(int value)
+    {
+        GC.KeepAlive(value);
+        return value >= 0;
+    }
+
     public static InitTarget NamedPointInitializer(int a, int b)
     {
         var target = new InitTarget { X = a, Y = b };

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
@@ -6,8 +6,8 @@ namespace ILInspector.Decompiler.Tests;
 // The stack-slot form folds member-store values into `new T { ... }` at the single
 // downstream escape. If a non-consumed (side-effecting) statement sits between the
 // member stores and the escape, folding moves the member-value computations after
-// it — reordering observable side effects. csc emits the dup-chain use contiguously,
-// so this is a synthetic-IR near-miss; paired with a contiguous positive canary.
+// it — reordering observable side effects. This pins the minimal IR near-miss;
+// ObjectInitializerPassTests covers the csc-emitted short-circuit argument shape.
 public class ObjectInitializerContiguityTests
 {
     static readonly TypeRef Type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -84,6 +84,18 @@ public class ObjectInitializerPassTests
     }
 
     [Fact]
+    public void InitializerArgumentBeforeShortCircuit_StaysLowered()
+    {
+        var function = Raised(nameof(CfgSampleClass.ObjectInitializerArgumentBeforeShortCircuit));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains(".X = a;", output);
+        Assert.DoesNotContain("new InitTarget {", output);
+    }
+
+    [Fact]
     public void NamedLocalObjectInitializer_RaisesIntoLocalDeclaration()
     {
         var function = Raised(nameof(CfgSampleClass.NamedPointInitializer));


### PR DESCRIPTION
## Summary

- Add a compiled fixture for the #1457 review follow-up: object initializer as an argument before a short-circuit `&&` argument.
- Assert that the decompiler keeps this csc-emitted shape lowered instead of folding it into an object initializer across the short-circuit branch.
- Clarify the synthetic contiguity test comment: it is the minimal IR near-miss, while the new fixture covers the csc-emitted reachability found in review.

Follow-up to #1457 / #1408.

## Evidence

Focused tests:

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests \
  -class ILInspector.Decompiler.Tests.ObjectInitializerContiguityTests
# 25 passed
```

This is test-only; no product behavior changes or corpus card claimed.
